### PR TITLE
Fix Express.js regex for docs & blog

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -130,7 +130,7 @@ function execute(port) {
   // handle all requests for document pages
   const app = express();
 
-  app.get(/^\/docs\/.*html$/, (req, res, next) => {
+  app.get(/\/docs\/.*html$/, (req, res, next) => {
     let url = req.path.toString().replace(siteConfig.baseUrl, '');
 
     // links is a map from a permalink to an id for each document
@@ -272,7 +272,7 @@ function execute(port) {
   });
 
   // Handle all requests for blog pages and posts.
-  app.get(/^\/blog\/.*html$/, (req, res) => {
+  app.get(/\/blog\/.*html$/, (req, res) => {
     // Regenerate the blog metadata in case it has changed. Consider improving
     // this to regenerate on file save rather than on page request.
     reloadMetadataBlog();


### PR DESCRIPTION
## Motivation

I unintentionally put ^ on docs & blogs regex for development server routing on previous PR #677.
I'm reverting it because if `baseUrl` is not `/`, it won't handle the request

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Use non `/` baseUrl (e.g: `/test/`)
```
cd website
yarn start
```

http://localhost:3000/test/blog works
<img width="926" alt="blog regex" src="https://user-images.githubusercontent.com/17883920/41111580-f08acff2-6aae-11e8-8290-77ed2b7c5f97.PNG">

http://localhost:3000/test/blog
<img width="957" alt="docs regex" src="https://user-images.githubusercontent.com/17883920/41111583-f42e8fea-6aae-11e8-8ff6-1e083643c305.PNG">


## Related PRs

#677 
