### PR TITLE
Check whether a previous/next doc actually exists

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -331,7 +331,7 @@ function generateMetadataDocs() {
       }
     }
   });
-  
+
   fs.writeFileSync(
     __dirname + "/../core/metadata.js",
     "/**\n" +


### PR DESCRIPTION
This would fail silently. The actual error, after some digging, was found to be:

```
TypeError: Cannot read property 'title' of undefined
    at /Users/hramos/git/react-native/website/node_modules/docusaurus/lib/server/readMetadata.js:321:11
    at Array.forEach (native)
    at Object.generateMetadataDocs (/Users/hramos/git/react-native/website/node_modules/docusaurus/lib/server/readMetadata.js:318:28)
    at reloadMetadata (/Users/hramos/git/react-native/website/node_modules/docusaurus/lib/server/server.js:66:18)
    at execute (/Users/hramos/git/react-native/website/node_modules/docusaurus/lib/server/server.js:126:3)
    at /Users/hramos/git/react-native/website/node_modules/docusaurus/lib/start-server.js:50:5
    at _fulfilled (/Users/hramos/git/react-native/website/node_modules/q/q.js:798:54)
    at self.promiseDispatch.done (/Users/hramos/git/react-native/website/node_modules/q/q.js:827:30)
    at Promise.promise.promiseDispatch (/Users/hramos/git/react-native/website/node_modules/q/q.js:760:13)
    at /Users/hramos/git/react-native/website/node_modules/q/q.js:574:44
```

