### PR TITLE
docs: add a link to easily add your project with a form

### DIFF
--- a/v1/website/pages/en/users.js
+++ b/v1/website/pages/en/users.js
@@ -50,11 +50,14 @@ class Users extends React.Component {
                 <translate>Is your project using Docusaurus?</translate>
               </p>
               <p>
-                Edit this page with a{' '}
-                <a href="https://github.com/facebook/docusaurus/edit/master/v1/website/data/users.js">
-                  Pull Request
+                <a href="https://build.amsterdam/your-company/docusaurus">
+                  Add your project
                 </a>{' '}
-                to add your logo.
+                or submit a{' '}
+                <a href="https://github.com/facebook/docusaurus/edit/master/website/data/users.js">
+                  Pull Request
+                </a>
+                .
               </p>
             </div>
           </div>


### PR DESCRIPTION
**Re: this discussion:** https://github.com/facebook/Docusaurus/issues/1080#issuecomment-440346187

### Why:
Adding a project to the users list now involves forking, editing a js file, uploading a logo, creating a PR, reviewing. Which can be made much simpler with a Github bot that transforms a form submission into the right Pull Request.

### What:
This PR links to a new web based submission form from the [users](https://docusaurus.io/en/users) page: https://build.amsterdam/your-company/docusaurus

### How:
* fill out the form
* submit
* backend creates a PR that updates the users.js and uploads the logo, and wraps it in a PR.

**As gif:**
![2018-12-17 20 54 25](https://user-images.githubusercontent.com/91795/50112618-e6ce8480-023f-11e9-93a0-d0f5c9788c28.gif)

### Example Bot PR:
How a bot PR looks like:
https://github.com/ymschaap/Docusaurus/pull/3

Let me know your thoughts if interested work on merging.
