### PR TITLE
Allow controlling number of blog posts in Recent Blogs sidebar.

### DIFF
--- a/docs/guides-blog.md
+++ b/docs/guides-blog.md
@@ -68,6 +68,19 @@ Not this.
 Or this.
 ```
 
+## Changing How Many Blog Posts Show on Sidebar
+
+By default, 5 recent blog posts are shown on the sidebar.
+
+You can configure a specifc amount of blog posts to show by adding a `blogSidebarCount` setting to your `siteConfig.js`.
+
+The available options are an integer repreenting the number of posts you wish to show or a string with the value 'ALL'.
+
+Example:
+```
+blogSidebarCount: 'ALL'
+```
+
 ## RSS Feed
 
 Docusaurus provides a simple RSS feed for your blog posts. Both RSS and Atom feed formats are supported. This data is automatically to your website page's HTML <HEAD> tag.

--- a/lib/core/BlogSidebar.js
+++ b/lib/core/BlogSidebar.js
@@ -22,8 +22,6 @@ class BlogSidebar extends React.Component {
       } else {
         blogSidebarCount = this.props.config.blogSidebarCount;
       }
-    } else {
-      blogSidebarCount = 5;
     }
 
     const contents = [

--- a/lib/core/BlogSidebar.js
+++ b/lib/core/BlogSidebar.js
@@ -13,16 +13,30 @@ const MetadataBlog = require('./MetadataBlog.js');
 
 class BlogSidebar extends React.Component {
   render() {
+    let blogSidebarCount = 5;
+    let blogSidebarTitle = 'Recent Posts';
+    if (this.props.config.blogSidebarCount) {
+      if (this.props.config.blogSidebarCount == 'ALL') {
+        blogSidebarCount = MetadataBlog.length;
+        blogSidebarTitle = 'All Blog Posts';
+      } else {
+        blogSidebarCount = this.props.config.blogSidebarCount;
+      }
+    } else {
+      blogSidebarCount = 5;
+    }
+
     const contents = [
       {
-        name: 'Recent Posts',
-        links: MetadataBlog.slice(0, 5),
+        name: blogSidebarTitle,
+        links: MetadataBlog.slice(0, blogSidebarCount),
       },
     ];
     const title = this.props.current && this.props.current.title;
+
     const current = {
       id: title || '',
-      category: 'Recent Posts',
+      category: blogSidebarTitle,
     };
     return (
       <Container className="docsNavContainer" id="docsNav" wrapper={false}>

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -365,9 +365,15 @@ function generateMetadataBlog() {
           filePathDateArr[2] +
           'T06:00:00.000Z'
       );
+      // allow easier sorting of blog by providing seconds since epoch
+      metadata.seconds = Math.round(metadata.date.getTime() / 1000);
 
       metadatas.push(metadata);
     });
+
+  const sortedMetadatas = metadatas.sort(
+    (a, b) => parseInt(b.seconds) - parseInt(a.seconds)
+  );
 
   fs.writeFileSync(
     __dirname + '/../core/MetadataBlog.js',
@@ -375,7 +381,7 @@ function generateMetadataBlog() {
       ' * @generated\n' +
       ' */\n' +
       'module.exports = ' +
-      JSON.stringify(metadatas, null, 2) +
+      JSON.stringify(sortedMetadatas, null, 2) +
       ';\n'
   );
 }


### PR DESCRIPTION
## Motivation

I wanted to allow showing all blog posts not just recent 5.

Also, inadvertently, solved a problem where post order on 'Recent Posts' was not sorted by time.

## Test Plan

1) Add 'blogSidebarCount' setting to siteConfig of a site with a blog an at least 6 posts.
2) Set 'blogSidebarCount' value to 3.
3) Run local server.
4) Observe that only 3 most recent posts show on sidebar.

5) Set 'blogSidebarCount' value to 'ALL'.
6) Run local server.
7) Observe that _all_ posts show on sidebar and title changes to "All Blog Posts"
