### PR TITLE
add translateable strings and allow overriding of english strings

### DIFF
--- a/lib/core/Doc.js
+++ b/lib/core/Doc.js
@@ -8,6 +8,15 @@
 const React = require("react");
 const Marked = require("./Marked.js");
 
+const translate = require("../server/translate.js").translate;
+
+const editThisDoc = translate(
+  "Edit this Doc|recruitment message asking to edit the doc source"
+);
+const translateThisDoc = translate(
+  "Translate this Doc|recruitment message asking to translate the docs"
+);
+
 // inner doc component for article itself
 class Doc extends React.Component {
   render() {
@@ -17,7 +26,7 @@ class Doc extends React.Component {
           className="edit-page-link button"
           href={this.props.config.editUrl + this.props.source}
           target="_blank">
-          Edit this Doc
+          {editThisDoc}
         </a>
       );
     if (this.props.language != "en") {
@@ -31,7 +40,7 @@ class Doc extends React.Component {
               this.props.language
             }
             target="_blank">
-            Translate this Doc
+            {translateThisDoc}
           </a>
         );
     }

--- a/lib/write-translations.js
+++ b/lib/write-translations.js
@@ -20,6 +20,14 @@ const babylon = require("babylon");
 const traverse = require("babel-traverse").default;
 const sidebars = require(CWD + "/sidebars.json");
 
+let currentTranslations = {
+  "localized-strings": {},
+  "pages-strings": {}
+};
+if (fs.existsSync(path)) {
+  currentTranslations = JSON.parse(fs.readFileSync(CWD + "/i18n/en.json", "utf8"));
+}
+
 function writeFileAndCreateFolder(file, content) {
   mkdirp.sync(file.replace(new RegExp("/[^/]*$"), ""));
   fs.writeFileSync(file, content);
@@ -121,6 +129,22 @@ function execute() {
     "Help Translate|recruit community translators for your project"
   ] =
     "Help Translate";
+  translations["pages-strings"][
+    "Edit this Doc|recruitment message asking to edit the doc source"
+  ] =
+    "Edit";
+  translations["pages-strings"][
+    "Translate this Doc|recruitment message asking to translate the docs"
+  ] =
+    "Translate";
+  translations["pages-strings"] = Object.assign(
+    translations["pages-strings"],
+    currentTranslations["pages-strings"],
+  );
+  translations["localized-strings"] = Object.assign(
+    translations["localized-strings"],
+    currentTranslations["localized-strings"],
+  );
   writeFileAndCreateFolder(
     CWD + "/i18n/en.json",
     JSON.stringify(translations, null, 2)


### PR DESCRIPTION
This adds "Translate this Doc" and "Edit this Doc" to the list of string that can be translated. Also changes how the translations are written so that en.json will overwrite specific translations. This allows for overriding Docusaurus provided strings that a project may not like (for example ReasonReact would like to say "Edit" instead of "Edit this Doc" in English).