### PR TITLE
Fix regex for non english versioned docs

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -180,8 +180,6 @@ function generateMetadataDocs() {
     process.exit(1);
   }
 
-  const regexSubFolder = /translated_docs\/(.*)\/.*/;
-
   const enabledLanguages = env.translation
     .enabledLanguages()
     .map(language => language.tag);
@@ -236,6 +234,7 @@ function generateMetadataDocs() {
   });
 
   // metadata for non-english docs
+  const regexSubFolder = /translated_docs\/(.*?)\/.*/;
   files = glob.sync(CWD + '/translated_docs/**');
   files.forEach(file => {
     let language = 'en';


### PR DESCRIPTION
Previously the regex was in greedy mode which would cause a bug.
For example, if the file path looks like
`/translated_docs/zh-CN/version-0.52/alert.md`
then the matched part would be `zh-CN/version-0.52` which is obviously wrong for language detection.