### PR TITLE
[Versioning] Replace diff with string comparison

### DIFF
--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -9,7 +9,6 @@ const CWD = process.cwd();
 const glob = require("glob");
 const fs = require("fs");
 const path = require("path");
-const diff = require("diff");
 const assert = require("assert");
 
 const siteConfig = require(CWD + "/siteConfig.js");
@@ -66,7 +65,10 @@ function extractMetadata(content) {
   for (let i = 0; i < lines.length - 1; ++i) {
     const keyvalue = lines[i].split(":");
     const key = keyvalue[0].trim();
-    let value = keyvalue.slice(1).join(":").trim();
+    let value = keyvalue
+      .slice(1)
+      .join(":")
+      .trim();
     try {
       value = JSON.parse(value);
     } catch (e) {}
@@ -95,18 +97,20 @@ files.forEach(file => {
   const metadata = res.metadata;
 
   if (!metadata.original_id) {
-    console.error(`No 'original_id' field found in ${file}. Perhaps you forgot to add it when importing prior versions of your docs?`);
+    console.error(
+      `No 'original_id' field found in ${file}. Perhaps you forgot to add it when importing prior versions of your docs?`
+    );
     throw new Error(
       `No 'original_id' field found in ${file}. Perhaps you forgot to add it when importing prior versions of your docs?`
     );
   }
   if (!metadata.id) {
     console.error(`No 'id' field found in ${file}.`);
-    throw new Error(
-      `No 'id' field found in ${file}.`
+    throw new Error(`No 'id' field found in ${file}.`);
+  } else if (metadata.id.indexOf("version-") === -1) {
+    console.error(
+      `The 'id' field in ${file} is missing the expected 'version-XX-' prefix. Perhaps you forgot to add it when importing prior versions of your docs?`
     );
-  } else if (metadata.id.indexOf('version-') === -1) {
-    console.error(`The 'id' field in ${file} is missing the expected 'version-XX-' prefix. Perhaps you forgot to add it when importing prior versions of your docs?`);
     throw new Error(
       `The 'id' field in ${file} is missing the expected 'version-XX-' prefix. Perhaps you forgot to add it when importing prior versions of your docs?`
     );
@@ -174,16 +178,10 @@ function diffLatestDoc(file, id) {
     return true;
   }
 
-  const diffs = diff.diffChars(
-    extractMetadata(fs.readFileSync(latestFile, "utf8")).rawContent,
-    extractMetadata(fs.readFileSync(file, "utf8")).rawContent
+  return (
+    extractMetadata(fs.readFileSync(latestFile, "utf8")).rawContent.trim() !==
+    extractMetadata(fs.readFileSync(file, "utf8")).rawContent.trim()
   );
-  diffs.forEach(part => {
-    if (part.added || part.removed) {
-      return true;
-    }
-  });
-  return false;
 }
 
 // return metadata for a versioned file given the file, its version (requested),

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "classnames": "^2.2.5",
     "commander": "^2.11.0",
     "crowdin-cli": "^0.3.0",
-    "diff": "^3.3.0",
     "escape-string-regexp": "^1.0.5",
     "express": "^4.15.3",
     "feed": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,10 +808,6 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-diff@^3.3.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
-
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"


### PR DESCRIPTION
When a version is cut, we check if a doc's content has changed to ensure we don't have multiple copies of the same doc in the repo. The diff check used here was taking a long time to check for changes across versions. We don't need to know the exact changes made to a doc, as we will be copying the whole file regardless. A plain string comparison should work here and be much faster.

We can explore using diff again in the future if we only wish to store incremental changes across versions. If we do that, lets make sure this is made in a performant manner.