### PR TITLE
fix: nested static in static breaks build

### DIFF
--- a/lib/server/generate.js
+++ b/lib/server/generate.js
@@ -159,15 +159,12 @@ async function execute() {
   }
 
   // copy all static files from docusaurus
-  files = glob.sync(join(__dirname, '..', 'static', '**'));
+  const libStaticDir = join(__dirname, '..', 'static');
+  files = glob.sync(join(libStaticDir, '**'));
   files.forEach(file => {
     // Why normalize? In case we are on Windows.
     // Remember the nuance of glob: https://www.npmjs.com/package/glob#windows
-    let targetFile = path.normalize(file);
-    targetFile = join(
-      buildDir,
-      targetFile.split(`${sep}static${sep}`)[1] || ''
-    );
+    const targetFile = path.normalize(file).replace(libStaticDir, buildDir);
     // parse css files to replace colors according to siteConfig
     if (file.match(/\.css$/)) {
       let cssContent = fs.readFileSync(file, 'utf8');
@@ -210,7 +207,8 @@ async function execute() {
   });
 
   // Copy all static files from user.
-  files = glob.sync(join(CWD, 'static', '**'), {dot: true});
+  const userStaticDir = join(CWD, 'static');
+  files = glob.sync(join(userStaticDir, '**'), {dot: true});
   files.forEach(file => {
     // Why normalize? In case we are on Windows.
     // Remember the nuance of glob: https://www.npmjs.com/package/glob#windows
@@ -265,8 +263,7 @@ async function execute() {
         fs.copySync(normalizedFile, targetFile);
       });
     } else if (!fs.lstatSync(normalizedFile).isDirectory()) {
-      const parts = normalizedFile.split(`${sep}static${sep}`);
-      const targetFile = join(buildDir, parts[1]);
+      const targetFile = normalizedFile.replace(userStaticDir, buildDir);
       mkdirp.sync(path.dirname(targetFile));
       fs.copySync(normalizedFile, targetFile);
     }
@@ -284,18 +281,19 @@ async function execute() {
   const enabledLanguages = env.translation
     .enabledLanguages()
     .map(lang => lang.tag);
-  files = glob.sync(join(CWD, 'pages', '**'));
+  const userPagesDir = join(CWD, 'pages');
+  files = glob.sync(join(userPagesDir, '**'));
   files.forEach(file => {
     // Why normalize? In case we are on Windows.
     // Remember the nuance of glob: https://www.npmjs.com/package/glob#windows
     const normalizedFile = path.normalize(file);
+    const relativeFile = normalizedFile.replace(userPagesDir, '');
     // render .js files to strings
     if (normalizedFile.match(/\.js$/)) {
       const pageID = path.basename(normalizedFile, '.js');
 
       // make temp file for sake of require paths
-      const parts = normalizedFile.split('pages');
-      let tempFile = join(__dirname, '..', 'pages', parts[1]);
+      let tempFile = join(__dirname, '..', 'pages', relativeFile);
       tempFile = tempFile.replace(
         path.basename(normalizedFile),
         `temp${path.basename(normalizedFile)}`
@@ -305,11 +303,11 @@ async function execute() {
 
       const ReactComp = require(tempFile);
 
-      let targetFile = join(buildDir, parts[1]);
+      let targetFile = join(buildDir, relativeFile);
       targetFile = targetFile.replace(/\.js$/, '.html');
 
       const regexLang = new RegExp(
-        `${escapeStringRegexp(`${sep}pages${sep}`)}(.*)${escapeStringRegexp(
+        `${escapeStringRegexp(`${userPagesDir}${sep}`)}(.*)${escapeStringRegexp(
           sep
         )}`
       );
@@ -384,8 +382,7 @@ async function execute() {
       fs.removeSync(tempFile);
     } else if (siteConfig.wrapPagesHTML && normalizedFile.match(/\.html$/)) {
       const pageID = path.basename(normalizedFile, '.html');
-      const parts = normalizedFile.split('pages');
-      const targetFile = join(buildDir, parts[1]);
+      const targetFile = join(buildDir, relativeFile);
       const str = renderToStaticMarkupWithDoctype(
         <Site language="en" config={siteConfig} metadata={{id: pageID}}>
           <div
@@ -399,8 +396,7 @@ async function execute() {
       writeFileAndCreateFolder(targetFile, str);
     } else if (!fs.lstatSync(normalizedFile).isDirectory()) {
       // copy other non .js files
-      const parts = normalizedFile.split('pages');
-      const targetFile = join(buildDir, parts[1]);
+      const targetFile = join(buildDir, relativeFile);
       mkdirp.sync(path.dirname(targetFile));
       fs.copySync(normalizedFile, targetFile);
     }


### PR DESCRIPTION
## Motivation

Fix #940 

If a user uses something like `storybook` which generates a `static` folder as well, `docusaurus-build` can break.
While this is no longer an issue in v2 implementation, we should still fix this in the current version

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try the reproducible demo of #940 

Use this PR's change

<img width="571" alt="fixed" src="https://user-images.githubusercontent.com/17883920/45379327-55dd8100-b632-11e8-84d5-53da4cbb3056.PNG">

cc @dakmoR
