### PR TITLE
Do not wrap on words in navigation links

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -978,6 +978,7 @@ a:hover code {
 .navigationSlider .slidingNav ul li {
   flex: 1;
   text-align: center;
+  white-space: nowrap;
   margin: 0;
 }
 .navigationSlider .slidingNav ul li a {


### PR DESCRIPTION
If you have text like "Getting Started", it will wrap on the space and not be one line.