### PR TITLE
Example Pages: Replace hard-coded values with siteConfig properties

### DIFF
--- a/examples/basics/core/Footer.js
+++ b/examples/basics/core/Footer.js
@@ -88,9 +88,7 @@ class Footer extends React.Component {
             height="45"
           />
         </a>
-        <section className="copyright">
-          Copyright &copy; {currentYear} Facebook Inc.
-        </section>
+        <section className="copyright">{this.props.config.copyright}</section>
       </footer>
     );
   }

--- a/examples/basics/pages/en/help.js
+++ b/examples/basics/pages/en/help.js
@@ -13,12 +13,19 @@ const GridBlock = CompLibrary.GridBlock;
 
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 
+function docUrl(doc, language) {
+  return siteConfig.baseUrl + 'docs/' + (language ? language + '/' : '') + doc;
+}
+
 class Help extends React.Component {
   render() {
+    let language = this.props.language || '';
     const supportLinks = [
       {
-        content:
-          'Learn more using the [documentation on this site.](/test-site/docs/en/doc1.html)',
+        content: `Learn more using the [documentation on this site.](${docUrl(
+          'doc1.html',
+          language
+        )})`,
         title: 'Browse Docs',
       },
       {

--- a/examples/basics/pages/en/users.js
+++ b/examples/basics/pages/en/users.js
@@ -17,6 +17,7 @@ class Users extends React.Component {
     if ((siteConfig.users || []).length === 0) {
       return null;
     }
+    const editUrl = siteConfig.repoUrl + '/edit/master/website/siteConfig.js';
     const showcase = siteConfig.users.map((user, i) => {
       return (
         <a href={user.infoLink} key={i}>
@@ -35,9 +36,7 @@ class Users extends React.Component {
             </div>
             <div className="logos">{showcase}</div>
             <p>Are you using this project?</p>
-            <a
-              href="https://github.com/facebook/docusaurus/edit/master/website/siteConfig.js"
-              className="button">
+            <a href={editUrl} className="button">
               Add your company
             </a>
           </div>


### PR DESCRIPTION
## Motivation

As outlined in #488, several sections in the Example pages were hard-coded.
Namely, the ``copyright`` inside ``footer.js`, the **edit** link inside ``users.js`` as well as the ``Learn more`` link inside ``help.js``.

This PR seeks to alleviate this behavior by utilizing properties found inside ``siteConfig.js``.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Initialize a new Example page by running ``docusaurus-init``, renaming ``blog-examples-from-docusaurus`` and ``docs-examples-from-docusaurus`` (as outlined in the [Getting started guide](https://docusaurus.io/docs/en/installation.html)) and, finally, running the local web server inside ``website`` via ``npm start`` or ``yarn start``.

2. Inside your browser, navigate to  http://localhost:3000.

3. Check the copyright notice inside the footer. It should look as follows.

![footerold](https://user-images.githubusercontent.com/1962554/37284360-8b211b64-25fb-11e8-9fe3-851ddf46638a.png)

4. Notice how this isn't the same copyright you set in ``siteConfig.js``.

5. Apply changes from PR.

6. Rebuild website with the changes.

7. Reload website.

8. Check footer again.

![footernew](https://user-images.githubusercontent.com/1962554/37284403-b4658dd4-25fb-11e8-939d-1cfef7e66b34.png)

9. The copyright notice should match the value inside ``sideConfig.js`` now.

### Additional tests:

Check the ``a href`` of the ``Learn more using the documentation on this site.`` link inside http://localhost:3000/test-site/help.html. It should now correctly link to the ``baseUrl`` configure inside ``siteConfig.js`` as well as the proper language version.

Inside http://localhost:3000/test-site/users.html click the ``Add Your Company" button.
Rather than being redirected to https://github.com/facebook/docusaurus/edit/master/website/siteConfig.js you should now be redirected to whatever you set your ``repoUrl`` inside ``siteConfig.js`` to.