### PR TITLE
Adding scrollbar to header when it overflows

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -978,6 +978,7 @@ pre code {
   box-sizing: border-box;
   display: flex;
   flex-wrap: nowrap;
+  overflow-x: auto;
   list-style: none;
   margin-top: 50px;
   width: 100%;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #441 

## Test Plan

1. Add many dummy entries into the `siteConfig.js`.
2. Use the Chrome devtools' ["Toggle Device Mode"](https://developers.google.com/web/tools/chrome-devtools/device-mode/) to simulate various responsive sizes. Note: Just make sure you refresh the page once when you switch to mobile mode. This guarantees that the page is loaded in the simulated mobile mode and any old CSS effects from the desktop mode are not into play.

![scroll_doc](https://user-images.githubusercontent.com/6594255/36075957-bae1a756-0f7b-11e8-8936-9cd5be6fa1bb.gif)

cc @JoelMarcey 
