### PR TITLE
Remove git commit status code check

### DIFF
--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -135,16 +135,11 @@ const currentCommit = shell.exec('git rev-parse HEAD').stdout.trim();
 
 shell.exec('git add --all');
 
-if (
-  shell.exec(
-    `git commit -m "Deploy website" -m "Deploy website version based on ${
-      currentCommit
-    }"`
-  ).code !== 0
-) {
-  shell.echo(`Error: Committing static website failed`);
-  shell.exit(1);
-}
+shell.exec(
+  `git commit -m "Deploy website" -m "Deploy website version based on ${
+    currentCommit
+  }"`
+);
 if (shell.exec(`git push origin ${DEPLOYMENT_BRANCH}`).code !== 0) {
   shell.echo('Error: Git push failed');
   shell.exit(1);


### PR DESCRIPTION
It's OK for git commit to return 1 when deploying the site in certain situations. In the case of https://circleci.com/gh/facebook/Docusaurus/659 the commit that triggered it added a file that did not affect the static site.
Reverting my prior change here.