### PR TITLE
Fix broken or redirected links

### DIFF
--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -80,7 +80,7 @@ Alias: `publish-gh-pages`
  - `CIRCLE_PROJECT_REPONAME`: The name of the git repo, e.g. "Docusaurus".
  - `CI_PULL_REQUEST`: Expected to be truthy if the current CI run was triggered by a commit in a pull request.
 
-You can learn more about configuring automatic deployments with CircleCI in the [Publishing guide](publishing.md).
+You can learn more about configuring automatic deployments with CircleCI in the [Publishing guide](getting-started-publishing.md).
 
 ---
 

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -29,7 +29,7 @@ Deploying your Docusaurus site to GitHub Pages is straightforward if you are alr
 
 > Even if your repo is private, anything published to a `gh-pages` branch will be [public](https://help.github.com/articles/user-organization-and-project-pages/).
 
-Most of the work to publish to GitHub pages is done for you automatically through the [`publish-gh-pages`](./commands.md#docusaurus-publish) script. You just need to determine the values for a few parameters required by the script.
+Most of the work to publish to GitHub pages is done for you automatically through the [`publish-gh-pages`](./api-commands.md#docusaurus-publish) script. You just need to determine the values for a few parameters required by the script.
 
 Two of the required parameters are set in the [`siteConfig.js`](api-site-config.md):
 
@@ -60,7 +60,7 @@ GIT_USER=<GIT_USER> \
 
 > The specified `GIT_USER` must have push access to the repository specified in the combination of `organizationName` and `projectName`.
 
-You should now be able to load your website by visiting its GitHub Pages URL, which could be something along the lines of https://_username_.github.io/_projectName_, or a custom domain if you have set that up. For example, Docusaurus' own GitHub Pages URL is https://docusaurus.io (it can also be accessed via https://facebook.github.io/docusaurus), because it is served from the `gh-pages` branch of the https://github.com/facebook/docusaurus GitHub repo. We highly encourage reading through the [GitHub Pages documentation](https://pages.github.com) to learn more about how this hosting solution works.
+You should now be able to load your website by visiting its GitHub Pages URL, which could be something along the lines of https://_username_.github.io/_projectName_, or a custom domain if you have set that up. For example, Docusaurus' own GitHub Pages URL is https://docusaurus.io (it can also be accessed via https://docusaurus.io/), because it is served from the `gh-pages` branch of the https://github.com/facebook/docusaurus GitHub repo. We highly encourage reading through the [GitHub Pages documentation](https://pages.github.com) to learn more about how this hosting solution works.
 
 You can run the command above any time you update the docs and wish to deploy the changes to your site. Running the script manually may be fine for sites where the documentation rarely changes and it is not too much of an inconvenience to remember to manually deploy changes.
 

--- a/docs/guides-custom-pages.md
+++ b/docs/guides-custom-pages.md
@@ -3,13 +3,13 @@ id: custom-pages
 title: Custom Pages
 ---
 
-You can add pages to your site that are not part of the standard docs or blog markdown files. You can do this by adding `.js` files to the `website/pages` directory. These files are [React](https://facebook.github.io/react) components and the `render()` is called to create them, backed by CSS classes, etc.
+You can add pages to your site that are not part of the standard docs or blog markdown files. You can do this by adding `.js` files to the `website/pages` directory. These files are [React](https://reactjs.org/) components and the `render()` is called to create them, backed by CSS classes, etc.
 
 ## Customizing Your Home Page
 
 The easiest way to get started customizing your home page is to use the example site that was [created](getting-started-site-creation.md) when you ran the [Docusaurus initialization script](getting-started-installation.md).
 
-You can [start](site-preparation.md#verifying-installation) your local server and go to `http://localhost:3000` to see what the example home page looks like. From there, edit the `website/pages/en/index.js` file and its various components to use the images and text you want for your project.
+You can [start](getting-started-preparation.md#verifying-installation) your local server and go to `http://localhost:3000` to see what the example home page looks like. From there, edit the `website/pages/en/index.js` file and its various components to use the images and text you want for your project.
 
 ## Adding Other Custom Pages
 

--- a/docs/guides-versioning.md
+++ b/docs/guides-versioning.md
@@ -87,4 +87,4 @@ yarn run rename-version 1.0.0 1.0.1
 
 ## Versioning and Translations
 
-If you wish to use versioning and translations features, the `crowdin.yaml` file should be set up to upload and download versioned documents to and from Crowdin for translation. Translated, versioned files will go into the folder `translated_docs/${language}/version-${version}/`. For more information, check out the [translations guide](translation.md).
+If you wish to use versioning and translations features, the `crowdin.yaml` file should be set up to upload and download versioned documents to and from Crowdin for translation. Translated, versioned files will go into the folder `translated_docs/${language}/version-${version}/`. For more information, check out the [translations guide](guides-translation.md).


### PR DESCRIPTION
## Motivation

Some links are 404 or 301 redirected.
This PR fixed this.

## Test Plan

I've found these broken link by [textlint](https://github.com/textlint/textlint/tree/master/packages/textlint "textlint") and [textlint-rule-no-dead-link](https://github.com/textlint-rule/textlint-rule-no-dead-link-fork "textlint-rule-no-dead-link").

- Test branch: <https://github.com/facebook/Docusaurus/compare/master...azu:textlint?expand=1>

Installation:
```shell-session
yarn add textlint @textlint-rule/textlint-rule-no-dead-link --dev
yarn textlint --init
yarn textlint docs/
```

Add `.textlintrc` setting:
```json
{
  "filters": {},
  "rules": {
    "@textlint-rule/no-dead-link": {
      "checkRelative": true
    }
  }
}
```

### Before

```shell-session
$ yarn textlint docs
yarn run v1.3.2
$ /Users/azu/.ghq/github.com/facebook/Docusaurus/node_modules/.bin/textlint docs

/Users/azu/.ghq/github.com/facebook/Docusaurus/docs/api-commands.md
  83:100  error  /Users/azu/.ghq/github.com/facebook/Docusaurus/docs/publishing.md is not found  @textlint-rule/no-dead-link

/Users/azu/.ghq/github.com/facebook/Docusaurus/docs/getting-started-preparation.md
  55:29  error  http://localhost:3000 is dead. (request to http://localhost:3000 failed, reason: connect ECONNREFUSED 127.0.0.1:3000)  @textlint-rule/no-dead-link

/Users/azu/.ghq/github.com/facebook/Docusaurus/docs/getting-started-publishing.md
  32:108  error    /Users/azu/.ghq/github.com/facebook/Docusaurus/docs/commands.md is not found  @textlint-rule/no-dead-link
  63:123  error    https://_username_.github.io/_projectName_ is dead. (404 Not Found)           @textlint-rule/no-dead-link
  63:311  error    https://facebook.github.io/docusaurus is dead. (404 Not Found)                @textlint-rule/no-dead-link
  79:10   ✓ error  https://github.com/settings/tokens is redirected. (302 Found)                 @textlint-rule/no-dead-link
  80:146  error    https://circleci.com/gh/ORG/REPO/edit#env-vars is dead. (401 Unauthorized)    @textlint-rule/no-dead-link

/Users/azu/.ghq/github.com/facebook/Docusaurus/docs/guides-custom-pages.md
   6:191  ✓ error  https://facebook.github.io/react is redirected. (301 Moved Permanently)               @textlint-rule/no-dead-link
  12:17   error    /Users/azu/.ghq/github.com/facebook/Docusaurus/docs/site-preparation.md is not found  @textlint-rule/no-dead-link

/Users/azu/.ghq/github.com/facebook/Docusaurus/docs/guides-versioning.md
  90:339  error  /Users/azu/.ghq/github.com/facebook/Docusaurus/docs/translation.md is not found  @textlint-rule/no-dead-link

✖ 10 problems (10 errors, 0 warnings)
✓ 2 fixable problems.
Try to run: $ textlint --fix [file]

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### After

I've fixed the above links.

(Following link can be ignored by [ignore](https://github.com/textlint-rule/textlint-rule-no-dead-link-fork#ignore "ignore") option)

```shell-session
$ yarn textlint docs
yarn run v1.3.2
$ /Users/azu/.ghq/github.com/facebook/Docusaurus/node_modules/.bin/textlint docs

/Users/azu/.ghq/github.com/facebook/Docusaurus/docs/getting-started-preparation.md
  55:29  error  http://localhost:3000 is dead. (request to http://localhost:3000 failed, reason: connect ECONNREFUSED 127.0.0.1:3000)  @textlint-rule/no-dead-link

/Users/azu/.ghq/github.com/facebook/Docusaurus/docs/getting-started-publishing.md
  63:123  error  https://_username_.github.io/_projectName_ is dead. (404 Not Found)         @textlint-rule/no-dead-link
  80:146  error  https://circleci.com/gh/ORG/REPO/edit#env-vars is dead. (401 Unauthorized)  @textlint-rule/no-dead-link

✖ 3 problems (3 errors, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

As a result, I can jump to fixed link.
