### PR TITLE
Handle build-files promise error & exit properly

### DIFF
--- a/lib/build-files.js
+++ b/lib/build-files.js
@@ -33,5 +33,11 @@ if (!fs.existsSync(CWD + '/siteConfig.js')) {
 
 // generate all static html files
 const generate = require('./server/generate.js');
-generate();
-console.log("Site built successfully. Generated files in 'build' folder.");
+generate()
+  .then(() => {
+    console.log("Site built successfully. Generated files in 'build' folder.");
+  })
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Motivation

Fix #805 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try with https://github.com/facebook/react-native-website, delete versioned_docs/version-0.5/removing-default-permissions.md from master.

Run docusaurus build

Before
<img width="694" alt="before3" src="https://user-images.githubusercontent.com/17883920/41963021-1eb1075a-7a29-11e8-8d99-ff52f2e80936.PNG">

After
<img width="693" alt="after3" src="https://user-images.githubusercontent.com/17883920/41963027-22be5816-7a29-11e8-9cef-80fdb7ef8ba4.PNG">

Try with Docusaurus, delete first doc from versioned_docs version-1.0.11 and `yarn build`
Before
<img width="696" alt="before4" src="https://user-images.githubusercontent.com/17883920/41963310-c9f44cda-7a29-11e8-91ea-5fd3c0e28108.PNG">

After
<img width="693" alt="after4" src="https://user-images.githubusercontent.com/17883920/41963277-b0ba350e-7a29-11e8-97d8-9544ad32f4df.PNG">

