### PR TITLE
Don't start server if versions.js is missing but versioning is enabled

### DIFF
--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -48,9 +48,17 @@ class Versioning {
     this.enabled = false;
     this.defaultVersion = null;
     this.versions = [];
-    this.error = null;
+    this.missingVersionsPage = false;
 
     this._load();
+  }
+
+  printMissingVersionsPageError() {
+    console.error(
+      `${chalk.yellow('No versions.js file found!')}` +
+        `\nYou should create your versions.js file in pages/en directory.` +
+        `\nPlease refer to https://docusaurus.io/docs/en/versioning.html.`
+    );
   }
 
   _load() {
@@ -63,9 +71,7 @@ class Versioning {
     }
 
     if (!fs.existsSync(versions_js)) {
-      this.error = `${chalk.yellow(
-        'No versions.js file found!'
-      )}\nYou should create your versions.js file in pages/en directory.\nPlease refer to https://docusaurus.io/docs/en/versioning.html.`;
+      this.missingVersionsPage = true;
     }
   }
 }

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -8,12 +8,14 @@
 const CWD = process.cwd();
 const fs = require('fs-extra');
 const path = require('path');
+const chalk = require('chalk');
 const siteConfig = require(CWD + '/siteConfig.js');
 
 const join = path.join;
 
 const languages_js = join(CWD, 'languages.js');
 const versions_json = join(CWD, 'versions.json');
+const versions_js = join(CWD + '/pages/en/versions.js');
 
 class Translation {
   constructor() {
@@ -46,6 +48,7 @@ class Versioning {
     this.enabled = false;
     this.defaultVersion = null;
     this.versions = [];
+    this.error = null;
 
     this._load();
   }
@@ -57,6 +60,12 @@ class Versioning {
       this.defaultVersion = siteConfig.defaultVersionShown
         ? siteConfig.defaultVersionShown
         : this.versions[0]; // otherwise show the latest version (other than next/master)
+    }
+
+    if (!fs.existsSync(versions_js)) {
+      this.error = `${chalk.yellow(
+        'No versions.js file found!'
+      )}\nYou should create your versions.js file in pages/en directory.\nPlease refer to https://docusaurus.io/docs/en/versioning.html.`;
     }
   }
 }

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -15,7 +15,7 @@ const join = path.join;
 
 const languages_js = join(CWD, 'languages.js');
 const versions_json = join(CWD, 'versions.json');
-const versions_js = join(CWD + '/pages/en/versions.js');
+const versions_js = join(CWD, 'pages/en/versions.js');
 
 class Translation {
   constructor() {

--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -35,12 +35,8 @@ if (!fs.existsSync(CWD + '/siteConfig.js')) {
   process.exit(1);
 }
 
-if (env.versioning.enabled && !fs.existsSync(CWD + '/pages/en/versions.js')) {
-  console.error(
-    `${chalk.yellow(
-      'No versions.js file found when versioning is enabled!'
-    )}\nYou should create your versions.js file in pages/en directory.\nPlease refer to https://docusaurus.io/docs/en/versioning.html.`
-  );
+if (env.versioning.enabled && env.versioning.error) {
+  console.error(env.versioning.error);
   process.exit(1);
 }
 

--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -35,8 +35,8 @@ if (!fs.existsSync(CWD + '/siteConfig.js')) {
   process.exit(1);
 }
 
-if (env.versioning.enabled && env.versioning.error) {
-  console.error(env.versioning.error);
+if (env.versioning.enabled && env.versioning.missingVersionsPage) {
+  env.versioning.printMissingVersionsPageError();
   process.exit(1);
 }
 

--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -26,10 +26,20 @@ const chalk = require('chalk');
 const fs = require('fs');
 const openBrowser = require('react-dev-utils/openBrowser');
 const CWD = process.cwd();
+const env = require('./server/env.js');
 
 if (!fs.existsSync(CWD + '/siteConfig.js')) {
   console.error(
     chalk.red('Error: No siteConfig.js file found in website folder!')
+  );
+  process.exit(1);
+}
+
+if (env.versioning.enabled && !fs.existsSync(CWD + '/pages/en/versions.js')) {
+  console.error(
+    `${chalk.yellow(
+      'No versions.js file found when versioning is enabled!'
+    )}\nYou should create your versions.js file in pages/en directory.\nPlease refer to https://docusaurus.io/docs/en/versioning.html.`
   );
   process.exit(1);
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -14,6 +14,7 @@ const mkdirp = require('mkdirp');
 const chalk = require('chalk');
 const readMetadata = require('./server/readMetadata.js');
 const versionFallback = require('./server/versionFallback.js');
+const env = require('./server/env.js');
 
 const CWD = process.cwd();
 let versions;
@@ -33,13 +34,8 @@ program
   })
   .parse(process.argv);
 
-const hasVersionFile = fs.existsSync(CWD + '/pages/en/versions.js');
-if (!hasVersionFile) {
-  console.error(
-    `${chalk.yellow(
-      'No versions.js file found!'
-    )}\nYou should create your versions.js file in pages/en directory.\nPlease refer to https://docusaurus.io/docs/en/versioning.html.`
-  );
+if (env.versioning.error) {
+  console.error(env.versioning.error);
   process.exit(1);
 }
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -34,8 +34,8 @@ program
   })
   .parse(process.argv);
 
-if (env.versioning.error) {
-  console.error(env.versioning.error);
+if (env.versioning.missingVersionsPage) {
+  env.versioning.printMissingVersionsPageError();
   process.exit(1);
 }
 


### PR DESCRIPTION
## Motivation

This prevents user to start the server when `versions.js` is missing but versioning is enabled
#betterengineering

Closes #228 based on https://github.com/facebook/Docusaurus/issues/228#issuecomment-368748690
Related to #297 #369 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- [X] Start server as normal. `versions.js` exists when versioning is enabled
 ```
cd website
yarn start
```

<img width="490" alt="no error - versions" src="https://user-images.githubusercontent.com/17883920/40784723-0b3fd70c-6519-11e8-972a-b3d23771955b.PNG">

- [X] Delete `versions.js` when versioning is enabled (`versions.json` exist) 

```
cd website
yarn start
```

<img width="495" alt="error" src="https://user-images.githubusercontent.com/17883920/40784647-d3f61d42-6518-11e8-860c-86198f79780f.PNG">

