### PR TITLE
[DocSearch] Treat latest version as current version

### DIFF
--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -30,7 +30,7 @@ class Site extends React.Component {
       this.props.config.url +
       this.props.config.baseUrl +
       (this.props.url || 'index.html');
-    let latestVersion;
+    let docsVersion = this.props.version || 'current';
 
     const highlightDefaultVersion = '9.12.0';
     const highlightConfig = this.props.config.highlight || {
@@ -39,7 +39,10 @@ class Site extends React.Component {
     };
     const highlightVersion = highlightConfig.version || highlightDefaultVersion;
     if (fs.existsSync(CWD + '/versions.json')) {
-      latestVersion = require(CWD + '/versions.json')[0];
+      const latestVersion = require(CWD + '/versions.json')[0];
+      if (docsVersion === latestVersion) {
+        docsVersion = 'current';
+      }
     }
 
     // We do not want a lang attribute for the html tag if we don't have a language set
@@ -122,7 +125,7 @@ class Site extends React.Component {
                 algoliaOptions: ${JSON.stringify(
                   this.props.config.algolia.algoliaOptions
                 )
-                  .replace('VERSION', this.props.version || latestVersion)
+                  .replace('VERSION', docsVersion)
                   .replace('LANGUAGE', this.props.language)}
               });
             `,


### PR DESCRIPTION
If the site is versioned, and the latest version is displayed, the URL will not change. We need to let Algolia know this is the case.

This change assumes that sites have configured DocSearch to consider the 'current' tag as one matching the latest version of the site. You can see this is the case with React Native's [own config](https://github.com/algolia/docsearch-configs/blob/dd8bd78c306e0929f2285409bdfaff5af9544c77/configs/react-native-versions.json). 

The logic goes:

If a version is specified via props and it does not match the latest version, we'll use that version with DocSearch.

If a version is specified via props and it matches the latest version, we'll use 'current' instead.

If no version is specified via props, assume 'current'.

# Test Plan

On [`react-native-website`](https://github.com/facebook/react-native-website) repo, after installing a version of Docusaurus with this patch applied:

1. Check http://localhost:3000/react-native/docs/getting-started.html (AKA 0.53-RC), confirm 'current' tag is used in script block
2. Check http://localhost:3000/react-native/docs/next/getting-started.html (AKA master), confirm 'next' tag is used in script block
3. Check http://localhost:3000/react-native/docs/0.52/getting-started.html (AKA 0.52), confirm '0.52' tag is used in script block

Script block above refers to the block where DocSearch is configured at the end of the HTML body, as such:

```
<script>
  var search = docsearch({
    apiKey: '2c98749b4a1e588efec53b2acec13025',
    indexName: 'react-native-versions',
    inputSelector: '#search_input_react',
    algoliaOptions: {"facetFilters":["tags:current"],"hitsPerPage":5}
  });
</script>
```