### PR TITLE
Remove animation on anchor hover

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -90,9 +90,11 @@ h2:hover a.hash-link,
 h3:hover a.hash-link,
 h4:hover a.hash-link {
   opacity: 0.5;
+  transition: none;
 }
 a.hash-link:hover {
   opacity: 1!important;
+  transition: none;
 }
 
 blockquote {


### PR DESCRIPTION
This is a small change. It removes the animation from anchor tags on hover, but keeps it on blur. General best practice to remove opening animations for items which are clicked via muscle memory (context menus, anchor links, etc).