### PR TITLE
docs: update siteConfig documentation for publishing with GitHub Pages

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -38,12 +38,14 @@ Deploying your Docusaurus site to GitHub Pages is straightforward if you are alr
 
 Most of the work to publish to GitHub pages is done for you automatically through the [`publish-gh-pages`](./api-commands.md#docusaurus-publish) script. You just need to determine the values for a few parameters required by the script.
 
-Two of the required parameters are set in the [`siteConfig.js`](api-site-config.md):
+The following parameters need to be set in the [`siteConfig.js`](api-site-config.md):
 
 | Name               | Description                                                                                                                                                                              |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `organizationName` | The GitHub user or organization that owns the repository. In the case of Docusaurus, that would be the "facebook" GitHub organization.                                                   |
 | `projectName`      | The name of the GitHub repository for your project. For example, Docusaurus is hosted at https://github.com/facebook/docusaurus, so our project name in this case would be "docusaurus". |
+| `url`              | Your website url. For project sites, this will be "https://_username_.github.io" |
+| `baseUrl`          | Base URL for your project. For projects sites, it follows the format "/_projectName_/". For https://github.com/facebook/docusaurus, `baseUrl` is "/docusaurus/" |
 
 > Docusaurus also supports deploying [user or organization sites](https://help.github.com/articles/user-organization-and-project-pages/#user--organization-pages). To do this, just set `projectName` to "_username_.github.io" (where _username_ is your username or organization name on GitHub) and `organizationName` to "_username_".  
 > For user or org sites, the publish script will deploy these sites to the root of the `master` branch of the _username_.github.io repo. In this case, note that you will want to have the Docusaurus infra, your docs, etc. either in another branch of the _username_.github.io repo (e.g., maybe call it `source`), or in another, separated repo (e.g. in the same as the documented source code).

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -44,8 +44,8 @@ The following parameters need to be set in the [`siteConfig.js`](api-site-config
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `organizationName` | The GitHub user or organization that owns the repository. In the case of Docusaurus, that would be the "facebook" GitHub organization.                                                   |
 | `projectName`      | The name of the GitHub repository for your project. For example, Docusaurus is hosted at https://github.com/facebook/docusaurus, so our project name in this case would be "docusaurus". |
-| `url`              | Your website url. For project sites, this will be "https://_username_.github.io" |
-| `baseUrl`          | Base URL for your project. For projects sites, it follows the format "/_projectName_/". For https://github.com/facebook/docusaurus, `baseUrl` is "/docusaurus/" |
+| `url`              | Your website's URL. For projects hosted on GitHub pages, this will be "https://_username_.github.io" |
+| `baseUrl`          | Base URL for your project. For projects hosted on GitHub pages, it follows the format "/_projectName_/". For https://github.com/facebook/docusaurus, `baseUrl` is `/docusaurus/`. |
 
 > Docusaurus also supports deploying [user or organization sites](https://help.github.com/articles/user-organization-and-project-pages/#user--organization-pages). To do this, just set `projectName` to "_username_.github.io" (where _username_ is your username or organization name on GitHub) and `organizationName` to "_username_".  
 > For user or org sites, the publish script will deploy these sites to the root of the `master` branch of the _username_.github.io repo. In this case, note that you will want to have the Docusaurus infra, your docs, etc. either in another branch of the _username_.github.io repo (e.g., maybe call it `source`), or in another, separated repo (e.g. in the same as the documented source code).


### PR DESCRIPTION
Updated publishing docs to resolve #1029

## Motivation

I had trouble publishing my first Docusaurus built site to GitHub pages (as detailed in #1029) and this PR has the updates to the documentation that were needed in order for me to publish my site.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only docs were changed. Run the site an ensure formatting is correct

![image](https://user-images.githubusercontent.com/21183154/46931796-89307880-d001-11e8-8b35-c3cb997af5e7.png)

## Related PRs
