### PR TITLE
Allow for header and empty body

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -72,6 +72,9 @@ function readSidebar() {
 // split markdown header
 function splitHeader(content) {
   const lines = content.split("\n");
+  if (lines[0] !== "---") {
+    return false;
+  }
   let i = 1;
   for (; i < lines.length - 1; ++i) {
     if (lines[i] === "---") {
@@ -88,9 +91,8 @@ function splitHeader(content) {
 function extractMetadata(content) {
   const metadata = {};
   const both = splitHeader(content);
-  // if no content returned, then that means there was no header, and both.header is the content
-  if (!both.content) {
-    return {metadata, rawContent: both.header};
+  if (both === false) {
+    return {metadata, rawContent: content};
   }
   const lines = both.header.split("\n");
   for (let i = 0; i < lines.length - 1; ++i) {
@@ -102,6 +104,7 @@ function extractMetadata(content) {
     } catch (e) {}
     metadata[key] = value;
   }
+
   return {metadata, rawContent: both.content};
 }
 


### PR DESCRIPTION
My hack of checking if the body was empty wasn't correct :(

```js
---
id: String
title: String
layout: stdlib
---
```

The above would be treated as pure content. Now it's working properly :)