### PR TITLE
move main.css below hljs css

### DIFF
--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -17,9 +17,9 @@ class Head extends React.Component {
     });
 
     const highlightDefaultVersion = '9.12.0';
-    const highlightConfig = this.props.config.highlight 
+    const highlightConfig = this.props.config.highlight
       || { version: highlightDefaultVersion, theme: 'default' };
-    const highlightVersion = highlightConfig.version || highlightDefaultVersion; 
+    const highlightVersion = highlightConfig.version || highlightDefaultVersion;
     const highlightTheme = highlightConfig.theme || 'default';
 
     const hasCustomScripts = this.props.config.scripts;
@@ -60,7 +60,7 @@ class Head extends React.Component {
         )}
         <link
           rel="stylesheet"
-          href={this.props.config.baseUrl + "css/main.css"}
+          href={`//cdnjs.cloudflare.com/ajax/libs/highlight.js/${highlightVersion}/styles/${highlightTheme}.min.css`}
         />
         {hasBlog && (
           <link
@@ -78,9 +78,11 @@ class Head extends React.Component {
             title={this.props.config.title + " Blog RSS Feed"}
           />
         )}
+
+        {/* Site defined code. Keep these at the end to avoid overriding. */}
         <link
           rel="stylesheet"
-          href={`//cdnjs.cloudflare.com/ajax/libs/highlight.js/${highlightVersion}/styles/${highlightTheme}.min.css`}
+          href={this.props.config.baseUrl + "css/main.css"}
         />
         {hasCustomScripts && this.props.config.scripts.map(function(source) {
           return (


### PR DESCRIPTION
This moves main.css to the bottom to allow it to easily override previous styles.