### PR TITLE
Document className prop of GridBlock

### DIFF
--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -41,10 +41,15 @@ A React container component using Docusaurus styles. Has optional padding and ba
 Padding choices: `'all'`, `'bottom'`, `'left'`, `'right'`, `'top'`.  
 Background choices: `'dark'`, `'highlight'`, `'light'`.
 
+The `className` prop is an optional prop that allows you to your own class names to the `Container` instance. It works like the `className` attribute in JSX. You can use this class name to customize the styling of contents within this `Container`.
+
 Example:
 
 ```jsx
-<Container padding={["bottom", "top"]} background="light">
+<Container
+  padding={["bottom", "top"]}
+  background="light"
+  className="myCustomClass">
   ...         
 </Container>
 ```

--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -36,7 +36,7 @@ const MarkdownBlock = CompLibrary.MarkdownBlock;
 
 ### `CompLibrary.Container`
 
-A React container component using Docusaurus styles. Has optional padding and background color attributes that you can configure.
+A React container component using Docusaurus styles. Has optional padding and background color props that you can configure.
 
 Padding choices: `all`, `bottom`, `left`, `right`, `top`.  
 Background choices: `dark`, `highlight`, `light`.
@@ -53,15 +53,17 @@ Example:
 
 A React component to organize text and images.
 
-The `align` attribute determines text alignment. Text alignment defaults to `left` and can be set to `center` or `right`.
+The `align` prop determines text alignment. Text alignment defaults to `'left'` and can be set to `'center'` or `'right'`.
 
-The `layout` attribute determines number of column sections per GridBlock. `layout` defaults to `twoColumn` and can be set to `threeColumn` or `fourColumn` as well.
+The `layout` prop determines number of column sections per GridBlock. `layout` defaults to `'twoColumn'` and can be set to `'threeColumn'` or `'fourColumn'` as well.
 
-The `contents` attribute is an array containing the contents of each section of the GridBlock. Each content object can have the following fields:
+The `className` prop is an optional prop that allows you to your own class names to the `GridBlock` instance. It works like the `className` attribute in JSX. You can use this class name to customize the styling of contents within this `GridBlock`.
+
+The `contents` prop is an array containing the contents of each section of the GridBlock. Each content object can have the following fields:
 
 - `content` for the text of this section, which is parsed from markdown
 - `image` for the path to an image to display
-- `imageAlign` field for image alignment relative to the text, which defaults to `top` and can be set to `bottom`, `left`, or `right`
+- `imageAlign` field for image alignment relative to the text, which defaults to `'top'` and can be set to `'bottom'`, `'left'`, or `'right'`
 - `title` for the title to display for this section, which is parsed from markdown
 - `imageLink` for a link destination from clicking the image
 - `imageAlt` for the description of what text will be shown in case the image is not available
@@ -71,6 +73,8 @@ Example:
 ```
 <GridBlock
   align="center"
+  layout="threeColumn"
+  className="myCustomClass"  
   contents={[
     {
       content: "Learn how to use this project",
@@ -90,7 +94,6 @@ Example:
       title: "More"
     }
   ]}
-  layout="threeColumn"
 />
 ```
 

--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -38,8 +38,8 @@ const MarkdownBlock = CompLibrary.MarkdownBlock;
 
 A React container component using Docusaurus styles. Has optional padding and background color props that you can configure.
 
-Padding choices: `all`, `bottom`, `left`, `right`, `top`.  
-Background choices: `dark`, `highlight`, `light`.
+Padding choices: `'all'`, `'bottom'`, `'left'`, `'right'`, `'top'`.  
+Background choices: `'dark'`, `'highlight'`, `'light'`.
 
 Example:
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In [#docusaurus-users](https://discordapp.com/channels/398180168688074762/398180168688074765), ludeed was asking about changing the image size for a particular `GridBlock` instance. Upon digging into the code, I found that it is possible as `GridBlock` takes in a `className` prop. Unfortunately, that prop is not documented and hence not very discoverable. This PR adds it to the documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Load page locally.

![screen shot 2018-04-08 at 12 25 27 pm](https://user-images.githubusercontent.com/1315101/38471633-95ce37b2-3b28-11e8-963a-7b8c78a2c6dd.png)

## Related PRs

None