### PR TITLE
Fixed css/main.css route

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -307,7 +307,7 @@ function execute(port, options) {
     }
   });
 
-  app.get(/main\.css$/, (req, res) => {
+  app.get(`${siteConfig.baseUrl}css/main.css`, (req, res) => {
     const mainCssPath = join(
       __dirname,
       '..',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When using `docusaurus-start` a server [treats any request that ends with `main.css`](https://github.com/facebook/Docusaurus/blob/e79e67ad2b765e0f4124a4325ad3d4e555a763c3/lib/server/server.js#L310) as one to serve `css/main.css`. That could break some custom assets in `static` dir that also have `main.css` name.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1. `css/main.css` is served:
    - run `docusarus-start` 
    - ensured a home page loads `css/main.css`
1. `css/main.css` and custom main.css are served:
    - added `api/main.css` to `static` dir
    - updated `siteConfig.js` with `separateCss: ["static/api"]`
    - run `docusarus-start`
    - ensured both `css/main.css` and `api/main.css` are served


## Related PRs

None.
