### PR TITLE
Add a check for languages.js in sitemap.js

### DIFF
--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -45,7 +45,9 @@ module.exports = function(callback) {
 
   let languages = null;
 
-  languages = require(CWD + "/languages.js");
+  if (fs.existsSync(CWD + "/languages.js")) {
+    languages = require(CWD + "/languages.js");
+  }
 
   let enabledLanguages = languages.filter(lang => {
     return lang.enabled == true;


### PR DESCRIPTION
Without this a build failure would occur for those that are not using the languages.js file.

e.g.,

```
sitemap.js triggered...
module.js:471
    throw err;
    ^

Error: Cannot find module '/home/ubuntu/fasttext-website/website/languages.js'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at module.exports (/home/ubuntu/fasttext-website/website/node_modules/docusaurus/lib/server/sitemap.js:48:15)
    at execute (/home/ubuntu/fasttext-website/website/node_modules/docusaurus/lib/server/generate.js:316:5)
    at Object.<anonymous> (/home/ubuntu/fasttext-website/website/node_modules/docusaurus/lib/build-files.js:31:1)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
Error: generating html failed
```