### PR TITLE
Fall back to English when expected translated strings are missing for selected language

### DIFF
--- a/lib/server/translate.js
+++ b/lib/server/translate.js
@@ -32,6 +32,22 @@ function translate(str) {
     !translation[language]["pages-strings"] ||
     !translation[language]["pages-strings"][str]
   ) {
+    // if a translated string doesn't exist, but english does then fallback
+    if (
+      translation["en"] &&
+      translation["en"]["pages-strings"] &&
+      translation["en"]["pages-strings"][str]
+    ) {
+      console.error(
+        "Could not find a string translation in '" +
+          language +
+          "' for string '" +
+          str +
+          "'. Using English version instead."
+      );
+
+      return parseEscapeSequences(translation["en"]["pages-strings"][str]);
+    }
     throw new Error(
       "Text that you've identified for translation ('" +
         str +


### PR DESCRIPTION
In many cases a site using localizations won't have pages-strings translated. In this event, use English instead of crashing server.