### PR TITLE
Add `blogSidebarCount` to the site config Docs

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -65,6 +65,8 @@ headerLinks: [
 
 `algolia` - Information for Algolia search integration. If this field is excluded, the search bar will not appear in the header.
 
+`blogSidebarCount` - Control the number of blog posts that show up in the sidebar. See the [adding a blog docs](guides-blog.md#changing-how-many-blog-posts-show-on-sidebar) for more information.
+
 `cname` - The CNAME for your website. It will go into a `CNAME` file when your site it built.
 
 `customDocsPath` - By default, Docusaurus expects your documentation to be in a directory called `docs`. This directory is at the same level as the `website` directory (i.e., not inside the `website` directory). You can specify a custom path to your documentation with this field. **Note that all of your documentation *.md files must still reside in a flat hierarchy. You cannot have your documents in nested directories**.


### PR DESCRIPTION
## Motivation

This is a config option. It should be in the config docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

local

## Related PRs

N/A
