### PR TITLE
fix: docusaurus-version should allow duplicate id in different subfolder

### DIFF
--- a/v1/lib/server/versionFallback.js
+++ b/v1/lib/server/versionFallback.js
@@ -128,7 +128,6 @@ function docVersion(id, reqVersion) {
 // returns whether a given file has content that differ from the
 // document with the given id
 function diffLatestDoc(file, id) {
-  console.log(`diffing file:${file} and id:${id}`);
   if (versions.length === 0) {
     return true;
   }

--- a/v1/lib/server/versionFallback.js
+++ b/v1/lib/server/versionFallback.js
@@ -76,9 +76,6 @@ files.forEach(file => {
     );
   }
 
-  if (!(metadata.original_id in available)) {
-    available[metadata.original_id] = new Set();
-  }
   // The version will be between "version-" and "-<metadata.original_id>"
   // e.g. version-1.0.0-beta.2-doc1 => 1.0.0-beta.2
   // e.g. version-1.0.0-doc2 => 1.0.0
@@ -87,6 +84,19 @@ files.forEach(file => {
     metadata.id.indexOf('version-') + 8, // version- is 8 characters
     metadata.id.lastIndexOf(`-${metadata.original_id}`),
   );
+
+  // the final id should be namespaced according to subdir to allow similar id across subfolder
+  const subDir = utils.getSubDir(
+    file,
+    path.join(versionFolder, `version-${version}`),
+  );
+  if (subDir) {
+    metadata.original_id = `${subDir}/${metadata.original_id}`;
+  }
+
+  if (!(metadata.original_id in available)) {
+    available[metadata.original_id] = new Set();
+  }
   available[metadata.original_id].add(version);
 
   if (!(version in versionFiles)) {
@@ -118,6 +128,7 @@ function docVersion(id, reqVersion) {
 // returns whether a given file has content that differ from the
 // document with the given id
 function diffLatestDoc(file, id) {
+  console.log(`diffing file:${file} and id:${id}`);
   if (versions.length === 0) {
     return true;
   }
@@ -127,6 +138,7 @@ function diffLatestDoc(file, id) {
   let version;
   try {
     version = docVersion(id, latest);
+    console.log(version);
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/v1/lib/server/versionFallback.js
+++ b/v1/lib/server/versionFallback.js
@@ -85,7 +85,7 @@ files.forEach(file => {
     metadata.id.lastIndexOf(`-${metadata.original_id}`),
   );
 
-  // the final id should be namespaced according to subdir to allow similar id across subfolder
+  // the original_id should be namespaced according to subdir to allow duplicate id in different subfolder
   const subDir = utils.getSubDir(
     file,
     path.join(versionFolder, `version-${version}`),

--- a/v1/lib/server/versionFallback.js
+++ b/v1/lib/server/versionFallback.js
@@ -137,7 +137,6 @@ function diffLatestDoc(file, id) {
   let version;
   try {
     version = docVersion(id, latest);
-    console.log(version);
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/v1/lib/version.js
+++ b/v1/lib/version.js
@@ -115,15 +115,15 @@ files.forEach(file => {
     metadata.title = metadata.id;
   }
 
-  if (!versionFallback.diffLatestDoc(file, metadata.id)) {
+  const docsDir = path.join(CWD, '../', readMetadata.getDocsPath());
+  const subDir = utils.getSubDir(file, docsDir);
+  const originalId = subDir ? `${subDir}/${metadata.id}` : metadata.id;
+  if (!versionFallback.diffLatestDoc(file, originalId)) {
     return;
   }
 
-  metadata.original_id = metadata.id;
-  metadata.id = `version-${version}-${metadata.id}`;
-
-  const docsDir = path.join(CWD, '../', readMetadata.getDocsPath());
-  const subDir = utils.getSubDir(file, docsDir);
+  metadata.original_id = originalId;
+  metadata.id = `version-${version}-${originalId}`;
   const targetFile = subDir
     ? `${versionFolder}/${subDir}/${path.basename(file)}`
     : `${versionFolder}/${path.basename(file)}`;


### PR DESCRIPTION
## Motivation

Fix #1113 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Created two files `ecosystem/bar.md` with id: bar and `hydra/bar.md` with id: bar
First, cut version 1.0.0 and a versioned docs is created
After that, cut version 2.0.0 again

Note that I added some debugging console.log for easy purpose

**Before**

Note that the versioning command is confused with id `bar` since it is not namespaced according to subdirectory.

![image](https://user-images.githubusercontent.com/17883920/48929859-572b0400-ef27-11e8-9f51-3a37d0003e03.png)

It incorrectly creates an extra version-2.0.0 file when there is no doc changes
![image](https://user-images.githubusercontent.com/17883920/48929881-79248680-ef27-11e8-9ee3-26c50fd5e4e3.png)


**After**
![image](https://user-images.githubusercontent.com/17883920/48929789-c6542880-ef26-11e8-8a2b-4eac48095516.png)


Since there is no change, no new files created
![image](https://user-images.githubusercontent.com/17883920/48929887-893c6600-ef27-11e8-9287-419b41b2ad82.png)

