### PR TITLE
Avoid `null` enabledLanguages when there is no `languages.js` file

### DIFF
--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -43,16 +43,22 @@ module.exports = function(callback) {
 
   let files = glob.sync(CWD + "/pages/**/*.js");
 
-  let languages = null;
+  // English-only is the default.
+  let enabledLanguages = [{
+    enabled: true,
+    name: "English",
+    tag: "en"
+  }];
 
+  // If we have a languages.js file, get all the enabled languages in there
   if (fs.existsSync(CWD + "/languages.js")) {
-    languages = require(CWD + "/languages.js");
+    let languages = require(CWD + "/languages.js");
+    enabledLanguages = languages.filter(lang => {
+      return lang.enabled == true;
+    });
   }
 
-  let enabledLanguages = languages.filter(lang => {
-    return lang.enabled == true;
-  });
-
+  // create a url mapping to all the enabled languages files
   files.map(file => {
     enabledLanguages.map(lang => {
       let url = file.split("/pages/en")[1];


### PR DESCRIPTION
```
sitemap.js triggered...
/Users/joelm/dev/Docusaurus-joel/lib/server/sitemap.js:63
var enabledLanguages = languages.filter(function (lang) {
                                  ^

TypeError: Cannot read property 'filter' of null
    at module.exports
```