### PR TITLE
Add table to clarify versioning documentation

### DIFF
--- a/docs/guides-versioning.md
+++ b/docs/guides-versioning.md
@@ -41,6 +41,15 @@ Documents in the `docs` folder will be considered part of version `next` and the
 
 Running the script again with `yarn run version 2.0.0` will create a version `2.0.0`, making version `2.0.0` the most recent set of documentation. Documents from version `1.0.0` will use the url `docs/1.0.0/doc1.html` while `2.0.0` will use `docs/doc1.html`.
 
+This table below summarizes Docusaurus versioning at a glance:
+
+| Version | Tag | URL
+| --- | --- | -- |
+| 1.0.0 | 1.0.0 | docs/1.0.0/doc1.html |
+| 1.0.1 | 1.0.1 | docs/1.0.1/doc1.html |
+| 2.0.0 | current | docs/doc1.html |
+| master branch | next | docs/next/doc1.html |
+
 ## Versioning Patterns
 
 You can create version numbers in whatever format you wish, and a new version can be created with any version number as long as it does not match an existing version. Version ordering is determined by the order in which versions are created, independently of how they are numbered.


### PR DESCRIPTION
## Motivation

I think that this issue can resolve and close https://github.com/facebook/Docusaurus/issues/433.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

IS:
![image](https://user-images.githubusercontent.com/1372946/38845975-d6d1ffb4-41ae-11e8-99b6-8526b27dcd02.png)

WAS:
![image](https://user-images.githubusercontent.com/1372946/38845983-dff20e86-41ae-11e8-9c88-034e079f78a2.png)

## Related PRs

Follow on to https://github.com/facebook/Docusaurus/pull/545.

## Questions

cc @yangshun @JoelMarcey  

(1) I considered deleting "Documents from version `1.0.0` will use the url `docs/1.0.0/doc1.html` while `2.0.0` will use `docs/doc1.html`" since seems redundant now, but wanted to run this change by you first. 

(2) I wasn't sure about bumping the version but did so to check my work, can drop the commit if incorrect! 