### PR TITLE
Fix font rendering on IE11

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -56,7 +56,9 @@ table {
 body {
   background: #f9f9f9;
   color: #393939;
-  font: normal 16px/1.4em -apple-system,system-ui,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Fira Sans','Droid Sans','Helvetica Neue',Arial,sans-serif;
+  font-family: -apple-system,system-ui,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Fira Sans','Droid Sans','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 1.4em;
   min-height: 100vh;
   text-align: left;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
This is an issue on IE11, it cannot pick the correct system font because the font `-apple-system` makes the value invalid and hence making the whole declaration invalid.

A good solution is to split the shorthand version into separate properties/values and it will work.

## Motivation

Part of fixing issues on IE11 https://github.com/facebook/Docusaurus/issues/585

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This is a UI issue, testing on IE11 and other browsers will be sufficient to prove it is working
