### PR TITLE
Fix documentation link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Docusaurus is a project for easily building, deploying, and maintaining open sou
 
 ## Installation
 
-Docusaurus is available as the [`docusaurus` package](https://www.npmjs.com/package/docusaurus-init) on [npm](https://www.npmjs.com).
+Docusaurus is available as the [`docusaurus` package](https://www.npmjs.com/package/docusaurus) on [npm](https://www.npmjs.com).
 
 We have also released the [`docusaurus-init` package](https://www.npmjs.com/package/docusaurus-init) to make [getting started](https://docusaurus.io/docs/en/installation.html) with Docusaurus even easier.
 


### PR DESCRIPTION
## Motivation

There was two times the same link, none of which was pointing to the correct npm package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Click on the link and see that the correct npm package is shown
