### PR TITLE
Ensure mutli-word page titles do not wrap

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -181,6 +181,7 @@ header h2 {
 
 .mainContainer {
   background: #f9f9f9;
+  flex: 1;
 }
 .mainContainer .wrapper {
   text-align: left;


### PR DESCRIPTION
If you happen to have a page with the title of "Getting Started", the title would wrap even if there was plenty of space.