### PR TITLE
docs: add info about setting custom ../docs folder name

### DIFF
--- a/docs/getting-started-preparation.md
+++ b/docs/getting-started-preparation.md
@@ -56,8 +56,7 @@ root-directory
 
 You will need to keep the `website/siteConfig.js` and `website/core/Footer.js`
 files, but may edit them as you wish. The value of the `customDocsPath` key in 
-`website/siteConfig.js` can be edited to change the Docusaurus `../docs` folder 
-name.
+`website/siteConfig.js` can be modified if you wish to use a different directory name or path.
 
 You should keep the `website/pages` and `website/static` directories, but may 
 change the content inside them as you wish. At the bare minimum you should have

--- a/docs/getting-started-preparation.md
+++ b/docs/getting-started-preparation.md
@@ -55,7 +55,9 @@ root-directory
 ## Preparation Notes
 
 You will need to keep the `website/siteConfig.js` and `website/core/Footer.js`
-files, but may edit them as you wish.
+files, but may edit them as you wish. The value of the `customDocsPath` key in 
+`website/siteConfig.js` can be edited to change the Docusaurus `../docs` folder 
+name.
 
 You should keep the `website/pages` and `website/static` directories, but may 
 change the content inside them as you wish. At the bare minimum you should have


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Add description of how to set a custom `../docs` folder name to docs at [getting-started-preparation.md](https://github.com/facebook/Docusaurus/blob/master/docs/getting-started-preparation.md).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Checked relevant doc file on local branch to see that new text was included and formatted.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

Resolves Issue #1082 