### PR TITLE
Fix missing fblike button in blog

### DIFF
--- a/lib/core/BlogPostLayout.js
+++ b/lib/core/BlogPostLayout.js
@@ -41,7 +41,7 @@ class BlogPostLayout extends React.Component {
     const fbLike = this.props.config.facebookAppId && (
       <div className="blogSocialSectionItem">
         <div
-          className="fb-like"
+          className="fb-like" // Facebook SDK require it to be 'fb-like')
           data-href={
             this.props.config.url +
             this.props.config.baseUrl +

--- a/lib/core/BlogPostLayout.js
+++ b/lib/core/BlogPostLayout.js
@@ -23,8 +23,9 @@ class BlogPostLayout extends React.Component {
     const fbComment = this.props.config.facebookAppId &&
       this.props.config.facebookComments && (
         <div className="blogSocialSectionItem">
+          {/* Facebook SDK require 'fb-comments' class */}
           <div
-            className="fb-comments" // Facebook SDK require it to be 'fb-comments'
+            className="fb-comments"
             data-href={
               this.props.config.url +
               this.props.config.baseUrl +
@@ -40,8 +41,9 @@ class BlogPostLayout extends React.Component {
 
     const fbLike = this.props.config.facebookAppId && (
       <div className="blogSocialSectionItem">
+        {/* Facebook SDK require 'fb-like' class */}
         <div
-          className="fb-like" // Facebook SDK require it to be 'fb-like'
+          className="fb-like"
           data-href={
             this.props.config.url +
             this.props.config.baseUrl +

--- a/lib/core/BlogPostLayout.js
+++ b/lib/core/BlogPostLayout.js
@@ -24,7 +24,7 @@ class BlogPostLayout extends React.Component {
       this.props.config.facebookComments && (
         <div className="blogSocialSectionItem">
           <div
-            className="fb-comments"
+            className="fb-comments" // Facebook SDK require it to be 'fb-comments'
             data-href={
               this.props.config.url +
               this.props.config.baseUrl +
@@ -41,7 +41,7 @@ class BlogPostLayout extends React.Component {
     const fbLike = this.props.config.facebookAppId && (
       <div className="blogSocialSectionItem">
         <div
-          className="fb-like" // Facebook SDK require it to be 'fb-like')
+          className="fb-like" // Facebook SDK require it to be 'fb-like'
           data-href={
             this.props.config.url +
             this.props.config.baseUrl +

--- a/lib/core/BlogPostLayout.js
+++ b/lib/core/BlogPostLayout.js
@@ -41,7 +41,7 @@ class BlogPostLayout extends React.Component {
     const fbLike = this.props.config.facebookAppId && (
       <div className="blogSocialSectionItem">
         <div
-          className="fbLike"
+          className="fb-like"
           data-href={
             this.props.config.url +
             this.props.config.baseUrl +

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -2050,7 +2050,7 @@ input::placeholder {
   padding-bottom: 5px;
 }
 
-.fbLike {
+.fb-like {
   display: block;
   margin-bottom: 20px;
   width: 100%;

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -2050,6 +2050,7 @@ input::placeholder {
   padding-bottom: 5px;
 }
 
+// don't change (Facebook SDK require this class name)
 .fb-like {
   display: block;
   margin-bottom: 20px;

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -2050,7 +2050,6 @@ input::placeholder {
   padding-bottom: 5px;
 }
 
-// don't change (Facebook SDK require this class name)
 .fb-like {
   display: block;
   margin-bottom: 20px;


### PR DESCRIPTION
## Motivation

Fix #814 

It should be
```js
className="fb-like"
```

According to https://developers.facebook.com/docs/plugins/like-button/

Instead of
```js
className="fbLike"
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="905" alt="asd" src="https://user-images.githubusercontent.com/17883920/42131186-a0d41b3e-7d2e-11e8-98ae-1491c1dab30b.PNG">


## Related PRs

#757 renamed "fb-like" to "fbLike"
