### PR TITLE
Publish-gh-pages should display the correct commit that triggers it

### DIFF
--- a/lib/publish-gh-pages.js
+++ b/lib/publish-gh-pages.js
@@ -84,6 +84,9 @@ if (shell.exec(`node ${path.join(__dirname, 'build-files.js')}`).code) {
   shell.exit(1);
 }
 
+// Save the commit hash that triggers publish-gh-pages before checking out to deployment branch
+const currentCommit = shell.exec('git rev-parse HEAD').stdout.trim();
+
 shell.cd(process.cwd());
 shell.cd('build');
 
@@ -154,9 +157,6 @@ fs.copy(
     }
 
     shell.cd(path.join('build', `${PROJECT_NAME}-${DEPLOYMENT_BRANCH}`));
-
-    const currentCommit = shell.exec('git rev-parse HEAD').stdout.trim();
-
     shell.exec('git add --all');
 
     const commitResults = shell.exec(


### PR DESCRIPTION
## Motivation

Current implementation of publish-gh-pages is slightly misleading. 

Consider this latest commit on `master` branch
https://github.com/facebook/Docusaurus/commit/8d45669f924a38e628d01066b6fc855eaff7e8d7
<img width="582" alt="Latest master commit on Docusaurus" src="https://user-images.githubusercontent.com/17883920/42288243-80778ea0-7fec-11e8-9d4f-6708516076e2.PNG">

When this got pushed, our circleci run `publish-gh-pages` and deploy the website at `gh-pages` branch
https://github.com/facebook/Docusaurus/commit/85ff1544384b0ecab344b19a72393790e50acd73
<img width="586" alt="Deploy website by docusaurus-bo" src="https://user-images.githubusercontent.com/17883920/42288649-3238534e-7fee-11e8-8c5f-f0f6e1b53da4.PNG">

If we look carefully, the commit message is
```
Deploy website version based on 1e6aa2b
```

And commit 1e6aa2b is actually just the previous commit on `gh-pages`

This is *WRONG*, we should display the commit that triggers the publish. Like this
```
Deploy website version based on 8d45669
```

## Analysis

This is caused by calling `git rev-parse HEAD` on the wrong branch. 

Before this PR, we try to `git checkout gh-pages` first 
https://github.com/facebook/Docusaurus/blob/8d45669f924a38e628d01066b6fc855eaff7e8d7/lib/publish-gh-pages.js#L102-L122

and then call `git rev-parse HEAD`. 
https://github.com/facebook/Docusaurus/blob/8d45669f924a38e628d01066b6fc855eaff7e8d7/lib/publish-gh-pages.js#L158

In this PR, we should call `git rev-parse HEAD` first before `git checkout gh-pages` and correctly use the correct commit hash

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan


1. Testing my logic -> call `git rev-parse HEAD` first before `git checkout gh-pages`
<img width="571" alt="1" src="https://user-images.githubusercontent.com/17883920/42288525-9d5e3806-7fed-11e8-87f1-f98c3ccf863f.PNG">

2. Test with my website
Consider this commit https://github.com/endiliey/endiliey.github.io/commit/4c6abe0786e2be11cda2ae7c8d847e957d6ba89d
<img width="590" alt="Triggering commit" src="https://user-images.githubusercontent.com/17883920/42290155-212bee00-7ff6-11e8-9440-ebbd78629dec.PNG">

Now the deploy commit shows the correct triggering commit
https://github.com/endiliey/endiliey.github.io/commit/936bbc3e2fa8d647aa824e138d52f7b8fbf17b2e
<img width="589" alt="Deploy shows triggering commit" src="https://user-images.githubusercontent.com/17883920/42290187-3f7f5a40-7ff6-11e8-8edb-15b29190deed.PNG">

Make debugging life easier 👍 
