### PR TITLE
Do not ignore the `layout` header

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -26,6 +26,7 @@ const SupportedHeaderFields = new Set([
   'sidebar_label',
   'original_id',
   'hide_title',
+  'layout',
 ]);
 
 // Can have a custom docs path. Top level folder still needs to be in directory


### PR DESCRIPTION
#347 added support for warning for unknown fields but didn't take into account `layout` which was added by #128

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
