### PR TITLE
fix(HeaderNav): append index.html to logo link when cleanUrl is disabled

### DIFF
--- a/v1/lib/core/nav/HeaderNav.js
+++ b/v1/lib/core/nav/HeaderNav.js
@@ -306,7 +306,8 @@ class HeaderNav extends React.Component {
             <a
               href={
                 this.props.baseUrl +
-                (env.translation.enabled ? this.props.language : '')
+                (env.translation.enabled ? this.props.language : '') +
+                (siteConfig.cleanUrl ? '' : 'index.html')
               }>
               {siteConfig.headerIcon && (
                 <img


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Without this change, when setting `cleanUrl: false` in `siteConfig.js`, the `href` of the link on the header nav logo will point to `/` instead of `/index.html`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

✔️ 

## Test Plan

Build an example doc with `cleanUrl: false` and check that the link on the logo ends with `index.html`.
