### PR TITLE
feat: show a warning message when md links are broken

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -150,9 +150,6 @@ An option to enable the docs showing the author who last updated the doc. Set to
 
 An option to enable the docs showing last update time. Set to `true` to show a line at the bottom right corner of each doc page as `Last updated on <date>`.
 
-#### `enableBrokenLinkWarning` [boolean]
-An option to enable a warning message in console when an in internal link is not resolved. Default to `false`.
-
 #### `facebookAppId` [string]
 
 If you want Facebook Like/Share buttons in the footer and at the bottom of your blog posts, provide a [Facebook application id](https://www.facebook.com/help/audiencenetwork/804209223039296).

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -150,6 +150,9 @@ An option to enable the docs showing the author who last updated the doc. Set to
 
 An option to enable the docs showing last update time. Set to `true` to show a line at the bottom right corner of each doc page as `Last updated on <date>`.
 
+#### `enableBrokenLinkWarning` [boolean]
+An option to enable a warning message in console when an in internal link is not resolved. Default to `false`.
+
 #### `facebookAppId` [string]
 
 If you want Facebook Like/Share buttons in the footer and at the bottom of your blog posts, provide a [Facebook application id](https://www.facebook.com/help/audiencenetwork/804209223039296).

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -108,7 +108,7 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
     }
   });
 
-  if (siteConfig.enableBrokenLinkWarning && mdBrokenLinks.length) {
+  if (mdBrokenLinks.length) {
     console.log(
       `[WARN] unresolved links in file '${metadata.source}' >`,
       mdBrokenLinks,

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -49,6 +49,7 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
   let content = oldContent;
   const mdLinks = [];
   const mdReferences = [];
+  const mdBrokenLinks = [];
 
   // find any inline-style links to markdown files
   const linkRegex = /(?:\]\()(?:\.\/)?([^'")\]\s>]+\.md)/g;
@@ -81,6 +82,8 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
         new RegExp(`\\]\\((\\./)?${mdLink}`, 'g'),
         `](${htmlLink}`,
       );
+    } else {
+      mdBrokenLinks.push(mdLink);
     }
   });
 
@@ -100,8 +103,14 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
         new RegExp(`\\]:(?:\\s)?(\\./|\\.\\./)?${refLink}`, 'g'),
         `]: ${htmlLink}`,
       );
+    } else {
+      mdBrokenLinks.push(refLink);
     }
   });
+
+  if (siteConfig.enableBrokenLinkWarning && mdBrokenLinks.length) {
+    console.log(`[WARN] unresolved links in file '${metadata.source}' >`, mdBrokenLinks);
+  }
   return content;
 }
 

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -109,7 +109,10 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
   });
 
   if (siteConfig.enableBrokenLinkWarning && mdBrokenLinks.length) {
-    console.log(`[WARN] unresolved links in file '${metadata.source}' >`, mdBrokenLinks);
+    console.log(
+      `[WARN] unresolved links in file '${metadata.source}' >`,
+      mdBrokenLinks,
+    );
   }
   return content;
 }


### PR DESCRIPTION
## 🚀 Feature

Show a warning message in the console that outputs a log when an internal link inside the documentation is broken. 

Fix #1111 

## Have you read the [Contributing Guidelines on issues](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#reporting-new-issues)?

Yes.

## Motivation

It can happen to have brokens links in the documentation that are caused by a change in the file id/path (e.g. a file is renamed, moved or simply there's a typo in the link) and then forgetting to update the link that points to it.
It's very hard discovering where they are in the docs and fix it.

## Pitch

It would be nice to introduce a check (maybe flaggable in the options) when running ```docusaurus start``` or ```docusaurus build``` that shows a warning message if a link in the markdown has an unresolved path.
