### PR TITLE
Always use PROJECT_NAME, even for user and org pages

### DIFF
--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -7,7 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const copydir = require('copy-dir');
 const fs = require('fs-extra');
 const path = require('path');
 const shell = require('shelljs');

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -7,6 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const copydir = require('copy-dir');
 const fs = require('fs-extra');
 const path = require('path');
 const shell = require('shelljs');
@@ -34,8 +35,6 @@ const USE_SSH = process.env.USE_SSH;
 // github.io indicates organization repos that deploy via master. All others use gh-pages.
 const DEPLOYMENT_BRANCH =
   PROJECT_NAME.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages';
-const PROJECT_PATH =
-  PROJECT_NAME.indexOf('.github.io') !== -1 ? '' : PROJECT_NAME;
 
 if (!ORGANIZATION_NAME) {
   shell.echo(
@@ -109,7 +108,7 @@ shell.exec('git rm -rf .');
 
 shell.cd('../..');
 
-fromPath = path.join('build', PROJECT_PATH, '/');
+fromPath = path.join('build', `${PROJECT_NAME}`);
 toPath = path.join('build', `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`);
 // In github.io case, project is deployed to root. Need to not recursively
 // copy the deployment-branch to be.
@@ -152,7 +151,7 @@ fs.copy(
     } else if (commitResults.code === 0) {
       // The commit might return a non-zero value when site is up to date.
       shell.echo(
-        `Website is live at: https://${ORGANIZATION_NAME}.github.io/${PROJECT_PATH}`
+        `Website is live at: https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}`
       );
       shell.exit(0);
     }


### PR DESCRIPTION
## Motivation

The symptom was that if we had a user or org page (e.g., https://JoelMarcey.github.io), we would try to copy files to a directory within a directory, getting errors like:

```
Error: Copying build assets failed with error 'Error: Cannot copy '/Users/joelm/dev/JoelMarcey.github.io/website/build' to a subdirectory of itself, '/Users/joelm/dev/JoelMarcey.github.io/website/build/JoelMarcey.github.io-master'.'
```

This is because we were setting the end of `fromPath` to empty if we were using an org or user page.

But we don't need to do that. The `PROJECT_NAME` (set in `siteConfig.js` as `projectName`) is the user or org repo

e.g., https://github.com/JoelMarcey/JoelMarcey.github.io/ has a `projectName` of `JoelMarcey.github.io` with an `organizationName` of `JoelMarcey`.

So now the `fromPath` and `toPath` look like:

`fromPath`: `build/JoelMarcey.github.io`
`toPath`: `buuid/JoelMarcey.github.io-master`

## Test Plan

Ran:

```
GIT_USER=JoelMarcey USE_SSH=true yarn docusaurus-publish
```

on two repos. One for an org/user site and one for a project site. Publish worked on both:

Org/user site: https://github.com/JoelMarcey/JoelMarcey.github.io/tree/master (https://JoelMarcey.github.io)
Project site: https://github.com/JoelMarcey/docusaurus-testing/tree/gh-pages (https://JoelMarcey.github.io/docusaurus-testing)

## Related PRs
N/A
