### PR TITLE
Add newlines at end of generated files

### DIFF
--- a/docusaurus-init/initialize.js
+++ b/docusaurus-init/initialize.js
@@ -39,7 +39,10 @@ console.log(
 );
 
 const packageContent = { scripts: { examples: "docusaurus-examples" } };
-fs.writeFileSync(CWD + "/website/package.json", JSON.stringify(packageContent));
+fs.writeFileSync(
+  CWD + "/website/package.json",
+  JSON.stringify(packageContent, null, 2) + "\n"
+);
 
 if (useYarn) {
   shell.exec("yarn add docusaurus --dev");

--- a/lib/copy-examples.js
+++ b/lib/copy-examples.js
@@ -42,7 +42,7 @@ if (fs.existsSync(CWD + '/package.json')) {
   packageContent.scripts['rename-version'] = 'docusaurus-rename-version';
   fs.writeFileSync(
     CWD + '/package.json',
-    JSON.stringify(packageContent, null, 2)
+    JSON.stringify(packageContent, null, 2) + '\n'
   );
   console.log(
     `${chalk.green('Wrote docusaurus scripts to package.json file.')}\n`

--- a/lib/rename-version.js
+++ b/lib/rename-version.js
@@ -80,7 +80,10 @@ if (versionIndex < 0) {
 }
 // replace old version with new version in versions.json file
 versions[versionIndex] = newVersion;
-fs.writeFileSync(CWD + '/versions.json', JSON.stringify(versions));
+fs.writeFileSync(
+  CWD + '/versions.json',
+  JSON.stringify(versions, null, 2) + '\n'
+);
 
 // if folder of docs for this version exists, rename folder and rewrite doc
 // headers to use new version

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -337,7 +337,7 @@ function generateMetadataDocs() {
       ' */\n' +
       'module.exports = ' +
       JSON.stringify(metadatas, null, 2) +
-      ';'
+      ';\n'
   );
 }
 
@@ -404,7 +404,7 @@ function generateMetadataBlog() {
       ' */\n' +
       'module.exports = ' +
       JSON.stringify(metadatas, null, 2) +
-      ';'
+      ';\n'
   );
 }
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -125,13 +125,16 @@ if (versionFallback.diffLatestSidebar()) {
 
   fs.writeFileSync(
     CWD + '/versioned_sidebars/version-' + version + '-sidebars.json',
-    JSON.stringify(versioned, null, 2),
+    JSON.stringify(versioned, null, 2) + '\n',
     'utf8'
   );
 }
 
 // update versions.json file
 versions.unshift(version);
-fs.writeFileSync(CWD + '/versions.json', JSON.stringify(versions, null, 2));
+fs.writeFileSync(
+  CWD + '/versions.json',
+  JSON.stringify(versions, null, 2) + '\n'
+);
 
 console.log(`${chalk.green('Version ' + version + ' created!\n')}`);

--- a/lib/write-translations.js
+++ b/lib/write-translations.js
@@ -176,7 +176,7 @@ function execute() {
       ),
       null,
       2
-    )
+    ) + '\n'
   );
 }
 


### PR DESCRIPTION
## Motivation

Various diff tools highlight a missing newline at end of files. This adds them where it seemed safe to do so.

## Test Plan

Careful code inspection.