### PR TITLE
Show scrollbar only when sidebar is too long

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1567,7 +1567,7 @@ input::placeholder {
     height: calc(100vh - 50px);
     position: -webkit-sticky;
     position: sticky;
-    overflow-y: scroll;
+    overflow-y: auto;
     top: 50px; /* Height of navbar */
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #793 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Normal height page

<img width="1552" alt="screen shot 2018-06-24 at 8 15 26 pm" src="https://user-images.githubusercontent.com/1315101/41828681-8bf2ede6-77eb-11e8-8606-edb41a78785a.png">

Short height page

<img width="1552" alt="screen shot 2018-06-24 at 8 15 30 pm" src="https://user-images.githubusercontent.com/1315101/41828685-908e6ae2-77eb-11e8-9f11-2e792ea5b293.png">

## Related PRs

#757 
