### PR TITLE
docs: reorganize siteConfig entry (#436)

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -17,21 +17,27 @@ The `siteConfig` object contains the bulk of the configuration settings for your
 
 ### Mandatory Fields
 
-`baseUrl` - baseUrl for your site. For example, `/pages/org/project/` is the baseUrl of https://git.facebook.com/pages/org/project/
+#### `baseUrl` [string]
+baseUrl for your site. For example, `/pages/org/project/` is the baseUrl of https://git.facebook.com/pages/org/project/
 
-`colors` - Color configurations for the site.
+#### `colors` [object]
+Color configurations for the site.
 
 * `primaryColor` is the color used the header navigation bar and sidebars.
 * `secondaryColor` is the color seen in the second row of the header navigation bar when the site window is narrow (including on mobile).
 * Custom color configurations can also be added. For example, if user styles are added with colors specified as `$myColor`, then adding a `myColor` field to `colors` will allow you to easily configure this color.
 
-`copyright` - The copyright string at footer of site and within feed
+#### `copyright` [string]
+The copyright string at footer of site and within feed
 
-`favicon` - URL for site favicon.
+#### `favicon` [string]
+URL for site favicon.
 
-`headerIcon` - URL for icon used in header navigation bar.
+#### `headerIcon` [string]
+URL for icon used in header navigation bar.
 
-`headerLinks` - Links that will be used in the header navigation bar. The `label` field of each object will be the link text and will also be translated for each language.
+#### `headerLinks` [array]
+Links that will be used in the header navigation bar. The `label` field of each object will be the link text and will also be translated for each language.
 
 Example Usage:
 
@@ -52,35 +58,47 @@ headerLinks: [
 ],
 ```
 
-`noIndex` - Boolean. If true, Docusaurus will politely ask crawlers and search engines to avoid indexing your site. This is done with a header tag and so only applies to docs and pages. Will not attempt to hide static resources. This is a best effort request. Malicious crawlers can and will still index your site.
+#### `noIndex` [boolean]
+Boolean. If true, Docusaurus will politely ask crawlers and search engines to avoid indexing your site. This is done with a header tag and so only applies to docs and pages. Will not attempt to hide static resources. This is a best effort request. Malicious crawlers can and will still index your site.
 
-`organizationName` - GitHub username of the organization or user hosting this project. This is used by the publishing script to determine where your GitHub pages website will be hosted.
+#### `organizationName` [string]
+GitHub username of the organization or user hosting this project. This is used by the publishing script to determine where your GitHub pages website will be hosted.
 
-`projectName` - Project name. This must match your GitHub repository project name (case-sensitive).
+#### `projectName` [string]
+Project name. This must match your GitHub repository project name (case-sensitive).
 
-`tagline` - Tagline for your website.
+#### `tagline` [string]
+Tagline for your website.
 
-`title` - Title for your website.
+#### `title` [string]
+Title for your website.
 
-`url` - URL for your website.
+#### `url` [string]
+URL for your website.
 
 ### Optional Fields
 
-`algolia` - Information for Algolia search integration. If this field is excluded, the search bar will not appear in the header. You must specify two values for this field, and one (`appId`) is optional.
+#### `algolia` [object]
+Information for Algolia search integration. If this field is excluded, the search bar will not appear in the header. You must specify two values for this field, and one (`appId`) is optional.
 
 * `apiKey` - the Algolia provided API key for your search.
 * `indexName` - the Algolia provided index name for your search (usually this is the project name)
 * `appId` - Algolia provides a default scraper for your docs. If you provide your own, you will probably get this id from them.
 
-`blogSidebarCount` - Control the number of blog posts that show up in the sidebar. See the [adding a blog docs](guides-blog.md#changing-how-many-blog-posts-show-on-sidebar) for more information.
+#### `blogSidebarCount` [number]
+Control the number of blog posts that show up in the sidebar. See the [adding a blog docs](guides-blog.md#changing-how-many-blog-posts-show-on-sidebar) for more information.
 
-`blogSidebarTitle` - Control the title of the blog sidebar. See the [adding a blog docs](guides-blog.md#changing-the-sidebar-title) for more information.
+#### `blogSidebarTitle` [string]
+Control the title of the blog sidebar. See the [adding a blog docs](guides-blog.md#changing-the-sidebar-title) for more information.
 
-`cleanUrl` - If `true`, allow URLs with no `html` extension. For example, a request to URL https://docusaurus.io/docs/installation will returns the same result as https://docusaurus.io/docs/installation.html.
+#### `cleanUrl` [string]
+If `true`, allow URLs with no `html` extension. For example, a request to URL https://docusaurus.io/docs/installation will returns the same result as https://docusaurus.io/docs/installation.html.
 
-`cname` - The CNAME for your website. It will go into a `CNAME` file when your site is built.
+#### `cname` [string]
+The CNAME for your website. It will go into a `CNAME` file when your site is built.
 
-`customDocsPath` - By default, Docusaurus expects your documentation to be in a directory called `docs`. This directory is at the same level as the `website` directory (i.e., not inside the `website` directory). You can specify a custom path to your documentation with this field.
+#### `customDocsPath` [string]
+By default, Docusaurus expects your documentation to be in a directory called `docs`. This directory is at the same level as the `website` directory (i.e., not inside the `website` directory). You can specify a custom path to your documentation with this field.
 
 ```js
 customDocsPath: 'docs/site';
@@ -90,23 +108,32 @@ customDocsPath: 'docs/site';
 customDocsPath: 'website-docs';
 ```
 
-`defaultVersionShown` - The default version for the site to be shown. If this is not set, the latest version will be shown.
+#### `defaultVersionShown` [string]
+The default version for the site to be shown. If this is not set, the latest version will be shown.
 
-`disableHeaderTitle` - An option to disable showing the title in the header next to the header icon. Exclude this field to keep the header as normal, otherwise set to `true`.
+#### `disableHeaderTitle` [boolean]
+An option to disable showing the title in the header next to the header icon. Exclude this field to keep the header as normal, otherwise set to `true`.
 
-`disableTitleTagline` - An option to disable showing the tagline in the title of main pages. Exclude this field to keep page titles as `Title • Tagline`. Set to `true` to make page titles just `Title`.
+#### `disableTitleTagline` [boolean]
+An option to disable showing the tagline in the title of main pages. Exclude this field to keep page titles as `Title • Tagline`. Set to `true` to make page titles just `Title`.
 
-`editUrl` - URL for editing docs, usage example: `editUrl + 'en/doc1.md'`. If this field is omitted, there will be no "Edit this Doc" button for each document.
+#### `editUrl` [string]
+URL for editing docs, usage example: `editUrl + 'en/doc1.md'`. If this field is omitted, there will be no "Edit this Doc" button for each document.
 
-`enableUpdateTime` - An option to enable the docs showing last update time. Set to `true` to show a line at the bottom right corner of each doc page as `Last Updated: dd/mm/yyyy hh:MM:ss Z`.
+#### `enableUpdateTime` [string]
+An option to enable the docs showing last update time. Set to `true` to show a line at the bottom right corner of each doc page as `Last Updated: dd/mm/yyyy hh:MM:ss Z`.
 
-`facebookAppId` - If you want Facebook Like/Share buttons in the footer and at the bottom of your blog posts, provide a [Facebook application id](https://www.facebook.com/help/audiencenetwork/804209223039296).
+#### `facebookAppId` [string]
+If you want Facebook Like/Share buttons in the footer and at the bottom of your blog posts, provide a [Facebook application id](https://www.facebook.com/help/audiencenetwork/804209223039296).
 
-`facebookComments` - Set this to `true` if you want to enable Facebook comments at the bottom of your blog post. `facebookAppId` has to be also set.
+#### `facebookComments` [boolean]
+Set this to `true` if you want to enable Facebook comments at the bottom of your blog post. `facebookAppId` has to be also set.
 
-`facebookPixelId` - [Facebook Pixel](https://www.facebook.com/business/a/facebook-pixel) ID to track page views.
+#### `facebookPixelId` [string]
+[Facebook Pixel](https://www.facebook.com/business/a/facebook-pixel) ID to track page views.
 
-`fonts` - Font-family CSS configuration for the site. If a font family is specified in `siteConfig.js` as `$myFont`, then adding a `myFont` key to an array in `fonts` will allow you to configure the font. Items appearing earlier in the array will take priority of later elements, so ordering of the fonts matter.
+#### `fonts` [object]
+Font-family CSS configuration for the site. If a font family is specified in `siteConfig.js` as `$myFont`, then adding a `myFont` key to an array in `fonts` will allow you to configure the font. Items appearing earlier in the array will take priority of later elements, so ordering of the fonts matter.
 
 In the below example, we have two sets of font configurations, `myFont` and `myOtherFont`. `Times New Roman` is the preferred font in `myFont`. `-apple-system` is the preferred in `myOtherFont`.
 
@@ -131,59 +158,102 @@ h1 {
 }
 ```
 
-`footerIcon` - URL for a footer icon. Currently used in the `core/Footer.js` file provided as an example, but it can be removed from that file.
+#### `footerIcon` [string]
+URL for a footer icon. Currently used in the `core/Footer.js` file provided as an example, but it can be removed from that file.
 
-`gaTrackingId` - Google Analytics tracking ID to track page views.
+#### `gaTrackingId` [string]
+Google Analytics tracking ID to track page views.
 
-`gaGtag` - Set this to `true` if you want to use [global site tags (gtag.js)](https://developers.google.com/gtagjs/) for Google analytics instead of `analytics.js`.
+#### `gaGtag` [boolean]
+Set this to `true` if you want to use [global site tags (gtag.js)](https://developers.google.com/gtagjs/) for Google analytics instead of `analytics.js`.
 
-`githubHost` - Hostname of your server. Useful if you are using GitHub Enterprise.
+#### `githubHost` [string]
+Hostname of your server. Useful if you are using GitHub Enterprise.
 
-`highlight` - [Syntax highlighting](api-doc-markdown.md) options:
+#### `highlight`
+[Syntax highlighting](api-doc-markdown.md) options:
 
-* `theme` is the name of the theme used by Highlight.js when highlighting code. You can find the [list of supported themes here](https://github.com/isagalaev/highlight.js/tree/master/src/styles).
-* `version` specifies a particular version of Highlight.js to be used.
-* `hljs` provides an escape valve by passing an instance of Highlight.js to the function specified here, allowing additional languages to be registered for syntax highlighting.
-* `defaultLang` defines a default language. It will be used if one is not specified at the top of the code block. You can find the [list of supported languages here](https://github.com/isagalaev/highlight.js/tree/master/src/languages).
-* `themeUrl` is the custom URL of CSS theme file that you want to use with Highlight.js. If this is provided, the `theme` and `version` fields will be ignored.
+```js
+{
+  // ...
+  highlight: {
+    // The name of the theme used by Highlight.js when highlighting code.
+    // You can find the list of supported themes here: 
+    // https://github.com/isagalaev/highlight.js/tree/master/src/styles
+    theme: 'default',
 
-`manifest` - Path to your web app manifest (e.g., `/manifest.json`). This will add a `<link>` tag to `<head>` with `rel` as `"manifest"` and `content` as the provided path.
+    // The particular version of Highlight.js to be used.
+    version: '9.12.0',
 
-`markdownOptions` - Override default [Remarkable options](https://github.com/jonschlinkert/remarkable#options) that will be used to render markdown.
+    // Escape valve by passing an instance of Highlight.js to the function specified here, allowing additional languages to be registered for syntax highlighting.
+    hljs: function(highlightJsInstance) {
+      // do something here
+    },
 
-`markdownPlugins` - An array of plugins to be loaded by Remarkable, the markdown parser and renderer used by Docusaurus. The plugin will receive a reference to the Remarkable instance, allowing custom parsing and rendering rules to be defined.
+    // Default language. 
+    // It will be used if one is not specified at the top of the code block. You can find the list of supported languages here:
+    // https://github.com/isagalaev/highlight.js/tree/master/src/languages
 
-`ogImage` - Local path to an Open Graph image (e.g., `img/myImage.png`). This image will show up when your site is shared on Facebook and other websites/apps where the Open Graph protocol is supported.
+    defaultLang: 'javascript',
 
-`onPageNav` - If you want a visible navigation option for representing topics on the current page. Currently, there is one accepted value for this option:
+    // custom URL of CSS theme file that you want to use with Highlight.js. If this is provided, the `theme` and `version` fields will be ignored.
+    themeUrl: 'http://foo.bar/custom.css'
+  },
+}
+```
+
+#### `manifest` [string]
+Path to your web app manifest (e.g., `/manifest.json`). This will add a `<link>` tag to `<head>` with `rel` as `"manifest"` and `content` as the provided path.
+
+#### `markdownPlugins` [array]
+An array of plugins to be loaded by Remarkable, the markdown parser and renderer used by Docusaurus. The plugin will receive a reference to the Remarkable instance, allowing custom parsing and rendering rules to be defined.
+
+#### `ogImage` [string]
+Local path to an Open Graph image (e.g., `img/myImage.png`). This image will show up when your site is shared on Facebook and other websites/apps where the Open Graph protocol is supported.
+
+#### `onPageNav` [string]
+If you want a visible navigation option for representing topics on the current page. Currently, there is one accepted value for this option:
 
 * `separate` - The secondary navigation is a separate pane defaulting on the right side of a document. See http://docusaurus.io/docs/en/translation.html for an example.
 
-`scripts` - Array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. Refer to the example below. The script tag will be inserted in the HTML head.
+#### `scripts` [array]
+Array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. Refer to the example below. The script tag will be inserted in the HTML head.
 
-`separateCss` - Directories inside which any `css` files will not be processed and concatenated to Docusaurus' styles. This is to support static `html` pages that may be separate from Docusaurus with completely separate styles.
+#### `separateCss` [string]
+Directories inside which any `css` files will not be processed and concatenated to Docusaurus' styles. This is to support static `html` pages that may be separate from Docusaurus with completely separate styles.
 
-`scrollToTop` - Set this to `true` if you want to enable the scroll to top button at the bottom of your site.
+#### `scrollToTop` [boolean]
+Set this to `true` if you want to enable the scroll to top button at the bottom of your site.
 
-`scrollToTopOptions` - Optional options configuration for the scroll to top button. You do not need to use this, even if you set `scrollToTop` to `true`; it just provides you more configuration control of the button. You can find more options [here](https://github.com/vfeskov/vanilla-back-to-top/blob/v7.1.14/OPTIONS.md). By default, we set the zIndex option to 100.
+#### `scrollToTopOptions` [object]
+Optional options configuration for the scroll to top button. You do not need to use this, even if you set `scrollToTop` to `true`; it just provides you more configuration control of the button. You can find more options [here](https://github.com/vfeskov/vanilla-back-to-top/blob/v7.1.14/OPTIONS.md). By default, we set the zIndex option to 100.
 
-`stylesheets` - Array of CSS sources to load. The values can be either strings or plain objects of attribute-value maps. The link tag will be inserted in the HTML head.
+#### `stylesheets` [array]
+Array of CSS sources to load. The values can be either strings or plain objects of attribute-value maps. The link tag will be inserted in the HTML head.
 
-`translationRecruitingLink` - URL for the `Help Translate` tab of language selection when languages besides English are enabled. This can be included you are using translations but does not have to be.
+#### `translationRecruitingLink` [string]
+URL for the `Help Translate` tab of language selection when languages besides English are enabled. This can be included you are using translations but does not have to be.
 
-`twitter` - Set this to `true` if you want a Twitter social button to appear at the bottom of your blog posts.
+#### `twitter` [boolean]
+Set this to `true` if you want a Twitter social button to appear at the bottom of your blog posts.
 
-`twitterUsername` - If you want a Twitter follow button at the bottom of your page, provide a Twitter username to follow. For example: `docusaurus`.
+#### `twitterUsername` [string]
+If you want a Twitter follow button at the bottom of your page, provide a Twitter username to follow. For example: `docusaurus`.
 
-`twitterImage` - Local path to your Twitter card image (e.g., `img/myImage.png`). This image will show up on the Twitter card when your site is shared on Twitter.
+#### `twitterImage` [string]
+Local path to your Twitter card image (e.g., `img/myImage.png`). This image will show up on the Twitter card when your site is shared on Twitter.
 
-`useEnglishUrl` - If you do not have [translations](guides-translation.md) enabled (e.g., by having a `languages.js` file), but still want a link of the form `/docs/en/doc.html` (with the `en`), set this to `true`.
+#### `useEnglishUrl` [string]
+If you do not have [translations](guides-translation.md) enabled (e.g., by having a `languages.js` file), but still want a link of the form `/docs/en/doc.html` (with the `en`), set this to `true`.
 
-`users` - The `users` array mentioned earlier.
+#### `users` [array]
+The `users` array mentioned earlier.
 
-`usePrism` - Array of languages to use Prism syntax highlighter. Refer to [Using Prism as additional syntax highlighter](api-doc-markdown.md#using-prism-as-additional-syntax-highlighter). Set it to `true` to use Prism on all languages.
+#### `usePrism` [array]
+Array of languages to use Prism syntax highlighter. Refer to [Using Prism as additional syntax highlighter](api-doc-markdown.md#using-prism-as-additional-syntax-highlighter). Set it to `true` to use Prism on all languages.
 
-`wrapPagesHTML` - Boolean flag to indicate whether `html` files in `/pages` should be wrapped with Docusaurus site styles, header and footer. This feature is experimental and relies on the files being `html` fragments instead of complete pages. It inserts the contents of your `html` file with no extra processing. Defaults to `false`.
+#### `wrapPagesHTML` [boolean]
+Boolean flag to indicate whether `html` files in `/pages` should be wrapped with Docusaurus site styles, header and footer. This feature is experimental and relies on the files being `html` fragments instead of complete pages. It inserts the contents of your `html` file with no extra processing. Defaults to `false`.
 
 Users can also add their own custom fields if they wish to provide some data across different files.
 


### PR DESCRIPTION
set the `setConfig` fields to `h4` instead of `li`, will create some spacing and make the docs less clustered.

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
