### PR TITLE
Updating step 2 to be more intuitive: "Avoiding use of the word github"

### DIFF
--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -13,11 +13,13 @@ We have created an easy script that will get all of the infrastructure set up fo
 
     > You have to be on Node >= 8.x and Yarn >= 1.5.
 
-1.  Create a project if none exists and change the directory to this project's root.
+1.  Create a project, if none exists, and change your the directory to this project's root.
 
     You will be creating the docs in this directory. The root directory may
     contain other files. The Docusaurus installation script will create two new
     directories: `docs-examples-from-docusaurus` and `website`.
+
+    > Commonly, either an existing or newly created GitHub project will be the location for your Docusaurus site, but that is not mandatory to use Docusaurus.
 
 1.  Run the Docusaurus installation script: `npx docusaurus-init`.
 

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -13,7 +13,7 @@ We have created an easy script that will get all of the infrastructure set up fo
 
     > You have to be on Node >= 8.x and Yarn >= 1.5.
 
-1.  Change directory to the root of your project's GitHub repo.
+1.  Create a project if none exists and change the directory to this project's root.
 
     You will be creating the docs in this directory. The root directory may
     contain other files. The Docusaurus installation script will create two new


### PR DESCRIPTION
Use of word Github is very confusing. When starting, most of devs wont have an existing github repo. And normally not everyone will be using Github. Since devs will be following this step by step: we need to stress on telling them to create a new or use existing local project folder which may or may not be a github repo.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Installation is foremost step to begin with this framework and this PR makes its more intuitive. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

No code changed. Only textual change for now

## Related PRs

This PR updates the doc
