### PR TITLE
Fix tests

### DIFF
--- a/lib/__tests__/build-files.test.js
+++ b/lib/__tests__/build-files.test.js
@@ -28,7 +28,7 @@ let outputAssetsFiles = [];
 
 function generateSite() {
   shell.cd('website');
-  shell.exec('yarn build');
+  shell.exec('yarn build', {silent: true});
 }
 
 function clearBuildFolder() {

--- a/lib/server/__tests__/docs.test.js
+++ b/lib/server/__tests__/docs.test.js
@@ -89,7 +89,8 @@ describe('getFile', () => {
   fs.existsSync = jest.fn().mockReturnValue(true);
   fs.readFileSync = jest.fn().mockImplementation(file => {
     const fakePath = file.replace(process.cwd().replace(/website$/, ''), '');
-    return fakeContent[fakePath];
+    const normalizedPath = fakePath.replace(/\\/g, '/');
+    return fakeContent[normalizedPath];
   });
 
   test('docs does not exist', () => {

--- a/lib/server/utils.js
+++ b/lib/server/utils.js
@@ -17,8 +17,10 @@ function getSubDir(file, refDir) {
 }
 
 function getLanguage(file, refDir) {
+  const separator = escapeStringRegexp(path.sep);
+  const baseDir = escapeStringRegexp(path.basename(refDir));
   const regexSubFolder = new RegExp(
-    `${escapeStringRegexp(path.basename(refDir))}/(.*?)/.*`
+    `${baseDir}${separator}(.*?)${separator}.*`
   );
   const match = regexSubFolder.exec(file);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix the Jest tests that fail on Windows, and suppress the noise that gets emitted from the 'Build files' test suite.
 
The problem with the failing tests was path separators separators being hard coded to '/'.

The build-tests emit a load of warnings to do with translation, e.g:

```
Could not find a string translation in 'es-ES' for string 'About Slash|no description given'. Using English version instead.
```
These fill up the console and make it difficult to see if the tests are actually passing or not. Given they can just be ignored (they aren't fatal errors, and aren't related to what the tests are checking), I suppressed the console output when the `yarn build` command is run within the 'Build files' test suite.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run the Jest tests and make sure they all pass.
I ran the tests on both Windows and Ubuntu and they pass.

## Related PRs

N/A
