### PR TITLE
remove declaration of unused constant in basics example

### DIFF
--- a/examples/basics/pages/en/help.js
+++ b/examples/basics/pages/en/help.js
@@ -11,8 +11,6 @@ const CompLibrary = require('../../core/CompLibrary.js');
 const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 
-const siteConfig = require(process.cwd() + '/siteConfig.js');
-
 function docUrl(doc, language) {
   return siteConfig.baseUrl + 'docs/' + (language ? language + '/' : '') + doc;
 }


### PR DESCRIPTION
any linter will complain about this, so lets fix it here