### PR TITLE
Fix header nav display for current language

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -24,7 +24,6 @@ const Metadata = require('../metadata.js');
 // language dropdown nav item for when translations are enabled
 class LanguageDropDown extends React.Component {
   render() {
-    let currentLanguage = 'English';
     setLanguage(this.props.language || 'en');
     let helpTranslateString = translate(
       'Help Translate|recruit community translators for your project'
@@ -32,7 +31,7 @@ class LanguageDropDown extends React.Component {
     // add all enabled languages to dropdown
     const enabledLanguages = env.translation
       .enabledLanguages()
-      .filter(lang => lang !== this.props.language)
+      .filter(lang => lang.tag !== this.props.language)
       .map(lang => (
         <li key={lang.tag}>
           <a href={siteConfig.baseUrl + lang.tag}>{lang.name}</a>
@@ -42,6 +41,13 @@ class LanguageDropDown extends React.Component {
     if (enabledLanguages.length < 1) {
       return null;
     }
+
+    // Get the current language full name for display in the header nav
+    const currentLanguage = env.translation
+      .enabledLanguages()
+      .filter(lang => lang.tag === this.props.language)
+      .map(lang => lang.name);
+
     // add Crowdin project recruiting link
     if (siteConfig.translationRecruitingLink) {
       enabledLanguages.push(


### PR DESCRIPTION
## Motivation

Even if we were on Spanish pages, it still showed English in the Header nav.
This makes it so that the Header nav shows the currently selected language.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local testing - header nav shows the right language

## Related PRs

N/A
