### PR TITLE
Use HTML entity instead of a unicode character

### DIFF
--- a/examples/core/Footer.js
+++ b/examples/core/Footer.js
@@ -111,7 +111,7 @@ class Footer extends React.Component {
           />
         </a>
         <section className="copyright">
-          Copyright © {currentYear} Facebook Inc.
+          Copyright &copy; {currentYear} Facebook Inc.
         </section>
       </footer>
     );


### PR DESCRIPTION
Some editors are unhappy using unicode in a file.  Let's use the HTML entity instead.