### PR TITLE
fix: docs asset links should follow specified docsUrl

### DIFF
--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -111,7 +111,10 @@ function getMarkup(rawContent, mdToHtml, metadata) {
   content = mdToHtmlify(content, mdToHtml, metadata);
 
   // replace any relative links to static assets (not in fenced code blocks) to absolute links
-  content = replaceAssetsLink(content, `${siteConfig.baseUrl}docs`);
+  const docsAssetsLocation = siteConfig.docsUrl
+    ? `${siteConfig.baseUrl}${siteConfig.docsUrl}`
+    : siteConfig.baseUrl.substring(0, siteConfig.baseUrl.length - 1);
+  content = replaceAssetsLink(content, docsAssetsLocation);
 
   const DocsLayout = require('../core/DocsLayout.js');
   return renderToStaticMarkupWithDoctype(

--- a/v1/lib/server/generate.js
+++ b/v1/lib/server/generate.js
@@ -101,7 +101,7 @@ async function execute() {
   if (fs.existsSync(join(CWD, '..', readMetadata.getDocsPath(), 'assets'))) {
     fs.copySync(
       join(CWD, '..', readMetadata.getDocsPath(), 'assets'),
-      join(buildDir, 'docs', 'assets'),
+      join(buildDir, siteConfig.docsUrl, 'assets'),
     );
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #1177 and #1203. Generated asset links were not following the `docsUrl` attribute specified in `siteConfig.js`. Docs assets were also placed into the `docs` folder in the build directory instead of following the specified `docsUrl`. This PR should fix these issues. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

#### Development Environment
Set `docsUrl` in `siteConfig.js` to `hello` and start local server. Asset links in docs should point to `/hello/assets/ASSET_NAME`. Docs assets should be served from `/hello/assets/ASSET_NAME`. Images should be displayed on the test site.

#### Production Environment
Set `docsUrl` in `siteConfig.js` to `hello` and build the site. Asset links in docs should point to `/hello/assets/ASSET_NAME`. Docs assets should be served from `/hello/assets/ASSET_NAME`. Images should be displayed on the test site. (See https://marvinchin.github.io/docusaurus-demo/hello/doc1)