### PR TITLE
enforce 70% width on mainContainer

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1443,6 +1443,7 @@ nav.toc .toggleNav .navBreadcrumb h2 {
 
   .sideNavVisible .navPusher .mainContainer {
     padding-top: 0;
+    max-width: 70%;
   }
 
   .docsNavContainer {


### PR DESCRIPTION
This enforces an already-unspoken rule that in the desktop nav view the body takes up 70% of the wrapper width. Not enforcing this can lead to the container growing to take up the width of it's children. The easiest way to cause issues is with `pre` tags with long lines of code. See example issue:

<img width="1186" alt="screen shot 2017-10-29 at 1 26 23 pm" src="https://user-images.githubusercontent.com/4370652/32147971-fb5ac9ce-bcac-11e7-9ec9-2784b5ff0049.png">
