### PR TITLE
Fix: Fix livereload on second try

### DIFF
--- a/v1/lib/server/liveReloadServer.js
+++ b/v1/lib/server/liveReloadServer.js
@@ -9,10 +9,9 @@ const gaze = require('gaze');
 const tinylr = require('tiny-lr');
 const readMetadata = require('./readMetadata.js');
 
-let reloadScriptUrl;
-
 function start(port) {
   process.env.NODE_ENV = 'development';
+  process.env.PORT = port;
   const server = tinylr();
   server.listen(port, () => {
     console.log('LiveReload server started on port %d', port);
@@ -26,11 +25,10 @@ function start(port) {
       });
     },
   );
-
-  reloadScriptUrl = `http://localhost:${port}/livereload.js`;
 }
 
-const getReloadScriptUrl = () => reloadScriptUrl;
+const getReloadScriptUrl =
+  () => `http://localhost:${process.env.PORT}/livereload.js`;
 
 module.exports = {
   start,

--- a/v1/lib/server/liveReloadServer.js
+++ b/v1/lib/server/liveReloadServer.js
@@ -27,8 +27,10 @@ function start(port) {
   );
 }
 
-const getReloadScriptUrl =
-  () => `http://localhost:${process.env.PORT}/livereload.js`;
+const getReloadScriptUrl = () => {
+  const port = process.env.PORT;
+  return `http://localhost:${port}/livereload.js`;
+};
 
 module.exports = {
   start,

--- a/v1/lib/server/liveReloadServer.js
+++ b/v1/lib/server/liveReloadServer.js
@@ -11,7 +11,7 @@ const readMetadata = require('./readMetadata.js');
 
 function start(port) {
   process.env.NODE_ENV = 'development';
-  process.env.PORT = port;
+  process.env.LIVERELOAD_PORT = port;
   const server = tinylr();
   server.listen(port, () => {
     console.log('LiveReload server started on port %d', port);
@@ -28,7 +28,7 @@ function start(port) {
 }
 
 const getReloadScriptUrl = () => {
-  const port = process.env.PORT;
+  const port = process.env.LIVERELOAD_PORT;
   return `http://localhost:${port}/livereload.js`;
 };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes LiveReload on second try (#1091), due to local variable defining livereload url losing its value during reload.

Fix #1091 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

`yarn start`, then edited `v1/website/pages/index.js` multiple times. Ensured that live reload now works.


## Related PRs
