### PR TITLE
Fix nav to take full width in the docs page

### DIFF
--- a/lib/core/DocsLayout.js
+++ b/lib/core/DocsLayout.js
@@ -66,7 +66,7 @@ class DocsLayout extends React.Component {
         metadata={metadata}>
         <div className="docMainWrapper wrapper">
           <DocsSidebar metadata={metadata} />
-          <Container className="mainContainer">
+          <Container className="mainContainer docMainContainer">
             <DocComponent
               metadata={metadata}
               content={content}
@@ -116,7 +116,7 @@ class DocsLayout extends React.Component {
               )}
           </Container>
           {hasOnPageNav && (
-            <nav className="onPageNav">
+            <nav className="onPageNav docOnPageNav">
               <OnPageNav rawContent={content} />
             </nav>
           )}

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -712,11 +712,6 @@ blockquote {
   .mainContainer .wrapper .posts .post {
     width: 100%;
   }
-
-  .docMainContainer {
-    flex-basis: 920px !important;
-    flex-grow: 0 !important;
-  }
 }
 /* End of Main Container */
 
@@ -1989,6 +1984,14 @@ input::placeholder {
     .tocToggler {
       display: none;
     }
+  }
+}
+
+
+@media only screen and (min-width: 1024px) {
+  .separateOnPageNav.sideNavVisible .navPusher .docMainContainer {
+    flex-basis: 920px;
+    flex-grow: 0;
   }
 }
 

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1955,6 +1955,11 @@ input::placeholder {
       width: auto;
     }
 
+    .docsNavContainer > :first-child {
+      width: 240px;
+      max-width: 240px;
+    }
+
     .separateOnPageNav.sideNavVisible .navPusher .mainContainer {
       flex: 1 auto;
       max-width: 100%;
@@ -1990,7 +1995,7 @@ input::placeholder {
 
 @media only screen and (min-width: 1024px) {
   .separateOnPageNav.sideNavVisible .navPusher .docMainContainer {
-    flex-basis: 920px;
+    flex-basis: 784px;
     flex-grow: 0;
   }
 }

--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -712,6 +712,11 @@ blockquote {
   .mainContainer .wrapper .posts .post {
     width: 100%;
   }
+
+  .docMainContainer {
+    flex-basis: 920px !important;
+    flex-grow: 0 !important;
+  }
 }
 /* End of Main Container */
 
@@ -1489,7 +1494,8 @@ input::placeholder {
 
 @media only screen and (min-width: 1024px) {
   .docMainWrapper {
-    width: 100%;
+    max-width:100% !important ;
+    margin: 0;
   }
 
   .docMainWrapper > * {
@@ -1564,7 +1570,9 @@ input::placeholder {
 
 @media only screen and (min-width: 1024px) {
   .docsNavContainer {
-    flex: 0 0 240px;
+    flex: 1 0 240px;
+    display: flex;
+    justify-content: flex-end;
     height: calc(100vh - 50px);
     position: -webkit-sticky;
     position: sticky;
@@ -1607,7 +1615,7 @@ input::placeholder {
   }
 
   .separateOnPageNav .docsNavContainer {
-    flex: 0 0 240px;
+    flex: 1 0 240px;
   }
 }
 
@@ -1967,6 +1975,10 @@ input::placeholder {
       position: -webkit-sticky;
       position: sticky;
       top: 90px;
+    }
+
+    .docOnPageNav {
+      flex: 1 0 240px;
     }
 
     .onPageNav > .toc-headings {


### PR DESCRIPTION
Fix #911

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix the Nav in the docs page to take the full width so that when scrolled it does not scroll the main container

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Run the website
2. Put the devtools to be slightly above the nav (so that we can scroll on it)
3. Try to scroll slightly outside the nav text
4. It should scroll the nav instead of the main container

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

No