### PR TITLE
Fix wrong latestVersion in server.js

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -195,7 +195,7 @@ function execute(port) {
       rawContent = insertTableOfContents(rawContent);
     }
 
-    let latestVersion = env.latestVersion;
+    let latestVersion = env.versioning.latestVersion;
 
     // replace any links to markdown files to their website html links
     Object.keys(mdToHtml).forEach(function(key, index) {


### PR DESCRIPTION
See https://github.com/facebook/Docusaurus/blob/master/lib/server/generate.js#L148
Since `generate.js` and `server.js` share a lot of codes, someone should definitely rewrite these two modules.