### PR TITLE
Improve publishing guide on Github Pages

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -75,7 +75,7 @@ GIT_USER=<GIT_USER> \
 
 > The specified `GIT_USER` must have push access to the repository specified in the combination of `organizationName` and `projectName`.
 
-You should now be able to load your website by visiting its GitHub Pages URL, which could be something along the lines of https://_username_.github.io/_projectName_, or a custom domain if you have set that up. For example, Docusaurus' own GitHub Pages URL is https://docusaurus.io (it can also be accessed via https://docusaurus.io/), because it is served from the `gh-pages` branch of the https://github.com/facebook/docusaurus GitHub repo. We highly encourage reading through the [GitHub Pages documentation](https://pages.github.com) to learn more about how this hosting solution works.
+You should now be able to load your website by visiting its GitHub Pages URL, which could be something along the lines of https://_username_.github.io/_projectName_, or a custom domain if you have set that up. For example, Docusaurus' own GitHub Pages URL is https://facebook.github.io/Docusaurus (it can also be accessed via https://docusaurus.io/), because it is served from the `gh-pages` branch of the https://github.com/facebook/docusaurus GitHub repo. We highly encourage reading through the [GitHub Pages documentation](https://pages.github.com) to learn more about how this hosting solution works.
 
 You can run the command above any time you update the docs and wish to deploy the changes to your site. Running the script manually may be fine for sites where the documentation rarely changes and it is not too much of an inconvenience to remember to manually deploy changes.
 


### PR DESCRIPTION
## Motivation

<img width="506" alt="confusing" src="https://user-images.githubusercontent.com/17883920/40064623-80a9cf86-5892-11e8-8441-47a1e8acb65e.PNG">

Docusaurus publishing doc might be confusing, it should be https://facebook.github.io/Docusaurus when referring to GitHub Pages URL, not the custom domain at https://docusaurus.io/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
```
cd website
npm run build
npm run start
```

Check the latest version documentation at http://localhost:3000/docs/en/next/publishing.html

<img width="956" alt="test" src="https://user-images.githubusercontent.com/17883920/40064179-8ecfbf2c-5891-11e8-88ca-e3de1b9529a3.PNG">


## Related PRs
Not applicable

## Other
Might need to change all the previous version of documentation as well. Documentation for v1.0.15 and below will still use https://docusaurus.io/ instead of https://facebook.github.io/Docusaurus 