### PR TITLE
fix: translated pages missing left TOC

### DIFF
--- a/v1/lib/core/DocsSidebar.js
+++ b/v1/lib/core/DocsSidebar.js
@@ -14,8 +14,9 @@ const readCategories = require('../server/readCategories.js');
 
 let languages;
 
-if (fs.existsSync(`../server/languages.js`)) {
-  languages = require(`../server/languages.js`);
+const CWD = process.cwd();
+if (fs.existsSync(`${CWD}/languages.js`)) {
+  languages = require(`${CWD}/languages.js`);
 } else {
   languages = [
     {


### PR DESCRIPTION
## Motivation

Fix #1112 

This is caused due to `languages` will always be set as `en`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Create fake translated docs in `v1/website/translated_docs/api-commands.md`

The left TOC is now correctly shown

<img width="960" alt="after" src="https://user-images.githubusercontent.com/17883920/48760756-d6c79180-ece1-11e8-9c8c-6b919425acaa.PNG">


## Related PRs

#892 
