### PR TITLE
Fixed button wrapping behavior on mobile

### DIFF
--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -47,21 +47,16 @@ class DocsLayout extends React.Component {
       idx(i18n, ['localized-strings', 'docs', id, 'title']) || defaultTitle;
     const hasOnPageNav = this.props.config.onPageNav === 'separate';
 
-    const previousTitle = i18n
-      ? translation[this.props.metadata.language]['localized-strings'][
-          metadata.previous_id
-        ] ||
-        translation[this.props.metadata.language]['localized-strings']
-          .previous ||
-        'Previous'
-      : metadata.previous_title || 'Previous';
-    const nextTitle = i18n
-      ? translation[this.props.metadata.language]['localized-strings'][
-          metadata.next_id
-        ] ||
-        translation[this.props.metadata.language]['localized-strings'].next ||
-        'Next'
-      : metadata.next_title || 'Next';
+    const previousTitle =
+      idx(i18n, ['localized-strings', metadata.previous_id]) ||
+      idx(i18n, ['localized-strings', 'previous']) ||
+      metadata.previous_title ||
+      'Previous';
+    const nextTitle =
+      idx(i18n, ['localized-strings', metadata.next_id]) ||
+      idx(i18n, ['localized-strings', 'next']) ||
+      metadata.next_title ||
+      'Next';
 
     return (
       <Site

--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -46,6 +46,23 @@ class DocsLayout extends React.Component {
         ] || this.props.metadata.title
       : this.props.metadata.title;
     const hasOnPageNav = this.props.config.onPageNav === 'separate';
+
+    const previousTitle = i18n
+      ? translation[this.props.metadata.language]['localized-strings'][
+          metadata.previous_id
+        ] ||
+        translation[this.props.metadata.language]['localized-strings']
+          .previous ||
+        'Previous'
+      : metadata.previous_title || 'Previous';
+    const nextTitle = i18n
+      ? translation[this.props.metadata.language]['localized-strings'][
+          metadata.next_id
+        ] ||
+        translation[this.props.metadata.language]['localized-strings'].next ||
+        'Next'
+      : metadata.next_title || 'Next';
+
     return (
       <Site
         config={this.props.config}
@@ -78,16 +95,15 @@ class DocsLayout extends React.Component {
                     metadata.localized_id,
                     metadata.previous_id
                   )}>
-                  ←{' '}
-                  {i18n
-                    ? translation[this.props.metadata.language][
-                        'localized-strings'
-                      ][metadata.previous_id] ||
-                      translation[this.props.metadata.language][
-                        'localized-strings'
-                      ].previous ||
-                      'Previous'
-                    : metadata.previous_title || 'Previous'}
+                  <span className="arrow-prev">← </span>
+                  <span
+                    className={
+                      previousTitle.match(/[a-z][A-Z]/)
+                        ? 'function-name-prevnext'
+                        : 'text-prev'
+                    }>
+                    {previousTitle}
+                  </span>
                 </a>
               )}
               {metadata.next_id && (
@@ -97,16 +113,15 @@ class DocsLayout extends React.Component {
                     metadata.localized_id,
                     metadata.next_id
                   )}>
-                  {i18n
-                    ? translation[this.props.metadata.language][
-                        'localized-strings'
-                      ][metadata.next_id] ||
-                      translation[this.props.metadata.language][
-                        'localized-strings'
-                      ].next ||
-                      'Next'
-                    : metadata.next_title || 'Next'}{' '}
-                  →
+                  <span
+                    className={
+                      nextTitle.match(/[a-z][A-Z]/)
+                        ? 'function-name-prevnext'
+                        : 'text-next'
+                    }>
+                    {nextTitle}
+                  </span>
+                  <span className="arrow-next"> →</span>
                 </a>
               )}
             </div>

--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -98,9 +98,8 @@ class DocsLayout extends React.Component {
                   <span className="arrow-prev">← </span>
                   <span
                     className={
-                      previousTitle.match(/[a-z][A-Z]/)
-                        ? 'function-name-prevnext'
-                        : 'text-prev'
+                      previousTitle.match(/[a-z][A-Z]/) &&
+                      'function-name-prevnext'
                     }>
                     {previousTitle}
                   </span>
@@ -115,9 +114,7 @@ class DocsLayout extends React.Component {
                   )}>
                   <span
                     className={
-                      nextTitle.match(/[a-z][A-Z]/)
-                        ? 'function-name-prevnext'
-                        : 'text-next'
+                      nextTitle.match(/[a-z][A-Z]/) && 'function-name-prevnext'
                     }>
                     {nextTitle}
                   </span>

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1545,8 +1545,13 @@ input::placeholder {
 }
 
 @media only screen and (max-width: 735px) {
-  .docs-prevnext {
-    height: 40px;
+  .docs-next {
+    clear: both;
+    float: left;
+    margin: 10px 0;
+  }
+  .docs-prev {
+    margin: 10px 0;
   }
 }
 /* End of Docs Navigation */

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1550,17 +1550,21 @@ input::placeholder {
     float: left;
     margin: 10px 0;
   }
+
   .docs-prev {
     margin: 10px 0;
   }
+
   .arrow-next {
     float: right;
     margin-left: 10px;
   }
+
   .arrow-prev {
     float: left;
     margin-right: 10px;
   }
+
   .function-name-prevnext {
     width: 200px;
     display: inline-block;

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1553,6 +1553,21 @@ input::placeholder {
   .docs-prev {
     margin: 10px 0;
   }
+  .arrow-next {
+    float: right;
+    margin-left: 10px;
+  }
+  .arrow-prev {
+    float: left;
+    margin-right: 10px;
+  }
+  .function-name-prevnext {
+    width: 200px;
+    display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 /* End of Docs Navigation */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3094,6 +3094,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
       "integrity": "sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg="
     },
+    "deepmerge": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
+      "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w=="
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #918 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1) Visit any doc page where lengthy text on the previous and next buttons caused the buttons to wrap and stack with no space in between (eg https://docusaurus.io/docs/en/navigation)
2) Check that it no longer stacks when the window is <735px. There should be ample space in between and the both buttons should float left.

It should look like this:
<img width="123" alt="screen shot 2018-08-27 at 5 23 31 pm" src="https://user-images.githubusercontent.com/15959269/44688125-400c7100-aa21-11e8-974e-d3147e818ed4.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
