### PR TITLE
Fix custom port number parsing...

### DIFF
--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -33,7 +33,7 @@ const program = require("commander");
 
 program.option("--port <number>", "Specify port number").parse(process.argv);
 
-const port = parseInt(program.port) || 3000;
+const port = parseInt(program.port, 10) || 3000;
 
 console.log("Checking if port " + port + " is free...");
 tcpPortUsed.check(port, "localhost")


### PR DESCRIPTION
Checking if a port was in use raised a bug where the port coming in from the command line is a string and not an int. And that was causing the check to fail. Make the port an int from the get go.

@vjeux found this bug when testing the new package.