### PR TITLE
docs: add missing trailing slash to sample site config base url

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -54,7 +54,7 @@ __Note:__ When you deploy as user/organization page, the publish script will dep
 const siteConfig = {
   ...
   url: 'https://__userName__.github.io', // Your website URL
-  baseUrl: '/testProject',
+  baseUrl: '/testProject/',
   projectName: 'testProject',
   organizationName: 'userName'
   ...


### PR DESCRIPTION
## Motivation

Fix #1189. Fix inconsistency between documentation and sample site config.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.