### PR TITLE
fix: pass docusaurus-publish cli args to build command

### DIFF
--- a/v1/lib/publish-gh-pages.js
+++ b/v1/lib/publish-gh-pages.js
@@ -89,7 +89,7 @@ if (CURRENT_BRANCH === DEPLOYMENT_BRANCH && !crossRepoPublish) {
   shell.exit(1);
 }
 
-if (shell.exec(`node ${path.join(__dirname, 'build-files.js')}`).code) {
+if (shell.exec(`node ${path.join(__dirname, 'build-files.js')} ${process.argv.slice(2).join(' ')}`).code) {
   shell.echo('Error: generating html failed');
   shell.exit(1);
 }

--- a/v1/lib/publish-gh-pages.js
+++ b/v1/lib/publish-gh-pages.js
@@ -89,7 +89,13 @@ if (CURRENT_BRANCH === DEPLOYMENT_BRANCH && !crossRepoPublish) {
   shell.exit(1);
 }
 
-if (shell.exec(`node ${path.join(__dirname, 'build-files.js')} ${process.argv.slice(2).join(' ')}`).code) {
+if (
+  shell.exec(
+    `node ${path.join(__dirname, 'build-files.js')} ${process.argv
+      .slice(2)
+      .join(' ')}`,
+  ).code
+) {
   shell.echo('Error: generating html failed');
   shell.exit(1);
 }


### PR DESCRIPTION
The --skip-image-compression flag is passed thru to the build command

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
