### PR TITLE
feat(v2): rewrite docs loading strategy

### DIFF
--- a/v2/.eslintignore
+++ b/v2/.eslintignore
@@ -2,3 +2,4 @@ generated
 __fixtures__
 dist
 node_modules
+build

--- a/v2/lib/core/App.js
+++ b/v2/lib/core/App.js
@@ -16,7 +16,7 @@ import docsSidebars from '@generated/docsSidebars'; // eslint-disable-line
 import pagesMetadatas from '@generated/pagesMetadatas'; // eslint-disable-line
 import siteConfig from '@generated/siteConfig'; //eslint-disable-line
 
-import DocusaurusContext from './docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 const data = {
   blogMetadatas,

--- a/v2/lib/core/App.js
+++ b/v2/lib/core/App.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React from 'react';
 import {renderRoutes} from 'react-router-config';
 
 import routes from '@generated/routes'; // eslint-disable-line
@@ -15,12 +16,34 @@ import docsSidebars from '@generated/docsSidebars'; // eslint-disable-line
 import pagesMetadatas from '@generated/pagesMetadatas'; // eslint-disable-line
 import siteConfig from '@generated/siteConfig'; //eslint-disable-line
 
-export default () =>
-  renderRoutes(routes, {
-    blogMetadatas,
-    docsMetadatas,
-    docsSidebars,
-    env,
-    pagesMetadatas,
-    siteConfig,
-  });
+import DocusaurusContext from './docusaurus-context';
+
+const data = {
+  blogMetadatas,
+  docsMetadatas,
+  docsSidebars,
+  env,
+  pagesMetadatas,
+  siteConfig,
+};
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      setContext: context => {
+        this.setState(context);
+      },
+    };
+  }
+
+  render() {
+    return (
+      <DocusaurusContext.Provider value={{...data, ...this.state}}>
+        {renderRoutes(routes)}
+      </DocusaurusContext.Provider>
+    );
+  }
+}
+
+export default App;

--- a/v2/lib/core/docusaurus-context.js
+++ b/v2/lib/core/docusaurus-context.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const DocusaurusContext = React.createContext({});
-
-export default DocusaurusContext;

--- a/v2/lib/core/docusaurus-context.js
+++ b/v2/lib/core/docusaurus-context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const DocusaurusContext = React.createContext({});
+
+export default DocusaurusContext;

--- a/v2/lib/docusaurus/context.js
+++ b/v2/lib/docusaurus/context.js
@@ -5,11 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.docContent {
-  margin-bottom: 48px;
-  min-height: calc(100vh - 50px);
-}
+import React from 'react';
 
-.paginatorContainer {
-  margin: 48px 0;
-}
+const DocusaurusContext = React.createContext({});
+
+export default DocusaurusContext;

--- a/v2/lib/docusaurus/head.js
+++ b/v2/lib/docusaurus/head.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import Helmet from 'react-helmet';
 

--- a/v2/lib/docusaurus/head.js
+++ b/v2/lib/docusaurus/head.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Helmet from 'react-helmet';
+
+function Head(props) {
+  return <Helmet {...props} />;
+}
+
+export default Head;

--- a/v2/lib/load/routes.js
+++ b/v2/lib/load/routes.js
@@ -6,10 +6,12 @@
  */
 
 async function genRoutesConfig({
+  siteConfig = {},
   docsMetadatas = {},
   pagesMetadatas = [],
   blogMetadatas = [],
 }) {
+  const {docsUrl, baseUrl} = siteConfig;
   function genDocsRoute(metadata) {
     const {permalink, source} = metadata;
     return `
@@ -31,9 +33,10 @@ async function genRoutesConfig({
       }`;
   }
 
+  const rootDocsUrl = baseUrl + docsUrl;
   const docsRoutes = `
   {
-    path: '/docs',
+    path: '${rootDocsUrl}',
     component: Doc,
     routes: [${Object.values(docsMetadatas)
       .map(genDocsRoute)

--- a/v2/lib/load/routes.js
+++ b/v2/lib/load/routes.js
@@ -13,36 +13,41 @@ async function genRoutesConfig({
   function genDocsRoute(metadata) {
     const {permalink, source} = metadata;
     return `
-  {
-    path: ${JSON.stringify(permalink)},
-    exact: true,
-    component: Loadable({
-      loader: () => import(/* webpackPrefetch: true */ ${JSON.stringify(
-        source,
-      )}),
-      loading: Loading,
-      render(loaded, props) {
-        let Content = loaded.default;
-        return (
-          <Doc {...props} metadata={${JSON.stringify(metadata)}}>
-            <Content />
-          </Doc>
-        );
-      }
-    })
-  }`;
+      {
+        path: '${permalink}',
+        exact: true,
+        component: Loadable({
+          loader: () => import(/* webpackPrefetch: true */ '${source}'),
+          loading: Loading,
+          render(loaded, props) {
+            let Content = loaded.default;
+            return (
+              <DocBody {...props} metadata={${JSON.stringify(metadata)}}>
+                <Content />
+              </DocBody>
+            );
+          }
+        })
+      }`;
   }
