### PR TITLE
onPageNav not showing on Safari #686

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1439,7 +1439,7 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   display: none;
 }
 
-@supports(position: sticky) {
+@supports ((position: -webkit-sticky) or (position: sticky))  {
   @media only screen and (min-width: 1024px) {
     .separateOnPageNav.doc .wrapper,
     .separateOnPageNav .headerWrapper.wrapper {


### PR DESCRIPTION
adding supports ((position: -webkit-sticky) to support Safari

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
