### PR TITLE
Add function to generate TOC from document headings

### DIFF
--- a/lib/core/getTOC.js
+++ b/lib/core/getTOC.js
@@ -1,0 +1,52 @@
+const Remarkable = require('remarkable');
+const toSlug = require('./toSlug');
+
+const tagToLevel = tag => Number(tag.slice(1));
+
+/**
+ * Returns a table of content from the headings
+ *
+ * @return array
+ * Array of heading objects with `hashLink`, `text` and `children` fields
+ *
+ */
+module.exports = (content, headingTags = 'h2', subHeadingTags = 'h3') => {
+  const headingLevels = [].concat(headingTags).map(tagToLevel);
+  const subHeadingLevels = subHeadingTags
+    ? [].concat(subHeadingTags).map(tagToLevel)
+    : [];
+
+  const md = new Remarkable();
+  const tokens = md.parse(content, {});
+  const headings = [];
+  for (let i = 0; i < tokens.length; i++) {
+    if (
+      tokens[i].type == 'heading_open' &&
+      headingLevels.concat(subHeadingLevels).includes(tokens[i].hLevel)
+    ) {
+      headings.push({
+        hLevel: tokens[i].hLevel,
+        text: tokens[i + 1].content,
+      });
+    }
+  }
+
+  const toc = [];
+  let current;
+  headings.forEach(heading => {
+    const entry = {
+      hashLink: toSlug(heading.text),
+      text: heading.text,
+      children: [],
+    };
+
+    if (headingLevels.includes(heading.hLevel)) {
+      toc.push(entry);
+      current = entry;
+    } else {
+      current && current.children.push(entry);
+    }
+  });
+
+  return toc;
+};


### PR DESCRIPTION
## Motivation

Adresses #344.

I separated this into two PRs. This one only adds the function to extract a table of contents out of a markdown document's header tags. The table of content only has two levels at most. By default h2 tags are used for top level headings and h3 for subheadings. This can be customized, and the idea is to allow users to choose the tags to be used as top level and sub headings from siteConfig. More info about that in the other PR.

## Test Plan

This function is pretty self-contained and should work from anywhere. Document markdown in => table of contents out.

## Related PRs

#475 