### PR TITLE
Ability to tweak the prism syntax

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -32,8 +32,6 @@ function execute(port) {
   const ENABLE_TRANSLATION = fs.existsSync(CWD + "/languages.js");
   const ENABLE_VERSIONING = fs.existsSync(CWD + "/versions.json");
 
-  let siteConfig = require(CWD + "/siteConfig.js");
-
   // remove a module and child modules from require cache, so server does not have
   // to be restarted
   function removeModuleAndChildrenFromCache(moduleName) {
@@ -61,6 +59,7 @@ function execute(port) {
   let readMetadata = require("./readMetadata.js");
   let Metadata;
   let MetadataBlog;
+  let siteConfig;
 
   function reloadMetadata() {
     removeModuleAndChildrenFromCache("./readMetadata.js");
@@ -81,6 +80,9 @@ function execute(port) {
   function reloadSiteConfig() {
     removeModuleAndChildrenFromCache(CWD + "/siteConfig.js");
     siteConfig = require(CWD + "/siteConfig.js");
+    if (siteConfig.prism) {
+      siteConfig.prism(require("../core/Prism.js").Prism);
+    }
   }
 
   /****************************************************************************/


### PR DESCRIPTION
I want to be able to tweak the default tokenizer for syntax highlighting. The current one isn't as good as it could be.

With this PR, I would be able to add this to the siteConfig and it would give me the Prism access so that I can get proper syntax highlighting:

```js
  prism: function(Prism) {
    Prism.languages.javascript = Prism.languages.extend("javascript", {
      keyword: /\b(alias|as|async|await|base class|...|with)\b/,
      constant: /\b[A-Z][a-zA-Z0-9_]*\b/,
      builtin: /\bopen_file|...|invariant_violation|invariant|getcwd\b/,
      function: /\b[_$a-z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\()/,
    });
  },
```