### PR TITLE
Fail properly when current branch is the same as the deployment one

### DIFF
--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -19,7 +19,8 @@ if (!shell.which('git')) {
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 const GIT_USER = process.env.GIT_USER;
 const CURRENT_BRANCH =
-  process.env.CIRCLE_BRANCH || shell.exec('git rev-parse --abbrev-ref HEAD');
+  process.env.CIRCLE_BRANCH ||
+  shell.exec('git rev-parse --abbrev-ref HEAD').stdout.trim();
 const ORGANIZATION_NAME =
   process.env.ORGANIZATION_NAME ||
   process.env.CIRCLE_PROJECT_USERNAME ||


### PR DESCRIPTION
## Motivation
I actually wanted something else of the publish script, and was looking into submitting another PR.

Then I found this bug.

In the publish script, shelljs' command output that parses the current branch wasn't unwrapped nor trimmed.
This means that when checking if the deployment branch is the same as the current branch, it would be comparing `master` to `{ stdout: 'master\n', stderr: '', ...etc }`. Which is `false`, of course -- so the script would continue and cause #406.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Skimmed through it (it's 2am in Sydney now 😴), I expect it to be the same as most other OSS projects

## Test Plan

Try publishing to an user/org site while you're on the `master` branch. Or to a project site when you're on `gh-pages`...

**The boom 💥**
_Have you read any cryptic error messages today?_
<img width="822" alt="screen shot 2018-06-01 at 01 47 26" src="https://user-images.githubusercontent.com/826553/40792643-c8be52c6-653d-11e8-9acb-a6f392ec9d0f.png">

**The fix 🤕**
Ah, clear error message, fine! 😎 
<img width="822" alt="screen shot 2018-06-01 at 01 49 16" src="https://user-images.githubusercontent.com/826553/40792908-59e8cc5e-653e-11e8-9846-466bc68e7bee.png">

