### PR TITLE
add sourceCodeButton to site config

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -33,7 +33,7 @@ Example Usage:
 ```js
 headerLinks: [
   // Links to document with id doc1 for current language/version
-  { doc: "doc1", label: "Getting Started" }, 
+  { doc: "doc1", label: "Getting Started" },
   // Link to page found at pages/en/help.js or if that does not exist, pages/help.js, for current language
   { page: "help", label: "Help" },
   // Links to href destination
@@ -52,8 +52,8 @@ headerLinks: [
 
 `colors` - Color configurations for the site.
 
-  - `primaryColor` is the color used the header navigation bar and sidebars. 
-  - `secondaryColor` is the color seen in the second row of the header navigation bar when the site window is narrow (including on mobile). 
+  - `primaryColor` is the color used the header navigation bar and sidebars.
+  - `secondaryColor` is the color seen in the second row of the header navigation bar when the site window is narrow (including on mobile).
   - `prismColor` is the color used in the background of syntax highlighting for code in documentation. It is recommended to be the same color as `primaryColor` in `rgba` form with an alpha value of `0.03`. Other fields can be added
   - Custom color configurations can also be added. For example, if user styles are added with colors specified as `$myColor`, then adding a `myColor` field to `colors` will allow you to easily configure this color.
 
@@ -78,6 +78,9 @@ headerLinks: [
 `algolia` - Information for Algolia search integration. If this field is excluded, the search bar will not appear in the header.
 
 `gaTrackingId` - Google Analytics tracking ID to track page views.
+
+
+`sourceCodeButton` - the type of button to use for pointing to your source code. If this field is non-null, the site will pull in the appropriate button code in the header, for you to be able to render as you see fit. Currently accepted values: `"github"`, `"none"`. Defaults to `"github"`.
 
 Users can also add their own custom fields if they wish to provide some data across different files.
 
@@ -130,8 +133,9 @@ const siteConfig = {
     apiKey:
       "0f9f28b9ab9efae89810921a351753b5",
     indexName: "github"
-  }
-  gaTrackingId: "U-A2352"
+  },
+  gaTrackingId: "U-A2352",
+  sourceCodeButton: "github"
 };
 
 module.exports = siteConfig;

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -17,6 +17,10 @@ class Head extends React.Component {
     links.map(link => {
       if (link.blog) hasBlog = true;
     });
+    let sourceCodeButton = this.props.config.sourceCodeButton;
+    // defaults to github, but other values may be allowed in the future
+    let includeGithubButton =
+      sourceCodeButton === 'github' || sourceCodeButton == null;
     return (
       <head>
         <meta charSet="utf-8" />
@@ -64,7 +68,9 @@ class Head extends React.Component {
             title={this.props.config.title + " Blog RSS Feed"}
           />
         )}
-        <script async defer src="https://buttons.github.io/buttons.js" />
+        {includeGithubButton &&
+          <script async defer src="https://buttons.github.io/buttons.js" />
+        }
       </head>
     );
   }


### PR DESCRIPTION
Pulling in the github button code is unnecessary if you don't want the button or if you host your code on gitlab etc. We should provide a way to opt out of loading this JS.

This is a breaking change, so I'm not really endorsing it unless everyone is excited about it. I think eventually it would be nice to have a config similar to algolia that generates a button for you and then a CompLibrary component to render it.