### PR TITLE
Include a `lang` property on html node

### DIFF
--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -42,7 +42,7 @@ class Site extends React.Component {
       latestVersion = require(CWD + '/versions.json')[0];
     }
     return (
-      <html>
+      <html lang={this.props.language}>
         <Head
           config={this.props.config}
           description={description}


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Google Chrome guesses the language if this is not present. Large quantities of source code can confuse it and lead to it selecting completely the wrong language.

## Test Plan

When I loaded the example docs before this change, google chrome offered to translate the page from Latin. After this change, it did not offer to translate
