### PR TITLE
Fix on-page nav height css bug

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1535,6 +1535,7 @@ nav.toc .toggleNav .navBreadcrumb h2 {
       flex: 0 0 240px;
       overflow-y: auto;
       max-height: calc(100vh - 110px);
+      align-self: flex-start;
     }
 
     .onPageNav > ul {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This fixes a css bug that caused the on-page nav to scroll up higher than necessary when the nav is too short.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Old behaviour: https://deploy-preview-1603--babel-new.netlify.com/docs/en/index.html
Click the last item "Compact" there and see the nav "disappear".

With this fix: https://deploy-preview-1604--babel-new.netlify.com/docs/en/index.html
Clicking "Compact" still keeps the nav in the visible area.

## Related PRs
https://github.com/babel/website/pull/1604
