### PR TITLE
Fix bug wrong metadata on `translated docs`

### DIFF
--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -122,15 +122,18 @@ function extractMetadata(content) {
 }
 
 // process the metadata for a document found in the docs folder
-function processMetadata(file) {
+function processMetadata(file, _language) {
   const result = extractMetadata(fs.readFileSync(file, 'utf8'));
 
-  let regexSubFolder = new RegExp(
-    '/' + escapeStringRegexp(getDocsPath()) + '/(.*)/.*/'
-  );
+  let language = _language;
+  if (!language) {
+    let regexSubFolder = new RegExp(
+      '/' + escapeStringRegexp(getDocsPath()) + '/(.*)/.*/'
+    );
 
-  const match = regexSubFolder.exec(file);
-  let language = match ? match[1] : 'en';
+    const match = regexSubFolder.exec(file);
+    language = match ? match[1] : 'en';
+  }
 
   const metadata = {};
   for (const fieldName of Object.keys(result.metadata)) {
@@ -271,7 +274,7 @@ function generateMetadataDocs() {
     const extension = path.extname(file);
 
     if (extension === '.md' || extension === '.markdown') {
-      const res = processMetadata(file);
+      const res = processMetadata(file, language);
       if (!res) {
         return;
       }

--- a/lib/server/readMetadata.js
+++ b/lib/server/readMetadata.js
@@ -122,10 +122,9 @@ function extractMetadata(content) {
 }
 
 // process the metadata for a document found in the docs folder
-function processMetadata(file, _language) {
+function processMetadata(file, language) {
   const result = extractMetadata(fs.readFileSync(file, 'utf8'));
 
-  let language = _language;
   if (!language) {
     let regexSubFolder = new RegExp(
       '/' + escapeStringRegexp(getDocsPath()) + '/(.*)/.*/'


### PR DESCRIPTION
## Motivation

There is a bug where metadata files are generated incorrectly when using multilingual features.

When `processMetadata` function is called in `translated_docs`, the logic to determine the multilingual language has bug.

We already knew the language so We did not have to do it twice.

[Incorrect - `core/metadata.js`]
The language is reversed (en - ko).
<img width="421" alt="2018-05-29 4 27 43" src="https://user-images.githubusercontent.com/7310854/40645690-0ec3ee3a-6362-11e8-9a3f-8ac2668699af.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

using multilingual features.

[Correct - `core/metadata.js`]
<img width="409" alt="2018-05-29 4 39 13" src="https://user-images.githubusercontent.com/7310854/40646399-023b2780-6364-11e8-8967-7c488a980306.png">


## Related PRs

https://github.com/facebook/Docusaurus/commit/e273dfc13b4031d4d20180d0de30b1c5280d2bf8#diff-a6ea8ce8e7c294d50b747139bc956138