### PR TITLE
Print out directory tree during docusaurus-init

### DIFF
--- a/lib/copy-examples.js
+++ b/lib/copy-examples.js
@@ -203,21 +203,21 @@ if (feature === 'translations') {
   });
 }
 
+const path = outerFolder + '/website';
 const tree = require('tree-node-cli');
-const string = tree(outerFolder + 'website', {
+const string = tree(path, {
   allFiles: true,
   exclude: [/node_modules/],
   maxDepth: 2,
 });
-if (exampleSiteCreated) {
-  console.log(
-    `${chalk.green('Example website created')} in ${chalk.green(
-      outerFolder + '/website'
-    )}\n`
-  );
-}
+console.log(`${chalk.green('How come this doesn\'t show up?')}\n`);
+console.log(path); // nothing shows up
+console.log(tree); // nothing shows up
+console.log(string); // nothing shows up
 
-console.log(`string here...doesn't show up...: ${chalk.yellow(string)}`);
+if (exampleSiteCreated) {
+  console.log(`${chalk.green('Even if I delete "Example website created" it still shows up on docusaurus-init?')}\n`);
+}
 
 if (docsCreated) {
   console.log(

--- a/lib/copy-examples.js
+++ b/lib/copy-examples.js
@@ -191,6 +191,16 @@ if (feature === 'translations') {
         errorOnExist: true,
       });
       exampleSiteCreated = true;
+      const tree = require('tree-node-cli');
+      const string = tree(outerFolder + '/website', {
+        allFiles: true,
+        exclude: [/node_modules/],
+        maxDepth: 2,
+      });
+      console.log(`${chalk.green('How come this doesn\'t show up?')}\n`);
+      if (exampleSiteCreated) {
+        console.log(`${chalk.green('Even if I delete "Example website created" it still shows up on docusaurus-init?')}\n`);
+      }
     } catch (e) {
       console.log(
         `${chalk.yellow(
@@ -201,22 +211,6 @@ if (feature === 'translations') {
       );
     }
   });
-}
-
-const path = outerFolder + '/website';
-const tree = require('tree-node-cli');
-const string = tree(path, {
-  allFiles: true,
-  exclude: [/node_modules/],
-  maxDepth: 2,
-});
-console.log(`${chalk.green('How come this doesn\'t show up?')}\n`);
-console.log(path); // nothing shows up
-console.log(tree); // nothing shows up
-console.log(string); // nothing shows up
-
-if (exampleSiteCreated) {
-  console.log(`${chalk.green('Even if I delete "Example website created" it still shows up on docusaurus-init?')}\n`);
 }
 
 if (docsCreated) {

--- a/lib/copy-examples.js
+++ b/lib/copy-examples.js
@@ -203,6 +203,12 @@ if (feature === 'translations') {
   });
 }
 
+const tree = require('tree-node-cli');
+const string = tree(outerFolder + 'website', {
+  allFiles: true,
+  exclude: [/node_modules/],
+  maxDepth: 2,
+});
 if (exampleSiteCreated) {
   console.log(
     `${chalk.green('Example website created')} in ${chalk.green(
@@ -210,6 +216,8 @@ if (exampleSiteCreated) {
     )}\n`
   );
 }
+
+console.log(`string here...doesn't show up...: ${chalk.yellow(string)}`);
 
 if (docsCreated) {
   console.log(

--- a/lib/copy-examples.js
+++ b/lib/copy-examples.js
@@ -191,16 +191,6 @@ if (feature === 'translations') {
         errorOnExist: true,
       });
       exampleSiteCreated = true;
-      const tree = require('tree-node-cli');
-      const string = tree(outerFolder + '/website', {
-        allFiles: true,
-        exclude: [/node_modules/],
-        maxDepth: 2,
-      });
-      console.log(`${chalk.green('How come this doesn\'t show up?')}\n`);
-      if (exampleSiteCreated) {
-        console.log(`${chalk.green('Even if I delete "Example website created" it still shows up on docusaurus-init?')}\n`);
-      }
     } catch (e) {
       console.log(
         `${chalk.yellow(
@@ -211,6 +201,14 @@ if (feature === 'translations') {
       );
     }
   });
+
+  if (exampleSiteCreated) {
+    const tree = require('tree-node-cli');
+    const dirString = tree(path.join(CWD, '..'), {
+      exclude: [/node_modules/],
+    });
+    console.log(dirString);
+  }
 }
 
 if (docsCreated) {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "request": "^2.81.0",
     "shelljs": "^0.7.8",
     "sitemap": "^1.13.0",
-    "tcp-port-used": "^0.1.2"
+    "tcp-port-used": "^0.1.2",
+    "tree-node-cli": "^1.1.1"
   },
   "bin": {
     "docusaurus-start": "./lib/start-server.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,7 +1327,7 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0:
+commander@^2.11.0, commander@^2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
@@ -5595,6 +5595,12 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.3:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+
+tree-node-cli@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tree-node-cli/-/tree-node-cli-1.1.1.tgz#ea11f7e6ceec670355c64d0cc9b7090dddaefc33"
+  dependencies:
+    commander "^2.15.1"
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
cc @yangshun This might be way off...wondering if there is anything wrong at first glance.

I `rm -rf website/` in Docusaurus. 

I tried replacing an existing `console.log` with new text.

When I run `docusaurus-init`, the old text appears, even though it's been deleted from the codebase. Is the repo reading `docusaurus-init` from npm or something and not from local `copy-examples.js`?
