### PR TITLE
Split showcase

### DIFF
--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -5,40 +5,69 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require("react");
+const React = require('react');
 
-const CompLibrary = require("../../core/CompLibrary.js");
+const CompLibrary = require('../../core/CompLibrary.js');
 const Container = CompLibrary.Container;
 
-const siteConfig = require(process.cwd() + "/siteConfig.js");
+const siteConfig = require(process.cwd() + '/siteConfig.js');
 
 class Users extends React.Component {
   render() {
-    const showcase = siteConfig.users.map((user, i) => {
-      return (
-        <a href={user.infoLink} key={i}>
-          <img src={user.image} title={user.caption} />
-        </a>
-      );
-    });
+    const fbShowcase = siteConfig.users
+      .filter(user => {
+        return user.fbOpenSource === true;
+      })
+      .map((user, i) => {
+        return (
+          <a href={user.infoLink} key={i}>
+            <img src={user.image} title={user.caption} />
+          </a>
+        );
+      });
+
+    const showcase = siteConfig.users
+      .filter(user => {
+        return !user.fbOpenSource;
+      })
+      .map((user, i) => {
+        return (
+          <a href={user.infoLink} key={i}>
+            <img src={user.image} title={user.caption} />
+          </a>
+        );
+      });
 
     return (
       <div className="mainContainer">
-        <Container padding={["bottom", "top"]}>
+        <Container padding={['bottom', 'top']}>
           <div className="showcaseSection">
             <div className="prose">
-              <h1>Who Is Using Docusaurus?</h1>
-              <p>This project is used by many open source projects including...</p>
+              <h1>Who is using Docusaurus?</h1>
+              <p>
+                Docusaurus powers some of Facebook's popular{' '}
+                <a href="https://code.facebook.com/projects/">
+                  open source projects
+                </a>.
+              </p>
+            </div>
+            <div className="logos">{fbShowcase}</div>
+            <div className="prose">
+              <p>
+                Docusaurus is also used by open source projects of all sizes.
+              </p>
             </div>
             <div className="logos">{showcase}</div>
             <div className="prose">
-              <p>Are you using this project?</p>
+              <p>Is your project using Docusaurus?</p>
+              <p>
+                Edit this page with a{' '}
+                <a href="https://github.com/facebook/docusaurus/edit/master/website/siteConfig.js">
+                  Pull Request
+                </a>{' '}
+                to add your logo.
+              </p>
             </div>
-            <a
-              href="https://github.com/facebook/docusaurus/edit/master/website/siteConfig.js"
-              className="button">
-              Add your project
-            </a>
           </div>
         </Container>
       </div>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -8,104 +8,112 @@
 /* List of projects/orgs using your project for the users page */
 const users = [
   {
-    caption: "Prettier",
-    image: "/img/prettier.png",
-    infoLink: "https://www.prettier.io",
-    pinned: true
+    caption: 'Prettier',
+    image: '/img/prettier.png',
+    infoLink: 'https://www.prettier.io',
+    fbOpenSource: false,
+    pinned: true,
   },
   {
-    caption: "FastText",
-    image: "/img/fasttext.png",
-    infoLink: "https://fasttext.cc",
-    pinned: true
+    caption: 'FastText',
+    image: '/img/fasttext.png',
+    infoLink: 'https://fasttext.cc',
+    fbOpenSource: true,
+    pinned: true,
   },
   {
-    caption: "Jest",
-    image: "/img/jest.png",
-    infoLink: "https://facebook.github.io/jest/",
-    pinned: true
+    caption: 'Jest',
+    image: '/img/jest.png',
+    infoLink: 'https://facebook.github.io/jest/',
+    fbOpenSource: true,
+    pinned: true,
   },
   {
-    caption: "Reason React",
-    image: "/img/reason-react.svg",
-    infoLink: "https://reasonml.github.io/reason-react/",
-    pinned: true
+    caption: 'Reason React',
+    image: '/img/reason-react.svg',
+    infoLink: 'https://reasonml.github.io/reason-react/',
+    fbOpenSource: true,
+    pinned: true,
   },
   {
-    caption: "MakeItOpen",
-    image: "/img/makeitopen.png",
-    infoLink: "http://makeitopen.com/",
-    pinned: true
+    caption: 'MakeItOpen',
+    image: '/img/makeitopen.png',
+    infoLink: 'http://makeitopen.com/',
+    fbOpenSource: true,
+    pinned: true,
   },
   {
-    caption: "React Native",
-    image: "/img/react-native.svg",
-    infoLink: "https://facebook.github.io/react-native",
-    pinned: true
+    caption: 'React Native',
+    image: '/img/react-native.svg',
+    infoLink: 'https://facebook.github.io/react-native',
+    fbOpenSource: true,
+    pinned: true,
   },
   {
-    caption: "Relay",
-    image: "/img/relay.svg",
-    infoLink: "https://facebook.github.io/relay/",
-    pinned: true
+    caption: 'Relay',
+    image: '/img/relay.svg',
+    infoLink: 'https://facebook.github.io/relay/',
+    fbOpenSource: true,
+    pinned: true,
   },
   {
-    caption: "Bucklescript",
-    image: "/img/bucklescript.svg",
-    infoLink: "https://bucklescript.github.io/",
-    pinned: true
+    caption: 'Bucklescript',
+    image: '/img/bucklescript.svg',
+    infoLink: 'https://bucklescript.github.io/',
+    fbOpenSource: true,
+    pinned: true,
   },
   {
-    caption: "Docusaurus",
-    image: "/img/docusaurus.svg",
-    infoLink: "https://www.docusaurus.io",
-    pinned: true
-  }
+    caption: 'Docusaurus',
+    image: '/img/docusaurus.svg',
+    infoLink: 'https://www.docusaurus.io',
+    fbOpenSource: true,
+    pinned: true,
+  },
 ];
 
 const siteConfig = {
-  title: "Docusaurus",
-  tagline: "Easy to Maintain Open Source Documentation Websites",
-  url: "https://docusaurus.io",
-  baseUrl: "/",
-  organizationName: "facebook",
-  projectName: "Docusaurus",
-  cname: "docusaurus.io",
+  title: 'Docusaurus',
+  tagline: 'Easy to Maintain Open Source Documentation Websites',
+  url: 'https://docusaurus.io',
+  baseUrl: '/',
+  organizationName: 'facebook',
+  projectName: 'Docusaurus',
+  cname: 'docusaurus.io',
   noIndex: false,
   users,
-  editUrl:
-    "https://github.com/facebook/docusaurus/edit/master/docs/",
+  editUrl: 'https://github.com/facebook/docusaurus/edit/master/docs/',
   headerLinks: [
-    { doc: "installation", label: "Docs" },
-    { page: "help", label: "Help" },
-    { page: "about-slash", label: "About /"},
-    { blog: true, label: "Blog" },
+    {doc: 'installation', label: 'Docs'},
+    {page: 'help', label: 'Help'},
+    {page: 'about-slash', label: 'About /'},
+    {blog: true, label: 'Blog'},
     {
-      href: "https://github.com/facebook/docusaurus",
-      label: "GitHub"
-    }
+      href: 'https://github.com/facebook/docusaurus',
+      label: 'GitHub',
+    },
   ],
-  headerIcon: "img/docusaurus.svg",
-  footerIcon: "img/docusaurus_monochrome.svg",
-  favicon: "img/docusaurus.ico",
+  headerIcon: 'img/docusaurus.svg',
+  footerIcon: 'img/docusaurus_monochrome.svg',
+  favicon: 'img/docusaurus.ico',
   algolia: {
-    apiKey: "3eb9507824b8be89e7a199ecaa1a9d2c",
-    indexName: "docusaurus"
+    apiKey: '3eb9507824b8be89e7a199ecaa1a9d2c',
+    indexName: 'docusaurus',
   },
   colors: {
-    primaryColor: "#2E8555",
-    secondaryColor: "#205C3B"
+    primaryColor: '#2E8555',
+    secondaryColor: '#205C3B',
   },
-  translationRecruitingLink: "https://crowdin.com/project/docusaurus",
-  copyright: "Copyright © " + new Date().getFullYear() + " Facebook Inc.",
+  translationRecruitingLink: 'https://crowdin.com/project/docusaurus',
+  copyright: 'Copyright © ' + new Date().getFullYear() + ' Facebook Inc.',
   highlight: {
-    theme: "solarized-dark"
+    theme: 'solarized-dark',
   },
-  scripts: ["https://buttons.github.io/buttons.js"],
-  gaTrackingId: "UA-44373548-31",
-  facebookAppId: "1615782811974223",
-  twitter: "true",
-  ogImage: "img/docusaurus.png",
+  scripts: ['https://buttons.github.io/buttons.js'],
+  gaTrackingId: 'UA-44373548-31',
+  facebookAppId: '1615782811974223',
+  twitter: 'true',
+  ogImage: 'img/docusaurus.png',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Facebook Open Source projects are shown at the top.

We introduce a new boolean to ensure we can pin non-FB projects to the frontpage.

# Test Plan

Showcase:
![screen shot 2017-12-18 at 10 46 01 am](https://user-images.githubusercontent.com/165856/34122348-0944e50a-e3e1-11e7-9e29-9c7158edd8ea.png)

Homepage:
![screen shot 2017-12-18 at 10 45 57 am](https://user-images.githubusercontent.com/165856/34122349-095ed6f4-e3e1-11e7-9b5d-e21fee7e12d8.png)
