### PR TITLE
Write CNAME file if custom domain

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -386,17 +386,10 @@ function execute() {
     }
   });
 
-  /* Generate CNAME file if the domain is custom */
-  if (!siteConfig.url.includes("github.io")) { // github.io urls are not custom
-    let cname = siteConfig.url;
-    let targetFile =
-      __dirname +
-      "/../../build" +
-      "/" +
-      siteConfig.projectName +
-      "/" +
-      "CNAME";
-    fs.writeFileSync(targetFile, cname);
+  /* Generate CNAME file if a custom domain is specified in siteConfig */
+  if (siteConfig.cname) {
+    let targetFile = CWD + "/build/" + siteConfig.projectName + "/CNAME";
+    fs.writeFileSync(targetFile, siteConfig.cname);
   }
 }
 


### PR DESCRIPTION
Custom domains in GitHub pages require a CNAME file. This file is automatically created for you if you add a custom
domain to the GitHub pages section of the "Settings" area in a GitHub repo.

However, the way we push to GitHub, we remove all files from a `gh-pages` branch before building and pushing the new
content on a rebuild. This includes removing the CNAME file, even if it was autogenerated when changing the setting.

So, just always create a CNAME file if the domain is a custom domain.