### PR TITLE
normalize header padding

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -503,7 +503,7 @@ header h2 {
   background: $primaryColor;
   color: #fff;
   min-height: 50px;
-  padding: 10px 0 8px;
+  padding: 9px 0;
   position: fixed;
   width: 100%;
   z-index: 9999;


### PR DESCRIPTION
This extra pixel causes a lot of visual headache. Harder to customize if we want as well. Mostly noticeable with the logo which is slightly low with the current styles.