### PR TITLE
add wrapPagesHTML which renders html snippets in pages inside of a header + footer

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -452,6 +452,16 @@ function execute() {
         writeFileAndCreateFolder(targetFile, str);
       }
       fs.removeSync(tempFile);
+    } else if (siteConfig.wrapPagesHTML && file.match(/\.html$/)) {
+      const parts = file.split('pages');
+      const targetFile = join(buildDir, parts[1]);
+      const str = renderToStaticMarkup(
+        <Site language="en" config={siteConfig}>
+          <div dangerouslySetInnerHTML={{__html: fs.readFileSync(file, { encoding: "utf8" })}} />
+        </Site>
+      );
+
+      writeFileAndCreateFolder(targetFile, str);
     } else if (!fs.lstatSync(file).isDirectory()) {
       // copy other non .js files
       let parts = file.split('pages');

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -375,7 +375,19 @@ function execute(port) {
         ))
       )
     ) {
-      res.send(fs.readFileSync(htmlFile, {encoding: 'utf8'}));
+      if (siteConfig.wrapPagesHTML) {
+        removeModuleAndChildrenFromCache("../core/Site.js");
+        const Site = require("../core/Site.js");
+        const str = renderToStaticMarkup(
+          <Site language="en" config={siteConfig}>
+            <div dangerouslySetInnerHTML={{__html: fs.readFileSync(htmlFile, { encoding: "utf8" })}} />
+          </Site>
+        );
+
+        res.send(str);
+      } else {
+        res.send(fs.readFileSync(htmlFile, { encoding: "utf8" }));
+      }
       return;
     }
 


### PR DESCRIPTION
This is a rough draft to get a sense of how we feel about this change. Built to fix https://github.com/facebook/Docusaurus/issues/247.

Problem:
Some languages have auto-generation of documentation as HTML snippets. (JS, OCaml, Java, etc. all of this functionality to varying degrees). The ability to co-locate documentation and code is powerful, so I don't want to give up this ability. I'd also like to be able to insert this code into a Docusaurus site and keep the header/footer styles.

Solution:
This PR makes it so that all .html files found in /pages are treated as html snippets and wrapped with the appropriate header/footer. Technically I don't think this would have to be behind a flag since you always have the ability to output raw HTML to /static, but for correctness sake I think the flag is useful. Since `wrapPagesHTML` adds a `head` to the snippets passed in it could create malformed HTML is someone isn't paying attention to use.

If this looks good I will add documentation for it! If not, I'd love ideas for ways to implement similar functionality.