+
+  const docsRoutes = `
+  {
+    path: '/docs',
+    component: Doc,
+    routes: [${Object.values(docsMetadatas)
+      .map(genDocsRoute)
+      .join(',')}],
+  }`;
 
   function genPagesRoute(metadata) {
     const {permalink, source} = metadata;
     return `
   {
-    path: ${JSON.stringify(permalink)},
+    path: '${permalink}',
     exact: true,
     component: Loadable({
-      loader: () => import(/* webpackPrefetch: true */ ${JSON.stringify(
-        source,
-      )}),
+      loader: () => import(/* webpackPrefetch: true */ '${source}'),
       loading: Loading,
       render(loaded, props) {
         let Content = loaded.default;
@@ -62,16 +67,16 @@ async function genRoutesConfig({
       const {posts} = metadata;
       return `
   {
-    path: ${JSON.stringify(permalink)},
+    path: '${permalink}',
     exact: true,
     component: Loadable.Map({
       loader: {
         ${posts
           .map(
             (p, i) =>
-              `post${i}: () => import(/* webpackPrefetch: true */ ${JSON.stringify(
-                p.source,
-              )})`,
+              `post${i}: () => import(/* webpackPrefetch: true */ '${
+                p.source
+              }')`,
           )
           .join(',\n\t\t\t\t')}
       },
@@ -92,12 +97,10 @@ async function genRoutesConfig({
 
     return `
   {
-    path: ${JSON.stringify(permalink)},
+    path: '${permalink}',
     exact: true,
     component: Loadable({
-      loader: () => import(/* webpackPrefetch: true */ ${JSON.stringify(
-        source,
-      )}),
+      loader: () => import(/* webpackPrefetch: true */ '${source}'),
       loading: Loading,
       render(loaded, props) {
         let MarkdownContent = loaded.default;
@@ -111,30 +114,26 @@ async function genRoutesConfig({
   }`;
   }
 
-  const notFoundRoute = `,
+  const notFoundRoute = `
   {
     path: '*',
-    component: NotFound
+    component: NotFound,
   }`;
-
-  const docsRoutes = Object.values(docsMetadatas)
-    .map(genDocsRoute)
-    .join(',');
 
   return (
     `import React from 'react';\n` +
     `import Loadable from 'react-loadable';\n` +
     `import Loading from '@theme/Loading';\n` +
     `import Doc from '@theme/Doc';\n` +
+    `import DocBody from '@theme/DocBody';\n` +
     `import BlogPost from '@theme/BlogPost';\n` +
     `import BlogPage from '@theme/BlogPage';\n` +
     `import Pages from '@theme/Pages';\n` +
     `import NotFound from '@theme/NotFound';\n` +
-    `const routes = [${docsRoutes},${pagesMetadatas
-      .map(genPagesRoute)
-      .join(',')},${blogMetadatas
-      .map(genBlogRoute)
-      .join(',')}${notFoundRoute}\n];\n` +
+    `const routes = [${docsRoutes},
+      ${pagesMetadatas.map(genPagesRoute).join(',')},
+      ${blogMetadatas.map(genBlogRoute).join(',')},
+      ${notFoundRoute}\n];\n` +
     `export default routes;\n`
   );
 }

--- a/v2/lib/theme/BlogPage/index.js
+++ b/v2/lib/theme/BlogPage/index.js
@@ -7,11 +7,11 @@
 
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 import Layout from '@theme/Layout'; // eslint-disable-line
 import BlogPost from '@theme/BlogPost'; // eslint-disable-line
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 function BlogPage(props) {
   const context = useContext(DocusaurusContext);
@@ -20,12 +20,12 @@ function BlogPage(props) {
 
   return (
     <Layout>
-      <Helmet>
+      <Head>
         <title>Blog</title>
         {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
         {language && <html lang={language} />}
         {language && <meta name="docsearch:language" content={language} />}
-      </Helmet>
+      </Head>
       <div>
         <ul>
           {blogMetadatas.map(metadata => (

--- a/v2/lib/theme/BlogPage/index.js
+++ b/v2/lib/theme/BlogPage/index.js
@@ -5,46 +5,39 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable */
-import React from 'react';
+import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 import Helmet from 'react-helmet';
-import Loadable from 'react-loadable';
 import Layout from '@theme/Layout'; // eslint-disable-line
 import BlogPost from '@theme/BlogPost'; // eslint-disable-line
-import Loading from '@theme/Loading';
 
-export default class BlogPage extends React.Component {
-  render() {
-    const {
-      metadata,
-      blogMetadatas,
-      language,
-      children,
-      siteConfig = {},
-    } = this.props;
-    const {posts} = metadata;
+import DocusaurusContext from '../../core/docusaurus-context';
 
-    const {baseUrl, favicon} = siteConfig;
-    return (
-      <Layout {...this.props}>
-        <Helmet>
-          <title>{'Blog'}</title>
-          {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
-          {language && <html lang={language} />}
-          {language && <meta name="docsearch:language" content={language} />}
-        </Helmet>
-        <div>
-          <ul>
-            {blogMetadatas.map(metadata => (
-              <li key={metadata.permalink}>
-                <Link to={metadata.permalink}>{metadata.permalink}</Link>
-              </li>
-            ))}
-          </ul>
-          {children}
-        </div>
-      </Layout>
-    );
-  }
+function BlogPage(props) {
+  const context = useContext(DocusaurusContext);
+  const {blogMetadatas, language, siteConfig = {}} = context;
+  const {baseUrl, favicon} = siteConfig;
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>Blog</title>
+        {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
+        {language && <html lang={language} />}
+        {language && <meta name="docsearch:language" content={language} />}
+      </Helmet>
+      <div>
+        <ul>
+          {blogMetadatas.map(metadata => (
+            <li key={metadata.permalink}>
+              <Link to={metadata.permalink}>{metadata.permalink}</Link>
+            </li>
+          ))}
+        </ul>
+        {props.children}
+      </div>
+    </Layout>
+  );
 }
+
+export default BlogPage;

--- a/v2/lib/theme/BlogPage/index.js
+++ b/v2/lib/theme/BlogPage/index.js
@@ -11,7 +11,7 @@ import Helmet from 'react-helmet';
 import Layout from '@theme/Layout'; // eslint-disable-line
 import BlogPost from '@theme/BlogPost'; // eslint-disable-line
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 function BlogPage(props) {
   const context = useContext(DocusaurusContext);

--- a/v2/lib/theme/BlogPost/index.js
+++ b/v2/lib/theme/BlogPost/index.js
@@ -7,11 +7,11 @@
 
 import React from 'react';
 import {Link} from 'react-router-dom';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 import classnames from 'classnames';
 import Layout from '@theme/Layout'; // eslint-disable-line
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 import styles from './styles.module.css';
 
@@ -90,11 +90,11 @@ class BlogPost extends React.Component {
     const {language, title} = metadata;
     return (
       <Layout>
-        <Helmet defaultTitle={siteConfig.title}>
+        <Head defaultTitle={siteConfig.title}>
           {title && <title>{title}</title>}
           {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
           {language && <html lang={language} />}
-        </Helmet>
+        </Head>
         {this.renderPostHeader()}
         {this.props.children}
       </Layout>

--- a/v2/lib/theme/BlogPost/index.js
+++ b/v2/lib/theme/BlogPost/index.js
@@ -11,7 +11,7 @@ import Helmet from 'react-helmet';
 import classnames from 'classnames';
 import Layout from '@theme/Layout'; // eslint-disable-line
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/BlogPost/index.js
+++ b/v2/lib/theme/BlogPost/index.js
@@ -5,18 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable */
 import React from 'react';
 import {Link} from 'react-router-dom';
 import Helmet from 'react-helmet';
 import classnames from 'classnames';
 import Layout from '@theme/Layout'; // eslint-disable-line
 
+import DocusaurusContext from '../../core/docusaurus-context';
+
 import styles from './styles.module.css';
-export default class BlogPost extends React.Component {
+
+class BlogPost extends React.Component {
   renderPostHeader() {
-    const {metadata, siteConfig} = this.props;
-    const {baseUrl} = siteConfig;
+    const {metadata} = this.context;
+    if (!metadata) {
+      return null;
+    }
+
     const {
       date,
       author,
@@ -80,19 +85,23 @@ export default class BlogPost extends React.Component {
   }
 
   render() {
-    const {metadata, children, siteConfig = {}} = this.props;
+    const {metadata = {}, siteConfig = {}} = this.context;
     const {baseUrl, favicon} = siteConfig;
     const {language, title} = metadata;
     return (
-      <Layout {...this.props}>
+      <Layout>
         <Helmet defaultTitle={siteConfig.title}>
           {title && <title>{title}</title>}
           {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
           {language && <html lang={language} />}
         </Helmet>
         {this.renderPostHeader()}
-        {children}
+        {this.props.children}
       </Layout>
     );
   }
 }
+
+BlogPost.contextType = DocusaurusContext;
+
+export default BlogPost;

--- a/v2/lib/theme/Doc/index.js
+++ b/v2/lib/theme/Doc/index.js
@@ -13,7 +13,7 @@ import Footer from '@theme/Footer'; // eslint-disable-line
 import Navbar from '@theme/Navbar'; // eslint-disable-line
 import Sidebar from '@theme/Sidebar'; // eslint-disable-line
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/Doc/index.js
+++ b/v2/lib/theme/Doc/index.js
@@ -6,14 +6,14 @@
  */
 
 import React, {useContext} from 'react';
-import {Route} from 'react-router-dom';
-import Helmet from 'react-helmet';
+import {renderRoutes} from 'react-router-config';
+import Head from '@docusaurus/head';
 
 import Footer from '@theme/Footer'; // eslint-disable-line
 import Navbar from '@theme/Navbar'; // eslint-disable-line
 import Sidebar from '@theme/Sidebar'; // eslint-disable-line
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 import styles from './styles.module.css';
 
@@ -25,30 +25,17 @@ function Doc(props) {
 
   return (
     <div>
-      <Helmet>
+      <Head>
         <title>{(metadata && metadata.title) || siteConfig.title}</title>
         {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
         {language && <html lang={language} />}
         {language && <meta name="docsearch:language" content={language} />}
         {version && <meta name="docsearch:version" content={version} />}
-      </Helmet>
+      </Head>
       <Navbar />
       <Sidebar />
       <div className={styles.mainContainer}>
-        <div className={styles.docContainer}>
-          {route.routes.map(routeObject => (
-            <Route
-              key={routeObject.path}
-              path={routeObject.path}
-              render={routeProps => (
-                <routeObject.component
-                  {...routeProps}
-                  routes={routeObject.routes}
-                />
-              )}
-            />
-          ))}
-        </div>
+        <div className={styles.docContainer}>{renderRoutes(route.routes)}</div>
         <Footer />
       </div>
     </div>

--- a/v2/lib/theme/Doc/index.js
+++ b/v2/lib/theme/Doc/index.js
@@ -5,74 +5,54 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable */
-import React from 'react';
-import {Link} from 'react-router-dom';
+import React, {useContext} from 'react';
+import {Route} from 'react-router-dom';
 import Helmet from 'react-helmet';
 
-import DocsPaginator from '@theme/DocsPaginator'; // eslint-disable-line
 import Footer from '@theme/Footer'; // eslint-disable-line
 import Navbar from '@theme/Navbar'; // eslint-disable-line
 import Sidebar from '@theme/Sidebar'; // eslint-disable-line
 
+import DocusaurusContext from '../../core/docusaurus-context';
+
 import styles from './styles.module.css';
 
-class Doc extends React.Component {
-  render() {
-    const {
-      docsMetadatas,
-      docsSidebars,
-      env,
-      location,
-      metadata,
-      pagesMetadatas,
-      siteConfig = {},
-      route,
-    } = this.props;
-    const {language, version} = metadata;
-    const {baseUrl, favicon} = siteConfig;
-    return (
-      <div>
-        <Helmet>
-          <title>{(metadata && metadata.title) || siteConfig.title}</title>
-          {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
-          {language && <html lang={language} />}
-          {language && <meta name="docsearch:language" content={language} />}
-          {version && <meta name="docsearch:version" content={version} />}
-        </Helmet>
-        <Navbar
-          docsMetadatas={docsMetadatas}
-          env={env}
-          metadata={metadata}
-          siteConfig={siteConfig}
-        />
-        <Sidebar
-          docsMetadatas={docsMetadatas}
-          docsSidebars={docsSidebars}
-          metadata={metadata}
-        />
-        <div className={styles.mainContainer}>
-          <div className={styles.docContainer}>
-            <div className={styles.docContent}>
-              <h1>{metadata.title}</h1>
-              {this.props.children}
-            </div>
-            <div className={styles.paginatorContainer}>
-              <DocsPaginator
-                docsMetadatas={docsMetadatas}
-                metadata={metadata}
-              />
-            </div>
-          </div>
-          <Footer
-            docsMetadatas={docsMetadatas}
-            location={location}
-            pagesMetadatas={pagesMetadatas}
-          />
+function Doc(props) {
+  const {metadata = {}, siteConfig = {}} = useContext(DocusaurusContext);
+  const {route} = props;
+  const {language, version} = metadata;
+  const {baseUrl, favicon} = siteConfig;
+
+  return (
+    <div>
+      <Helmet>
+        <title>{(metadata && metadata.title) || siteConfig.title}</title>
+        {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
+        {language && <html lang={language} />}
+        {language && <meta name="docsearch:language" content={language} />}
+        {version && <meta name="docsearch:version" content={version} />}
+      </Helmet>
+      <Navbar />
+      <Sidebar />
+      <div className={styles.mainContainer}>
+        <div className={styles.docContainer}>
+          {route.routes.map(routeObject => (
+            <Route
+              key={routeObject.path}
+              path={routeObject.path}
+              render={routeProps => (
+                <routeObject.component
+                  {...routeProps}
+                  routes={routeObject.routes}
+                />
+              )}
+            />
+          ))}
         </div>
+        <Footer />
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 export default Doc;

--- a/v2/lib/theme/DocBody/index.js
+++ b/v2/lib/theme/DocBody/index.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useContext, useEffect} from 'react';
+
+import DocsPaginator from '@theme/DocsPaginator'; // eslint-disable-line
+import DocusaurusContext from '../../core/docusaurus-context';
+
+import styles from './styles.module.css';
+
+function DocBody(props) {
+  const {children, metadata} = props;
+  const context = useContext(DocusaurusContext);
+  useEffect(() => {
+    context.setContext({
+      metadata,
+    });
+  }, []);
+
+  return (
+    <div>
+      <div className={styles.docContent}>
+        <h1>{metadata.title}</h1>
+        {children}
+      </div>
+      <div className={styles.paginatorContainer}>
+        <DocsPaginator />
+      </div>
+    </div>
+  );
+}
+
+export default DocBody;

--- a/v2/lib/theme/DocBody/index.js
+++ b/v2/lib/theme/DocBody/index.js
@@ -8,7 +8,7 @@
 import React, {useContext, useEffect} from 'react';
 
 import DocsPaginator from '@theme/DocsPaginator'; // eslint-disable-line
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/DocBody/index.js
+++ b/v2/lib/theme/DocBody/index.js
@@ -8,7 +8,7 @@
 import React, {useContext, useEffect} from 'react';
 
 import DocsPaginator from '@theme/DocsPaginator'; // eslint-disable-line
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/DocBody/styles.module.css
+++ b/v2/lib/theme/DocBody/styles.module.css
@@ -5,11 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.mainContainer {
-  padding-left: 300px;
+.docContent {
+  margin-bottom: 48px;
 }
 
-.docContainer {
-  flex-grow: 1;
-  padding: 0 40px;
+.paginatorContainer {
+  margin: 48px 0;
 }

--- a/v2/lib/theme/DocsPaginator/index.js
+++ b/v2/lib/theme/DocsPaginator/index.js
@@ -5,49 +5,56 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
+
+import DocusaurusContext from "../../core/docusaurus-context";
 
 import styles from './styles.module.css';
 
-export default class DocsPaginator extends React.Component {
-  render() {
-    const {docsMetadatas, metadata} = this.props;
-    return (
-      <div className={styles.paginatorContainer}>
-        <div>
-          {metadata.previous &&
-            docsMetadatas[metadata.previous] && (
-              <Link
-                className={styles.paginatorLink}
-                to={docsMetadatas[metadata.previous].permalink}>
-                <svg className={styles.arrow} viewBox="0 0 24 24">
-                  <g>
-                    <line x1="19" y1="12" x2="5" y2="12" />
-                    <polyline points="12 19 5 12 12 5" />
-                  </g>
-                </svg>{' '}
-                <span className={styles.label}>{metadata.previous_title}</span>
-              </Link>
-            )}
-        </div>
-        <div className={styles.paginatorRightContainer}>
-          {metadata.next &&
-            docsMetadatas[metadata.next] && (
-              <Link
-                className={styles.paginatorLink}
-                to={docsMetadatas[metadata.next].permalink}>
-                <span className={styles.label}>{metadata.next_title}</span>{' '}
-                <svg className={styles.arrow} viewBox="0 0 24 24">
-                  <g>
-                    <line x1="5" y1="12" x2="19" y2="12" />
-                    <polyline points="12 5 19 12 12 19" />
-                  </g>
-                </svg>
-              </Link>
-            )}
-        </div>
-      </div>
-    );
+function DocsPaginator() {
+  const context = useContext(DocusaurusContext);
+  const {docsMetadatas, metadata} = context;
+  if (!metadata) {
+    return null;
   }
+
+  return (
+    <div className={styles.paginatorContainer}>
+      <div>
+        {metadata.previous &&
+          docsMetadatas[metadata.previous] && (
+            <Link
+              className={styles.paginatorLink}
+              to={docsMetadatas[metadata.previous].permalink}>
+              <svg className={styles.arrow} viewBox="0 0 24 24">
+                <g>
+                  <line x1="19" y1="12" x2="5" y2="12" />
+                  <polyline points="12 19 5 12 12 5" />
+                </g>
+              </svg>{' '}
+              <span className={styles.label}>{metadata.previous_title}</span>
+            </Link>
+          )}
+      </div>
+      <div className={styles.paginatorRightContainer}>
+        {metadata.next &&
+          docsMetadatas[metadata.next] && (
+            <Link
+              className={styles.paginatorLink}
+              to={docsMetadatas[metadata.next].permalink}>
+              <span className={styles.label}>{metadata.next_title}</span>{' '}
+              <svg className={styles.arrow} viewBox="0 0 24 24">
+                <g>
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </g>
+              </svg>
+            </Link>
+          )}
+      </div>
+    </div>
+  );
 }
+
+export default DocsPaginator;

--- a/v2/lib/theme/DocsPaginator/index.js
+++ b/v2/lib/theme/DocsPaginator/index.js
@@ -8,7 +8,7 @@
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/DocsPaginator/index.js
+++ b/v2/lib/theme/DocsPaginator/index.js
@@ -8,7 +8,7 @@
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
-import DocusaurusContext from "../../core/docusaurus-context";
+import DocusaurusContext from '../../core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/DocsPaginator/index.js
+++ b/v2/lib/theme/DocsPaginator/index.js
@@ -8,7 +8,7 @@
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/Footer/index.js
+++ b/v2/lib/theme/Footer/index.js
@@ -5,12 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
+
+import DocusaurusContext from "../../core/docusaurus-context";
 
 import styles from './styles.module.css';
 
-function Footer(props) {
+function Footer() {
+  const context = useContext(DocusaurusContext);
+  const {pagesMetadatas} = context;
+
   return (
     <footer className={styles.footer}>
       <section className={styles.footerRow}>
@@ -78,7 +83,7 @@ function Footer(props) {
         <div className={styles.footerColumn}>
           <h3 className={styles.footerColumnTitle}>Pages</h3>
           <ul className={styles.footerList}>
-            {props.pagesMetadatas.map(metadata => (
+            {pagesMetadatas.map(metadata => (
               <li key={metadata.permalink} className={styles.footerListItem}>
                 <Link className={styles.footerLink} to={metadata.permalink}>
                   {metadata.permalink}

--- a/v2/lib/theme/Footer/index.js
+++ b/v2/lib/theme/Footer/index.js
@@ -8,7 +8,7 @@
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/Footer/index.js
+++ b/v2/lib/theme/Footer/index.js
@@ -8,7 +8,7 @@
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
-import DocusaurusContext from "../../core/docusaurus-context";
+import DocusaurusContext from '../../core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/Footer/index.js
+++ b/v2/lib/theme/Footer/index.js
@@ -8,7 +8,7 @@
 import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/Layout/index.js
+++ b/v2/lib/theme/Layout/index.js
@@ -12,33 +12,14 @@ import Navbar from '@theme/Navbar'; // eslint-disable-line
 
 import './styles.css';
 
-/* eslint-disable react/prefer-stateless-function */
-export default class Layout extends React.Component {
-  render() {
-    const {
-      children,
-      pagesMetadatas = [],
-      docsMetadatas = {},
-      env,
-      siteConfig,
-      location,
-      metadata,
-    } = this.props;
-    return (
-      <div>
-        <Navbar
-          docsMetadatas={docsMetadatas}
-          env={env}
-          metadata={metadata}
-          siteConfig={siteConfig}
-        />
-        {children}
-        <Footer
-          docsMetadatas={docsMetadatas}
-          location={location}
-          pagesMetadatas={pagesMetadatas}
-        />
-      </div>
-    );
-  }
+function Layout({children}) {
+  return (
+    <div>
+      <Navbar />
+      {children}
+      <Footer />
+    </div>
+  );
 }
+
+export default Layout;

--- a/v2/lib/theme/Loading/index.js
+++ b/v2/lib/theme/Loading/index.js
@@ -14,6 +14,7 @@ export default props => {
     console.log(props.error);
     return <div align="center">Error</div>;
   }
+
   if (props.pastDelay) {
     return (
       <div className={styles.loader}>
@@ -22,5 +23,6 @@ export default props => {
       </div>
     );
   }
+
   return null;
 };

--- a/v2/lib/theme/Markdown/index.js
+++ b/v2/lib/theme/Markdown/index.js
@@ -5,13 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable */
-
-import React from 'react';
+import React, {useContext} from 'react';
 import Helmet from 'react-helmet';
 
+import DocusaurusContext from '../../core/docusaurus-context';
+
 function Markdown(props) {
-  const {siteConfig} = props;
+  const context = useContext(DocusaurusContext);
+  const {metadata, siteConfig} = context;
   const highlight = Object.assign(
     {},
     {

--- a/v2/lib/theme/Markdown/index.js
+++ b/v2/lib/theme/Markdown/index.js
@@ -6,9 +6,9 @@
  */
 
 import React, {useContext} from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 function Markdown(props) {
   const context = useContext(DocusaurusContext);
@@ -31,9 +31,9 @@ function Markdown(props) {
 
   return (
     <div>
-      <Helmet>
+      <Head>
         <link rel="stylesheet" type="text/css" href={highlightThemeURL} />
-      </Helmet>
+      </Head>
       <div>{props.children}</div>
     </div>
   );

--- a/v2/lib/theme/Markdown/index.js
+++ b/v2/lib/theme/Markdown/index.js
@@ -12,7 +12,7 @@ import DocusaurusContext from '../../core/docusaurus-context';
 
 function Markdown(props) {
   const context = useContext(DocusaurusContext);
-  const {metadata, siteConfig} = context;
+  const {siteConfig} = context;
   const highlight = Object.assign(
     {},
     {

--- a/v2/lib/theme/Markdown/index.js
+++ b/v2/lib/theme/Markdown/index.js
@@ -8,7 +8,7 @@
 import React, {useContext} from 'react';
 import Helmet from 'react-helmet';
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 function Markdown(props) {
   const context = useContext(DocusaurusContext);

--- a/v2/lib/theme/Navbar/index.js
+++ b/v2/lib/theme/Navbar/index.js
@@ -9,7 +9,7 @@ import React, {useContext} from 'react';
 import {NavLink} from 'react-router-dom';
 
 import Search from '@theme/Search';
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 import styles from './styles.module.css';
 
 function Navbar(props) {

--- a/v2/lib/theme/Navbar/index.js
+++ b/v2/lib/theme/Navbar/index.js
@@ -11,7 +11,7 @@ import {NavLink} from 'react-router-dom';
 import Search from '@theme/Search';
 import styles from './styles.module.css';
 
-import DocusaurusContext from "../../core/docusaurus-context";
+import DocusaurusContext from '../../core/docusaurus-context';
 
 function Navbar(props) {
   const context = useContext(DocusaurusContext);

--- a/v2/lib/theme/Navbar/index.js
+++ b/v2/lib/theme/Navbar/index.js
@@ -5,14 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useContext} from 'react';
 import {NavLink} from 'react-router-dom';
 
 import Search from '@theme/Search';
 import styles from './styles.module.css';
 
+import DocusaurusContext from "../../core/docusaurus-context";
+
 function Navbar(props) {
-  const {siteConfig = {}, env = {}, metadata = {}, docsMetadatas = {}} = props;
+  const context = useContext(DocusaurusContext);
+  const {
+    siteConfig = {},
+    env = {},
+    metadata = {},
+    docsMetadatas = {},
+  } = context;
   const {baseUrl, headerLinks, headerIcon, algolia} = siteConfig;
   const {language: thisLanguage, version: thisVersion} = metadata;
 

--- a/v2/lib/theme/Navbar/index.js
+++ b/v2/lib/theme/Navbar/index.js
@@ -9,9 +9,8 @@ import React, {useContext} from 'react';
 import {NavLink} from 'react-router-dom';
 
 import Search from '@theme/Search';
+import DocusaurusContext from 'core/docusaurus-context';
 import styles from './styles.module.css';
-
-import DocusaurusContext from '../../core/docusaurus-context';
 
 function Navbar(props) {
   const context = useContext(DocusaurusContext);

--- a/v2/lib/theme/NotFound.js
+++ b/v2/lib/theme/NotFound.js
@@ -8,18 +8,18 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 
-export default class NotFound extends React.Component {
-  render() {
-    return (
-      <Layout {...this.props}>
-        <div>404 Page Not Found</div>
-        <div>
-          <img
-            alt="Not found"
-            src="https://d2gg9evh47fn9z.cloudfront.net/800px_COLOURBOX3889253.jpg"
-          />
-        </div>
-      </Layout>
-    );
-  }
+function NotFound() {
+  return (
+    <Layout>
+      <div>404 Page Not Found</div>
+      <div>
+        <img
+          alt="Not found"
+          src="https://d2gg9evh47fn9z.cloudfront.net/800px_COLOURBOX3889253.jpg"
+        />
+      </div>
+    </Layout>
+  );
 }
+
+export default NotFound;

--- a/v2/lib/theme/Pages/index.js
+++ b/v2/lib/theme/Pages/index.js
@@ -5,26 +5,28 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable */
-import React from 'react';
-import {Link} from 'react-router-dom';
+import React, {useContext} from 'react';
 import Helmet from 'react-helmet';
 import Layout from '@theme/Layout'; // eslint-disable-line
 
-export default class Pages extends React.Component {
-  render() {
-    const {metadata, children, siteConfig = {}} = this.props;
-    const {baseUrl, favicon} = siteConfig;
-    const {language} = metadata;
-    return (
-      <Layout {...this.props}>
-        <Helmet defaultTitle={siteConfig.title}>
-          {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
-          {language && <html lang={language} />}
-          {language && <meta name="docsearch:language" content={language} />}
-        </Helmet>
-        {children}
-      </Layout>
-    );
-  }
+import DocusaurusContext from '../../core/docusaurus-context';
+
+function Pages({children}) {
+  const context = useContext(DocusaurusContext);
+  const {metadata = {}, siteConfig = {}} = context;
+  const {baseUrl, favicon} = siteConfig;
+  const {language} = metadata;
+
+  return (
+    <Layout>
+      <Helmet defaultTitle={siteConfig.title}>
+        {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
+        {language && <html lang={language} />}
+        {language && <meta name="docsearch:language" content={language} />}
+      </Helmet>
+      {children}
+    </Layout>
+  );
 }
+
+export default Pages;

--- a/v2/lib/theme/Pages/index.js
+++ b/v2/lib/theme/Pages/index.js
@@ -6,10 +6,10 @@
  */
 
 import React, {useContext} from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 import Layout from '@theme/Layout'; // eslint-disable-line
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 function Pages({children}) {
   const context = useContext(DocusaurusContext);
@@ -19,11 +19,11 @@ function Pages({children}) {
 
   return (
     <Layout>
-      <Helmet defaultTitle={siteConfig.title}>
+      <Head defaultTitle={siteConfig.title}>
         {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
         {language && <html lang={language} />}
         {language && <meta name="docsearch:language" content={language} />}
-      </Helmet>
+      </Head>
       {children}
     </Layout>
   );

--- a/v2/lib/theme/Pages/index.js
+++ b/v2/lib/theme/Pages/index.js
@@ -9,7 +9,7 @@ import React, {useContext} from 'react';
 import Helmet from 'react-helmet';
 import Layout from '@theme/Layout'; // eslint-disable-line
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 function Pages({children}) {
   const context = useContext(DocusaurusContext);

--- a/v2/lib/theme/Search/index.js
+++ b/v2/lib/theme/Search/index.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import DocusaurusContext from '../../core/docusaurus-context';
+import DocusaurusContext from 'core/docusaurus-context';
 
 import './styles.css';
 

--- a/v2/lib/theme/Search/index.js
+++ b/v2/lib/theme/Search/index.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 
 import './styles.css';
 

--- a/v2/lib/theme/Search/index.js
+++ b/v2/lib/theme/Search/index.js
@@ -7,18 +7,20 @@
 
 import React from 'react';
 
+import DocusaurusContext from '../../core/docusaurus-context';
+
 import './styles.css';
 
 class Search extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       enabled: true,
     };
   }
 
   componentDidMount() {
-    const {siteConfig = {}, metadata = {}} = this.props;
+    const {siteConfig = {}, metadata = {}} = this.context;
     const {version: thisVersion, language: thisLanguage} = metadata;
     const {algolia} = siteConfig;
 
@@ -57,5 +59,7 @@ class Search extends React.Component {
     ) : null;
   }
 }
+
+Search.contextType = DocusaurusContext;
 
 export default Search;

--- a/v2/lib/theme/Sidebar/index.js
+++ b/v2/lib/theme/Sidebar/index.js
@@ -5,14 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useContext} from 'react';
 
 import SidebarLink from './SidebarLink';
 import SidebarCategory from './SidebarCategory';
+
+import DocusaurusContext from "../../core/docusaurus-context";
+
 import styles from './styles.module.css';
 
-function Sidebar(props) {
-  const {metadata, docsSidebars, docsMetadatas} = props;
+function Sidebar() {
+  const context = useContext(DocusaurusContext);
+  const {metadata = {}, docsSidebars, docsMetadatas} = context;
   const {sidebar, language} = metadata;
 
   if (!sidebar) {

--- a/v2/lib/theme/Sidebar/index.js
+++ b/v2/lib/theme/Sidebar/index.js
@@ -7,10 +7,9 @@
 
 import React, {useContext} from 'react';
 
+import DocusaurusContext from 'core/docusaurus-context';
 import SidebarLink from './SidebarLink';
 import SidebarCategory from './SidebarCategory';
-
-import DocusaurusContext from '../../core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/theme/Sidebar/index.js
+++ b/v2/lib/theme/Sidebar/index.js
@@ -7,7 +7,7 @@
 
 import React, {useContext} from 'react';
 
-import DocusaurusContext from 'core/docusaurus-context';
+import DocusaurusContext from '@docusaurus/context';
 import SidebarLink from './SidebarLink';
 import SidebarCategory from './SidebarCategory';
 

--- a/v2/lib/theme/Sidebar/index.js
+++ b/v2/lib/theme/Sidebar/index.js
@@ -10,7 +10,7 @@ import React, {useContext} from 'react';
 import SidebarLink from './SidebarLink';
 import SidebarCategory from './SidebarCategory';
 
-import DocusaurusContext from "../../core/docusaurus-context";
+import DocusaurusContext from '../../core/docusaurus-context';
 
 import styles from './styles.module.css';
 

--- a/v2/lib/webpack/base.js
+++ b/v2/lib/webpack/base.js
@@ -71,10 +71,10 @@ module.exports = function createBaseConfig(props, isServer) {
     .set('@build', outDir)
     .set('@generated', path.resolve(__dirname, '../core/generated'))
     .set('@core', path.resolve(__dirname, '../core'))
+    .set('@docusaurus', path.resolve(__dirname, '../docusaurus'))
     .end()
     .modules.add(path.resolve(__dirname, '../../node_modules')) // Prioritize our own node modules.
-    .add(path.resolve(__dirname, '../')) // Load from root of library.
-    .add('node_modules');
+    .add(path.resolve(siteDir, 'node_modules')); // load user node_modules
 
   function applyBabel(rule) {
     rule

--- a/v2/lib/webpack/base.js
+++ b/v2/lib/webpack/base.js
@@ -72,8 +72,8 @@ module.exports = function createBaseConfig(props, isServer) {
     .set('@generated', path.resolve(__dirname, '../core/generated'))
     .set('@core', path.resolve(__dirname, '../core'))
     .end()
-    .modules // prioritize our own node modules
-    .add(path.resolve(__dirname, '../../node_modules'))
+    .modules.add(path.resolve(__dirname, '../../node_modules')) // Prioritize our own node modules.
+    .add(path.resolve(__dirname, '../')) // Load from root of library.
     .add('node_modules');
 
   function applyBabel(rule) {

--- a/v2/lib/webpack/loaders/markdown/index.js
+++ b/v2/lib/webpack/loaders/markdown/index.js
@@ -150,7 +150,7 @@ module.exports = function(fileString) {
 import React from 'react';
 import Markdown from '@theme/Markdown';
 export default () => (
-  <Markdown siteConfig={${JSON.stringify(siteConfig)}}>
+  <Markdown>
     <div dangerouslySetInnerHTML={{__html: ${JSON.stringify(html)}}} />
   </Markdown>
 );`;

--- a/v2/package.json
+++ b/v2/package.json
@@ -80,6 +80,7 @@
     "mini-css-extract-plugin": "^0.4.1",
     "portfinder": "^1.0.13",
     "prismjs": "^1.15.0",
+    "react-helmet": "^5.2.0",
     "react-loadable": "^5.5.0",
     "react-router-config": "^1.0.0-beta.4",
     "react-router-dom": "^4.3.1",
@@ -99,8 +100,7 @@
   },
   "peerDependencies": {
     "react": "^16.7.0-alpha.0",
-    "react-dom": "^16.7.0-alpha.0",
-    "react-helmet": "^5.2.0"
+    "react-dom": "^16.7.0-alpha.0"
   },
   "engines": {
     "node": ">=8"

--- a/v2/test/__fixtures__/simple-site/pages/hello/world.js
+++ b/v2/test/__fixtures__/simple-site/pages/hello/world.js
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class World extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>World</title>
-        </Helmet>
+        </Head>
         <div>Hello World </div>
       </div>
     );

--- a/v2/test/__fixtures__/simple-site/pages/index.js
+++ b/v2/test/__fixtures__/simple-site/pages/index.js
@@ -6,16 +6,16 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class Home extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>Home</title>
           <link rel="stylesheet" type="text/css" href="/css/basic.css" />
-        </Helmet>
+        </Head>
         <div>Home ... </div>
       </div>
     );

--- a/v2/test/__fixtures__/translated-site/pages/hello/world.js
+++ b/v2/test/__fixtures__/translated-site/pages/hello/world.js
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class World extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>World</title>
-        </Helmet>
+        </Head>
         <div>Hello World </div>
       </div>
     );

--- a/v2/test/__fixtures__/translated-site/pages/index.js
+++ b/v2/test/__fixtures__/translated-site/pages/index.js
@@ -6,16 +6,16 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class Home extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>Home</title>
           <link rel="stylesheet" type="text/css" href="/css/basic.css" />
-        </Helmet>
+        </Head>
         <div>Home ... </div>
       </div>
     );

--- a/v2/test/__fixtures__/transversioned-site/pages/hello/world.js
+++ b/v2/test/__fixtures__/transversioned-site/pages/hello/world.js
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class World extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>World</title>
-        </Helmet>
+        </Head>
         <div>Hello World </div>
       </div>
     );

