### PR TITLE
Add Facebook Pixel ID setting

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -90,6 +90,8 @@ customDocsPath: "website-docs"
 
 `facebookAppId` - If you want Facebook Like/Share buttons at the bottom of your blog posts, provide a [Facebook application id](https://www.facebook.com/help/audiencenetwork/804209223039296), and the buttons will show up on all blog posts.
 
+`facebookPixelId` - Facebook Pixel ID to track page views.
+
 `fonts` - Font-family css configuration for the site. If a font family is specified in `siteConfig.js` as `$myFont`, then adding a `myFont` key to an array in `fonts` will allow you to configure the font. Items appearing earlier in the array will take priority of later elements, so ordering of the fonts matter.
 
 In the below example, we have two sets of font configurations, `myFont` and `myOtherFont`. `Times New Roman` is the preferred font in `myFont`. `-apple-system` is the preferred in `myOtherFont`.
@@ -217,6 +219,7 @@ const siteConfig = {
   scripts: [ "https://docusaurus.io/slash.js" ],
   stylesheets: [ "https://docusaurus.io/style.css" ],
   facebookAppId: "1615782811974223",
+  facebookPixelId: "352490515235776",
   twitter: "true"
 };
 

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -112,6 +112,24 @@ class Site extends React.Component {
               }}
             />
           )}
+          {this.props.config.facebookPixelId && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
+              !function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '${this.props.config.facebookPixelId}');
+              fbq('track', 'PageView');
+                `,
+              }}
+            />
+          )}
           {this.props.config.twitter && (
             <script
               dangerouslySetInnerHTML={{


### PR DESCRIPTION
This PR adds a new configuration option to set the ID of a Facebook Pixel to track page views.

## Motivation

Using the Facebook Pixel to track page views in the generated docs site.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- Create a [Facebook Pixel](https://www.facebook.com/business/a/facebook-pixel) (or get the ID of an existing one.)
- Update your Docusaurus' siteConfig.js file and add a new field named `facebookPixelId` to the exported object `siteConfig`. The value should be the ID of the pixel referenced in the previous step.
  - Example `facebookAppId: '352490515235776',`
- Launch your docs site generated by Docusaurus by running `npm start` in the `website` folder.
- Navigate to the home page e.g. `http://localhost:3000/`
- Verify the pixel is firing `Page View` events. These are some of the options:
  - Using the [Pixel Helper](https://developers.facebook.com/docs/facebook-pixel/pixel-helper) Chrome plugin.
  - Using the [Event Debugger](https://developers.facebook.com/docs/analytics/debugging) of [Facebook Analytics](https://analytics.facebook.com/).

![image](https://user-images.githubusercontent.com/18663703/37434272-792845de-27b5-11e8-9aff-17eb5e93619c.png)

![image](https://user-images.githubusercontent.com/18663703/37434401-d38a92de-27b5-11e8-99d0-54825f3b38e7.png)

