### PR TITLE
fix: warn unsupported languages by prismjs 

### DIFF
--- a/v1/lib/core/renderMarkdown.js
+++ b/v1/lib/core/renderMarkdown.js
@@ -56,7 +56,9 @@ class MarkdownRenderer {
               } catch (err) {
                 if (err.code === 'MODULE_NOT_FOUND') {
                   const unsupportedLanguageError = chalk.yellow(
-                    `Warning: language-${language} is not supported by prismjs.` +
+                    `Warning: ${chalk.red(
+                      language,
+                    )} is not supported by prismjs.` +
                       '\nPlease refer to https://prismjs.com/#languages-list for the list of supported languages.',
                   );
                   console.log(unsupportedLanguageError);

--- a/v1/lib/core/renderMarkdown.js
+++ b/v1/lib/core/renderMarkdown.js
@@ -9,19 +9,21 @@ const hljs = require('highlight.js');
 const Markdown = require('remarkable');
 const prismjs = require('prismjs');
 const deepmerge = require('deepmerge');
-
+const chalk = require('chalk');
 const anchors = require('./anchors.js');
 
 const CWD = process.cwd();
 
 const alias = {
   js: 'jsx',
+  html: 'markup',
+  sh: 'bash',
+  md: 'markdown',
 };
 
 class MarkdownRenderer {
   constructor() {
     const siteConfig = require(`${CWD}/siteConfig.js`);
-
     let markdownOptions = {
       // Highlight.js expects hljs css classes on the code element.
       // This results in <pre><code class="hljs css languages-jsx">
@@ -45,14 +47,20 @@ class MarkdownRenderer {
                 siteConfig.usePrism.length > 0 &&
                 siteConfig.usePrism.indexOf(lang) !== -1)
             ) {
+              const language = alias[lang] || lang;
               try {
-                const language = alias[lang] || lang;
                 // Currently people using prismjs on Node have to individually require()
                 // every single language (https://github.com/PrismJS/prism/issues/593)
                 require(`prismjs/components/prism-${language}.min`);
                 return prismjs.highlight(str, prismjs.languages[language]);
               } catch (err) {
-                console.error(err);
+                if (err.code === 'MODULE_NOT_FOUND') {
+                  const unsupportedLanguageError = chalk.yellow(
+                    `Warning: language-${language} is not supported by prismjs.` +
+                      '\nPlease refer to https://prismjs.com/#languages-list for the list of supported languages.',
+                  );
+                  console.log(unsupportedLanguageError);
+                } else console.error(err);
               }
             }
             if (hljs.getLanguage(lang)) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #1076 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The stacktrace errors thrown by prismjs for unsupported languages (eg: `toml`) are now logged only as a warning message instead of logging the entire stack trace. This can be tested by doing the following changes:
 1. Set `usePrism:true` in `siteConfig.js`.
 2. Modify docs/api-doc-markdown.md to render a language not supported by prismjs.
	Eg: (toml)
	```toml
		# This is a TOML document. Boom.
		title = "TOML Example"
		
		[dog]
		name = "Lucky"
		breed = "Labrador"
		
		[cat]
		name = "Fluffy"
		breed = "Siamese"
	```

3. 
```bash
	cd website
	yarn start
```

 A warning message similar to the screenshot below would be logged in the console.

![prism-errors](https://user-images.githubusercontent.com/11358903/48340095-c71bcd80-e68f-11e8-89be-cef13998ba0d.PNG)

