### PR TITLE
Add unidecode for heading slugs

### DIFF
--- a/lib/core/toSlug.js
+++ b/lib/core/toSlug.js
@@ -5,24 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const unidecode = require('unidecode');
+
 module.exports = string => {
-  //  var accents = "àáäâèéëêìíïîòóöôùúüûñç";
-  const accents =
-    '\u00e0\u00e1\u00e4\u00e2\u00e8' +
-    '\u00e9\u00eb\u00ea\u00ec\u00ed\u00ef' +
-    '\u00ee\u00f2\u00f3\u00f6\u00f4\u00f9' +
-    '\u00fa\u00fc\u00fb\u00f1\u00e7';
 
-  const without = 'aaaaeeeeiiiioooouuuunc';
-
-  let slug = string
-    .toString()
+  let slug = unidecode(string.toString())
     // Handle uppercase characters
     .toLowerCase()
-    // Handle accentuated characters
-    .replace(new RegExp('[' + accents + ']', 'g'), c => {
-      return without.charAt(accents.indexOf(c));
-    })
     // Replace `.`, `(` and `?` with blank string like Github does
     .replace(/\.|\(|\?/g, '')
     // Dash special characters

--- a/lib/core/toSlug.js
+++ b/lib/core/toSlug.js
@@ -8,7 +8,6 @@
 const unidecode = require('unidecode');
 
 module.exports = string => {
-
   let slug = unidecode(string.toString())
     // Handle uppercase characters
     .toLowerCase()

--- a/package-lock.json
+++ b/package-lock.json
@@ -5441,6 +5441,11 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
       "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
     },
+    "unidecode": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
+      "integrity": "sha1-77swFTi8RSRqmsjFWdcvAVMFBT4="
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "request": "^2.81.0",
     "shelljs": "^0.7.8",
     "sitemap": "^1.13.0",
-    "tcp-port-used": "^0.1.2"
+    "tcp-port-used": "^0.1.2",
+    "unidecode": "^0.1.8"
   },
   "bin": {
     "docusaurus-start": "./lib/start-server.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3515,6 +3515,10 @@ underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
+unidecode@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/unidecode/-/unidecode-0.1.8.tgz#efbb301538bc45246a9ac8c559d72f015305053e"
+
 universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"


### PR DESCRIPTION
## Motivation

Fixes #541 
Turns out that node-slug only deals with symbols not letters. I ended up using a transliteration library and kept all the other `toSlug` rules same as before. So this is a hotfix that just adds non-latin unicode letters to the slugs without making any breaking changes. I think I'll open a new issue for some ideas on how to improve slugs further.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Add a heading like this `### 第一章` to a doc. The generated slug should be `#di-yi-zhang`


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
