### PR TITLE
Fix problems with a horizontal scrollbar

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1827,7 +1827,7 @@ footer .sitemap .nav-home:focus {
     display: flex;
     flex-direction: column;
     margin: 0 2em 3em;
-    width: 100%;
+    width: calc(100% - 4em);
   }
 }
 


### PR DESCRIPTION
@JoelMarcey okay, so I investigated a little and realized that the original page didn't actually have as substantial a scrollbar problem as it did once my change was pushed (maybe even not at all).

So I found out that I had incorrectly set the width to `100%` without keeping in mind the margin of `2em`, and it wasn't too difficult to realize that the white space to the right was exactly as big as the margin so I just went ahead and changed the width from `100%` to `calc(100% - 4em)` to account for a `2em` margin on each side. Needless to say, it works perfectly now.

**`calc()` usage**: https://caniuse.com/#feat=calc
**Screenshot**:
![localhost_3000_docs_en_custom-pages html iphone 6_7_8](https://user-images.githubusercontent.com/13121330/37601132-4b618d24-2baf-11e8-9aef-56459672fb7b.png)

