### PR TITLE
Provide additional debugging information

### DIFF
--- a/lib/server/readCategories.js
+++ b/lib/server/readCategories.js
@@ -57,8 +57,8 @@ function readCategories(sidebar) {
         if (!articles[metadata.next]) {
           throw new Error(
             metadata.version
-              ? `Improper sidebars file for version ${metadata.version}. Make sure that all documents with ids specified in this version's sidebar file exist and that no ids are repeated.`
-              : `Improper sidebars.json file. Make sure that documents with the ids specified in sidebars.json exist and that no ids are repeated.`
+              ? `Improper sidebars file for version ${metadata.version}, document with id '${metadata.next}' not found. Make sure that all documents with ids specified in this version's sidebar file exist and that no ids are repeated.`
+              : `Improper sidebars.json file, document with id '${metadata.next}' not found. Make sure that documents with the ids specified in sidebars.json exist and that no ids are repeated.`
           );
         }
         previous[articles[metadata.next].id] = metadata.id;


### PR DESCRIPTION
Let the user know which id we were not able to load, to help with debugging.