### PR TITLE
Output the full path to build folder to aid when deploying site.

### DIFF
--- a/lib/build-files.js
+++ b/lib/build-files.js
@@ -34,4 +34,4 @@ if (!fs.existsSync(CWD + '/siteConfig.js')) {
 // generate all static html files
 const generate = require('./server/generate.js');
 generate();
-console.log("Site built successfully. Generated files in 'build' folder.");
+console.log("Site built successfully. Generated files in '"+CWD+"/build' folder.");


### PR DESCRIPTION
This adds information to the console log with the full path to the build folder to help aid when deploying a site within a container where folder paths are not absolute or known before hand.