### PR TITLE
Use absoluteURL instead of relativeURL for next/prev links

### DIFF
--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -13,17 +13,18 @@ const OnPageNav = require('./nav/OnPageNav.js');
 const Site = require('./Site.js');
 const translation = require('../server/translation.js');
 const path = require('path');
+const url = require('url');
 
 // component used to generate whole webpage for docs, including sidebar/header/footer
 class DocsLayout extends React.Component {
   getRelativeURL = (from, to) => {
     const extension = this.props.config.cleanUrl ? '' : '.html';
-    return (
+    const relativeHref =
       path
         .relative(from, to)
         .replace('\\', '/')
-        .replace(/^\.\.\//, '') + extension
-    );
+        .replace(/^\.\.\//, '') + extension;
+    return url.resolve(`/${this.props.metadata.permalink}`, relativeHref);
   };
 
   render() {
@@ -47,8 +48,7 @@ class DocsLayout extends React.Component {
         description={content.trim().split('\n')[0]}
         language={metadata.language}
         version={metadata.version}
-        metadata={metadata}
-        removeTrailingSlash={true}>
+        metadata={metadata}>
         <div className="docMainWrapper wrapper">
           <DocsSidebar metadata={metadata} />
           <Container className="mainContainer">

--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -47,7 +47,8 @@ class DocsLayout extends React.Component {
         description={content.trim().split('\n')[0]}
         language={metadata.language}
         version={metadata.version}
-        metadata={metadata}>
+        metadata={metadata}
+        removeTrailingSlash={true}>
         <div className="docMainWrapper wrapper">
           <DocsSidebar metadata={metadata} />
           <Container className="mainContainer">

--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -24,7 +24,10 @@ class DocsLayout extends React.Component {
         .relative(from, to)
         .replace('\\', '/')
         .replace(/^\.\.\//, '') + extension;
-    return url.resolve(`/${this.props.metadata.permalink}`, relativeHref);
+    return url.resolve(
+      `${this.props.config.baseUrl}${this.props.metadata.permalink}`,
+      relativeHref
+    );
   };
 
   render() {

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -169,16 +169,6 @@ class Site extends React.Component {
               }/livereload.js`}
             />
           )}
-          {this.props.removeTrailingSlash && (
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `
-                if (window.location.pathname !== '/' && window.location.pathname.endsWith('/')) {
-                  window.location = window.location.pathname.replace(/\\/$/, '');
-                }`,
-              }}
-            />
-          )}
         </body>
       </html>
     );

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -169,6 +169,16 @@ class Site extends React.Component {
               }/livereload.js`}
             />
           )}
+          {this.props.removeTrailingSlash && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
+                if (window.location.pathname !== '/' && window.location.pathname.endsWith('/')) {
+                  window.location = window.location.pathname.replace(/\\/$/, '');
+                }`,
+              }}
+            />
+          )}
         </body>
       </html>
     );


### PR DESCRIPTION
## Motivation

- Fixes #780 & https://github.com/babel/website/issues/1693

Our docs prev/next button is build with relative path in mind. But relative path is really `relative`

If our current url is https://babeljs.io/docs/en/babel-plugin-transform-runtime
`<a href='babel-register'/>` will translate to https://babeljs.io/docs/en/babel-register

If our current url is https://babeljs.io/docs/en/babel-plugin-transform-runtime/
`<a href='babel-register'/>` will translate to https://babeljs.io/docs/en/babel-plugin-transform-runtime/babel-register which is wrong

The fix is to use absolute url 😄 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Before
Go to https://docusaurus.io/docs/en/installation/ (notice the ending slash `/`) and click `previous/next` button, 404 page
![before](https://user-images.githubusercontent.com/17883920/41498691-8404a46c-71a6-11e8-8439-79b7d51b180c.gif)


After
Go to http://localhost:3000/docs/en/installation/ (notice the ending slash `/`) and click `previous/next` button, no problem
![after](https://user-images.githubusercontent.com/17883920/41504363-fa50383e-721e-11e8-955a-a539dba0d1c5.gif)



