### PR TITLE
Fix last updated time misleading, only show when file content change or otherwise when it first created

### DIFF
--- a/v1/lib/core/__tests__/utils.test.js
+++ b/v1/lib/core/__tests__/utils.test.js
@@ -99,32 +99,38 @@ describe('utils', () => {
     fs.unlinkSync(tempFilePath);
 
     // test renaming and moving file
+
     const tempFilePath2 = path.join(__dirname, '__fixtures__', '.temp2');
-    fs.writeFileSync(tempFilePath2, 'Lorem ipsum :)');
-
-    shell.exec(`git add ${tempFilePath2}`);
-    shell.exec(`git commit -m "Create new file" --only ${tempFilePath2}`);
-
-    const createTime = utils.getGitLastUpdated(tempFilePath2);
-    expect(typeof createTime).toBe('string');
-
-    // rename / move the file
-    fs.mkdirSync(path.join(__dirname, '__fixtures__', 'test'));
     const tempFilePath3 = path.join(
       __dirname,
       '__fixtures__',
       'test',
       '.temp3',
     );
-    shell.exec(`git mv ${tempFilePath2} ${tempFilePath3}`);
-    shell.exec(`git commit -m "Rename the file"`);
 
+    // create new file
+    shell.exec = jest.fn(() => ({
+      stdout:
+        '1539502055\n' +
+        '\n' +
+        ' create mode 100644 v1/lib/core/__tests__/__fixtures__/.temp2\n',
+    }));
+    const createTime = utils.getGitLastUpdated(tempFilePath2);
+    expect(typeof createTime).toBe('string');
+
+    // rename / move the file
+    shell.exec = jest.fn(() => ({
+      stdout:
+        '1539502056\n' +
+        '\n' +
+        ' rename v1/lib/core/__tests__/__fixtures__/{.temp2 => test/.temp3} (100%)\n' +
+        '1539502055\n' +
+        '\n' +
+        ' create mode 100644 v1/lib/core/__tests__/__fixtures__/.temp2\n',
+    }));
     const lastUpdateTime = utils.getGitLastUpdated(tempFilePath3);
+    // should only consider file content change
     expect(lastUpdateTime).toEqual(createTime);
-
-    fs.unlinkSync(tempFilePath3);
-    fs.rmdirSync(path.join(__dirname, '__fixtures__', 'test'));
-    shell.exec(`git reset HEAD^^`);
   });
 
   test('idx', () => {

--- a/v1/lib/core/__tests__/utils.test.js
+++ b/v1/lib/core/__tests__/utils.test.js
@@ -7,6 +7,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const shell = require('shelljs');
 const utils = require('../utils');
 
 const blogPostWithTruncateContents = fs.readFileSync(
@@ -96,6 +97,34 @@ describe('utils', () => {
     fs.writeFileSync(tempFilePath, 'Lorem ipsum :)');
     expect(utils.getGitLastUpdated(tempFilePath)).toBeNull();
     fs.unlinkSync(tempFilePath);
+
+    // test renaming and moving file
+    const tempFilePath2 = path.join(__dirname, '__fixtures__', '.temp2');
+    fs.writeFileSync(tempFilePath2, 'Lorem ipsum :)');
+
+    shell.exec(`git add ${tempFilePath2}`);
+    shell.exec(`git commit -m "Create new file" --only ${tempFilePath2}`);
+
+    const createTime = utils.getGitLastUpdated(tempFilePath2);
+    expect(typeof createTime).toBe('string');
+
+    // rename / move the file
+    fs.mkdirSync(path.join(__dirname, '__fixtures__', 'test'));
+    const tempFilePath3 = path.join(
+      __dirname,
+      '__fixtures__',
+      'test',
+      '.temp3',
+    );
+    shell.exec(`git mv ${tempFilePath2} ${tempFilePath3}`);
+    shell.exec(`git commit -m "Rename the file"`);
+
+    const lastUpdateTime = utils.getGitLastUpdated(tempFilePath3);
+    expect(lastUpdateTime).toEqual(createTime);
+
+    fs.unlinkSync(tempFilePath3);
+    fs.rmdirSync(path.join(__dirname, '__fixtures__', 'test'));
+    shell.exec(`git reset HEAD^^`);
   });
 
   test('idx', () => {

--- a/v1/lib/core/utils.js
+++ b/v1/lib/core/utils.js
@@ -61,11 +61,13 @@ function getGitLastUpdated(filepath) {
     .split('\n')
     .filter(String);
 
-  const timeSpan = records.find((item, index, arr) =>
-    // The correct timeSpan will be a number which is not followed by summary meaning
-    // the next element is also a number OR it is the last 2 element (since the
-    // last element will always be the summary -- 'create mode ... ')
-    isNormalInteger(item) && (index + 2 === arr.length || isNormalInteger(arr[index + 1]))
+  const timeSpan = records.find(
+    (item, index, arr) =>
+      // The correct timeSpan will be a number which is not followed by summary meaning
+      // the next element is also a number OR it is the last 2 element (since the
+      // last element will always be the summary -- 'create mode ... ')
+      isNormalInteger(item) &&
+      (index + 2 === arr.length || isNormalInteger(arr[index + 1])),
   );
   if (timeSpan) {
     const date = new Date(parseInt(timeSpan, 10) * 1000);


### PR DESCRIPTION


## Motivation

Fix #1015 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. run `git log --follow --summary [some file relative path]
2. see the result and capture the last date where commit is about content change not rename / move
3. Run the localhost for v1 (`cd v1 && yarn start`), check in the site

## Related PRs

No
