### PR TITLE
Fix horizontal overflow in sidebar

### DIFF
--- a/v1/lib/static/css/main.css
+++ b/v1/lib/static/css/main.css
@@ -1610,7 +1610,7 @@ input::placeholder {
 
 .collapsible .arrow {
   float: right;
-  margin-right: 5px;
+  margin-right: 8px;
   transform: rotate(90deg);
   transition: transform 200ms linear;
 }


### PR DESCRIPTION
When the sidebar is collapsible, a horizontal scrollbar can be seen, e.g.:

https://docusaurus.io/docs/en/installation - https://i.imgur.com/IkrkLrp.png

This is caused by the arrow being rendered outside of the sidebar box.

## Motivation

Fix an overflow bug in sidebar.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The issue is visible in the official documentation. Fix should be visible in the PR preview.
