### PR TITLE
Correct Prism CSS class for code blocks

### DIFF
--- a/lib/core/renderMarkdown.js
+++ b/lib/core/renderMarkdown.js
@@ -24,7 +24,7 @@ class MarkdownRenderer {
     const md = new Markdown({
       // Highlight.js expects hljs css classes on the code element.
       // This results in <pre><code class="hljs css languages-jsx">
-      langPrefix: 'hljs css languages-',
+      langPrefix: 'hljs css language-',
       highlight(str, lang) {
         lang =
           lang || (siteConfig.highlight && siteConfig.highlight.defaultLang);

--- a/lib/static/css/prism.css
+++ b/lib/static/css/prism.css
@@ -1,14 +1,11 @@
 /**
- * prism.js default theme for JavaScript, CSS and HTML
+ * Modified prism.js default theme for JavaScript, CSS and HTML
  * Based on dabblet (http://dabblet.com)
  * @author Lea Verou
  */
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: black;
-  background: none;
-  text-shadow: 0 1px white;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   text-align: left;
   white-space: pre;
@@ -25,23 +22,6 @@ pre[class*="language-"] {
   -moz-hyphens: none;
   -ms-hyphens: none;
   hyphens: none;
-}
-
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-}
-
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-}
-
-@media print {
-  code[class*="language-"],
-  pre[class*="language-"] {
-    text-shadow: none;
-  }
 }
 
 /* Code blocks */


### PR DESCRIPTION
## Motivation

CSS class for Prism.js still look to be incorrect - this prevents using existing Prism.js themes out of the box.

See: https://github.com/PrismJS/prism/blob/master/themes/prism-coy.css

![image](https://user-images.githubusercontent.com/1234523/43168629-9e29d774-8f63-11e8-93d8-800697102048.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes - and signed CLA.

## Test Plan

No tests required.

## Related PRs

#735 #842 
