### PR TITLE
Simplify installation steps

### DIFF
--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -11,7 +11,7 @@ Docusaurus was designed from the ground up to be easily installed and used to ge
     
 1. Go into the root of your GitHub repo directory where you will be creating the docs.
 1. `npx docusaurus-init`
-    > Alternativiely, you can install it globally with either `yarn global add docusaurus-init` or `npm install --global docusaurus-init`. After that, run `docusaurus-init`.
+    > If you don't have Node 8.2+ or if you prefer to install Docusaurus globally, run `yarn global add docusaurus-init` or `npm install --global docusaurus-init`. After that, run `docusaurus-init`.
 
 > After Docusaurus is installed, moving forward, you can check your current version of Docusaurus by going into the `website` directory and typing `yarn outdated` or `npm outdated`. You can update to the [latest version](https://www.npmjs.com/package/docusaurus) of Docusaurus by typing `yarn upgrade --latest` or `npm update`.
 

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -10,10 +10,12 @@ Docusaurus was designed from the ground up to be easily installed and used to ge
     > While we recommend Node 8.x or greater, your Node version must at least 6.x.
     
 1. Go into the root of your GitHub repo directory where you will be creating the docs.
-1. `yarn global add docusaurus-init` or `npm install --global docusaurus-init`
-1. `docusaurus-init`
+1. `npx docusaurus-init`
+    > Alternativiely, you can install it globally with either `yarn global add docusaurus-init` or `npm install --global docusaurus-init`. After that, run `docusaurus-init`.
 
-> After docusaurus is installed, moving forward, you can check your current version of Docusaurus by going into the `website` directory and typing `npm list docusaurus`. You can update to the [latest version](https://www.npmjs.com/package/docusaurus) of Docusaurus by typing `npm update`.
+> After Docusaurus is installed, moving forward, you can check your current version of Docusaurus by going into the `website` directory and typing `yarn outdated` or `npm outdated`. You can update to the [latest version](https://www.npmjs.com/package/docusaurus) of Docusaurus by typing `yarn upgrade --latest` or `npm update`.
+
+## Verifying Installation
 
 Along with previously existing files and directories, your root directory will now contain a structure similar to:
 
@@ -38,10 +40,6 @@ root-of-repo
 │   └── siteConfig.js
 │   └── static
 ```
-
-> If you do not want to install the init script globally, you can install it locally and then run it via `npx docusaurus-init` or from the `node_modules` directory that is created via `./node_modules/.bin/docusaurus-init`. You may want to remove the created `package.json` file and `node_modules` directory after you run the script.
-
-## Verifying Installation
 
 Running the Docusaurus initialization script, `docusaurus-init`, produces a runnable, example website to base your site upon.
 

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -13,7 +13,7 @@ Docusaurus was designed from the ground up to be easily installed and used to ge
 1. `npx docusaurus-init`
     > If you don't have Node 8.2+ or if you prefer to install Docusaurus globally, run `yarn global add docusaurus-init` or `npm install --global docusaurus-init`. After that, run `docusaurus-init`.
 
-> After Docusaurus is installed, moving forward, you can check your current version of Docusaurus by going into the `website` directory and typing `yarn outdated` or `npm outdated`. You can update to the [latest version](https://www.npmjs.com/package/docusaurus) of Docusaurus by typing `yarn upgrade --latest` or `npm update`.
+> After Docusaurus is installed, moving forward, you can check your current version of Docusaurus by going into the `website` directory and typing `yarn outdated docusaurus` or `npm outdated docusaurus`. You can update to the [latest version](https://www.npmjs.com/package/docusaurus) of Docusaurus by typing `yarn upgrade docusaurus --latest` or `npm update docusaurus`.
 
 ## Verifying Installation
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After going through installation steps for first time, I had thoughts on some changes that could further simplify new users.

- Since `docusaurus-init` is run seldomly, `npx` keeps it simpler, and subsequent runs will be using the latest version.
- `outdated` command provides more meaningful view of current and latest version
- Moved file and directory example down into _Verifying Installation_ section as it is not an actual step to installation, but merely for verifying.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

None

## Related PRs

None
