### PR TITLE
Fix anchors erroring when heading is empty

### DIFF
--- a/lib/core/__tests__/anchors.test.js
+++ b/lib/core/__tests__/anchors.test.js
@@ -6,10 +6,13 @@
  */
 
 const anchors = require('../anchors');
+const rules = require('remarkable/lib/rules');
 
 const md = {
   renderer: {
-    rules: {},
+    rules: {
+      heading_open: rules.heading_open,
+    },
   },
 };
 
@@ -108,4 +111,9 @@ test('Anchor index resets on each render', () => {
   expect(render(tokens, 2, options, env2)).toContain(
     'id="almost-unique-heading-1"'
   );
+});
+
+test('Anchor uses default renderer when empty', () => {
+  expect(render([{hLevel: 1}, {content: null}], 0, {}, {})).toEqual('<h1>');
+  expect(render([{hLevel: 2}, {content: ''}], 0, {}, {})).toEqual('<h2>');
 });

--- a/lib/core/anchors.js
+++ b/lib/core/anchors.js
@@ -11,19 +11,26 @@ const toSlug = require('./toSlug.js');
  * The anchors plugin adds GFM-style anchors to headings.
  */
 function anchors(md) {
+  const originalRender = md.renderer.rules.heading_open;
+
   md.renderer.rules.heading_open = function(tokens, idx, options, env) {
     const textToken = tokens[idx + 1];
-    const anchor = toSlug(textToken.content, env);
 
-    return (
-      '<h' +
-      tokens[idx].hLevel +
-      '><a class="anchor" aria-hidden="true" id="' +
-      anchor +
-      '"></a><a href="#' +
-      anchor +
-      '" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>'
-    );
+    if (textToken.content) {
+      const anchor = toSlug(textToken.content, env);
+
+      return (
+        '<h' +
+        tokens[idx].hLevel +
+        '><a class="anchor" aria-hidden="true" id="' +
+        anchor +
+        '"></a><a href="#' +
+        anchor +
+        '" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>'
+      );
+    }
+
+    return originalRender(tokens, idx, options, env);
   };
 }
 


### PR DESCRIPTION
## Motivation

Found a bug because one of our Markdown docs contained an empty heading

```md
# Heading 1
##

Notice the empty Heading 2, makes the anchors `toSlug()` crash because of the internal `toString()` usage
```

Here's part of the stacktrace:
```sh
TypeError: Cannot read property 'toString' of undefined
    at module.exports (/[...]/node_modules/docusaurus/lib/core/toSlug.js:41:6)
    at Object.md.renderer.rules.heading_open (/[...]/node_modules/docusaurus/lib/core/anchors.js:16:20)
    at Renderer.render (/[...]/node_modules/remarkable/lib/renderer.js:71:39)
    at Remarkable.render (/[...]/node_modules/remarkable/lib/index.js:152:24)
    [...]
```
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I added a test to specifically check for these cases.