### PR TITLE
Add separate on-page navigation sidebar

### DIFF
--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -9,6 +9,7 @@ const React = require('react');
 const Container = require('./Container.js');
 const Doc = require('./Doc.js');
 const DocsSidebar = require('./DocsSidebar.js');
+const OnPageNav = require('./nav/OnPageNav.js');
 const Site = require('./Site.js');
 const translation = require('../server/translation.js');
 
@@ -25,7 +26,7 @@ class DocsLayout extends React.Component {
     return (
       <Site
         config={this.props.config}
-        className="sideNavVisible"
+        className="sideNavVisible doc"
         title={
           i18n
             ? translation[this.props.metadata.language]['localized-strings'][
@@ -90,6 +91,12 @@ class DocsLayout extends React.Component {
               )}
             </div>
           </Container>
+          {this.props.config.onPageNav == 'separate' && (
+            <OnPageNav
+              config={this.props.config}
+              rawContent={this.props.children}
+            />
+          )}
         </div>
       </Site>
     );

--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -92,10 +92,9 @@ class DocsLayout extends React.Component {
             </div>
           </Container>
           {this.props.config.onPageNav == 'separate' && (
-            <OnPageNav
-              config={this.props.config}
-              rawContent={this.props.children}
-            />
+            <nav className="onPageNav">
+              <OnPageNav rawContent={this.props.children} />
+            </nav>
           )}
         </div>
       </Site>

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -11,6 +11,7 @@ const HeaderNav = require('./nav/HeaderNav.js');
 const Head = require('./Head.js');
 const Footer = require(process.cwd() + '/core/Footer.js');
 const translation = require('../server/translation.js');
+const classNames = require('classnames');
 
 const CWD = process.cwd();
 
@@ -63,7 +64,11 @@ class Site extends React.Component {
           title={title}
           url={url}
         />
-        <body className={this.props.className}>
+        <body
+          className={classNames({
+            [this.props.className]: true,
+            separateOnPageNav: this.props.config.onPageNav == 'separate',
+          })}>
           <HeaderNav
             config={this.props.config}
             baseUrl={this.props.config.baseUrl}

--- a/lib/core/getTOC.js
+++ b/lib/core/getTOC.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const Remarkable = require('remarkable');
 const toSlug = require('./toSlug');
 

--- a/lib/core/getTOC.js
+++ b/lib/core/getTOC.js
@@ -1,0 +1,52 @@
+const Remarkable = require('remarkable');
+const toSlug = require('./toSlug');
+
+const tagToLevel = tag => Number(tag.slice(1));
+
+/**
+ * Returns a table of content from the headings
+ *
+ * @return array
+ * Array of heading objects with `hashLink`, `text` and `children` fields
+ *
+ */
+module.exports = (content, headingTags = 'h2', subHeadingTags = 'h3') => {
+  const headingLevels = [].concat(headingTags).map(tagToLevel);
+  const subHeadingLevels = subHeadingTags
+    ? [].concat(subHeadingTags).map(tagToLevel)
+    : [];
+
+  const md = new Remarkable();
+  const tokens = md.parse(content, {});
+  const headings = [];
+  for (let i = 0; i < tokens.length; i++) {
+    if (
+      tokens[i].type == 'heading_open' &&
+      headingLevels.concat(subHeadingLevels).includes(tokens[i].hLevel)
+    ) {
+      headings.push({
+        hLevel: tokens[i].hLevel,
+        text: tokens[i + 1].content,
+      });
+    }
+  }
+
+  const toc = [];
+  let current;
+  headings.forEach(heading => {
+    const entry = {
+      hashLink: toSlug(heading.text),
+      text: heading.text,
+      children: [],
+    };
+
+    if (headingLevels.includes(heading.hLevel)) {
+      toc.push(entry);
+      current = entry;
+    } else {
+      current && current.children.push(entry);
+    }
+  });
+
+  return toc;
+};

--- a/lib/core/nav/OnPageNav.js
+++ b/lib/core/nav/OnPageNav.js
@@ -6,6 +6,8 @@
  */
 
 const React = require('react');
+
+const siteConfig = require(process.cwd() + '/siteConfig.js');
 const getTOC = require('../getTOC');
 
 const Link = ({hashLink, text}) => <a href={`#${hashLink}`}>{text}</a>;
@@ -13,7 +15,7 @@ const Link = ({hashLink, text}) => <a href={`#${hashLink}`}>{text}</a>;
 const Headings = ({headings}) => {
   if (!headings.length) return null;
   return (
-    <ul>
+    <ul className="toc-headings">
       {headings.map((heading, i) => (
         <li key={i}>
           <Link hashLink={heading.hashLink} text={heading.text} />
@@ -26,16 +28,12 @@ const Headings = ({headings}) => {
 
 class OnPageNav extends React.Component {
   render() {
-    const customTags = this.props.config.onPageNavHeadings;
+    const customTags = siteConfig.onPageNavHeadings;
     const headings = customTags
       ? getTOC(this.props.rawContent, customTags.topLevel, customTags.sub)
       : getTOC(this.props.rawContent);
 
-    return (
-      <nav className="onPageNav">
-        <Headings headings={headings} />
-      </nav>
-    );
+    return <Headings headings={headings} />;
   }
 }
 

--- a/lib/core/nav/OnPageNav.js
+++ b/lib/core/nav/OnPageNav.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const getTOC = require('../getTOC');
+
+const Link = ({hashLink, text}) => <a href={`#${hashLink}`}>{text}</a>;
+
+const Headings = ({headings}) => {
+  if (!headings.length) return null;
+  return (
+    <ul>
+      {headings.map((heading, i) => (
+        <li key={i}>
+          <Link hashLink={heading.hashLink} text={heading.text} />
+          <Headings headings={heading.children} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+class OnPageNav extends React.Component {
+  render() {
+    const customTags = this.props.config.onPageNavHeadings;
+    const headings = customTags
+      ? getTOC(this.props.rawContent, customTags.topLevel, customTags.sub)
+      : getTOC(this.props.rawContent);
+
+    return (
+      <nav className="onPageNav">
+        <Headings headings={headings} />
+      </nav>
+    );
+  }
+}
+
+module.exports = OnPageNav;

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1495,71 +1495,67 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   }
 }
 
+.onPageNav {
+  display: none;
+}
+.onPageNav::-webkit-scrollbar {
+  display: none;
+}
+
 @supports(position: sticky) {
   @media only screen and (min-width: 1024px) {
     .separateOnPageNav.doc .wrapper,
     .separateOnPageNav .headerWrapper.wrapper {
-      max-width: 1400;
+      max-width: 1400px;
     }
-  
+
     .doc.separateOnPageNav .docsNavContainer {
       flex: 0 0 240px;
       margin: 40px 0 0;
     }
-  
+
     .doc.separateOnPageNav nav.toc:last-child {
       padding-bottom: 0;
       width: auto;
     }
-  
+
     .doc.separateOnPageNav.sideNavVisible .navPusher .mainContainer {
       max-width: 100%;
       flex: 1 auto;
       padding: 0 40px 50px;
       min-width: 0;
     }
-  }
 
-  .separateOnPageNav .onPageNav {
-    display: none;
-  }
-  
-  .separateOnPageNav .onPageNav::-webkit-scrollbar {
-    display: none;
-  }
-  
-  @media only screen and (min-width: 1024px) {
-    .separateOnPageNav .onPageNav {
+    .onPageNav {
       display: block;
       position: -webkit-sticky;
       position: sticky;
       top: 110px;
       flex: 0 0 240px;
-      align-self: flex-start;
       overflow-y: auto;
       max-height: calc(100vh - 110px);
     }
-  
-    .separateOnPageNav .onPageNav > ul {
+
+    .onPageNav > ul {
       border-left: 1px solid #e0e0e0;
       padding: 10px 0 2px 15px;
     }
-  
-    .separateOnPageNav .onPageNav a {
+
+    .onPageNav a {
       color: #717171;
     }
-  
-    .separateOnPageNav .onPageNav ul li {
+
+    .onPageNav ul li {
       font-size: 12px;
       line-height: 14px;
       padding-bottom: 12px;
     }
-  
-    .separateOnPageNav .onPageNav ul ul {
+
+    .onPageNav ul ul {
       padding: 8px 0 0 20px;
     }
-  
-    .separateOnPageNav .onPageNav ul ul li {
+
+    .onPageNav ul ul li {
       padding-bottom: 8px;
     }
   }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1494,6 +1494,77 @@ nav.toc .toggleNav .navBreadcrumb h2 {
     padding: 0 10px;
   }
 }
+
+@supports(position: sticky) {
+  @media only screen and (min-width: 1024px) {
+    .separateOnPageNav.doc .wrapper,
+    .separateOnPageNav .headerWrapper.wrapper {
+      max-width: 1400;
+    }
+  
+    .doc.separateOnPageNav .docsNavContainer {
+      flex: 0 0 240px;
+      margin: 40px 0 0;
+    }
+  
+    .doc.separateOnPageNav nav.toc:last-child {
+      padding-bottom: 0;
+      width: auto;
+    }
+  
+    .doc.separateOnPageNav.sideNavVisible .navPusher .mainContainer {
+      max-width: 100%;
+      flex: 1 auto;
+      padding: 0 40px 50px;
+      min-width: 0;
+    }
+  }
+
+  .separateOnPageNav .onPageNav {
+    display: none;
+  }
+  
+  .separateOnPageNav .onPageNav::-webkit-scrollbar {
+    display: none;
+  }
+  
+  @media only screen and (min-width: 1024px) {
+    .separateOnPageNav .onPageNav {
+      display: block;
+      position: -webkit-sticky;
+      position: sticky;
+      top: 110px;
+      flex: 0 0 240px;
+      align-self: flex-start;
+      overflow-y: auto;
+      max-height: calc(100vh - 110px);
+    }
+  
+    .separateOnPageNav .onPageNav > ul {
+      border-left: 1px solid #e0e0e0;
+      padding: 10px 0 2px 15px;
+    }
+  
+    .separateOnPageNav .onPageNav a {
+      color: #717171;
+    }
+  
+    .separateOnPageNav .onPageNav ul li {
+      font-size: 12px;
+      line-height: 14px;
+      padding-bottom: 12px;
+    }
+  
+    .separateOnPageNav .onPageNav ul ul {
+      padding: 8px 0 0 20px;
+    }
+  
+    .separateOnPageNav .onPageNav ul ul li {
+      padding-bottom: 8px;
+    }
+  }
+}
+
 table {
   background: #F8F8F8;
   border: 1px solid #B0B0B0;


### PR DESCRIPTION
## Motivation

This is how the table of contents generated from the document's headers can be displayed as a separate sticky sidebar on the right side of the document. I can write the corresponding docs when we finalize on all the ways the navigation can be displayed through the option `onPageNav`. This is currently using `'separate'`. The other possible values could be `false` for no on-page navigation, or `'inline'` to have it show up underneath the current item's link in the existing sidebar similar to #349.

As for the heading tags used to generate the TOC the default is same as this:
```
onPageNavHeadings: {topLevel: "h2", sub: "h3"}
```

`topLevel` and `sub` can be strings like above or arrays of strings. `sub` can also be a falsy value or empty array to indicate the user only needs top level headings.

Another example:
```
onPageNavHeadings: {topLevel: ["h2", "h3", "h4"], sub: null}
```

This will collect all h2, h3, and h4 tags as top headings and generate no sub headings. 

## Test Plan

All css rules are only applied in browsers that support the css sticky position, and larger than 1024px screens. With this option on (`onPageNav: 'separate'`) the menu wrapper becomes wider site-wide. That's the only change that affects all the site. All other css changes only affect doc pages.

## Related PRs

#474 
