### PR TITLE
Fix infinite redirect

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -196,7 +196,7 @@ function execute() {
     writeFileAndCreateFolder(targetFile, str);
 
     // generate english page redirects when languages are enabled
-    if (ENABLE_TRANSLATION) {
+    if (ENABLE_TRANSLATION && metadata.permalink.indexOf("docs/en") !== -1) {
       const redirectComp = (
         <Redirect
           metadata={metadata}


### PR DESCRIPTION
Fix. Basically the logic I added to redirect files from /docs/file.html was being written into /language/file.html sorry about that. I now only write into /docs for files in /docs/en.