### PR TITLE
Simplifying DocSearch documentation

### DIFF
--- a/docs/guides-search.md
+++ b/docs/guides-search.md
@@ -3,45 +3,34 @@ id: search
 title: Enabling Search
 ---
 
-Docusaurus supports search using [Algolia DocSearch](https://community.algolia.com/docsearch/). Once you have set up your site, [enter your site information](https://community.algolia.com/docsearch/) to have Algolia crawl your website's documentation pages. Algolia will then send you an API key and index name for your site.
+Docusaurus supports search using [Algolia DocSearch][1]. Once your website is online, you can [submit it to DocSearch][2]. Algolia will then send you credentials you can add to your `siteConfig.js`.
+
+DocSearch works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API. Note that your website need to be publicly available for this to work (ie. not behind a firewall). This service is free.
 
 ## Enabling the Search Bar
 
-Enter your search-only API key and index name into `siteConfig.js` in the `algolia` section to enable search for your site.
+Enter your API key and index name (sent by Algolia) into `siteConfig.js` in the `algolia` section to enable search for your site.
 
 ```js
 const siteConfig = {
   ...
   algolia: {
-    apiKey: 'my-search-only-api-key-1234',
-    indexName: 'my-index-name'
+    apiKey: 'my-api-key',
+    indexName: 'my-index-name',
+    algoliaOptions: {} // Optional, if provided by Algolia
   },
   ...
 };
 ```
 
-## Extra Search Options
-
-You can also specify extra [search options used by Algolia](https://community.algolia.com/docsearch/documentation/) by using an `algoliaOptions` field in `algolia`. This may be useful if you want to provide different search results for the different versions or languages of your docs. Any occurrences of "VERSION" or "LANGUAGE" will be replaced by the version or language of the current page, respectively. More details about search options can be [found here](https://www.algolia.com/doc/api-reference/api-parameters/#overview).
-
-```js
-const siteConfig = {
-  ...
-  algolia: {
-    ...
-    algoliaOptions: {
-      facetFilters: [ 'tags:VERSION' ],
-      hitsPerPage: 5
-    }
-  },
-};
-```
+Algolia might provide you with [extra search options][3]. If so, you should add
+them to the `algoliaOptions` object.
 
 ## Controlling the Location of the Search Bar
 
 By default, the search bar will be the rightmost element in the top navigation bar.
 
-If you want to change the default location, add the `searchBar` flag in the `headerLinks` field of `siteConfig.js` in your desired location. For example, you may want the search bar in between your internal and external links.
+If you want to change the default location, add the `searchBar` flag in the `headerLinks` field of `siteConfig.js` in your desired location. For example, you may want the search bar between your internal and external links.
 
 ```js
 const siteConfig = {
@@ -62,3 +51,8 @@ const siteConfig = {
 To disable the search bar, comment out (recommended) or delete the `algolia` section in the `siteConfig.js` file.
 
 Also, if you have customized the location of the search bar in `headerLinks`, set `search: false`.
+
+
+[1]: https://community.algolia.com/docsearch/
+[2]: https://community.algolia.com/docsearch/
+[3]: https://community.algolia.com/docsearch/documentation/

--- a/docs/guides-search.md
+++ b/docs/guides-search.md
@@ -3,7 +3,7 @@ id: search
 title: Enabling Search
 ---
 
-Docusaurus supports search using [Algolia DocSearch][1]. Once your website is online, you can [submit it to DocSearch][2]. Algolia will then send you credentials you can add to your `siteConfig.js`.
+Docusaurus supports search using [Algolia DocSearch](https://community.algolia.com/docsearch/). Once your website is online, you can [submit it to DocSearch](https://community.algolia.com/docsearch/). Algolia will then send you credentials you can add to your `siteConfig.js`.
 
 DocSearch works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API. Note that your website need to be publicly available for this to work (ie. not behind a firewall). This service is free.
 
@@ -23,8 +23,7 @@ const siteConfig = {
 };
 ```
 
-Algolia might provide you with [extra search options][3]. If so, you should add
-them to the `algoliaOptions` object.
+Algolia might provide you with [extra search options](https://community.algolia.com/docsearch/documentation/). If so, you should add them to the `algoliaOptions` object.
 
 ## Controlling the Location of the Search Bar
 
@@ -51,8 +50,3 @@ const siteConfig = {
 To disable the search bar, comment out (recommended) or delete the `algolia` section in the `siteConfig.js` file.
 
 Also, if you have customized the location of the search bar in `headerLinks`, set `search: false`.
-
-
-[1]: https://community.algolia.com/docsearch/
-[2]: https://community.algolia.com/docsearch/
-[3]: https://community.algolia.com/docsearch/documentation/


### PR DESCRIPTION
## Motivation

Hello, Tim from Algolia here. I'm one of the maintainers of DocSearch, and by reading the DocSearch/Docusaurus documentation I thought it could be simplified by slightly rewording the current version.

Here are the main points:
- I explained a bit more how DocSearch works (trying to explain that it's an external service that requires the website to be online)
- I removed mentions to the _search_ API key as in that case, it's always a _search_ (as opposed to _admin_) API key that is used
- I removed the part about faceting on the version. I thought it was confusing as without a specific UI to display the faceting, this part alone won't do much. I might submit a PR later to specifically handle faceting by version, including the required layout changes, but as it was today I think it would just create confusion rather that adding value.

Hope that helps :)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

I did :)

