### PR TITLE
Fixes #104 by providing a useful error message

### DIFF
--- a/lib/server/translate.js
+++ b/lib/server/translate.js
@@ -27,6 +27,18 @@ function setLanguage(lang) {
 }
 
 function translate(str) {
+  if (
+    !translation[language] ||
+    !translation[language]["pages-strings"] ||
+    !translation[language]["pages-strings"][str]
+  ) {
+    throw new Error(
+      "Text that you've identified for translation hasn't been added to the global list in 'en.json'. To solve this problem run 'yarn write-translations'."
+    );
+  }
+  console.log(translation[language]);
+  console.log(translation[language]["pages-strings"]);
+  console.log(translation[language]["pages-strings"][str]);
   return parseEscapeSequences(translation[language]["pages-strings"][str]);
 }
 

--- a/lib/write-translations.js
+++ b/lib/write-translations.js
@@ -26,6 +26,8 @@ function writeFileAndCreateFolder(file, content) {
 }
 
 function execute() {
+  console.log("Writing translation files...");
+
   let translations = {
     "localized-strings": {
       next: "Next",


### PR DESCRIPTION
Puts a helpful error message directing user to run `yarn write-translations`.

A future push will automatically run this step.