### PR TITLE
Blog feed fixes #370

### DIFF
--- a/lib/core/Remarkable.js
+++ b/lib/core/Remarkable.js
@@ -1,29 +1,9 @@
 'use strict';
 
 const React = require('react');
-const hljs = require('highlight.js');
-const Markdown = require('remarkable');
-const toSlug = require('./toSlug.js');
+const renderMarkdown = require('./renderMarkdown.js');
 
 const CWD = process.cwd();
-
-/**
- * The anchors plugin adds GFM-style anchors to headings.
- */
-function anchors(md) {
-  md.renderer.rules.heading_open = function(tokens, idx /*, options, env */) {
-    const textToken = tokens[idx + 1];
-    return (
-      '<h' +
-      tokens[idx].hLevel +
-      '><a class="anchor" aria-hidden="true" name="' +
-      toSlug(textToken.content) +
-      '"></a><a href="#' +
-      toSlug(textToken.content) +
-      '" aria-hidden="true" class="hash-link" ><svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>'
-    );
-  };
-}
 
 class Remarkable extends React.Component {
   content() {
@@ -31,7 +11,7 @@ class Remarkable extends React.Component {
       return (
         <span
           dangerouslySetInnerHTML={{
-            __html: this.renderMarkdown(this.props.source),
+            __html: renderMarkdown(this.props.source),
           }}
         />
       );
@@ -39,59 +19,13 @@ class Remarkable extends React.Component {
       return React.Children.map(this.props.children, child => {
         if (typeof child === 'string') {
           return (
-            <span
-              dangerouslySetInnerHTML={{__html: this.renderMarkdown(child)}}
-            />
+            <span dangerouslySetInnerHTML={{__html: renderMarkdown(child)}} />
           );
         } else {
           return child;
         }
       });
     }
-  }
-
-  renderMarkdown(source) {
-    if (!this.md) {
-      const siteConfig = require(CWD + '/siteConfig.js');
-
-      this.md = new Markdown({
-        // Highlight.js expects hljs css classes on the code element.
-        // This results in <pre><code class="hljs css javascript">
-        langPrefix: 'hljs css ',
-        highlight: function(str, lang) {
-          lang =
-            lang || (siteConfig.highlight && siteConfig.highlight.defaultLang);
-          if (lang && hljs.getLanguage(lang)) {
-            try {
-              return hljs.highlight(lang, str).value;
-            } catch (err) {}
-          }
-
-          try {
-            return hljs.highlightAuto(str).value;
-          } catch (err) {}
-
-          return '';
-        },
-        html: true,
-        linkify: true,
-      });
-
-      // Register anchors plugin
-      this.md.use(anchors);
-
-      // Allow client sites to register their own plugins
-      if (siteConfig.markdownPlugins) {
-        siteConfig.markdownPlugins.forEach(function(plugin) {
-          this.md.use(plugin);
-        }, this);
-      }
-    }
-    const html = this.md.render(source);
-
-    // Ensure fenced code blocks use Highlight.js hljs class
-    // https://github.com/jonschlinkert/remarkable/issues/224
-    return html.replace(/<pre><code>/g, '<pre><code class="hljs">');
   }
 
   render() {

--- a/lib/core/renderMarkdown.js
+++ b/lib/core/renderMarkdown.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const hljs = require('highlight.js');
+const Markdown = require('remarkable');
+const toSlug = require('./toSlug.js');
+
+const CWD = process.cwd();
+
+/**
+ * The anchors plugin adds GFM-style anchors to headings.
+ */
+function anchors(md) {
+  md.renderer.rules.heading_open = function(tokens, idx /*, options, env */) {
+    const textToken = tokens[idx + 1];
+    return (
+      '<h' +
+      tokens[idx].hLevel +
+      '><a class="anchor" aria-hidden="true" name="' +
+      toSlug(textToken.content) +
+      '"></a><a href="#' +
+      toSlug(textToken.content) +
+      '" aria-hidden="true" class="hash-link" ><svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>'
+    );
+  };
+}
+
+class MarkdownRenderer {
+  constructor() {
+    const siteConfig = require(CWD + '/siteConfig.js');
+
+    const md = new Markdown({
+      // Highlight.js expects hljs css classes on the code element.
+      // This results in <pre><code class="hljs css javascript">
+      langPrefix: 'hljs css ',
+      highlight: function(str, lang) {
+        lang =
+          lang || (siteConfig.highlight && siteConfig.highlight.defaultLang);
+        if (lang && hljs.getLanguage(lang)) {
+          try {
+            return hljs.highlight(lang, str).value;
+          } catch (err) {}
+        }
+
+        try {
+          return hljs.highlightAuto(str).value;
+        } catch (err) {}
+
+        return '';
+      },
+      html: true,
+      linkify: true,
+    });
+
+    // Register anchors plugin
+    md.use(anchors);
+
+    // Allow client sites to register their own plugins
+    if (siteConfig.markdownPlugins) {
+      siteConfig.markdownPlugins.forEach(function(plugin) {
+        md.use(plugin);
+      });
+    }
+
+    this._md = md;
+  }
+
+  toHtml(source) {
+    const html = this._md.render(source);
+
+    // Ensure fenced code blocks use Highlight.js hljs class
+    // https://github.com/jonschlinkert/remarkable/issues/224
+    return html.replace(/<pre><code>/g, '<pre><code class="hljs">');
+  }
+}
+
+const renderMarkdown = new MarkdownRenderer();
+
+module.exports = source => {
+  return renderMarkdown.toHtml(source);
+};

--- a/lib/server/feed.js
+++ b/lib/server/feed.js
@@ -19,6 +19,8 @@ const blogFolder = path.resolve('../blog/');
 const blogRootURL = siteConfig.url + '/blog';
 const jestImage = siteConfig.url + '/' + siteConfig.headerIcon;
 
+const renderMarkdown = require('../core/renderMarkdown.js');
+
 /****************************************************************************/
 
 let readMetadata;
@@ -62,6 +64,8 @@ module.exports = function(type) {
         content = contentArr[0];
       }
     }
+
+    content = renderMarkdown(content);
 
     feed.addItem({
       title: post.title,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix bug detailed in issue #370 

Closes #370 

## Test Plan

The test docusaurus website has a blog post with a description containing HTML. 
1. Manually check that blog posts/documentation pages still correctly render markdown as HTML.
1. Manually check the rss and atom feeds (`http://localhost:3000/blog/feed.xml` and `http://localhost:3000/blog/atom.xml`) now have the description in HTML rather than markdown.

## Related PRs

None
