### PR TITLE
feat(): add appId into algoliaConfig 

### DIFF
--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -121,7 +121,7 @@ class Site extends React.Component {
               var search = docsearch({
                 ${
                   this.props.config.algolia.appId
-                    ? `appId: '${this.props.config.algolia.appId},'`
+                    ? `appId: '${this.props.config.algolia.appId}',`
                     : ''
                 }
                 apiKey: '${this.props.config.algolia.apiKey}',
@@ -143,7 +143,7 @@ class Site extends React.Component {
               var search = docsearch({
                 ${
                   this.props.config.algolia.appId
-                    ? `appId: '${this.props.config.algolia.appId},'`
+                    ? `appId: '${this.props.config.algolia.appId}',`
                     : ''
                 }
                 apiKey: '${this.props.config.algolia.apiKey}',

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -119,6 +119,11 @@ class Site extends React.Component {
                 dangerouslySetInnerHTML={{
                   __html: `
               var search = docsearch({
+                ${
+                  this.props.config.algolia.appId
+                    ? `appId: '${this.props.config.algolia.appId},'`
+                    : ''
+                }
                 apiKey: '${this.props.config.algolia.apiKey}',
                 indexName: '${this.props.config.algolia.indexName}',
                 inputSelector: '#search_input_react',
@@ -136,6 +141,11 @@ class Site extends React.Component {
                 dangerouslySetInnerHTML={{
                   __html: `
               var search = docsearch({
+                ${
+                  this.props.config.algolia.appId
+                    ? `appId: '${this.props.config.algolia.appId},'`
+                    : ''
+                }
                 apiKey: '${this.props.config.algolia.apiKey}',
                 indexName: '${this.props.config.algolia.indexName}',
                 inputSelector: '#search_input_react'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Allow user to add their own appId into algolia configuration.
See the issue [465](https://github.com/facebook/Docusaurus/issues/465)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Do not change siteConfig.js
  - Run yarnpkg start from ../website
  - Make sure search work as before
- Add appId into algolia config in siteConfig.js, 
  - Run yarnpkg start from ../website
  - Make sure search work and effectively use given appId (note i it did my own set of apiKey/appId for this test)
 
Note i did also ran yarn jest and yarn prettier.

## Related PRs

Not related to any pr.
