### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+lib/core/metadata.js
+lib/core/MetadataBlog.js
+yarn.lock
+website
+docs


### PR DESCRIPTION
Add a separate `.npmignore` file with `website` and `docs` since there shouldn't be any reason those folders need to get published to `npm` with everything else.