### PR TITLE
Reduce init script verbosity.

### DIFF
--- a/docusaurus-init/initialize.js
+++ b/docusaurus-init/initialize.js
@@ -20,6 +20,9 @@ if (shell.which("yarn")) {
 
 if (fs.existsSync(CWD + "/website")) {
   console.error(chalk.yellow("Website folder already exists.\n"));
+  console.log(
+    "In order for Docusaurus to get set up as your static site generator, you will need to remove any existing 'website' folder from your root directory. If you are migrating from another static site generator, you may want to move your old website folder to a different location."
+  );
   process.exit(1);
 }
 

--- a/lib/copy-examples.js
+++ b/lib/copy-examples.js
@@ -7,23 +7,53 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const CWD = process.cwd();
-const fs = require("fs-extra");
-const path = require("path");
-const glob = require("glob");
 const chalk = require("chalk");
+const commander = require("commander");
+const fs = require("fs-extra");
+const glob = require("glob");
+const path = require("path");
+
+const CWD = process.cwd();
 
 let feature;
 
-const program = require("commander");
-program
+commander
   .arguments("[feature]")
   .action(feat => {
     feature = feat;
   })
   .parse(process.argv);
 
+// add scripts to package.json file
+if (fs.existsSync(CWD + "/package.json")) {
+  const packageContent = JSON.parse(
+    fs.readFileSync(CWD + "/package.json", "utf8")
+  );
+  if (!packageContent.scripts) {
+    packageContent.scripts = {};
+  }
+  packageContent.scripts["start"] = "docusaurus-start";
+  packageContent.scripts["build"] = "docusaurus-build";
+  packageContent.scripts["publish-gh-pages"] = "docusaurus-publish";
+  packageContent.scripts["examples"] = "docusaurus-examples";
+  packageContent.scripts["write-translations"] =
+    "docusaurus-write-translations";
+  packageContent.scripts["version"] = "docusaurus-version";
+  packageContent.scripts["rename-version"] = "docusaurus-rename-version";
+  fs.writeFileSync(
+    CWD + "/package.json",
+    JSON.stringify(packageContent, null, 2)
+  );
+  console.log(
+    `${chalk.green("Wrote docusaurus scripts to package.json file.")}\n`
+  );
+}
+
 const outerFolder = path.basename(path.dirname(CWD));
+
+let docsCreated = false;
+let blogCreated = false;
+let exampleSiteCreated = false;
 
 // handles cases where feature is "translations", "versions" or neither/not present
 if (feature === "translations") {
@@ -37,11 +67,7 @@ if (feature === "translations") {
     );
   } else {
     fs.copySync(folder + "/crowdin.yaml", CWD + "/../crowdin.yaml");
-    console.log(
-      `${chalk.green("Example crowdin.yaml file created")} in ${chalk.yellow(
-        outerFolder + "/"
-      )}.\n`
-    );
+    exampleSiteCreated = true;
   }
   let files = glob.sync(folder + "/**/*");
   files.forEach(file => {
@@ -57,13 +83,7 @@ if (feature === "translations") {
         overwrite: false,
         errorOnExist: true
       });
-      console.log(
-        `${chalk.green(
-          "Example " + path.basename(filePath) + " file created"
-        )} in ${chalk.yellow(
-          "website" + filePath.split(path.basename(filePath))[0]
-        )}.\n`
-      );
+      exampleSiteCreated = true;
     } catch (e) {
       console.log(
         `${chalk.yellow(
@@ -88,13 +108,7 @@ if (feature === "translations") {
         overwrite: false,
         errorOnExist: true
       });
-      console.log(
-        `${chalk.green(
-          "Example " + path.basename(filePath) + " file created"
-        )} in ${chalk.yellow(
-          "website" + filePath.split(path.basename(filePath))[0]
-        )}.\n`
-      );
+      exampleSiteCreated = true;
     } catch (e) {
       console.log(
         `${chalk.yellow(
@@ -121,13 +135,8 @@ if (feature === "translations") {
       folder + "/docs-examples-from-docusaurus",
       CWD + "/../docs-examples-from-docusaurus"
     );
-    console.log(
-      `${chalk.green("Example docs created")} in ${chalk.yellow(
-        outerFolder + "/docs-examples-from-docusaurus"
-      )}! Rename the folder to ${chalk.yellow(
-        outerFolder + "/docs"
-      )} to see the example docs on your site.\n`
-    );
+    exampleSiteCreated = true;
+    docsCreated = true;
   }
   // copy blog examples
   if (fs.existsSync(CWD + "/blog-examples-from-docusaurus")) {
@@ -143,28 +152,18 @@ if (feature === "translations") {
       path.join(folder, "blog-examples-from-docusaurus"),
       path.join(CWD, "blog-examples-from-docusaurus")
     );
-    console.log(
-      `${chalk.green("Example blog posts created")} in ${chalk.yellow(
-        outerFolder + "/website/blog-examples-from-docusaurus"
-      )}! Rename the folder to ${chalk.yellow(
-        outerFolder + "/website/blog"
-      )} to see the example blog posts on your site.\n`
-    );
+    exampleSiteCreated = true;
+    blogCreated = true;
   }
   // copy .gitignore file
   if (fs.existsSync(CWD + "/.gitignore")) {
     console.log(
       `${chalk.yellow(".gitignore already exists")} in ${chalk.yellow(
-        "website/"
+        CWD
       )}. Rename or remove the file to regenerate an example version.\n`
     );
   } else {
     fs.copySync(path.join(folder, "gitignore"), path.join(CWD, ".gitignore"));
-    console.log(
-      `${chalk.green("Example .gitignore file created")} in ${chalk.yellow(
-        "website/"
-      )}.\n`
-    );
   }
   // copy other files
   let files = glob.sync(folder + "/**/*");
@@ -186,13 +185,7 @@ if (feature === "translations") {
         overwrite: false,
         errorOnExist: true
       });
-      console.log(
-        `${chalk.green(
-          "Example " + path.basename(filePath) + " file created"
-        )} in ${chalk.yellow(
-          "website" + filePath.split(path.basename(filePath))[0]
-        )}.\n`
-      );
+      exampleSiteCreated = true;
     } catch (e) {
       console.log(
         `${chalk.yellow(
@@ -205,27 +198,30 @@ if (feature === "translations") {
   });
 }
 
-// add scripts to package.json file
-if (fs.existsSync(CWD + "/package.json")) {
-  const packageContent = JSON.parse(
-    fs.readFileSync(CWD + "/package.json", "utf8")
-  );
-  if (!packageContent.scripts) {
-    packageContent.scripts = {};
-  }
-  packageContent.scripts["start"] = "docusaurus-start";
-  packageContent.scripts["build"] = "docusaurus-build";
-  packageContent.scripts["publish-gh-pages"] = "docusaurus-publish";
-  packageContent.scripts["examples"] = "docusaurus-examples";
-  packageContent.scripts["write-translations"] =
-    "docusaurus-write-translations";
-  packageContent.scripts["version"] = "docusaurus-version";
-  packageContent.scripts["rename-version"] = "docusaurus-rename-version";
-  fs.writeFileSync(
-    CWD + "/package.json",
-    JSON.stringify(packageContent, null, 2)
-  );
+if (exampleSiteCreated) {
   console.log(
-    `${chalk.green("Wrote docusaurus scripts to package.json file.")}\n`
+    `${chalk.green("Example website created")} in ${chalk.green(
+      CWD + "/website"
+    )}\n`
+  );
+}
+
+if (docsCreated) {
+  console.log(
+    `Rename ${chalk.yellow(
+      outerFolder + "/docs-examples-from-docusaurus"
+    )} to ${chalk.yellow(
+      outerFolder + "/docs"
+    )} to see the example docs on your site.\n`
+  );
+}
+
+if (blogCreated) {
+  console.log(
+    `Rename ${chalk.yellow(
+      outerFolder + "/website/blog-examples-from-docusaurus"
+    )} to ${chalk.yellow(
+      outerFolder + "/website/blog"
+    )} to see the example blog posts on your site.\n`
   );
 }


### PR DESCRIPTION
Fixes #123

Running docusaurus-init will now output the following:


```
Wrote docusaurus scripts to package.json file.

.gitignore already exists in /Users/hramos/git/docusaurus. Rename or remove the file to regenerate an example version.

Example website created in git//Users/hramos/git/docusaurus/website

Rename git/docs-examples-from-docusaurus to git/docs to see the example docs on your site.

Rename git/website/blog-examples-from-docusaurus to git/website/blog to see the example blog posts on your site.
```

Note that this does not yet print a tree representation of the files created in the filesystem, but it greatly simplifies the logspew.