### PR TITLE
Fix broken link to site-config

### DIFF
--- a/docs/guides-custom-pages.md
+++ b/docs/guides-custom-pages.md
@@ -43,7 +43,7 @@ Static `.html` files can also be used, but they will not include Docusaurus's he
 
 If you wish to use Docusaurus's stylesheet, you can access it at `${baseUrl}css/main.css`. If you wish to use separate css for these static pages, you can exclude them from being concatenated to Docusaurus's styles by adding them into the `siteConfig.separateCss` field in `siteConfig.js`.
 
-> You can set the [`$wrapPagesHTML` site config option](site-config.md#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
+> You can set the [`$wrapPagesHTML` site config option](api-site-config.md#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
 
 ## Customizing Your Site Footer
 

--- a/docs/guides-custom-pages.md
+++ b/docs/guides-custom-pages.md
@@ -43,7 +43,7 @@ Static `.html` files can also be used, but they will not include Docusaurus's he
 
 If you wish to use Docusaurus's stylesheet, you can access it at `${baseUrl}css/main.css`. If you wish to use separate css for these static pages, you can exclude them from being concatenated to Docusaurus's styles by adding them into the `siteConfig.separateCss` field in `siteConfig.js`.
 
-> You can set the [`$wrapPagesHTML` site config option](site-config.md#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
+> You can set the [`$wrapPagesHTML` site config option](site-config.html#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
 
 ## Customizing Your Site Footer
 

--- a/docs/guides-custom-pages.md
+++ b/docs/guides-custom-pages.md
@@ -39,11 +39,12 @@ Of course, you are also free to write your own pages. It is strongly suggested t
 
 ## Adding Static Pages
 
-Static `.html` files can also be used, but they will not include Docusaurus's header, footer, or styles by default. These can be added to the `static` folder in the same way as other [static assets](api-pages.md#using-static-assets). Alternatively, they can be placed in the `pages` folder and would be served as-is instead of being rendered from React.
+Static `.
+` files can also be used, but they will not include Docusaurus's header, footer, or styles by default. These can be added to the `static` folder in the same way as other [static assets](api-pages.md#using-static-assets). Alternatively, they can be placed in the `pages` folder and would be served as-is instead of being rendered from React.
 
 If you wish to use Docusaurus's stylesheet, you can access it at `${baseUrl}css/main.css`. If you wish to use separate css for these static pages, you can exclude them from being concatenated to Docusaurus's styles by adding them into the `siteConfig.separateCss` field in `siteConfig.js`.
 
-> You can set the [`$wrapPagesHTML` site config option](site-config.html#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
+> You can set the [`$wrapPagesHTML` site config option](api-site-config.md#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
 
 ## Customizing Your Site Footer
 

--- a/docs/guides-custom-pages.md
+++ b/docs/guides-custom-pages.md
@@ -39,12 +39,11 @@ Of course, you are also free to write your own pages. It is strongly suggested t
 
 ## Adding Static Pages
 
-Static `.
-` files can also be used, but they will not include Docusaurus's header, footer, or styles by default. These can be added to the `static` folder in the same way as other [static assets](api-pages.md#using-static-assets). Alternatively, they can be placed in the `pages` folder and would be served as-is instead of being rendered from React.
+Static `.html` files can also be used, but they will not include Docusaurus's header, footer, or styles by default. These can be added to the `static` folder in the same way as other [static assets](api-pages.md#using-static-assets). Alternatively, they can be placed in the `pages` folder and would be served as-is instead of being rendered from React.
 
 If you wish to use Docusaurus's stylesheet, you can access it at `${baseUrl}css/main.css`. If you wish to use separate css for these static pages, you can exclude them from being concatenated to Docusaurus's styles by adding them into the `siteConfig.separateCss` field in `siteConfig.js`.
 
-> You can set the [`$wrapPagesHTML` site config option](api-site-config.md#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
+> You can set the [`$wrapPagesHTML` site config option](site-config.html#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
 
 ## Customizing Your Site Footer
 

--- a/docs/guides-custom-pages.md
+++ b/docs/guides-custom-pages.md
@@ -43,7 +43,7 @@ Static `.html` files can also be used, but they will not include Docusaurus's he
 
 If you wish to use Docusaurus's stylesheet, you can access it at `${baseUrl}css/main.css`. If you wish to use separate css for these static pages, you can exclude them from being concatenated to Docusaurus's styles by adding them into the `siteConfig.separateCss` field in `siteConfig.js`.
 
-> You can set the [`$wrapPagesHTML` site config option](site-config.html#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
+> You can set the [`$wrapPagesHTML` site config option](site-config.md#optional-fields) in order to wrap raw HTML fragments with the Docusaurus site styling, header and footer.
 
 ## Customizing Your Site Footer
 


### PR DESCRIPTION
## Motivation
On https://docusaurus.io/docs/en/custom-pages.html the $wrapPagesHTML site config link is referencing https://docusaurus.io/docs/en/site-config.md#optional-fields. It appears that it should reference https://docusaurus.io/docs/en/site-config.html#optional-fields

## Test Plan

Visual - replaced "md" with "html" 

https://docusaurus.io/docs/en/site-config.md#optional-fields

https://docusaurus.io/docs/en/site-config.html#optional-fields

## Related PRs

https://github.com/facebook/Docusaurus/pull/426/commits/b1ecd989d45d99f110392e2753063cc72d0c4bfb