### PR TITLE
Support for Docusaurus gh-pages on Github Enterprise

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -62,9 +62,7 @@ headerLinks: [
 
 `title` - Title for your website.
 
-`url` - url for your site.
-
-`githubHost` -  (optional) if you're using GitHub Enterprise, hostname of your server.
+`url` - URL for your website.
 
 ### Optional Fields
 
@@ -132,6 +130,8 @@ h1 {
 `gaTrackingId` - Google Analytics tracking ID to track page views.
 
 `gaGtag` - Set this to `true` if you want to use [global site tags (gtag.js)](https://developers.google.com/gtagjs/) for Google analytics instead of `analytics.js`.
+
+`githubHost` - Hostname of your server. Useful if you are using GitHub Enterprise.
 
 `highlight` - [Syntax highlighting](api-doc-markdown.md) options:
 

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -64,6 +64,8 @@ headerLinks: [
 
 `url` - url for your site.
 
+`githubHost` -  (optional) if you're using GitHub Enterprise, hostname of your server.
+
 ### Optional Fields
 
 `algolia` - Information for Algolia search integration. If this field is excluded, the search bar will not appear in the header. You must specify two values for this field, and one (`appId`) is optional.

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -207,13 +207,10 @@ You can also configure Netlify to rebuild on every commit to your repo, or only 
 
 ### Publishing to GitHub Enterprise
 
-GitHub enterprise installations should work in the same manner as github.com; you need only identify the organization's GitHub Enterprise host.
+GitHub enterprise installations should work in the same manner as github.com; you only need to identify the organization's GitHub Enterprise host.
 
 | Name          | Description                                     |
 | ------------- | ----------------------------------------------- |
 | `GITHUB_HOST` | The hostname for the GitHub enterprise server.  |
 
-Steps to publish to GitHub Enterprise:
-
-1. Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname.
-1. Alternatively, set an environment variable `GITHUB_HOST` when executing the publication step.
+Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname. Alternatively, set an environment variable `GITHUB_HOST` when executing the publish command.

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -204,3 +204,17 @@ Steps to configure your Docusaurus-powered site on Netlify.
 1. Click **Deploy site**
 
 You can also configure Netlify to rebuild on every commit to your repo, or only `master` branch commits.
+
+### Publishing to Github Enterprise
+
+GitHub enterprise installations should work in the same manner as Github.com;
+you need only identify the organization's Github Enterprise host.
+
+| Name          | Description                                     |
+| ------------- | ----------------------------------------------- |
+| `GITHUB_HOST` | The hostname for the github enterprise server.  |
+
+Steps to publish to Github Enterprise:
+
+1. Alter your siteConfig.js to add a property `'githubHost'` which represents the Github Enterprise hostname.
+1. Alternatively, set an environment variable GITHUB_HOST when executing the publication step.

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -205,16 +205,15 @@ Steps to configure your Docusaurus-powered site on Netlify.
 
 You can also configure Netlify to rebuild on every commit to your repo, or only `master` branch commits.
 
-### Publishing to Github Enterprise
+### Publishing to GitHub Enterprise
 
-GitHub enterprise installations should work in the same manner as Github.com;
-you need only identify the organization's Github Enterprise host.
+GitHub enterprise installations should work in the same manner as github.com; you need only identify the organization's GitHub Enterprise host.
 
 | Name          | Description                                     |
 | ------------- | ----------------------------------------------- |
-| `GITHUB_HOST` | The hostname for the github enterprise server.  |
+| `GITHUB_HOST` | The hostname for the GitHub enterprise server.  |
 
-Steps to publish to Github Enterprise:
+Steps to publish to GitHub Enterprise:
 
-1. Alter your siteConfig.js to add a property `'githubHost'` which represents the Github Enterprise hostname.
-1. Alternatively, set an environment variable GITHUB_HOST when executing the publication step.
+1. Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname.
+1. Alternatively, set an environment variable `GITHUB_HOST` when executing the publication step.

--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -36,10 +36,6 @@ const siteConfig = {
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...
   //   organizationName: 'JoelMarcey'
 
-  // Optional
-  // If you're using GitHub Enterprise hosting, specify your GHE host here.
-  // githubHost: 'github.mycompany.com'
-
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
     {doc: 'doc1', label: 'Docs'},

--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -36,6 +36,10 @@ const siteConfig = {
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...
   //   organizationName: 'JoelMarcey'
 
+  // Optional
+  // If you're using GitHub Enterprise hosting, specify your GHE host here.
+  // githubHost: 'github.mycompany.com'
+
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
     {doc: 'doc1', label: 'Docs'},

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -35,6 +35,11 @@ const USE_SSH = process.env.USE_SSH;
 // github.io indicates organization repos that deploy via master. All others use gh-pages.
 const DEPLOYMENT_BRANCH =
   PROJECT_NAME.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages';
+// for github enterprise support, should be possible to specify a different host than github.com
+const GITHUB_HOST =
+  process.env.GITHUB_HOST ||
+  siteConfig.githubHost ||
+  'github.com';
 
 if (!ORGANIZATION_NAME) {
   shell.echo(
@@ -52,9 +57,9 @@ if (!PROJECT_NAME) {
 
 let remoteBranch;
 if (USE_SSH === 'true') {
-  remoteBranch = `git@github.com:${ORGANIZATION_NAME}/${PROJECT_NAME}.git`;
+  remoteBranch = `git@${GITHUB_HOST}:${ORGANIZATION_NAME}/${PROJECT_NAME}.git`;
 } else {
-  remoteBranch = `https://${GIT_USER}@github.com/${ORGANIZATION_NAME}/${PROJECT_NAME}.git`;
+  remoteBranch = `https://${GIT_USER}@${GITHUB_HOST}/${ORGANIZATION_NAME}/${PROJECT_NAME}.git`;
 }
 
 if (IS_PULL_REQUEST) {
@@ -149,9 +154,12 @@ fs.copy(
       shell.echo('Error: Git push failed');
       shell.exit(1);
     } else if (commitResults.code === 0) {
-      // The commit might return a non-zero value when site is up to date.
+        // The commit might return a non-zero value when site is up to date.
+      const websiteURL = (GITHUB_HOST === 'github.com') ?
+              `https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}` : // github.com hosted repo
+              `https://${GITHUB_HOST}/pages/${ORGANIZATION_NAME}/${PROJECT_NAME}` // github enterprise repo.
       shell.echo(
-        `Website is live at: https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}`
+        `Website is live at: ${websiteURL}`
       );
       shell.exit(0);
     }

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -35,9 +35,10 @@ const USE_SSH = process.env.USE_SSH;
 // github.io indicates organization repos that deploy via master. All others use gh-pages.
 const DEPLOYMENT_BRANCH =
   PROJECT_NAME.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages';
-// for github enterprise support, should be possible to specify a different host than github.com
+const GITHUB_DOMAIN = 'github.com';
+// For GitHub enterprise, allow specifying a different host.
 const GITHUB_HOST =
-  process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
+  process.env.GITHUB_HOST || siteConfig.githubHost || GITHUB_DOMAIN;
 
 if (!ORGANIZATION_NAME) {
   shell.echo(
@@ -154,7 +155,7 @@ fs.copy(
     } else if (commitResults.code === 0) {
       // The commit might return a non-zero value when site is up to date.
       const websiteURL =
-        GITHUB_HOST === 'github.com'
+        GITHUB_HOST === GITHUB_DOMAIN
           ? `https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}` // gh-pages hosted repo
           : `https://${GITHUB_HOST}/pages/${ORGANIZATION_NAME}/${PROJECT_NAME}`; // GitHub enterprise hosting.
       shell.echo(`Website is live at: ${websiteURL}`);

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -37,9 +37,7 @@ const DEPLOYMENT_BRANCH =
   PROJECT_NAME.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages';
 // for github enterprise support, should be possible to specify a different host than github.com
 const GITHUB_HOST =
-  process.env.GITHUB_HOST ||
-  siteConfig.githubHost ||
-  'github.com';
+  process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
 
 if (!ORGANIZATION_NAME) {
   shell.echo(
@@ -154,13 +152,12 @@ fs.copy(
       shell.echo('Error: Git push failed');
       shell.exit(1);
     } else if (commitResults.code === 0) {
-        // The commit might return a non-zero value when site is up to date.
-      const websiteURL = (GITHUB_HOST === 'github.com') ?
-              `https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}` : // github.com hosted repo
-              `https://${GITHUB_HOST}/pages/${ORGANIZATION_NAME}/${PROJECT_NAME}` // github enterprise repo.
-      shell.echo(
-        `Website is live at: ${websiteURL}`
-      );
+      // The commit might return a non-zero value when site is up to date.
+      const websiteURL =
+        GITHUB_HOST === 'github.com'
+          ? `https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}` // github.com hosted repo
+          : `https://${GITHUB_HOST}/pages/${ORGANIZATION_NAME}/${PROJECT_NAME}`; // github enterprise repo.
+      shell.echo(`Website is live at: ${websiteURL}`);
       shell.exit(0);
     }
   }

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -155,8 +155,8 @@ fs.copy(
       // The commit might return a non-zero value when site is up to date.
       const websiteURL =
         GITHUB_HOST === 'github.com'
-          ? `https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}` // github.com hosted repo
-          : `https://${GITHUB_HOST}/pages/${ORGANIZATION_NAME}/${PROJECT_NAME}`; // github enterprise repo.
+          ? `https://${ORGANIZATION_NAME}.github.io/${PROJECT_NAME}` // gh-pages hosted repo
+          : `https://${GITHUB_HOST}/pages/${ORGANIZATION_NAME}/${PROJECT_NAME}`; // GitHub enterprise hosting.
       shell.echo(`Website is live at: ${websiteURL}`);
       shell.exit(0);
     }


### PR DESCRIPTION
## Motivation

In attempting to use Docusaurus for internal documentation in my employer's Github Enterprise server, I discovered that publish-gh-pages script assumes github.com.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.  I found no issue even matching 'enterprise', which I would expect if others had tried this.

## Test Plan

I verified by actually publishing to my company's Github Enterprise server. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

I updated the appropriate docs files in the `master` branch: 
  - docs/api-site-config.md
  - examples/basics/siteConfig.js

I assume that your CI process uses docs in master and runs a `publish-gh-pages`; and thus there is no need for a separate PR for docs? 

 Let me know,  I'm happy to include a separate PR if necessary.

