### PR TITLE
Switch rsync for fs-extra

### DIFF
--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -7,8 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const fs = require('fs-extra');
 const path = require('path');
-const Rsync = require('rsync');
 const shell = require('shelljs');
 
 if (!shell.which('git')) {
@@ -114,23 +114,29 @@ toPath = path.join('build', `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`);
 // In github.io case, project is deployed to root. Need to not recursively
 // copy the deployment-branch to be.
 excludePath = `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`;
+
 // cannot use shell.cp because it doesn't support copying dotfiles and we
 // need to copy directories like .circleci, for example
 // https://github.com/shelljs/shelljs/issues/79
-const rsync = new Rsync()
-  .flags('rt')
-  .exclude(excludePath)
-  .exclude('.DS_Store')
-  .source(fromPath)
-  .destination(toPath);
+fs.copy(
+  fromPath,
+  toPath,
+  (src, dest) => {
+    if (src.indexOf('.DS_Store') !== -1) {
+      return false;
+    }
+    if (src.indexOf(excludePath) !== -1) {
+      return false;
+    }
 
-rsync.execute((error, code, cmd) => {
-  if (code !== 0) {
-    shell.echo(
-      `Error: Copying build assets failed with code ${code} and error '${error}'`
-    );
-    shell.exit(1);
-  } else {
+    return true;
+  },
+  error => {
+    if (error) {
+      shell.echo(`Error: Copying build assets failed with error '${error}'`);
+      shell.exit(1);
+    }
+
     shell.cd(path.join('build', `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`));
 
     const currentCommit = shell.exec('git rev-parse HEAD').stdout.trim();
@@ -151,4 +157,4 @@ rsync.execute((error, code, cmd) => {
       shell.exit(0);
     }
   }
-});
+);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "escape-string-regexp": "^1.0.5",
     "express": "^4.15.3",
     "feed": "^1.1.0",
-    "fs-extra": "^3.0.1",
+    "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
     "highlight.js": "^9.12.0",
     "react": "^15.5.4",
@@ -45,7 +45,6 @@
     "react-dom-factories": "^1.0.1",
     "remarkable": "^1.7.1",
     "request": "^2.81.0",
-    "rsync": "^0.6.1",
     "shelljs": "^0.7.8",
     "sitemap": "^1.13.0",
     "tcp-port-used": "^0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,12 +1423,12 @@ front-matter@^2.3.0:
   dependencies:
     js-yaml "^3.10.0"
 
-fs-extra@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
+    jsonfile "^4.0.0"
     universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
@@ -2173,9 +2173,9 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -2952,10 +2952,6 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@^2.6.2:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
-
-rsync@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/rsync/-/rsync-0.6.1.tgz#3681a0098bd8750448f8bf9da1fee09f7763742b"
 
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"


### PR DESCRIPTION
Turns out the rsync package still requires rsync to be available locally. We can just use fs.copy here, which does not have shell.cp's issue with dot files.

Test Plan:

Ran publish script, confirmed .circleci files are published, without pushing .DS_Store files.