### PR TITLE
Move Verifying Installation section to Installation doc

### DIFF
--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -8,7 +8,7 @@ Docusaurus was designed from the ground up to be easily installed and used to ge
 1. Go into the root of your GitHub repo directory where you will be creating the docs.
 1. `yarn global add docusaurus-init` or `npm install --global docusaurus-init`
 1. `docusaurus-init`
-
+1. Verify the installation
 Along with previously existing files and directories, your root directory will now contain a structure similar to:
 
 ```bash
@@ -34,3 +34,15 @@ root-of-repo
 ```
 
 > If you do not want to install the init script globally, you can install it locally and then run it via `npx docusaurus-init` or from the `node_modules` directory that is created via `./node_modules/.bin/docusaurus-init`. You may want to remove the created `package.json` file and `node_modules` directory after you run the script.
+
+## Verifying Installation
+
+Running the Docusaurus initialization script, `docusaurus-init`, produces a runnable, example website to base your site upon.
+
+1. In your root, rename `docs-examples-from-docusaurus` to `docs`.
+1. `cd website`
+1. Rename `blog-examples-from-docusaurus` to `blog`.
+1. Run the local webserver via `yarn start` or `npm start`.
+1. Load the example site at http://localhost:3000. You should see the example site loaded in your web browser.
+
+![](/img/getting-started-preparation-verify.png)

--- a/docs/getting-started-preparation.md
+++ b/docs/getting-started-preparation.md
@@ -43,15 +43,3 @@ You will need to keep the `website/siteConfig.js` and `website/core/Footer.js` f
 You should keep the `website/pages` and `website/static` folders, but may change the content inside them as you wish. At the bare minimum you should have an `en/index.js` or `en/index.html` file inside `website/pages` and an image to use as your header icon inside `website/static`.
 
 The `website/blog-examples-from-docusaurus` and `docs-examples-from-docusaurus` folders contain example blog and document markdown files. As shown below when you verify that the example site runs correctly, if you wish to run Docusaurus with these files, you need to rename the folders to `website/blog` and `docs`, respectively.
-
-## Verifying Installation
-
-Running the Docusaurus initialization script, `docusaurus-init`, produces a runnable, example website to base your site upon.
-
-1. In your root, rename `docs-examples-from-docusaurus` to `docs`.
-1. `cd website`
-1. Rename `blog-examples-from-docusaurus` to `blog`.
-1. Run the local webserver via `yarn start` or `npm start`.
-1. Load the example site at http://localhost:3000. You should see the example site loaded in your web browser.
-
-![](/img/getting-started-preparation-verify.png)


### PR DESCRIPTION

## Motivation
The verifying installation section on site preparation is not in the right place 
and I think maybe this should be in the installation section.

In (https://github.com/facebook/Docusaurus/issues/431) @JoelMarcey mentions about the first paragraph that will need to be updated but I didn't know what should be updated in there.



