### PR TITLE
Add Home Assistant to users

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -140,6 +140,13 @@ const users = [
     fbOpenSource: false,
     pinned: false,
   },
+  {
+    caption: 'Home Assistant',
+    image: 'https://developers.home-assistant.io/img/logo-responsive.svg',
+    infoLink: 'https://developers.home-assistant.io/',
+    fbOpenSource: false,
+    pinned: false,
+  },
 ];
 
 const siteConfig = {

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -57,6 +57,13 @@ const users = [
     pinned: false,
   },
   {
+    caption: 'Home Assistant',
+    image: 'https://developers.home-assistant.io/img/logo-responsive.svg',
+    infoLink: 'https://developers.home-assistant.io/',
+    fbOpenSource: false,
+    pinned: false,
+  },
+  {
     caption: 'Jest',
     image: '/img/jest.png',
     infoLink: 'https://facebook.github.io/jest/',
@@ -137,13 +144,6 @@ const users = [
     caption: 'Vuls',
     image: 'https://vuls.io/img/docs/vuls_logo.png',
     infoLink: 'https://vuls.io/',
-    fbOpenSource: false,
-    pinned: false,
-  },
-  {
-    caption: 'Home Assistant',
-    image: 'https://developers.home-assistant.io/img/logo-responsive.svg',
-    infoLink: 'https://developers.home-assistant.io/',
     fbOpenSource: false,
     pinned: false,
   },


### PR DESCRIPTION
This adds Home Assistant as a user of Docusaurus. Based on the previous entry, we want to refer to the logo from another domain, so I linked it from our Docusaurus website.

Screenshot:

![image](https://user-images.githubusercontent.com/1444314/39402533-c76469a6-4b2f-11e8-989b-035aebc4cd3a.png)
