### PR TITLE
Enable custom meta description for custom pages

### DIFF
--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -29,6 +29,33 @@ MyPage.title = 'My Custom Title';
 module.exports = MyPage;
 ```
 
+## Description for Pages
+
+By default, the description your page is `tagline` set in [`siteConfig.js`](api-site-config.md). If you want to set a specific description for your custom pages, add a `description` class property on your exported React component. 
+
+Example:
+
+```js
+const React = require('react');
+
+class MyPage extends React.Component {
+  render() {
+    // ... your rendering code
+  }
+}
+
+MyPage.description = 'My Custom Description';
+
+module.exports = MyPage;
+```
+
+This will be translated to a description metadata tag on the generated HTML.
+
+```html
+<meta property="og:description" content="My Custom Description"/>
+<meta name="description" content="My Custom Description"/>
+```
+
 ## Page Require Paths
 
 Docusaurus provides a few useful React components for users to write their own pages, found in the `CompLibrary` module. This module is provided as part of Docusaurus in `node_modules/docusaurus`, so to access it, pages in the `pages` directory are temporarily copied into `node_modules/docusaurus` when rendering to static HTML. As seen in the example files, this means that a user page at `pages/en/index.js` uses a require path to `'../../core/CompLibrary.js'` to import the provided components.

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -36,6 +36,7 @@ class Head extends React.Component {
         <title>{this.props.title}</title>
         <meta name="viewport" content="width=device-width" />
         <meta name="generator" content="Docusaurus" />
+        <meta name="description" content={this.props.description} />
         <meta property="og:title" content={this.props.title} />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={this.props.url} />

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -509,6 +509,7 @@ async function execute() {
               language={language}
               config={siteConfig}
               title={ReactComp.title}
+              description={ReactComp.description}
               metadata={{id: pageID}}>
               <ReactComp language={language} />
             </Site>
@@ -528,6 +529,7 @@ async function execute() {
             title={ReactComp.title}
             language={language}
             config={siteConfig}
+            description={ReactComp.description}
             metadata={{id: pageID}}>
             <ReactComp language={language} />
           </Site>
@@ -545,6 +547,7 @@ async function execute() {
             title={ReactComp.title}
             language={language}
             config={siteConfig}
+            description={ReactComp.description}
             metadata={{id: pageID}}>
             <ReactComp language={language} />
           </Site>

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -449,6 +449,7 @@ function execute(port) {
           language={language}
           config={siteConfig}
           title={ReactComp.title}
+          description={ReactComp.description}
           metadata={{id: path.basename(userFile, '.js')}}>
           <ReactComp language={language} />
         </Site>


### PR DESCRIPTION
## Motivation

1. Fixes #751
2. Enable user to set their own description (Inspired from #704)

### For Your Information
`<meta name="description" content="" /> `
Search engines show the meta description in search results mostly when the searched for phrase is contained in the description. Optimizing the meta description is a very important aspect of on-page SEO 

`<meta property="og:description" content="" />`
This is used for Open Graph description meta. Usually used by crawler of social media like Facebook / Twitter

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Changes
Previously, all custom pages description will always be `tagline` because we never pass `description` props.

https://github.com/facebook/Docusaurus/blob/18c01327a3082962165263c37b4a49d5426fbf53/lib/core/Site.js#L31


Adding custom description for your custom pages is as simple as adding description class property to your React component.

Example:
```js
class Index extends React.Component {
  // ... some code
}
Index.description = 'Endilie is an undergraduate student at Nanyang Technological University (2019). He likes to write & code in his free time';
```

## Test Plan

Facebook URL Linter
https://developers.facebook.com/tools/debug/

Before
<img width="726" alt="before-og-description-fb" src="https://user-images.githubusercontent.com/17883920/41203146-b0609908-6d05-11e8-8d59-259f84466e13.PNG">

After
<img width="870" alt="after-og-description-fb" src="https://user-images.githubusercontent.com/17883920/41203148-b507f1c2-6d05-11e8-9587-04914c9a052e.PNG">

https://totheweb.com/learning_center/tool-test-google-title-meta-description-lengths/

Before
<img width="414" alt="before" src="https://user-images.githubusercontent.com/17883920/41203153-c34719fc-6d05-11e8-8cab-c3b94edca71c.PNG">

After
<img width="442" alt="after" src="https://user-images.githubusercontent.com/17883920/41203155-c8eee948-6d05-11e8-994b-5bc2800ee98a.PNG">
