### PR TITLE
feat(v2): support external links & linking to docs from other sidebars

### DIFF
--- a/v2/lib/load/docs/order.js
+++ b/v2/lib/load/docs/order.js
@@ -1,52 +1,66 @@
 // build the docs meta such as next, previous, category and sidebar
+
 module.exports = function createOrder(allSidebars = {}) {
   const order = {};
-  if (!allSidebars) {
-    return order;
-  }
-  Object.keys(allSidebars).forEach(sidebar => {
-    const categories = allSidebars[sidebar];
 
-    let ids = [];
+  Object.keys(allSidebars).forEach(sidebarId => {
+    const sidebar = allSidebars[sidebarId];
+
+    const ids = [];
     const categoryOrder = [];
     const subCategoryOrder = [];
-    Object.keys(categories).forEach(category => {
-      if (Array.isArray(categories[category])) {
-        ids = ids.concat(categories[category]);
-
-        // eslint-disable-next-line
-        for (let i = 0; i < categories[category].length; i++) {
-          categoryOrder.push(category);
-          subCategoryOrder.push(undefined);
+    const indexItems = ({items, categoryLabel, subCategoryLabel}) => {
+      items.forEach(item => {
+        switch (item.type) {
+          case 'category':
+            indexItems({
+              items: item.items,
+              categoryLabel: categoryLabel || item.label,
+              subCategoryLabel: categoryLabel && item.label,
+            });
+            break;
+          case 'ref':
+          case 'link':
+            // refs and links should not be shown in navigation
+            break;
+          case 'doc':
+            ids.push(item.id);
+            categoryOrder.push(categoryLabel);
+            subCategoryOrder.push(subCategoryLabel);
+            break;
+          default:
+            throw new Error(
+              `Unknown item type: ${item.type}. Item: ${JSON.stringify(item)}`,
+            );
         }
-      } else {
-        Object.keys(categories[category]).forEach(subCategory => {
-          ids = ids.concat(categories[category][subCategory]);
+      });
+    };
 
-          // eslint-disable-next-line
-          for (let i = 0; i < categories[category][subCategory].length; i++) {
-            categoryOrder.push(category);
-            subCategoryOrder.push(subCategory);
-          }
-        });
-      }
-    });
+    indexItems({items: sidebar});
 
     // eslint-disable-next-line
     for (let i = 0; i < ids.length; i++) {
       const id = ids[i];
       let previous;
       let next;
-      if (i > 0) previous = ids[i - 1];
-      if (i < ids.length - 1) next = ids[i + 1];
+
+      if (i > 0) {
+        previous = ids[i - 1];
+      }
+
+      if (i < ids.length - 1) {
+        next = ids[i + 1];
+      }
+
       order[id] = {
         previous,
         next,
-        sidebar,
+        sidebar: sidebarId,
         category: categoryOrder[i],
         subCategory: subCategoryOrder[i],
       };
     }
   });
+
   return order;
 };

--- a/v2/lib/load/docs/sidebars.js
+++ b/v2/lib/load/docs/sidebars.js
@@ -2,6 +2,110 @@ const fs = require('fs-extra');
 const path = require('path');
 const {idx} = require('../utils');
 
+/**
+ * Check that item contains only allowed keys
+ *
+ * @param {Object} item
+ * @param {Array<string>} keys
+ */
+function assertItem(item, keys) {
+  const unknownKeys = Object.keys(item).filter(
+    key => !keys.includes(key) && key !== 'type',
+  );
+
+  if (unknownKeys.length) {
+    throw new Error(
+      `Unknown sidebar item keys: ${unknownKeys}. Item: ${JSON.stringify(
+        item,
+      )}`,
+    );
+  }
+}
+
+/**
+ * Normalizes recursively category and all its children. Ensures, that at the end
+ * each item will be an object with the corresponding type
+ *
+ * @param {Array<Object>} category
+ * @param {number} [level=0]
+ *
+ * @return {Array<Object>}
+ */
+function normalizeCategory(category, level = 0) {
+  if (level === 2) {
+    throw new Error(
+      `Can not process ${
+        category.label
+      } category. Categories can be nested only one level deep.`,
+    );
+  }
+
+  assertItem(category, ['items', 'label']);
+
+  if (!Array.isArray(category.items)) {
+    throw new Error(
+      `Error loading ${category.label} category. Category items must be array.`,
+    );
+  }
+
+  const items = category.items.map(item => {
+    switch (item.type) {
+      case 'category':
+        return normalizeCategory(item, level + 1);
+      case 'link':
+        assertItem(item, ['href', 'label']);
+        break;
+      case 'ref':
+        assertItem(item, ['id', 'label']);
+        break;
+      default:
+        if (typeof item === 'string') {
+          return {
+            type: 'doc',
+            id: item,
+          };
+        }
+
+        if (item.type !== 'doc') {
+          throw new Error(`Unknown sidebar item type: ${item.type}`);
+        }
+
+        assertItem(item, ['id', 'label']);
+        break;
+    }
+
+    return item;
+  });
+
+  return {...category, items};
+}
+
+/**
+ * Converts sidebars object to mapping to arrays of sidebar item objects
+ *
+ * @param  {{[key: string]: Object}} sidebars
+ *
+ * @return {{[key: string]: Array<Object>}}
+ */
+function normalizeSidebar(sidebars) {
+  return Object.entries(sidebars).reduce((acc, [sidebarId, sidebar]) => {
+    let normalizedSidebar = sidebar;
+
+    if (!Array.isArray(sidebar)) {
+      // convert sidebar to a more generic structure
+      normalizedSidebar = Object.entries(sidebar).map(([label, items]) => ({
+        type: 'category',
+        label,
+        items,
+      }));
+    }
+
+    acc[sidebarId] = normalizedSidebar.map(item => normalizeCategory(item));
+
+    return acc;
+  }, {});
+}
+
 module.exports = function loadSidebars({siteDir, env}, deleteCache = true) {
   let allSidebars = {};
 
@@ -34,5 +138,6 @@ module.exports = function loadSidebars({siteDir, env}, deleteCache = true) {
       });
     }
   }
-  return allSidebars;
+
+  return normalizeSidebar(allSidebars);
 };

