### PR TITLE
fix: omit wrapping quotes around font generic values

### DIFF
--- a/v1/lib/server/server.js
+++ b/v1/lib/server/server.js
@@ -322,9 +322,20 @@ function execute(port) {
     });
 
     if (siteConfig.fonts) {
+      const fontGenericValues = [
+        'serif',
+        'sans-serif',
+        'monospace',
+        'cursive',
+        'fantasy',
+        'system-ui',
+        'inherit',
+        'initial',
+        'unset',
+      ];
       Object.keys(siteConfig.fonts).forEach(key => {
         const fontString = siteConfig.fonts[key]
-          .map(font => `"${font}"`)
+          .map(font => (fontGenericValues.includes(font) ? font : `"${font}"`))
           .join(', ');
         cssContent = cssContent.replace(
           new RegExp(`\\$${key}`, 'g'),

--- a/v1/lib/server/server.js
+++ b/v1/lib/server/server.js
@@ -329,6 +329,7 @@ function execute(port) {
         'cursive',
         'fantasy',
         'system-ui',
+        '-apple-system',
         'inherit',
         'initial',
         'unset',


### PR DESCRIPTION
## Motivation

For performance reasons, I wanted to use generic font family values in my site's css, like this in **siteConfig.js**:

```js
  /* custom fonts for website */
  fonts: {
    mainFont: [
      '-apple-system',
      'system-ui',
      'sans-serif'
    ],
    secondaryFont: [
      'sans-serif'
    ],
    accentFont: [
      '-apple-system',
      'system-ui',
    ],
  },
```

The generated CSS output from the above looked something like this

```css
font-family: "-apple-system", "system-ui", "sans-serif";
```

which, while "valid", does not produce the intended style. Quotes are used for named font families, while generic font values are unquoted. I say "valid" because CSS will parse the names and attempt to match them to a named font family but that will fail and not ever actually use the generic font value, which is not the expected behavior. I would have expected the output to be:

```css
font-family: -apple-system, system-ui, sans-serif;
```

I've fixed this by adding a list of generic font values to compare against. If the font provided does not match the approved list, it will be wrapped in quotes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've tested this on the Docusaurus website running locally, as well as in the project I'm looking to update (not yet committed though). 

- Pull changes
- Run Docusaurus site locally
- Add fonts key and values to siteConfig.js
    ```
  fonts: {
      mainFont: [
        'Roboto',
        'system-ui',
        'sans-serif'
      ]
  },
    ```
- In **custom.css**, add a style declaration that uses `$mainFont`.
    ```
    body {
       font-family: $mainFont;
    }
    ```
- Expect the generated css values to be

    ```
    body {
       font-family: "Roboto", system-ui, sans-serif;
    } 
    ```