### PR TITLE
feat: customizable search placeholder

### DIFF
--- a/docs/guides-search.md
+++ b/docs/guides-search.md
@@ -61,6 +61,20 @@ const siteConfig = {
 };
 ```
 
+## Customizing the placeholder
+
+If you want to change the placeholder (which defaults to *Search*), add the `placeholder` field in your config. For example, you may want the search bar to display *Ask me something*:
+
+```js
+const siteConfig = {	
+  ...	
+  algolia: {	
+    ...	
+    placeholder: 'Ask me something'
+  },	
+};	
+```
+
 ## Disabling the Search Bar
 
 To disable the search bar, comment out (recommended) or delete the `algolia` section in the `siteConfig.js` file.

--- a/v1/lib/core/nav/HeaderNav.js
+++ b/v1/lib/core/nav/HeaderNav.js
@@ -131,13 +131,14 @@ class HeaderNav extends React.Component {
     let docGroupActive = false;
     if (link.search && this.props.config.algolia) {
       // return algolia search bar
+      const placeholder = this.props.config.algolia.placeholder || "Search";
       return (
         <li className="navSearchWrapper reactNavSearchWrapper" key="search">
           <input
             id="search_input_react"
             type="text"
-            placeholder="Search"
-            title="Search"
+            placeholder={placeholder}
+            title={placeholder}
           />
         </li>
       );


### PR DESCRIPTION
## Motivation

Some might want to change the search bar placeholder. Either for a non-english documentation or just for something funnier than *Search*.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="570" alt="capture d ecran 2018-11-23 a 10 40 54" src="https://user-images.githubusercontent.com/17004545/48937387-33a78f80-ef0e-11e8-9c3b-802ec5fd470d.png">
