### PR TITLE
Rename latestVersion to defaultVersion

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -84,6 +84,9 @@ customDocsPath: 'docs/site'
 ```js
 customDocsPath: 'website-docs'
 ```
+
+`defaultVersionShown` - The default version for the site. If this is not set, the latest version will be shown.
+
 `disableHeaderTitle` - An option to disable showing the title in the header next to the header icon. Exclude this field to keep the header as normal, otherwise set to `true`.
 
 `disableTitleTagline` - An option to disable showing the tagline in the title of main pages. Exclude this field to keep page titles as `Title • Tagline`. Set to `true` to make page titles just `Title`.
@@ -181,6 +184,7 @@ const siteConfig = {
   // For github.io type URLS, you would combine the url and baseUrl like:
   // url: 'https://reasonml.github.io',
   // baseUrl: '/reason-react/',
+  defaultVersionShown: '1.0.0',
   organizationName: 'facebook',
   projectName: 'docusaurus',
   noIndex: false,

--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -144,7 +144,7 @@ class HeaderNav extends React.Component {
       const versionPart =
         env.versioning.enabled && this.props.version !== 'next'
           ? 'version-' +
-            (this.props.version || env.versioning.latestVersion) +
+            (this.props.version || env.versioning.defaultVersion) +
             '-'
           : '';
       const id = langPart + versionPart + link.doc;
@@ -243,7 +243,7 @@ class HeaderNav extends React.Component {
             </a>
             {env.versioning.enabled && (
               <a href={versionsLink}>
-                <h3>{this.props.version || env.versioning.latestVersion}</h3>
+                <h3>{this.props.version || env.versioning.defaultVersion}</h3>
               </a>
             )}
             {this.renderResponsiveNav()}

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -44,7 +44,7 @@ class Translation {
 class Versioning {
   constructor() {
     this.enabled = false;
-    this.latestVersion = null;
+    this.defaultVersion = null;
     this.versions = [];
 
     this._load();
@@ -54,7 +54,7 @@ class Versioning {
     if (fs.existsSync(versions_json)) {
       this.enabled = true;
       this.versions = JSON.parse(fs.readFileSync(versions_json, 'utf8'));
-      this.latestVersion = siteConfig.defaultVersionShown
+      this.defaultVersion = siteConfig.defaultVersionShown
         ? siteConfig.defaultVersionShown
         : this.versions[0]; // otherwise show the latest version (other than next/master)
     }

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -143,7 +143,7 @@ async function execute() {
       rawContent = insertTableOfContents(rawContent);
     }
 
-    let latestVersion = env.versioning.latestVersion;
+    let defaultVersion = env.versioning.defaultVersion;
 
     // replace any links to markdown files to their website html links
     Object.keys(mdToHtml).forEach(function(key, index) {
@@ -151,7 +151,7 @@ async function execute() {
       link = link.replace('/en/', '/' + language + '/');
       link = link.replace(
         '/VERSION/',
-        metadata.version && metadata.version !== latestVersion
+        metadata.version && metadata.version !== defaultVersion
           ? '/' + metadata.version + '/'
           : '/'
       );

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -190,7 +190,7 @@ function execute(port) {
       rawContent = insertTableOfContents(rawContent);
     }
 
-    let latestVersion = env.versioning.latestVersion;
+    let defaultVersion = env.versioning.defaultVersion;
 
     // replace any links to markdown files to their website html links
     Object.keys(mdToHtml).forEach(function(key, index) {
@@ -198,7 +198,7 @@ function execute(port) {
       link = link.replace('/en/', '/' + language + '/');
       link = link.replace(
         '/VERSION/',
-        metadata.version && metadata.version !== latestVersion
+        metadata.version && metadata.version !== defaultVersion
           ? '/' + metadata.version + '/'
           : '/'
       );

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -201,7 +201,6 @@ const siteConfig = {
   ogImage: 'img/docusaurus.png',
   twitterImage: 'img/docusaurus.png',
   onPageNav: 'separate',
-  defaultVersionShown: '1.0.12',
 };
 
 module.exports = siteConfig;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -201,6 +201,7 @@ const siteConfig = {
   ogImage: 'img/docusaurus.png',
   twitterImage: 'img/docusaurus.png',
   onPageNav: 'separate',
+  defaultVersionShown: '1.0.12',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Using `defaultVersion` is clearer than `latestVersion` #636. Also wanted to update the siteConfig docs to include `defaultVersionShown`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan
- Add `defaultVersionShown: '1.0.12'` to siteConfig.
- Version should be 1.0.12 when viewing the website.
![screen shot 2018-05-05 at 4 42 47 pm](https://user-images.githubusercontent.com/5081708/39668483-d9493080-5083-11e8-8314-caf360c7b067.png)


## Related PRs
None.
