### PR TITLE
Remove authorImage

### DIFF
--- a/lib/core/BlogPost.js
+++ b/lib/core/BlogPost.js
@@ -56,14 +56,6 @@ class BlogPost extends React.Component {
           </a>
         </div>
       );
-    } else if (post.authorImage) {
-      return (
-        <div className={className}>
-          <a href={post.authorURL} target="_blank" rel="noreferrer noopener">
-            <img src={post.authorImage} />
-          </a>
-        </div>
-      );
     } else if (post.authorImageURL) {
       return (
         <div className={className}>


### PR DESCRIPTION
## Motivation

Deprecate `authorImage`. We now use `authorImageURL`. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

N/A, addressed in https://github.com/facebook/Docusaurus/pull/577.

## Related PRs

`authorImage` was replaced by `authorImageURL` in https://github.com/facebook/Docusaurus/pull/577.

`authorImage` was then removed from react-native-website in https://github.com/facebook/react-native-website/pull/314. So now `authorImage` can be removed from Docusaurus.

`authorImage` was undocumented to begin with, so no docs changes.
