### PR TITLE
Regenerate blog metadata on request to blog

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -269,13 +269,16 @@ function execute(port) {
     res.send(feed('rss'));
   });
 
-  // handle all requests for blog pages and posts
+  // Handle all requests for blog pages and posts.
   app.get(/blog\/.*html$/, (req, res) => {
-    // generate all of the blog pages
+    // Regenerate the blog metadata in case it has changed. Consider improving
+    // this to regenerate on file save rather than on page request.
+    reloadMetadataBlog();
+    // Generate all of the blog pages.
     removeModuleAndChildrenFromCache(join('..', 'core', 'BlogPageLayout.js'));
     const BlogPageLayout = require(join('..', 'core', 'BlogPageLayout.js'));
     const blogPages = {};
-    // make blog pages with 10 posts per page
+    // Make blog pages with 10 posts per page.
     const perPage = 10;
     for (
       let page = 0;
@@ -535,7 +538,7 @@ function execute(port) {
             console.error('No response');
           }
         } else {
-          console.error('request failed:', err);
+          console.error('Request failed:', err);
         }
       }
     );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #237. I'm not entirely sure if this is the best fix as it can be quite an expensive operation if there are many blog posts. IMO a better way would be to watch the blog files and only regenerate when it changes, but both ways has it pros and cons. Feel free to close this if you prefer the file watching method.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Load /blog
1. Change some text in the top blog post
1. Reload /blog
1. Text update is reflected

## Related PRs

NA
