### PR TITLE
support optional siteConfig.users

### DIFF
--- a/examples/basics/pages/en/users.js
+++ b/examples/basics/pages/en/users.js
@@ -14,6 +14,9 @@ const siteConfig = require(process.cwd() + '/siteConfig.js');
 
 class Users extends React.Component {
   render() {
+    if ((siteConfig.users || []).length === 0) {
+      return null;
+    }
     const showcase = siteConfig.users.map((user, i) => {
       return (
         <a href={user.infoLink} key={i}>


### PR DESCRIPTION
Fixes Issue #402 caused by removing optional users array from siteConfig file. Users array is now validated before using its properties.

## Motivation

Wanted to make an Open Source first contribution

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Use the examples script to copy over users.js and index.js (where the error occurs)
$ npm run examples

2. Comment the users array of siteConfig
![null_users](https://user-images.githubusercontent.com/15572567/36961903-2dcb35a2-2002-11e8-9824-bcc008fc868b.png)

3. Run build to generate the known error
$ npm run build
![build_error](https://user-images.githubusercontent.com/15572567/36961933-552367fa-2002-11e8-9b2a-93ce18c33186.png)

4. Implement changes for users validation to allow for optional users array
![users_validation](https://user-images.githubusercontent.com/15572567/36961972-7abe3562-2002-11e8-821a-b211439d7a87.png)

5. Run build to build fix
$ npm run build
![build_success](https://user-images.githubusercontent.com/15572567/36962001-981ef7cc-2002-11e8-88fc-65fdcc386af7.png)

6. Start test site
$ npm start
![working_start](https://user-images.githubusercontent.com/15572567/36962014-a755598e-2002-11e8-8a95-8510b15801b3.png)
