### PR TITLE
Show onPageNav on mobile devices

### DIFF
--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -28,7 +28,7 @@ class SideNav extends React.Component {
                 </span>
               </h2>
               <div className="tocToggler" id="tocToggler">
-                <i className="icon-list" />
+                <i className="icon-toc" />
               </div>
             </div>
             <div className="navGroups">

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -39,9 +39,16 @@ class SideNav extends React.Component {
         <script
           dangerouslySetInnerHTML={{
             __html: `
-            (function() {
+            document.addEventListener('DOMContentLoaded', function() {
               createToggler('#navToggler', '#docsNav', 'docsSliderActive');
               createToggler('#tocToggler', 'body', 'tocActive');
+
+              const headings = document.querySelector('.toc-headings');
+              headings && headings.addEventListener('click', function(event) {
+                if (event.target.tagName === 'A') {
+                  document.body.classList.remove('tocActive');
+                }
+              }, false);
 
               function createToggler(togglerSelector, targetSelector, className) {
                 var toggler = document.querySelector(togglerSelector);
@@ -53,7 +60,7 @@ class SideNav extends React.Component {
                   target.classList.toggle(className);
                 };
               }
-            }());
+            });
         `,
           }}
         />

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -27,6 +27,9 @@ class SideNav extends React.Component {
                   {this.getLocalizedCategoryString(this.props.current.category)}
                 </span>
               </h2>
+              <div className="tocToggler" id="tocToggler">
+                <i className="icon-list" />
+              </div>
             </div>
             <div className="navGroups">
               {this.props.contents.map(this.renderCategory, this)}
@@ -36,11 +39,21 @@ class SideNav extends React.Component {
         <script
           dangerouslySetInnerHTML={{
             __html: `
-          var toggler = document.getElementById('navToggler');
-          var nav = document.getElementById('docsNav');
-          toggler.onclick = function() {
-            nav.classList.toggle('docsSliderActive');
-          };
+            (function() {
+              createToggler('#navToggler', '#docsNav', 'docsSliderActive');
+              createToggler('#tocToggler', 'body', 'tocActive');
+
+              function createToggler(togglerSelector, targetSelector, className) {
+                var toggler = document.querySelector(togglerSelector);
+                var target = document.querySelector(targetSelector);
+
+                toggler.onclick = function(event) {
+                  event.preventDefault();
+
+                  target.classList.toggle(className);
+                };
+              }
+            }());
         `,
           }}
         />

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1232,24 +1232,11 @@ ul#languages li {
   border: 0;
   color: #393939;
 }
-nav.toc {
-  width: 240px;
-}
 nav.toc section {
   padding: 0;
   position: relative;
 }
-nav.toc:last-child {
-  padding-bottom: 100px;
-}
 @media only screen and (max-width: 735px) {
-  nav.toc {
-    width: 100%;
-  }
-  nav.toc:last-child {
-    padding-bottom: 0;
-  }
-
   a.anchor {
     top: -144px;
   }
@@ -1427,40 +1414,11 @@ nav.toc .toggleNav .navBreadcrumb h2 {
 .tocActive .icon-list {
   transform: rotate(45deg);
 }
-.tocActive .navToggle, .tocActive .navBreadcrumb h2 {
-  visibility: hidden;
-}
 
 @media only screen and (min-width: 736px) {
-  nav.toc section .navGroups {
-    padding: 40px 0 0;
-  }
-  .navToggle {
-    display: none;
-  }
-
-  .docsSliderActive .mainContainer {
-    display: block;
-  }
-
   .sideNavVisible .navPusher .mainContainer {
     padding-top: 0;
     max-width: 70%;
-  }
-
-  .docsNavContainer {
-    background: none;
-    box-sizing: border-box;
-    height: auto;
-    margin: 40px 40px 0 0;
-    overflow-y: auto;
-    position: relative;
-    width: 300px;
-  }
-
-  nav.toc section .navGroups {
-    display: block;
-    padding-top: 0px;
   }
 
   .docMainWrapper {
@@ -1475,13 +1433,6 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   }
   .docMainWrapper .wrapper {
     padding-top: 0;
-  }
-
-  .docsNavContainer nav.toc .navBreadcrumb {
-    display: none;
-  }
-  .navBreadcrumb h2 {
-    padding: 0 10px;
   }
 }
 
@@ -1510,6 +1461,31 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   padding-bottom: 5px;
 }
 
+@media only screen and (min-width: 1024px) {
+  nav.toc {
+    width: 240px;
+  }
+  nav.toc section .navGroups {
+    display: block;
+    padding: 0px;
+  }
+  .docsNavContainer {
+    background: none;
+    box-sizing: border-box;
+    height: auto;
+    margin: 40px 40px 0 0;
+    overflow-y: auto;
+    position: relative;
+    width: 300px;
+  }
+  .docsNavContainer nav.toc .navBreadcrumb {
+    display: none;
+  }
+  .navBreadcrumb h2 {
+    padding: 0 10px;
+  }
+}
+
 @supports ((position: -webkit-sticky) or (position: sticky))  {
   @media only screen and (max-width: 735px) {
     .tocActive .onPageNav {
@@ -1526,24 +1502,23 @@ nav.toc .toggleNav .navBreadcrumb h2 {
       overscroll-behavior: contain;
     }
 
+    .tocActive .navToggle,
+    .tocActive .navBreadcrumb h2 {
+      visibility: hidden;
+    }
+
     .tocActive .onPageNav > .toc-headings {
       padding: 12px 0;
     }
   }
 
-  @media only screen and (min-width: 1024px) {
+  @media only screen and (min-width: 736px) {
     .separateOnPageNav.doc .wrapper,
     .separateOnPageNav .headerWrapper.wrapper {
       max-width: 1400px;
     }
 
-    .doc.separateOnPageNav .docsNavContainer {
-      flex: 0 0 240px;
-      margin: 55px 0 0;
-    }
-
-    .doc.separateOnPageNav nav.toc:last-child {
-      padding-bottom: 0;
+    .doc.separateOnPageNav nav.toc {
       width: auto;
     }
 
@@ -1568,6 +1543,17 @@ nav.toc .toggleNav .navBreadcrumb h2 {
     .onPageNav > .toc-headings {
       border-left: 1px solid #e0e0e0;
       padding: 10px 0 2px 15px;
+    }
+
+    .tocToggler {
+      display: none;
+    }
+  }
+
+  @media only screen and (min-width: 1024px) {
+    .doc.separateOnPageNav .docsNavContainer {
+      flex: 0 0 240px;
+      margin: 55px 0 0;
     }
   }
 }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -203,6 +203,7 @@ header h2 {
 .mainContainer {
   background: #f9f9f9;
   flex: 1 1 auto;
+  max-width: 100%;
   font-size: 18px;
 }
 .mainContainer .wrapper {
@@ -1416,7 +1417,7 @@ nav.toc .toggleNav .navBreadcrumb h2 {
 }
 
 @media only screen and (min-width: 736px) {
-  .sideNavVisible .navPusher .mainContainer {
+  .doc.separateOnPageNav .navPusher .mainContainer {
     padding-top: 0;
     max-width: 70%;
   }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1214,6 +1214,7 @@ ul#languages li {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding-bottom: 50px;
+  overscroll-behavior: contain;
 }
 
 .docsNavContainer nav.toc .navBreadcrumb {
@@ -1230,9 +1231,6 @@ ul#languages li {
 .navBreadcrumb span {
   border: 0;
   color: #393939;
-}
-.navBreadcrumb i {
-  padding: 0 4px;
 }
 nav.toc {
   width: 240px;
@@ -1309,6 +1307,9 @@ nav.toc .toggleNav .navToggle i::after {
   width: 5px;
   z-index: 10;
 }
+.toggleNav h2 i {
+  padding: 0 4px;
+}
 nav.toc .toggleNav .navToggle i::after {
   border-width: 5px 5px 0;
   margin-top: 2px;
@@ -1321,6 +1322,9 @@ nav.toc .toggleNav .navToggle i::after {
 }
 .docsSliderActive nav.toc .toggleNav .navToggle i {
   opacity: 0;
+}
+.docsSliderActive .tocToggler {
+  visibility: hidden;
 }
 nav.toc .toggleNav .navGroup {
   margin-bottom: 20px;
@@ -1364,7 +1368,8 @@ nav.toc .toggleNav ul li a:focus {
 nav.toc .toggleNav ul li a.navItemActive {
   color: $primaryColor;
 }
-.docsSliderActive nav.toc .navBreadcrumb {
+.docsSliderActive nav.toc .navBreadcrumb,
+.tocActive .navBreadcrumb {
   border-bottom: 1px solid #ccc;
   margin-bottom: 20px;
   position: fixed;
@@ -1377,9 +1382,53 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   line-height: 32px;
   margin: 0;
   padding: 0;
+  flex-grow: 1;
 }
 .docsSliderActive nav.toc section .navGroups {
   display: block;
+}
+.tocToggler {
+  height: 32px;
+  line-height: 32px;
+  padding-left: 20px;
+  cursor: pointer;
+}
+.icon-list {
+  box-sizing: border-box;
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: normal;
+  top: -1px;
+}
+.icon-list,
+.icon-list::before,
+.icon-list::after {
+  width: 4px;
+  height: 4px;
+  border: 1px solid currentColor;
+  background-color: currentColor;
+  border-radius: 50%;
+  box-sizing: border-box;
+}
+.icon-list::before,
+.icon-list::after {
+  content: "";
+  position: absolute;
+}
+.icon-list::before {
+  top: -7px;
+  left: -1px;
+}
+.icon-list::after {
+  top: 5px;
+  left: -1px;
+}
+.tocActive .icon-list {
+  transform: rotate(45deg);
+}
+.tocActive .navToggle, .tocActive .navBreadcrumb h2 {
+  visibility: hidden;
 }
 
 @media only screen and (min-width: 736px) {
@@ -1443,7 +1492,45 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   display: none;
 }
 
+.onPageNav a {
+  color: #717171;
+}
+
+.onPageNav ul li {
+  font-size: 12px;
+  line-height: 17px;
+  padding-bottom: 9px;
+}
+
+.onPageNav ul ul {
+  padding: 8px 0 0 20px;
+}
+
+.onPageNav ul ul li {
+  padding-bottom: 5px;
+}
+
 @supports ((position: -webkit-sticky) or (position: sticky))  {
+  @media only screen and (max-width: 735px) {
+    .tocActive .onPageNav {
+      display: block;
+      position: fixed;
+      top: 148px;
+      background: #fff;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 10;
+      padding: 0 20px;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+    }
+
+    .tocActive .onPageNav > .toc-headings {
+      padding: 12px 0;
+    }
+  }
+
   @media only screen and (min-width: 1024px) {
     .separateOnPageNav.doc .wrapper,
     .separateOnPageNav .headerWrapper.wrapper {
@@ -1478,27 +1565,9 @@ nav.toc .toggleNav .navBreadcrumb h2 {
       align-self: flex-start;
     }
 
-    .onPageNav > ul {
+    .onPageNav > .toc-headings {
       border-left: 1px solid #e0e0e0;
       padding: 10px 0 2px 15px;
-    }
-
-    .onPageNav a {
-      color: #717171;
-    }
-
-    .onPageNav ul li {
-      font-size: 12px;
-      line-height: 17px;
-      padding-bottom: 9px;
-    }
-
-    .onPageNav ul ul {
-      padding: 8px 0 0 20px;
-    }
-
-    .onPageNav ul ul li {
-      padding-bottom: 5px;
     }
   }
 }
@@ -1862,7 +1931,7 @@ footer .social {
     width: 100%;
     box-sizing: border-box;
   }
-  
+
   /* those make the footer sticky and work even in IE 11 */
   .navPusher > :first-child {
     flex-grow: 1;

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1377,11 +1377,12 @@ nav.toc .toggleNav .navBreadcrumb h2 {
 }
 .tocToggler {
   height: 32px;
+  padding: 0 10px;
+  margin-right: -10px;
   line-height: 32px;
-  padding-left: 20px;
   cursor: pointer;
 }
-.icon-list {
+.icon-toc {
   box-sizing: border-box;
   position: relative;
   display: inline-block;
@@ -1389,9 +1390,9 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   line-height: normal;
   top: -1px;
 }
-.icon-list,
-.icon-list::before,
-.icon-list::after {
+.icon-toc,
+.icon-toc::before,
+.icon-toc::after {
   width: 4px;
   height: 4px;
   border: 1px solid currentColor;
@@ -1399,21 +1400,35 @@ nav.toc .toggleNav .navBreadcrumb h2 {
   border-radius: 50%;
   box-sizing: border-box;
 }
-.icon-list::before,
-.icon-list::after {
+.icon-toc::before,
+.icon-toc::after {
   content: "";
   position: absolute;
 }
-.icon-list::before {
+.icon-toc::before {
   top: -7px;
   left: -1px;
 }
-.icon-list::after {
+.icon-toc::after {
   top: 5px;
   left: -1px;
 }
-.tocActive .icon-list {
+.tocActive .icon-toc {
   transform: rotate(45deg);
+  width: 3px;
+  height: 16px;
+  border-radius: 0;
+}
+.tocActive .icon-toc::before {
+  top: 50%;
+  left: 50%;
+  height: 3px;
+  width: 16px;
+  border-radius: 0;
+  transform: translate(-50%, -50%);
+}
+.tocActive .icon-toc::after {
+  content: '';
 }
 
 @media only screen and (min-width: 736px) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR adds support for onPageNav for mobile and tablet devices

This PR closes #662 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

### ToC Hidden

![toc-hidden](https://user-images.githubusercontent.com/2536916/40998861-b80bb75c-6911-11e8-8ca2-0df4d8a1cda8.png)

### ToC Shown

![toc-shown](https://user-images.githubusercontent.com/2536916/41062897-cf9fe252-69df-11e8-8dee-8e44de1f003c.png)

### Tablet devices

For tablets I've decided to show onPageNav instead of sideNav. The sideNav is accessible through breadcrumbs menu like on mobile devices.

![toc-ipad](https://user-images.githubusercontent.com/2536916/41059789-41d81380-69d6-11e8-8112-600edabdd073.png)

