### PR TITLE
Wrong logic on `write-translation.js`

### DIFF
--- a/lib/write-translations.js
+++ b/lib/write-translations.js
@@ -24,7 +24,7 @@ let currentTranslations = {
   'localized-strings': {},
   'pages-strings': {},
 };
-if (fs.existsSync(path)) {
+if (fs.existsSync(CWD + '/i18n/en.json')) {
   currentTranslations = JSON.parse(
     fs.readFileSync(CWD + '/i18n/en.json', 'utf8')
   );


### PR DESCRIPTION
## Motivation

I found wrong logic on `lib/write-translation.js`

```javascript
const path = require('path');
...
if (fs.existsSync(path)) {  // wrong code. `path` is NodeJs module
  currentTranslations = JSON.parse(
    fs.readFileSync(CWD + '/i18n/en.json', 'utf8')
  );
}
```

As a result, `currentTranslations` is always empty.
Because, the contents of `i18n/en.json` are always lost.

It's correct code

```javascript
if (fs.existsSync(CWD + '/i18n/en.json')) {
  currentTranslations = JSON.parse(
    fs.readFileSync(CWD + '/i18n/en.json', 'utf8')
  );
}
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

## Related PRs
