### PR TITLE
Don't watch node_modules dir in dev server mode

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -558,7 +558,7 @@ function execute(port) {
   // gaze watches some specified dirs and triggers a callback when they change.
   gaze(
     [
-      '../docs/**/*', // docs
+      '../' + readMetadata.getDocsPath() + '/**/*', // docs
       '**/*', // website
       '!node_modules/**/*', // node_modules
     ],

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -560,6 +560,7 @@ function execute(port) {
     [
       '../docs/**/*', // docs
       '**/*', // website
+      '!node_modules/**/*', // node_modules
     ],
     function() {
       // Listen for all kinds of file changes - modified/added/deleted.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Noticed high CPU usage when start a project. When printed out [a list of files to be watched](https://github.com/shama/gaze/blob/master/lib/gaze.js#L189) saw 12k files from `node_modules`. And since `gaze` [supports the negate pattern](https://github.com/shama/gaze/blob/master/test/patterns_test.js#L27) I'd like to add `!node_modules/**/*`.

Related issue https://github.com/facebook/Docusaurus/issues/699

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes, I did.

## Test Plan

https://github.com/facebook/Docusaurus/issues/699

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
