### PR TITLE
Use fixed position on mobile nav

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1041,10 +1041,10 @@ a:hover code {
 }
 .navigationSlider .slidingNav {
   box-sizing: border-box;
-  position: absolute;
-  left: -10px;
-  right: -10px;
-  top: -10px;
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
   bottom: auto;
 }
 .navigationSlider .slidingNav.slidingNavActive {


### PR DESCRIPTION
This doesn't actually change the look of the site at all, but this CSS was very unintuitive when I was working with it. I think when mobile this menu should always be positioned relative to the screen, not it's parent. Fixed is a little more explicit about that behavior.