### PR TITLE
Bugfix - Include baseUrl when redirecting /docs/ pages in a localized project

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -202,7 +202,7 @@ function execute() {
           metadata={metadata}
           language={language}
           config={siteConfig}
-          redirect={"/" + metadata.permalink}
+          redirect={"/" + siteConfig.baseUrl + metadata.permalink}
         />
       );
       const redirectStr = renderToStaticMarkup(redirectComp);


### PR DESCRIPTION
This includes the baseUrl as part of the redirect route.