### PR TITLE
Added customHeaderFields option to siteConfig.js  #1209

### DIFF
--- a/v1/lib/server/readMetadata.js
+++ b/v1/lib/server/readMetadata.js
@@ -24,7 +24,7 @@ const utils = require('./utils.js');
 
 const docsPart = `${siteConfig.docsUrl ? `${siteConfig.docsUrl}/` : ''}`;
 
-const SupportedHeaderFields = new Set([
+const defaultHeaderFields = [
   'id',
   'title',
   'author',
@@ -35,7 +35,13 @@ const SupportedHeaderFields = new Set([
   'hide_title',
   'layout',
   'custom_edit_url',
-]);
+];
+
+const customHeaderFields = siteConfig.customHeaderFields || [];
+
+const SupportedHeaderFields = new Set(
+  defaultHeaderFields.concat(customHeaderFields)
+);
 
 let allSidebars;
 if (fs.existsSync(`${CWD}/sidebars.json`)) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Proposed patch for "Add option to siteConfig.js to configure supported headers in front matter #1209"
> https://github.com/facebook/Docusaurus/issues/1209

It would be nice to configure supported header fields in the front matter so that Docusaurus won't produce warnings in the console output. Currently, custom fields in the front matter produce warnings.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Need help with automation, tested manually for the time being:

**Reproduce warnings**
Add custom fileds into any of the markdown documents:
```yaml
---
id: version-1.7.0-doc-markdown
title: Markdown Features
original_id: doc-markdown
custom_field: 'custom value'
custom_field1: 'custom value2'
---
```
 
* add custom fields in `v1\website\versioned_docs\version-1.7.0\api-doc-markdown.md`
*  `cd v1/website && yarn build`

The output will have: 
```
Header field "custom_field" in C:/github/avishnyakov/Docusaurus/v1/website/versioned_docs/version-1.7.0/api-doc-markdown.md is nots upported.
Header field "custom_field2" in C:/github/avishnyakov/Docusaurus/v1/website/versioned_docs/version-1.7.0/api-doc-markdown.md is not supported.
```

* apply this PR
* modify `v1\website\siteConfig.js` adding `customHeaderFields` option:
```js
const siteConfig = {
  // ....
  docsSideNavCollapsible: true,
  customHeaderFields: [
    'custom_field',
    'custom_field2'
  ]
}
```

* rerun `cd v1/website && yarn build`, ensure that no warnings are in the output
* add new custom fields in the markdown files
* rerun `cd v1/website && yarn build`, ensure that there are warnings are in the output for the fields not mentioned in the `v1\website\siteConfig.js` 

## Related PRs
Guess we need to update siteConfig doco in `v1\website\versioned_docs\version-1.7.0` one this is approved?