### PR TITLE
feat: add keyboard shortcut to focus search

### DIFF
--- a/v1/lib/core/Site.js
+++ b/v1/lib/core/Site.js
@@ -107,6 +107,21 @@ class Site extends React.Component {
               }}
             />
           )}
+          {this.props.config.algolia && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
+                document.addEventListener('keyup', function(e) {
+                  // keyCode for '/' (slash)
+                  if (e.keyCode === 191) {
+                    var search = document.getElementById('search_input_react');
+                    search && search.focus();
+                  }
+                });
+              `,
+              }}
+            />
+          )}
           {this.props.config.algolia &&
             (this.props.config.algolia.algoliaOptions ? (
               <script

--- a/v1/lib/core/Site.js
+++ b/v1/lib/core/Site.js
@@ -114,7 +114,7 @@ class Site extends React.Component {
                 document.addEventListener('keyup', function(e) {
                   // keyCode for '/' (slash)
                   if (e.keyCode === 191) {
-                    var search = document.getElementById('search_input_react');
+                    const search = document.getElementById('search_input_react');
                     search && search.focus();
                   }
                 });

--- a/v1/lib/core/Site.js
+++ b/v1/lib/core/Site.js
@@ -112,6 +112,9 @@ class Site extends React.Component {
               dangerouslySetInnerHTML={{
                 __html: `
                 document.addEventListener('keyup', function(e) {
+                  if (e.target !== document.body) {
+                    return;
+                  }
                   // keyCode for '/' (slash)
                   if (e.keyCode === 191) {
                     const search = document.getElementById('search_input_react');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

This PR adds a keyboard shortcut `/` for focusing the search input.

## Motivation

Was browsing the `draft-js` docs and found myself wishing this VIM keyboard shortcut existed since it is becoming more common across various websites. Not sure if where I've put this is the most appropriate place though.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep!

## Test Plan

* Tested locally running `yarn start` from `v1/`
* Would love some suggestions on where/how to add unit tests

![demo](https://github.com/third774/Docusaurus/raw/crafting-pr/focus-search.gif)

## Related PRs

I don't believe this PR is related to any others.
