### PR TITLE
allow copy from /build in github.io case

### DIFF
--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -113,7 +113,9 @@ shell.cd('../..');
 shell.cp(
   "-R",
   // in github.io case, project is deployed to root. need to not recursively
-  // copy the deployment-branch to be.
+  // copy the deployment-branch to be. 
+  // The !(...) represents the same thing as "everything but this"
+  // Copies everything in /build except the directory after the !.
   path.join("build", PROJECT_PATH, `!(${PROJECT_NAME}-${DEPLOYMENT_BRANCH})`),
   path.join("build", `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`)
 );


### PR DESCRIPTION
More changes for github.io case. Testing the previous work on bucklescript.github.io caused some issues that this PR should address.