### PR TITLE
Add support for Web App Manifest in siteConfig

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -147,6 +147,8 @@ h1 {
 * `defaultLang` defines a default language. It will be used if one is not specified at the top of the code block. You can find the [list of supported languages here](https://github.com/isagalaev/highlight.js/tree/master/src/languages).
 * `themeUrl` is the custom URL of CSS theme file that you want to use with Highlight.js. If this is provided, the `theme` and `version` fields will be ignored.
 
+`manifest` - Local path to your Web App Manifest (e.g., `/manifest.json`). This will add manifest.json to head link with rel as "manifest".
+
 `markdownPlugins` - An array of plugins to be loaded by Remarkable, the markdown parser and renderer used by Docusaurus. The plugin will receive a reference to the Remarkable instance, allowing custom parsing and rendering rules to be defined.
 
 `ogImage` - Local path to an Open Graph image (e.g., `img/myImage.png`). This image will show up when your site is shared on Facebook and other websites/apps where the Open Graph protocol is supported.

--- a/lib/core/Head.js
+++ b/lib/core/Head.js
@@ -66,6 +66,9 @@ class Head extends React.Component {
         {this.props.redirect && (
           <meta httpEquiv="refresh" content={`0; URL=${this.props.redirect}`} />
         )}
+        {this.props.config.manifest && (
+          <link rel="manifest" content={siteUrl + this.props.config.manifest} />
+        )}
         <link
           rel="shortcut icon"
           href={this.props.config.baseUrl + this.props.config.favicon}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
To improve user experience and low load time for re-visiting users, I would like to include a service worker to make it a Progressive Web App. Adding service worker is easy with `scripts` in siteConfig but one would require manifest.json to be able to add it to the home screen. With the current code base, there is no extra field to add manifest.json to the head.

Thus have added an optional field `manifest` in siteConfig and update the `lib/core/Head.js` along with `docs/api-site-config.md` accordingly.

## Test Plan

Well as the code implies if the config key exists then create the `<link />` tag accordingly. No special test cases are required.