### PR TITLE
Fix wrong sitemap for alternate url

### DIFF
--- a/lib/core/__tests__/utils.test.js
+++ b/lib/core/__tests__/utils.test.js
@@ -46,4 +46,30 @@ describe('utils', () => {
       utils.extractBlogPostSummary(blogPostWithoutTruncateContents)
     ).toMatchSnapshot();
   });
+
+  test('getPath', () => {
+    expect(utils.getPath('/docs/en/versioning.html', true)).toBe(
+      '/docs/en/versioning'
+    );
+    expect(utils.getPath('/en/users.html', true)).toBe('/en/users');
+    expect(utils.getPath('/docs/en/asd/index.html', true)).toBe('/docs/en/asd');
+    expect(utils.getPath('/en/help/index.html', true)).toBe('/en/help');
+    expect(utils.getPath('/en/help.a.b.c.d.e.html', true)).toBe(
+      '/en/help.a.b.c.d.e'
+    );
+    expect(utils.getPath('/en/help.js', true)).toBe('/en/help');
+    expect(utils.getPath('/docs/en/versioning.html', false)).toBe(
+      '/docs/en/versioning.html'
+    );
+    expect(utils.getPath('/en/users.html', false)).toBe('/en/users.html');
+  });
+
+  test('removeExtension', () => {
+    expect(utils.removeExtension('/endiliey.html')).toBe('/endiliey');
+    expect(utils.removeExtension('/a.b/')).toBe('/a.b/');
+    expect(utils.removeExtension('/a.b/c.png')).toBe('/a.b/c');
+    expect(utils.removeExtension('/a.b/c.d.e')).toBe('/a.b/c.d');
+    expect(utils.removeExtension('/docs/test')).toBe('/docs/test');
+    expect(utils.removeExtension('pages.js')).toBe('pages');
+  });
 });

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -20,12 +20,16 @@ function extractBlogPostSummary(content) {
   return content.substring(0, BLOG_POST_SUMMARY_LENGTH);
 }
 
+function removeExtension(path) {
+  return path.replace(/\.[^/.]+$/, '');
+}
+
 function getPath(path, cleanUrl = false) {
   if (cleanUrl) {
     if (path.endsWith('/index.html')) {
       return path.replace(/\/index.html$/, '');
     } else {
-      return path.replace(/\.html$/, '');
+      return removeExtension(path);
     }
   }
   return path;
@@ -36,4 +40,5 @@ module.exports = {
   extractBlogPostBeforeTruncate,
   extractBlogPostSummary,
   getPath,
+  removeExtension,
 };

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -16,6 +16,7 @@ async function execute() {
   const readMetadata = require('./readMetadata.js');
   const path = require('path');
   const getTOC = require('../core/getTOC.js');
+  const utils = require('../core/utils.js');
   const React = require('react');
   const mkdirp = require('mkdirp');
   const glob = require('glob');
@@ -164,7 +165,7 @@ async function execute() {
     // replace any links to markdown files to their website html links
     Object.keys(mdToHtml).forEach(function(key, index) {
       let link = mdToHtml[key];
-      link = siteConfig.cleanUrl ? link.replace(/\.html$/, '') : link;
+      link = utils.getPath(link, siteConfig.cleanUrl);
       link = link.replace('/en/', '/' + language + '/');
       link = link.replace(
         '/VERSION/',
@@ -205,9 +206,10 @@ async function execute() {
       env.translation.enabled &&
       metadata.permalink.indexOf('docs/en') !== -1
     ) {
-      const redirectlink = siteConfig.cleanUrl
-        ? metadata.permalink.replace(/\.html$/, '')
-        : metadata.permalink;
+      const redirectlink = utils.getPath(
+        metadata.permalink,
+        siteConfig.cleanUrl
+      );
       const redirectComp = (
         <Redirect
           metadata={metadata}

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -17,6 +17,7 @@ function execute(port, options) {
   const fs = require('fs-extra');
   const path = require('path');
   const getTOC = require('../core/getTOC');
+  const utils = require('../core/utils');
   const {
     blogRouting,
     docsRouting,
@@ -226,7 +227,7 @@ function execute(port, options) {
     // replace any links to markdown files to their website html links
     Object.keys(mdToHtml).forEach(function(key, index) {
       let link = mdToHtml[key];
-      link = siteConfig.cleanUrl ? link.replace(/\.html$/, '') : link;
+      link = utils.getPath(link, siteConfig.cleanUrl);
       link = link.replace('/en/', '/' + language + '/');
       link = link.replace(
         '/VERSION/',

--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -11,6 +11,7 @@ const glob = require('glob');
 const CWD = process.cwd();
 
 const sitemap = require('sitemap');
+const utils = require('../core/utils');
 
 const siteConfig = require(CWD + '/siteConfig.js');
 
@@ -67,9 +68,7 @@ module.exports = function(callback) {
 
   MetadataBlog.map(blog => {
     urls.push({
-      url:
-        '/blog/' +
-        (siteConfig.cleanUrl ? blog.path.replace(/\.html$/, '') : blog.path),
+      url: '/blog/' + utils.getPath(blog.path, siteConfig.cleanUrl),
       changefreq: 'weekly',
       priority: 0.3,
     });
@@ -79,14 +78,13 @@ module.exports = function(callback) {
     .filter(key => Metadata[key].language === 'en')
     .map(key => {
       let doc = Metadata[key];
+      let docUrl = utils.getPath(doc.permalink, siteConfig.cleanUrl);
       let links = enabledLanguages.map(lang => {
-        let langUrl = doc.permalink.replace('docs/en/', `docs/${lang.tag}/`);
+        let langUrl = docUrl.replace('docs/en/', `docs/${lang.tag}/`);
         return {lang: lang.tag, url: langUrl};
       });
       urls.push({
-        url: siteConfig.cleanUrl
-          ? doc.permalink.replace(/\.html$/, '')
-          : doc.permalink,
+        url: docUrl,
         changefreq: 'hourly',
         priority: 1.0,
         links,


### PR DESCRIPTION
## Motivation

#765 missed the implementation for langUrl, so the sitemap url is wrong for alternate url
<img width="959" alt="826" src="https://user-images.githubusercontent.com/17883920/42237692-1dc6e88e-7f31-11e8-9aaf-e3b3cabfcc89.PNG">

In addition, I refactored few places to use `getPath` function instead of using `replace(/\.html$/, '')` just for reusability. Added tests also for regression on the function

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test all url seems to work locally

And sitemap is now correct on alternate
<img width="377" alt="cor" src="https://user-images.githubusercontent.com/17883920/42237877-abd6e16a-7f31-11e8-99d9-eb10d17e0f60.PNG">


## Related PRs

#765 
