### PR TITLE
fix: sidebar scrolling on ios devices

### DIFF
--- a/v1/lib/core/nav/SideNav.js
+++ b/v1/lib/core/nav/SideNav.js
@@ -134,8 +134,8 @@ class SideNav extends React.Component {
           dangerouslySetInnerHTML={{
             __html: `
             document.addEventListener('DOMContentLoaded', function() {
-              createToggler('#navToggler', '#docsNav', 'docsSliderActive');
-              createToggler('#tocToggler', 'body', 'tocActive');
+              createModalToggler('#navToggler', 'docsSliderActive');
+              createModalToggler('#tocToggler', 'tocActive');
 
               const headings = document.querySelector('.toc-headings');
               headings && headings.addEventListener('click', function(event) {
@@ -144,19 +144,51 @@ class SideNav extends React.Component {
                 }
               }, false);
 
-              function createToggler(togglerSelector, targetSelector, className) {
+              function createModalToggler(togglerSelector, className) {
                 var toggler = document.querySelector(togglerSelector);
-                var target = document.querySelector(targetSelector);
 
                 if (!toggler) {
                   return;
                 }
 
-                toggler.onclick = function(event) {
-                  event.preventDefault();
+                toggler.onclick = isIOS() ? getIOSToggleHandler(className) : getToggleHandler(className);
+              }
 
-                  target.classList.toggle(className);
-                };
+              function isIOS() {
+                var iOSDevices = ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'];
+              
+                if (!!navigator.platform) {
+                  while (iOSDevices.length) {
+                    if (navigator.platform === iOSDevices.pop()) {
+                       return true; 
+                    }
+                  }
+                }
+              
+                return false;
+              }
+
+              function getToggleHandler(className) {
+                return function(event) {
+                  event.preventDefault();
+                  document.body.classList.toggle(className);
+                }
+              }
+
+              function getIOSToggleHandler(className) {
+                var savedScrollY;
+
+                return function(event) {
+                  event.preventDefault();
+                  var isToggledOnNow = document.body.classList.contains(className);
+                  if (isToggledOnNow) {
+                    document.body.classList.remove(className, 'ios')
+                    window.scrollTo(0, savedScrollY);
+                  } else {
+                    savedScrollY = window.scrollY;
+                    document.body.classList.add(className, 'ios')
+                  }
+                }
               }
             });
         `,

--- a/v1/lib/static/css/main.css
+++ b/v1/lib/static/css/main.css
@@ -1616,7 +1616,21 @@ input::placeholder {
   }
 }
 
-.docsSliderActive.docsNavContainer {
+.tocActive, .docsSliderActive {
+  overflow: hidden;
+}
+
+.tocActive.ios, .docsSliderActive.ios {
+  position: fixed;
+}
+
+.tocActive.ios .mainContainer, 
+.docsSliderActive.ios .mainContainer {
+  transform: translate3d(0,0,0);
+  -webkit-transform: translate3d(0,0,0);
+}
+
+.docsSliderActive .docsNavContainer {
   box-sizing: border-box;
   height: 100%;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #877. The reason of the bug is specification of Safari on iOS devices. If for the Chrome is enough just to add overflow: hidden for the body, for Safari it does not work till you set the `position: fixed;`. But in this way you lose your scrolling position. So I created a closure which saves the last scroll position in order to set it back when the sidebar is closed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

First tab is the scolling before the fix. The second one is after.

![pull](https://user-images.githubusercontent.com/17337276/50200875-0372d580-0382-11e9-858f-ed9e7d61dd79.gif)

