### PR TITLE
fix: copy static image as it is if image compression fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Thank you to the following contributors who helped with this release:
 - Docusaurus own search will now search the docs in the correct language & version [\#859](https://github.com/facebook/Docusaurus/pull/859)
 - Fix phrase emphasis not italicized [\#850](https://github.com/facebook/Docusaurus/pull/850)
 - Blogpost summary for blog feed is now properly truncated [\#880](https://github.com/facebook/Docusaurus/pull/880)
+- Fix failure to copy static image if image compression fail [\#887](https://github.com/facebook/Docusaurus/pull/887)
 
 **Chore and Maintenance**
 - Remove unused files [\#881](https://github.com/facebook/Docusaurus/pull/881)

--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -247,11 +247,9 @@ async function execute() {
       !commander.skipImageCompression
     ) {
       const parts = normalizedFile.split(`${sep}static${sep}`);
-      const targetDirectory = join(
-        buildDir,
-        parts[1].substring(0, parts[1].lastIndexOf(sep))
-      );
-      mkdirp.sync(path.dirname(targetDirectory));
+      const targetFile = join(buildDir, parts[1]);
+      const targetDirectory = path.dirname(targetFile);
+      mkdirp.sync(targetDirectory);
       imagemin([normalizedFile], targetDirectory, {
         use: [
           imageminOptipng(),
@@ -261,6 +259,10 @@ async function execute() {
           }),
           imageminGifsicle(),
         ],
+      }).catch(error => {
+        // if image compression fail, just copy it as it is
+        console.error(error);
+        fs.copySync(normalizedFile, targetFile);
       });
     } else if (!fs.lstatSync(normalizedFile).isDirectory()) {
       const parts = normalizedFile.split(`${sep}static${sep}`);


### PR DESCRIPTION
## Motivation

Fix #701 

There is no error handling on https://github.com/facebook/Docusaurus/blob/ef80581e8ef950a0865fc7851407c672c4bbd510/lib/server/generate.js#L255-L264

If the image compression fails, it will cause the image to be missing.

Example: 
https://circleci.com/gh/facebook/Docusaurus/2846
<img width="957" alt="error" src="https://user-images.githubusercontent.com/17883920/43676271-8e1c2ed4-9820-11e8-8255-27f8a46c9c4f.PNG">


The build succeed but along the line there is an unhandled promise. Causing `christopher-chedeau.jpg` and `ricky-vetter.jpg` to be missing.

<img width="940" alt="missing image" src="https://user-images.githubusercontent.com/17883920/43673726-46d0ef68-97fa-11e8-8826-841fc8ff70f1.PNG">

This PR add a fallback functionality to copy the image as it is if the image compression fail

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

https://deploy-preview-887--docusaurus-preview.netlify.com/

## Related PRs

#654 
