### PR TITLE
Skip processing any docs with empty/no front matter instead of throwing error

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -106,6 +106,9 @@ function execute() {
 
     if (extension === ".md" || extension === ".markdown") {
       const result = readMetadata.processMetadata(file);
+      if (!result) {
+        return;
+      }
 
       const metadata = result.metadata;
       let rawContent = result.rawContent;

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -60,6 +60,9 @@ function extractMetadata(content) {
 
 function processMetadata(file) {
   const result = extractMetadata(fs.readFileSync(file, "utf8"));
+  if (!result.metadata || !result.rawContent) {
+    return null;
+  }
 
   const regexSubFolder = /docs\/(.*)\/.*/;
 
@@ -120,6 +123,9 @@ function generateDocsMetadata() {
 
     if (extension === ".md" || extension === ".markdown") {
       const res = processMetadata(file);
+      if (!res) {
+        return;
+      }
       const metadata = res.metadata;
       metadatas.push(metadata);
     }


### PR DESCRIPTION
Allows the user to still run Docusaurus while writing new, incomplete markdown files in their `docs` folder without having Docusaurus throw errors. Any markdown files with either no front matter headers or empty front matter headers will be ignored by Docusaurus. 

Markdown files with existing but improper headers will still throw errors. (Improving on these error messages will be done in the future.)

Description of this functionality will be added to updated documentation once it gets published to npm.