### PR TITLE
Fix HeaderNav linking to versions page to depends on cleanUrl

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -21,6 +21,7 @@ const readMetadata = require('../../server/readMetadata.js');
 readMetadata.generateMetadataDocs();
 const Metadata = require('../metadata.js');
 const utils = require('../utils.js');
+const extension = siteConfig.cleanUrl ? '' : '.html';
 
 // language dropdown nav item for when translations are enabled
 class LanguageDropDown extends React.Component {
@@ -200,7 +201,6 @@ class HeaderNav extends React.Component {
     } else if (link.page) {
       // set link to page with current page's language if appropriate
       const language = this.props.language || '';
-      const extension = siteConfig.cleanUrl ? '' : '.html';
       if (fs.existsSync(CWD + '/pages/en/' + link.page + '.js')) {
         href =
           siteConfig.baseUrl +
@@ -243,8 +243,8 @@ class HeaderNav extends React.Component {
     const versionsLink =
       this.props.baseUrl +
       (env.translation.enabled
-        ? this.props.language + '/versions.html'
-        : 'versions.html');
+        ? this.props.language + '/versions' + extension
+        : 'versions' + extension);
     return (
       <div className="fixedHeaderContainer">
         <div className="headerWrapper wrapper">


### PR DESCRIPTION
## Motivation

Remove hardcoded `.html` extension from HeaderNav.js
Missed this one out from #677 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
**Before**
Still use `.html` extension when `cleanUrl` is true. Although the page without `.html` version is also accessible.
![unclean](https://user-images.githubusercontent.com/17883920/41200387-5bcee9fa-6cd6-11e8-8387-3b6ecc6b5aef.gif)

**After**
Don't use `.html` extension when `cleanUrl` is true
![clean](https://user-images.githubusercontent.com/17883920/41200390-6059715c-6cd6-11e8-97ef-1d1a541b4cf7.gif)