### PR TITLE
fix: missing default value for grid block content objects

### DIFF
--- a/v1/lib/core/GridBlock.js
+++ b/v1/lib/core/GridBlock.js
@@ -11,7 +11,16 @@ const classNames = require('classnames');
 const MarkdownBlock = require('./MarkdownBlock.js');
 
 class GridBlock extends React.Component {
-  renderBlock(block) {
+  renderBlock(origBlock) {
+    const blockDefaults = {
+      imageAlign: 'left',
+    };
+
+    const block = {
+      ...blockDefaults,
+      ...origBlock,
+    };
+
     const blockClasses = classNames('blockElement', this.props.className, {
       alignCenter: this.props.align === 'center',
       alignRight: this.props.align === 'right',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #1184. The default value for the `alignImage` key was not applied. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The screenshots below show the content of a GridBlock content component with the `alignImage` key omitted before/after the fix.

Before (image missing):

<img width="470" alt="screenshot 2019-01-16 at 4 24 42 pm" src="https://user-images.githubusercontent.com/17447681/51235766-4fc62b00-19ab-11e9-8f9b-81e770fcbc97.png">


After (image in left position):

<img width="488" alt="screenshot 2019-01-16 at 4 22 45 pm" src="https://user-images.githubusercontent.com/17447681/51235781-56ed3900-19ab-11e9-81f1-28a858aeb12f.png">