### PR TITLE
Restore the ability to use the --port command line argument

### DIFF
--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -37,7 +37,7 @@ const program = require('commander');
 
 program.option('--port <number>', 'Specify port number').parse(process.argv);
 
-let port = process.env.PORT || 3000;
+let port = parseInt(program.port, 10) || process.env.PORT || 3000;
 let numAttempts = 0;
 const MAX_ATTEMPTS = 10;
 checkPort();


### PR DESCRIPTION
The behavior was changed in #516. With this change, both the command line argument and environment variable will work.