### PR TITLE
Fix wrong CSS language prefix for fenced blocks

### DIFF
--- a/lib/core/renderMarkdown.js
+++ b/lib/core/renderMarkdown.js
@@ -23,8 +23,8 @@ class MarkdownRenderer {
 
     const md = new Markdown({
       // Highlight.js expects hljs css classes on the code element.
-      // This results in <pre><code class="hljs css javascript">
-      langPrefix: 'hljs css languages- ',
+      // This results in <pre><code class="hljs css languages-jsx">
+      langPrefix: 'hljs css languages-',
       highlight: function(str, lang) {
         lang =
           lang || (siteConfig.highlight && siteConfig.highlight.defaultLang);


### PR DESCRIPTION
## Motivation

Fix #840

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="956" alt="after" src="https://user-images.githubusercontent.com/17883920/42426309-8f5d8e4a-8359-11e8-8aaa-14db47042a95.PNG">