### PR TITLE
Guard against lack of `layouts` in siteConfig.js

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -229,7 +229,10 @@ function execute(port) {
     const DocsLayout = require('../core/DocsLayout.js');
 
     let Doc;
-    if (metadata.layout && siteConfig.layouts[metadata.layout]) {
+    if (
+      metadata.layout && siteConfig.layouts &&
+      siteConfig.layouts[metadata.layout]
+    ) {
       Doc = siteConfig.layouts[metadata.layout]({
         React,
         MarkdownBlock: require('../core/MarkdownBlock.js'),


### PR DESCRIPTION
If a document states a `layout` in its header but `layouts` doesn't exist in `siteConfig.js` the doc would not render.

I tested by having a `layout` entry in a doc header and no `layouts` entry in `siteConfig.js`, made sure the document loaded.