### PR TITLE
[markdown] Remove client-side syntax highlighting

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -56,7 +56,6 @@ headerLinks: [
 
   - `primaryColor` is the color used the header navigation bar and sidebars.
   - `secondaryColor` is the color seen in the second row of the header navigation bar when the site window is narrow (including on mobile).
-  - `codeColor` is the background color in code blocks.
   - Custom color configurations can also be added. For example, if user styles are added with colors specified as `$myColor`, then adding a `myColor` field to `colors` will allow you to easily configure this color.
 
 `copyright` - The copyright string at footer of site and within feed

--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -35,8 +35,7 @@ const siteConfig = {
   /* colors for website */
   colors: {
     primaryColor: "#2E8555",
-    secondaryColor: "#205C3B",
-    codeColor: "#002B36",
+    secondaryColor: "#205C3B"
   },
   // This copyright info is used in /core/Footer.js and blog rss/atom feeds.
   copyright:

--- a/lib/core/Remarkable.js
+++ b/lib/core/Remarkable.js
@@ -7,6 +7,9 @@ const toSlug = require("./toSlug.js");
 
 const CWD = process.cwd();
 
+/**
+ * The anchors plugin adds GFM-style anchors to headings.
+ */
 function anchors(md) {
   md.renderer.rules.heading_open = function(tokens, idx /*, options, env */) {
     return '<h' + tokens[idx].hLevel + '>' + '<a class="anchor" name="' + toSlug(tokens[idx+1].content) + '"></a>';
@@ -84,7 +87,9 @@ class Remarkable extends React.Component {
 
     }
 
-    return this.md.render(source);
+    // Ensure fenced code blocks use Highlight.js hljs class
+    // https://github.com/jonschlinkert/remarkable/issues/224
+    return this.md.render(source).replace('<pre><code>','<pre><code class="hljs">');
   }
 }
 

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -737,7 +737,6 @@ pre code {
   display:block;
   margin: 20px 0;
   padding:0.5em;
-  background-color: $codeColor;
   border-left: 4px solid $primaryColor;
   font-family: "SFMono-Regular",source-code-pro,Menlo,Monaco,Consolas,"Roboto Mono","Droid Sans Mono","Liberation Mono",Consolas,"Courier New",Courier,monospace;
   font-size: 13px;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -63,8 +63,7 @@ const siteConfig = {
   },
   colors: {
     primaryColor: "#2E8555",
-    secondaryColor: "#205C3B",
-    codeColor: "#002B36",
+    secondaryColor: "#205C3B"
   },
   translationRecruitingLink: "https://crowdin.com/project/docusaurus",
   copyright: "Copyright © " + new Date().getFullYear() + " Facebook Inc.",


### PR DESCRIPTION
In my previous commit, I was applying syntax highlighting twice (on the server side, as well as client side). This PR removes the client side bit.

A side effect is that code blocks don't automatically get assigned the correct class, so I've had to make use of the `langPrefix` option to apply the `.hljs` class to code blocks. Unfortunately this only works properly when a fenced code block specifies a language, otherwise the `langPrefix` won't be applied and the code block will not have the correct CSS class.

I've worked around this by applying Docusaurus's code block styling to `pre code` instead of `.hljs`, which mostly works, but it would have left plain (non-language) fenced code blocks lacking a background color (which was been handled by Highlight.js). I am bringing back the `codeColor` site config to allow sites to declare the background color, which ideally should match their Highlight theme.

All of this is non-ideal, and perhaps it's best to consider other markdown libraries that may work better with either Highlight.js or Prism.js.

## Test Plan

Verify that the Markdown Features doc renders nicely:

![screen shot 2017-10-26 at 8 20 07 am](https://user-images.githubusercontent.com/165856/32061453-82b63e6e-ba26-11e7-8225-25fb6fd2bc0d.png)

