### PR TITLE
Add back babel preset for React plugins package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.24.1",
     "babel-register": "^6.24.1",
     "babel-traverse": "^6.25.0",
     "babylon": "^6.17.4",


### PR DESCRIPTION
This fixes the circular JSON error in https://github.com/facebookexperimental/Docusaurus/issues/89

Maybe its not the best workaround here, but I think it does the trick.

Fixes #89