### PR TITLE
Fix links in blog Atom feed

### DIFF
--- a/lib/server/feed.js
+++ b/lib/server/feed.js
@@ -16,7 +16,7 @@ const CWD = process.cwd();
 const siteConfig = require(CWD + '/siteConfig.js');
 
 const blogFolder = path.resolve('../blog/');
-const blogRootURL = siteConfig.url + '/blog';
+const blogRootURL = siteConfig.url + siteConfig.baseUrl + 'blog';
 const jestImage = siteConfig.url + '/' + siteConfig.headerIcon;
 
 /****************************************************************************/

--- a/lib/server/feed.js
+++ b/lib/server/feed.js
@@ -17,7 +17,8 @@ const siteConfig = require(CWD + '/siteConfig.js');
 
 const blogFolder = path.resolve('../blog/');
 const blogRootURL = siteConfig.url + siteConfig.baseUrl + 'blog';
-const jestImage = siteConfig.url + '/' + siteConfig.headerIcon;
+const siteImageURL =
+  siteConfig.url + siteConfig.baseUrl + siteConfig.headerIcon;
 
 /****************************************************************************/
 
@@ -46,7 +47,7 @@ module.exports = function(type) {
       ' news and events.',
     id: blogRootURL,
     link: blogRootURL,
-    image: jestImage,
+    image: siteImageURL,
     copyright: siteConfig.copyright,
     updated: new Date(MetadataBlog[0].date),
   });


### PR DESCRIPTION
The root URL was missing the baseURL portion. This is fine when a site is hosted on a custom URL such as docusaurus.io, because the generated URL will be valid (docusaurus.io/blog), but it breaks when the site is hosted on GitHub Pages (the React Native feed was using facebook.github.io/blog as the rootURL).

The [current React Native feed](http://facebook.github.io/react-native/blog/atom.xml) looks like this (truncated):

```
<feed xmlns="http://www.w3.org/2005/Atom">
<id>https://facebook.github.io/blog</id>
<title>React Native Blog</title>
<updated>2018-01-18T06:00:00Z</updated>
<generator>Feed for Node.js</generator>
<link rel="alternate" href="https://facebook.github.io/blog"/>
<subtitle>
The best place to stay up-to-date with the latest React Native news and events.
</subtitle>
<logo>https://facebook.github.ioimg/header_logo.png</logo>
<entry>
<title type="html">
<![CDATA[
Implementing Twitter’s App Loading Animation in React Native
]]>
</title>
<id>
https://facebook.github.io/blog/2018/01/18/implementing-twitters-app-loading-animation-in-react-native.html
</id>
<link href="https://facebook.github.io/blog/2018/01/18/implementing-twitters-app-loading-animation-in-react-native.html"></link>
<updated>2018-01-18T06:00:00Z</updated>
<summary type="html">
<![CDATA[
Twitter’s iOS app has a loading animation I quite enjoy. <img src="/react-native/blog/assets/loading-screen-01.gif" style="float: left; padding-right: 80px; padding-bottom: 20px"/> Once the app is ready, the Twitter logo delightfully expands, revea
]]>
</summary>
<author>
<name>Eli White</name>
<uri>https://github.com/TheSavior</uri>
</author>
</entry>
```

Note that the id at the top is incorrect (<id>https://facebook.github.io/blog</id>), as well as the individual entry links (<id>https://facebook.github.io/blog/2018/01/18/implementing-twitters-app-loading-animation-in-react-native.html</id>).

After this change, the URLs should result in <id>https://facebook.github.io/react-native/blog</id> and <id>https://facebook.github.io/react-native/blog/2018/01/18/implementing-twitters-app-loading-animation-in-react-native.html</id> respectively.

Docusaurus's [own feed is fine](https://docusaurus.io/blog/atom.xml), because it's base URL is a plain / as it is hosted on its own domain.

# Test Plan

Generate feed in `react-native-website`, confirm links have been fixed:

```
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
    <id>https://facebook.github.io/react-native/blog</id>
    <title>React Native Blog</title>
    <updated>2018-01-18T06:00:00Z</updated>
    <generator>Feed for Node.js</generator>
    <link rel="alternate" href="https://facebook.github.io/react-native/blog"/>
    <subtitle>The best place to stay up-to-date with the latest React Native news and events.</subtitle>
    <logo>https://facebook.github.io/img/header_logo.png</logo>
    <entry>
        <title type="html"><![CDATA[Implementing Twitter’s App Loading Animation in React Native]]></title>
        <id>https://facebook.github.io/react-native/blog/2018/01/18/implementing-twitters-app-loading-animation-in-react-native.html</id>
        <link href="https://facebook.github.io/react-native/blog/2018/01/18/implementing-twitters-app-loading-animation-in-react-native.html">
        </link>
        <updated>2018-01-18T06:00:00Z</updated>
        <summary type="html"><![CDATA[Twitter’s iOS app has a loading animation I quite enjoy.

<img src="/react-native/blog/assets/loading-screen-01.gif" style="float: left; padding-right: 80px; padding-bottom: 20px"/>

Once the app is ready, the Twitter logo delightfully expands, revea]]></summary>
        <author>
            <name>Eli White</name>
            <uri>https://github.com/TheSavior</uri>
        </author>
    </entry>
```