### PR TITLE
Disable the padding of the p tag inside the blockquote tag

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -123,6 +123,10 @@ blockquote {
   border-left: 5px solid rgba(191, 87, 73, 0.2);
 }
 
+blockquote > p:first-child {
+  padding-top: 0;
+}
+
 h1, h2, h3, h4 {
   font-weight: 300;
   color: $primaryColor;

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -123,7 +123,7 @@ blockquote {
   border-left: 5px solid rgba(191, 87, 73, 0.2);
 }
 
-blockquote > p:first-child {
+.wrapper blockquote > p:first-child {
   padding-top: 0;
 }
 


### PR DESCRIPTION
## Motivation

Extra padding in quote block makes all the text not vertically aligned. Looks weird.

![image](https://user-images.githubusercontent.com/1444314/40759605-cb990da2-6460-11e8-8ed4-23cddce8fe2d.png)

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Linking to a page in the netlify preview deploy that shows the padding removed.

## Related PRs

None