### PR TITLE
Adding scrollbar to header, only on mobile

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1203,6 +1203,12 @@ ul#languages li {
   }
 }
 
+@media only screen and (max-device-width: 735px) {
+  .navigationSlider .slidingNav ul {
+    overflow-x: auto;
+  }
+}
+
 .docs-prevnext {
   margin: 20px 0;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #441. This has a different implementation than #444 in order to avoid #445. Only in the case of when screen size is lesser than `735px`, we need a scrollbar.

## Test Plan

1. Add many dummy entries into the `siteConfig.js`.
2. Use the Chrome devtools' ["Toggle Device Mode"](https://developers.google.com/web/tools/chrome-devtools/device-mode/) to simulate various responsive sizes. Note: Just make sure you refresh the page once when you switch to mobile mode. This guarantees that the page is loaded in the simulated mobile mode and any old CSS effects from the desktop mode are not into play.
3. Also, test the search in every mode so that #445 doesn't come back.

![scroll_doc](https://user-images.githubusercontent.com/6594255/36075957-bae1a756-0f7b-11e8-8936-9cd5be6fa1bb.gif)

cc @JoelMarcey 
