### PR TITLE
Sitemap local

### DIFF
--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -82,7 +82,6 @@ module.exports = function(callback) {
 
   Object.keys(Metadata).filter(key => Metadata[key].language === "en").map(key => {
     let doc = Metadata[key];
-    console.log(doc);
     let links = enabledLanguages.map(lang => {
       let langUrl = doc.permalink.replace("docs/en/", `docs/${lang.tag}/`);
       return { lang: lang.tag, url: langUrl };


### PR DESCRIPTION
According to the [Google sitemap spec](https://support.google.com/webmasters/answer/2620865?hl=en) and the [example of alternate languages](https://www.npmjs.com/package/sitemap#example-of-indicating-alternate-language-pages), I think this is the correct way to write the sitemap. This should help avoid getting alt-language pages in English search results and generally improve search.

Here's an example of the ReasonReact sitemap generated with this code: https://gist.github.com/rickyvetter/d12435cbed09f537459bbb64ee5c77de