### PR TITLE
Fix typo error on `Tips & Tricks`

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -158,7 +158,7 @@ jobs:
     branches:
       ignore: gh-pages
     steps:
-      -run: echo "Skipping tests on gh-pages branch"
+      - run: echo "Skipping tests on gh-pages branch"
 ```
 
 Save this file as `config.yml` and place it in a `.circleci` folder inside your `website/static` folder.


### PR DESCRIPTION
## Motivation
Error on `circle.ci`

<img width="1039" alt="2018-05-28 5 30 33" src="https://user-images.githubusercontent.com/7310854/40605336-0978455e-629d-11e8-8ef3-227152617022.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ok

<img width="1039" alt="2018-05-28 5 32 51" src="https://user-images.githubusercontent.com/7310854/40605388-3197465c-629d-11e8-8fed-19d2d778e91c.png">
