### PR TITLE
Configure sitemap depending on whether clean URLs enabled

### DIFF
--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -59,7 +59,9 @@ module.exports = function(callback) {
   // create a url mapping to all the enabled languages files
   files.map(file => {
     let url = file.split('/pages/en')[1];
-    url = siteConfig.cleanUrl ? url.replace(/\.js$/, '') : url.replace(/\.js$/, '.html');
+    url = siteConfig.cleanUrl
+      ? url.replace(/\.js$/, '')
+      : url.replace(/\.js$/, '.html');
     let links = enabledLanguages.map(lang => {
       let langUrl = lang.tag + url;
       return {lang: lang.tag, url: langUrl};
@@ -69,7 +71,10 @@ module.exports = function(callback) {
 
   MetadataBlog.map(blog => {
     urls.push({
-      url: '/blog/' + siteConfig.cleanUrl ? blog.path.replace(/\.html$/, '') : blog.path,
+      url:
+        '/blog/' + siteConfig.cleanUrl
+          ? blog.path.replace(/\.html$/, '')
+          : blog.path,
       changefreq: 'weekly',
       priority: 0.3,
     });
@@ -84,7 +89,9 @@ module.exports = function(callback) {
         return {lang: lang.tag, url: langUrl};
       });
       urls.push({
-        url: siteConfig.cleanUrl ? doc.permalink.replace(/\.html$/, '') : doc.permalink,
+        url: siteConfig.cleanUrl
+          ? doc.permalink.replace(/\.html$/, '')
+          : doc.permalink,
         changefreq: 'hourly',
         priority: 1.0,
         links,

--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -59,7 +59,7 @@ module.exports = function(callback) {
   // create a url mapping to all the enabled languages files
   files.map(file => {
     let url = file.split('/pages/en')[1];
-    url = url.replace(/\.js$/, '.html');
+    url = siteConfig.cleanUrl ? url.replace(/\.js$/, '') : url.replace(/\.js$/, '.html');
     let links = enabledLanguages.map(lang => {
       let langUrl = lang.tag + url;
       return {lang: lang.tag, url: langUrl};
@@ -67,11 +67,9 @@ module.exports = function(callback) {
     urls.push({url, changefreq: 'weekly', priority: 0.5, links});
   });
 
-  let htmlFiles = glob.sync(CWD + '/pages/**/*.html');
-
   MetadataBlog.map(blog => {
     urls.push({
-      url: '/blog/' + blog.path,
+      url: '/blog/' + siteConfig.cleanUrl ? blog.path.replace(/\.html$/, '') : blog.path,
       changefreq: 'weekly',
       priority: 0.3,
     });
@@ -86,7 +84,7 @@ module.exports = function(callback) {
         return {lang: lang.tag, url: langUrl};
       });
       urls.push({
-        url: doc.permalink,
+        url: siteConfig.cleanUrl ? doc.permalink.replace(/\.html$/, '') : doc.permalink,
         changefreq: 'hourly',
         priority: 1.0,
         links,


### PR DESCRIPTION
## Motivation

If you have `cleanUrl` enabled, make the sitemap have no `.html` extension at the end too. Otherwise keep the `.html` extension.

Ref: https://github.com/facebook/Docusaurus/pull/744#issuecomment-396492849

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

<img width="1678" alt="screenshot 2018-06-12 11 02 14" src="https://user-images.githubusercontent.com/3757713/41308286-58b87ea6-6e30-11e8-9a44-e6c3e5e2bbcb.png">


## Related PRs

https://github.com/facebook/Docusaurus/pull/744
