### PR TITLE
Allow multiple `-` in a version string

### DIFF
--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -120,7 +120,13 @@ files.forEach(file => {
   if (!(metadata.original_id in available)) {
     available[metadata.original_id] = new Set();
   }
-  const version = metadata.id.split('-')[1];
+  // The version will be between "version-" and "-<docid>"
+  // e.g. version-1.0.0-beta.2-doc1 => 1.0.0-beta.2
+  // e.g. version-1.0.0-doc2 => 1.0.0
+  const version = metadata.id.substring(
+    metadata.id.indexOf('-') + 1,
+    metadata.id.lastIndexOf('-')
+  );
   available[metadata.original_id].add(version);
 
   if (!(version in versionFiles)) {

--- a/lib/server/versionFallback.js
+++ b/lib/server/versionFallback.js
@@ -120,12 +120,13 @@ files.forEach(file => {
   if (!(metadata.original_id in available)) {
     available[metadata.original_id] = new Set();
   }
-  // The version will be between "version-" and "-<docid>"
+  // The version will be between "version-" and "-<metadata.original_id>"
   // e.g. version-1.0.0-beta.2-doc1 => 1.0.0-beta.2
   // e.g. version-1.0.0-doc2 => 1.0.0
+  // e.g. version-1.0.0-getting-started => 1.0.0
   const version = metadata.id.substring(
-    metadata.id.indexOf('-') + 1,
-    metadata.id.lastIndexOf('-')
+    metadata.id.indexOf('version-') + 8, // version- is 8 characters
+    metadata.id.lastIndexOf('-' + metadata.original_id)
   );
   available[metadata.original_id].add(version);
 


### PR DESCRIPTION
Fixes #450 

## Motivation

Right now we were assuming that there would be no `-` in a version.
That was breaking things.

This allows more flexibility for versions like:

1.0.0-beta.2

## Test Plan

Was able to successfully build versions that contained multiple dashes

## Related PRs

Ref #455
