### PR TITLE
No need for chromeframe tag

### DIFF
--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -27,7 +27,7 @@ class Head extends React.Component {
     return (
       <head>
         <meta charSet="utf-8" />
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge, chrome=1" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         <title>{this.props.title}</title>
         <meta name="viewport" content="width=device-width" />
         <meta name="generator" content="Docusaurus" />


### PR DESCRIPTION
Remove the unneeded chromeframe tag, it has long since been retired by Google and was only ever needed for very old IE (would render the page in Chrome within IE).
REF: http://www.chromium.org/developers/how-tos/chrome-frame-getting-started

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
