### PR TITLE
Hide TOC menu when onPageNav is not separate

### DIFF
--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -28,10 +28,11 @@ class SideNav extends React.Component {
                   {this.getLocalizedCategoryString(this.props.current.category)}
                 </span>
               </h2>
-              {siteConfig.onPageNav === 'separate' &&
+              {siteConfig.onPageNav === 'separate' && (
                 <div className="tocToggler" id="tocToggler">
                   <i className="icon-toc" />
-                </div>}
+                </div>
+              )}
             </div>
             <div className="navGroups">
               {this.props.contents.map(this.renderCategory, this)}

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -28,13 +28,10 @@ class SideNav extends React.Component {
                   {this.getLocalizedCategoryString(this.props.current.category)}
                 </span>
               </h2>
-              {
-                siteConfig.onPageNav === 'separate'
-                &&
+              {siteConfig.onPageNav === 'separate' &&
                 <div className="tocToggler" id="tocToggler">
                   <i className="icon-toc" />
-                </div>
-              }
+                </div>}
             </div>
             <div className="navGroups">
               {this.props.contents.map(this.renderCategory, this)}

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -30,6 +30,7 @@ class SideNav extends React.Component {
               </h2>
               {
                 siteConfig.onPageNav === 'separate'
+                &&
                 <div className="tocToggler" id="tocToggler">
                   <i className="icon-toc" />
                 </div>

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -28,9 +28,12 @@ class SideNav extends React.Component {
                   {this.getLocalizedCategoryString(this.props.current.category)}
                 </span>
               </h2>
-              <div className="tocToggler" id="tocToggler">
-                <i className="icon-toc" />
-              </div>
+              {
+                siteConfig.onPageNav === 'separate'
+                <div className="tocToggler" id="tocToggler">
+                  <i className="icon-toc" />
+                </div>
+              }
             </div>
             <div className="navGroups">
               {this.props.contents.map(this.renderCategory, this)}

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -28,13 +28,11 @@ class SideNav extends React.Component {
                   {this.getLocalizedCategoryString(this.props.current.category)}
                 </span>
               </h2>
-              {
-                siteConfig.onPageNav === 'separate'
-                &&
+              {siteConfig.onPageNav === 'separate' && (
                 <div className="tocToggler" id="tocToggler">
                   <i className="icon-toc" />
                 </div>
-              }
+              )}
             </div>
             <div className="navGroups">
               {this.props.contents.map(this.renderCategory, this)}

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -12,16 +12,7 @@ const siteConfig = require(process.cwd() + '/siteConfig.js');
 const translation = require('../../server/translation.js');
 const utils = require('../utils.js');
 
-const mobileMenu = (
-  <div className="tocToggler" id="tocToggler">
-    <i className="icon-toc" />
-  </div>
-);
-
 class SideNav extends React.Component {
-  showMobileMenu = () => {
-    return siteConfig.onPageNav === 'separate' ? mobileMenu : null;
-  };
   render() {
     return (
       <nav className="toc">
@@ -37,7 +28,13 @@ class SideNav extends React.Component {
                   {this.getLocalizedCategoryString(this.props.current.category)}
                 </span>
               </h2>
-              {this.showMobileMenu()}
+              {
+                siteConfig.onPageNav === 'separate'
+                &&
+                <div className="tocToggler" id="tocToggler">
+                  <i className="icon-toc" />
+                </div>
+              }
             </div>
             <div className="navGroups">
               {this.props.contents.map(this.renderCategory, this)}

--- a/lib/core/nav/SideNav.js
+++ b/lib/core/nav/SideNav.js
@@ -12,7 +12,16 @@ const siteConfig = require(process.cwd() + '/siteConfig.js');
 const translation = require('../../server/translation.js');
 const utils = require('../utils.js');
 
+const mobileMenu = (
+  <div className="tocToggler" id="tocToggler">
+    <i className="icon-toc" />
+  </div>
+);
+
 class SideNav extends React.Component {
+  showMobileMenu = () => {
+    return siteConfig.onPageNav === 'separate' ? mobileMenu : null;
+  };
   render() {
     return (
       <nav className="toc">
@@ -28,11 +37,7 @@ class SideNav extends React.Component {
                   {this.getLocalizedCategoryString(this.props.current.category)}
                 </span>
               </h2>
-              {siteConfig.onPageNav === 'separate' && (
-                <div className="tocToggler" id="tocToggler">
-                  <i className="icon-toc" />
-                </div>
-              )}
+              {this.showMobileMenu()}
             </div>
             <div className="navGroups">
               {this.props.contents.map(this.renderCategory, this)}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

1.) Go to website/siteConfig and set onPageNav to false or anything other than 'separate'.
2.) go to the web app and click on the docs page then shrink the screen down to mobile size.
 
RESULT: the three dot menu should not display.


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
