### PR TITLE
Remove built-in GitHub Button

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -80,8 +80,6 @@ headerLinks: [
 
 `gaTrackingId` - Google Analytics tracking ID to track page views.
 
-`sourceCodeButton` - the type of button to use for pointing to your source code. If this field is non-null, the site will pull in the appropriate button code in the header, for you to be able to render as you see fit. Currently accepted values: `"github"`, `"none"`. Defaults to `"github"`.
-
 `highlight` - [Syntax highlighting](api-doc-markdown.md) options:
 
  - `theme` is the name of the theme used by Highlight.js when highlighting code.
@@ -142,7 +140,6 @@ const siteConfig = {
     indexName: "github"
   },
   gaTrackingId: "U-A2352",
-  sourceCodeButton: "github",
   highlight: {
     theme: 'default'
   },

--- a/examples/basics/core/Footer.js
+++ b/examples/basics/core/Footer.js
@@ -10,10 +10,10 @@ const React = require("react");
 const githubButton = (
   <a
     className="github-button"
-    href="https://github.com/deltice/test-site"
+    href={this.props.config.repoUrl}
     data-icon="octicon-star"
     data-count-href="/deltice/test-site/stargazers"
-    data-count-api="/repos/deltice/test-site#stargazers_count"
+    data-show-count={true}
     data-count-aria-label="# stargazers on GitHub"
     aria-label="Star this project on GitHub"
   >

--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -18,7 +18,7 @@ const users = [
 const siteConfig = {
   title: "Test Site" /* title for your website */,
   tagline: "A website for testing",
-  url: "https://deltice.github.io" /* your github url */,
+  url: "https://deltice.github.io" /* your website url */,
   baseUrl: "/test-site/" /* base url for your project */,
   projectName: "test-site",
   headerLinks: [
@@ -45,7 +45,12 @@ const siteConfig = {
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks
     theme: "default"
-  }
+  },
+  scripts: [
+    "https://buttons.github.io/buttons.js"
+  ],
+  // You may provide arbitrary config keys to be used as needed by your template.
+  repoUrl: "https://github.com/deltice/test-site",
 };
 
 module.exports = siteConfig;

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -15,10 +15,6 @@ class Head extends React.Component {
     links.map(link => {
       if (link.blog) hasBlog = true;
     });
-    const sourceCodeButton = this.props.config.sourceCodeButton;
-    // defaults to GitHub, but other values may be allowed in the future
-    const includeGitHubButton =
-      sourceCodeButton === "github" || sourceCodeButton == null;
 
     const highlightDefaultVersion = '9.12.0';
     const highlightConfig = this.props.config.highlight 
@@ -81,9 +77,6 @@ class Head extends React.Component {
             href={this.props.config.url + "/blog/feed.xml"}
             title={this.props.config.title + " Blog RSS Feed"}
           />
-        )}
-        {includeGitHubButton && (
-          <script async defer src="https://buttons.github.io/buttons.js" />
         )}
         <link
           rel="stylesheet"

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -48,9 +48,7 @@ class Footer extends React.Component {
               className="github-button"
               href="https://github.com/facebookexperimental/docusaurus"
               data-icon="octicon-star"
-              data-count-href="/facebookexperimental/docusaurus/stargazers"
-              data-count-api="/repos/facebookexperimental/docusaurus#stargazers_count"
-              data-count-aria-label="# stargazers on GitHub"
+              data-show-count="true"
               aria-label="Star this project on GitHub"
             >
               Star

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -56,7 +56,6 @@ const siteConfig = {
   headerIcon: "img/docusaurus.svg",
   footerIcon: "img/docusaurus_monochrome.svg",
   favicon: "img/docusaurus.ico",
-  // See https://docusaurus.io/docs/search for more information about Aloglia
   algolia: {
     apiKey: "3eb9507824b8be89e7a199ecaa1a9d2c",
     indexName: "docusaurus"


### PR DESCRIPTION
Previously, we exposed a sourceCodeButton key that would allow a GitHub button to be displayed in your template. However, the code was not provided by Docusaurus itself - it's available in the basic template, and the template was not checking for the presence of the config key.

I think part of the reasoning for providing was key is that it allowed us to conditionally include the GitHub button script include in the header. Now that we have a "scripts" key that allows arbitrary configs to be loaded, I think we can remove the sourceCodeButton key and let people roll out their own implementations.

For ease of use, the example template contains all the code you need to use this button in your site.

Fixes #44.