### PR TITLE
refactor(v2): better page `preloading`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "url": "https://github.com/facebook/Docusaurus.git"
   },
   "scripts": {
+    "lint:v1": "cd v1 && yarn lint",
+    "lint:v2": "cd v2 && yarn lint",
     "precommit": "lint-staged",
     "prettier": "prettier --config .prettierrc --write \"**/*.js\"",
     "prettier:diff": "prettier --config .prettierrc --list-different \"**/*.js\"",
@@ -17,7 +19,7 @@
   },
   "lint-staged": {
     "linters": {
-      "{v1,v2}/**/*.js": ["yarn lint --fix", "yarn prettier", "git add"]
+      "{v1,v2}/**/*.js": ["yarn lint:v1 --fix", "yarn lint:v2 --fix", "yarn prettier", "git add"]
     }
   }
 }

--- a/v2/lib/core/clientEntry.js
+++ b/v2/lib/core/clientEntry.js
@@ -1,14 +1,13 @@
 import React from 'react';
+import Loadable from 'react-loadable';
 import {BrowserRouter} from 'react-router-dom';
 import ReactDOM from 'react-dom';
 
 import App from './App';
-import prerender from './prerender';
-import routes from '@generated/routes'; // eslint-disable-line
 
 // Client side render (e.g: running in browser) to become single-page application (SPA)
-if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-  prerender(routes, window.location.pathname).then(() => {
+if (typeof document !== 'undefined') {
+  Loadable.preloadReady().then(() => {
     ReactDOM.render(
       <BrowserRouter>
         <App />

--- a/v2/lib/core/preload.js
+++ b/v2/lib/core/preload.js
@@ -4,7 +4,7 @@ import {matchRoutes} from 'react-router-config';
  * This helps us to make sure all the async component for that particular route
  * is loaded before rendering. This is to avoid loading screens on first page load
  */
-export default function prerender(routeConfig, providedLocation) {
+export default function preload(routeConfig, providedLocation) {
   const matches = matchRoutes(routeConfig, providedLocation);
   return Promise.all(
     matches.map(match => {

--- a/v2/lib/core/serverEntry.js
+++ b/v2/lib/core/serverEntry.js
@@ -4,13 +4,13 @@ import ReactDOMServer from 'react-dom/server';
 import Helmet from 'react-helmet';
 
 import App from './App';
-import prerender from './prerender';
+import preload from './preload';
 import routes from '@generated/routes'; // eslint-disable-line
 import webpackClientStats from '@build/client.stats.json'; //eslint-disable-line
 
 // Renderer for static-site-generator-webpack-plugin (async rendering via promises)
 export default function render(locals) {
-  return prerender(routes, locals.path).then(() => {
+  return preload(routes, locals.path).then(() => {
     const context = {};
     const appHtml = ReactDOMServer.renderToString(
       <StaticRouter location={locals.path} context={context}>


### PR DESCRIPTION
## Motivation

- Fix linting precommit
- Use native react-loadable `preloadReady` on client
- Rename `prerender` to `preload` since that is what is it actually doing (to avoid bunch of loading screens on first page)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before
<img width="493" alt="capture" src="https://user-images.githubusercontent.com/17883920/45893883-4c58d380-bdff-11e8-9171-28e8136297c8.PNG">

After
<img width="695" alt="after" src="https://user-images.githubusercontent.com/17883920/45893890-4f53c400-bdff-11e8-9353-1e73e14813f4.PNG">

For the website, still works normally
