### PR TITLE
fix sidebar file name issue in rename-version

### DIFF
--- a/lib/rename-version.js
+++ b/lib/rename-version.js
@@ -117,9 +117,9 @@ if (fs.existsSync(CWD + '/versioned_docs/version-' + currentVersion)) {
 // if sidebar file exists for this version, rename sidebar file and rewrite
 // doc ids in the file
 let currentSidebarFile =
-  CWD + '/versioned_sidebars/version-' + currentVersion + '-sidebar.json';
+  CWD + '/versioned_sidebars/version-' + currentVersion + '-sidebars.json';
 let newSidebarFile =
-  CWD + '/versioned_sidebars/version-' + newVersion + '-sidebar.json';
+  CWD + '/versioned_sidebars/version-' + newVersion + '-sidebars.json';
 if (fs.existsSync(currentSidebarFile)) {
   fs.renameSync(currentSidebarFile, newSidebarFile);
   let sidebarContent = fs.readFileSync(newSidebarFile, 'utf8');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #227 (edited by Endiliey)

To fix the sidebars.json rename-version bug reported here: [Bug 227](https://github.com/facebook/Docusaurus/issues/227)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The issue was with sidebar file not being renamed on using rename-version command
To test it you can follow this:
1) Checkout the master branch of Docusaurus
2) Use this command to create a new version: `yarn run version 1.2.3`
3) Rename the version using this command: `yarn run rename-version 1.2.3 1.2.4`
4) Notice the file in versioned_sidebars, it won't have been renamed
5) Clear all the changes and checkout the branch in this PR
6) Repeat steps 2 and 3 and notice that the file will be renamed
