### PR TITLE
fix: headerNav should link to 'blog/', not 'blog' for consistency

### DIFF
--- a/lib/core/nav/HeaderNav.js
+++ b/lib/core/nav/HeaderNav.js
@@ -210,7 +210,7 @@ class HeaderNav extends React.Component {
       href = link.href;
     } else if (link.blog) {
       // set link to blog url
-      href = `${this.props.baseUrl}blog`;
+      href = `${this.props.baseUrl}blog/`;
     }
     const itemClasses = classNames({
       siteNavGroupActive:


### PR DESCRIPTION
## Motivation

Since at build we created `blog/index.html`, just to be consistent let's link it as `blog/` instead of `blog`

For GitHub Pages, the behavior is as below:

`blog/` -> try `blog/index.html`
`blog` -> try `blog.html`, if 404 then `blog/index.html`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Everything still works

![image](https://user-images.githubusercontent.com/17883920/44849019-587fc400-ac8b-11e8-94a2-7d7f7ee54d0f.png)