### PR TITLE
Improve <table> appearance

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1563,48 +1563,60 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   }
 }
 
+/* Tables */
+
 table {
-  background: #F8F8F8;
-  border: 1px solid #B0B0B0;
   border-collapse: collapse;
+  border-spacing: 0;
   display: table;
+  font-size: 14px;
   margin: 20px 0;
 }
+
 table thead {
-  border-bottom: 1px solid #B0B0B0;
+  border-color: inherit;
   display: table-header-group;
+  vertical-align: middle;
 }
+
 table tbody {
   display: table-row-group;
+  vertical-align: middle;
 }
+
+table th,
+table td {
+  border: 1px solid #dbdbdb;
+  padding: .5em .75em;
+  vertical-align: top;
+}
+
 table tr {
+  border-color: inherit;
   display: table-row;
+  vertical-align: inherit;
 }
-table tr:nth-of-type(odd) {
-  background: #E8E8E8;
+
+table tr:nth-child(2n) {
+  background: #f5f5f5;
 }
-table tr th, table tr td {
-  border-right: 1px dotted #B0B0B0;
-  display: table-cell;
-  font-size: 14px;
-  line-height: 1.3em;
-  padding: 10px;
-  text-align: left;
+
+table tr th {
+  font-weight: bold;
 }
-table tr th:last-of-type, table tr td:last-of-type {
-  border-right: 0;
+
+.table tbody tr:last-child th,
+.table tbody tr:last-child td {
+  border-bottom-width: 0;
 }
-table tr th code, table tr td code {
+
+table th code,
+table td code {
   color: #2db04b;
   display: inline-block;
   font-size: 12px;
 }
-table tr th {
-  color: #000000;
-  font-weight: bold;
-  font-family: -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Arial,sans-serif;
-  text-transform: uppercase;
-}
+
 .mainContainer:not(.blogContainer) .wrapper .post,
 .blogContainer .posts,
 .blogContainer .lonePost {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #356. General changes made:

- Don't uppercase heading cells. This is usually unwanted and should not be a default.
- Switch the stripe background to be on even cells to prevent tables with one row from appearing just gray.
- Make the stripe background color a bit lighter. It was a little too dark.
- Remove some of the unnecessary CSS and selector nesting. 

In general, these changes should be an improvement for existing users unless they have heavily customized the table styling, then it might conflict.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Before

<img width="550" alt="screen shot 2018-04-25 at 11 02 32 pm" src="https://user-images.githubusercontent.com/1315101/39288468-ef480342-48dc-11e8-8b6b-e2e8a80b5254.png">

After

<img width="548" alt="screen shot 2018-04-25 at 11 02 40 pm" src="https://user-images.githubusercontent.com/1315101/39288444-d2c7fb14-48dc-11e8-9909-0dd915e7854f.png">

## Related PRs

NA.
