### PR TITLE
upstream small screen header changes

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -557,6 +557,15 @@ header h2 {
   margin-left: 10px;
   font-size: 16px;
 }
+@media (max-width: 375px) {
+  .logo {
+    display: none;
+  }
+
+  .headerTitle {
+    font-size: 17px;
+  }
+}
 
 .promoSection {
   display: flex;


### PR DESCRIPTION
This is an upstream of reasonml/reason-react#94. More discussion there, but on iPhone 5 and other common small screen devices the search bar conflicts with the header name.