### PR TITLE
Fix: correct docs linking for custom `defaultVersionShown`

### DIFF
--- a/lib/server/__tests__/docs.test.js
+++ b/lib/server/__tests__/docs.test.js
@@ -34,6 +34,7 @@ jest.mock('../env', () => ({
   versioning: {
     enabled: true,
     defaultVersion: '1.0.0',
+    latestVersion: '1.0.0',
   },
 }));
 

--- a/lib/server/docs.js
+++ b/lib/server/docs.js
@@ -57,7 +57,7 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
       htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);
       htmlLink = htmlLink.replace(
         '/VERSION/',
-        metadata.version && metadata.version !== env.versioning.defaultVersion
+        metadata.version && metadata.version !== env.versioning.latestVersion
           ? `/${metadata.version}/`
           : '/'
       );

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -45,6 +45,7 @@ class Translation {
 class Versioning {
   constructor() {
     this.enabled = false;
+    this.latestVersion = null;
     this.defaultVersion = null;
     this.versions = [];
     this.missingVersionsPage = false;
@@ -64,9 +65,10 @@ class Versioning {
     if (fs.existsSync(versionsJSONFile)) {
       this.enabled = true;
       this.versions = JSON.parse(fs.readFileSync(versionsJSONFile, 'utf8'));
+      this.latestVersion = this.versions[0];
       this.defaultVersion = siteConfig.defaultVersionShown
         ? siteConfig.defaultVersionShown
-        : this.versions[0]; // otherwise show the latest version (other than next/master)
+        : this.latestVersion; // otherwise show the latest version (other than next/master)
     }
 
     if (!fs.existsSync(versionsFile)) {


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/react-native-website/issues/505

If we set `defaultVersionShown` in Docusaurus

```js
const siteConfig = {
  defaultVersionShown: '1.3.1',
  // .....
};
```

When we go to http://localhost:3000/docs/en/1.3.1/site-preparation the docs linking is wrong, it became http://localhost:3000/docs/en/installation instead of http://localhost:3000/docs/en/1.3.1/installation

<img width="958" alt="before" src="https://user-images.githubusercontent.com/17883920/43914971-e90606c0-9c3b-11e8-9d9a-bfe013909d95.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

After this PR the docs linking is now correct

<img width="774" alt="after" src="https://user-images.githubusercontent.com/17883920/43914998-005b4330-9c3c-11e8-9f3f-aafb6cdec96f.png">