### PR TITLE
Update deployment script to work on github.io repos as well

### DIFF
--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -60,7 +60,7 @@ if (IS_PULL_REQUEST) {
 
 // build static html files, then push to DEPLOYMENT_BRANCH branch of specified repo
 
-if (CIRCLE_BRANCH === DEPLOYMENT_BRANCH) {
+if (CURRENT_BRANCH === DEPLOYMENT_BRANCH) {
   shell.echo(`Cannot deploy from a ${DEPLOYMENT_BRANCH} branch. Only to it`);
   shell.exit(1);
 }


### PR DESCRIPTION
Naive check for `.github.io`. There is possibility for very small false positive rate, but likely nothing we care about.

This will conflict with #250 - happy to rebase around that.

With #255, will address #253.