### PR TITLE
Add missing i18n support in side nav breadcrumb

### DIFF
--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -23,7 +23,9 @@ class SideNav extends React.Component {
               </div>
               <h2>
                 <i>›</i>
-                <span>{this.props.current.category}</span>
+                <span>
+                  {this.getLocalizedCategoryString(this.props.current.category)}
+                </span>
               </h2>
             </div>
             <div className="navGroups">


### PR DESCRIPTION
Hello, I have noticed another (as in yesterday's PR #477) place where internationalization support seemed to be missing and submit this PR to hopefully help fixing gaps.

## Motivation

When in a configuration where screen width is limited (e.g. small smartphone), a breadcrumb appears to help the user know where s·he is.
The breadcrumb simply was not taking selected language into account—in the case where localization was enabled and an additional language added.
This PR is here to localize the breadcrumb label, leveraging a local existing function for this purpose.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes; the file went through prettier, which should conform to expected format and please the CI checker.
Manual tests were done.

## Test Plan

1. Have a project with localization enabled, additional language supported and a content leading to multiple sections in the side nav bar

2. Reduce the size of the browser to the minimum to simulate a small device with limited width: the side navigation bar should appear, with the breadcrumb

3. Change language (by selecting it through the upper-right drop down menu) and navigate using the breadcrumb: all breadcrumb labels should take the selected language into account

## Related PRs

PR #477 is in the same vein.
