### PR TITLE
Remove dependency from website package.json

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,8 +9,5 @@
 		"rename-version": "../lib/rename-version.js",
 		"crowdin-upload": "crowdin-cli --config ../crowdin.yaml upload sources --auto-update -b master",
 		"crowdin-download": "crowdin-cli --config ../crowdin.yaml download -b master"
-	},
-	"dependencies": {
-		"docusaurus": "^1.0.0-alpha.41"
 	}
 }


### PR DESCRIPTION
This isn't needed and we don't need to keep up with it everytime we push a package.

We only have to keep up with the versioning in the main package.json