### PR TITLE
fix: make search bar taller on widescreen

### DIFF
--- a/v1/lib/static/css/main.css
+++ b/v1/lib/static/css/main.css
@@ -934,6 +934,14 @@ input#search_input_react {
   width: 170px;
 }
 
+.navSearchWrapper:before {
+  left: 24px;
+}
+
+.navSearchWrapper:after {
+  left: 35px;
+}
+
 input#search_input_react:focus,
 input#search_input_react:active {
   color: #fff;
@@ -1368,7 +1376,7 @@ input::placeholder {
     font-size: 14px;
     line-height: 20px;
     outline: none;
-    padding-left: 25px;
+    padding-left: 38px;
     position: relative;
     transition: background-color 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55),
       width 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55), color 0.2s ease;
@@ -1424,6 +1432,13 @@ input::placeholder {
     position: relative;
     right: auto;
     top: auto;
+  }
+
+  .reactNavSearchWrapper input#search_input_react {
+    height: 100%;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 38px;
   }
 
   .navSearchWrapper .algolia-autocomplete {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It looks nicer when it's taller. Takes UI inspiration from Redux.

<img width="1532" alt="screen shot 2019-01-28 at 9 19 48 pm" src="https://user-images.githubusercontent.com/1315101/51885941-953b0e80-2342-11e9-9054-e165129fe61a.png">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See Netlify

## Related PRs

NA
