### PR TITLE
Add language & version meta for algolia docsearch

### DIFF
--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -42,6 +42,12 @@ class Head extends React.Component {
         <meta name="viewport" content="width=device-width" />
         <meta name="generator" content="Docusaurus" />
         <meta name="description" content={this.props.description} />
+        {this.props.version && (
+          <meta name="docsearch:version" content={this.props.version} />
+        )}
+        {this.props.language && (
+          <meta name="docsearch:language" content={this.props.language} />
+        )}
         <meta property="og:title" content={this.props.title} />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={this.props.url} />

--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -61,6 +61,8 @@ class Site extends React.Component {
           description={description}
           title={title}
           url={url}
+          language={this.props.language}
+          version={this.props.version}
         />
         <body
           className={classNames({


### PR DESCRIPTION
## Motivation

https://github.com/algolia/docsearch-configs/pull/454#issuecomment-396883396

In order to help algolia docsearch scrape our docs better, we will provide Docsearch metadata.
cc @s-pace

## Changes

Provide docsearch metadata on head. Example:
```
<meta name="docsearch:version" content='1.2.1'>
<meta name="docsearch:language" content='en'>
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before
<img width="960" alt="before" src="https://user-images.githubusercontent.com/17883920/41545190-3cdad3ec-734d-11e8-843e-8c6e75379bdf.PNG">

After
<img width="960" alt="after-next" src="https://user-images.githubusercontent.com/17883920/41545200-41acfbe8-734d-11e8-8976-4049a9637456.PNG">
