### PR TITLE
fix(css): nav seam of 1px in mobile view

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1214,7 +1214,7 @@ input::placeholder {
   left: 0;
   position: fixed;
   right: 0;
-  top: 0;
+  top: -1px;
 }
 
 .navigationSlider .slidingNav.slidingNavActive {


### PR DESCRIPTION
## Motivation

Users viewing Docusaurus site on mobile devices could experience this issue #820. It also seemed like a quick fix to me and I wanted to contribute to this project starting with something simple.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I only had to change one line of CSS that seemed to resolve this.

### Docusaurus website

First I played with the Docusaurus website in Safari by resizing and zooming it in. This seemed to trigger the issue multiple times.

**Before:**

![image](https://user-images.githubusercontent.com/17332418/42292172-e5dcebee-7fd0-11e8-9bb4-29b801e7a68d.png)

**After fix:**

![image](https://user-images.githubusercontent.com/17332418/42292181-ee7e1c64-7fd0-11e8-9e8a-ea8acad9abbe.png)

### ReasonML

I also did the same on the website of ReasonML, but this time in Chrome. In Chrome it was more difficult to trigger the issue, but sometimes it happened.

**Before:**

![image](https://user-images.githubusercontent.com/17332418/42292269-8b559d6e-7fd1-11e8-84e8-ea33a67471ec.png)

**After fix:**

![image](https://user-images.githubusercontent.com/17332418/42292274-9568dfdc-7fd1-11e8-9856-5f3884bfe6ae.png)

### Cause

It seems to be caused by the fixed positioning that sometime 'glitches' in the browsers and shows a line of 1px. If you change the `top` property to 10px for example you see it better.

### Fix

Change the value of the `top` property of the `.navigationSlider .slidingNav` query to `-1px`.

