### PR TITLE
Switch Jest URL to jestjs.io

### DIFF
--- a/website/blog/2017-12-14-introducing-docusaurus.md
+++ b/website/blog/2017-12-14-introducing-docusaurus.md
@@ -141,7 +141,7 @@ Special thanks also goes out to our earliest [adopters](https://docusaurus.io/en
 
 - [BuckleScript](https://bucklescript.github.io/)
 - [FastText](https://fasttext.cc)
-- [Jest](https://facebook.github.io/jest/)
+- [Jest](https://jestjs.io)
 - [Make It Open](http://makeitopen.com)
 - [Prettier](https://prettier.io/)
 - [Reason-react](https://reasonml.github.io/reason-react/)

--- a/website/data/users.js
+++ b/website/data/users.js
@@ -101,7 +101,7 @@ module.exports = [
   {
     caption: 'Jest',
     image: '/img/users/jest.png',
-    infoLink: 'https://facebook.github.io/jest/',
+    infoLink: 'https://jestjs.io',
     fbOpenSource: true,
     pinned: true,
   },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Updating the Jest URL for the new site.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Verify the Jest URL has been update on the [home](https://deploy-preview-807--docusaurus-preview.netlify.com/en/) page users section, [users](https://deploy-preview-807--docusaurus-preview.netlify.com/en/users) page and the [Introducing Docusaurus](https://deploy-preview-807--docusaurus-preview.netlify.com/blog/2017/12/14/introducing-docusaurus#acknowledgements) blog post.

## Related PRs

See facebook/jest#6549
