### PR TITLE
Versioning ids should be based on whether translation is enabled

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -126,8 +126,7 @@ class HeaderNav extends React.Component {
         : '';
       const versionPart =
         env.versioning.enabled && this.props.version !== 'next'
-          ? (this.props.language || 'en') +
-            '-version-' +
+          ? 'version-' +
             (this.props.version || env.versioning.latestVersion) +
             '-'
           : '';

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -272,15 +272,18 @@ function generateMetadataDocs() {
           'version-' + metadata.version + '-',
           ''
         );
-        metadata.next = (env.translation.enabled ? metadata.language + '-' : '') + order[id].next;
+        metadata.next =
+          (env.translation.enabled ? metadata.language + '-' : '') +
+          order[id].next;
       }
       if (order[id].previous) {
         metadata.previous_id = order[id].previous.replace(
           'version-' + metadata.version + '-',
           ''
         );
-        metadata.previous = (env.translation.enabled ? metadata.language + '-' : '') + order[id].previous;
-
+        metadata.previous =
+          (env.translation.enabled ? metadata.language + '-' : '') +
+          order[id].previous;
       }
     }
     metadatas[metadata.id] = metadata;

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 const glob = require('glob');
 const chalk = require('chalk');
 
-const env = require('./env');
+const env = require('./env.js');
 const siteConfig = require(CWD + '/siteConfig.js');
 const versionFallback = require('./versionFallback.js');
 const escapeStringRegexp = require('escape-string-regexp');
@@ -272,14 +272,15 @@ function generateMetadataDocs() {
           'version-' + metadata.version + '-',
           ''
         );
-        metadata.next = metadata.language + '-' + order[id].next;
+        metadata.next = (env.translation.enabled ? metadata.language + '-' : '') + order[id].next;
       }
       if (order[id].previous) {
         metadata.previous_id = order[id].previous.replace(
           'version-' + metadata.version + '-',
           ''
         );
-        metadata.previous = metadata.language + '-' + order[id].previous;
+        metadata.previous = (env.translation.enabled ? metadata.language + '-' : '') + order[id].previous;
+
       }
     }
     metadatas[metadata.id] = metadata;

--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
+const env = require('./env.js');
 const siteConfig = require(CWD + '/siteConfig.js');
 
 const ENABLE_TRANSLATION = fs.existsSync(CWD + '/languages.js');
@@ -212,7 +213,7 @@ function processVersionMetadata(file, version, useVersion, language) {
     'version-' + version + '-'
   );
   metadata.localized_id = metadata.id;
-  metadata.id = language + '-' + metadata.id;
+  metadata.id = (env.translation.enabled ? language + '-' : '') + metadata.id;
   metadata.language = language;
   metadata.version = version;
 


### PR DESCRIPTION
Ref: ff117979c69e7bbe8c0c3286c15970a1a0854bba and a5e963dba134bf0f6a83908d49cd59ce06704cb3

## Motivation

Versioning ids should be based on whether translation is enabled. 

## Test Plan

Tested locally on:

Docusaurus
Relay (which has versioning)
Test site from `npm run examples`

## Related PRs

Ref: ff117979c69e7bbe8c0c3286c15970a1a0854bba and a5e963dba134bf0f6a83908d49cd59ce06704cb3
