### PR TITLE
Add missing i18n support in header link

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -193,7 +193,8 @@ class HeaderNav extends React.Component {
       <div className="fixedHeaderContainer">
         <div className="headerWrapper wrapper">
           <header>
-            <a href={this.props.baseUrl}>
+            <a href={this.props.baseUrl +
+              (env.translation.enabled ? this.props.language : '')}>
               {siteConfig.headerIcon && (
                 <img
                   className="logo"

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -193,8 +193,11 @@ class HeaderNav extends React.Component {
       <div className="fixedHeaderContainer">
         <div className="headerWrapper wrapper">
           <header>
-            <a href={this.props.baseUrl +
-              (env.translation.enabled ? this.props.language : '')}>
+            <a
+              href={
+                this.props.baseUrl +
+                (env.translation.enabled ? this.props.language : '')
+              }>
               {siteConfig.headerIcon && (
                 <img
                   className="logo"


### PR DESCRIPTION
Hello and thank you for this project!

## Motivation

I have noticed that the link to go to the "main" page in the navigation header (the one in the upper-left corner, with the header icon) was always targeting the page in the default—`en`—language, even if localization is enabled and another language was selected (e.f. `fr`).
I think this is something that has been forgotten as I expected the link to take the currently selected language into account.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

As this is a very small modification, I quickly tried to set up a local working environment to be able to run "prettier" and "Jest tests", but could not get it working within a 2 mn time box so I admit I skipped those steps.
I made sure the line was still < 80 characters (which was not before I read the Contributing Guidelines) and had the right number of spaces for indentation though.
Disclaimer: I am not a JavaScript/JSX developer.

## Test Plan

1. Have a site with translation enabled and at least another language in addition to English.

2. Go to the main page of the site

3. Change language with the drop-down on the upper-right corner

4. Check that the link to the main page in the upper-left corner,—in the navigation header, the one with the header icon—correctly targets the main page in the selected language

## Related PRs

None (as far as I've looked for).
