### PR TITLE
Fix margin for right-aligned images

### DIFF
--- a/lib/core/GridBlock.js
+++ b/lib/core/GridBlock.js
@@ -20,6 +20,7 @@ class GridBlock extends React.Component {
       imageAlignSide:
         block.image &&
         (block.imageAlign === 'left' || block.imageAlign === 'right'),
+      imageAlignRight: block.image && block.imageAlign === 'right',
       imageAlignTop: block.image && block.imageAlign === 'top',
       threeByGridBlock: this.props.layout === 'threeColumn',
       twoByGridBlock: this.props.layout === 'twoColumn',

--- a/lib/core/GridBlock.js
+++ b/lib/core/GridBlock.js
@@ -16,12 +16,13 @@ class GridBlock extends React.Component {
       alignCenter: this.props.align === 'center',
       alignRight: this.props.align === 'right',
       fourByGridBlock: this.props.layout === 'fourColumn',
-      imageAlignBottom: block.image && block.imageAlign === 'bottom',
       imageAlignSide:
         block.image &&
         (block.imageAlign === 'left' || block.imageAlign === 'right'),
-      imageAlignRight: block.image && block.imageAlign === 'right',
       imageAlignTop: block.image && block.imageAlign === 'top',
+      imageAlignRight: block.image && block.imageAlign === 'right',
+      imageAlignBottom: block.image && block.imageAlign === 'bottom',
+      imageAlignLeft: block.image && block.imageAlign === 'left',
       threeByGridBlock: this.props.layout === 'threeColumn',
       twoByGridBlock: this.props.layout === 'twoColumn',
     });

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -821,6 +821,10 @@ pre code {
   margin-left: auto;
   margin-right: auto;
 }
+.imageAlignRight .blockImage {
+  margin-right: 0;
+  margin-left: 40px;
+}
 .container .gridBlock .blockContent p {
   padding: 0;
 }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -795,7 +795,6 @@ pre code {
 .imageAlignSide .blockImage {
   max-width: 500px;
   flex: 0 1 500px;
-  margin-right: 40px;
 }
 @media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
   .imageAlignSide .blockImage {
@@ -822,8 +821,10 @@ pre code {
   margin-right: auto;
 }
 .imageAlignRight .blockImage {
-  margin-right: 0;
   margin-left: 40px;
+}
+.imageAlignLeft .blockImage {
+  margin-right: 40px;
 }
 .container .gridBlock .blockContent p {
   padding: 0;


### PR DESCRIPTION
## Motivation

@cyan33 found this bug and submitted it to the Jest repo, I thought I'd put in a quick fix

Closes https://github.com/facebook/jest/issues/5299
Closes https://github.com/facebook/Docusaurus/issues/397

## Test Plan
Tested using the `website/` within this project

Before: 

![](http://dp.hanlon.io/0a321k1M051F/Image%202018-01-13%20at%203.11.56%20PM.png)

After: 

![](http://dp.hanlon.io/452h1t1g0D3d/Image%202018-01-13%20at%203.05.51%20PM.png)
