### PR TITLE
Fix flex children's width not calculated correctly

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -888,7 +888,7 @@ pre code {
   }
   .gridBlock .twoByGridBlock {
     box-sizing: border-box;
-    flex: 1 0 50%;
+    flex: 1 0 40%;
     padding: 10px;
   }
   .gridBlock .threeByGridBlock {
@@ -898,7 +898,7 @@ pre code {
   }
   .gridBlock .fourByGridBlock {
     box-sizing: border-box;
-    flex: 1 0 25%;
+    flex: 1 0 20%;
     padding: 10px;
   }
 
@@ -915,7 +915,7 @@ pre code {
   }
   .gridBlock .twoByGridBlock {
     box-sizing: border-box;
-    flex: 1 0 50%;
+    flex: 1 0 40%;
     padding: 10px 20px;
   }
   .gridBlock .threeByGridBlock {
@@ -925,7 +925,7 @@ pre code {
   }
   .gridBlock .fourByGridBlock {
     box-sizing: border-box;
-    flex: 1 0 25%;
+    flex: 1 0 20%;
     padding: 10px 20px;
   }
 }


### PR DESCRIPTION
This is a known issue on IE11 caused by the fact that IE add the padding value to the `flex-basis` leading to increase in the size of the column beyond intended. The block behave as if has `box-sizing` set to `content-box` even if it is set correctly.

Reference: https://github.com/philipwalton/flexbugs#flexbug-7

## Motivation

Part of fixing issues on IE11 https://github.com/facebook/Docusaurus/issues/585

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes