### PR TITLE
Enable setting of title for custom pages

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -498,6 +498,7 @@ async function execute() {
             <Site
               language={language}
               config={siteConfig}
+              title={ReactComp.title}
               metadata={{id: pageID}}>
               <ReactComp language={language} />
             </Site>
@@ -513,7 +514,11 @@ async function execute() {
         let language = env.translation.enabled ? 'en' : '';
         translate.setLanguage(language);
         const str = renderToStaticMarkupWithDoctype(
-          <Site language={language} config={siteConfig} metadata={{id: pageID}}>
+          <Site
+            title={ReactComp.title}
+            language={language}
+            config={siteConfig}
+            metadata={{id: pageID}}>
             <ReactComp language={language} />
           </Site>
         );
@@ -526,7 +531,11 @@ async function execute() {
         let language = env.translation.enabled ? 'en' : '';
         translate.setLanguage(language);
         const str = renderToStaticMarkupWithDoctype(
-          <Site language={language} config={siteConfig} metadata={{id: pageID}}>
+          <Site
+            title={ReactComp.title}
+            language={language}
+            config={siteConfig}
+            metadata={{id: pageID}}>
             <ReactComp language={language} />
           </Site>
         );

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -442,6 +442,7 @@ function execute(port) {
         <Site
           language={language}
           config={siteConfig}
+          title={ReactComp.title}
           metadata={{id: path.basename(userFile, '.js')}}>
           <ReactComp language={language} />
         </Site>

--- a/website/pages/en/about-slash.js
+++ b/website/pages/en/about-slash.js
@@ -39,5 +39,5 @@ class AboutSlash extends React.Component {
 AboutSlash.defaultProps = {
   language: "en"
 };
-
+AboutSlash.title = 'About Slash';
 module.exports = AboutSlash;

--- a/website/pages/en/about-slash.js
+++ b/website/pages/en/about-slash.js
@@ -39,5 +39,7 @@ class AboutSlash extends React.Component {
 AboutSlash.defaultProps = {
   language: "en"
 };
+
 AboutSlash.title = 'About Slash';
+
 module.exports = AboutSlash;

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -61,4 +61,5 @@ class Help extends React.Component {
   }
 }
 
+Help.title = 'Need help';
 module.exports = Help;

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -61,5 +61,6 @@ class Help extends React.Component {
   }
 }
 
-Help.title = 'Need help';
+Help.title = 'Help';
+
 module.exports = Help;

--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -80,4 +80,5 @@ class Users extends React.Component {
   }
 }
 
+Users.title = `Who's Using This?`;
 module.exports = Users;

--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -80,5 +80,6 @@ class Users extends React.Component {
   }
 }
 
-Users.title = `Who's Using This?`;
+Users.title = 'Users';
+
 module.exports = Users;

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -101,5 +101,5 @@ class Versions extends React.Component {
     );
   }
 }
-
+Versions.title = 'Versions';
 module.exports = Versions;

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -101,5 +101,7 @@ class Versions extends React.Component {
     );
   }
 }
+
 Versions.title = 'Versions';
+
 module.exports = Versions;


### PR DESCRIPTION
## Motivation

Fixes #478 and https://github.com/prettier/prettier/issues/4062

When user write custom pages like `users.js`, they cannot set their own title in the browser. It is defaulted to general title of the website. This simple PR fix this issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
```
cd website
yarn start
```

- [X] Test on development server
http://localhost:3000/en/users.html

Not providing title in `pages/en/user.js`

```js
class Users extends React.Component {
  render() {
  // ... some code
  }
}
module.exports = Users;
```

<img width="421" alt="dev-no-title" src="https://user-images.githubusercontent.com/17883920/40722169-295099fa-644e-11e8-9ba6-27e7be757b4e.png">


Providing title in `pages/en/user.js`
```js
class Users extends React.Component {
  render() {
  // ... some code
  }
}
Users.title = 'Who is using this';
module.exports = Users;
```
<img width="258" alt="dev-title" src="https://user-images.githubusercontent.com/17883920/40722454-f7f14cf0-644e-11e8-875d-fe94cb7605cd.png">


- [X]  Test on production using https://www.npmjs.com/package/serve
http://localhost:5000/en/users.html

Not providing title in `pages/en/user.js`
<img width="450" alt="prod-no-title" src="https://user-images.githubusercontent.com/17883920/40722328-976ccbfc-644e-11e8-9481-33341482c689.png">

Providing title in `pages/en/user.js`
<img width="295" alt="prod-title" src="https://user-images.githubusercontent.com/17883920/40722337-9fbea7d0-644e-11e8-84fe-88d4b9969e0d.png">

- [X] Test on production for Docusaurus with custom title using Netlify
https://deploy-preview-704--docusaurus-preview.netlify.com/en/users.html
<img width="461" alt="netlify-title" src="https://user-images.githubusercontent.com/17883920/40722393-c8b4c3cc-644e-11e8-8d69-b358a8eb72c1.png">

