### PR TITLE
Fixing Issue 305 - broken links because of language

### DIFF
--- a/examples/basics/core/Footer.js
+++ b/examples/basics/core/Footer.js
@@ -10,12 +10,12 @@ const React = require('react');
 class Footer extends React.Component {
   docUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
-    return baseUrl + 'docs/' + (language? language + '/' : '') + doc;
+    return baseUrl + 'docs/' + (language ? language + '/' : '') + doc;
   }
 
   pageUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
-    return baseUrl + (language? language + '/' : '') + doc;
+    return baseUrl + (language ? language + '/' : '') + doc;
   }
 
   render() {

--- a/examples/basics/core/Footer.js
+++ b/examples/basics/core/Footer.js
@@ -8,6 +8,16 @@
 const React = require('react');
 
 class Footer extends React.Component {
+  docUrl(doc, language) {
+    const baseUrl = this.props.config.baseUrl;
+    return baseUrl + 'docs/' + (language? language + '/' : '') + doc;
+  }
+
+  pageUrl(doc, language) {
+    const baseUrl = this.props.config.baseUrl;
+    return baseUrl + (language? language + '/' : '') + doc;
+  }
+
   render() {
     const currentYear = new Date().getFullYear();
     return (
@@ -25,40 +35,19 @@ class Footer extends React.Component {
           </a>
           <div>
             <h5>Docs</h5>
-            <a
-              href={
-                this.props.config.baseUrl +
-                'docs/' +
-                this.props.language +
-                '/doc1.html'
-              }>
+            <a href={this.docUrl('doc1.html', this.props.language)}>
               Getting Started (or other categories)
             </a>
-            <a
-              href={
-                this.props.config.baseUrl +
-                'docs/' +
-                this.props.language +
-                '/doc2.html'
-              }>
+            <a href={this.docUrl('doc2.html', this.props.language)}>
               Guides (or other categories)
             </a>
-            <a
-              href={
-                this.props.config.baseUrl +
-                'docs/' +
-                this.props.language +
-                '/doc3.html'
-              }>
+            <a href={this.docUrl('doc3.html', this.props.language)}>
               API Reference (or other categories)
             </a>
           </div>
           <div>
             <h5>Community</h5>
-            <a
-              href={
-                this.props.config.baseUrl + this.props.language + '/users.html'
-              }>
+            <a href={this.pageUrl('users.html', this.props.language)}>
               User Showcase
             </a>
             <a

--- a/examples/basics/pages/en/index.js
+++ b/examples/basics/pages/en/index.js
@@ -19,11 +19,11 @@ function imgUrl(img) {
 }
 
 function docUrl(doc, language) {
-  return siteConfig.baseUrl + 'docs/' + language + '/' + doc;
+  return siteConfig.baseUrl + 'docs/' + (language? language + '/' : '') + doc;
 }
 
 function pageUrl(page, language) {
-  return siteConfig.baseUrl + language + '/' + page;
+  return siteConfig.baseUrl + (language? language + '/' : '') + page;
 }
 
 class Button extends React.Component {
@@ -73,7 +73,7 @@ const PromoSection = props => (
 
 class HomeSplash extends React.Component {
   render() {
-    let language = this.props.language || 'en';
+    let language = this.props.language || '';
     return (
       <SplashContainer>
         <Logo img_src={imgUrl('docusaurus.svg')} />

--- a/examples/basics/pages/en/index.js
+++ b/examples/basics/pages/en/index.js
@@ -19,11 +19,11 @@ function imgUrl(img) {
 }
 
 function docUrl(doc, language) {
-  return siteConfig.baseUrl + 'docs/' + (language? language + '/' : '') + doc;
+  return siteConfig.baseUrl + 'docs/' + (language ? language + '/' : '') + doc;
 }
 
 function pageUrl(page, language) {
-  return siteConfig.baseUrl + (language? language + '/' : '') + page;
+  return siteConfig.baseUrl + (language ? language + '/' : '') + page;
 }
 
 class Button extends React.Component {

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -33,7 +33,8 @@ class LanguageDropDown extends React.Component {
       'Help Translate|recruit community translators for your project'
     );
     // add all enabled languages to dropdown
-    const enabledLanguages = env.translation.enabledLanguages()
+    const enabledLanguages = env.translation
+      .enabledLanguages()
       .filter(lang => lang !== this.props.language)
       .map(lang => (
         <li key={lang.tag}>
@@ -118,10 +119,13 @@ class HeaderNav extends React.Component {
       );
     } else if (link.doc) {
       // set link to document with current page's language/version
-      const langPart = env.translation.enabled? this.props.language + '-' : '';
-      const versionPart = (env.translation.enabled && this.props.version !== 'next')
-        ? '-version-' + (this.props.version || env.versioning.latestVersion) + '-'
-        : '';
+      const langPart = env.translation.enabled ? this.props.language + '-' : '';
+      const versionPart =
+        env.translation.enabled && this.props.version !== 'next'
+          ? '-version-' +
+            (this.props.version || env.versioning.latestVersion) +
+            '-'
+          : '';
       const id = langPart + versionPart + link.doc;
       if (!Metadata[id]) {
         if (id != link.doc) {
@@ -142,7 +146,10 @@ class HeaderNav extends React.Component {
       const language = this.props.language || '';
       if (fs.existsSync(CWD + '/pages/en/' + link.page + '.js')) {
         href =
-          siteConfig.baseUrl + (language? language + '/' : '') + link.page + '.html';
+          siteConfig.baseUrl +
+          (language ? language + '/' : '') +
+          link.page +
+          '.html';
       } else {
         href = siteConfig.baseUrl + link.page + '.html';
       }

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -182,10 +182,12 @@ class HeaderNav extends React.Component {
         <div className="headerWrapper wrapper">
           <header>
             <a href={this.props.baseUrl}>
-              <img
-                className="logo"
-                src={this.props.baseUrl + siteConfig.headerIcon}
-              />
+              {siteConfig.headerIcon && (
+                <img
+                  className="logo"
+                  src={this.props.baseUrl + siteConfig.headerIcon}
+                />
+              )}
               {!this.props.config.disableHeaderTitle && (
                 <h2 className="headerTitle">{this.props.title}</h2>
               )}

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -11,16 +11,11 @@ const React = require('react');
 const fs = require('fs');
 const siteConfig = require(CWD + '/siteConfig.js');
 const translation = require('../../server/translation.js');
+const env = require('../../server/env.js');
 
 const translate = require('../../server/translate.js').translate;
 const setLanguage = require('../../server/translate.js').setLanguage;
 
-const ENABLE_TRANSLATION = fs.existsSync(CWD + '/languages.js');
-const ENABLE_VERSIONING = fs.existsSync(CWD + '/versions.json');
-let versions;
-if (ENABLE_VERSIONING) {
-  versions = require(CWD + '/versions.json');
-}
 const readMetadata = require('../../server/readMetadata.js');
 readMetadata.generateMetadataDocs();
 const Metadata = require('../metadata.js');
@@ -28,26 +23,23 @@ const Metadata = require('../metadata.js');
 // language dropdown nav item for when translations are enabled
 class LanguageDropDown extends React.Component {
   render() {
-    const enabledLanguages = [];
+    if (!env.translation.enabled) {
+      return null;
+    }
+
     let currentLanguage = 'English';
     setLanguage(this.props.language);
     let helpTranslateString = translate(
       'Help Translate|recruit community translators for your project'
     );
     // add all enabled languages to dropdown
-    translation['languages'].map(lang => {
-      if (lang.tag == this.props.language) {
-        currentLanguage = lang.name;
-      }
-      if (lang.tag == this.props.language) {
-        return;
-      }
-      enabledLanguages.push(
+    const enabledLanguages = env.translation.enabledLanguages()
+      .filter(lang => lang !== this.props.language)
+      .map(lang => (
         <li key={lang.tag}>
           <a href={siteConfig.baseUrl + lang.tag}>{lang.name}</a>
         </li>
-      );
-    });
+      ));
     // if no languages are enabled besides English, return null
     if (enabledLanguages.length < 1) {
       return null;
@@ -126,17 +118,11 @@ class HeaderNav extends React.Component {
       );
     } else if (link.doc) {
       // set link to document with current page's language/version
-      let id;
-      if (!ENABLE_VERSIONING || this.props.version === 'next') {
-        id = this.props.language + '-' + link.doc;
-      } else {
-        id =
-          this.props.language +
-          '-version-' +
-          (this.props.version || versions[0]) +
-          '-' +
-          link.doc;
-      }
+      const langPart = env.translation.enabled? this.props.language + '-' : '';
+      const versionPart = (env.translation.enabled && this.props.version !== 'next')
+        ? '-version-' + (this.props.version || env.versioning.latestVersion) + '-'
+        : '';
+      const id = langPart + versionPart + link.doc;
       if (!Metadata[id]) {
         if (id != link.doc) {
           throw new Error(
@@ -153,9 +139,10 @@ class HeaderNav extends React.Component {
       href = this.props.config.baseUrl + Metadata[id].permalink;
     } else if (link.page) {
       // set link to page with current page's language if appropriate
+      const language = this.props.language || '';
       if (fs.existsSync(CWD + '/pages/en/' + link.page + '.js')) {
         href =
-          siteConfig.baseUrl + this.props.language + '/' + link.page + '.html';
+          siteConfig.baseUrl + (language? language + '/' : '') + link.page + '.html';
       } else {
         href = siteConfig.baseUrl + link.page + '.html';
       }
@@ -180,7 +167,7 @@ class HeaderNav extends React.Component {
   render() {
     const versionsLink =
       this.props.baseUrl +
-      (ENABLE_TRANSLATION
+      (env.translation.enabled
         ? this.props.language + '/versions.html'
         : 'versions.html');
     return (
@@ -188,19 +175,17 @@ class HeaderNav extends React.Component {
         <div className="headerWrapper wrapper">
           <header>
             <a href={this.props.baseUrl}>
-              {siteConfig.headerIcon && (
-                <img
-                  className="logo"
-                  src={this.props.baseUrl + siteConfig.headerIcon}
-                />
-              )}
+              <img
+                className="logo"
+                src={this.props.baseUrl + siteConfig.headerIcon}
+              />
               {!this.props.config.disableHeaderTitle && (
                 <h2 className="headerTitle">{this.props.title}</h2>
               )}
             </a>
-            {ENABLE_VERSIONING && (
+            {env.versioning.enabled && (
               <a href={versionsLink}>
-                <h3>{this.props.version || versions[0]}</h3>
+                <h3>{this.props.version || env.versioning.latestVersion}</h3>
               </a>
             )}
             {this.renderResponsiveNav()}

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const CWD = process.cwd();
+const fs = require('fs-extra');
+const path = require('path');
+
+const join = path.join;
+
+const languages_js = join(CWD, 'lanauages.js');
+const translation_js = join(CWD, 'translation.js');
+const versions_json = join(CWD, 'versions.json');
+
+class Translation {
+  constructor() {
+    this.enabled = false;
+    this.languages = [
+      {
+        enabled: true,
+        name: 'English',
+        tag: 'en',
+      },
+    ];
+
+    this._load();
+  }
+
+  enabledLanguages() {
+    return this.languages
+      .filter(lang => lang.enabled);
+  }
+
+  _load() {
+    if (fs.existsSync(languages_js)) {
+      this.enabled = true;
+      this.languages = require(language_js);
+      this.translation = require(translation_js);
+    }
+  }
+};
+
+class Versioning {
+  constructor() {
+    this.enabled = false;
+    this.latestVersion = null;
+    this.versions = [];
+
+    this._load();
+  }
+
+  _load() {
+    if (fs.existsSync(versions_json)) {
+      this.enabled = true;
+      this.versions = JSON.parse(
+        fs.readFileSync(versions_json, 'utf8')
+      );
+      this.latestVersion = this.versions[0];
+    }
+  }
+}
+
+const env = {
+    translation: new Translation(),
+    versioning: new Versioning()
+};
+
+module.exports = env;

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -30,8 +30,7 @@ class Translation {
   }
 
   enabledLanguages() {
-    return this.languages
-      .filter(lang => lang.enabled);
+    return this.languages.filter(lang => lang.enabled);
   }
 
   _load() {
@@ -41,7 +40,7 @@ class Translation {
       this.translation = require(translation_js);
     }
   }
-};
+}
 
 class Versioning {
   constructor() {
@@ -55,17 +54,15 @@ class Versioning {
   _load() {
     if (fs.existsSync(versions_json)) {
       this.enabled = true;
-      this.versions = JSON.parse(
-        fs.readFileSync(versions_json, 'utf8')
-      );
+      this.versions = JSON.parse(fs.readFileSync(versions_json, 'utf8'));
       this.latestVersion = this.versions[0];
     }
   }
 }
 
 const env = {
-    translation: new Translation(),
-    versioning: new Versioning()
+  translation: new Translation(),
+  versioning: new Versioning(),
 };
 
 module.exports = env;

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -72,7 +72,8 @@ function execute() {
   console.log('generate.js triggered...');
 
   // array of tags of enabled languages
-  const enabledLanguages = env.translation.enabledLanguages()
+  const enabledLanguages = env.translation
+    .enabledLanguages()
     .map(lang => lang.tag);
 
   readMetadata.generateMetadataDocs();
@@ -185,7 +186,10 @@ function execute() {
     writeFileAndCreateFolder(targetFile, str);
 
     // generate english page redirects when languages are enabled
-    if (env.translation.enabled && metadata.permalink.indexOf('docs/en') !== -1) {
+    if (
+      env.translation.enabled &&
+      metadata.permalink.indexOf('docs/en') !== -1
+    ) {
       const redirectComp = (
         <Redirect
           metadata={metadata}
@@ -429,10 +433,7 @@ function execute() {
             <ReactComp language={language} />
           </Site>
         );
-        writeFileAndCreateFolder(
-          targetFile.replace('/en/', '/'),
-          str
-        );
+        writeFileAndCreateFolder(targetFile.replace('/en/', '/'), str);
       } else {
         // allow for rendering of other files not in pages/en folder
         let language = '';
@@ -442,10 +443,7 @@ function execute() {
             <ReactComp language={language} />
           </Site>
         );
-        writeFileAndCreateFolder(
-          targetFile.replace('/en/', '/'),
-          str
-        );
+        writeFileAndCreateFolder(targetFile.replace('/en/', '/'), str);
       }
       fs.removeSync(tempFile);
     } else if (!fs.lstatSync(file).isDirectory()) {

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -20,30 +20,15 @@ function execute() {
   const glob = require('glob');
   const chalk = require('chalk');
   const Site = require('../core/Site.js');
+  const env = require('./env.js');
   const siteConfig = require(CWD + '/siteConfig.js');
   const translate = require('./translate.js');
-  const versionFallback = require('./versionFallback.js');
 
   const feed = require('./feed.js');
   const sitemap = require('./sitemap.js');
 
   const join = path.join;
 
-  const ENABLE_TRANSLATION = fs.existsSync(join(CWD, 'languages.js'));
-  const ENABLE_VERSIONING = fs.existsSync(join(CWD, 'versions.json'));
-
-  let languages;
-  if (ENABLE_TRANSLATION) {
-    languages = require(CWD + '/languages.js');
-  } else {
-    languages = [
-      {
-        enabled: true,
-        name: 'English',
-        tag: 'en',
-      },
-    ];
-  }
   // create the folder path for a file if it does not exist, then write the file
   function writeFileAndCreateFolder(file, content) {
     mkdirp.sync(file.replace(new RegExp('/[^/]*$'), ''));
@@ -87,10 +72,8 @@ function execute() {
   console.log('generate.js triggered...');
 
   // array of tags of enabled languages
-  const enabledLanguages = [];
-  languages.filter(lang => lang.enabled).map(lang => {
-    enabledLanguages.push(lang.tag);
-  });
+  const enabledLanguages = env.translation.enabledLanguages()
+    .map(lang => lang.tag);
 
   readMetadata.generateMetadataDocs();
   const Metadata = require('../core/metadata.js');
@@ -134,7 +117,7 @@ function execute() {
     // determine what file to use according to its id
     let file;
     if (metadata.original_id) {
-      if (ENABLE_TRANSLATION && metadata.language !== 'en') {
+      if (env.translation.enabled && metadata.language !== 'en') {
         file = join(CWD, 'translated_docs', metadata.language, metadata.source);
       } else {
         file = join(CWD, 'versioned_docs', metadata.source);
@@ -161,12 +144,7 @@ function execute() {
       rawContent = insertTableOfContents(rawContent);
     }
 
-    let latestVersion;
-    if (ENABLE_VERSIONING) {
-      latestVersion = JSON.parse(
-        fs.readFileSync(join(CWD, 'versions.json'), 'utf8')
-      )[0];
-    }
+    let latestVersion = env.versioning.latestVersion;
 
     // replace any links to markdown files to their website html links
     Object.keys(mdToHtml).forEach(function(key, index) {
@@ -207,7 +185,7 @@ function execute() {
     writeFileAndCreateFolder(targetFile, str);
 
     // generate english page redirects when languages are enabled
-    if (ENABLE_TRANSLATION && metadata.permalink.indexOf('docs/en') !== -1) {
+    if (env.translation.enabled && metadata.permalink.indexOf('docs/en') !== -1) {
       const redirectComp = (
         <Redirect
           metadata={metadata}
@@ -443,21 +421,31 @@ function execute() {
             str
           );
         }
+
+        // write to base level
+        let language = '';
+        const str = renderToStaticMarkup(
+          <Site language={language} config={siteConfig}>
+            <ReactComp language={language} />
+          </Site>
+        );
+        writeFileAndCreateFolder(
+          targetFile.replace('/en/', '/'),
+          str
+        );
       } else {
         // allow for rendering of other files not in pages/en folder
-        let language = 'en';
-        for (let i = 0; i < langParts.length; i++) {
-          if (enabledLanguages.indexOf(langParts[i]) !== -1) {
-            language = langParts[i];
-          }
-        }
+        let language = '';
         translate.setLanguage(language);
         const str = renderToStaticMarkup(
           <Site language={language} config={siteConfig}>
             <ReactComp language={language} />
           </Site>
         );
-        writeFileAndCreateFolder(targetFile, str);
+        writeFileAndCreateFolder(
+          targetFile.replace('/en/', '/'),
+          str
+        );
       }
       fs.removeSync(tempFile);
     } else if (!fs.lstatSync(file).isDirectory()) {
@@ -465,15 +453,6 @@ function execute() {
       let parts = file.split('pages');
       let targetFile = join(buildDir, parts[1]);
       mkdirp.sync(targetFile.replace(new RegExp('/[^/]*$'), ''));
-      fs.copySync(file, targetFile);
-    }
-  });
-
-  // copy html files in 'en' to base level as well
-  files = glob.sync(join(buildDir, 'en', '**'));
-  files.forEach(file => {
-    let targetFile = file.replace(join(buildDir, 'en'), join(buildDir));
-    if (file.match(/\.html$/)) {
       fs.copySync(file, targetFile);
     }
   });

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -116,7 +116,7 @@ function processMetadata(file) {
   );
 
   const match = regexSubFolder.exec(file);
-  let language = match? match[1] : 'en';
+  let language = match ? match[1] : 'en';
 
   const metadata = result.metadata;
   const rawContent = result.rawContent;
@@ -132,7 +132,7 @@ function processMetadata(file) {
     metadata.title = metadata.id;
   }
 
-  const langPart = env.translation.endabled? language + '/' : '';
+  const langPart = env.translation.endabled ? language + '/' : '';
   let versionPart = '';
   if (env.versioning.enabled) {
     metadata.version = 'next';
@@ -143,8 +143,8 @@ function processMetadata(file) {
 
   // change ids previous, next
   metadata.localized_id = metadata.id;
-  metadata.id = (env.translation.enabled? language + '-' : '')  + metadata.id;
-  metadata.language = env.translation.enabled? language : 'en';
+  metadata.id = (env.translation.enabled ? language + '-' : '') + metadata.id;
+  metadata.language = env.translation.enabled ? language : 'en';
 
   const order = readSidebar();
   const id = metadata.localized_id;
@@ -155,11 +155,13 @@ function processMetadata(file) {
 
     if (order[id].next) {
       metadata.next_id = order[id].next;
-      metadata.next = (env.translation.enabled? language + '-' : '') + order[id].next;
+      metadata.next =
+        (env.translation.enabled ? language + '-' : '') + order[id].next;
     }
     if (order[id].previous) {
       metadata.previous_id = order[id].previous;
-      metadata.previous = (env.translation.enabled? language + '-' : '') + order[id].previous;
+      metadata.previous =
+        (env.translation.enabled ? language + '-' : '') + order[id].previous;
     }
   }
 
@@ -180,7 +182,8 @@ function generateMetadataDocs() {
 
   const regexSubFolder = /translated_docs\/(.*)\/.*/;
 
-  const enabledLanguages = env.translation.enabledLanguages()
+  const enabledLanguages = env.translation
+    .enabledLanguages()
     .map(language => language.tag);
 
   const metadatas = {};

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -68,7 +68,8 @@ function readSidebar() {
 
 // split markdown header
 function splitHeader(content) {
-  const lines = content.split('\n');
+  // New line characters need to handle all operating systems.
+  const lines = content.split(/\r?\n/);
   if (lines[0] !== '---') {
     return {};
   }
@@ -132,7 +133,8 @@ function processMetadata(file) {
     metadata.title = metadata.id;
   }
 
-  const langPart = env.translation.endabled ? language + '/' : '';
+  const langPart =
+    env.translation.endabled || siteConfig.useEnglishUrl ? language + '/' : '';
   let versionPart = '';
   if (env.versioning.enabled) {
     metadata.version = 'next';
@@ -170,8 +172,6 @@ function processMetadata(file) {
 
 // process metadata for all docs and save into core/metadata.js
 function generateMetadataDocs() {
-  console.log('Generating Metadata for Docs....');
-
   let order;
   try {
     order = readSidebar();
@@ -322,13 +322,6 @@ function generateMetadataBlog() {
   const metadatas = [];
 
   let files = glob.sync(CWD + '/blog/**/*.*');
-  if (!files || files.length == 0) {
-    console.error(
-      `${chalk.yellow(
-        CWD + '/blog/ appears to be empty'
-      )} Make sure you've put your blog files in your Docusaurus 'website' folder.`
-    );
-  }
   files
     .sort()
     .reverse()

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -11,24 +11,11 @@ const path = require('path');
 const fs = require('fs');
 const glob = require('glob');
 const chalk = require('chalk');
+
+const env = require('./env');
 const siteConfig = require(CWD + '/siteConfig.js');
 const versionFallback = require('./versionFallback.js');
 const escapeStringRegexp = require('escape-string-regexp');
-
-const ENABLE_VERSIONING = fs.existsSync(CWD + '/versions.json');
-
-let languages;
-if (fs.existsSync(CWD + '/languages.js')) {
-  languages = require(CWD + '/languages.js');
-} else {
-  languages = [
-    {
-      enabled: true,
-      name: 'English',
-      tag: 'en',
-    },
-  ];
-}
 
 // Can have a custom docs path. Top level folder still needs to be in directory
 // at the same level as `website`, not inside `website`.
@@ -81,8 +68,7 @@ function readSidebar() {
 
 // split markdown header
 function splitHeader(content) {
-  // New line characters need to handle all operating systems.
-  const lines = content.split(/\r?\n/);
+  const lines = content.split('\n');
   if (lines[0] !== '---') {
     return {};
   }
@@ -129,11 +115,8 @@ function processMetadata(file) {
     '/' + escapeStringRegexp(getDocsPath()) + '/(.*)/.*/'
   );
 
-  let language = 'en';
   const match = regexSubFolder.exec(file);
-  if (match) {
-    language = match[1];
-  }
+  let language = match? match[1] : 'en';
 
   const metadata = result.metadata;
   const rawContent = result.rawContent;
@@ -149,28 +132,19 @@ function processMetadata(file) {
     metadata.title = metadata.id;
   }
 
-  if (languages.length === 1 && !siteConfig.useEnglishUrl) {
-    metadata.permalink = 'docs/' + metadata.id + '.html';
-  } else {
-    metadata.permalink = 'docs/' + language + '/' + metadata.id + '.html';
+  const langPart = env.translation.endabled? language + '/' : '';
+  let versionPart = '';
+  if (env.versioning.enabled) {
+    metadata.version = 'next';
+    versionPart = 'next/';
   }
 
-  if (ENABLE_VERSIONING) {
-    metadata.version = 'next';
-    if (languages.length === 1 && !siteConfig.useEnglishUrl) {
-      metadata.permalink = metadata.permalink.replace('docs/', 'docs/next/');
-    } else {
-      metadata.permalink = metadata.permalink.replace(
-        'docs/' + language + '/',
-        'docs/' + language + '/next/'
-      );
-    }
-  }
+  metadata.permalink = 'docs/' + langPart + versionPart + metadata.id + '.html';
 
   // change ids previous, next
   metadata.localized_id = metadata.id;
-  metadata.id = language + '-' + metadata.id;
-  metadata.language = language;
+  metadata.id = (env.translation.enabled? language + '-' : '')  + metadata.id;
+  metadata.language = env.translation.enabled? language : 'en';
 
   const order = readSidebar();
   const id = metadata.localized_id;
@@ -181,11 +155,11 @@ function processMetadata(file) {
 
     if (order[id].next) {
       metadata.next_id = order[id].next;
-      metadata.next = language + '-' + order[id].next;
+      metadata.next = (env.translation.enabled? language + '-' : '') + order[id].next;
     }
     if (order[id].previous) {
       metadata.previous_id = order[id].previous;
-      metadata.previous = language + '-' + order[id].previous;
+      metadata.previous = (env.translation.enabled? language + '-' : '') + order[id].previous;
     }
   }
 
@@ -194,6 +168,8 @@ function processMetadata(file) {
 
 // process metadata for all docs and save into core/metadata.js
 function generateMetadataDocs() {
+  console.log('Generating Metadata for Docs....');
+
   let order;
   try {
     order = readSidebar();
@@ -204,10 +180,8 @@ function generateMetadataDocs() {
 
   const regexSubFolder = /translated_docs\/(.*)\/.*/;
 
-  const enabledLanguages = [];
-  languages.filter(lang => lang.enabled).map(lang => {
-    enabledLanguages.push(lang.tag);
-  });
+  const enabledLanguages = env.translation.enabledLanguages()
+    .map(language => language.tag);
 
   const metadatas = {};
   const defaultMetadatas = {};
@@ -345,6 +319,13 @@ function generateMetadataBlog() {
   const metadatas = [];
 
   let files = glob.sync(CWD + '/blog/**/*.*');
+  if (!files || files.length == 0) {
+    console.error(
+      `${chalk.yellow(
+        CWD + '/blog/ appears to be empty'
+      )} Make sure you've put your blog files in your Docusaurus 'website' folder.`
+    );
+  }
   files
     .sort()
     .reverse()

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -134,7 +134,7 @@ function processMetadata(file) {
   }
 
   const langPart =
-    env.translation.endabled || siteConfig.useEnglishUrl ? language + '/' : '';
+    env.translation.enabled || siteConfig.useEnglishUrl ? language + '/' : '';
   let versionPart = '';
   if (env.versioning.enabled) {
     metadata.version = 'next';

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -382,7 +382,8 @@ function execute(port) {
     const regexLang = /(.*)\/.*\.html$/;
     const match = regexLang.exec(req.path);
     const parts = match[1].split('/');
-    const enabledLangTags = env.translation.enabledLanguages()
+    const enabledLangTags = env.translation
+      .enabledLanguages()
       .map(lang => lang.tag);
 
     for (let i = 0; i < parts.length; i++) {

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -9,6 +9,7 @@
 function execute(port) {
   const extractTranslations = require('../write-translations.js');
 
+  const env = require('./env.js');
   const translation = require('./translation.js');
   const express = require('express');
   const React = require('react');
@@ -23,15 +24,12 @@ function execute(port) {
   const glob = require('glob');
   const chalk = require('chalk');
   const translate = require('./translate.js');
-  const versionFallback = require('./versionFallback');
 
   const feed = require('./feed.js');
   const sitemap = require('./sitemap.js');
   // const sitemap = require("sitemap");
 
   const CWD = process.cwd();
-  const ENABLE_TRANSLATION = fs.existsSync(CWD + '/languages.js');
-  const ENABLE_VERSIONING = fs.existsSync(CWD + '/versions.json');
 
   // remove a module and child modules from require cache, so server does not have
   // to be restarted
@@ -122,6 +120,8 @@ function execute(port) {
 
   /****************************************************************************/
 
+  console.log('server.js triggered...');
+
   reloadMetadata();
   reloadMetadataBlog();
   extractTranslations();
@@ -168,14 +168,14 @@ function execute(port) {
     // determine what file to use according to its id
     let file;
     if (metadata.original_id) {
-      if (ENABLE_TRANSLATION && metadata.language !== 'en') {
+      if (env.translation.enabled && metadata.language !== 'en') {
         file =
           CWD + '/translated_docs/' + metadata.language + '/' + metadata.source;
       } else {
         file = CWD + '/versioned_docs/' + metadata.source;
       }
     } else {
-      if (metadata.language === 'en') {
+      if (!env.translation.enabled || metadata.language === 'en') {
         file =
           CWD + '/../' + readMetadata.getDocsPath() + '/' + metadata.source;
       } else {
@@ -197,12 +197,7 @@ function execute(port) {
       rawContent = insertTableOfContents(rawContent);
     }
 
-    let latestVersion;
-    if (ENABLE_VERSIONING) {
-      latestVersion = JSON.parse(
-        fs.readFileSync(CWD + '/versions.json', 'utf8')
-      )[0];
-    }
+    let latestVersion = env.latestVersion;
 
     // replace any links to markdown files to their website html links
     Object.keys(mdToHtml).forEach(function(key, index) {
@@ -383,21 +378,20 @@ function execute(port) {
     file = file.replace(siteConfig.baseUrl, '');
     let userFile = CWD + '/pages/' + file;
 
-    let language = 'en';
+    let language = '';
     const regexLang = /(.*)\/.*\.html$/;
     const match = regexLang.exec(req.path);
     const parts = match[1].split('/');
-    const enabledLangTags = [];
-    for (let i = 0; i < translation['languages'].length; i++) {
-      enabledLangTags.push(translation['languages'][i].tag);
-    }
+    const enabledLangTags = env.translation.enabledLanguages()
+      .map(lang => lang.tag);
+
     for (let i = 0; i < parts.length; i++) {
       if (enabledLangTags.indexOf(parts[i]) !== -1) {
         language = parts[i];
       }
     }
     let englishFile = CWD + '/pages/' + file;
-    if (language !== 'en') {
+    if (language && language !== 'en') {
       englishFile = englishFile.replace('/' + language + '/', '/en/');
     }
 
@@ -523,6 +517,7 @@ function execute(port) {
   });
 
   app.listen(port);
+  console.log('listening on port: ' + port);
   console.log('Open http://localhost:' + port + '/');
 }
 

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -120,8 +120,6 @@ function execute(port) {
 
   /****************************************************************************/
 
-  console.log('server.js triggered...');
-
   reloadMetadata();
   reloadMetadataBlog();
   extractTranslations();
@@ -518,7 +516,6 @@ function execute(port) {
   });
 
   app.listen(port);
-  console.log('listening on port: ' + port);
   console.log('Open http://localhost:' + port + '/');
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This is to fix https://github.com/facebook/Docusaurus/issues/305

The root cause of the problem is using 'en' as default language regardless of translation enabled or not.

However 'en' and no translation are two different cases. The fix has two major parts:

1) Components. Basically use empty `language` property as an indication of no translation.
2) Template generation. Basically handle the case of no translation.
For readability I've created a new file `env.js` which encapsulate simple translation and versioning logic. So other places can just call `env.translation.enabled` to check.

I try to keep the changes minimal but sill has to modify quite a few files.

## Test Plan

I've tested run server and generate locally.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
