### PR TITLE
Fix incorrect version links

### DIFF
--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -82,7 +82,7 @@ class Versions extends React.Component {
                         </td>
                         <td>
                           <a
-                            href={`https://github.com/facebook/relay/releases/tag/v${version}`}>
+                            href={`https://github.com/facebook/Docusaurus/releases/tag/v${version}`}>
                             Release Notes
                           </a>
                         </td>
@@ -93,7 +93,7 @@ class Versions extends React.Component {
             </table>
             <p>
               You can find past versions of this project{' '}
-              <a href="https://github.com/"> on GitHub </a>.
+              <a href="https://github.com/facebook/Docusaurus/releases">on GitHub</a>.
             </p>
           </div>
         </Container>

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -24,7 +24,7 @@ class Versions extends React.Component {
         <Container className="mainContainer versionsContainer">
           <div className="post">
             <header className="postHeader">
-              <h2>{siteConfig.title + ' Versions'}</h2>
+              <h2>{siteConfig.title} Versions</h2>
             </header>
             <h3 id="latest">Current version (Stable)</h3>
             <p>Latest version of Docusaurus.</p>
@@ -57,7 +57,7 @@ class Versions extends React.Component {
                     </a>
                   </td>
                   <td>
-                    <a href={'https://github.com/facebook/docusaurus'}>Source Code</a>
+                    <a href="https://github.com/facebook/Docusaurus">Source Code</a>
                   </td>
                 </tr>
               </tbody>
@@ -69,7 +69,7 @@ class Versions extends React.Component {
                 {versions.map(
                   version =>
                     version !== latestVersion && (
-                      <tr>
+                      <tr key={version}>
                         <th>{version}</th>
                         <td>
                           <a
@@ -92,8 +92,8 @@ class Versions extends React.Component {
               </tbody>
             </table>
             <p>
-              You can find past versions of this project{' '}
-              <a href="https://github.com/facebook/Docusaurus/releases">on GitHub</a>.
+              You can find past versions of this project on{' '}
+              <a href="https://github.com/facebook/Docusaurus/releases">GitHub</a>.
             </p>
           </div>
         </Container>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- The releases page was incorrectly pointing to Relay's releases page.
- Add missing key to `render`.
- General formatting improvements.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Load versions page locally and clicked around.

## Related PRs

NA
