### PR TITLE
feat(markdown): support `text` language for code block style without any highlighting

### DIFF
--- a/lib/core/renderMarkdown.js
+++ b/lib/core/renderMarkdown.js
@@ -28,6 +28,9 @@ class MarkdownRenderer {
       highlight(str, lang) {
         lang =
           lang || (siteConfig.highlight && siteConfig.highlight.defaultLang);
+        if (lang === 'text') {
+          return str;
+        }
         if (lang) {
           try {
             if (


### PR DESCRIPTION
## Motivation

Close #874 

Currently, [highlight.js supported languages](https://github.com/highlightjs/highlight.js/tree/master/src/languages) and [prism.js supported languages](https://github.com/PrismJS/prism/tree/master/components) does not support `text` language

Our current logic for unsupported prism.js / highlight.js language is that we try to detect the language automatically with this code below:
https://github.com/facebook/Docusaurus/blob/75538395beb3bcd7591f586877d5971c51d4f5db/lib/core/renderMarkdown.js#L57-L59

Hence, there is no way for user to remove any highlighting for code block defined like this
<img width="342" alt="test" src="https://user-images.githubusercontent.com/17883920/43338202-475f1650-9208-11e8-929f-dd17ab6e295e.PNG">


It will be detected as JavaScript although it has been tagged as 'text' by user
This PR enables user to have `code block style without any highlighting` by using `text` language

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

````text

---
title: EXAMPLE
---

```text
function $initHighlight(block, cls) {
  try {
    if (cls.search(/\bno\-highlight\b/) != -1)
      return process(block, true, 0x0F) +
             ` class="${cls}"`;
  } catch (e) {
    /* handle exception */
  }
  for (var i = 0 / 2; i < classes.length; i++) {
    if (checkCondition(classes[i]) === undefined)
      console.log('undefined');
  }
}

export  $initHighlight;
```

```js
function $initHighlight(block, cls) {
  try {
    if (cls.search(/\bno\-highlight\b/) != -1)
      return process(block, true, 0x0F) +
             ` class="${cls}"`;
  } catch (e) {
    /* handle exception */
  }
  for (var i = 0 / 2; i < classes.length; i++) {
    if (checkCondition(classes[i]) === undefined)
      console.log('undefined');
  }
}

export  $initHighlight;
```

````

Before
<img width="953" alt="before" src="https://user-images.githubusercontent.com/17883920/43338364-b7222086-9208-11e8-9946-661892791ba5.PNG">


After
<img width="939" alt="after" src="https://user-images.githubusercontent.com/17883920/43337921-990d2be6-9207-11e8-8536-487cfd1af511.PNG">