### PR TITLE
fix: change sidebar chevron icon to use svg

### DIFF
--- a/v1/lib/core/nav/SideNav.js
+++ b/v1/lib/core/nav/SideNav.js
@@ -69,7 +69,17 @@ class SideNav extends React.Component {
     if (siteConfig.docsSideNavCollapsible) {
       categoryClassName += ' collapsible';
       ulClassName = 'hide';
-      arrow = <span className="arrow">&#8963;</span>;
+      arrow = (
+        <span className="arrow">
+          <svg width="24" height="24" viewBox="0 0 24 24">
+            <path
+              fill="#565656"
+              d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+            />
+            <path d="M0 0h24v24H0z" fill="none" />
+          </svg>
+        </span>
+      );
     }
 
     return (

--- a/v1/lib/static/css/main.css
+++ b/v1/lib/static/css/main.css
@@ -1626,6 +1626,7 @@ input::placeholder {
 .collapsible .arrow {
   float: right;
   margin-right: 8px;
+  margin-top: -4px;
   transform: rotate(90deg);
   transition: transform 200ms linear;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Unicode rendering is font-dependent which is then system dependent. Changing it to an SVG to make it more consistent across devices.

Fixes #1207.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="1532" alt="screen shot 2019-01-28 at 9 43 52 pm" src="https://user-images.githubusercontent.com/1315101/51886830-4000fc00-2346-11e9-8c3f-7c99d50cfe50.png">

## Related PRs

NA