### PR TITLE
Choosing another language doesn't reset version & url

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -33,11 +33,29 @@ class LanguageDropDown extends React.Component {
     const enabledLanguages = env.translation
       .enabledLanguages()
       .filter(lang => lang.tag !== this.props.language)
-      .map(lang => (
-        <li key={lang.tag}>
-          <a href={siteConfig.baseUrl + lang.tag}>{lang.name}</a>
-        </li>
-      ));
+      .map(lang => {
+        // build the href so that we try to stay in current url but change the language.
+        let href = siteConfig.baseUrl + lang.tag;
+        if (
+          this.props.current &&
+          this.props.current.permalink &&
+          this.props.language
+        ) {
+          href =
+            siteConfig.baseUrl +
+            this.props.current.permalink.replace(
+              `/${this.props.language}/`,
+              `/${lang.tag}/`
+            );
+        } else if (this.props.current.id && this.props.current.id !== 'index') {
+          href = siteConfig.baseUrl + lang.tag + '/' + this.props.current.id;
+        }
+        return (
+          <li key={lang.tag}>
+            <a href={utils.getPath(href, this.props.cleanUrl)}>{lang.name}</a>
+          </li>
+        );
+      });
     // if no languages are enabled besides English, return null
     if (enabledLanguages.length < 1) {
       return null;
@@ -131,6 +149,8 @@ class HeaderNav extends React.Component {
           <LanguageDropDown
             baseUrl={this.props.baseUrl}
             language={this.props.language}
+            current={this.props.current}
+            cleanUrl={this.props.config.cleanUrl}
             key="languagedropdown"
           />
         );


### PR DESCRIPTION
## Motivation

Fixes #732  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
cd website
yarn start
```

**Before this PR**
Choosing language will reset to homepage and default version.
![demo2](https://user-images.githubusercontent.com/17883920/41086311-3ad77724-6a6c-11e8-985f-3258a49458e3.gif)


**After this PR**
Choosing language will only change the language of the URL. Does not reset version / go back to homepage
![demo](https://user-images.githubusercontent.com/17883920/41086097-8920fb5e-6a6b-11e8-8a59-625f6a54245d.gif)

Note that the demo cannot find the file because when we preview on localhost, we have not gone through the Crowdin upload and download processes yet like we will when we publish via Circle (see our circle.yml file).
