### PR TITLE
Fix for consistency and completeness

### DIFF
--- a/docs/guides-versioning.md
+++ b/docs/guides-versioning.md
@@ -7,6 +7,20 @@ You can use the `version` script to cut a new documentation version based on the
 
 ## How to Create New Versions
 
+Run the following script to generate a starter versions page listing all the site versions:
+
+```
+yarn examples translations
+```
+
+This creates the following file:
+
+```
+pages/en/versions.js
+```
+
+You can edit this file later on to customize how you display the versions. 
+
 Add the following script to your `package.json` file if it doesn't already exist:
 
 ```json
@@ -25,12 +39,11 @@ yarn run version 1.0.0
 
 This will preserve all documents currently in the `docs` folder and make them available as documentation for version `1.0.0`.
 
-If, for example, you ran the version script with 1.0.0 as the version number, version 1.0.0 is considered the latest release version for your project, and the site will display the version number next to the title in the header.
+If, for example, you ran the version script with 1.0.0 as the version number, version 1.0.0 is considered the latest release version for your project. The site will display the version number next to the title in the header. This version number links to a versions page that you created earlier.
 
 Documents in the `docs` folder will be considered part of version `next` and they are available, for example, at the url `docs/next/doc1.html`. Documents from the latest version use the url `docs/doc1.html`.
 
 Running the script again with `yarn run version 2.0.0` will create a version `2.0.0`, making version 2.0.0 the most recent set of documentation. Documents from version `1.0.0` will use the url `docs/1.0.0/doc1.html` while `2.0.0` will use `docs/doc1.html`.
-
 
 ## Versioning Patterns
 


### PR DESCRIPTION
Changed to keep consistency with other parts of the doc - "you" versus "users". Also used yarn commands to be consistent with other docs on the website.