### PR TITLE
Fix HTML copy file generation

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -465,7 +465,9 @@ function execute() {
   // copy html files in 'en' to base level as well
   files = glob.sync(CWD + "/build/" + siteConfig.projectName + "/en/**");
   files.forEach(file => {
-    let targetFile = file.replace("en/", "");
+    let targetFile = file.replace(
+      CWD + "/build/" + siteConfig.projectName + "/en/",
+      CWD + "/build/" + siteConfig.projectName + "/");
     if (file.match(/\.html$/)) {
       fs.copySync(file, targetFile);
     }


### PR DESCRIPTION
Found an issue copying over files from build/en/ folder during the build generation. Fixed the regex for that.

Test:

Tested on my local install of makeitopen.com. With the fix, I was able to get the files generated.