### PR TITLE
Allow edit URL to be customized with doc metadata

### DIFF
--- a/docs/api-doc-markdown.md
+++ b/docs/api-doc-markdown.md
@@ -38,7 +38,7 @@ original_id: doc1
 ---
 ```
 
-`edit_url`: The url for editing this document. If this field is not present, the document's `edit_url` will fallback to `editUrl` from optional fields of `siteConfig.js`. See [siteConfig.js](site-config.md) docs for more information.
+`custom_edit_url`: The url for editing this document. If this field is not present, the document's edit url will fallback to `editUrl` from optional fields of `siteConfig.js`. See [siteConfig.js](site-config.md) docs for more information.
 
 For example:
 
@@ -46,7 +46,7 @@ For example:
 ---
 id: doc-markdown
 title: Markdown Features
-edit_url: https://github.com/facebook/Docusaurus/edit/master/docs/api-doc-markdown.md
+custom_edit_url: https://github.com/facebook/Docusaurus/edit/master/docs/api-doc-markdown.md
 ---
 ```
 

--- a/docs/api-doc-markdown.md
+++ b/docs/api-doc-markdown.md
@@ -38,6 +38,18 @@ original_id: doc1
 ---
 ```
 
+`edit_url`: The url for editing this document. If this field is not present, the document's `edit_url` will fallback to `editUrl` from optional fields of `siteConfig.js`. See [siteConfig.js](site-config.md) docs for more information.
+
+For example:
+
+```markdown
+---
+id: doc-markdown
+title: Markdown Features
+edit_url: https://github.com/facebook/Docusaurus/edit/master/docs/api-doc-markdown.md
+---
+```
+
 ### Blog Posts
 
 Blog Posts use the following markdown header fields that are enclosed by a line `---` on either side:

--- a/lib/core/Doc.js
+++ b/lib/core/Doc.js
@@ -28,7 +28,7 @@ class Doc extends React.Component {
     }
 
     const editUrl =
-      this.props.metadata.edit_url ||
+      this.props.metadata.custom_edit_url ||
       (this.props.config.editUrl && this.props.config.editUrl + docSource);
     let editLink = editUrl && (
       <a className="edit-page-link button" href={editUrl} target="_blank">

--- a/lib/core/Doc.js
+++ b/lib/core/Doc.js
@@ -27,11 +27,11 @@ class Doc extends React.Component {
       docSource = docSource.match(new RegExp(/version-.*\/(.*\.md)/, 'i'))[1];
     }
 
-    let editLink = this.props.config.editUrl && (
-      <a
-        className="edit-page-link button"
-        href={this.props.config.editUrl + docSource}
-        target="_blank">
+    const editUrl =
+      this.props.metadata.edit_url ||
+      (this.props.config.editUrl && this.props.config.editUrl + docSource);
+    let editLink = editUrl && (
+      <a className="edit-page-link button" href={editUrl} target="_blank">
         {editThisDoc}
       </a>
     );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Some of the Markdown docs are generated and therefore should not be edited. Instead contributors should edit the source data files (e.g. `.json` or `.yaml` or otherwise) which are used to generate the final Markdown docs.

## Test Plan

<!-- (Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!) -->

Documentation has been updated to reflect usage.

Example:

```markdown
---
id: options
title: Options
sidebar_label: Options
edit_url: https://github.com/unibeautify/unibeautify/edit/master/src/options.ts
---
```

Notice the Edit Button in the following screenshot does not have a link in the conventional `editUrl` format. In this screenshot my cursor is hovering over the Edit Button and its URL is shown in the bottom left corner.

![image](https://user-images.githubusercontent.com/1885333/36058253-b33cebc2-0df1-11e8-9b57-8aad8ea721c9.png)

Live demos from Pull Request: https://github.com/Unibeautify/website/pull/39/files
- https://deploy-preview-39--unibeautify.netlify.com/docs/options.html
  - https://github.com/Unibeautify/website/blob/master/docs/options.md
- https://deploy-preview-39--unibeautify.netlify.com/docs/language-javascript.html
  - https://github.com/Unibeautify/website/blob/master/docs/language-javascript.md

## Related PRs

<!-- (If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.) -->

None.