### PR TITLE
Fix bad routing regex for docs & blogs

### DIFF
--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -34,10 +34,14 @@ describe('Routing', () => {
   });
   test('docs not classified as blog', () => {
     expect(blogRegex.exec('/docs/en/blog.html')).toBeNull();
+    expect(blogRegex.exec('/docs/en/blog/blog.html')).toBeNull();
     expect(blogRegex2.exec('/test/docs/en/blog.html')).toBeNull();
+    expect(blogRegex2.exec('/test/docs/en/blog/blog.html')).toBeNull();
   });
   test('blog not classified as docs', () => {
     expect(docsRegex.exec('/blog/docs.html')).toBeNull();
+    expect(docsRegex.exec('/blog/docs/docs.html')).toBeNull();
     expect(docsRegex2.exec('/test/blog/docs.html')).toBeNull();
+    expect(docsRegex2.exec('/test/blog/docs/docs.html')).toBeNull();
   });
 });

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -32,13 +32,12 @@ describe('Blog routing', () => {
     expect('/react/docs/en/blog.html').not.toMatch(blogRegex2);
     expect('/react/docs/en/blog/blog.html').not.toMatch(blogRegex2);
   });
-
 });
 
 describe('Docs routing', () => {
   const docsRegex = docsRouting('/');
   const docsRegex2 = docsRouting('/reason/');
-  
+
   test('valid docs', () => {
     expect('/docs/en/test.html').toMatch(docsRegex);
     expect('/reason/docs/en/test.html').toMatch(docsRegex2);

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -7,41 +7,57 @@
 
 const {docsRouting, blogRouting} = require('../routing');
 
-describe('Routing', () => {
-  const docsRegex = docsRouting('/');
-  const docsRegex2 = docsRouting('/test/');
+describe('Blog routing', () => {
   const blogRegex = blogRouting('/');
-  const blogRegex2 = blogRouting('/test/');
-  test('valid docs', () => {
-    expect(docsRegex.exec('/docs/en/test.html')).not.toBeNull();
-    expect(docsRegex2.exec('/test/docs/en/test.html')).not.toBeNull();
-  });
-  test('invalid docs', () => {
-    expect(docsRegex.exec('/test/docs/en/test.html')).toBeNull();
-    expect(docsRegex2.exec('/docs/en/test.html')).toBeNull();
-  });
+  const blogRegex2 = blogRouting('/react/');
+
   test('valid blog', () => {
-    expect(blogRegex.exec('/blog/test.html')).not.toBeNull();
-    expect(blogRegex2.exec('/test/blog/test.html')).not.toBeNull();
+    expect('/blog/test.html').toMatch(blogRegex);
+    expect('/react/blog/test.html').toMatch(blogRegex2);
   });
+
   test('invalid blog', () => {
-    expect(blogRegex.exec('/test/blog/test.html')).toBeNull();
-    expect(blogRegex2.exec('/blog/test.html')).toBeNull();
+    expect('/react/blog/test.html').not.toMatch(blogRegex);
+    expect('/blog/test.html').not.toMatch(blogRegex2);
   });
-  test('png not classified as docs or blog', () => {
-    expect(docsRegex.exec('/docs/en/notvalid.png')).toBeNull();
-    expect(docsRegex2.exec('/test/docs/en/notvalid.png')).toBeNull();
+
+  test('assets not classified as blog', () => {
+    expect('/blog/assets/any.png').not.toMatch(blogRegex);
+    expect('/react/blog/assets/any.png').not.toMatch(blogRegex2);
   });
+
   test('docs not classified as blog', () => {
-    expect(blogRegex.exec('/docs/en/blog.html')).toBeNull();
-    expect(blogRegex.exec('/docs/en/blog/blog.html')).toBeNull();
-    expect(blogRegex2.exec('/test/docs/en/blog.html')).toBeNull();
-    expect(blogRegex2.exec('/test/docs/en/blog/blog.html')).toBeNull();
+    expect('/docs/en/blog.html').not.toMatch(blogRegex);
+    expect('/docs/en/blog/blog.html').not.toMatch(blogRegex);
+    expect('/react/docs/en/blog.html').not.toMatch(blogRegex2);
+    expect('/react/docs/en/blog/blog.html').not.toMatch(blogRegex2);
   });
+
+});
+
+describe('Docs routing', () => {
+  const docsRegex = docsRouting('/');
+  const docsRegex2 = docsRouting('/reason/');
+  
+  test('valid docs', () => {
+    expect('/docs/en/test.html').toMatch(docsRegex);
+    expect('/reason/docs/en/test.html').toMatch(docsRegex2);
+  });
+
+  test('invalid docs', () => {
+    expect('/reason/docs/en/test.html').not.toMatch(docsRegex);
+    expect('/docs/en/test.html').not.toMatch(docsRegex2);
+  });
+
+  test('assets not classified as docs', () => {
+    expect('/docs/en/notvalid.png').not.toMatch(docsRegex);
+    expect('/reason/docs/en/notvalid.png').not.toMatch(docsRegex2);
+  });
+
   test('blog not classified as docs', () => {
-    expect(docsRegex.exec('/blog/docs.html')).toBeNull();
-    expect(docsRegex.exec('/blog/docs/docs.html')).toBeNull();
-    expect(docsRegex2.exec('/test/blog/docs.html')).toBeNull();
-    expect(docsRegex2.exec('/test/blog/docs/docs.html')).toBeNull();
+    expect('/blog/docs.html').not.toMatch(docsRegex);
+    expect('/blog/docs/docs.html').not.toMatch(docsRegex);
+    expect('/reason/blog/docs.html').not.toMatch(docsRegex2);
+    expect('/reason/blog/docs/docs.html').not.toMatch(docsRegex2);
   });
 });

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {docsRouting, blogRouting} = require('../routing');
+
+describe('Routing', () => {
+  const docsRegex = docsRouting('/');
+  const docsRegex2 = docsRouting('/test/');
+  const blogRegex = blogRouting('/');
+  const blogRegex2 = blogRouting('/test/');
+  test('valid docs', () => {
+    expect(docsRegex.exec('/docs/en/test.html')).not.toBeNull();
+    expect(docsRegex2.exec('/test/docs/en/test.html')).not.toBeNull();
+  });
+  test('invalid docs', () => {
+    expect(docsRegex.exec('/test/docs/en/test.html')).toBeNull();
+    expect(docsRegex2.exec('/docs/en/test.html')).toBeNull();
+  });
+  test('valid blog', () => {
+    expect(blogRegex.exec('/blog/test.html')).not.toBeNull();
+    expect(blogRegex2.exec('/test/blog/test.html')).not.toBeNull();
+  });
+  test('invalid blog', () => {
+    expect(blogRegex.exec('/test/blog/test.html')).toBeNull();
+    expect(blogRegex2.exec('/blog/test.html')).toBeNull();
+  });
+  test('png not classified as docs or blog', () => {
+    expect(docsRegex.exec('/docs/en/notvalid.png')).toBeNull();
+    expect(docsRegex2.exec('/test/docs/en/notvalid.png')).toBeNull();
+  });
+  test('docs not classified as blog', () => {
+    expect(blogRegex.exec('/docs/en/blog.html')).toBeNull();
+    expect(blogRegex2.exec('/test/docs/en/blog.html')).toBeNull();
+  });
+  test('blog not classified as docs', () => {
+    expect(docsRegex.exec('/blog/docs.html')).toBeNull();
+    expect(docsRegex2.exec('/test/blog/docs.html')).toBeNull();
+  });
+});

--- a/lib/core/routing.js
+++ b/lib/core/routing.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const escapeStringRegexp = require('escape-string-regexp');
+
+function docsRouting(baseUrl) {
+  return new RegExp(`^${escapeStringRegexp(baseUrl)}docs\/.*html$`);
+}
+
+function blogRouting(baseUrl) {
+  return new RegExp(`^${escapeStringRegexp(baseUrl)}blog\/.*html$`);
+}
+
+module.exports = {
+  docsRouting,
+  blogRouting,
+};

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -20,12 +20,12 @@ function execute(port, options) {
   const path = require('path');
   const color = require('color');
   const getTOC = require('../core/getTOC');
+  const {docsRouting, blogRouting} = require('../core/routing');
   const mkdirp = require('mkdirp');
   const glob = require('glob');
   const chalk = require('chalk');
   const gaze = require('gaze');
   const tinylr = require('tiny-lr');
-  const escapeStringRegexp = require('escape-string-regexp');
 
   const constants = require('../core/constants');
   const translate = require('./translate');
@@ -133,10 +133,7 @@ function execute(port, options) {
   const app = express();
 
   // handle all requests for document pages
-  const docRegex = new RegExp(
-    `^${escapeStringRegexp(siteConfig.baseUrl)}docs\/.*html$`
-  );
-  app.get(docRegex, (req, res, next) => {
+  app.get(docsRouting(siteConfig.baseUrl), (req, res, next) => {
     let url = req.path.toString().replace(siteConfig.baseUrl, '');
 
     // links is a map from a permalink to an id for each document
@@ -279,10 +276,7 @@ function execute(port, options) {
   });
 
   // Handle all requests for blog pages and posts.
-  const blogRegex = new RegExp(
-    `^${escapeStringRegexp(siteConfig.baseUrl)}blog\/.*html$`
-  );
-  app.get(blogRegex, (req, res) => {
+  app.get(blogRouting(siteConfig.baseUrl), (req, res) => {
     // Regenerate the blog metadata in case it has changed. Consider improving
     // this to regenerate on file save rather than on page request.
     reloadMetadataBlog();

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -25,6 +25,7 @@ function execute(port, options) {
   const chalk = require('chalk');
   const gaze = require('gaze');
   const tinylr = require('tiny-lr');
+  const escapeStringRegexp = require('escape-string-regexp');
 
   const constants = require('../core/constants');
   const translate = require('./translate');
@@ -129,10 +130,13 @@ function execute(port, options) {
   extractTranslations();
   reloadSiteConfig();
 
-  // handle all requests for document pages
   const app = express();
 
-  app.get(/\/docs\/.*html$/, (req, res, next) => {
+  // handle all requests for document pages
+  const docRegex = new RegExp(
+    `^${escapeStringRegexp(siteConfig.baseUrl)}docs\/.*html$`
+  );
+  app.get(docRegex, (req, res, next) => {
     let url = req.path.toString().replace(siteConfig.baseUrl, '');
 
     // links is a map from a permalink to an id for each document
@@ -275,7 +279,10 @@ function execute(port, options) {
   });
 
   // Handle all requests for blog pages and posts.
-  app.get(/\/blog\/.*html$/, (req, res) => {
+  const blogRegex = new RegExp(
+    `^${escapeStringRegexp(siteConfig.baseUrl)}blog\/.*html$`
+  );
+  app.get(blogRegex, (req, res) => {
     // Regenerate the blog metadata in case it has changed. Consider improving
     // this to regenerate on file save rather than on page request.
     reloadMetadataBlog();


### PR DESCRIPTION
## Motivation

This fix a bug on our express.js routing classifying `blog` docs as blog pages. 
Consider this scenario, user create a `blog.md` in docs folder

```
---
id: blog
title: blog
---

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupi
```

What happen when we access `/docs/en/next/blog` ?
<img width="946" alt="before" src="https://user-images.githubusercontent.com/17883920/41811275-0b92db72-773f-11e8-83fd-cb6c6657641c.PNG">

It is misclassified as blog pages due to express.js routing defined at
https://github.com/facebook/Docusaurus/blob/c5661b0e1e131803709852adc2283fb4894aabcc/lib/server/server.js#L278

This PR ensure more strict regex routing for docs & blog

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

access `/docs/en/next/blog` in development
<img width="802" alt="after" src="https://user-images.githubusercontent.com/17883920/41811291-43b4b5e8-773f-11e8-91d6-7c1127137235.PNG">