### PR TITLE
Fix undefined variable error when adding custom page

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -530,7 +530,10 @@ async function execute() {
             <ReactComp language={language} />
           </Site>
         );
-        writeFileAndCreateFolder(targetFile.replace(sep + en + sep, sep), str);
+        writeFileAndCreateFolder(
+          targetFile.replace(sep + 'en' + sep, sep),
+          str
+        );
       }
       fs.removeSync(tempFile);
     } else if (siteConfig.wrapPagesHTML && normalizedFile.match(/\.html$/)) {


### PR DESCRIPTION
## Motivation
I tried to add a custom page to Docosaurus
<img width="192" alt="buggg" src="https://user-images.githubusercontent.com/17883920/40267746-ccc766b2-5b94-11e8-8d1a-6b68b7874d04.PNG">

Build the static files
```
cd website
yarn build
```

But got an error `en is not defined`
<img width="670" alt="en undefined" src="https://user-images.githubusercontent.com/17883920/40267821-000e854a-5b96-11e8-94aa-386e673ee61d.PNG">

This is because of a typo
https://github.com/facebook/Docusaurus/blob/b66045f28478e05a7de701bb644412c1898fc0af/lib/server/generate.js#L533

It should be
```writeFileAndCreateFolder(targetFile.replace(sep + 'en' + sep, sep), str);```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
cd website
yarn build
```

<img width="539" alt="success" src="https://user-images.githubusercontent.com/17883920/40267759-23443f88-5b95-11e8-9918-2f5af42d2428.PNG">

Run test in root folder
```
yarn test
```

<img width="223" alt="pass" src="https://user-images.githubusercontent.com/17883920/40267803-ac3cd034-5b95-11e8-900a-4c71763c7038.PNG">




## Related PRs
#490 