### PR TITLE
Fix gap on mobile devices when scrolling

### DIFF
--- a/v1/lib/static/css/main.css
+++ b/v1/lib/static/css/main.css
@@ -724,6 +724,7 @@ blockquote {
   position: fixed;
   width: 100%;
   z-index: 9999;
+  transform: translate3d(0,0,0);
 }
 
 @media only screen and (min-width: 1024px) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I wanted to resolve #1152. The problem was caused by "momentum" style scrolling on some mobile devices. Fixed by addition of `translate3d(0,0,0)` in order to enable GPU during the scrolling animation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tested on iPhone 7 and iPhone XS.
The first tab is before(with the white gap), the second one is after the changes(no gap at all).
![111111](https://user-images.githubusercontent.com/17337276/50042923-6cfa9780-0095-11e9-9118-6ba38f54c4a4.gif)
