### PR TITLE
Better error when parsing headerLinks.doc fields

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -133,17 +133,25 @@ class HeaderNav extends React.Component {
           : '';
       const id = langPart + versionPart + link.doc;
       if (!Metadata[id]) {
-        if (id != link.doc) {
-          throw new Error(
-            "It looks like you've enabled language support, but haven't provided translated files. The document with id: '" +
-              id +
-              "' doesn't exist."
-          );
+        let errorStr =
+          "Processing the following `doc` field in `headerLinks` within `siteConfig.js`: '" +
+          link.doc +
+          "'";
+        if (id === link.doc) {
+          errorStr +=
+            ' It looks like there is no document with that id that exists in your docs directory. Please double check the spelling of your `doc` field and the `id` fields of your docs.';
+        } else {
+          errorStr +=
+            '. Check the spelling of your `doc` field. If that seems sane, and a document in your docs folder exists with that `id` value, \nthen this is likely a bug in Docusaurus.' +
+            ' Docusaurus thinks one or both of translations (currently set to: ' +
+            env.translation.enabled +
+            ') or versioning (currently set to: ' +
+            env.versioning.enabled +
+            ") is enabled when maybe they should not be. \nThus my internal id for this doc is: '" +
+            id +
+            "'.";
         }
-        throw new Error(
-          'A headerLink is specified with a document that does not exist. No document exists with id: ' +
-            link.doc
-        );
+        throw new Error(errorStr);
       }
       href = this.props.config.baseUrl + Metadata[id].permalink;
     } else if (link.page) {

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -149,7 +149,7 @@ class HeaderNav extends React.Component {
             env.versioning.enabled +
             ") is enabled when maybe they should not be. \nThus my internal id for this doc is: '" +
             id +
-            "'.";
+            "'. Please file an issue for this possible bug on GitHub.";
         }
         throw new Error(errorStr);
       }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -91,7 +91,7 @@ const siteConfig = {
   users,
   editUrl: 'https://github.com/facebook/docusaurus/edit/master/docs/',
   headerLinks: [
-    {doc: 'installsation', label: 'Docs'},
+    {doc: 'installation', label: 'Docs'},
     {page: 'help', label: 'Help'},
     {page: 'about-slash', label: 'About /'},
     {blog: true, label: 'Blog'},

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -91,7 +91,7 @@ const siteConfig = {
   users,
   editUrl: 'https://github.com/facebook/docusaurus/edit/master/docs/',
   headerLinks: [
-    {doc: 'installation', label: 'Docs'},
+    {doc: 'installsation', label: 'Docs'},
     {page: 'help', label: 'Help'},
     {page: 'about-slash', label: 'About /'},
     {blog: true, label: 'Blog'},


### PR DESCRIPTION
Closes #309

## Motivation

Many people thought the current message was too cryptic. I agree. And it could be misleading.

## Test Plan

Tested locally on the Docusaurus site (which has translations) and the testsite that comes with the initialization script (which does not have versioning or translations).

## Related PRs

None
