### PR TITLE
Add option to disable live reload server during development

### DIFF
--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -145,6 +145,7 @@ This script will build the static website, apply translations if necessary, and 
 | Options           | Default | Description                                                                                                                          |
 | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `--port <number>` | `3000`  | The website will be served from port 3000 by default, but if the port is taken up, Docusaurus will attempt to find an available one. |
+| `--live <boolean>` | `true`  | Allows you to turn off the on-by-default live reload server. |
 
 ---
 

--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -145,7 +145,7 @@ This script will build the static website, apply translations if necessary, and 
 | Options           | Default | Description                                                                                                                          |
 | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `--port <number>` | `3000`  | The website will be served from port 3000 by default, but if the port is taken up, Docusaurus will attempt to find an available one. |
-| `--live <boolean>` | `true`  | Allows you to turn off the on-by-default live reload server. |
+| `--watch <boolean>` | `true`  | Allows you to turn off the on-by-default file watching live reload server. |
 
 ---
 

--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -145,7 +145,7 @@ This script will build the static website, apply translations if necessary, and 
 | Options           | Default | Description                                                                                                                          |
 | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `--port <number>` | `3000`  | The website will be served from port 3000 by default, but if the port is taken up, Docusaurus will attempt to find an available one. |
-| `--watch <boolean>` | `true`  | Allows you to turn off the on-by-default file watching live reload server. |
+| `--watch` | -  | Whether to watch the files and live reload the page when files are changed. Defaults to true. Disable this by using `--no-watch`. |
 
 ---
 

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -568,7 +568,7 @@ function execute(port, options) {
     });
   });
 
-  if (options.live) startLiveReload();
+  if (options.watch) startLiveReload();
   app.listen(port);
 
   function startLiveReload() {

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-function execute(port) {
+function execute(port, options) {
   const extractTranslations = require('../write-translations');
 
   const metadataUtils = require('./metadataUtils');
@@ -568,35 +568,38 @@ function execute(port) {
     });
   });
 
-  // Start LiveReload server.
-  process.env.NODE_ENV = 'development';
-  const server = tinylr();
-  server.listen(constants.LIVE_RELOAD_PORT, function() {
-    console.log(
-      'LiveReload server started on port %d',
-      constants.LIVE_RELOAD_PORT
-    );
-  });
-
-  // gaze watches some specified dirs and triggers a callback when they change.
-  gaze(
-    [
-      '../' + readMetadata.getDocsPath() + '/**/*', // docs
-      '**/*', // website
-      '!node_modules/**/*', // node_modules
-    ],
-    function() {
-      // Listen for all kinds of file changes - modified/added/deleted.
-      this.on('all', function() {
-        // Notify LiveReload clients that there's a change.
-        // Typically, LiveReload will only refresh the changed paths,
-        // so we use / here to force a full-page reload.
-        server.notifyClients(['/']);
-      });
-    }
-  );
-
+  if (options.live) startLiveReload();
   app.listen(port);
+
+  function startLiveReload() {
+    // Start LiveReload server.
+    process.env.NODE_ENV = 'development';
+    const server = tinylr();
+    server.listen(constants.LIVE_RELOAD_PORT, function() {
+      console.log(
+        'LiveReload server started on port %d',
+        constants.LIVE_RELOAD_PORT
+      );
+    });
+
+    // gaze watches some specified dirs and triggers a callback when they change.
+    gaze(
+      [
+        '../' + readMetadata.getDocsPath() + '/**/*', // docs
+        '**/*', // website
+        '!node_modules/**/*', // node_modules
+      ],
+      function() {
+        // Listen for all kinds of file changes - modified/added/deleted.
+        this.on('all', function() {
+          // Notify LiveReload clients that there's a change.
+          // Typically, LiveReload will only refresh the changed paths,
+          // so we use / here to force a full-page reload.
+          server.notifyClients(['/']);
+        });
+      }
+    );
+  }
 }
 
 module.exports = execute;

--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -44,7 +44,7 @@ const program = require('commander');
 
 program
   .option('--port <number>', 'Specify port number')
-  .option('--live', 'Toggle live reload', {isDefault: true})
+  .option('--no-watch', 'Toggle live reload file watching')
   .parse(process.argv);
 
 let port = parseInt(program.port, 10) || process.env.PORT || 3000;
@@ -71,7 +71,7 @@ function checkPort() {
       } else {
         // start local server on specified port
         const server = require('./server/server.js');
-        server(port, program);
+        server(port, program.opts());
         const host = `http://localhost:${port}`;
         console.log('Docusaurus server started on port %d', port);
         openBrowser(host);

--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -42,7 +42,10 @@ if (env.versioning.enabled && env.versioning.missingVersionsPage) {
 
 const program = require('commander');
 
-program.option('--port <number>', 'Specify port number').parse(process.argv);
+program
+  .option('--port <number>', 'Specify port number')
+  .option('--live', 'Toggle live reload', {isDefault: true})
+  .parse(process.argv);
 
 let port = parseInt(program.port, 10) || process.env.PORT || 3000;
 let numAttempts = 0;
@@ -68,7 +71,7 @@ function checkPort() {
       } else {
         // start local server on specified port
         const server = require('./server/server.js');
-        server(port);
+        server(port, program);
         const host = `http://localhost:${port}`;
         console.log('Docusaurus server started on port %d', port);
         openBrowser(host);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I ran into an issue where the live reload (specifically file watching) was causing CPU pegging when used with Docker on Mac (https://github.com/docker/for-mac/issues/1759). Disabling live reload fixes the issue and doesn't make the laptop fan go at full blast.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I could not think of a graceful way to test this in the automated test suite.

## Description

This pr adds a `--live` option to `docusaurus-start` that defaults to true, so does not change the default behavior. If you do `--no-live` it won't run the live reload server.