### PR TITLE
Do not set html lang attribute if there is no language set

### DIFF
--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -41,17 +41,17 @@ class Site extends React.Component {
     if (fs.existsSync(CWD + '/versions.json')) {
       latestVersion = require(CWD + '/versions.json')[0];
     }
-    
+
     // We do not want a lang attribute for the html tag if we don't have a language set
     let htmlElementProps;
     if (this.props.language) {
-      htmlElementProps =  {
+      htmlElementProps = {
         lang: this.props.language,
-      }
+      };
     } else {
-      htmlElementProps = {}
+      htmlElementProps = {};
     }
-    
+
     return (
       <html {...htmlElementProps}>
         <Head

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -41,8 +41,19 @@ class Site extends React.Component {
     if (fs.existsSync(CWD + '/versions.json')) {
       latestVersion = require(CWD + '/versions.json')[0];
     }
+    
+    // We do not want a lang attribute for the html tag if we don't have a language set
+    let htmlElementProps;
+    if (this.props.language) {
+      htmlElementProps =  {
+        lang: this.props.language,
+      }
+    } else {
+      htmlElementProps = {}
+    }
+    
     return (
-      <html lang={this.props.language}>
+      <html {...htmlElementProps}>
         <Head
           config={this.props.config}
           description={description}


### PR DESCRIPTION
## Motivation

Do not want 

```
<html lang=''>
```

## Test Plan

`docusaurus-init` test site and React Native did not have `lang` attribute
docusaurus.io and Reason-React did

## Related PRs

Stemming from the changes made in #316 