### PR TITLE
[WIP] Call out common errors made during a versioned site migration

### DIFF
--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -94,6 +94,21 @@ files.forEach(file => {
   const res = extractMetadata(fs.readFileSync(file, "utf8"));
   const metadata = res.metadata;
 
+  if (!metadata.original_id) {
+    const error = `Error parsing versioned docs: No 'original_id' field found in ${file}. Perhaps you forgot to add it when importing prior versions of your docs?`;
+    console.error(error);
+    throw new Error(error);
+  }
+  if (!metadata.id) {
+    const error = `Error parsing versioned docs: No 'id' field found in ${file}.`;
+    console.error(error);
+    throw new Error(error);
+  } else if (metadata.id.indexOf('version-') === -1) {
+    const error = `Error parsing versioned docs: The 'id' field in ${file} is missing the expected 'version-XX-' prefix. Perhaps you forgot to add it when importing prior versions of your docs?`;
+    console.error(error);
+    throw new Error(error);
+  }
+
   if (!(metadata.original_id in available)) {
     available[metadata.original_id] = new Set();
   }


### PR DESCRIPTION
Improving the UX here. Previous behavior: we'd show the full error and stacktrace. In some of these cases, we can do a better job of letting people know where they made a mistake.