### PR TITLE
Add back information about extra search options

### DIFF
--- a/docs/guides-search.md
+++ b/docs/guides-search.md
@@ -22,6 +22,22 @@ const siteConfig = {
   ...
 };
 ```
+-## Extra Search Options
+-	
+-You can also specify extra [search options used by Algolia](https://community.algolia.com/docsearch/documentation/) by using an `algoliaOptions` field in `algolia`. This may be useful if you want to provide different search results for the different versions or languages of your docs. Any occurrences of "VERSION" or "LANGUAGE" will be replaced by the version or language of the current page, respectively. More details about search options can be [found here](https://www.algolia.com/doc/api-reference/api-parameters/#overview).	
+-	
+-```js	
+-const siteConfig = {	
+-  ...	
+-  algolia: {	
+-    ...	
+-    algoliaOptions: {	
+-      facetFilters: [ 'tags:VERSION' ],	
+-      hitsPerPage: 5	
+-    }	
+-  },	
+-};	
+-``
 
 Algolia might provide you with [extra search options](https://community.algolia.com/docsearch/documentation/). If so, you should add them to the `algoliaOptions` object.
 


### PR DESCRIPTION
I added back information about extra search options for Algolia. A previous commit removed the section about extra search options, but it appears the information might actually be useful.

## Motivation

Fixes #743 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
