### PR TITLE
Remove author name when unused

### DIFF
--- a/lib/core/BlogPost.js
+++ b/lib/core/BlogPost.js
@@ -103,13 +103,15 @@ class BlogPost extends React.Component {
     return (
       <header className="postHeader">
         {this.renderAuthorPhoto()}
-        <p className="post-authorName">
-          <a href={post.authorURL} target="_blank">
-            {post.author}
-          </a>
-          <br />
-          {post.authorTitle}
-        </p>
+        {post.author ? (
+          <p className="post-authorName">
+            <a href={post.authorURL} target="_blank">
+              {post.author}
+            </a>
+            <br />
+            {post.authorTitle}
+          </p>
+        ) : null}
         {this.renderTitle()}
         <p className="post-meta">
           {month} {day}, {year}


### PR DESCRIPTION
The empty div still has padding applied to it in CSS. Doesn't look great. Especially noticeable on posts without author names or photos.

Before:
<img width="416" alt="screen shot 2017-10-17 at 9 06 47 pm" src="https://user-images.githubusercontent.com/4370652/31700608-65f9eb2a-b37f-11e7-918c-c188e08273eb.png">
After:
<img width="429" alt="screen shot 2017-10-17 at 9 07 05 pm" src="https://user-images.githubusercontent.com/4370652/31700611-68ab5048-b37f-11e7-9c72-7c46d47a073e.png">