### PR TITLE
 Add key to stylesheet links in Head.js

### DIFF
--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -87,11 +87,7 @@ class Head extends React.Component {
         {this.props.config.stylesheets &&
           this.props.config.stylesheets.map(function(source, idx) {
             return (
-              <link
-                rel="stylesheet"
-                key={'stylesheet' + idx}
-                href={source}
-              />
+              <link rel="stylesheet" key={'stylesheet' + idx} href={source} />
             );
           })}
         {this.props.config.scripts &&

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -85,8 +85,14 @@ class Head extends React.Component {
 
         {/* External resources */}
         {this.props.config.stylesheets &&
-          this.props.config.stylesheets.map(function(source) {
-            return <link rel="stylesheet" href={source} />;
+          this.props.config.stylesheets.map(function(source, idx) {
+            return (
+              <link
+                rel="stylesheet"
+                key={'stylesheet' + idx}
+                href={source}
+              />
+            );
           })}
         {this.props.config.scripts &&
           this.props.config.scripts.map(function(source, idx) {


### PR DESCRIPTION
## Motivation

I was adding a google font through `siteConfig.stylesheets` and noticed the following error:

```
Starting Docusaurus server on port 3000...
Open http://localhost:3000/
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Head`. See https://fb.me/react-warning-keys for more information.
    in link (created by Head)
    in Head (created by Site)
    in html (created by Site)
    in Site (created by DocsLayout)
    in DocsLayout
```

This fixes that by adding the key prop. Following the same style as used for `siteConfig.scripts`

## Test Plan

- ran `npm run prettier`
- `npm run test` pass
- verified with npm link that error message was gone with this patch applied 