### PR TITLE
Change algoliaOptions back to object

### DIFF
--- a/docs/guides-search.md
+++ b/docs/guides-search.md
@@ -29,7 +29,10 @@ const siteConfig = {
   ...
   algolia: {
     ...
-    algoliaOptions: '{ facetFilters: [ "tags:VERSION" ], hitsPerPage: 5 }'
+    algoliaOptions: { 
+      facetFilters: [ "tags:VERSION" ], 
+      hitsPerPage: 5 
+    }
   },
 }
 ```

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -99,9 +99,11 @@ class Site extends React.Component {
                 apiKey: '${this.props.config.algolia.apiKey}',
                 indexName: '${this.props.config.algolia.indexName}',
                 inputSelector: '#search_input_react',
-                algoliaOptions: '${this.props.config.algolia.algoliaOptions
+                algoliaOptions: ${
+                  JSON.stringify(this.props.config.algolia.algoliaOptions)
                   .replace("VERSION", this.props.version || latestVersion)
-                  .replace("LANGUAGE", this.props.language)}'
+                  .replace("LANGUAGE", this.props.language)
+                }
               });
             `
                   }}


### PR DESCRIPTION
Prior to this PR, Docusaurus would expect algoliaOptions to be a String. DocSearch expects an object here.
We now convert the object to a string temporarily in order to do any necessary text replacement.

Test Plan

Verified with React Native.