### PR TITLE
Fixed styling of links for Draft.js documentation

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -217,7 +217,8 @@ header h2 {
 }
 .mainContainer .wrapper a,
 .inner .projectIntro a {
-  text-decoration: none;
+  text-decoration: underline;
+  background-color: lightblue;
 }
 .mainContainer .wrapper a:hover,
 .mainContainer .wrapper a:focus,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In the Draft.js documentation such as on this page, https://draftjs.org/docs/getting-started.html, the links are not clearly visible. This change was recommended by @Prinzhorn in issue https://github.com/facebook/draft-js/issues/1778 of the draft.js repository.

### Have you read the [Contributing Guidelines on pull requests]
Yes I have read it and signed the CLA.

## Test Plan

I verified these changes work by testing them with google chrome's developer tools.

Picture before the change:

![before](https://user-images.githubusercontent.com/25648267/41057508-471465ba-6995-11e8-96ce-f91e96b8bb03.PNG)


Picture after change:

![after](https://user-images.githubusercontent.com/25648267/41057523-51412708-6995-11e8-88b3-84dec8d13af5.PNG)


## Related PRs

I do not think this PR changes any functionality since it only changes the styling of links.