--- a/v2/lib/theme/Sidebar/SidebarCategory.js
+++ b/v2/lib/theme/Sidebar/SidebarCategory.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import styles from './styles.css';
+
+export default function SidebarCategory({
+  label,
+  items,
+  subCategory,
+  renderItem,
+}) {
+  const Heading = subCategory ? 'h4' : 'h3';
+
+  return (
+    <div
+      className={classnames(styles.sidebarGroup, {
+        [styles.sidebarSubGroup]: subCategory,
+      })}
+      key={label}>
+      <Heading
+        className={classnames(
+          styles.sidebarItem,
+          styles.sidebarGroupTitle,
+          styles.sidebarGroupCategoryTitle,
+        )}>
+        {label}
+      </Heading>
+
+      <ul className={styles.sidebarList}>{items.map(renderItem)}</ul>
+    </div>
+  );
+}

--- a/v2/lib/theme/Sidebar/SidebarLink.js
+++ b/v2/lib/theme/Sidebar/SidebarLink.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import {NavLink} from 'react-router-dom';
+import classnames from 'classnames';
+
+import styles from './styles.css';
+
+export default function SidebarLink({href, label}) {
+  const isExternal = /^(https?:|\/\/)/.test(href);
+  const Link = isExternal
+    ? // eslint-disable-next-line jsx-a11y/anchor-has-content
+      ({to, activeClassName, ...linkProps}) => <a {...linkProps} href={to} />
+    : NavLink;
+
+  return (
+    <li className={styles.sidebarListItem}>
+      <Link
+        activeClassName={styles.sidebarLinkActive}
+        className={classnames(styles.sidebarLink, styles.sidebarItem)}
+        to={href}>
+        {label}
+      </Link>
+    </li>
+  );
+}

--- a/v2/lib/theme/Sidebar/styles.css
+++ b/v2/lib/theme/Sidebar/styles.css
@@ -17,6 +17,13 @@
   padding: 8px 12px;
 }
 
+.sidebarGroup {
+}
+
+.sidebarSubGroup {
+  margin-left: 5px;
+}
+
 .sidebarGroupTitle {
   font-size: 1em;
   font-weight: 500;

--- a/v2/lib/theme/Sidebar/styles.css
+++ b/v2/lib/theme/Sidebar/styles.css
@@ -17,11 +17,8 @@
   padding: 8px 12px;
 }
 
