### PR TITLE
Adding baseUrl to feed links.

### DIFF
--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -29,10 +29,10 @@ class Head extends React.Component {
           highlight.version
         }/styles/${highlight.theme}.min.css`;
 
-    // ensure the feedBase variable does not end in a slash
-    const feedBase = (
-      this.props.config.url + this.props.config.baseUrl
-    ).replace(/\/$/, '');
+    // ensure the siteUrl variable ends with a single slash
+    const siteUrl =
+      (this.props.config.url + this.props.config.baseUrl).replace(/\/*$/, '') +
+      '/';
 
     return (
       <head>
@@ -48,22 +48,14 @@ class Head extends React.Component {
         {this.props.config.ogImage && (
           <meta
             property="og:image"
-            content={
-              this.props.config.url +
-              this.props.config.baseUrl +
-              this.props.config.ogImage
-            }
+            content={siteUrl + this.props.config.ogImage}
           />
         )}
         <meta name="twitter:card" content="summary" />
         {this.props.config.twitterImage && (
           <meta
             name="twitter:image"
-            content={
-              this.props.config.url +
-              this.props.config.baseUrl +
-              this.props.config.twitterImage
-            }
+            content={siteUrl + this.props.config.twitterImage}
           />
         )}
         {this.props.config.noIndex && <meta name="robots" content="noindex" />}
@@ -85,7 +77,7 @@ class Head extends React.Component {
           <link
             rel="alternate"
             type="application/atom+xml"
-            href={feedBase + '/blog/atom.xml'}
+            href={siteUrl + 'blog/atom.xml'}
             title={this.props.config.title + ' Blog ATOM Feed'}
           />
         )}
@@ -93,7 +85,7 @@ class Head extends React.Component {
           <link
             rel="alternate"
             type="application/rss+xml"
-            href={feedBase + '/blog/feed.xml'}
+            href={siteUrl + 'blog/feed.xml'}
             title={this.props.config.title + ' Blog RSS Feed'}
           />
         )}

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -80,7 +80,11 @@ class Head extends React.Component {
           <link
             rel="alternate"
             type="application/atom+xml"
-            href={this.props.config.url + '/blog/atom.xml'}
+            href={
+              this.props.config.url +
+              this.props.config.baseUrl +
+              '/blog/atom.xml'
+            }
             title={this.props.config.title + ' Blog ATOM Feed'}
           />
         )}
@@ -88,7 +92,11 @@ class Head extends React.Component {
           <link
             rel="alternate"
             type="application/rss+xml"
-            href={this.props.config.url + '/blog/feed.xml'}
+            href={
+              this.props.config.url +
+              this.props.config.baseUrl +
+              '/blog/feed.xml'
+            }
             title={this.props.config.title + ' Blog RSS Feed'}
           />
         )}

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -29,6 +29,11 @@ class Head extends React.Component {
           highlight.version
         }/styles/${highlight.theme}.min.css`;
 
+    // ensure the feedBase variable does not end in a slash
+    const feedBase = (
+      this.props.config.url + this.props.config.baseUrl
+    ).replace(/\/$/, '');
+
     return (
       <head>
         <meta charSet="utf-8" />
@@ -80,11 +85,7 @@ class Head extends React.Component {
           <link
             rel="alternate"
             type="application/atom+xml"
-            href={
-              this.props.config.url +
-              this.props.config.baseUrl +
-              '/blog/atom.xml'
-            }
+            href={feedBase + '/blog/atom.xml'}
             title={this.props.config.title + ' Blog ATOM Feed'}
           />
         )}
@@ -92,11 +93,7 @@ class Head extends React.Component {
           <link
             rel="alternate"
             type="application/rss+xml"
-            href={
-              this.props.config.url +
-              this.props.config.baseUrl +
-              '/blog/feed.xml'
-            }
+            href={feedBase + '/blog/feed.xml'}
             title={this.props.config.title + ' Blog RSS Feed'}
           />
         )}

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -31,7 +31,7 @@ class Head extends React.Component {
 
     // ensure the siteUrl variable ends with a single slash
     const siteUrl =
-      (this.props.config.url + this.props.config.baseUrl).replace(/\/*$/, '') +
+      (this.props.config.url + this.props.config.baseUrl).replace(/\/+$/, '') +
       '/';
 
     return (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This hopefully fixes a bug reported in jest:
https://github.com/facebook/jest/issues/6418

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I considered adding a test for this, but there didn't appear to be any for this file.  I can add them if you would like.  For the time being, all I did was use the following as a smoke test:
- view-source:https://facebook.github.io/jest/blog/
- confirm `og:image` url works: https://facebook.github.io/jest/img/opengraph.png
- confirm `atom.xml` url is incorrect: https://facebook.github.io/blog/atom.xml
- after this pr, it *should* match: https://facebook.github.io/jest/blog/atom.xml

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
