### PR TITLE
fix: add margin-bottom: 0 to blog post author

### DIFF
--- a/v1/lib/static/css/main.css
+++ b/v1/lib/static/css/main.css
@@ -2076,6 +2076,7 @@ input::placeholder {
   justify-content: center;
   margin-right: 10px;
   margin-top: 0;
+  margin-bottom: 0;
   padding: 0;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Before:
![image](https://user-images.githubusercontent.com/1404810/51532221-e2e5e180-1e3f-11e9-90c2-07841f366dfb.png)

![image](https://user-images.githubusercontent.com/1404810/51532231-e7aa9580-1e3f-11e9-8524-6a32298284f7.png)

After:
![image](https://user-images.githubusercontent.com/1404810/51532286-fe50ec80-1e3f-11e9-9e0a-455b2b010b4f.png)

![image](https://user-images.githubusercontent.com/1404810/51532247-eda07680-1e3f-11e9-8d80-7e851c80b3fc.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See motivation

## Related PRs

N/A