### PR TITLE
Add rel="noreferrer noopener" to <a> with target="_blank"

### DIFF
--- a/examples/basics/core/Footer.js
+++ b/examples/basics/core/Footer.js
@@ -52,11 +52,15 @@ class Footer extends React.Component {
             </a>
             <a
               href="http://stackoverflow.com/questions/tagged/"
-              target="_blank">
+              target="_blank"
+              rel="noreferrer noopener">
               Stack Overflow
             </a>
             <a href="https://discordapp.com/">Project Chat</a>
-            <a href="https://twitter.com/" target="_blank">
+            <a
+              href="https://twitter.com/"
+              target="_blank"
+              rel="noreferrer noopener">
               Twitter
             </a>
           </div>
@@ -80,6 +84,7 @@ class Footer extends React.Component {
         <a
           href="https://code.facebook.com/projects/"
           target="_blank"
+          rel="noreferrer noopener"
           className="fbOpenSource">
           <img
             src={this.props.config.baseUrl + 'img/oss_logo.png'}

--- a/lib/core/BlogPost.js
+++ b/lib/core/BlogPost.js
@@ -109,7 +109,9 @@ class BlogPost extends React.Component {
         <div className="authorBlock">
           {post.author ? (
             <p className="post-authorName">
-              <a href={post.authorURL} target="_blank"
+              <a
+                href={post.authorURL}
+                target="_blank"
                 rel="noreferrer noopener">
                 {post.author}
               </a>

--- a/lib/core/BlogPost.js
+++ b/lib/core/BlogPost.js
@@ -44,7 +44,7 @@ class BlogPost extends React.Component {
     if (post.authorFBID) {
       return (
         <div className={className}>
-          <a href={post.authorURL} target="_blank">
+          <a href={post.authorURL} target="_blank" rel="noreferrer noopener">
             <img
               src={
                 'https://graph.facebook.com/' +
@@ -58,7 +58,7 @@ class BlogPost extends React.Component {
     } else if (post.authorImage) {
       return (
         <div className={className}>
-          <a href={post.authorURL} target="_blank">
+          <a href={post.authorURL} target="_blank" rel="noreferrer noopener">
             <img src={post.authorImage} />
           </a>
         </div>
@@ -109,7 +109,8 @@ class BlogPost extends React.Component {
         <div className="authorBlock">
           {post.author ? (
             <p className="post-authorName">
-              <a href={post.authorURL} target="_blank">
+              <a href={post.authorURL} target="_blank"
+                rel="noreferrer noopener">
                 {post.author}
               </a>
               {post.authorTitle}

--- a/lib/core/Doc.js
+++ b/lib/core/Doc.js
@@ -31,7 +31,8 @@ class Doc extends React.Component {
       this.props.metadata.custom_edit_url ||
       (this.props.config.editUrl && this.props.config.editUrl + docSource);
     let editLink = editUrl && (
-      <a className="edit-page-link button" href={editUrl} target="_blank">
+      <a className="edit-page-link button" href={editUrl} target="_blank"
+        rel="noreferrer noopener">
         {editThisDoc}
       </a>
     );
@@ -50,7 +51,8 @@ class Doc extends React.Component {
             '/' +
             this.props.language
           }
-          target="_blank">
+          target="_blank"
+          rel="noreferrer noopener">
           {translateThisDoc}
         </a>
       );

--- a/lib/core/Doc.js
+++ b/lib/core/Doc.js
@@ -31,7 +31,10 @@ class Doc extends React.Component {
       this.props.metadata.custom_edit_url ||
       (this.props.config.editUrl && this.props.config.editUrl + docSource);
     let editLink = editUrl && (
-      <a className="edit-page-link button" href={editUrl} target="_blank"
+      <a
+        className="edit-page-link button"
+        href={editUrl}
+        target="_blank"
         rel="noreferrer noopener">
         {editThisDoc}
       </a>

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -46,7 +46,9 @@ class LanguageDropDown extends React.Component {
     if (siteConfig.translationRecruitingLink) {
       enabledLanguages.push(
         <li key="recruiting">
-          <a href={siteConfig.translationRecruitingLink} target="_blank">
+          <a href={siteConfig.translationRecruitingLink}
+            target="_blank"
+            rel="noreferrer noopener">
             {helpTranslateString}
           </a>
         </li>

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -46,7 +46,8 @@ class LanguageDropDown extends React.Component {
     if (siteConfig.translationRecruitingLink) {
       enabledLanguages.push(
         <li key="recruiting">
-          <a href={siteConfig.translationRecruitingLink}
+          <a
+            href={siteConfig.translationRecruitingLink}
             target="_blank"
             rel="noreferrer noopener">
             {helpTranslateString}

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -92,8 +92,8 @@ class Footer extends React.Component {
         <a
           href="https://code.facebook.com/projects/"
           target="_blank"
-          className="fbOpenSource"
-        >
+          rel="noreferrer noopener"
+          className="fbOpenSource">
           <img
             src={`${this.props.config.baseUrl}img/oss_logo.png`}
             alt="Facebook Open Source"


### PR DESCRIPTION
## Motivation

Fix a lesser-known but common security vulnerability in websites.

`rel="noopener noreferrer"` should be added to links containing `target="_blank"` as a precaution against reverse tabnabbing. Since it's common for documentation websites to link to external sites, this should be added by default to the example code (as well as the whole code base).

For more information, please refer to the following article:
https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run the website and click on affected links

## Related PRs

None
