### PR TITLE
Incorrect file path for netlify publishing

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -172,7 +172,7 @@ Steps to configure your Docusaurus-powered site on Netlify.
 1. Select the branch to deploy. Default is `master`
 1. Configure your build steps:
     * For your build command enter: `cd website; npm install; npm run build;`
-    * For publish directory: `build/<projectName>` (use the `projectName` from your `siteConfig`)
+    * For publish directory: `website/build/<projectName>` (use the `projectName` from your `siteConfig`)
 
 1. Click **Deploy site**
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I tried following the guide to publish my website on Netlify (on April 29, 2018), however it did not work until I changed the path to include "website/".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

I skimmed it briefly after seeing this question.
