### PR TITLE
Use `path` module instead of string concat `/`

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -26,8 +26,10 @@ function execute() {
   const feed = require("./feed.js");
   const sitemap = require("./sitemap.js");
 
-  const ENABLE_TRANSLATION = fs.existsSync(CWD + "/languages.js");
-  const ENABLE_VERSIONING = fs.existsSync(CWD + "/versions.json");
+  const join = path.join;
+
+  const ENABLE_TRANSLATION = fs.existsSync(join(CWD, "languages.js"));
+  const ENABLE_VERSIONING = fs.existsSync(join(CWD, "versions.json"));
 
   let languages;
   if (ENABLE_TRANSLATION) {
@@ -92,6 +94,16 @@ function execute() {
   readMetadata.generateMetadataDocs();
   const Metadata = require("../core/metadata.js");
 
+  // TODO: what if the project is a github org page? We should not use
+  // siteConfig.projectName in this case. Otherwise a GitHub org doc URL would
+  // look weird: https://myorg.github.io/myorg/docs
+
+  // TODO: siteConfig.projectName is a misnomer. The actual project name is
+  // `title`. `projectName` is only used to generate a folder, which isn't
+  // needed when the project's a GitHub org page
+
+  const buildDir = join(CWD, "build", siteConfig.projectName);
+
   // mdToHtml is a map from a markdown file name to its html link, used to
   // change relative markdown links that work on GitHub into actual site links
   const mdToHtml = {};
@@ -113,7 +125,7 @@ function execute() {
   const DocsLayout = require("../core/DocsLayout.js");
   const Redirect = require("../core/Redirect.js");
 
-  fs.removeSync(CWD + "/build");
+  fs.removeSync(join(CWD, "build"));
 
   // create html files for all docs by going through all doc ids
   Object.keys(Metadata).forEach(id => {
@@ -122,17 +134,15 @@ function execute() {
     let file;
     if (metadata.original_id) {
       if (ENABLE_TRANSLATION && metadata.language !== "en") {
-        file =
-          CWD + "/translated_docs/" + metadata.language + "/" + metadata.source;
+        file = join(CWD, "translated_docs", metadata.language, metadata.source);
       } else {
-        file = CWD + "/versioned_docs/" + metadata.source;
+        file = join(CWD, "versioned_docs", metadata.source);
       }
     } else {
       if (metadata.language === "en") {
-        file = CWD + "/../" + readMetadata.getDocsPath() + "/" + metadata.source;
+        file = join(CWD, "..", readMetadata.getDocsPath(), metadata.source);
       } else {
-        file =
-          CWD + "/translated_docs/" + metadata.language + "/" + metadata.source;
+        file = join(CWD, "translated_docs", metadata.language, metadata.source);
       }
     }
 
@@ -153,7 +163,7 @@ function execute() {
     let latestVersion;
     if (ENABLE_VERSIONING) {
       latestVersion = JSON.parse(
-        fs.readFileSync(CWD + "/versions.json", "utf8")
+        fs.readFileSync(join(CWD, "versions.json"), "utf8")
       )[0];
     }
 
@@ -191,8 +201,8 @@ function execute() {
       </DocsLayout>
     );
     const str = renderToStaticMarkup(docComp);
-    const targetFile =
-      CWD + "/build/" + siteConfig.projectName + "/" + metadata.permalink;
+
+    const targetFile = join(buildDir, metadata.permalink);
     writeFileAndCreateFolder(targetFile, str);
 
     // generate english page redirects when languages are enabled
@@ -208,33 +218,31 @@ function execute() {
       const redirectStr = renderToStaticMarkup(redirectComp);
 
       // create a redirects page for doc files
-      const redirectFile =
-        CWD +
-        "/build/" +
-        siteConfig.projectName +
-        "/" +
-        metadata.permalink.replace("docs/en", "docs");
+      const redirectFile = join(
+        buildDir,
+        metadata.permalink.replace("docs/en", "docs")
+      );
       writeFileAndCreateFolder(redirectFile, redirectStr);
     }
   });
 
   // copy docs assets if they exist
-  if (fs.existsSync(CWD + "/../" + readMetadata.getDocsPath() + "/assets")) {
+  if (fs.existsSync(join(CWD, "..", readMetadata.getDocsPath(), "assets"))) {
     fs.copySync(
-      CWD + "/../" + readMetadata.getDocsPath() + "/assets",
-      CWD + "/build/" + siteConfig.projectName + "/docs/assets"
+      join(CWD, readMetadata.getDocsPath(), "assets"),
+      join(buildDir, "docs", "assets")
     );
   }
 
   // create html files for all blog posts (each article)
-  if (fs.existsSync(__dirname + "../core/MetadataBlog.js")) {
-    fs.removeSync(__dirname + "../core/MetadataBlog.js");
+  if (fs.existsSync(join(__dirname, "..", "core", "MetadataBlog.js"))) {
+    fs.removeSync(join(__dirname, "..", "core", "MetadataBlog.js"));
   }
   readMetadata.generateMetadataBlog();
   const MetadataBlog = require("../core/MetadataBlog.js");
   const BlogPostLayout = require("../core/BlogPostLayout.js");
 
-  let files = glob.sync(CWD + "/blog/**/*.*");
+  let files = glob.sync(join(CWD, "blog", "**", "*.*"));
   files
     .sort()
     .reverse()
@@ -266,14 +274,14 @@ function execute() {
         <BlogPostLayout
           metadata={metadata}
           language={language}
-          config={siteConfig}>
+          config={siteConfig}
+        >
           {rawContent}
         </BlogPostLayout>
       );
       const str = renderToStaticMarkup(blogPostComp);
 
-      let targetFile =
-        CWD + "/build/" + siteConfig.projectName + "/blog/" + filePath;
+      let targetFile = join(buildDir, "blog", filePath);
       writeFileAndCreateFolder(targetFile, str);
     });
   // create html files for all blog pages (collections of article previews)
@@ -291,49 +299,43 @@ function execute() {
     );
     const str = renderToStaticMarkup(blogPageComp);
 
-    let targetFile =
-      CWD +
-      "/build/" +
-      siteConfig.projectName +
-      "/blog" +
-      (page > 0 ? "/page" + (page + 1) : "") +
-      "/index.html";
+    let targetFile = join(
+      buildDir,
+      "blog",
+      page > 0 ? "page" + (page + 1) : "",
+      "index.html"
+    );
     writeFileAndCreateFolder(targetFile, str);
   }
   // create rss files for all blog pages, if there are any blog files
   if (MetadataBlog.length > 0) {
-    let targetFile =
-      CWD + "/build/" + siteConfig.projectName + "/blog/feed.xml";
+    let targetFile = join(buildDir, "blog", "feed.xml");
     writeFileAndCreateFolder(targetFile, feed());
-    targetFile = CWD + "/build/" + siteConfig.projectName + "/blog/atom.xml";
+    targetFile = join(buildDir, "blog", "atom.xml");
     writeFileAndCreateFolder(targetFile, feed("atom"));
   }
 
   // create sitemap
   if (MetadataBlog.length > 0 && Object.keys(Metadata).length > 0) {
-    let targetFile = CWD + "/build/" + siteConfig.projectName + "/sitemap.xml";
+    let targetFile = join(buildDir, "sitemap.xml");
     sitemap(xml => {
       writeFileAndCreateFolder(targetFile, xml);
     });
   }
 
   // copy blog assets if they exist
-  if (fs.existsSync(CWD + "/blog/assets")) {
-    fs.copySync(
-      CWD + "/blog/assets",
-      CWD + "/build/" + siteConfig.projectName + "/blog/assets"
-    );
+  if (fs.existsSync(join(CWD, "blog", "assets"))) {
+    fs.copySync(join(CWD, "blog", "assets"), join(buildDir, "blog", "assets"));
   }
 
   // copy all static files from docusaurus
-  files = glob.sync(__dirname + "/../static/**");
+  files = glob.sync(join(__dirname, "..", "static", "**"));
   files.forEach(file => {
-    let targetFile =
-      CWD +
-      "/build/" +
-      siteConfig.projectName +
-      "/" +
-      file.split("/static/")[1];
+    let targetFile = join(
+      buildDir,
+      // TODO: use x-platform path functions
+      file.split("/static/")[1] || ""
+    );
     // parse css files to replace colors according to siteConfig
     if (file.match(/\.css$/)) {
       let cssContent = fs.readFileSync(file, "utf8");
@@ -364,12 +366,11 @@ function execute() {
   });
 
   // copy all static files from user
-  files = glob.sync(CWD + "/static/**");
+  files = glob.sync(join(CWD, "static", "**"));
   files.forEach(file => {
     // parse css files to replace colors according to siteConfig
     if (file.match(/\.css$/) && !isSeparateCss(file)) {
-      const mainCss =
-        CWD + "/build/" + siteConfig.projectName + "/css/main.css";
+      const mainCss = join(buildDir, "css", "main.css");
       let cssContent = fs.readFileSync(file, "utf8");
       cssContent = fs.readFileSync(mainCss, "utf8") + "\n" + cssContent;
 
@@ -381,8 +382,7 @@ function execute() {
       fs.writeFileSync(mainCss, cssContent);
     } else if (!fs.lstatSync(file).isDirectory()) {
       let parts = file.split("/static/");
-      let targetFile =
-        CWD + "/build/" + siteConfig.projectName + "/" + parts[1];
+      let targetFile = join(buildDir, parts[1]);
       mkdirp.sync(targetFile.replace(new RegExp("/[^/]*$"), ""));
       fs.copySync(file, targetFile);
     }
@@ -390,13 +390,13 @@ function execute() {
 
   // compile/copy pages from user
   let pagesArr = [];
-  files = glob.sync(CWD + "/pages/**");
+  files = glob.sync(join(CWD, "pages", "**"));
   files.forEach(file => {
     // render .js files to strings
     if (file.match(/\.js$/)) {
       // make temp file for sake of require paths
       const parts = file.split("pages");
-      let tempFile = __dirname + "/../pages" + parts[1];
+      let tempFile = join(__dirname, "..", "pages", parts[1]);
       tempFile = tempFile.replace(
         path.basename(file),
         "temp" + path.basename(file)
@@ -406,8 +406,7 @@ function execute() {
 
       const ReactComp = require(tempFile);
 
-      let targetFile =
-        CWD + "/build/" + siteConfig.projectName + "/" + parts[1];
+      let targetFile = join(buildDir, parts[1]);
       targetFile = targetFile.replace(/\.js$/, ".html");
 
       const regexLang = /\/pages\/(.*)\//;
@@ -420,6 +419,7 @@ function execute() {
           // skip conversion from english file if a file exists for this language
           if (
             language !== "en" &&
+            // TODO: use path functions
             fs.existsSync(file.replace("/en/", "/" + language + "/"))
           ) {
             continue;
@@ -431,6 +431,7 @@ function execute() {
             </Site>
           );
           writeFileAndCreateFolder(
+            // TODO: use path functions
             targetFile.replace("/en/", "/" + language + "/"),
             str
           );
@@ -455,19 +456,16 @@ function execute() {
     } else if (!fs.lstatSync(file).isDirectory()) {
       // copy other non .js files
       let parts = file.split("pages");
-      let targetFile =
-        CWD + "/build/" + siteConfig.projectName + "/" + parts[1];
+      let targetFile = join(buildDir, parts[1]);
       mkdirp.sync(targetFile.replace(new RegExp("/[^/]*$"), ""));
       fs.copySync(file, targetFile);
     }
   });
 
   // copy html files in 'en' to base level as well
-  files = glob.sync(CWD + "/build/" + siteConfig.projectName + "/en/**");
+  files = glob.sync(join(buildDir, "en", "**"));
   files.forEach(file => {
-    let targetFile = file.replace(
-      CWD + "/build/" + siteConfig.projectName + "/en/",
-      CWD + "/build/" + siteConfig.projectName + "/");
+    let targetFile = file.replace(join(buildDir, "en"), join(buildDir));
     if (file.match(/\.html$/)) {
       fs.copySync(file, targetFile);
     }
@@ -475,7 +473,7 @@ function execute() {
 
   // Generate CNAME file if a custom domain is specified in siteConfig
   if (siteConfig.cname) {
-    let targetFile = CWD + "/build/" + siteConfig.projectName + "/CNAME";
+    let targetFile = join(buildDir, "CNAME");
     fs.writeFileSync(targetFile, siteConfig.cname);
   }
 }


### PR DESCRIPTION
This also in part prepares for #253. I discovered a bug when setting `projectName` to `""`, and some `"build/" + projectName + "/foo"` concatenated into `"build//foo"`. Granted, it's a hack, but we should use `path` anyway.

Test: tested on https://github.com/BuckleScript/bucklescript.github.io. Seems working