### PR TITLE
Generate redirect files when languages is enabled (languages.js is present)

### DIFF
--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -18,7 +18,7 @@ class Head extends React.Component {
     let sourceCodeButton = this.props.config.sourceCodeButton;
     // defaults to github, but other values may be allowed in the future
     let includeGithubButton =
-      sourceCodeButton === 'github' || sourceCodeButton == null;
+      sourceCodeButton === "github" || sourceCodeButton == null;
     return (
       <head>
         <meta charSet="utf-8" />
@@ -34,6 +34,12 @@ class Head extends React.Component {
           <meta
             property="og:image"
             content={this.props.config.baseUrl + this.props.config.ogImage}
+          />
+        )}
+        {this.props.redirect && (
+          <meta
+            http-equiv="refresh"
+            content={"2; URL=" + this.props.redirect}
           />
         )}
         <link
@@ -66,10 +72,13 @@ class Head extends React.Component {
             title={this.props.config.title + " Blog RSS Feed"}
           />
         )}
-        {includeGithubButton &&
+        {includeGithubButton && (
           <script async defer src="https://buttons.github.io/buttons.js" />
-        }
-        <script type="text/javascript" src={this.props.config.baseUrl + "js/webplayer.js"} />
+        )}
+        <script
+          type="text/javascript"
+          src={this.props.config.baseUrl + "js/webplayer.js"}
+        />
         <script type="text/javascript" src="https://snack.expo.io/embed.js" />
       </head>
     );

--- a/lib/core/Redirect.js
+++ b/lib/core/Redirect.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require("react");
+const fs = require("fs");
+const Head = require("./Head.js");
+const translation = require("../server/translation.js");
+
+const CWD = process.cwd();
+
+// Component used to provide same head, header, footer, other scripts to all pages
+class Redirect extends React.Component {
+  render() {
+    const tagline = translation[this.props.language]
+      ? translation[this.props.language]["localized-strings"].tagline
+      : this.props.config.tagline;
+    const title = this.props.title
+      ? this.props.title + " · " + this.props.config.title
+      : (!this.props.config.disableTitleTagline &&
+          this.props.config.title + " · " + tagline) ||
+        this.props.config.title;
+    const description = this.props.description || tagline;
+    const url =
+      this.props.config.url +
+      this.props.config.baseUrl +
+      (this.props.url || "index.html");
+    let latestVersion;
+
+    const redirect = this.props.redirect || false;
+
+    if (fs.existsSync(CWD + "/versions.json")) {
+      latestVersion = require(CWD + "/versions.json")[0];
+    }
+    return (
+      <html>
+        <Head
+          config={this.props.config}
+          description={description}
+          title={title}
+          url={url}
+          redirect={redirect}
+        />
+        <body className={this.props.className}>
+          The page you are looking for has moved. If you are not redirected to
+          the new page in three seconds, then you can navigate to the new page
+          by using <a href={this.props.redirect}>this link</a>.
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                <!--
+                window.setTimeout(
+                  function(){window.location.href = "${this.props
+                    .redirect}"},3000
+                );
+                // -->
+                `
+            }}
+          />
+        </body>{" "}
+      </html>
+    );
+  }
+}
+module.exports = Redirect;

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -108,6 +108,7 @@ function execute() {
   });
 
   const DocsLayout = require("../core/DocsLayout.js");
+  const Redirect = require("../core/Redirect.js");
 
   fs.removeSync(CWD + "/build");
 
@@ -189,8 +190,29 @@ function execute() {
     const str = renderToStaticMarkup(docComp);
     const targetFile =
       CWD + "/build/" + siteConfig.projectName + "/" + metadata.permalink;
-
     writeFileAndCreateFolder(targetFile, str);
+
+    // generate english page redirects when languages are enabled
+    if (ENABLE_TRANSLATION) {
+      const redirectComp = (
+        <Redirect
+          metadata={metadata}
+          language={language}
+          config={siteConfig}
+          redirect={"/" + metadata.permalink}
+        />
+      );
+      const redirectStr = renderToStaticMarkup(redirectComp);
+
+      // create a redirects page for doc files
+      const redirectFile =
+        CWD +
+        "/build/" +
+        siteConfig.projectName +
+        "/" +
+        metadata.permalink.replace("docs/en", "docs");
+      writeFileAndCreateFolder(redirectFile, redirectStr);
+    }
   });
 
   // copy docs assets if they exist


### PR DESCRIPTION
This change adds a <Redirect/> component and the required change in "generate.js" that will add a html page into the root /docs folder that reroutes visitors to the corresponding file in /docs/en.

This should fix the issue Jest is having with missing pages due to the switch to Docusaurus.