### PR TITLE
Added support for anchors on sidebar

### DIFF
--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -108,6 +108,9 @@ class SideNav extends React.Component {
       </li>
     );
   }
+  getAnchors(metadata){
+    return metadata.anchors ? metadata.anchors : [];
+  }
   renderItemLink(link) {
     const itemClasses = classNames('navListItem', {
       navListItemActive: link.id === this.props.current.id,
@@ -121,7 +124,7 @@ class SideNav extends React.Component {
           {this.getLocalizedString(link)}
         </a>
         <ul className="navAnchors">
-          {link.anchors.map(
+          {this.getAnchors(link).map(
             anchor => this.renderItemAnchors(anchor, link),
             this
           )}

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -108,7 +108,7 @@ class SideNav extends React.Component {
       </li>
     );
   }
-  getAnchors(metadata){
+  getAnchors(metadata) {
     return metadata.anchors ? metadata.anchors : [];
   }
   renderItemLink(link) {

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -92,6 +92,22 @@ class SideNav extends React.Component {
     }
     return null;
   }
+  renderItemAnchors(anchor, link) {
+    const itemClasses = classNames('navAnchorItem', {
+      navListItemActive: link.id === this.props.current.id,
+    });
+    const linkClasses = classNames('navAnchor', {
+      navItemActive: link.id === this.props.current.id,
+    });
+    const href = this.getLink(link) + '#' + anchor;
+    return (
+      <li className={itemClasses} key={link.id}>
+        <a className={linkClasses} href={href}>
+          {anchor}
+        </a>
+      </li>
+    );
+  }
   renderItemLink(link) {
     const itemClasses = classNames('navListItem', {
       navListItemActive: link.id === this.props.current.id,
@@ -104,6 +120,12 @@ class SideNav extends React.Component {
         <a className={linkClasses} href={this.getLink(link)}>
           {this.getLocalizedString(link)}
         </a>
+        <ul className="navAnchors">
+          {link.anchors.map(
+            anchor => this.renderItemAnchors(anchor, link),
+            this
+          )}
+        </ul>
       </li>
     );
   }

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -43,9 +43,24 @@ function readSidebar() {
 
     let ids = [];
     let categoryOrder = [];
+    let categoryAnchors = {};
     Object.keys(categories).forEach(category => {
-      ids = ids.concat(categories[category]);
-      for (let i = 0; i < categories[category].length; i++) {
+      let currentCategories;
+      if (Array.isArray(categories[category])) {
+        currentCategories = categories[category];
+      } else {
+        currentCategories = Object.keys(categories[category]);
+        Object.keys(categories[category]).forEach(page => {
+          if (
+            categories[category][page].anchors &&
+            Array.isArray(categories[category][page].anchors)
+          ) {
+            categoryAnchors[page] = categories[category][page].anchors;
+          }
+        });
+      }
+      ids = ids.concat(currentCategories);
+      for (let i = 0; i < currentCategories.length; i++) {
         categoryOrder.push(category);
       }
     });
@@ -60,6 +75,7 @@ function readSidebar() {
         next: next,
         sidebar: sidebar,
         category: categoryOrder[i],
+        anchors: categoryAnchors[id] || [],
       };
     }
   });
@@ -154,6 +170,7 @@ function processMetadata(file) {
   if (order[id]) {
     metadata.sidebar = order[id].sidebar;
     metadata.category = order[id].category;
+    metadata.anchors = order[id].anchors;
 
     if (order[id].next) {
       metadata.next_id = order[id].next;

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1193,11 +1193,10 @@ ul#languages li {
   .navigationSlider .slidingNav ul li a:hover {
     color: #fff;
   }
-  .navigationSlider .slidingNav ul li.navItemActive a {
+  .navigationSlider .slidingNav ul li.navItemActive a,.navigationSlider .slidingNav ul li.navAnchorActive a {
     color: #fff;
   }
 }
-
 .docs-prevnext {
   margin: 20px 0;
 }
@@ -1392,6 +1391,9 @@ nav.toc .toggleNav ul {
   padding-left: 0;
   padding-right: 24px;
 }
+nav.toc .toggleNav ul.navAnchors {
+  padding-left: 10px;
+}
 nav.toc .toggleNav ul li {
   list-style-type: none;
   padding-bottom: 0;
@@ -1410,7 +1412,7 @@ nav.toc .toggleNav ul li a {
 nav.toc .toggleNav ul li a:hover, nav.toc .toggleNav ul li a:focus {
   color: $primaryColor;
 }
-nav.toc .toggleNav ul li a.navItemActive {
+nav.toc .toggleNav ul li a.navItemActive, nav.toc .toggleNav ul li a.navAnchorActive{
   color: $primaryColor;
 }
 .docsSliderActive nav.toc .navBreadcrumb {


### PR DESCRIPTION

## Motivation

Hi, i like this project and so I have decided to improve the docusaurus functionality implementing the one suggested by @JoelMarcey. 

## Test Plan

I haven't completed the feature yet. It works now but I have to add support for i18n and add some styles. 
I have added an option key for each category into the sidebar.json called anchors. This key is an array of anchors. The anchors are saved as metadata inside metadata.js and then they will be rendered into sidebar as an ul list inside category (image below) .

![image](https://user-images.githubusercontent.com/5365582/34310261-c3271e98-e756-11e7-977c-c32958ff0891.png)


## Related PRs


