### PR TITLE
Warn if an id can be extracted from a file.

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -125,7 +125,11 @@ function processMetadata(file) {
   metadata.source = path.basename(file);
 
   if (!metadata.id) {
-    console.log(chalk.yellow(`Warning: Unable to extract metadata from ${file}. Please make sure it has a valid header!`))
+    console.log(
+      chalk.yellow(
+        `Warning: Unable to extract metadata from ${file}. Please make sure it has a valid header!`
+      )
+    );
     metadata.id = path.basename(file, path.extname(file));
   }
   if (metadata.id.includes('/')) {

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -105,6 +105,7 @@ function extractMetadata(content) {
     } catch (e) {}
     metadata[key] = value;
   }
+
   return {metadata, rawContent: both.content};
 }
 
@@ -124,6 +125,7 @@ function processMetadata(file) {
   metadata.source = path.basename(file);
 
   if (!metadata.id) {
+    console.log(chalk.yellow(`Warning: Unable to extract metadata from ${file}. Please make sure it has a valid header!`))
     metadata.id = path.basename(file, path.extname(file));
   }
   if (metadata.id.includes('/')) {


### PR DESCRIPTION
It can break sidebars if it is referenced and is unable to be processed.

This is similiar to #347, except I am warning if it is missing an integral field.