### PR TITLE
Fix body class

### DIFF
--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -56,6 +56,8 @@ class Site extends React.Component {
       htmlElementProps = {};
     }
 
+    const className = this.props.className || '';
+
     return (
       <html {...htmlElementProps}>
         <Head
@@ -66,7 +68,7 @@ class Site extends React.Component {
         />
         <body
           className={classNames({
-            [this.props.className]: true,
+            [className]: className,
             separateOnPageNav: this.props.config.onPageNav == 'separate',
           })}>
           <HeaderNav


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes a minor bug introduced with the changes for the on-page nav feature. When `<Site>` was being called without a `className` prop, the string `"undefined"` would get added to the body element as a superfluous class name.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Can be seen in the help page or the blog listing page for example.
![body](https://user-images.githubusercontent.com/2972085/37864962-1765edec-2f76-11e8-8e98-f3b75ddead85.png)
