### PR TITLE
Show warning console if version.js file is missing

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -33,6 +33,16 @@ program
   })
   .parse(process.argv);
 
+const hasVersionFile = fs.existsSync(CWD + '/pages/en/versions.js');
+if (!hasVersionFile) {
+  console.error(
+    `${chalk.yellow(
+      'No versions.js file found!'
+    )}\nYou should create your versions.js file in pages/en directory.\nPlease refer to https://docusaurus.io/docs/en/versioning.html.`
+  );
+  process.exit(1);
+}
+
 if (typeof version === 'undefined') {
   console.error(
     `${chalk.yellow(


### PR DESCRIPTION
## Motivation

As discussed in #369, we have to give better error message if `version.js` file is missing in `pages/en` directory.

The solution was to add warning console if someone ran the version script before creating the `versions.js` page

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Warning console example if `version.js` file is not found
![screen shot 2018-05-20 at 10 33 46 am](https://user-images.githubusercontent.com/12716084/40275456-90cc57e6-5c19-11e8-9393-32754dd75ac4.png)

Success example if `version.js` file is found
![image](https://user-images.githubusercontent.com/12716084/40275487-35c8c77a-5c1a-11e8-9ca3-b2a1e6ed16f7.png)

Run `yarn test` and it pass all unit test

## Related PRs

No
