### PR TITLE
Switch to GFM-style heading anchors

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -140,10 +140,6 @@ const siteConfig = {
     indexName: "github"
   },
   gaTrackingId: "U-A2352",
-<<<<<<< HEAD
-  sourceCodeButton: "github",
-=======
->>>>>>> ba666cc6aedd12651cc61fc9364e15a7f8eb8388
   highlight: {
     theme: 'default'
   },

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -128,6 +128,7 @@ class Site extends React.Component {
                 }}
               />
             ))}
+            
         </body>
       </html>
     );

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -167,10 +167,6 @@ header h2 {
   padding: 0 20px;
 }
 
-article div>*:first-child {
-  margin-top: 0 !important;
-}
-
 .projectLogo {
   display: none;
   pointer-events: none;
@@ -241,10 +237,10 @@ article div>*:first-child {
 .container .wrapper h2 {
   color: $primaryColor;
   font-size: 22px;
+  line-height: 1em;
+  margin-top: 20px;
   text-align: left;
   padding: 10px 0;
-  margin-top: 20px;
-  line-height: 1;
 }
 .container .wrapper h2.blockHeader {
   color: white;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -71,5 +71,4 @@ const siteConfig = {
   }
 };
 
-
 module.exports = siteConfig;


### PR DESCRIPTION
Switches the fade-in heading anchor from a hash to a link SVG as seen in GFM on GitHub.

Test Plan

Verified Docusaurus site.

Before:

![screen shot 2017-10-24 at 10 24 56 am](https://user-images.githubusercontent.com/165856/31958196-d151d754-b8a5-11e7-84c1-c730ba353464.png)


After:

![screen shot 2017-10-24 at 10 24 41 am](https://user-images.githubusercontent.com/165856/31958205-d4d31ee2-b8a5-11e7-8a8a-ec49f831850f.png)

