### PR TITLE
Fix & refactor server routing + add tests

### DIFF
--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -8,6 +8,7 @@
 const {
   blogRouting,
   docsRouting,
+  dotRouting,
   feedRouting,
   noExtRouting,
   pageRouting,
@@ -68,6 +69,32 @@ describe('Docs routing', () => {
   });
 });
 
+describe('Dot routing', () => {
+  const dotRegex = dotRouting();
+
+  test('valid url with dot after last slash', () => {
+    expect('/docs/en/test.23').toMatch(dotRegex);
+    expect('/robots.hai.2').toMatch(dotRegex);
+    expect('/blog/1.2.3').toMatch(dotRegex);
+    expect('/this.is.my').toMatch(dotRegex);
+  });
+
+  test('html file is invalid', () => {
+    expect('/docs/en.html').not.toMatch(dotRegex);
+    expect('/users.html').not.toMatch(dotRegex);
+    expect('/blog/asdf.html').not.toMatch(dotRegex);
+    expect('/end/1234/asdf.html').not.toMatch(dotRegex);
+    expect('/test/lol.huam.html').not.toMatch(dotRegex);
+  });
+
+  test('extension-less url is not valid', () => {
+    expect('/reason/test').not.toMatch(dotRegex);
+    expect('/asdff').not.toMatch(dotRegex);
+    expect('/blog/asdf.ghg/').not.toMatch(dotRegex);
+    expect('/end/1234.23.55/').not.toMatch(dotRegex);
+  });
+});
+
 describe('Feed routing', () => {
   const feedRegex = feedRouting('/');
   const feedRegex2 = feedRouting('/reason/');
@@ -84,6 +111,7 @@ describe('Feed routing', () => {
     expect('/blog/test.xml').not.toMatch(feedRegex);
     expect('/reason/blog/atom.xml').not.toMatch(feedRegex);
     expect('/reason/blog/feed.xml').not.toMatch(feedRegex);
+    expect('/blog/feed.xml/test.html').not.toMatch(feedRegex);
     expect('/blog/atom.xml').not.toMatch(feedRegex2);
     expect('/blog/feed.xml').not.toMatch(feedRegex2);
     expect('/reason/blog/test.xml').not.toMatch(feedRegex2);

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -183,6 +183,7 @@ describe('Sitemap routing', () => {
 
   test('invalid sitemap url', () => {
     expect('/reason/sitemap.xml').not.toMatch(sitemapRegex);
+    expect('/reason/sitemap.xml.html').not.toMatch(sitemapRegex);
     expect('/sitemap/sitemap.xml').not.toMatch(sitemapRegex);
     expect('/reason/sitemap/sitemap.xml').not.toMatch(sitemapRegex);
     expect('/sitemap.xml').not.toMatch(sitemapRegex2);

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -9,6 +9,7 @@ const {
   blogRouting,
   docsRouting,
   feedRouting,
+  noExtRouting,
   pageRouting,
   sitemapRouting,
 } = require('../routing');
@@ -93,6 +94,26 @@ describe('Feed routing', () => {
   test('not a feed', () => {
     expect('/blog/atom').not.toMatch(feedRegex);
     expect('/reason/blog/feed').not.toMatch(feedRegex2);
+  });
+});
+
+describe('Extension-less url routing', () => {
+  const noExtRegex = noExtRouting();
+
+  test('valid no extension url', () => {
+    expect('/test').toMatch(noExtRegex);
+    expect('/reason/test').toMatch(noExtRegex);
+  });
+
+  test('url with file extension', () => {
+    expect('/robots.txt').not.toMatch(noExtRegex);
+    expect('/reason/robots.txt').not.toMatch(noExtRegex);
+    expect('/docs/en/docu.html').not.toMatch(noExtRegex);
+    expect('/reason/robots.html').not.toMatch(noExtRegex);
+    expect('/blog/atom.xml').not.toMatch(noExtRegex);
+    expect('/reason/sitemap.xml').not.toMatch(noExtRegex);
+    expect('/main.css').not.toMatch(noExtRegex);
+    expect('/reason/custom.css').not.toMatch(noExtRegex);
   });
 });
 

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {docsRouting, blogRouting} = require('../routing');
+const {
+  blogRouting,
+  docsRouting,
+  feedRouting,
+  sitemapRouting,
+} = require('../routing');
 
 describe('Blog routing', () => {
   const blogRegex = blogRouting('/');
@@ -60,3 +65,55 @@ describe('Docs routing', () => {
     expect('/reason/blog/docs/docs.html').not.toMatch(docsRegex2);
   });
 });
+
+describe('Feed routing', () => {
+  const feedRegex = feedRouting('/');
+  const feedRegex2 = feedRouting('/reason/');
+
+  test('valid feed url', () => {
+    expect('/blog/atom.xml').toMatch(feedRegex);
+    expect('/blog/feed.xml').toMatch(feedRegex);
+    expect('/reason/blog/atom.xml').toMatch(feedRegex2);
+    expect('/reason/blog/feed.xml').toMatch(feedRegex2);
+  });
+
+  test('invalid feed url', () => {
+    expect('/blog/blog/feed.xml').not.toMatch(feedRegex);
+    expect('/blog/test.xml').not.toMatch(feedRegex);
+    expect('/reason/blog/atom.xml').not.toMatch(feedRegex);
+    expect('/reason/blog/feed.xml').not.toMatch(feedRegex);
+    expect('/blog/atom.xml').not.toMatch(feedRegex2);
+    expect('/blog/feed.xml').not.toMatch(feedRegex2);
+    expect('/reason/blog/test.xml').not.toMatch(feedRegex2);
+    expect('/reason/blog/blog/feed.xml').not.toMatch(feedRegex2);
+    expect('/reason/blog/blog/atom.xml').not.toMatch(feedRegex2);
+  });
+
+  test('not a feed', () => {
+    expect('/blog/atom').not.toMatch(feedRegex);
+    expect('/reason/blog/feed').not.toMatch(feedRegex2);
+  });
+});
+
+describe('Sitemap routing', () => {
+  const sitemapRegex = sitemapRouting('/');
+  const sitemapRegex2 = sitemapRouting('/reason/');
+
+  test('valid sitemap url', () => {
+    expect('/sitemap.xml').toMatch(sitemapRegex);
+    expect('/reason/sitemap.xml').toMatch(sitemapRegex2);
+  });
+
+  test('invalid sitemap url', () => {
+    expect('/reason/sitemap.xml').not.toMatch(sitemapRegex);
+    expect('/sitemap/sitemap.xml').not.toMatch(sitemapRegex);
+    expect('/reason/sitemap/sitemap.xml').not.toMatch(sitemapRegex);
+    expect('/sitemap.xml').not.toMatch(sitemapRegex2);
+  });
+
+  test('not a sitemap', () => {
+    expect('/sitemap').not.toMatch(sitemapRegex);
+    expect('/reason/sitemap').not.toMatch(sitemapRegex2);
+  });
+});
+

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -9,6 +9,7 @@ const {
   blogRouting,
   docsRouting,
   feedRouting,
+  pageRouting,
   sitemapRouting,
 } = require('../routing');
 
@@ -95,6 +96,33 @@ describe('Feed routing', () => {
   });
 });
 
+describe('Page routing', () => {
+  const pageRegex = pageRouting('/');
+  const pageRegex2 = pageRouting('/reason/');
+
+  test('valid page url', () => {
+    expect('/index.html').toMatch(pageRegex);
+    expect('/reason/index.html').toMatch(pageRegex2);
+  });
+
+  test('docs not considered as page', () => {
+    expect('/docs/en/test.html').not.toMatch(pageRegex);
+    expect('/reason/docs/en/test.html').not.toMatch(pageRegex2);
+  });
+
+  test('blog not considered as page', () => {
+    expect('/blog/index.html').not.toMatch(pageRegex);
+    expect('/reason/blog/index.html').not.toMatch(pageRegex2);
+  });
+
+  test('not a page', () => {
+    expect('/yangshun.jpg').not.toMatch(pageRegex);
+    expect('/reason/endilie.png').not.toMatch(pageRegex2);
+  });
+
+
+});
+
 describe('Sitemap routing', () => {
   const sitemapRegex = sitemapRouting('/');
   const sitemapRegex2 = sitemapRouting('/reason/');
@@ -116,4 +144,3 @@ describe('Sitemap routing', () => {
     expect('/reason/sitemap').not.toMatch(sitemapRegex2);
   });
 });
-

--- a/lib/core/__tests__/routing.test.js
+++ b/lib/core/__tests__/routing.test.js
@@ -102,7 +102,9 @@ describe('Page routing', () => {
 
   test('valid page url', () => {
     expect('/index.html').toMatch(pageRegex);
+    expect('/en/help.html').toMatch(pageRegex);
     expect('/reason/index.html').toMatch(pageRegex2);
+    expect('/reason/ro/users.html').toMatch(pageRegex2);
   });
 
   test('docs not considered as page', () => {
@@ -119,8 +121,6 @@ describe('Page routing', () => {
     expect('/yangshun.jpg').not.toMatch(pageRegex);
     expect('/reason/endilie.png').not.toMatch(pageRegex2);
   });
-
-
 });
 
 describe('Sitemap routing', () => {

--- a/lib/core/routing.js
+++ b/lib/core/routing.js
@@ -19,9 +19,11 @@ function feedRouting(baseUrl) {
 }
 
 function pageRouting(baseUrl) {
+  const gr = regex => regex.toString().replace(/(^\/|\/$)/gm, '');
   return new RegExp(
-    `(?!^${escape(baseUrl)}docs\/.*html$|^${escape(baseUrl)}blog\/.*html$)` +
-    `^${escape(baseUrl)}.*\.html$`
+    `(?!${gr(docsRouting(baseUrl))}|${gr(blogRouting(baseUrl))})^${escape(
+      baseUrl
+    )}.*\.html$`
   );
 }
 

--- a/lib/core/routing.js
+++ b/lib/core/routing.js
@@ -4,27 +4,35 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const escapeStringRegexp = require('escape-string-regexp');
+const escape = require('escape-string-regexp');
 
 function blogRouting(baseUrl) {
-  return new RegExp(`^${escapeStringRegexp(baseUrl)}blog\/.*html$`);
+  return new RegExp(`^${escape(baseUrl)}blog\/.*html$`);
 }
 
 function docsRouting(baseUrl) {
-  return new RegExp(`^${escapeStringRegexp(baseUrl)}docs\/.*html$`);
+  return new RegExp(`^${escape(baseUrl)}docs\/.*html$`);
 }
 
 function feedRouting(baseUrl) {
-  return new RegExp(`^${escapeStringRegexp(baseUrl)}blog\/(feed\.xml|atom\.xml)`);
+  return new RegExp(`^${escape(baseUrl)}blog\/(feed\.xml|atom\.xml)`);
+}
+
+function pageRouting(baseUrl) {
+  return new RegExp(
+    `(?!^${escape(baseUrl)}docs\/.*html$|^${escape(baseUrl)}blog\/.*html$)` +
+    `^${escape(baseUrl)}.*\.html$`
+  );
 }
 
 function sitemapRouting(baseUrl) {
-  return new RegExp(`^${escapeStringRegexp(baseUrl)}sitemap.xml`);
+  return new RegExp(`^${escape(baseUrl)}sitemap.xml`);
 }
 
 module.exports = {
   blogRouting,
   docsRouting,
   feedRouting,
+  pageRouting,
   sitemapRouting,
 };

--- a/lib/core/routing.js
+++ b/lib/core/routing.js
@@ -6,15 +6,25 @@
  */
 const escapeStringRegexp = require('escape-string-regexp');
 
-function docsRouting(baseUrl) {
-  return new RegExp(`^${escapeStringRegexp(baseUrl)}docs\/.*html$`);
-}
-
 function blogRouting(baseUrl) {
   return new RegExp(`^${escapeStringRegexp(baseUrl)}blog\/.*html$`);
 }
 
+function docsRouting(baseUrl) {
+  return new RegExp(`^${escapeStringRegexp(baseUrl)}docs\/.*html$`);
+}
+
+function feedRouting(baseUrl) {
+  return new RegExp(`^${escapeStringRegexp(baseUrl)}blog\/(feed\.xml|atom\.xml)`);
+}
+
+function sitemapRouting(baseUrl) {
+  return new RegExp(`^${escapeStringRegexp(baseUrl)}sitemap.xml`);
+}
+
 module.exports = {
-  docsRouting,
   blogRouting,
+  docsRouting,
+  feedRouting,
+  sitemapRouting,
 };

--- a/lib/core/routing.js
+++ b/lib/core/routing.js
@@ -18,6 +18,10 @@ function feedRouting(baseUrl) {
   return new RegExp(`^${escape(baseUrl)}blog\/(feed\.xml|atom\.xml)`);
 }
 
+function noExtRouting() {
+  return new RegExp(`\/[^\.]*\/?$`);
+}
+
 function pageRouting(baseUrl) {
   const gr = regex => regex.toString().replace(/(^\/|\/$)/gm, '');
   return new RegExp(
@@ -36,5 +40,6 @@ module.exports = {
   docsRouting,
   feedRouting,
   pageRouting,
+  noExtRouting,
   sitemapRouting,
 };

--- a/lib/core/routing.js
+++ b/lib/core/routing.js
@@ -14,12 +14,16 @@ function docsRouting(baseUrl) {
   return new RegExp(`^${escape(baseUrl)}docs\/.*html$`);
 }
 
+function dotRouting() {
+  return /(?!.*html$)^\/.*\.[^\n\/]+$/;
+}
+
 function feedRouting(baseUrl) {
-  return new RegExp(`^${escape(baseUrl)}blog\/(feed\.xml|atom\.xml)`);
+  return new RegExp(`^${escape(baseUrl)}blog\/(feed\.xml|atom\.xml)$`);
 }
 
 function noExtRouting() {
-  return new RegExp(`\/[^\.]*\/?$`);
+  return /\/[^\.]*\/?$/;
 }
 
 function pageRouting(baseUrl) {
@@ -38,6 +42,7 @@ function sitemapRouting(baseUrl) {
 module.exports = {
   blogRouting,
   docsRouting,
+  dotRouting,
   feedRouting,
   pageRouting,
   noExtRouting,

--- a/lib/core/routing.js
+++ b/lib/core/routing.js
@@ -36,7 +36,7 @@ function pageRouting(baseUrl) {
 }
 
 function sitemapRouting(baseUrl) {
-  return new RegExp(`^${escape(baseUrl)}sitemap.xml`);
+  return new RegExp(`^${escape(baseUrl)}sitemap.xml$`);
 }
 
 module.exports = {

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -130,6 +130,24 @@ function execute(port, options) {
     return false;
   }
 
+  function requestFile(url, res, notFoundCallback) {
+    request.get(url, (error, response, body) => {
+      if (!error) {
+        if (response) {
+          if (response.statusCode === 404 && notFoundCallback) {
+            notFoundCallback();
+          } else {
+            res.status(response.statusCode).send(body);
+          }
+        } else {
+          console.error('No response');
+        }
+      } else {
+        console.error('Request failed:', error);
+      }
+    });
+  }
+
   /****************************************************************************/
 
   reloadMetadata();
@@ -551,32 +569,16 @@ function execute(port, options) {
 
   // "redirect" requests to pages ending with "/" or no extension so that,
   // for example, request to "blog" returns "blog/index.html" or "blog.html"
-  app.get(noExtRouting(), (req, res) => {
-    const requestFile = (url, notFoundCallback) => {
-      request.get(url, (error, response, body) => {
-        if (!error) {
-          if (response) {
-            if (response.statusCode === 404 && notFoundCallback) {
-              notFoundCallback();
-            } else {
-              res.status(response.statusCode).send(body);
-            }
-          } else {
-            console.error('No response');
-          }
-        } else {
-          console.error('Request failed:', error);
-        }
-      });
-    };
+  app.get(noExtRouting(), (req, res, next) => {
     let slash = req.path.toString().endsWith('/') ? '' : '/';
     let requestUrl = 'http://localhost:' + port + req.path;
-    requestFile(requestUrl + slash + 'index.html', () => {
+    requestFile(requestUrl + slash + 'index.html', res, () => {
       requestFile(
         slash === '/'
           ? requestUrl + '.html'
           : requestUrl.replace(/\/$/, '.html'),
-        null
+        res,
+        next
       );
     });
   });

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -25,6 +25,7 @@ function execute(port, options) {
     docsRouting,
     feedRouting,
     pageRouting,
+    noExtRouting,
     sitemapRouting,
   } = require('../core/routing');
   const mkdirp = require('mkdirp');
@@ -550,7 +551,7 @@ function execute(port, options) {
 
   // "redirect" requests to pages ending with "/" or no extension so that,
   // for example, request to "blog" returns "blog/index.html" or "blog.html"
-  app.get(/\/[^\.]*\/?$/, (req, res) => {
+  app.get(noExtRouting(), (req, res) => {
     const requestFile = (url, notFoundCallback) => {
       request.get(url, (error, response, body) => {
         if (!error) {

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -282,7 +282,7 @@ function execute(port, options) {
   });
 
   // Handle all requests for blog pages and posts.
-  app.get(blogRouting(siteConfig.baseUrl), (req, res) => {
+  app.get(blogRouting(siteConfig.baseUrl), (req, res, next) => {
     // Regenerate the blog metadata in case it has changed. Consider improving
     // this to regenerate on file save rather than on page request.
     reloadMetadataBlog();
@@ -335,6 +335,11 @@ function execute(port, options) {
       }
       file = file.replace(new RegExp('/', 'g'), '-');
       file = join(CWD, 'blog', file);
+
+      if (!fs.existsSync(file)) {
+        next();
+        return;
+      }
 
       const result = metadataUtils.extractMetadata(
         fs.readFileSync(file, {encoding: 'utf8'})
@@ -400,7 +405,7 @@ function execute(port, options) {
       } else {
         res.send(fs.readFileSync(htmlFile, {encoding: 'utf8'}));
       }
-      return;
+      next();
     }
 
     // look for user provided react file either in specified path or in path for english files

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -23,6 +23,7 @@ function execute(port, options) {
   const {
     blogRouting,
     docsRouting,
+    dotRouting,
     feedRouting,
     pageRouting,
     noExtRouting,
@@ -581,6 +582,16 @@ function execute(port, options) {
         next
       );
     });
+  });
+
+  // handle special cleanUrl case like '/blog/1.2.3' & '/blog.robots.hai'
+  // where we should try to serve 'blog/1.2.3.html' & '/blog.robots.hai.html'
+  app.get(dotRouting(), (req, res, next) => {
+    if (!siteConfig.cleanUrl) {
+      next();
+      return;
+    }
+    requestFile('http://localhost:' + port + req.path + '.html', res, next);
   });
 
   if (options.watch) startLiveReload();

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -430,6 +430,7 @@ function execute(port, options) {
         res.send(fs.readFileSync(htmlFile, {encoding: 'utf8'}));
       }
       next();
+      return;
     }
 
     // look for user provided react file either in specified path or in path for english files

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -20,7 +20,12 @@ function execute(port, options) {
   const path = require('path');
   const color = require('color');
   const getTOC = require('../core/getTOC');
-  const {docsRouting, blogRouting} = require('../core/routing');
+  const {
+    blogRouting,
+    docsRouting,
+    feedRouting,
+    sitemapRouting,
+  } = require('../core/routing');
   const mkdirp = require('mkdirp');
   const glob = require('glob');
   const chalk = require('chalk');
@@ -257,7 +262,7 @@ function execute(port, options) {
     res.send(renderToStaticMarkupWithDoctype(docComp));
   });
 
-  app.get('/sitemap.xml', function(req, res) {
+  app.get(sitemapRouting(siteConfig.baseUrl), (req, res) => {
     res.set('Content-Type', 'application/xml');
 
     sitemap(xml => {
@@ -265,14 +270,15 @@ function execute(port, options) {
     });
   });
 
-  app.get(/blog\/.*xml$/, (req, res) => {
+  app.get(feedRouting(siteConfig.baseUrl), (req, res, next) => {
     res.set('Content-Type', 'application/rss+xml');
-    let parts = req.path.toString().split('blog/');
-    if (parts[1].toLowerCase() == 'atom.xml') {
+    let file = req.path.toString().split('blog/')[1].toLowerCase();
+    if (file == 'atom.xml') {
       res.send(feed('atom'));
-      return;
+    } else if (file == 'feed.xml') {
+      res.send(feed('rss'));
     }
-    res.send(feed('rss'));
+    next();
   });
 
   // Handle all requests for blog pages and posts.

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -297,9 +297,9 @@ function execute(port, options) {
       .toString()
       .split('blog/')[1]
       .toLowerCase();
-    if (file == 'atom.xml') {
+    if (file === 'atom.xml') {
       res.send(feed('atom'));
-    } else if (file == 'feed.xml') {
+    } else if (file === 'feed.xml') {
       res.send(feed('rss'));
     }
     next();

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -24,6 +24,7 @@ function execute(port, options) {
     blogRouting,
     docsRouting,
     feedRouting,
+    pageRouting,
     sitemapRouting,
   } = require('../core/routing');
   const mkdirp = require('mkdirp');
@@ -272,7 +273,10 @@ function execute(port, options) {
 
   app.get(feedRouting(siteConfig.baseUrl), (req, res, next) => {
     res.set('Content-Type', 'application/rss+xml');
-    let file = req.path.toString().split('blog/')[1].toLowerCase();
+    let file = req.path
+      .toString()
+      .split('blog/')[1]
+      .toLowerCase();
     if (file == 'atom.xml') {
       res.send(feed('atom'));
     } else if (file == 'feed.xml') {
@@ -372,7 +376,7 @@ function execute(port, options) {
   });
 
   // handle all other main pages
-  app.get('*.html', (req, res, next) => {
+  app.get(pageRouting(siteConfig.baseUrl), (req, res, next) => {
     // look for user provided html file first
     let htmlFile = req.path.toString().replace(siteConfig.baseUrl, '');
     htmlFile = join(CWD, 'pages', htmlFile);


### PR DESCRIPTION
## Motivation


Changes

- Fix `sitemap.xml` routing to be properly on it's correct place.
Example: when baseUrl is `/jest/`, it should only be accessible at `/jest/sitemap.xml` and not at `/sitemap.xml`
- Fix `blog/atom.xml` and `blog/feed.xml` routing to be properly in it's correct place
- Fix wrong logic/ bug where `blog/test.xml` or any `blog/*.xml` will send `blog/feed.xml`
- Fix wrong logic at blog routing in which if file does not exist, we properly exit (not send wrong file) & use `next` middleware function
- Fix page routing regex, previously all `.html` files will hit this path, we should ignore it if it's `docs` or `blog` pages. 100% more efficient
- Add a lot of tests with jest to catch regression & routing regex are refactored to `lib/core/routing.js` so that our routing is still true in v2
- Refactor extension-less url routing + add test
- Fix #796 by adding dot routing (special case like `http://localhost:3000/blog/2018/05/27/1.13.0` + test

Before
<img width="442" alt="before2" src="https://user-images.githubusercontent.com/17883920/41811385-307be166-7741-11e8-9770-c41520360ede.PNG">

After
<img width="945" alt="working" src="https://user-images.githubusercontent.com/17883920/41821164-1cee0920-780f-11e8-984b-3f146b323cb4.PNG">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test in development, everything work as per normal
![working](https://user-images.githubusercontent.com/17883920/41818245-0c359990-77dd-11e8-9345-8f8b3b657d94.gif)