### PR TITLE
Change pointer events on language dropdown

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1009,6 +1009,8 @@ pre code {
 #languages-dropdown {
   position: absolute;
   width:100%;
+  /* positioning can block the main menu on mobile */
+  pointer-events: none;
 }
 #languages-dropdown.visible {
   display: flex;
@@ -1021,6 +1023,7 @@ ul#languages-dropdown-items {
   background-color: $primaryColor;
   flex-direction: column;
   min-width: 120px;
+  pointer-events: all;
 }
 
 ul#languages li {


### PR DESCRIPTION
The dropdown positioning makes it overlay the main menu on mobile layout. This means that clicking the language button a second time doesn't close the menu.