### PR TITLE
Prevent page scrolling to top when clicking languages button on header

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -101,8 +101,10 @@ class LanguageDropDown extends React.Component {
             __html: `
         const languagesMenuItem = document.getElementById("languages-menu");
         const languagesDropDown = document.getElementById("languages-dropdown");
-        languagesMenuItem.addEventListener("click", function(){
-          if(languagesDropDown.className == "hide") {
+        languagesMenuItem.addEventListener("click", function(event) {
+          event.preventDefault();
+
+          if (languagesDropDown.className == "hide") {
             languagesDropDown.className = "visible";
           } else {
             languagesDropDown.className = "hide";


### PR DESCRIPTION
## Motivation

Prevent the page scrolling to the top when you click the Languages button on the header

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```bash
cd /path/to/docusaurus-repo
yarn
cd website
npm run start
```

Scroll down the page a bit, click the languages button on the header and ensure it doesn't scroll back to the top
