### PR TITLE
Index page composition

### DIFF
--- a/examples/basics/pages/en/index.js
+++ b/examples/basics/pages/en/index.js
@@ -14,6 +14,18 @@ const GridBlock = CompLibrary.GridBlock;
 
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 
+function imgUrl(img) {
+  return siteConfig.baseUrl + 'img/' + img;
+}
+
+function docUrl(doc, language) {
+  return siteConfig.baseUrl + 'docs/' + language + '/' + doc;
+}
+
+function pageUrl(page, language) {
+  return siteConfig.baseUrl + language + '/' + page;
+}
+
 class Button extends React.Component {
   render() {
     return (
@@ -30,154 +42,182 @@ Button.defaultProps = {
   target: '_self',
 };
 
-class HomeSplash extends React.Component {
-  render() {
-    return (
-      <div className="homeContainer">
-        <div className="homeSplashFade">
-          <div className="wrapper homeWrapper">
-            <div className="projectLogo">
-              <img src={siteConfig.baseUrl + 'img/docusaurus.svg'} />
-            </div>
-            <div className="inner">
-              <h2 className="projectTitle">
-                {siteConfig.title}
-                <small>{siteConfig.tagline}</small>
-              </h2>
-              <div className="section promoSection">
-                <div className="promoRow">
-                  <div className="pluginRowBlock">
-                    <Button href="#try">Try It Out</Button>
-                    <Button
-                      href={
-                        siteConfig.baseUrl +
-                        'docs/' +
-                        this.props.language +
-                        '/doc1.html'
-                      }>
-                      Example Link
-                    </Button>
-                    <Button
-                      href={
-                        siteConfig.baseUrl +
-                        'docs/' +
-                        this.props.language +
-                        '/doc2.html'
-                      }>
-                      Example Link 2
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+const SplashContainer = (props) => (
+  <div className="homeContainer">
+    <div className="homeSplashFade">
+      <div className="wrapper homeWrapper">
+        {props.children}
       </div>
+    </div>
+  </div>
+)
+
+const Logo = (props) => (
+  <div className="projectLogo">
+    <img src={props.img_src} />
+  </div>
+)
+
+const ProjectTitle = (props) => (
+  <h2 className="projectTitle">
+    {siteConfig.title}
+    <small>{siteConfig.tagline}</small>
+  </h2>
+)
+
+const PromoSection = (props) => (
+  <div className="section promoSection">
+    <div className="promoRow">
+      <div className="pluginRowBlock">
+        {props.children}
+      </div>
+    </div>
+  </div>
+)
+
+class HomeSplash extends React.Component {
+
+  render() {
+    let language = this.props.language || 'en';
+    return (
+      <SplashContainer>
+        <Logo img_src={imgUrl('docusaurus.svg')} />
+        <div className="inner">
+          <ProjectTitle />
+          <PromoSection>
+            <Button href="#try">Try It Out</Button>
+            <Button href={docUrl('doc1.html', language)}>
+              Example Link
+            </Button>
+            <Button href={docUrl('doc2.html', language)}>
+              Example Link 2
+            </Button>
+          </PromoSection>
+        </div>
+      </SplashContainer>
     );
   }
+}
+
+const Block = (props) => (
+  <Container padding={['bottom', 'top']} id={props.id} background={props.background}>
+    <GridBlock
+      align="center"
+      contents={props.children}
+      layout={props.layout}
+    />
+  </Container>
+);
+
+const Features = (props) => (
+  <Block layout="fourColumn">
+    {[
+      {
+        content: 'This is the content of my feature',
+        image: imgUrl('docusaurus.svg'),
+        imageAlign: 'top',
+        title: 'Feature One',
+      },
+      {
+        content: 'The content of my second feature',
+        image: imgUrl('docusaurus.svg'),
+        imageAlign: 'top',
+        title: 'Feature Two',
+      },
+    ]}
+  </Block>
+);
+
+const FeatureCallout = (props) => (
+  <div
+    className="productShowcaseSection paddingBottom"
+    style={{textAlign: 'center'}}>
+    <h2>Feature Callout</h2>
+    <MarkdownBlock>These are features of this project</MarkdownBlock>
+  </div>
+)
+
+const LearnHow = (props) => (
+  <Block background="light">
+    {[
+      {
+        content: 'Talk about learning how to use this',
+        image: imgUrl('docusaurus.svg'),
+        imageAlign: 'right',
+        title: 'Learn How',
+      },
+    ]}
+  </Block>
+)
+
+const TryOut = (props) => (
+  <Block id="try">
+    {[
+      {
+        content: 'Talk about trying this out',
+        image: imgUrl('docusaurus.svg'),
+        imageAlign: 'left',
+        title: 'Try it Out',
+      },
+    ]}
+  </Block>
+)
+
+const Description = (props) => (
+  <Block background="dark">
+    {[
+      {
+        content:
+          'This is another description of how this project is useful',
+        image: imgUrl('docusaurus.svg'),
+        imageAlign: 'right',
+        title: 'Description',
+      },
+    ]}
+  </Block>
+)
+
+const Showcase = (props) => {
+  const showcase = siteConfig.users
+    .filter(user => {
+      return user.pinned;
+    })
+    .map((user, i) => {
+      return (
+        <a href={user.infoLink} key={i}>
+          <img src={user.image} title={user.caption} />
+        </a>
+      );
+    });
+
+  return (
+    <div className="productShowcaseSection paddingBottom">
+      <h2>{"Who's Using This?"}</h2>
+      <p>This project is used by all these people</p>
+      <div className="logos">{showcase}</div>
+      <div className="more-users">
+        <a className="button" href={pageUrl('users.html', props.language)}>
+          More {siteConfig.title} Users
+        </a>
+      </div>
+    </div>
+  )
 }
 
 class Index extends React.Component {
   render() {
     let language = this.props.language || 'en';
-    const showcase = siteConfig.users
-      .filter(user => {
-        return user.pinned;
-      })
-      .map(user => {
-        return (
-          <a href={user.infoLink}>
-            <img src={user.image} title={user.caption} />
-          </a>
-        );
-      });
 
     return (
       <div>
         <HomeSplash language={language} />
         <div className="mainContainer">
-          <Container padding={['bottom', 'top']}>
-            <GridBlock
-              align="center"
-              contents={[
-                {
-                  content: 'This is the content of my feature',
-                  image: siteConfig.baseUrl + 'img/docusaurus.svg',
-                  imageAlign: 'top',
-                  title: 'Feature One',
-                },
-                {
-                  content: 'The content of my second feature',
-                  image: siteConfig.baseUrl + 'img/docusaurus.svg',
-                  imageAlign: 'top',
-                  title: 'Feature Two',
-                },
-              ]}
-              layout="fourColumn"
-            />
-          </Container>
-
-          <div
-            className="productShowcaseSection paddingBottom"
-            style={{textAlign: 'center'}}>
-            <h2>Feature Callout</h2>
-            <MarkdownBlock>These are features of this project</MarkdownBlock>
-          </div>
-
-          <Container padding={['bottom', 'top']} background="light">
-            <GridBlock
-              contents={[
-                {
-                  content: 'Talk about learning how to use this',
-                  image: siteConfig.baseUrl + 'img/docusaurus.svg',
-                  imageAlign: 'right',
-                  title: 'Learn How',
-                },
-              ]}
-            />
-          </Container>
-
-          <Container padding={['bottom', 'top']} id="try">
-            <GridBlock
-              contents={[
-                {
-                  content: 'Talk about trying this out',
-                  image: siteConfig.baseUrl + 'img/docusaurus.svg',
-                  imageAlign: 'left',
-                  title: 'Try it Out',
-                },
-              ]}
-            />
-          </Container>
-
-          <Container padding={['bottom', 'top']} background="dark">
-            <GridBlock
-              contents={[
-                {
-                  content:
-                    'This is another description of how this project is useful',
-                  image: siteConfig.baseUrl + 'img/docusaurus.svg',
-                  imageAlign: 'right',
-                  title: 'Description',
-                },
-              ]}
-            />
-          </Container>
-
-          <div className="productShowcaseSection paddingBottom">
-            <h2>{"Who's Using This?"}</h2>
-            <p>This project is used by all these people</p>
-            <div className="logos">{showcase}</div>
-            <div className="more-users">
-              <a
-                className="button"
-                href={
-                  siteConfig.baseUrl + this.props.language + '/' + 'users.html'
-                }>
-                More {siteConfig.title} Users
-              </a>
-            </div>
-          </div>
+          <Features />
+          <FeatureCallout />
+          <LearnHow />
+          <TryOut />
+          <Description />
+          <Showcase language={language} />
         </div>
       </div>
     );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I was using Docusaurus to create website for one of my projects to try out. I find customizing index page took me a bit more time, mainly because of the pretty big, nested, render() method. Splitting into small components as React always recommended would help users to customize the page easier.

I tried to move those small components into a common place so potentially could be shared but failed. I think it is because the way template generation works. Inside index.js file is still an improvement, but if there is a better place please do that and close this request.

BTW, this PR also fixed the showcase links `key` issue on this page.

## Test Plan

I tested by creating a new website and copy the changed files over then manual test the site.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
