### PR TITLE
fix: wrong padding for single row mobile nav

### DIFF
--- a/v1/lib/core/Site.js
+++ b/v1/lib/core/Site.js
@@ -7,12 +7,14 @@
 
 const React = require('react');
 const fs = require('fs');
+const classNames = require('classnames');
 
 const HeaderNav = require('./nav/HeaderNav.js');
 const Head = require('./Head.js');
 
 const Footer = require(`${process.cwd()}/core/Footer.js`);
 const translation = require('../server/translation.js');
+const env = require('../server/env.js');
 const liveReloadServer = require('../server/liveReloadServer.js');
 const {idx} = require('./utils.js');
 
@@ -20,6 +22,15 @@ const CWD = process.cwd();
 
 // Component used to provide same head, header, footer, other scripts to all pages
 class Site extends React.Component {
+  mobileNavHasOneRow(headerLinks) {
+    const hasLanguageDropdown =
+      env.translation.enabled && env.translation.enabledLanguages().length > 1;
+    const hasOrdinaryHeaderLinks = headerLinks.some(
+      link => !(link.languages || link.search),
+    );
+    return !(hasLanguageDropdown || hasOrdinaryHeaderLinks);
+  }
+
   render() {
     const tagline =
       idx(translation, [this.props.language, 'localized-strings', 'tagline']) ||
@@ -43,6 +54,12 @@ class Site extends React.Component {
       docsVersion = latestVersion;
     }
 
+    const navPusherClasses = classNames('navPusher', {
+      singleRowMobileNav: this.mobileNavHasOneRow(
+        this.props.config.headerLinks,
+      ),
+    });
+
     return (
       <html lang={this.props.language}>
         <Head
@@ -62,7 +79,7 @@ class Site extends React.Component {
             version={this.props.version}
             current={this.props.metadata}
           />
-          <div className="navPusher">
+          <div className={navPusherClasses}>
             {this.props.children}
             <Footer config={this.props.config} language={this.props.language} />
           </div>

--- a/v1/lib/static/css/main.css
+++ b/v1/lib/static/css/main.css
@@ -1317,6 +1317,10 @@ input::placeholder {
   z-index: 99;
 }
 
+.singleRowMobileNav.navPusher {
+  padding-top: 50px;
+}
+
 .navPusher:after {
   background: rgba(0, 0, 0, 0.4);
   content: '';
@@ -1988,6 +1992,10 @@ input::placeholder {
       right: 0;
       top: 148px;
       z-index: 10;
+    }
+
+    .tocActive .singleRowMobileNav .onPageNav {
+      top: 98px;
     }
 
     .tocActive .navToggle,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #1187. Padding for certain components assumed that there will always be two rows in the nav bar in mobile view. Here we handle the case where the nav bar only has a single row on mobile devices.

I'm not 100% certain if `Site.js` is the best place to check whether the mobile nav bar occupies a single row, or if I'm applying the `singleRowMobileNav` class at the most suitable place. Please do let me know if there is a better way to achieve this!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

We test for the cases where there are two rows in the mobile nav bar (at least 1 doc/blog/page/href/language link) and when there is one row in the mobile nav bar (no doc/blog/page/href/language link).

### Padding for mobile devices should be correct when there are two rows in the mobile nav bar:
<img width="872" alt="screenshot 2019-01-20 at 12 58 50 am" src="https://user-images.githubusercontent.com/17447681/51430036-2d087080-1c50-11e9-9781-098a8166bd9d.png">
<img width="872" alt="screenshot 2019-01-20 at 12 58 59 am" src="https://user-images.githubusercontent.com/17447681/51430044-3eea1380-1c50-11e9-98ab-564e77a3a563.png">
<img width="872" alt="screenshot 2019-01-20 at 12 59 10 am" src="https://user-images.githubusercontent.com/17447681/51430046-41e50400-1c50-11e9-81ad-988675d6ff67.png">

### Padding for mobile devices should be correct when there is one row in the mobile nav bar:
<img width="869" alt="screenshot 2019-01-20 at 1 05 15 am" src="https://user-images.githubusercontent.com/17447681/51430062-67720d80-1c50-11e9-8d6f-ea768c82a8ba.png">
<img width="873" alt="screenshot 2019-01-20 at 1 05 21 am" src="https://user-images.githubusercontent.com/17447681/51430063-6b059480-1c50-11e9-8704-a7d67fb5b957.png">
<img width="873" alt="screenshot 2019-01-20 at 1 05 30 am" src="https://user-images.githubusercontent.com/17447681/51430064-6e008500-1c50-11e9-84d2-8cc014dc5835.png">

### Padding for full screen devices should be correct when there are two rows in the mobile nav bar:
<img width="1679" alt="screenshot 2019-01-20 at 1 08 50 am" src="https://user-images.githubusercontent.com/17447681/51430084-b1f38a00-1c50-11e9-8208-46a6f7e8a316.png">

### Padding for full screen devices should be correct when there is one row in the mobile nav bar
<img width="1680" alt="screenshot 2019-01-20 at 1 07 57 am" src="https://user-images.githubusercontent.com/17447681/51430076-a1431400-1c50-11e9-8044-fe379528c9b3.png">