### PR TITLE
Allow customizing of blog author image URL documentation

### DIFF
--- a/docs/guides-blog.md
+++ b/docs/guides-blog.md
@@ -42,7 +42,8 @@ The only required field is `title`; however, we provide options to add author in
 
 - `author` - The text label of the author byline.
 - `authorURL` - The url associated with the author. This could be a Twitter, GitHub, Facebook account, etc.
-- `authorFBID` - The Facebook ID that is used to extract the profile picture. (Note: If you prefer to use a different image than the Facebook profile picture, put `authorImageURL` instead.)
+- `authorFBID` - The Facebook ID that is used to extract the profile picture. (Note: If you use `authorFBID` and `authorImageURL`, `authorFBID` will take precedence.)
+- `authorImageURL` - The url associated with the author's image. (Note: If you use `authorFBID` and `authorImageURL`, `authorFBID` will take precedence. Don't include `authorFBID` if you want `authorImageURL` to appear.)
 - `title` - The blog post title.
 
 

--- a/docs/guides-blog.md
+++ b/docs/guides-blog.md
@@ -32,7 +32,7 @@ authorFBID: 503283835
 title: Introducing Docusaurus
 ---
 
-Lorem Ipusm...
+Lorem Ipsum...
 ```
 
 

--- a/docs/guides-blog.md
+++ b/docs/guides-blog.md
@@ -32,7 +32,7 @@ authorFBID: 503283835
 title: Introducing Docusaurus
 ---
 
-Lorem Ipusm..
+Lorem Ipusm...
 ```
 
 
@@ -42,7 +42,7 @@ The only required field is `title`; however, we provide options to add author in
 
 - `author` - The text label of the author byline.
 - `authorURL` - The url associated with the author. This could be a Twitter, GitHub, Facebook account, etc.
-- `authorFBID` - The Facebook ID that is used to extract the profile picture.
+- `authorFBID` - The Facebook ID that is used to extract the profile picture. (Note: If you prefer to use a different image than the Facebook profile picture, put `authorImageURL` instead.)
 - `title` - The blog post title.
 
 

--- a/docs/guides-blog.md
+++ b/docs/guides-blog.md
@@ -41,9 +41,9 @@ Lorem Ipsum...
 The only required field is `title`; however, we provide options to add author information to your blog post as well.
 
 - `author` - The text label of the author byline.
-- `authorURL` - The url associated with the author. This could be a Twitter, GitHub, Facebook account, etc.
-- `authorFBID` - The Facebook ID that is used to extract the profile picture. (Note: If you use `authorFBID` and `authorImageURL`, `authorFBID` will take precedence.)
-- `authorImageURL` - The url associated with the author's image. (Note: If you use `authorFBID` and `authorImageURL`, `authorFBID` will take precedence. Don't include `authorFBID` if you want `authorImageURL` to appear.)
+- `authorURL` - The URL associated with the author. This could be a Twitter, GitHub, Facebook account, etc.
+- `authorFBID` - The Facebook profile ID that is used to fetch the profile picture.
+- `authorImageURL` - A URL to the author's image. (Note: If you use both `authorFBID` and `authorImageURL`, `authorFBID` will take precedence. Don't include `authorFBID` if you want `authorImageURL` to appear.)
 - `title` - The blog post title.
 
 

--- a/docs/guides-blog.md
+++ b/docs/guides-blog.md
@@ -43,7 +43,7 @@ The only required field is `title`; however, we provide options to add author in
 - `author` - The text label of the author byline.
 - `authorURL` - The URL associated with the author. This could be a Twitter, GitHub, Facebook account, etc.
 - `authorFBID` - The Facebook profile ID that is used to fetch the profile picture.
-- `authorImageURL` - A URL to the author's image. (Note: If you use both `authorFBID` and `authorImageURL`, `authorFBID` will take precedence. Don't include `authorFBID` if you want `authorImageURL` to appear.)
+- `authorImageURL` - The URL to the author's image. (Note: If you use both `authorFBID` and `authorImageURL`, `authorFBID` will take precedence. Don't include `authorFBID` if you want `authorImageURL` to appear.)
 - `title` - The blog post title.
 
 

--- a/lib/core/BlogPost.js
+++ b/lib/core/BlogPost.js
@@ -56,6 +56,14 @@ class BlogPost extends React.Component {
           </a>
         </div>
       );
+    } else if (post.authorImage) {
+      return (
+        <div className={className}>
+          <a href={post.authorURL} target="_blank" rel="noreferrer noopener">
+            <img src={post.authorImage} />
+          </a>
+        </div>
+      );
     } else if (post.authorImageURL) {
       return (
         <div className={className}>

--- a/lib/core/BlogPost.js
+++ b/lib/core/BlogPost.js
@@ -56,11 +56,11 @@ class BlogPost extends React.Component {
           </a>
         </div>
       );
-    } else if (post.authorImage) {
+    } else if (post.authorImageURL) {
       return (
         <div className={className}>
           <a href={post.authorURL} target="_blank" rel="noreferrer noopener">
-            <img src={post.authorImage} />
+            <img src={post.authorImageURL} />
           </a>
         </div>
       );


### PR DESCRIPTION
## Motivation

@yangshun and I discussed this issue at our Week 2 meeting. Let me know what you think!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

First I verified that this functionality already existed by changing Joel's image to Daria. 

![image](https://user-images.githubusercontent.com/1372946/38855289-ec8b8482-41d7-11e8-9374-7997456ebf47.png)

//

Then I updated the docs. I thought it made sense to rename `authorImage` to `authorImageURL`, which matches existing `authorURL` and is more self-documenting.

IS:
![image](https://user-images.githubusercontent.com/1372946/38855340-0df72bf8-41d8-11e8-9cd2-4969de7b6168.png)

WAS:
![image](https://user-images.githubusercontent.com/1372946/38855350-150f0f00-41d8-11e8-9519-356ddbfbf0e8.png)

## Related PRs

N/A
