### PR TITLE
Update deprecated GitHub Buttons data-count-api

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require("react");
+const React = require('react');
 
 const GitHubButton = props => (
   <a
@@ -13,7 +13,7 @@ const GitHubButton = props => (
     href={`https://github.com/${props.config.organizationName}/${props.config.projectName}`}
     data-icon="octicon-star"
     data-count-href={`/${props.config.organizationName}/${props.config.projectName}/stargazers`}
-    data-count-api={`/repos/${props.config.organizationName}/${props.config.projectName}#stargazers_count`}
+    data-show-count="true"
     data-count-aria-label="# stargazers on GitHub"
     aria-label="Star this project on GitHub"
   >


### PR DESCRIPTION
## Motivation

Noticed this while working on another task on this repo

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

IS:
![image](https://user-images.githubusercontent.com/1372946/39393225-7e8cd640-4a77-11e8-97ea-b8f31126008c.png)

WAS:
![image](https://user-images.githubusercontent.com/1372946/39393228-85081caa-4a77-11e8-8f34-dee4d9c3b00c.png)

## Related PRs

N/A

---

cc @yangshun 