### PR TITLE
On mobile, hide title if logo exists

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -213,17 +213,14 @@ class HeaderNav extends React.Component {
   }
 
   render() {
+    const headerClass = siteConfig.headerIcon
+      ? 'headerTitleWithLogo'
+      : 'headerTitle';
     const versionsLink =
       this.props.baseUrl +
       (env.translation.enabled
         ? this.props.language + '/versions.html'
         : 'versions.html');
-    let headerClass;
-    if (siteConfig.headerIcon) {
-      headerClass="headerTitleHidden"
-    } else {
-      headerClass="headerTitle"
-    }
     return (
       <div className="fixedHeaderContainer">
         <div className="headerWrapper wrapper">

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -218,6 +218,12 @@ class HeaderNav extends React.Component {
       (env.translation.enabled
         ? this.props.language + '/versions.html'
         : 'versions.html');
+    let headerClass;
+    if (siteConfig.headerIcon) {
+      headerClass="headerTitleHidden"
+    } else {
+      headerClass="headerTitle"
+    }
     return (
       <div className="fixedHeaderContainer">
         <div className="headerWrapper wrapper">
@@ -235,7 +241,7 @@ class HeaderNav extends React.Component {
                 />
               )}
               {!this.props.config.disableHeaderTitle && (
-                <h2 className="headerTitle">{this.props.title}</h2>
+                <h2 className={headerClass}>{this.props.title}</h2>
               )}
             </a>
             {env.versioning.enabled && (

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -522,7 +522,7 @@ header h2 {
   margin-left: 10px;
   font-size: 16px;
 }
-@media (max-width: 375px) {
+@media (max-width: 480px) {
   .headerTitle {
     font-size: 17px;
   }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -526,7 +526,7 @@ header h2 {
   .headerTitle {
     font-size: 17px;
   }
-  .headerTitleHidden {
+  .headerTitleWithLogo {
     display: none !important;
   }
 }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -523,12 +523,11 @@ header h2 {
   font-size: 16px;
 }
 @media (max-width: 375px) {
-  .logo {
-    display: none;
-  }
-
   .headerTitle {
     font-size: 17px;
+  }
+  .headerTitleHidden {
+    display: none !important;
   }
 }
 


### PR DESCRIPTION
## Motivation

Resolves: https://github.com/facebook/Docusaurus/issues/613

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

IS with this PR:

Mobile:
![image](https://user-images.githubusercontent.com/1372946/39560506-5de64f2c-4e53-11e8-9f29-8e0be7f989f1.png)

Tablet (no change):
![image](https://user-images.githubusercontent.com/1372946/39593259-1fa57808-4ebe-11e8-910e-a1655a7f5a7f.png)

Desktop (no change):
![image](https://user-images.githubusercontent.com/1372946/39593015-76f91020-4ebd-11e8-970f-e3537940bc7e.png)

***

WAS:

Mobile:
![image](https://user-images.githubusercontent.com/1372946/39560552-d003db2e-4e53-11e8-9165-98982c38cbaf.png)

Tablet (no change):
![image](https://user-images.githubusercontent.com/1372946/39593164-e6ec244e-4ebd-11e8-8519-993b4be1876e.png)

Desktop (no change):
![image](https://user-images.githubusercontent.com/1372946/39593054-993b8d98-4ebd-11e8-9178-5d5513ff7aa5.png)


## Related PRs

It didn't seem like a docs update was necessary?

cc @yangshun @JoelMarcey 