### PR TITLE
feat: use 'sidebar_label' instead of 'title' in prev/next buttons

### DIFF
--- a/docs/api-doc-markdown.md
+++ b/docs/api-doc-markdown.md
@@ -17,7 +17,7 @@ Documents use the following markdown header fields that are enclosed by a line `
 
 `hide_title`: Whether to hide the title at the top of the doc.
 
-`sidebar_label`: The text shown in the document sidebar for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.
+`sidebar_label`: The text shown in the document sidebar and in the next/previous button for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.
 
 For example:
 

--- a/v1/lib/core/DocsLayout.js
+++ b/v1/lib/core/DocsLayout.js
@@ -60,11 +60,23 @@ class DocsLayout extends React.Component {
     const hasOnPageNav = this.props.config.onPageNav === 'separate';
 
     const previousTitle =
+      idx(i18n, [
+        'localized-strings',
+        'docs',
+        metadata.previous_id,
+        'sidebar_label',
+      ]) ||
       idx(i18n, ['localized-strings', 'docs', metadata.previous_id, 'title']) ||
       idx(i18n, ['localized-strings', 'previous']) ||
       metadata.previous_title ||
       'Previous';
     const nextTitle =
+      idx(i18n, [
+        'localized-strings',
+        'docs',
+        metadata.next_id,
+        'sidebar_label',
+      ]) ||
       idx(i18n, ['localized-strings', 'docs', metadata.next_id, 'title']) ||
       idx(i18n, ['localized-strings', 'next']) ||
       metadata.next_title ||


### PR DESCRIPTION
## Motivation

see #1085 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

<img width="995" alt="capture d ecran 2018-11-21 a 13 35 56" src="https://user-images.githubusercontent.com/17004545/48841802-c91e1480-ed92-11e8-9713-c96d4ea803e7.png">
<img width="995" alt="capture d ecran 2018-11-21 a 13 36 29" src="https://user-images.githubusercontent.com/17004545/48841807-cc190500-ed92-11e8-8a24-de2c0307e8a0.png">

