### PR TITLE
Enhance footer with Facebook and Twitter buttons

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -154,7 +154,7 @@ h1 {
 
 `twitter` - Set this to `true` if you want a Twitter social button to appear at the bottom of your blog posts.
 
-`twitterId` - If you want a Twitter follow button at the bottom of your page, provide a twitter id to follow. For example: `docusaurus`
+`twitterId` - If you want a Twitter follow button in the footer, provide a twitter id to follow. For example: `docusaurus`.
 
 `twitterImage` - Local path to your Twitter card image (e.g., `img/myImage.png`). This image will show up on the Twitter card when your site is shared on Twitter.
 

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -154,6 +154,8 @@ h1 {
 
 `twitter` - Set this to `true` if you want a Twitter social button to appear at the bottom of your blog posts.
 
+`twitterId` - If you want a Twitter follow button at the bottom of your page, provide a twitter id to follow. For example: `docusaurus`
+
 `twitterImage` - Local path to your Twitter card image (e.g., `img/myImage.png`). This image will show up on the Twitter card when your site is shared on Twitter.
 
 `useEnglishUrl` - If you do not have [translations](guides-translation.md) enabled (e.g., by having a `languages.js` file), but still want a link of the form `/docs/en/doc.html` (with the `en`), set this to `true`.
@@ -231,6 +233,7 @@ const siteConfig = {
   facebookAppId: '1615782811974223',
   facebookPixelId: '352490515235776',
   twitter: 'true',
+  twitterId: 'docusaurus',
   twitterImage: 'img/docusaurus.png',
   ogImage: 'img/docusaurus.png',
 };

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -93,7 +93,7 @@ customDocsPath: 'website-docs'
 
 `editUrl` - url for editing docs, usage example: `editUrl + 'en/doc1.md'`. If this field is omitted, there will be no "Edit this Doc" button for each document.
 
-`facebookAppId` - If you want Facebook Like/Share buttons at the bottom of your blog posts, provide a [Facebook application id](https://www.facebook.com/help/audiencenetwork/804209223039296), and the buttons will show up on all blog posts.
+`facebookAppId` - If you want Facebook Like/Share buttons in the footer and at the bottom of your blog posts, provide a [Facebook application id](https://www.facebook.com/help/audiencenetwork/804209223039296).
 
 `facebookPixelId` - [Facebook Pixel](https://www.facebook.com/business/a/facebook-pixel) ID to track page views.
 

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -154,7 +154,7 @@ h1 {
 
 `twitter` - Set this to `true` if you want a Twitter social button to appear at the bottom of your blog posts.
 
-`twitterUsername` - If you want a Twitter follow button at the bottom of your page, provide a twitter username to follow. For example: `docusaurus`
+`twitterUsername` - If you want a Twitter follow button at the bottom of your page, provide a Twitter username to follow. For example: `docusaurus`.
 
 `twitterImage` - Local path to your Twitter card image (e.g., `img/myImage.png`). This image will show up on the Twitter card when your site is shared on Twitter.
 

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -154,7 +154,7 @@ h1 {
 
 `twitter` - Set this to `true` if you want a Twitter social button to appear at the bottom of your blog posts.
 
-`twitterId` - If you want a Twitter follow button in the footer, provide a twitter id to follow. For example: `docusaurus`.
+`twitterUsername` - If you want a Twitter follow button at the bottom of your page, provide a twitter username to follow. For example: `docusaurus`
 
 `twitterImage` - Local path to your Twitter card image (e.g., `img/myImage.png`). This image will show up on the Twitter card when your site is shared on Twitter.
 
@@ -233,7 +233,7 @@ const siteConfig = {
   facebookAppId: '1615782811974223',
   facebookPixelId: '352490515235776',
   twitter: 'true',
-  twitterId: 'docusaurus',
+  twitterUsername: 'docusaurus',
   twitterImage: 'img/docusaurus.png',
   ogImage: 'img/docusaurus.png',
 };

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -111,7 +111,7 @@ class Site extends React.Component {
               }}
             />
           )}
-          {this.props.config.twitter && (
+          {(this.props.config.twitter || this.props.config.twitterUsername) && (
             <script
               dangerouslySetInnerHTML={{
                 __html: `window.twttr=(function(d,s, id){var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return t;js=d.createElement(s);js.id=id;js.src='https://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js, fjs);t._e = [];t.ready = function(f) {t._e.push(f);};return t;}(document, 'script', 'twitter-wjs'));`,

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1826,6 +1826,10 @@ footer .copyright {
   text-align: center;
 }
 
+footer .social {
+  padding: 5px 0;
+}
+
 .entry-share {
   padding: 36px 0;
   display: block;

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -8,21 +8,51 @@ const PropTypes = require('prop-types');
 
 const React = require('react');
 
-const GitHubButton = props => (
-  <a
-    className="github-button" // part of the https://buttons.github.io/buttons.js script in siteConfig.js
-    href={`https://github.com/${props.config.organizationName}/${props.config.projectName}`}
-    data-icon="octicon-star"
-    data-count-href={`/${props.config.organizationName}/${props.config.projectName}/stargazers`}
-    data-show-count="true"
-    data-count-aria-label="# stargazers on GitHub"
-    aria-label="Star this project on GitHub"
-  >
-    Star
-  </a>
+const SocialFooter = props => (
+  <div>
+    <div>
+      <h5>Github</h5>
+      <a
+        className="github-button" // part of the https://buttons.github.io/buttons.js script in siteConfig.js
+        href={`https://github.com/${props.config.organizationName}/${
+          props.config.projectName
+        }`}
+        data-count-href={`/${props.config.organizationName}/${
+          props.config.projectName
+        }/stargazers`}
+        data-show-count="true"
+        data-count-aria-label="# stargazers on GitHub"
+        aria-label="Star this project on GitHub">
+        {props.config.projectName}
+      </a>
+    </div>
+    {props.config.twitterId ? (
+      <div>
+        <h5>Twitter</h5>
+        <a
+          href={`https://twitter.com/${props.config.twitterId}`}
+          className="twitter-follow-button">
+          Follow @{props.config.twitterId}
+        </a>
+      </div>
+    ) : null}
+    {props.config.facebookAppId ? (
+      <div>
+        <h5>Facebook</h5>
+        <div
+          className="fb-like"
+          data-href={props.config.url}
+          data-layout="standard"
+          data-share="true"
+          data-width="225"
+          data-show-faces="false"
+        />
+      </div>
+    ) : null}
+  </div>
 );
 
-GitHubButton.propTypes = {
+SocialFooter.propTypes = {
   config: PropTypes.object
 };
 
@@ -77,17 +107,8 @@ class Footer extends React.Component {
             >
               User Showcase
             </a>
-            <a href="https://twitter.com/docusaurus">
-              Twitter
-            </a>
           </div>
-          <div>
-            <h5>More</h5>
-            <a href="https://github.com/facebook/docusaurus">
-              GitHub
-            </a>
-            <GitHubButton config={this.props.config} />
-          </div>
+          <SocialFooter config={this.props.config} />
         </section>
 
         <a

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -10,8 +10,8 @@ const React = require('react');
 
 const SocialFooter = props => (
   <div>
-    <div>
-      <h5>GitHub</h5>
+    <h5>More</h5>
+    <div className="social">
       <a
         className="github-button" // part of the https://buttons.github.io/buttons.js script in siteConfig.js
         href={`https://github.com/${props.config.organizationName}/${
@@ -27,8 +27,7 @@ const SocialFooter = props => (
       </a>
     </div>
     {props.config.twitterUsername && (
-      <div>
-        <h5>Twitter</h5>
+      <div className="social">
         <a
           href={`https://twitter.com/${props.config.twitterUsername}`}
           className="twitter-follow-button">
@@ -37,8 +36,7 @@ const SocialFooter = props => (
       </div>
     )}
     {props.config.facebookAppId && (
-      <div>
-        <h5>Facebook</h5>
+      <div className="social">
         <div
           className="fb-like"
           data-href={props.config.url}

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -26,17 +26,17 @@ const SocialFooter = props => (
         {props.config.projectName}
       </a>
     </div>
-    {props.config.twitterId ? (
+    {props.config.twitterUsername && (
       <div>
         <h5>Twitter</h5>
         <a
-          href={`https://twitter.com/${props.config.twitterId}`}
+          href={`https://twitter.com/${props.config.twitterUsername}`}
           className="twitter-follow-button">
-          Follow @{props.config.twitterId}
+          Follow @{props.config.twitterUsername}
         </a>
       </div>
-    ) : null}
-    {props.config.facebookAppId ? (
+    )}
+    {props.config.facebookAppId && (
       <div>
         <h5>Facebook</h5>
         <div
@@ -48,7 +48,7 @@ const SocialFooter = props => (
           data-show-faces="false"
         />
       </div>
-    ) : null}
+    )}
   </div>
 );
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -11,7 +11,7 @@ const React = require('react');
 const SocialFooter = props => (
   <div>
     <div>
-      <h5>Github</h5>
+      <h5>GitHub</h5>
       <a
         className="github-button" // part of the https://buttons.github.io/buttons.js script in siteConfig.js
         href={`https://github.com/${props.config.organizationName}/${

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -50,6 +50,7 @@ const siteConfig = {
   gaTrackingId: 'UA-44373548-31',
   facebookAppId: '1615782811974223',
   twitter: 'true',
+  twitterId: 'docusaurus',
   ogImage: 'img/docusaurus.png',
   twitterImage: 'img/docusaurus.png',
   onPageNav: 'separate',

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -50,7 +50,7 @@ const siteConfig = {
   gaTrackingId: 'UA-44373548-31',
   facebookAppId: '1615782811974223',
   twitter: 'true',
-  twitterId: 'docusaurus',
+  twitterUsername: 'docusaurus',
   ogImage: 'img/docusaurus.png',
   twitterImage: 'img/docusaurus.png',
   onPageNav: 'separate',


### PR DESCRIPTION
## Motivation

This feature/enhancement was requested in #218 .

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
```
cd website
npm run start
```

Test 4 cases by tweaking siteConfig.js:
1. With facebook & twitter (facebookAppId & twitterId exist)
<img width="941" alt="footer-all" src="https://user-images.githubusercontent.com/17883920/40096049-983d1382-5901-11e8-9cf0-a12692035e5d.PNG">

2. No facebook & twitter (facebookAppId & twitterId does not exist)
<img width="911" alt="footer-no-fb-no-twitter" src="https://user-images.githubusercontent.com/17883920/40095851-b5d6a706-5900-11e8-9e1e-54d8219104b2.PNG">

3. No facebook (facebookAppId does not exist & twitterId exist)
<img width="938" alt="footer-no-fb" src="https://user-images.githubusercontent.com/17883920/40095855-bcf35ae8-5900-11e8-921c-9d941b24d529.PNG">

4.. No twitter (facebookAppId exist & twitterId does not exist)
<img width="879" alt="footer-no-twitter" src="https://user-images.githubusercontent.com/17883920/40095862-c378c1c8-5900-11e8-92a7-6784a7fc8164.PNG">

Check updated docs for api siteconfig
1. Remove `docs` from .npmignore
2. Run the website
```
cd website
npm run start
```

3. Latest doc at http://localhost:3000/docs/en/next/site-config.html
<img width="489" alt="twitterid" src="https://user-images.githubusercontent.com/17883920/40095968-33f9b470-5901-11e8-969d-86146ebd8f6b.PNG">

<img width="286" alt="twitterid-ex" src="https://user-images.githubusercontent.com/17883920/40095975-381da8a4-5901-11e8-9419-0e796a53cf0d.PNG">

Run test in root folder
```
npm test
```
<img width="466" alt="test" src="https://user-images.githubusercontent.com/17883920/40096267-acf1d62c-5902-11e8-9f7e-88ab89d9f61d.PNG">


## Related Issues

#625 Facebook share dialog won't work if app is not set to public
