### PR TITLE
add baseUrl to sitemap URLs

### DIFF
--- a/lib/server/sitemap.js
+++ b/lib/server/sitemap.js
@@ -83,7 +83,7 @@ module.exports = function(callback) {
     });
 
   const sm = sitemap.createSitemap({
-    hostname: siteConfig.url,
+    hostname: siteConfig.url + siteConfig.baseUrl,
     cacheTime: 600 * 1000, // 600 sec - cache purge period
     urls,
   });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #901. Currently the URLs in sitemap are incorrect when `baseUrl` != `/`. This PR fixes the bug.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan
It works locally.
![](https://i.imgur.com/md1T4MM.png)
![](https://i.imgur.com/3IpPApJ.png)

When baseUrl = `/`
![](https://i.imgur.com/FJe8PB1.png)
![](https://i.imgur.com/TYbrxwf.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
