### PR TITLE
[Versioning] Fix issue when a doc is added

### DIFF
--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -133,7 +133,7 @@ files.forEach(file => {
 function docVersion(id, req_version) {
   if (!available[id]) {
     throw new Error(
-      `Document with id '${id}' was requested but none was found across all versions.`
+      `Document with id '${id}' was requested but no document with that id could be located.`
     );
   }
   // iterate through versions until a version less than or equal to the requested


### PR DESCRIPTION
The doc <-> version discovery logic here was failing to return the correct version. With the fix, we now ensure we go from newest version to oldest, returning the first hit we find. This results in the most up to date doc being returned, given a max version number.

This fixed the issue I was running into with RN.