### PR TITLE
Add form field title for a11y

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -107,7 +107,7 @@ class HeaderNav extends React.Component {
       // return algolia search bar
       return (
         <li className="navSearchWrapper reactNavSearchWrapper" key="search">
-          <input id="search_input_react" type="text" placeholder="Search" />
+          <input id="search_input_react" type="text" placeholder="Search" title="Search" />
         </li>
       );
     } else if (link.languages) {

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -107,7 +107,12 @@ class HeaderNav extends React.Component {
       // return algolia search bar
       return (
         <li className="navSearchWrapper reactNavSearchWrapper" key="search">
-          <input id="search_input_react" type="text" placeholder="Search" title="Search" />
+          <input
+            id="search_input_react"
+            type="text"
+            placeholder="Search"
+            title="Search"
+          />
         </li>
       );
     } else if (link.languages) {


### PR DESCRIPTION
## Motivation

Resolves part of: https://github.com/facebook/Docusaurus/issues/462

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run `pa11y localhost:3000` before and after this change to confirm that the below error was solved.

```
 • Error: This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.
   ├── WCAG2AA.Principle1.Guideline1_3.1_3_1.F68
   ├── #search_input_react
   └── <input type="text" id="search_input_react" placeholder="Search" class="aa-input" autocomplete="off" spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-labelledby="search_input_react" aria-owns="algolia-autocomplete...
```

## Related PRs

N/A
