### PR TITLE
Split out @generated string

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -331,7 +331,7 @@ function generateMetadataDocs() {
   fs.writeFileSync(
     __dirname + '/../core/metadata.js',
     '/**\n' +
-      ' * @generated\n' +
+      ' * @' + 'generated\n' + // separate this out for Nuclide treating @generated as readonly
       ' */\n' +
       'module.exports = ' +
       JSON.stringify(metadatas, null, 2) +
@@ -397,7 +397,7 @@ function generateMetadataBlog() {
   fs.writeFileSync(
     __dirname + '/../core/MetadataBlog.js',
     '/**\n' +
-      ' * @generated\n' +
+      ' * @' + 'generated\n' + // separate this out for Nuclide treating @generated as readonly
       ' */\n' +
       'module.exports = ' +
       JSON.stringify(sortedMetadatas, null, 2) +

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -331,7 +331,8 @@ function generateMetadataDocs() {
   fs.writeFileSync(
     __dirname + '/../core/metadata.js',
     '/**\n' +
-      ' * @' + 'generated\n' + // separate this out for Nuclide treating @generated as readonly
+    ' * @' +
+    'generated\n' + // separate this out for Nuclide treating @generated as readonly
       ' */\n' +
       'module.exports = ' +
       JSON.stringify(metadatas, null, 2) +
@@ -397,7 +398,8 @@ function generateMetadataBlog() {
   fs.writeFileSync(
     __dirname + '/../core/MetadataBlog.js',
     '/**\n' +
-      ' * @' + 'generated\n' + // separate this out for Nuclide treating @generated as readonly
+    ' * @' +
+    'generated\n' + // separate this out for Nuclide treating @generated as readonly
       ' */\n' +
       'module.exports = ' +
       JSON.stringify(sortedMetadatas, null, 2) +


### PR DESCRIPTION
## Motivation

Nuclide treats files with `@generated` as read-only. This can fix that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local site

## Related PRs

N/A
