### PR TITLE
Only use live-reload in development environment

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -546,31 +546,32 @@ function execute(port) {
   });
 
   // Start LiveReload server.
-  process.env.NODE_ENV = 'development';
-  const server = tinylr();
-  server.listen(constants.LIVE_RELOAD_PORT, function() {
-    console.log(
-      'LiveReload server started on port %d',
-      constants.LIVE_RELOAD_PORT
-    );
-  });
+  if (process.env.NODE_ENV === 'development') {
+    const server = tinylr();
+    server.listen(constants.LIVE_RELOAD_PORT, function () {
+      console.log(
+        'LiveReload server started on port %d',
+        constants.LIVE_RELOAD_PORT
+      );
+    });
 
-  // gaze watches some specified dirs and triggers a callback when they change.
-  gaze(
-    [
-      '../docs/**/*', // docs
-      '**/*', // website
-    ],
-    function() {
-      // Listen for all kinds of file changes - modified/added/deleted.
-      this.on('all', function() {
-        // Notify LiveReload clients that there's a change.
-        // Typically, LiveReload will only refresh the changed paths,
-        // so we use / here to force a full-page reload.
-        server.notifyClients(['/']);
-      });
-    }
-  );
+    // gaze watches some specified dirs and triggers a callback when they change.
+    gaze(
+      [
+        '../docs/**/*', // docs
+        '**/*', // website
+      ],
+      function() {
+        // Listen for all kinds of file changes - modified/added/deleted.
+        this.on('all', function() {
+          // Notify LiveReload clients that there's a change.
+          // Typically, LiveReload will only refresh the changed paths,
+          // so we use / here to force a full-page reload.
+          server.notifyClients(['/']);
+        });
+      }
+    );
+  }
 
   app.listen(port);
 }


### PR DESCRIPTION
The recently added live-reload functionality seems to be enabled in all environments, including prod. I'm not sure if this was on purpose.
When deploying the latest version, we noticed a lot more context switches on our production servers, presumably because of this change.

Also, I'm not sure if hardcoding `process.env.NODE_ENV` to 'development' happened by accident.
This PR reverts that and disables live-reload in non-development environments.