--- a/v2/test/__fixtures__/transversioned-site/pages/index.js
+++ b/v2/test/__fixtures__/transversioned-site/pages/index.js
@@ -6,16 +6,16 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class Home extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>Home</title>
           <link rel="stylesheet" type="text/css" href="/css/basic.css" />
-        </Helmet>
+        </Head>
         <div>Home ... </div>
       </div>
     );

--- a/v2/test/__fixtures__/versioned-site/pages/hello/world.js
+++ b/v2/test/__fixtures__/versioned-site/pages/hello/world.js
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class World extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>World</title>
-        </Helmet>
+        </Head>
         <div>Hello World </div>
       </div>
     );

--- a/v2/test/__fixtures__/versioned-site/pages/index.js
+++ b/v2/test/__fixtures__/versioned-site/pages/index.js
@@ -6,16 +6,16 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 export default class Home extends React.Component {
   render() {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>Home</title>
           <link rel="stylesheet" type="text/css" href="/css/basic.css" />
-        </Helmet>
+        </Head>
         <div>Home ... </div>
       </div>
     );

--- a/v2/website/package.json
+++ b/v2/website/package.json
@@ -8,7 +8,6 @@
     "docusaurus": "../",
     "react": "^16.7.0-alpha.0",
     "react-dom": "^16.7.0-alpha.0",
-    "react-helmet": "^5.2.0",
     "react-youtube": "^7.6.0"
   }
 }

