### PR TITLE
Remove keys warning when loading scripts

### DIFF
--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -83,9 +83,13 @@ class Head extends React.Component {
             <link rel="stylesheet" href={source} />
           );
         })}
-        {this.props.config.scripts && this.props.config.scripts.map(function(source) {
+        {this.props.config.scripts && this.props.config.scripts.map(function(source, idx) {
           return (
-            <script type="text/javascript" src={source} />
+            <script
+              type="text/javascript"
+              key={"script" + idx}
+              src={source}
+            />
           );
         })}
 


### PR DESCRIPTION
Trivial change. Removes a react-warning-keys from the console when the scripts siteConfig param is used.

## Test Plan

Verified with local React Native client site.