### PR TITLE
[RFC] Move custom translation strings to its own file

### DIFF
--- a/lib/write-translations.js
+++ b/lib/write-translations.js
@@ -20,13 +20,13 @@ const babylon = require('babylon');
 const traverse = require('babel-traverse').default;
 const sidebars = require(CWD + '/sidebars.json');
 
-let currentTranslations = {
+let overrideTranslations = {
   'localized-strings': {},
   'pages-strings': {},
 };
-if (fs.existsSync(CWD + '/i18n/en.json')) {
-  currentTranslations = JSON.parse(
-    fs.readFileSync(CWD + '/i18n/en.json', 'utf8')
+if (fs.existsSync(CWD + '/data/custom-translation-strings.json')) {
+  overrideTranslations = JSON.parse(
+    fs.readFileSync(CWD + '/data/custom-translation-strings.json', 'utf8')
   );
 }
 
@@ -158,11 +158,11 @@ function execute() {
     'Translate';
   translations['pages-strings'] = Object.assign(
     translations['pages-strings'],
-    currentTranslations['pages-strings']
+    overrideTranslations['pages-strings']
   );
   translations['localized-strings'] = Object.assign(
     translations['localized-strings'],
-    currentTranslations['localized-strings']
+    overrideTranslations['localized-strings']
   );
   writeFileAndCreateFolder(
     CWD + '/i18n/en.json',

--- a/website/data/custom-translation-strings.json
+++ b/website/data/custom-translation-strings.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "This file is used to provide custom strings for translations, including overriding defaults",
+  "localized-strings": {
+    "translation": "Translations and Localization"
+  },
+  "pages-strings" : {
+        "Help Translate|recruit community translators for your project": "Help Us Translate"
+  }
+}


### PR DESCRIPTION
## Motivation

Allowing custom and overriding translation strings in `en.json` caused us to not delete `en.json` like we used to do and thus would not allow updates to header to be reflected any longer.

Fixes #713

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local testing

## Related PRs

https://github.com/facebook/Docusaurus/pull/158
https://github.com/facebook/Docusaurus/pull/710
