### PR TITLE
Fix port check

### DIFF
--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -43,9 +43,9 @@ tcpPortUsed.check(port, "localhost")
       chalk.red("Port " + port + " is in use")
     );
     process.exit(1);
+  } else {
+    // start local server on specified port
+    const server = require("./server/server.js");
+    server(port);
   }
 });
-
-// start local server on specified port
-const server = require("./server/server.js");
-server(port);


### PR DESCRIPTION
Since the check is async, starting the server on the port was happening before the check finished. Thus even if the port wasn't being used, it would error out as if it was because the server would start it before the check was finished.
This way we only start the server after the check finishes.