### PR TITLE
fix: Previous / next page buttons label

### DIFF
--- a/v1/lib/core/DocsLayout.js
+++ b/v1/lib/core/DocsLayout.js
@@ -60,12 +60,12 @@ class DocsLayout extends React.Component {
     const hasOnPageNav = this.props.config.onPageNav === 'separate';
 
     const previousTitle =
-      idx(i18n, ['localized-strings', metadata.previous_id]) ||
+      idx(i18n, ['localized-strings', 'docs', metadata.previous_id, 'title']) ||
       idx(i18n, ['localized-strings', 'previous']) ||
       metadata.previous_title ||
       'Previous';
     const nextTitle =
-      idx(i18n, ['localized-strings', metadata.next_id]) ||
+      idx(i18n, ['localized-strings', 'docs', metadata.next_id, 'title']) ||
       idx(i18n, ['localized-strings', 'next']) ||
       metadata.next_title ||
       'Next';


### PR DESCRIPTION
## Motivation

Fixes #1078.

The problem was that the path to get the right title wasn't right : `['localized-strings', metadata.previous_id]` was always undefined.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep

