### PR TITLE
Open browser with correct baseurl

### DIFF
--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -72,7 +72,8 @@ function checkPort() {
         // start local server on specified port
         const server = require('./server/server.js');
         server(port, program.opts());
-        const host = `http://localhost:${port}`;
+        const baseUrl = require(CWD + '/siteConfig.js').baseUrl;
+        const host = `http://localhost:${port}${baseUrl}`;
         console.log('Docusaurus server started on port %d', port);
         openBrowser(host);
       }

--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -72,7 +72,7 @@ function checkPort() {
         // start local server on specified port
         const server = require('./server/server.js');
         server(port, program.opts());
-        const baseUrl = require(CWD + '/siteConfig.js').baseUrl;
+        const {baseUrl} = require(CWD + '/siteConfig.js');
         const host = `http://localhost:${port}${baseUrl}`;
         console.log('Docusaurus server started on port %d', port);
         openBrowser(host);


### PR DESCRIPTION
## Motivation

#799 make the routing stricter to properly use baseUrl to prevent routing bugs.

However, currently local dev will always load `localhost:port` regardless of baseUrl. We should always load the correct baseUrl.

Fix #818 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

use `/reason/` as baseUrl
```
cd website
yarn start
```

<img width="958" alt="1" src="https://user-images.githubusercontent.com/17883920/42131083-de73e648-7d2b-11e8-8d76-3c8eb1fd51f4.PNG">

use `/` as baseUrl
```
cd website
yarn start
```

<img width="960" alt="2" src="https://user-images.githubusercontent.com/17883920/42131088-e9bd4288-7d2b-11e8-90dc-e58fff65a68c.PNG">
