### PR TITLE
Fix search bar width for mobile nav

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -711,7 +711,7 @@ input#search_input_react:focus, input#search_input_react:active {
 }
 @media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
   .navSearchWrapper {
-    width: 50%;
+    width: 40%;
   }
 }
 input::-webkit-input-placeholder {

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -709,7 +709,7 @@ input#search_input_react:focus, input#search_input_react:active {
   color: #fff;
   width: 220px;
 }
-@media only screen and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .navSearchWrapper {
     width: 40%;
   }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -709,7 +709,7 @@ input#search_input_react:focus, input#search_input_react:active {
   color: #fff;
   width: 220px;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-device-width: 735px) {
   .navSearchWrapper {
     width: 40%;
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #571. Shorten search bar by 10% on mobile since it doesn't really make too big of a visual difference being shorter.

This is just a quick fix and the nav bar CSS could probably be improved. There's no need for a `min-device-width` in the media query as the search bar should probably be shortenened for devices below the `min-device-width` as well.

This fix shouldn't affect existing users as shortening the search bar should be a backward-compatible change.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested on latest device resolutions in Chrome Devtools. This width works well on all of the devices available, even iPhone 5S, which is only 320px wide.

The following screenshots were taken on Pixel 2.

#### Before

<img src="https://user-images.githubusercontent.com/1315101/38852800-0ac6ed40-41d0-11e8-8014-838a697cfa91.png" width="400"/>

#### After

<img src="https://user-images.githubusercontent.com/1315101/38852815-1da230fa-41d0-11e8-871c-823cac89b348.png" width="400"/>
