### PR TITLE
Add config option to allow disabled header title

### DIFF
--- a/examples/siteConfig.js
+++ b/examples/siteConfig.js
@@ -48,6 +48,7 @@ const siteConfig = {
   ],
   /* path to images for header/footer */
   headerIcon: "img/docusaurus.svg",
+  disableHeaderTitle: false /* disable title text in header (only show headerIcon) */,
   footerIcon: "img/docusaurus.svg",
   favicon: "img/favicon.png",
   /* default link for docsSidebar */

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -113,9 +113,10 @@ class HeaderNav extends React.Component {
           <header>
             <a href={this.props.baseUrl}>
               <img src={this.props.baseUrl + siteConfig.headerIcon} />
-              <h2>
-                {this.props.title}
-              </h2>
+              {!this.props.config.disableHeaderTitle &&
+                <h2>
+                  {this.props.title}
+                </h2>}
             </a>
             {this.renderResponsiveNav()}
           </header>


### PR DESCRIPTION
Per request of fastText team, header title text can be disabled. The headerIcon will still link to the main page. The config option is optional, so if it is not specified in `siteConfig.js`, the header title will appear.

![screen shot 2017-07-17 at 10 37 29 am](https://user-images.githubusercontent.com/15843721/28281483-1b0c7966-6adc-11e7-995b-2d5afead42ec.png)
![screen shot 2017-07-17 at 10 38 12 am](https://user-images.githubusercontent.com/15843721/28281484-1ca9d070-6adc-11e7-9496-72acdd85b097.png)
