### PR TITLE
feat: use doc's title or id as default when link name is not provided

### DIFF
--- a/v1/lib/server/__tests__/__fixtures__/doc4.md
+++ b/v1/lib/server/__tests__/__fixtures__/doc4.md
@@ -1,0 +1,12 @@
+---
+id: doc4
+title: Document 4
+---
+
+### Existing Docs
+
+- [doc1](doc1.md)
+- [doc2](./doc2.md)
+
+### Empty Title Docs
+- [](doc1.md)

--- a/v1/lib/server/__tests__/__fixtures__/metadata.js
+++ b/v1/lib/server/__tests__/__fixtures__/metadata.js
@@ -51,6 +51,16 @@ module.exports = {
     previous_title: 'Document 2',
     sort: 3,
   },
+  'en-doc4': {
+    id: 'en-doc4',
+    title: 'Document 4',
+    source: 'doc4.md',
+    version: 'next',
+    permalink: 'docs/en/next/doc4.html',
+    localized_id: 'doc4',
+    language: 'en',
+    sidebar: 'docs',
+  },
   'en-reflinks': {
     id: 'en-reflinks',
     title: 'Reference Links',

--- a/v1/lib/server/__tests__/__snapshots__/docs.test.js.snap
+++ b/v1/lib/server/__tests__/__snapshots__/docs.test.js.snap
@@ -4,7 +4,7 @@ exports[`mdToHtmlify if link's name is not provided replace it with the doc titl
 "
 ### Existing Docs
 
-- [doc1Document 1](/docs/en/next/doc1)
+- [doc1](/docs/en/next/doc1)
 - [doc2](/docs/en/next/doc2)
 
 ### Empty Title Docs

--- a/v1/lib/server/__tests__/__snapshots__/docs.test.js.snap
+++ b/v1/lib/server/__tests__/__snapshots__/docs.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`mdToHtmlify if link's name is not provided replace it with the doc title or id, 1`] = `
+"
+### Existing Docs
+
+- [doc1Document 1](/docs/en/next/doc1)
+- [doc2](/docs/en/next/doc2)
+
+### Empty Title Docs
+- [Document 1](/docs/en/next/doc1)"
+`;
+
 exports[`mdToHtmlify transform link even in subdirectory 1`] = `
 "
 Test subdirectory file

--- a/v1/lib/server/__tests__/__snapshots__/readCategories.test.js.snap
+++ b/v1/lib/server/__tests__/__snapshots__/readCategories.test.js.snap
@@ -86,6 +86,25 @@ Array [
     "title": "Test 2",
     "type": "CATEGORY",
   },
+  Object {
+    "children": Array [
+      Object {
+        "item": Object {
+          "id": "en-doc4",
+          "language": "en",
+          "localized_id": "doc4",
+          "permalink": "docs/en/next/doc4.html",
+          "sidebar": "docs",
+          "source": "doc4.md",
+          "title": "Document 4",
+          "version": "next",
+        },
+        "type": "LINK",
+      },
+    ],
+    "title": undefined,
+    "type": "CATEGORY",
+  },
 ]
 `;
 

--- a/v1/lib/server/__tests__/docs.test.js
+++ b/v1/lib/server/__tests__/docs.test.js
@@ -55,6 +55,11 @@ const doc3 = fs.readFileSync(
   'utf8',
 );
 
+const doc4 = fs.readFileSync(
+  path.join(__dirname, '__fixtures__', 'doc4.md'),
+  'utf8',
+);
+
 const refLinks = fs.readFileSync(
   path.join(__dirname, '__fixtures__', 'reflinks.md'),
   'utf8',
@@ -63,6 +68,7 @@ const refLinks = fs.readFileSync(
 const rawContent1 = metadataUtils.extractMetadata(doc1).rawContent;
 const rawContent2 = metadataUtils.extractMetadata(doc2).rawContent;
 const rawContent3 = metadataUtils.extractMetadata(doc3).rawContent;
+const rawContent4 = metadataUtils.extractMetadata(doc4).rawContent;
 const rawContentRefLinks = metadataUtils.extractMetadata(refLinks).rawContent;
 
 describe('mdToHtmlify', () => {
@@ -88,6 +94,15 @@ describe('mdToHtmlify', () => {
     expect(content2).toContain('/docs/en/next/');
     expect(content2).toMatchSnapshot();
     expect(content2).not.toEqual(rawContent2);
+  });
+
+  test("if link's name is not provided replace it with the doc title or id,", () => {
+    const metadata = Metadata['en-doc4'];
+    metadata.titles = {doc1: 'Document 1'};
+    const content4 = docs.mdToHtmlify(rawContent4, mdToHtml, metadata);
+    expect(content4).toContain('/docs/en/next/');
+    expect(content4).toMatchSnapshot();
+    expect(content4).not.toEqual(rawContent4);
   });
 
   test('transform link even in subdirectory', () => {

--- a/v1/lib/server/__tests__/readCategories.test.js
+++ b/v1/lib/server/__tests__/readCategories.test.js
@@ -40,7 +40,7 @@ describe('readCategories', () => {
     const categories = readCategories('docs', generalMetadata, languages);
 
     expect(categories.en).toBeDefined();
-    expect(categories.en.length).toBe(2);
+    expect(categories.en.length).toBe(3);
     expect(categories.en).toMatchSnapshot();
   });
 

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -70,7 +70,7 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
   let etMatch = emptyTitleRegex.exec(content);
   while (etMatch !== null) {
     const htmlLink = mdToHtml[etMatch[1]];
-    if (htmlLink) {
+    if (htmlLink && metadata.titles) {
       const id = removeExtension(etMatch[1]);
       mdEmptyLinks[htmlLink] = metadata.titles[id] || id;
     }

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -90,9 +90,15 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
           ? `/${metadata.version}/`
           : '/',
       );
+      // replace all matched links
       content = content.replace(
         new RegExp(`\\]\\((\\./)?${mdLink}`, 'g'),
-        `${title}](${htmlLink}`,
+        `](${htmlLink}`,
+      );
+      // replace only links with empty title
+      content = content.replace(
+        new RegExp(`\\[\\]\\((\\./)?${htmlLink}`, 'g'),
+        `[${title}](${htmlLink}`,
       );
     }
   });

--- a/v1/lib/server/generate.js
+++ b/v1/lib/server/generate.js
@@ -69,8 +69,13 @@ async function execute() {
 
   // create html files for all docs by going through all doc ids
   const mdToHtml = metadataUtils.mdToHtml(Metadata, siteConfig.baseUrl);
+  const titles = Object.keys(Metadata).reduce((obj, key) => {
+    obj[key] = Metadata[key].title;
+    return obj;
+  }, {});
   Object.keys(Metadata).forEach(id => {
     const metadata = Metadata[id];
+    metadata.titles = titles;
     const file = docs.getFile(metadata);
     if (!file) {
       return;


### PR DESCRIPTION
## 🚀 Feature

Use the doc's title or id as default when a link name in the markdown is not provided. 

For example, when we have a link like ```[](foo.md)``` it would be nice if Docusaurus could read the title of the document 'foo.md' and generate automatically a link to ```[Foo Title](foo.md)```.

### How it currently works
Example:

*docs/doc1.md*:
```
---
id: doc1
title: Document 1
---
```

*docs/doc2.md*:
```
---
id: doc2
title: Document 2
---
- [Custom Link Name](doc1.md)
- [](doc1.md)
```

At the moment, in *docs/doc2.md* the link with empty name is omitted:

Output:
- [Custom Link Name](doc1.md)
- [](doc1.md)

### How it would work
In *docs/doc2.md* the link with empty name is replaced with the doc1's title (if exists) or it's id:

Output:
- [Custom Link Name](doc1.md)
- [Document 1](doc1.md)

## Have you read the [Contributing Guidelines on issues](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#reporting-new-issues)?

Yes.
