### PR TITLE
fix: edit url should support versioned subdirectories

### DIFF
--- a/v1/lib/core/Doc.js
+++ b/v1/lib/core/Doc.js
@@ -24,7 +24,7 @@ class Doc extends React.Component {
 
     if (this.props.version && this.props.version !== 'next') {
       // If versioning is enabled and the current version is not next, we need to trim out "version-*" from the source if we want a valid edit link.
-      docSource = docSource.match(new RegExp(/version-.*\/(.*\.md)/, 'i'))[1];
+      docSource = docSource.match(new RegExp(/version-.*?\/(.*\.md)/, 'i'))[1];
     }
 
     const editUrl =


### PR DESCRIPTION
## Motivation

Fix #1153 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Create `learn/01-intro-to-muster.md`

```md
---
id: version-1.0.11-introduction
title: Introduction
original_id: introduction
---

Muster is a reactive state and data management library. It can:
- Collect data from multiple sources (user input, files, APIs, databases, etc.)
- Process the data in a reactive way, meaning that when the source (e.g. a file) changes, your logic that depends on that file gets re-run
- Manage dependencies between different pieces of logic
- Expose the data and logic as a graph
- Transparently handle synchronous and asynchronous data

![Muster Intro](assets/muster-intro.png)

Every Muster application expresses its data as a set of graph **nodes**, which can create links (dependencies) between each other. Muster introduces a concept of typed nodes, and different types of edges (called **operations**) between these nodes.

Muster operates a **virtual** graph, in the sense that Muster allows the creation of **matchers** which don’t exist in memory until they’re invoked – so the potential, virtual nodes are there but the actual entities haven’t yet been retrieved.
```

Before

<img width="960" alt="before" src="https://user-images.githubusercontent.com/17883920/49752696-19cac280-fcec-11e8-95a0-5c1387ce3b11.png">


After

<img width="959" alt="after" src="https://user-images.githubusercontent.com/17883920/49752701-1d5e4980-fcec-11e8-9e75-f8ec3b9c42da.png">

**Solution Explained:**

Simple regex fix. This is because we should lazyly quantify the preceding characters to match the subdirectories

Example:
`version-.*?\/(.*\.md)` for `version-1.0.11/learn/01-intro-to-muster.md` is `learn/01-intro-to-muster.md`
but `version-.*\/(.*\.md)` for `version-1.0.11/learn/01-intro-to-muster.md` is `01-intro-to-muster.md` which is wrong