### PR TITLE
Update document metadata processing

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,5 @@
+---
+---
 ## Getting Started
 
 ### Project Structure

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -11,7 +11,6 @@ const CWD = process.cwd();
 
 const path = require("path");
 const fs = require("fs");
-const os = require("os");
 const glob = require("glob");
 const siteConfig = require(CWD + "/siteConfig.js");
 const versionFallback = require("./versionFallback.js");
@@ -71,7 +70,7 @@ function readSidebar() {
 }
 
 function splitHeader(content) {
-  const lines = content.split(os.EOL);
+  const lines = content.split("\n");
   let i = 1;
   for (; i < lines.length - 1; ++i) {
     if (lines[i] === "---") {
@@ -88,12 +87,15 @@ function splitHeader(content) {
 function extractMetadata(content) {
   const metadata = {};
   const both = splitHeader(content);
+  // if no content returned, then that means there was no header, and both.header is the content
+  if (!both.content) {
+    return { metadata, rawContent: both.header };
+  }
   const lines = both.header.split("\n");
   for (let i = 0; i < lines.length - 1; ++i) {
     const keyvalue = lines[i].split(":");
     const key = keyvalue[0].trim();
     let value = keyvalue.slice(1).join(":").trim();
-    // Handle the case where you have "Community #10"
     try {
       value = JSON.parse(value);
     } catch (e) {}
@@ -105,9 +107,6 @@ function extractMetadata(content) {
 // process the metadata for a document found in the docs folder
 function processMetadata(file) {
   const result = extractMetadata(fs.readFileSync(file, "utf8"));
-  if (!result.metadata || !result.rawContent) {
-    return null;
-  }
 
   const regexSubFolder = /docs\/(.*)\/.*/;
 
@@ -120,6 +119,16 @@ function processMetadata(file) {
   const metadata = result.metadata;
   const rawContent = result.rawContent;
   metadata.source = path.basename(file);
+
+  if (!metadata.id) {
+    metadata.id = path.basename(file, path.extname(file));
+  }
+  if (metadata.id.includes("/") || metadata.id.includes(".")) {
+    throw new Error('Document id cannot include "/" or ".".');
+  }
+  if (!metadata.title) {
+    metadata.title = metadata.id;
+  }
 
   if (languages.length === 1 && !siteConfig.useEnglishUrl) {
     metadata.permalink = "docs/" + metadata.id + ".html";
@@ -221,21 +230,23 @@ function generateDocsMetadata() {
   const versionData = versionFallback.docData();
   versionData.forEach(metadata => {
     const id = metadata.localized_id;
-    metadata.sidebar = order[id].sidebar;
-    metadata.category = order[id].category;
-    if (order[id].next) {
-      metadata.next_id = order[id].next.replace(
-        "version-" + metadata.version + "-",
-        ""
-      );
-      metadata.next = metadata.language + "-" + order[id].next;
-    }
-    if (order[id].previous) {
-      metadata.previous_id = order[id].previous.replace(
-        "version-" + metadata.version + "-",
-        ""
-      );
-      metadata.previous = metadata.language + "-" + order[id].previous;
+    if (order[id]) {
+      metadata.sidebar = order[id].sidebar;
+      metadata.category = order[id].category;
+      if (order[id].next) {
+        metadata.next_id = order[id].next.replace(
+          "version-" + metadata.version + "-",
+          ""
+        );
+        metadata.next = metadata.language + "-" + order[id].next;
+      }
+      if (order[id].previous) {
+        metadata.previous_id = order[id].previous.replace(
+          "version-" + metadata.version + "-",
+          ""
+        );
+        metadata.previous = metadata.language + "-" + order[id].previous;
+      }
     }
     metadatas[metadata.id] = metadata;
   });

--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -60,6 +60,10 @@ function splitHeader(content) {
 function extractMetadata(content) {
   const metadata = {};
   const both = splitHeader(content);
+  // if no content returned, then that means there was no header, and both.header is the content
+  if (!both.content) {
+    return { metadata, rawContent: both.header };
+  }
   const lines = both.header.split("\n");
   for (let i = 0; i < lines.length - 1; ++i) {
     const keyvalue = lines[i].split(":");
@@ -265,8 +269,9 @@ function diffLatestSidebar() {
     return true;
   }
   const currentSidebar = CWD + "/sidebars.json";
+  // if no current sidebar file, return false so no sidebar file gets copied
   if (!fs.existsSync(currentSidebar)) {
-    // TO DO: error message
+    return false;
   }
 
   // compare for equality between latest version sidebar with version prefixes

--- a/lib/version.js
+++ b/lib/version.js
@@ -20,7 +20,7 @@ const versionFallback = require("./server/versionFallback.js");
 const CWD = process.cwd();
 let versions;
 if (fs.existsSync(CWD + "/versions.json")) {
- versions = require(CWD + "/versions.json");
+  versions = require(CWD + "/versions.json");
 } else {
   versions = [];
 }
@@ -37,14 +37,18 @@ program
 
 if (typeof version === "undefined") {
   console.error(
-    `${chalk.yellow("No version number specified!")}\nPass the version you wish to create as an argument.\nEx: 1.0.0`
+    `${chalk.yellow(
+      "No version number specified!"
+    )}\nPass the version you wish to create as an argument.\nEx: 1.0.0`
   );
   process.exit(1);
 }
 
 if (versions.includes(version)) {
   console.error(
-    `${chalk.yellow("This version already exists!")}\nSpecify a new version to create that does not already exist.`
+    `${chalk.yellow(
+      "This version already exists!"
+    )}\nSpecify a new version to create that does not already exist.`
   );
   process.exit(1);
 }
@@ -74,7 +78,13 @@ files.forEach(file => {
   let metadata = res.metadata;
   let rawContent = res.rawContent;
   if (!metadata.id) {
-    return;
+    metadata.id = path.basename(file, path.extname(file));
+  }
+  if (metadata.id.includes("/") || metadata.id.includes(".")) {
+    throw new Error('Document id cannot include "/" or ".".');
+  }
+  if (!metadata.title) {
+    metadata.title = metadata.id;
   }
 
   if (!versionFallback.diffLatestDoc(file, metadata.id)) {

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
     "build": "../lib/build-files.js",
     "publish-gh-pages": "../lib/publish-gh-pages.js",
     "examples": "../lib/copy-examples.js",
-    "write-translations": "../lib/write-translations.js"
+    "write-translations": "../lib/write-translations.js",
+    "version": "../lib/version.js"
   }
 }


### PR DESCRIPTION
- Files with no markdown header now get processed instead of ignored
- Files with no `id` markdown field use the file name as the default `id`. Files with no `title` markdown field use the `id` as the default `title`.
- Throw an error if a doc `id` contains `/` or `.`
- Split lines by `\n` instead of `os.EOL` in `splitHeader` function. Since the keys and values going into the `metadata` in `extractMetadata` get trimmed anyway, using `os.EOL` actually just causes extra issues. Splitting by `\n` when lines end with `\r\n` will give correct results, but splitting by `\r\n` when lines end with `\n` will not. This also means Windows users don't have to convert the example docs files to use Windows line endings when they want to get started quickly.
(Tested previously and this was the only change needed to make Docusaurus work for Windows, have not tested recently but will do that later.)