### PR TITLE
Add custom title for page documentation

### DIFF
--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -11,11 +11,11 @@ Any `.js` files in `website/pages` will be rendered to static html using the pat
 
 ## Titles for Pages
 
-By default, the title of your page is `Title • Tagline` where `title` and `tagline` field are set in [`siteConfig.js`](api-site-config.md). You can exclude the tagline by setting `disableTitleTagline` to `true`. If you want to set a specific title for your page, add a `title` class property on your exported React component.
+By default, the title of your page is `<title> • <tagline>` where `title` and `tagline` fields are set in [`siteConfig.js`](api-site-config.md). You can exclude the tagline in the title by setting `disableTitleTagline` to `true`. If you want to set a specific title for your custom pages, add a `title` class property on your exported React component.
 
 Example:
 
-```jsx
+```js
 const React = require('react');
 
 class MyPage extends React.Component {

--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -9,6 +9,24 @@ Docusaurus provides support for writing pages as React components inside the `we
 
 Any `.js` files in `website/pages` will be rendered to static html using the path of the file after "pages". Files in `website/pages/en` will also get copied out into `pages` and will OVERRIDE any files of the same name in `pages`. For example, the page for the `website/pages/en/help.js` file will be found at the url `${baseUrl}en/help.js` as well as the url `${baseUrl}help.js`, where `${baseUrl}` is the `baseUrl` field set in your [siteConfig.js file](api-site-config.md).
 
+## Title for Pages
+
+By default, the title of your page is `Title • Tagline` where `title` and `tagline` field are set in your [siteConfig.js file](api-site-config.md). You can exclude the tagline by setting `disableTitleTagline` to `true`. If you want to set a specific title for your page, add a `title` field on your React component.
+
+Example:
+
+```jsx
+const React = require('react');
+
+class MyPage extends React.Component {
+  render() {
+    // ... your rendering code
+  }
+}
+MyPage.title = 'My Custom Title';
+module.exports = MyPage;
+```
+
 ## Page Require Paths
 
 Docusaurus provides a few useful React components for users to write their own pages, found in the `CompLibrary` module. This module is provided as part of Docusaurus in `node_modules/docusaurus`, so to access it, pages in the `pages` folder are temporarily copied into `node_modules/docusaurus` when rendering to static html. As seen in the example files, this means that a user page at `pages/en/index.js` uses a require path to `'../../core/CompLibrary.js'` to import the provided components.

--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -9,9 +9,9 @@ Docusaurus provides support for writing pages as React components inside the `we
 
 Any `.js` files in `website/pages` will be rendered to static html using the path of the file after "pages". Files in `website/pages/en` will also get copied out into `pages` and will OVERRIDE any files of the same name in `pages`. For example, the page for the `website/pages/en/help.js` file will be found at the url `${baseUrl}en/help.js` as well as the url `${baseUrl}help.js`, where `${baseUrl}` is the `baseUrl` field set in your [siteConfig.js file](api-site-config.md).
 
-## Title for Pages
+## Titles for Pages
 
-By default, the title of your page is `Title • Tagline` where `title` and `tagline` field are set in your [siteConfig.js file](api-site-config.md). You can exclude the tagline by setting `disableTitleTagline` to `true`. If you want to set a specific title for your page, add a `title` field on your React component.
+By default, the title of your page is `Title • Tagline` where `title` and `tagline` field are set in [`siteConfig.js`](api-site-config.md). You can exclude the tagline by setting `disableTitleTagline` to `true`. If you want to set a specific title for your page, add a `title` class property on your exported React component.
 
 Example:
 
@@ -23,7 +23,9 @@ class MyPage extends React.Component {
     // ... your rendering code
   }
 }
+
 MyPage.title = 'My Custom Title';
+
 module.exports = MyPage;
 ```
 


### PR DESCRIPTION
## Motivation

Follow-up PR #704 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- [X] Test on development
http://localhost:3000/docs/en/next/api-pages.html
<img width="954" alt="doc" src="https://user-images.githubusercontent.com/17883920/40762078-8fae0a6a-64d1-11e8-8f7b-582d3e21b5cc.PNG">

- [X] Test on production using netlify
https://deploy-preview-712--docusaurus-preview.netlify.com/docs/en/next/api-pages.html 
