### PR TITLE
Improve CSS media queries

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -709,7 +709,7 @@ input#search_input_react:focus, input#search_input_react:active {
   color: #fff;
   width: 220px;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .navSearchWrapper {
     width: 50%;
   }
@@ -756,7 +756,7 @@ pre code {
   font-weight: normal;
   text-decoration: none;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   a.edit-page-link.button{
     display: none;
   }
@@ -796,7 +796,7 @@ pre code {
   max-width: 500px;
   flex: 0 1 500px;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .imageAlignSide .blockImage {
     display: none;
   }
@@ -882,7 +882,7 @@ pre code {
 .container.paddingTop {
   padding-top: 80px;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .container.paddingBottom {
     padding-bottom: 40px;
   }
@@ -1204,7 +1204,7 @@ ul#languages li {
   }
 }
 
-@media only screen and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .navigationSlider .slidingNav ul {
     overflow-x: auto;
   }
@@ -1219,7 +1219,7 @@ ul#languages li {
 .docs-prev {
   float: left;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .docs-prevnext {
     height: 40px;
   }
@@ -1276,7 +1276,7 @@ nav.toc section {
 nav.toc:last-child {
   padding-bottom: 100px;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   nav.toc {
     width: 100%;
   }
@@ -1658,7 +1658,7 @@ table tr th {
 .blog-recent > a {
   float: left;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .blog-recent {
     height: 40px;
   }
@@ -1734,7 +1734,7 @@ h6:hover .header-link {
   width: 110px;
   padding: 20px;
 }
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .gridBlock .fourByGridBlock {
     box-sizing: border-box;
     flex: 1 0 26%;
@@ -1776,7 +1776,7 @@ h6:hover .header-link {
   padding: 20px;
 }
 
-@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
+@media only screen and (max-width: 735px) {
   .showcaseSection .logos img {
     max-height: 64px;
     width: 64px;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Realized that the CSS of the site was using `device-width` media queries, which is [deprecated](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/device-width). Use of `device-width` is not encouraged because it uses the hardware width rather than the viewport width.

This [Stack Overflow thread](https://stackoverflow.com/questions/15276218/css-media-queries-min-width-and-min-device-width-conflicting) explains well why it's a bad idea:

> If your resolution is large enough to get you in one break point, but the width of the browser is small enough to get you in another one, you'll end up with an odd combination of both.

In fact, the site is already suffering from this bug, for example, for the mobile web version of the [installation page](https://docusaurus.io/docs/en/installation.html), the "Edit" button is shown even though it's not supposed to, going by the media query:

```css
@media only screen and (min-device-width: 360px) and (max-device-width: 735px) {
  a.edit-page-link.button {
    display: none;
  }
}
```

I replaced all `device-width` with the `width` variants and removed redundant `min-width`s. Having the `min-width` breakpoint does not make much sense because there are is no CSS written to handle the widths smaller than the ones the CSS currently has.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Loaded the page on Chrome Devtools Pixel 2 resolution and navigated all the pages. No visible issues found.

## Related PRs

None
