### PR TITLE
Fix multiple level dir problem

### DIFF
--- a/v1/lib/server/server.js
+++ b/v1/lib/server/server.js
@@ -110,7 +110,7 @@ function execute(port) {
   const app = express();
 
   app.get(routing.docs(siteConfig.baseUrl), (req, res, next) => {
-    const url = req.path.toString().replace(siteConfig.baseUrl, '');
+    const url = decodeURI(req.path.toString().replace(siteConfig.baseUrl, ''));
     const metadata =
       Metadata[
         Object.keys(Metadata).find(id => Metadata[id].permalink === url)

--- a/v1/lib/server/utils.js
+++ b/v1/lib/server/utils.js
@@ -12,7 +12,7 @@ const path = require('path');
 const escapeStringRegexp = require('escape-string-regexp');
 
 function getSubDir(file, refDir) {
-  const subDir = path.dirname(path.relative(refDir, file)).replace('\\', '/');
+  const subDir = path.dirname(path.relative(refDir, file)).replace(/\\/g, '/');
   return subDir !== '.' && !subDir.includes('..') ? subDir : null;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

1. [BUG] While using multiple level directory (like `docs/a/b/c/d.md`), `metadata.id` will be `a/b/c\\d` on windows, caused local devserver read file incorrectly.

2. [BUG] While using filename which should be escaped in URI, which caused local devserver can't find file.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

1. create file `docs/a/b/c/d.md`

2. create file `docs/测试.md`
