### PR TITLE
docs: fix broken header image link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <p align="center">Docusaurus</p>
-  <a href="https://docusaurus.io"><img src="/website/static/img/slash-introducing.svg" alt="Docusaurus"></a>
+  <a href="https://docusaurus.io"><img src="/v1/website/static/img/slash-introducing.svg" alt="Docusaurus"></a>
 </h1>
 
 <p align="center">


### PR DESCRIPTION
## Motivation

The main header image in the readme has been broken for a while since the repo was reorganized into v1 and v2 folders.  I don't know if you're going to keep reorganizing things, in which case you might want to fix this issue differently, but this one-liner just uses the image from the v1 folder.  So feel free to take or leave this PR ! :)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

N/A