### PR TITLE
Add the ability to define a default language

### DIFF
--- a/lib/core/Remarkable.js
+++ b/lib/core/Remarkable.js
@@ -42,7 +42,6 @@ class Remarkable extends React.Component {
 
   renderMarkdown(source) {
     if (!this.md) {
-      // Allow client sites to register their own plugins
       const siteConfig = require(CWD + "/siteConfig.js");
 
       this.md = new Markdown({
@@ -68,6 +67,7 @@ class Remarkable extends React.Component {
       // Register anchors plugin
       this.md.use(anchors);
 
+      // Allow client sites to register their own plugins
       if (siteConfig.markdownPlugins) {
         siteConfig.markdownPlugins.forEach(function(plugin) {
           this.md.use(plugin);


### PR DESCRIPTION
I don't want to have to add the language i'm working on to every single block nor do I want to rely on a default heuristic to find the language.

This adds the ability to write

```js
highlight: { defaultLang: 'xxxx' }
```

in `siteConfig.js` to force the language when not specified.

I tested it without a a highlight block, without a defaultLang attribute and with one and with a wrong one. All of them work as expected.