### PR TITLE
Add  documentation for `onPageNav`

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -126,6 +126,10 @@ h1 {
 
 `ogImage` - url for an Open Graph image. This image will show up when your site is shared on Facebook, Twitter and any other websites/apps where the Open Graph protocol is supported.
 
+`onPageNav` - If you want a visible navigation option for representing topics on the current page. Currently, there is one accepted value for this option:
+
+- `separate` - The secondary navigation is a separate pane defaulting on the right side of a document. See http://docusaurus.io/docs/en/translation.html for an example.
+
 `organizationName` - GitHub username of the organization or user hosting this project. This is used by the publishing script to determine where your GitHub pages website will be hosted.
 
 `scripts` - Array of JavaScript sources to load. The script tag will be inserted in the HTML head.

--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -62,6 +62,8 @@ const siteConfig = {
   scripts: ['https://buttons.github.io/buttons.js'],
   // You may provide arbitrary config keys to be used as needed by your template.
   repoUrl: 'https://github.com/facebook/test-site',
+  /* On page navigation for the current documentation page */
+  // onPageNav: 'separate',
 };
 
 module.exports = siteConfig;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -163,6 +163,7 @@ const siteConfig = {
   facebookAppId: '1615782811974223',
   twitter: 'true',
   ogImage: 'img/docusaurus.png',
+  onPageNav: 'separate',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
## Motivation

Adds documentation for `onPageNav`, which enables secondary, page-specific navigation.

And enable this option for docusaurus.io

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local site testing

## Related PRs

https://github.com/facebook/Docusaurus/pull/475/