### PR TITLE
Ignore and warn about unsupported header fields

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -18,8 +18,13 @@ const versionFallback = require('./versionFallback.js');
 const escapeStringRegexp = require('escape-string-regexp');
 
 const SupportedHeaderFields = new Set([
-  'id', 'title', 'author', 'authorURL', 'authorFBID',
-  'sidebar_label', 'original_id',
+  'id', 
+  'title', 
+  'author', 
+  'authorURL', 
+  'authorFBID',
+  'sidebar_label', 
+  'original_id',
 ]);
 
 // Can have a custom docs path. Top level folder still needs to be in directory

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -22,7 +22,7 @@ const SupportedHeaderFields = new Set([
   'title',
   'author',
   'authorURL',
-  'authorFBID'
+  'authorFBID',
   'sidebar_label',
   'original_id',
 ]);

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -17,6 +17,11 @@ const siteConfig = require(CWD + '/siteConfig.js');
 const versionFallback = require('./versionFallback.js');
 const escapeStringRegexp = require('escape-string-regexp');
 
+const SupportedHeaderFields = new Set([
+  'id', 'title', 'author', 'authorURL', 'authorFBID',
+  'sidebar_label', 'original_id',
+]);
+
 // Can have a custom docs path. Top level folder still needs to be in directory
 // at the same level as `website`, not inside `website`.
 //   e.g., docs/whereDocsReallyExist
@@ -119,7 +124,15 @@ function processMetadata(file) {
   const match = regexSubFolder.exec(file);
   let language = match ? match[1] : 'en';
 
-  const metadata = result.metadata;
+  const metadata = {};
+  for (const fieldName of Object.keys(result.metadata)) {
+    if (SupportedHeaderFields.has(fieldName)) {
+      metadata[fieldName] = result.metadata[fieldName];
+    } else {
+      console.warn(`Header field "${fieldName}" in ${file} is not supported.`);
+    }
+  }
+
   const rawContent = result.rawContent;
   metadata.source = path.basename(file);
 

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -18,12 +18,12 @@ const versionFallback = require('./versionFallback.js');
 const escapeStringRegexp = require('escape-string-regexp');
 
 const SupportedHeaderFields = new Set([
-  'id', 
-  'title', 
-  'author', 
-  'authorURL', 
-  'authorFBID',
-  'sidebar_label', 
+  'id',
+  'title',
+  'author',
+  'authorURL',
+  'authorFBID'
+  'sidebar_label',
   'original_id',
 ]);
 


### PR DESCRIPTION
Unsupported header fields might mess up the creation of metadata.js (e.g.: next).
Skip unknown header fields and log a warn about them.

I believe these are all the supported fields at the moment?