### PR TITLE
Add Recent Posts button at bottom of blog posts

### DIFF
--- a/lib/core/BlogPostLayout.js
+++ b/lib/core/BlogPostLayout.js
@@ -40,9 +40,9 @@ class BlogPostLayout extends React.Component {
                 config={this.props.config}
               />
             </div>
-            <div className="blog-recent-bar">
+            <div className="blog-recent">
               <a
-                className="blog-recent button"
+                className="button"
                 href={this.props.config.baseUrl + "blog"}
               >
                 Recent Posts

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1554,14 +1554,14 @@ table tr th {
   overflow: hidden;
   width: 70px;
 }
-.blog-recent-bar {
+.blog-recent {
   margin: 20px 0;
 }
-.blog-recent {
+.blog-recent > a {
   float: left;
 }
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
-  .blog-recent-bar {
+  .blog-recent {
     height: 40px;
   }
 }


### PR DESCRIPTION
Add a button for easy navigation back to blog page at bottom of each blog post.

![screen shot 2017-07-17 at 11 48 58 am](https://user-images.githubusercontent.com/15843721/28284485-f7c2e472-6ae5-11e7-984a-14217a9e3d47.png)

![screen shot 2017-07-17 at 11 48 46 am](https://user-images.githubusercontent.com/15843721/28284486-f8cbb0c4-6ae5-11e7-8d4c-f1834db7bdff.png)

The `css` additions were made so that the button appears in the same way that doc navigation buttons do, referencing the `docs-prevnext` and `docs-prev` elements.