### PR TITLE
Fix wrong sitemap for blog

### DIFF
--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -72,9 +72,8 @@ module.exports = function(callback) {
   MetadataBlog.map(blog => {
     urls.push({
       url:
-        '/blog/' + siteConfig.cleanUrl
-          ? blog.path.replace(/\.html$/, '')
-          : blog.path,
+        '/blog/' +
+        (siteConfig.cleanUrl ? blog.path.replace(/\.html$/, '') : blog.path),
       changefreq: 'weekly',
       priority: 0.3,
     });


### PR DESCRIPTION
## Motivation

https://github.com/facebook/Docusaurus/pull/799#issuecomment-399825501

Our sitemap url for blog is always wrong due to wrong logic. 

Consider this
<img width="342" alt="consider" src="https://user-images.githubusercontent.com/17883920/41831057-6d91fd56-7877-11e8-981a-1fc4a784ccea.PNG">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before
<img width="844" alt="before" src="https://user-images.githubusercontent.com/17883920/41831095-a58b4532-7877-11e8-8863-cf3cc14fd321.PNG">

After
<img width="776" alt="after" src="https://user-images.githubusercontent.com/17883920/41831076-91a4b6ac-7877-11e8-8199-c89d957284ee.PNG">


## Related PRs

#765