-.sidebarGroup {
-}
-
 .sidebarSubGroup {
-  margin-left: 5px;
+  margin-left: 0.25em;
 }
 
 .sidebarGroupTitle {

--- a/v2/test/load/docs/__snapshots__/sidebars.test.js.snap
+++ b/v2/test/load/docs/__snapshots__/sidebars.test.js.snap
@@ -2,43 +2,99 @@
 
 exports[`loadSidebars normal site with sidebars 1`] = `
 Object {
-  "docs": Object {
-    "Getting Started": Array [
-      "installation",
-    ],
-    "Guides": Array [
-      "blog",
-    ],
-  },
+  "docs": Array [
+    Object {
+      "items": Array [
+        Object {
+          "id": "installation",
+          "type": "doc",
+        },
+      ],
+      "label": "Getting Started",
+      "type": "category",
+    },
+    Object {
+      "items": Array [
+        Object {
+          "id": "blog",
+          "type": "doc",
+        },
+      ],
+      "label": "Guides",
+      "type": "category",
+    },
+  ],
 }
 `;
 
 exports[`loadSidebars site with sidebars & versioned sidebars 1`] = `
 Object {
-  "docs": Object {
-    "Getting Started": Array [
-      "installation",
-    ],
-    "Guides": Array [
-      "blog",
-    ],
-  },
-  "version-1.0.0-docs": Object {
-    "Getting Started": Array [
-      "version-1.0.0-installation",
-    ],
-    "Guides": Array [
-      "version-1.0.0-blog",
-    ],
-  },
-  "version-1.0.1-docs": Object {
-    "Getting Started": Array [
-      "version-1.0.1-installation",
-    ],
-    "Guides": Array [
-      "version-1.0.1-blog",
-    ],
-  },
+  "docs": Array [
+    Object {
+      "items": Array [
+        Object {
+          "id": "installation",
+          "type": "doc",
+        },
+      ],
+      "label": "Getting Started",
+      "type": "category",
+    },
+    Object {
+      "items": Array [
+        Object {
+          "id": "blog",
+          "type": "doc",
+        },
+      ],
+      "label": "Guides",
+      "type": "category",
+    },
+  ],
+  "version-1.0.0-docs": Array [
+    Object {
+      "items": Array [
+        Object {
+          "id": "version-1.0.0-installation",
+          "type": "doc",
+        },
+      ],
+      "label": "Getting Started",
+      "type": "category",
+    },
+    Object {
+      "items": Array [
+        Object {
+          "id": "version-1.0.0-blog",
+          "type": "doc",
+        },
+      ],
+      "label": "Guides",
+      "type": "category",
+    },
+  ],
+  "version-1.0.1-docs": Array [
+    Object {
+      "items": Array [
+        Object {
+          "id": "version-1.0.1-installation",
+          "type": "doc",
+        },
+      ],
+      "label": "Getting Started",
+      "type": "category",
+    },
+    Object {
+      "items": Array [
+        Object {
+          "id": "version-1.0.1-blog",
+          "type": "doc",
+        },
+      ],
+      "label": "Guides",
+      "type": "category",
+    },
+  ],
 }
 `;
 

--- a/v2/test/load/docs/order.test.js
+++ b/v2/test/load/docs/order.test.js
@@ -3,16 +3,36 @@ import createOrder from '@lib/load/docs/order';
 describe('createOrder', () => {
   test('multiple sidebars with subcategory', () => {
     const result = createOrder({
-      docs: {
-        Category1: {
-          'Subcategory 1': ['doc1'],
-          'Subcategory 2': ['doc2'],
+      docs: [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [
+            {
+              type: 'category',
+              label: 'Subcategory 1',
+              items: [{type: 'doc', id: 'doc1'}],
+            },
+            {
+              type: 'category',
+              label: 'Subcategory 2',
+              items: [{type: 'doc', id: 'doc2'}],
+            },
+          ],
         },
-        Category2: ['doc3', 'doc4'],
-      },
-      otherDocs: {
-        Category1: ['doc5'],
-      },
+        {
+          type: 'category',
+          label: 'Category2',
+          items: [{type: 'doc', id: 'doc3'}, {type: 'doc', id: 'doc4'}],
+        },
+      ],
+      otherDocs: [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [{type: 'doc', id: 'doc5'}],
+        },
+      ],
     });
     expect(result).toEqual({
       doc1: {
@@ -54,13 +74,25 @@ describe('createOrder', () => {
   });
   test('multiple sidebars without subcategory', () => {
     const result = createOrder({
-      docs: {
-        Category1: ['doc1', 'doc2'],
-        Category2: ['doc3', 'doc4'],
-      },
-      otherDocs: {
-        Category1: ['doc5'],
-      },
+      docs: [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [{type: 'doc', id: 'doc1'}, {type: 'doc', id: 'doc2'}],
+        },
+        {
+          type: 'category',
+          label: 'Category2',
+          items: [{type: 'doc', id: 'doc3'}, {type: 'doc', id: 'doc4'}],
+        },
+      ],
+      otherDocs: [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [{type: 'doc', id: 'doc5'}],
+        },
+      ],
     });
     expect(result).toEqual({
       doc1: {
@@ -103,13 +135,25 @@ describe('createOrder', () => {
 
   test('versioned sidebars', () => {
     const result = createOrder({
-      docs: {
-        Category1: ['doc1'],
-      },
-      'version-1.2.3-docs': {
-        Category1: ['version-1.2.3-doc2'],
-        Category2: ['version-1.2.3-doc1'],
-      },
+      docs: [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [{type: 'doc', id: 'doc1'}],
+        },
+      ],
+      'version-1.2.3-docs': [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [{type: 'doc', id: 'version-1.2.3-doc2'}],
+        },
+        {
+          type: 'category',
+          label: 'Category2',
+          items: [{type: 'doc', id: 'version-1.2.3-doc1'}],
+        },
+      ],
     });
     expect(result).toEqual({
       doc1: {
@@ -136,9 +180,74 @@ describe('createOrder', () => {
     });
   });
 
+  test('multiple sidebars with subcategories, refs and external links', () => {
+    const result = createOrder({
+      docs: [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [
+            {
+              type: 'category',
+              label: 'Subcategory 1',
+              items: [{type: 'link', href: '//example.com', label: 'bar'}],
+            },
+            {
+              type: 'category',
+              label: 'Subcategory 2',
+              items: [{type: 'doc', id: 'doc2'}],
+            },
+            {
+              type: 'category',
+              label: 'Subcategory 1',
+              items: [{type: 'link', href: '//example2.com', label: 'baz'}],
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Category2',
+          items: [{type: 'doc', id: 'doc3'}, {type: 'ref', id: 'doc4'}],
+        },
+      ],
+      otherDocs: [
+        {
+          type: 'category',
+          label: 'Category1',
+          items: [{type: 'doc', id: 'doc5'}],
+        },
+      ],
+    });
+    expect(result).toEqual({
+      doc2: {
+        category: 'Category1',
+        subCategory: 'Subcategory 2',
+        next: 'doc3',
+        previous: undefined,
+        sidebar: 'docs',
+      },
+      doc3: {
+        category: 'Category2',
+        subCategory: undefined,
+        next: undefined,
+        previous: 'doc2',
+        sidebar: 'docs',
+      },
+      doc5: {
+        category: 'Category1',
+        subCategory: undefined,
+        next: undefined,
+        previous: undefined,
+        sidebar: 'otherDocs',
+      },
+    });
+  });
+
   test('edge cases', () => {
     expect(createOrder({})).toEqual({});
-    expect(createOrder(null)).toEqual({});
     expect(createOrder(undefined)).toEqual({});
+    expect(() => createOrder(null)).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot convert undefined or null to object"`,
+    );
   });
 });


### PR DESCRIPTION
This PR implements #827, #868 (v1 PR pending)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR will improve sidebar to support:

* new categories array syntax like in #1026 (but I've changed `ids` to `items`)
* links to docs from other sidebars
* links to other docusaurus non-docs pages
* links to external resources
* possibility to easily add new sidebar items types with any custom options

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have added some examples in `sidebar.json`. It looks like this:

```json
{
  "docs": {
    "Category 1": [
      {
        "type": "link",
        "label": "Github",
        "href": "http://github.com"
      },
      {
        "type": "category",
        "label": "Subcategory 1",
        "items": [
          "foo/bar",
          "foo/baz"
        ]
      },
      {
        "type": "category",
        "label": "Subcategory 2",
        "items": [
          {
            "type": "ref",
            "id": "intro"
          },
          "hello",
          {
            "type": "link",
            "label": "Google",
            "href": "http://google.com"
          }
        ]
      }
    ],
    "Category 2": ["code"]
  },
  "test": {
    "Test Ref links": [
      {
        "type": "doc",
        "id": "intro"
      },
      {
        "type": "ref",
        "id": "code"
      }
    ]
  }
}
```

The `type` field can be one of the following:

* `doc` — low level name for simple link to doc. Should contain `id` field
* `ref` — link to some docId, but without binding this doc to current sidebar. Should contain `id` field
* `link` — the type used to render any link in sidebar (doc and ref are converted to this type too). Should contain `href` and `label` fields
* `category` — category :) should contain `label` and `items` fields (I think this should be a better name, because we will handle not only ids in this array)

I'm normalizing sidebars to this low-level format immediately after reading them (including versioned sidebars) in `v2/lib/load/docs/sidebars.js`. During normalization I'm checking, that all the items contain only allowed fields and that we won't have sub-sub-categories.

Normalized structure is much more predictable and reliable, which allow us to simplify logic (it won't be needed to test for each type of possible sidebar syntaxes in each function) during docs ordering and during sidebar rendering on client side. In future we can even more simplify this by implementing visitor pattern, like in e.g. babel.

### Docs Paginator behavior

I've decided to ignore `ref` and `link` items, when building data for docs paginator. If you send user to `ref` doc, the sidebar will be changed. If you send user to `link` it may even leave our site. I think that's not expected behavior for the user.

### Unit tests

I've added one new test to test for `ref` and `link` processing in order.js. All other cases seems to be covered with older tests after I've fixed them