--- a/v2/website/pages/index.js
+++ b/v2/website/pages/index.js
@@ -6,7 +6,7 @@
  */
 
 import React, {useEffect, useState} from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 
 import classnames from 'classnames';
 
@@ -129,9 +129,9 @@ function Home() {
 
   return (
     <div>
-      <Helmet key={featureIndex}>
+      <Head key={featureIndex}>
         <title>Docusaurus</title>
-      </Helmet>
+      </Head>
       <div className={classnames(styles.section, styles.banner)}>
         <div className={classnames(styles.sectionInner, styles.bannerInner)}>
           <h1 className={styles.header}>Docusaurus</h1>

--- a/v2/website/pages/youtube.js
+++ b/v2/website/pages/youtube.js
@@ -6,7 +6,7 @@
  */
 /* eslint-disable */
 import React from 'react';
-import Helmet from 'react-helmet';
+import Head from '@docusaurus/head';
 import YouTube from 'react-youtube';
 
 export default class Player extends React.Component {
@@ -21,9 +21,9 @@ export default class Player extends React.Component {
 
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>My Youtube</title>
-        </Helmet>
+        </Head>
         <div align="center">
           {/* this is a React-youtube component */}
           <YouTube videoId="d9IxdwEFk1c" opts={opts} onReady={this._onReady} />

--- a/v2/website/yarn.lock
+++ b/v2/website/yarn.lock
@@ -810,6 +810,10 @@ address@1.0.3, address@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
 
+agentkeepalive@^2.2.0:
+  version "2.2.0"
+  resolved "http://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz#c5d1bd4b129008f1163f236f86e5faea2026e2ef"
+
 ajv-errors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.0.tgz#ecf021fa108fd17dfb5e6b383f2dd233e31ffc59"
@@ -826,6 +830,26 @@ ajv@^6.0.1, ajv@^6.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+algoliasearch@^3.24.5:
+  version "3.30.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.30.0.tgz#355585e49b672e5f71d45b9c2b371ecdff129cd1"
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.8"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
 
 ansi-align@^2.0.0:
   version "2.0.0"
@@ -991,6 +1015,12 @@ async@^1.5.2:
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+
+autocomplete.js@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.29.0.tgz#0185f7375ee9daf068f7d52d794bc90dcd739fd7"
+  dependencies:
+    immediate "^3.2.3"
 
 autolinker@~0.15.0:
   version "0.15.3"
@@ -1898,6 +1928,15 @@ dir-glob@^2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
+docsearch.js@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/docsearch.js/-/docsearch.js-2.5.2.tgz#1a3521c92e5f252cc522c57357ef1c47b945b381"
+  dependencies:
+    algoliasearch "^3.24.5"
+    autocomplete.js "^0.29.0"
+    hogan.js "^3.0.2"
+    to-factory "^1.0.0"
+
 docusaurus@../:
   version "2.0.0"
   dependencies:
@@ -1916,6 +1955,7 @@ docusaurus@../:
     commander "^2.16.0"
     connect-history-api-fallback "^1.5.0"
     css-loader "^1.0.0"
+    docsearch.js "^2.5.2"
     escape-html "^1.0.3"
     escape-string-regexp "^1.0.5"
     front-matter "^2.3.0"
@@ -1935,7 +1975,6 @@ docusaurus@../:
     react-loadable "^5.5.0"
     react-router-config "^1.0.0-beta.4"
     react-router-dom "^4.3.1"
-    react-youtube "^7.6.0"
     remarkable "^1.7.1"
     semver "^5.5.0"
     shelljs "^0.8.2"
@@ -1962,6 +2001,10 @@ dom-serializer@0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
+
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -2076,6 +2119,13 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
 
+envify@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
+  dependencies:
+    esprima "^4.0.0"
+    through "~2.3.4"
+
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -2126,6 +2176,10 @@ es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
+es6-promise@^4.1.0:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
+
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
@@ -2172,7 +2226,7 @@ eval@^0.1.0:
   dependencies:
     require-like ">= 0.1.1"
 
-events@^1.0.0:
+events@^1.0.0, events@^1.1.0:
   version "1.1.1"
   resolved "http://registry.npmjs.org/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
@@ -2387,6 +2441,10 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -2532,6 +2590,13 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
+global@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
+
 globals@^11.1.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
@@ -2675,6 +2740,13 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hogan.js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
+  dependencies:
+    mkdirp "0.3.0"
+    nopt "1.0.10"
+
 hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
@@ -2800,6 +2872,10 @@ ignore-walk@^3.0.1:
 ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
+immediate@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -3122,6 +3198,10 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isarray@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.4.tgz#38e7bcbb0f3ba1b7933c86ba1894ddfc3781bbb7"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3650,6 +3730,12 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
+
 mini-css-extract-plugin@^0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.4.tgz#c10410a004951bd3cedac1da69053940fccb625d"
@@ -3727,6 +3813,10 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mkdirp@0.3.0:
+  version "0.3.0"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
 
 mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
@@ -3889,6 +3979,12 @@ node-version@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.2.0.tgz#34fde3ffa8e1149bd323983479dda620e1b5060d"
 
+nopt@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -3959,7 +4055,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@~1.0.0:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
@@ -4343,6 +4439,10 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -4400,7 +4500,7 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-querystring-es3@^0.2.0:
+querystring-es3@^0.2.0, querystring-es3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
@@ -4637,6 +4737,12 @@ redent@^2.0.0:
   dependencies:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
+
+reduce@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce/-/reduce-1.0.1.tgz#14fa2e5ff1fc560703a020cbb5fbaab691565804"
+  dependencies:
+    object-keys "~1.0.0"
 
 regenerate-unicode-properties@^7.0.0:
   version "7.0.0"
@@ -5321,7 +5427,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@^2.3.6:
+through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "http://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5352,6 +5458,10 @@ tmp@^0.0.33:
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+
+to-factory@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-factory/-/to-factory-1.0.0.tgz#8738af8bd97120ad1d4047972ada5563bf9479b1"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -5406,6 +5516,12 @@ tslib@^1.9.0:
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
 
 type-is@^1.6.16:
   version "1.6.16"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

So that when navigating between doc pages the whole page doesn't unmount. Also shift all the props into context, treating it as a global store (like Redux). We no longer have to pass props around and can just use components freely without caring about what data is passed in!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Try navigating between docs. Only the doc content should unmount.

## Related PRs

NA.
