### PR TITLE
Add doctype to generated html files.

### DIFF
--- a/lib/__tests__/build-files.tests.js
+++ b/lib/__tests__/build-files.tests.js
@@ -34,7 +34,7 @@ beforeAll(() => {
   generateSite();
   return Promise.all([
     glob(docsDir + '/**/*.md'),
-    glob(buildDir + '/' + siteConfig.projectName + '/docs/*.html'),
+    glob(buildDir + '/' + siteConfig.projectName + '/docs/**/*.html'),
     glob(docsDir + '/assets/*'),
     glob(buildDir + '/' + siteConfig.projectName + '/img/*'),
   ]).then(function(results) {
@@ -67,6 +67,14 @@ test('Generated HTML for each Markdown resource', function() {
     const data = fs.readFileSync(file, 'utf8');
     const frontmatter = fm(data);
     expect(metadata).toContain(frontmatter.attributes.id + '.html');
+  });
+});
+
+test('Generated HTML files contains doctype', function() {
+  outputHTMLFiles.forEach(function(file) {
+    const data = fs.readFileSync(file, 'utf-8');
+    const hasDoctype = data.match(/<![a-zA-Z]+.(html)+>/g) ? true : false;
+    expect(hasDoctype).toBeTruthy();
   });
 });
 

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -180,7 +180,7 @@ function execute() {
         {rawContent}
       </DocsLayout>
     );
-    const str = renderToStaticMarkup(docComp);
+    const str = '<!DOCTYPE html>' + renderToStaticMarkup(docComp);
 
     const targetFile = join(buildDir, metadata.permalink);
     writeFileAndCreateFolder(targetFile, str);
@@ -198,7 +198,8 @@ function execute() {
           redirect={siteConfig.baseUrl + metadata.permalink}
         />
       );
-      const redirectStr = renderToStaticMarkup(redirectComp);
+      const redirectStr =
+        '<!DOCTYPE html>' + renderToStaticMarkup(redirectComp);
 
       // create a redirects page for doc files
       const redirectFile = join(
@@ -261,7 +262,7 @@ function execute() {
           {rawContent}
         </BlogPostLayout>
       );
-      const str = renderToStaticMarkup(blogPostComp);
+      const str = '<!DOCTYPE html>' + renderToStaticMarkup(blogPostComp);
 
       let targetFile = join(buildDir, 'blog', filePath);
       writeFileAndCreateFolder(targetFile, str);
@@ -279,7 +280,7 @@ function execute() {
         config={siteConfig}
       />
     );
-    const str = renderToStaticMarkup(blogPageComp);
+    const str = '<!DOCTYPE html>' + renderToStaticMarkup(blogPageComp);
 
     let targetFile = join(
       buildDir,
@@ -414,11 +415,13 @@ function execute() {
             continue;
           }
           translate.setLanguage(language);
-          const str = renderToStaticMarkup(
-            <Site language={language} config={siteConfig}>
-              <ReactComp language={language} />
-            </Site>
-          );
+          const str =
+            '<!DOCTYPE html>' +
+            renderToStaticMarkup(
+              <Site language={language} config={siteConfig}>
+                <ReactComp language={language} />
+              </Site>
+            );
           writeFileAndCreateFolder(
             // TODO: use path functions
             targetFile.replace('/en/', '/' + language + '/'),
@@ -429,36 +432,42 @@ function execute() {
         // write to base level
         let language = env.translation.enabled ? 'en' : '';
         translate.setLanguage(language);
-        const str = renderToStaticMarkup(
-          <Site language={language} config={siteConfig}>
-            <ReactComp language={language} />
-          </Site>
-        );
+        const str =
+          '<!DOCTYPE html>' +
+          renderToStaticMarkup(
+            <Site language={language} config={siteConfig}>
+              <ReactComp language={language} />
+            </Site>
+          );
         writeFileAndCreateFolder(targetFile.replace('/en/', '/'), str);
       } else {
         // allow for rendering of other files not in pages/en folder
         let language = env.translation.enabled ? 'en' : '';
         translate.setLanguage(language);
-        const str = renderToStaticMarkup(
-          <Site language={language} config={siteConfig}>
-            <ReactComp language={language} />
-          </Site>
-        );
+        const str =
+          '<!DOCTYPE html>' +
+          renderToStaticMarkup(
+            <Site language={language} config={siteConfig}>
+              <ReactComp language={language} />
+            </Site>
+          );
         writeFileAndCreateFolder(targetFile.replace('/en/', '/'), str);
       }
       fs.removeSync(tempFile);
     } else if (siteConfig.wrapPagesHTML && file.match(/\.html$/)) {
       const parts = file.split('pages');
       const targetFile = join(buildDir, parts[1]);
-      const str = renderToStaticMarkup(
-        <Site language="en" config={siteConfig}>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: fs.readFileSync(file, {encoding: 'utf8'}),
-            }}
-          />
-        </Site>
-      );
+      const str =
+        '<!DOCTYPE html>' +
+        renderToStaticMarkup(
+          <Site language="en" config={siteConfig}>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: fs.readFileSync(file, {encoding: 'utf8'}),
+              }}
+            />
+          </Site>
+        );
 
       writeFileAndCreateFolder(targetFile, str);
     } else if (!fs.lstatSync(file).isDirectory()) {


### PR DESCRIPTION
## Motivation

Notice missing doctype for html generated files.
Related issue: #383

## Test Plan

### With Jest

Run unit test with `yarn run test`, a new test has been added to ensure that generated files have a doctype.

<details>
 <summary>Unit test screenshot</summary>
<img width="464" alt="capture d ecran 2018-01-08 a 17 29 41" src="https://user-images.githubusercontent.com/1331358/34695614-92aa218e-f499-11e7-9e74-d23556e2fcab.png">
</details>

### Manually

Otherwhise, build the project in `website` directory with `yarn run build` and go to `/website/build` directory in order to manually check that html files starts with a doctype.

<details>
 <summary>Manually build test screenshot</summary>
<img width="1280" alt="capture d ecran 2018-01-08 a 17 34 07" src="https://user-images.githubusercontent.com/1331358/34695789-2c1794b4-f49a-11e7-916d-d9939cb7895b.png">

</details>


  