### PR TITLE
Switch to rsync package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,6 @@ jobs:
               echo "machine github.com login facebook-github-bot" > ~/.netrc
             fi
       - run:
-          name: Install Dependencies
-          command: sudo apt install rsync
-      - run:
           name: Deploy Website
           command: |
             if [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -118,7 +118,6 @@ excludePath = `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`;
 // need to copy directories like .circleci, for example
 // https://github.com/shelljs/shelljs/issues/79
 const rsync = new Rsync()
-  // .shell('ssh')
   .flags('rt')
   .exclude(excludePath)
   .exclude('.DS_Store')

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -7,8 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const shell = require('shelljs');
 const path = require('path');
+const Rsync = require('rsync');
+const shell = require('shelljs');
 
 if (!shell.which('git')) {
   shell.echo('Sorry, this script requires git');
@@ -116,30 +117,37 @@ excludePath = `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`;
 // cannot use shell.cp because it doesn't support copying dotfiles and we
 // need to copy directories like .circleci, for example
 // https://github.com/shelljs/shelljs/issues/79
-if (
-  shell.exec(
-    `rsync -rt --exclude=${excludePath} --exclude=.DS_Store ${fromPath} ${toPath}`
-  ).code !== 0
-) {
-  shell.echo(`Error: Copying build assets failed`);
-  shell.exit(1);
-}
+const rsync = new Rsync()
+  // .shell('ssh')
+  .flags('rt')
+  .exclude(excludePath)
+  .exclude('.DS_Store')
+  .source(fromPath)
+  .destination(toPath);
 
-shell.cd(path.join('build', `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`));
+rsync.execute((error, code, cmd) => {
+  if (code !== 0) {
+    shell.echo(`Error: Copying build assets failed`);
+    shell.exit(1);
+  } else {
+    shell.cd(path.join('build', `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`));
 
-const currentCommit = shell.exec('git rev-parse HEAD').stdout.trim();
+    const currentCommit = shell.exec('git rev-parse HEAD').stdout.trim();
 
-shell.exec('git add --all');
+    shell.exec('git add --all');
 
-shell.exec(
-  `git commit -m "Deploy website" -m "Deploy website version based on ${currentCommit}"`
-);
-if (shell.exec(`git push origin ${DEPLOYMENT_BRANCH}`).code !== 0) {
-  shell.echo('Error: Git push failed');
-  shell.exit(1);
-} else {
-  shell.echo(
-    `Website is live at: https://${ORGANIZATION_NAME}.github.io/${PROJECT_PATH}`
-  );
-  shell.exit(0);
-}
+    const commitResults = shell.exec(
+      `git commit -m "Deploy website" -m "Deploy website version based on ${currentCommit}"`
+    );
+    if (shell.exec(`git push origin ${DEPLOYMENT_BRANCH}`).code !== 0) {
+      shell.echo('Error: Git push failed');
+      shell.exit(1);
+    } else if (commitResults.code === 0) {
+      // The commit might return a non-zero value when site is up to date.
+      shell.echo(
+        `Website is live at: https://${ORGANIZATION_NAME}.github.io/${PROJECT_PATH}`
+      );
+      shell.exit(0);
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom-factories": "^1.0.1",
     "remarkable": "^1.7.1",
     "request": "^2.81.0",
+    "rsync": "^0.6.1",
     "shelljs": "^0.7.8",
     "sitemap": "^1.13.0",
     "tcp-port-used": "^0.1.2"
@@ -60,11 +61,11 @@
     "docusaurus-feed": "./lib/generate-feed.js"
   },
   "devDependencies": {
-    "prettier": "^1.9.1",
     "filepath": "^1.1.0",
     "front-matter": "^2.3.0",
     "glob-promise": "^3.3.0",
     "jest": "^21.2.1",
+    "prettier": "^1.9.1",
     "rimraf": "^2.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,6 +2953,10 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@^2.6.2:
   dependencies:
     glob "^7.0.5"
 
+rsync@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/rsync/-/rsync-0.6.1.tgz#3681a0098bd8750448f8bf9da1fee09f7763742b"
+
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"


### PR DESCRIPTION
This removes the need to install rsync natively in CI.

Otherwise, clients will need to ensure their build systems have rsync installed.

# Test Plan

```
$ node ../lib/publish-gh-pages.js
```

Confirm `Docusaurus-gh-pages` is created and dot files are preserved.

![screen shot 2017-12-19 at 10 25 14 am](https://user-images.githubusercontent.com/165856/34172543-43c0fa0e-e4a7-11e7-8c97-642aa05cc767.png)
