### PR TITLE
Fix bug unable to search docs according to its version

### DIFF
--- a/lib/core/Site.js
+++ b/lib/core/Site.js
@@ -33,13 +33,11 @@ class Site extends React.Component {
       this.props.config.url +
       this.props.config.baseUrl +
       (this.props.url || 'index.html');
-    let docsVersion = this.props.version || 'current';
+    let docsVersion = this.props.version;
 
-    if (fs.existsSync(CWD + '/versions.json')) {
+    if (!docsVersion && fs.existsSync(CWD + '/versions.json')) {
       const latestVersion = require(CWD + '/versions.json')[0];
-      if (docsVersion === latestVersion) {
-        docsVersion = 'current';
-      }
+      docsVersion = latestVersion;
     }
 
     // We do not want a lang attribute for the html tag if we don't have a language set


### PR DESCRIPTION
## Motivation

As per https://docusaurus.io/docs/en/search#extra-search-options
> Any occurrences of "VERSION" or "LANGUAGE" will be replaced by the version or language of the current page, respectively. 

However, the current implementation is currently broken, while algolia docsearch expect something like '1.3.0', we provide 'current' as the version if we are currently in the latest stable version. 

https://github.com/facebook/Docusaurus/blob/c5661b0e1e131803709852adc2283fb4894aabcc/lib/core/Site.js#L36-L43

https://github.com/facebook/Docusaurus/blob/c5661b0e1e131803709852adc2283fb4894aabcc/lib/core/Site.js#L130-L134

Docusaurus.io docsearch is working fine because we don't search according to current version.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Use this algolia index for testing and use version facetfilters
```
algolia: {
    apiKey: 'c53337307f1787a9199348cd8263f666',
    indexName: 'docusaurus_meta',
    algoliaOptions: {
      facetFilters: [ "language:LANGUAGE", "version:VERSION" ] 
    }
  },
````

Before (search is broken)
<img width="939" alt="before" src="https://user-images.githubusercontent.com/17883920/41812562-029e32a0-7758-11e8-802b-1da35175f988.PNG">

After this PR (search according to current version)
<img width="960" alt="after" src="https://user-images.githubusercontent.com/17883920/41812578-32e4c708-7758-11e8-9935-672009a9c708.PNG">
