### PR TITLE
Do not ignore 'custom_edit_url'

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -27,6 +27,7 @@ const SupportedHeaderFields = new Set([
   'original_id',
   'hide_title',
   'layout',
+  'custom_edit_url',
 ]);
 
 // Can have a custom docs path. Top level folder still needs to be in directory


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Receiving header field 'custom_edit_url' is not supported in terminal

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

* Add custom_edit_url to any `.md' file
* Start server and verify you receive the not supported message
* Add custom_edit_url into readMetadata.js
* Start server again and verify that that message is no longer reported in terminal
* Regress

## Related PRs

None
