### PR TITLE
ename typo

### DIFF
--- a/lib/rename-version.js
+++ b/lib/rename-version.js
@@ -130,7 +130,7 @@ if (fs.existsSync(currentSidebarFile)) {
 }
 
 console.log(
-  `${chalk.green('Successfully enamed version ')}${chalk.yellow(
+  `${chalk.green('Successfully renamed version ')}${chalk.yellow(
     currentVersion
   )}${chalk.green(' to version ')}${chalk.yellow(newVersion)}\n`
 );


### PR DESCRIPTION
This trivial PR 'enames' the ename typo displayed when running docusaurus-rename-version.