### PR TITLE
feat(v2): better UX to avoid first page load flashing screen

### DIFF
--- a/v2/lib/core/clientEntry.js
+++ b/v2/lib/core/clientEntry.js
@@ -6,15 +6,16 @@
  */
 
 import React from 'react';
-import Loadable from 'react-loadable';
 import {BrowserRouter} from 'react-router-dom';
 import ReactDOM from 'react-dom';
 
 import App from './App';
+import preload from './preload';
+import routes from '@generated/routes'; // eslint-disable-line
 
 // Client side render (e.g: running in browser) to become single-page application (SPA)
-if (typeof document !== 'undefined') {
-  Loadable.preloadReady().then(() => {
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  preload(routes, window.location.pathname).then(() => {
     ReactDOM.render(
       <BrowserRouter>
         <App />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

`Loadable.preloadReady` wasn't able to handle nested react-router config. So after #1092, we can see flashing screen on first page load. Better to use own custom preload function like in serverEntry

See test plan for clearer *before* and *after*

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

**Before**
Notice the flashing screen whereby it is still in Loading state

![before-preload](https://user-images.githubusercontent.com/17883920/48175613-c3aedc00-e347-11e8-91f9-7f4a1e19eb02.gif)

**After**

Notice how natural is first page reload
![after-preload](https://user-images.githubusercontent.com/17883920/48175612-c3164580-e347-11e8-8e6e-7ee0f068828d.gif)
