### PR TITLE
Don't throw if a doc hasn't been versioned yet

### DIFF
--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -133,9 +133,7 @@ files.forEach(file => {
 // what the requested version is
 function docVersion(id, req_version) {
   if (!available[id]) {
-    throw new Error(
-      `Document with id '${id}' was requested but no document with that id could be located.`
-    );
+    return null;
   }
   // iterate through versions until a version less than or equal to the requested
   // is found, then check if that version has an available file to use

--- a/lib/version.js
+++ b/lib/version.js
@@ -96,8 +96,7 @@ files.forEach(file => {
   metadata.original_id = metadata.id;
   metadata.id = 'version-' + version + '-' + metadata.id;
 
-  const targetFile =
-    CWD + '/versioned_docs/version-' + version + '/' + path.basename(file);
+  const targetFile = versionFolder + '/' + path.basename(file);
 
   fs.writeFileSync(targetFile, makeHeader(metadata) + rawContent, 'utf8');
 });


### PR DESCRIPTION
Instead of throwing, return `null` because that means we have a
new doc in our versioning sequence

(Also, cleaned up a bit of code as I researched this)

Fixes #450

## Motivation

We had a showstopping bug where versioning would not work if you tried to add a new file to the documentation set.

## Test Plan

Versioned a set of docs as 1.0.0
Added a new doc to the master set
Ran

```
npm run version 2.0.0
```

The new doc was part of version 2.0.0

## Related PRs

N/A