### PR TITLE
fix: transformation of url to cleanUrl / pretty url

### DIFF
--- a/lib/core/__tests__/utils.test.js
+++ b/lib/core/__tests__/utils.test.js
@@ -52,8 +52,10 @@ describe('utils', () => {
     expect(cleanPath('/en/users')).toBe('/en/users');
     expect(cleanPath('/docs/versioning.html')).toBe('/docs/versioning');
     expect(cleanPath('/en/users.html')).toBe('/en/users');
-    expect(cleanPath('/docs/en/asd/index.html')).toBe('/docs/en/asd');
-    expect(cleanPath('/en/help/index.html')).toBe('/en/help');
+    expect(cleanPath('/docs/en/asd/index.html')).toBe('/docs/en/asd/');
+    expect(cleanPath('/en/help/index.html')).toBe('/en/help/');
+    expect(cleanPath('/index.html')).toBe('/');
+    expect(cleanPath('/react/index.html')).toBe('/react/');
     expect(cleanPath('/en/help.a.b.c.d.e.html')).toBe('/en/help.a.b.c.d.e');
     expect(cleanPath('/en/help.js')).toBe('/en/help.js');
     expect(cleanPath('/test.md')).toBe('/test.md');

--- a/lib/core/__tests__/utils.test.js
+++ b/lib/core/__tests__/utils.test.js
@@ -39,20 +39,27 @@ describe('utils', () => {
   });
 
   test('getPath', () => {
-    expect(utils.getPath('/docs/en/versioning.html', true)).toBe(
-      '/docs/en/versioning'
-    );
-    expect(utils.getPath('/en/users.html', true)).toBe('/en/users');
-    expect(utils.getPath('/docs/en/asd/index.html', true)).toBe('/docs/en/asd');
-    expect(utils.getPath('/en/help/index.html', true)).toBe('/en/help');
-    expect(utils.getPath('/en/help.a.b.c.d.e.html', true)).toBe(
-      '/en/help.a.b.c.d.e'
-    );
-    expect(utils.getPath('/en/help.js', true)).toBe('/en/help');
+    // does not change/transform path
+    expect(utils.getPath('/en/users.html', false)).toBe('/en/users.html');
     expect(utils.getPath('/docs/en/versioning.html', false)).toBe(
       '/docs/en/versioning.html'
     );
-    expect(utils.getPath('/en/users.html', false)).toBe('/en/users.html');
+    expect(utils.getPath(undefined, false)).toBeUndefined();
+    expect(utils.getPath(null, false)).toBeNull();
+
+    // transform to pretty/clean path
+    const cleanPath = pathStr => utils.getPath(pathStr, true);
+    expect(cleanPath('/en/users')).toBe('/en/users');
+    expect(cleanPath('/docs/versioning.html')).toBe('/docs/versioning');
+    expect(cleanPath('/en/users.html')).toBe('/en/users');
+    expect(cleanPath('/docs/en/asd/index.html')).toBe('/docs/en/asd');
+    expect(cleanPath('/en/help/index.html')).toBe('/en/help');
+    expect(cleanPath('/en/help.a.b.c.d.e.html')).toBe('/en/help.a.b.c.d.e');
+    expect(cleanPath('/en/help.js')).toBe('/en/help.js');
+    expect(cleanPath('/test.md')).toBe('/test.md');
+    expect(cleanPath('/blog/7.0.0')).toBe('/blog/7.0.0');
+    expect(cleanPath('/test/5.html.2')).toBe('/test/5.html.2');
+    expect(cleanPath('/docs/en/5.2')).toBe('/docs/en/5.2');
   });
 
   test('removeExtension', () => {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -24,7 +24,7 @@ function getPath(pathStr, cleanUrl = false) {
     return pathStr;
   }
   return pathStr.endsWith('/index.html')
-    ? pathStr.replace(/\/index.html$/, '')
+    ? pathStr.replace(/index\.html$/, '')
     : removeExtension(pathStr);
 }
 

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -15,17 +15,17 @@ function extractBlogPostBeforeTruncate(content) {
   return content.split(TRUNCATE_MARKER)[0];
 }
 
-function removeExtension(path) {
-  return path.replace(/\.[^/.]+$/, '');
+function removeExtension(pathStr) {
+  return pathStr.replace(/\.[^/.]+$/, '');
 }
 
-function getPath(path, cleanUrl = false) {
-  if (cleanUrl) {
-    return path.endsWith('/index.html')
-      ? path.replace(/\/index.html$/, '')
-      : removeExtension(path);
+function getPath(pathStr, cleanUrl = false) {
+  if (!pathStr || !cleanUrl || !pathStr.endsWith('.html')) {
+    return pathStr;
   }
-  return path;
+  return pathStr.endsWith('/index.html')
+    ? pathStr.replace(/\/index.html$/, '')
+    : removeExtension(pathStr);
 }
 
 module.exports = {


### PR DESCRIPTION
## Motivation

Fix #922 and https://github.com/babel/website/issues/1780

cc @hzoo 

## Changes

- Pretty/cleanUrl should only remove html extension and not other extension
- Stronger test for the `getPath` function that transform url to clean url.
- cleanUrl of `/react/index.html` should be `/react/` and not `/react`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

```md
//2018-08-27-7.0.0.md
---
layout: post
title:  "Babel 7 Released"
author: Henry Zhu
authorURL: https://twitter.com/left_pad
date:   2018-08-27 18:00:00
categories: announcements
share_text: "Babel 7 Released"
---

After almost 2 years, 4k commits, over 50 pre-releases, and a lot of help we are excited to announce the release of Babel 7. It's been almost [3 years](https://babeljs.io/blog/2015/10/29/6.0.0) since the release of Babel 6! There's a lot of moving parts so please bear with us in the first weeks of release.

<!-- truncate -->

> If you appreciate the work we're doing on Babel, you can sponsor Babel on [Open Collective](https://opencollective.com/babel), support me on [Patreon](https://www.patreon.com/henryzhu), or get you or your company involved with Babel as part of work. We'd appreciate the collective ownership of this vital project in the JavaScript community!

## It's Happening! 🎉

Software is never going to be perfect but we're ready to ship something that's already been used in production for some time now! [`@babel/core`](https://www.npmjs.com/package/@babel/core) is already at 5.1 mil downloads/month because of its usage in tools like [Next.js 6](https://zeit.co/blog/next6), [vue-cli 3.0](https://medium.com/the-vue-point/vue-cli-3-0-is-here-c42bebe28fbb), [React Native 0.56](https://facebook.github.io/react-native/blog/2018/07/04/releasing-react-native-056), and even [Wordpress's frontend](https://github.com/Automattic/wp-calypso) 🙂!

## Babel's Role

I'd like to start this post by re-introducing Babel's [role](https://www.youtube.com/watch?v=fntd0sPMOtQ) in the JavaScript ecosystem over the last few years.
```

Header title URL should be correct now.

![blogtitle](https://user-images.githubusercontent.com/17883920/44695724-231a8100-aaa7-11e8-9107-cd437198a361.gif)
