### PR TITLE
fix: relative markdown reference linking

### DIFF
--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -73,7 +73,7 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
     while (mdMatch !== null) {
       /* Replace it to correct html link */
       let htmlLink =
-        mdToHtml[mdMatch[1]] || mdToHtml[resolve(metadata.source, mdMatch[1])];
+        mdToHtml[resolve(metadata.source, mdMatch[1])] || mdToHtml[mdMatch[1]];
       if (htmlLink) {
         htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
         htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -6,6 +6,7 @@
  */
 const CWD = process.cwd();
 const {join} = require('path');
+const {resolve} = require('url');
 const fs = require('fs-extra');
 const React = require('react');
 const loadConfig = require('./config');
@@ -50,67 +51,47 @@ function getFile(metadata) {
 }
 
 function mdToHtmlify(oldContent, mdToHtml, metadata) {
-  let content = oldContent;
-  const mdLinks = [];
-  const mdReferences = [];
+  /* Store broken links */
   const mdBrokenLinks = [];
 
-  // find any inline-style links to markdown files
-  const linkRegex = /(?:\]\()(?:\.\/)?([^'")\]\s>]+\.md)/g;
-  let linkMatch = linkRegex.exec(content);
-  while (linkMatch !== null) {
-    mdLinks.push(linkMatch[1]);
-    linkMatch = linkRegex.exec(content);
-  }
-  // find any reference-style links to markdown files
-  const refRegex = /(?:\]:)(?:\s)?(?:\.\/|\.\.\/)?([^'")\]\s>]+\.md)/g;
-  let refMatch = refRegex.exec(content);
-  while (refMatch !== null) {
-    mdReferences.push(refMatch[1]);
-    refMatch = refRegex.exec(content);
-  }
-
-  // replace markdown links to their website html links
-  new Set(mdLinks).forEach(mdLink => {
-    let htmlLink = mdToHtml[mdLink];
-    if (htmlLink) {
-      htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
-      htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);
-      htmlLink = htmlLink.replace(
-        '/VERSION/',
-        metadata.version && metadata.version !== env.versioning.latestVersion
-          ? `/${metadata.version}/`
-          : '/',
-      );
-      content = content.replace(
-        new RegExp(`\\]\\((\\./)?${mdLink}`, 'g'),
-        `](${htmlLink}`,
-      );
-    } else {
-      mdBrokenLinks.push(mdLink);
+  let content = oldContent;
+  /* Replace internal markdown linking (except in fenced blocks) */
+  let fencedBlock = false;
+  const lines = content.split('\n').map(line => {
+    if (line.trim().startsWith('```')) {
+      fencedBlock = !fencedBlock;
     }
-  });
+    if (fencedBlock) return line;
 
-  // replace markdown refernces to their website html links
-  new Set(mdReferences).forEach(refLink => {
-    let htmlLink = mdToHtml[refLink];
-    if (htmlLink) {
-      htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
-      htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);
-      htmlLink = htmlLink.replace(
-        '/VERSION/',
-        metadata.version && metadata.version !== env.versioning.latestVersion
-          ? `/${metadata.version}/`
-          : '/',
-      );
-      content = content.replace(
-        new RegExp(`\\]:(?:\\s)?(\\./|\\.\\./)?${refLink}`, 'g'),
-        `]: ${htmlLink}`,
-      );
-    } else {
-      mdBrokenLinks.push(refLink);
+    let modifiedLine = line;
+    /* Replace inline-style links or reference-style links e.g:
+    This is [Document 1](doc1.md) -> we replace this doc1.md with correct link
+    [doc1]: doc1.md -> we replace this doc1.md with correct link
+    */
+    const mdRegex = /(?:(?:\]\()|(?:\]:\s?))(?!https)([^'")\]\s>]+\.md)/g;
+    let mdMatch = mdRegex.exec(modifiedLine);
+    while (mdMatch !== null) {
+      /* Replace it to correct html link */
+      let htmlLink =
+        mdToHtml[mdMatch[1]] || mdToHtml[resolve(metadata.source, mdMatch[1])];
+      if (htmlLink) {
+        htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
+        htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);
+        htmlLink = htmlLink.replace(
+          '/VERSION/',
+          metadata.version && metadata.version !== env.versioning.latestVersion
+            ? `/${metadata.version}/`
+            : '/',
+        );
+        modifiedLine = modifiedLine.replace(mdMatch[1], htmlLink);
+      } else {
+        mdBrokenLinks.push(mdMatch[1]);
+      }
+      mdMatch = mdRegex.exec(modifiedLine);
     }
+    return modifiedLine;
   });
+  content = lines.join('\n');
 
   if (mdBrokenLinks.length) {
     console.log(

--- a/v2/lib/webpack/loaders/markdown/index.js
+++ b/v2/lib/webpack/loaders/markdown/index.js
@@ -70,8 +70,8 @@ module.exports = function(fileString) {
         const mdLink = mdMatch[1];
         const targetSource = `${sourceDir}/${mdLink}`;
         const {permalink} =
-          sourceToMetadata[targetSource] ||
           sourceToMetadata[resolve(thisSource, mdLink)] ||
+          sourceToMetadata[targetSource] ||
           {};
         if (permalink) {
           modifiedLine = modifiedLine.replace(mdLink, permalink);

--- a/v2/lib/webpack/loaders/markdown/index.js
+++ b/v2/lib/webpack/loaders/markdown/index.js
@@ -8,6 +8,7 @@
 const fm = require('front-matter');
 const {getOptions} = require('loader-utils');
 const path = require('path');
+const {resolve} = require('url');
 const Remarkable = require('remarkable');
 const hljs = require('highlight.js');
 const chalk = require('chalk');
@@ -58,37 +59,25 @@ module.exports = function(fileString) {
       if (fencedBlock) return line;
 
       let modifiedLine = line;
-      const inlineLinks = [];
-      const refLinks = [];
-
-      /* Replace inline-style links e.g:
-      This is [Document 1](doc1.md) -> we replace this doc1.md with correct link
-      */
-      const inlineRegex = /(?:\]\()(?:\.\/)?([^'")\]\s>]+\.md)/g;
-      let inlineMatch = inlineRegex.exec(content);
-      while (inlineMatch !== null) {
-        inlineLinks.push(inlineMatch[1]);
-        inlineMatch = inlineRegex.exec(content);
-      }
-
-      /* Replace reference-style links e.g:
-        This is [Document 1][doc1].
+      /* Replace inline-style links or reference-style links e.g:
+        This is [Document 1](doc1.md) -> we replace this doc1.md with correct link
         [doc1]: doc1.md -> we replace this doc1.md with correct link
       */
-      const refRegex = /(?:\]:)(?:\s)?(?:\.\/|\.\.\/)?([^'")\]\s>]+\.md)/g;
-      let refMatch = refRegex.exec(content);
-      while (refMatch !== null) {
-        refLinks.push(refMatch[1]);
-        refMatch = refRegex.exec(content);
-      }
-
-      [...refLinks, ...inlineLinks].forEach(mdLink => {
+      const mdRegex = /(?:(?:\]\()|(?:\]:\s?))(?!https)([^'")\]\s>]+\.md)/g;
+      let mdMatch = mdRegex.exec(modifiedLine);
+      while (mdMatch !== null) {
+        /* Replace it to correct html link */
+        const mdLink = mdMatch[1];
         const targetSource = `${sourceDir}/${mdLink}`;
-        const {permalink} = sourceToMetadata[targetSource] || {};
+        const {permalink} =
+          sourceToMetadata[targetSource] ||
+          sourceToMetadata[resolve(thisSource, mdLink)] ||
+          {};
         if (permalink) {
           modifiedLine = modifiedLine.replace(mdLink, permalink);
         }
-      });
+        mdMatch = mdRegex.exec(modifiedLine);
+      }
       return modifiedLine;
     });
     content = lines.join('\n');


### PR DESCRIPTION
## Motivation

Fix #1137 

Upon finding, we actually never really support relative markdown linking since initial release. Things has been working so far because lot of people refer to doc by doing `[test](dir1/test.md]`, however `[test](../test.md)` will not work because we never really properly resolve it when replacing the markdown linking

The key change here is this

```js
mdToHtml[resolve(metadata.source, mdMatch[1])];
```

Oh another thing is we no longer replace markdown linking in fenced blocks 👍

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Clone the Redux repo at https://github.com/reduxjs/redux
2. Check out the `docs-rebuild` branch, specifically as of commit https://github.com/reduxjs/redux/commit/944df4ab9036cc82d244db4127a3e0f214740182 
3. Start Docusaurus

Before

![before](https://user-images.githubusercontent.com/17883920/49371783-92051700-f733-11e8-8d2a-efd1fdb18c59.gif)


After

![after](https://user-images.githubusercontent.com/17883920/49371477-8533f380-f732-11e8-99fd-06673f448564.gif)


cc @markerikson
