### PR TITLE
Add the ability to render html and linkify links

### DIFF
--- a/lib/core/Remarkable.js
+++ b/lib/core/Remarkable.js
@@ -18,12 +18,6 @@ function anchors(md) {
 }
 
 class Remarkable extends React.Component {
-  componentWillUpdate(nextProps, nextState) {
-    if (nextProps.options !== this.props.options) {
-      this.md = new Markdown(nextProps.options);
-    }
-  }
-
   content() {
     if (this.props.source) {
       return <span dangerouslySetInnerHTML={{ __html: this.renderMarkdown(this.props.source) }} />;
@@ -61,7 +55,9 @@ class Remarkable extends React.Component {
           } catch (err) {}
 
           return '';
-        }
+        },
+        html: true,
+        linkify: true,
       });
 
       // Register anchors plugin
@@ -90,12 +86,11 @@ class Remarkable extends React.Component {
         {this.content()}
       </Container>
     );
-  }  
+  }
 }
 
 Remarkable.defaultProps = {
   container: 'div',
-  options: {},
 };
 
 module.exports = Remarkable;


### PR DESCRIPTION
Marked had the ability to display html code. This is useful if you want to embed iframes, set size to images... This allows arbitrary html to be embedded with no sanitization, so `<script>alert()</script>` will be executed. This isn't such a big issue since the markdown is written only by contributors.

I also removed the componentWillUpdate call since it's not used (and wrong).