### PR TITLE
Fix .gitignore placement when running example script or docusaurus-init

### DIFF
--- a/examples/basics/gitignore
+++ b/examples/basics/gitignore
@@ -1,11 +1,13 @@
-node_modules
 .DS_Store
+
+node_modules
+
 lib/core/metadata.js
 lib/core/MetadataBlog.js
+
 website/translated_docs
 website/build/
 website/yarn.lock
 website/node_modules
-
 website/i18n/*
 !website/i18n/en.json

--- a/lib/copy-examples.js
+++ b/lib/copy-examples.js
@@ -156,15 +156,20 @@ if (feature === 'translations') {
     blogCreated = true;
   }
   // copy .gitignore file
-  if (fs.existsSync(CWD + '/.gitignore')) {
+  let gitignoreName = '.gitignore';
+  if (fs.existsSync(CWD + '/../.gitignore')) {
+    gitignoreName = '.gitignore-example-from-docusaurus';
     console.log(
       `${chalk.yellow('.gitignore already exists')} in ${chalk.yellow(
         CWD
-      )}. Rename or remove the file to regenerate an example version.\n`
+      )}. Creating an example gitignore file for you to copy from if desired.\n`
     );
-  } else {
-    fs.copySync(path.join(folder, 'gitignore'), path.join(CWD, '.gitignore'));
   }
+  fs.copySync(
+    path.join(folder, 'gitignore'),
+    path.join(CWD, '/../' + gitignoreName)
+  );
+
   // copy other files
   let files = glob.sync(folder + '/**/*');
   files.forEach(file => {


### PR DESCRIPTION
## Motivation

This puts `.gitignore` in the root instead of the `website` directory. If one exists, we create an example file to be used and copied from

Fixes #415

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local testing with and without an existing `.gitignore` file.

## Related PRs

N/A
