### PR TITLE
Fix translation functionality to properly condense whitespace and parse escaped characters

### DIFF
--- a/lib/server/translate-plugin.js
+++ b/lib/server/translate-plugin.js
@@ -19,7 +19,7 @@ module.exports = function translatePlugin(babel) {
           return;
         }
         /* assume translate element only has one child which is the text */
-        const text = path.node.children[0].value.trim();
+        const text = path.node.children[0].value.trim().replace(/\s+/g, " ");
         let description = "no description given";
         const attributes = path.node.openingElement.attributes;
         for (let i = 0; i < attributes.length; i++) {

--- a/lib/server/translate.js
+++ b/lib/server/translate.js
@@ -11,12 +11,25 @@ const translation = require("./translation.js");
 
 let language = "en";
 
+/* handle escaped characters that get converted into json strings */
+function parseEscapeSequences(str) {
+  return str
+    .replace(new RegExp("\\\\n", "g"), "\n")
+    .replace(new RegExp("\\\\b", "g"), "\b")
+    .replace(new RegExp("\\\\f", "g"), "\f")
+    .replace(new RegExp("\\\\r", "g"), "\r")
+    .replace(new RegExp("\\\\t", "g"), "\t")
+    .replace(new RegExp("\\\\'", "g"), "'")
+    .replace(new RegExp('\\\\"', "g"), '"')
+    .replace(new RegExp("\\\\", "g"), "\\");
+}
+
 function setLanguage(lang) {
   language = lang;
 }
 
 function translate(str) {
-  return translation[language]["pages-strings"][str];
+  return parseEscapeSequences(translation[language]["pages-strings"][str]);
 }
 
 module.exports = {

--- a/lib/write-translations.js
+++ b/lib/write-translations.js
@@ -73,7 +73,9 @@ function execute() {
             path.node.type === "JSXElement" &&
             path.node.openingElement.name.name === "translate"
           ) {
-            const text = path.node.children[0].value.trim();
+            const text = path.node.children[0].value
+              .trim()
+              .replace(/\s+/g, " ");
             let description = "no description given";
             const attributes = path.node.openingElement.attributes;
             for (let i = 0; i < attributes.length; i++) {


### PR DESCRIPTION
Static analysis of javascript files now condenses whitespace so that formatting will not interfere with the generated strings file.

For example, these two will now generate the same string: 
```jsx
<translate> Learn more about how to
use Docusaurus </translate>
```
```jsx
<translate> Learn more about how to use Docusaurus </translate>
```

Escaped characters now get properly parsed after reading in from JSON. This particularly affects usages of text in objects like with GridBlocks. For example, the following tag used in a GridBlock:
```jsx
<translate> Learn more about how to \n\n use Docusaurus </translate>
```
will show on the site as:
```
Learn more about how to
use Docusaurus
```
instead of:
```
Learn more about how to use \n\n Docusaurus
```
