### PR TITLE
Cross repo publishing

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -45,7 +45,8 @@ Two of the required parameters are set in the [`siteConfig.js`](api-site-config.
 | `organizationName` | The GitHub user or organization that owns the repository. In the case of Docusaurus, that would be the "facebook" GitHub organization.                                                   |
 | `projectName`      | The name of the GitHub repository for your project. For example, Docusaurus is hosted at https://github.com/facebook/docusaurus, so our project name in this case would be "docusaurus". |
 
-> Docusaurus also supports deploying [user or organization sites](https://help.github.com/articles/user-organization-and-project-pages/#user--organization-pages). These sites will be served from the `master` branch of the repo. So, you will want to have the Docusaurus infra, your docs, etc. in another branch (e.g., maybe call it `source`). To do this, just set `projectName` to "_username_.github.io" (where _username_ is your username or organization name on GitHub) and `organizationName` to "_username_". The publish script will automatically deploy your site to the root of the `master` branch to be served.
+> Docusaurus also supports deploying [user or organization sites](https://help.github.com/articles/user-organization-and-project-pages/#user--organization-pages). To do this, just set `projectName` to "_username_.github.io" (where _username_ is your username or organization name on GitHub) and `organizationName` to "_username_".  
+> The publish script will deploy these sites to the root of the `master` branch of this _username_.github.io repo. In this case, note that you will want to have the Docusaurus infra, your docs, etc. either in another branch of this repo (e.g., maybe call it `source`), or in another, separated repo (e.g. in the same as the documented source code).
 
 > While we recommend setting the `projectName` and `organizationName` in `siteConfig.js`, you can also use environment variables `ORGANIZATION_NAME` and `PROJECT_NAME`.
 

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -46,7 +46,7 @@ Two of the required parameters are set in the [`siteConfig.js`](api-site-config.
 | `projectName`      | The name of the GitHub repository for your project. For example, Docusaurus is hosted at https://github.com/facebook/docusaurus, so our project name in this case would be "docusaurus". |
 
 > Docusaurus also supports deploying [user or organization sites](https://help.github.com/articles/user-organization-and-project-pages/#user--organization-pages). To do this, just set `projectName` to "_username_.github.io" (where _username_ is your username or organization name on GitHub) and `organizationName` to "_username_".  
-> The publish script will deploy these sites to the root of the `master` branch of this _username_.github.io repo. In this case, note that you will want to have the Docusaurus infra, your docs, etc. either in another branch of this repo (e.g., maybe call it `source`), or in another, separated repo (e.g. in the same as the documented source code).
+> For user or org sites, the publish script will deploy these sites to the root of the `master` branch of the _username_.github.io repo. In this case, note that you will want to have the Docusaurus infra, your docs, etc. either in another branch of the _username_.github.io repo (e.g., maybe call it `source`), or in another, separated repo (e.g. in the same as the documented source code).
 
 > While we recommend setting the `projectName` and `organizationName` in `siteConfig.js`, you can also use environment variables `ORGANIZATION_NAME` and `PROJECT_NAME`.
 

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -97,20 +97,27 @@ if (
 
 shell.cd(`${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`);
 
-if (shell.exec(`git checkout origin/${DEPLOYMENT_BRANCH}`).code !== 0) {
-  if (shell.exec(`git checkout --orphan ${DEPLOYMENT_BRANCH}`).code !== 0) {
-    shell.echo(`Error: Git checkout ${DEPLOYMENT_BRANCH} failed`);
-    shell.exit(1);
-  }
-} else {
-  if (
-    shell.exec(`git checkout -b ${DEPLOYMENT_BRANCH}`).code +
-      shell.exec(`git branch --set-upstream-to=origin/${DEPLOYMENT_BRANCH}`)
-        .code !==
-    0
-  ) {
-    shell.echo(`Error: Git checkout ${DEPLOYMENT_BRANCH} failed`);
-    shell.exit(1);
+// If the default branch is the one we're deploying to, then we'll fail to create it.
+// This is the case of a cross-repo publish, where we clone a github.io repo with a default master branch.
+const defaultBranch = shell
+  .exec('git rev-parse --abbrev-ref HEAD')
+  .stdout.trim();
+if (defaultBranch !== DEPLOYMENT_BRANCH) {
+  if (shell.exec(`git checkout origin/${DEPLOYMENT_BRANCH}`).code !== 0) {
+    if (shell.exec(`git checkout --orphan ${DEPLOYMENT_BRANCH}`).code !== 0) {
+      shell.echo(`Error: Git checkout ${DEPLOYMENT_BRANCH} failed`);
+      shell.exit(1);
+    }
+  } else {
+    if (
+      shell.exec(`git checkout -b ${DEPLOYMENT_BRANCH}`).code +
+        shell.exec(`git branch --set-upstream-to=origin/${DEPLOYMENT_BRANCH}`)
+          .code !==
+      0
+    ) {
+      shell.echo(`Error: Git checkout ${DEPLOYMENT_BRANCH} failed`);
+      shell.exit(1);
+    }
   }
 }
 

--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -66,9 +66,15 @@ if (IS_PULL_REQUEST) {
   shell.exit(0);
 }
 
+// When we want to do a cross repo publish (#717), we can allow publishing to the same branch.
+const currentRepoUrl = shell.exec('git remote get-url origin').stdout.trim();
+const crossRepoPublish = !currentRepoUrl.endsWith(
+  `${ORGANIZATION_NAME}/${PROJECT_NAME}.git`
+);
+
 // build static html files, then push to DEPLOYMENT_BRANCH branch of specified repo
 
-if (CURRENT_BRANCH === DEPLOYMENT_BRANCH) {
+if (CURRENT_BRANCH === DEPLOYMENT_BRANCH && !crossRepoPublish) {
   shell.echo(`Cannot deploy from a ${DEPLOYMENT_BRANCH} branch. Only to it`);
   shell.exit(1);
 }


### PR DESCRIPTION
## Motivation

I'm maintaining the [express-validator org](https://github.com/express-validator), and I like keeping docs close to the source, so that external contributors and I can submit PRs that contain the complete change.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

👍 

## Test Plan for Cross Repo publishing
1. Have your source docs in one repo (say `foo/foo`), and point `siteConfig.js` to another (e.g. set `projectName` to `foo.github.io`);
2. Make sure you're on the `master` branch;
3. Run the `publish-gh-pages` script;
4. Note how the script doesn't complain about publishing from `master` and to `master`. `foo.github.io` should now have been updated with the latest version of your awesome docs written with Docusaurus;
5. Make a change, repeat, profit!

![kapture 2018-06-13 at 1 27 29](https://user-images.githubusercontent.com/826553/41300421-0b1cec80-6ea9-11e8-8987-c605d9a56e14.gif)

## Test Plan for same repo publishing
1. Point `siteConfig.js` to the repo the docs are going to be hosted on -- e.g. set `organizationName` to `foo` and `projectName` to `bar`, while your git remote is `foo/bar`);
2. Make sure you're on the `master` branch;
3. Run the `publish-gh-pages` script;
4. Note your `gh-pages` getting updated with your changes. Watch how `foo.github.io/bar` gets updated with the latest version of your awesome docs written with Docusaurus.

![kapture 2018-06-15 at 1 22 16](https://user-images.githubusercontent.com/826553/41421968-4518ddfc-703b-11e8-8fc6-7fab9e35f365.gif)

## Test Plan for same repo publishing from wrong branch
1. Point `siteConfig.js` to the repo the docs are going to be hosted on -- e.g. set `organizationName` to `foo` and `projectName` to `foo.github.io`, while your git remote is `foo/foo.github.io`;
2. Make sure you're on the `master` branch;
3. Run the `publish-gh-pages` script;
4. Watch the script deny publishing from `master` to `master`.

![kapture 2018-06-15 at 1 31 43](https://user-images.githubusercontent.com/826553/41422655-b3c27154-703c-11e8-8aba-ec8481f67b86.gif)

## Related PRs
I have a related issue actually: #717