### PR TITLE
Check for required folders based upon headerLinks right up front

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -220,9 +220,29 @@ class HeaderNav extends React.Component {
     if (!languages) {
       headerLinks.push({ languages: true });
     }
-    // add search bar to end if location not specified
     let search = false;
     headerLinks.forEach(link => {
+      if (link.doc && !fs.existsSync(CWD + "/../docs/")) {
+        throw new Error(
+          "You have 'doc' in your headerLinks, but no 'docs' folder exists one level up from " +
+          "'website' folder. Are you running the examples? If so, make sure you rename " +
+          "'docs-examples-from-docusaurus' to 'docs'."
+        );
+      }
+      if (link.blog && !fs.existsSync(CWD + "/blog/")) {
+        throw new Error(
+          "You have 'blog' in your headerLinks, but no 'blog' folder exists in your " +
+          "website folder. Are you running the examples? If so, make sure you rename " +
+          "'blog-examples-from-docusaurus' to 'blog'."
+        );
+      }
+      if (link.page && !fs.existsSync(CWD + "/pages/")) {
+        throw new Error(
+          "You have 'page' in your headerLinks, but no 'pages' folder exists in your " +
+          "'website' folder."
+        );
+      }
+      // We will add search bar to end if location not specified
       if (link.search) {
         search = true;
       }


### PR DESCRIPTION
I was getting this error when running the examples:

```
Error: It looks like you've enabled language support, but haven't provided translated files. The document with id: 'en-doc1' doesn't exist.
```

However, this error was an indirect result of me not renaming the `docs-examples-from-docusaurus` directory to `docs` since I had `doc` in my
`headerLinks` in the example siteConfig.js.

So let's check the headerLinks and make sure we have the required directories.

Here is an example of the error if I try to load a Docusaurus site just after running `npm run examples` without having renamed the directories.

```
Error: You have 'doc' in your headerLinks, but no 'docs' folder exists one level up from 'website' folder. Are you running the examples? If so, make sure you rename 'docs-examples-from-docusaurus' to 'docs'.
    at /Users/joelm/dev/test/website/node_modules/docusaurus/lib/core/nav/HeaderNav.js:226:15
:
:
```

Test Plan: Tested a local package in verdaccio