### PR TITLE
Update code.facebook.com links to appropriate new destination

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 [Docusaurus](https://docusaurus.io) is our way to hopefully help creating open source documentation easier. We currently have [multiple open source projects using it](https://docusaurus.io/en/users.html), with many more planned. If you're interested in contributing to Docusaurus, hopefully this document makes the process for contributing clear.
 
-## [Code of Conduct](https://code.facebook.com/codeofconduct)
+## [Code of Conduct](https://code.fb.com/codeofconduct)
 
-Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.fb.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
 
 ## Get involved
 

--- a/v1/examples/basics/core/Footer.js
+++ b/v1/examples/basics/core/Footer.js
@@ -84,7 +84,7 @@ class Footer extends React.Component {
         </section>
 
         <a
-          href="https://code.facebook.com/projects/"
+          href="https://opensource.facebook.com/"
           target="_blank"
           rel="noreferrer noopener"
           className="fbOpenSource">

--- a/v1/website/blog/2018-04-30-How-I-Converted-Profilo-To-Docusaurus.md
+++ b/v1/website/blog/2018-04-30-How-I-Converted-Profilo-To-Docusaurus.md
@@ -13,7 +13,7 @@ authorTwitter: abernathyca
 
 This is the story of the rather short journey it took to create the [Profilo](https://facebookincubator.github.io/profilo/) website using Docusaurus.
 
-Profilo, an Android library for collecting performance traces from production, [was announced](https://code.facebook.com/posts/356115241551826/profilo-understanding-app-performance-in-the-wild/) earlier this year. The project was [published on GitHub](https://github.com/facebookincubator/profilo/tree/802042f90f990998a272387e371b893af52465b8) with a less than [a handful or Markdown files](https://github.com/facebookincubator/profilo/tree/802042f90f990998a272387e371b893af52465b8/docs) to describe its functionality and no website to showcase any branding and highlight the logo. The task at hand was to turn these existing docs and logo into a website.
+Profilo, an Android library for collecting performance traces from production, [was announced](https://code.fb.com/android/profilo-understanding-app-performance-in-the-wild/) earlier this year. The project was [published on GitHub](https://github.com/facebookincubator/profilo/tree/802042f90f990998a272387e371b893af52465b8) with a less than [a handful or Markdown files](https://github.com/facebookincubator/profilo/tree/802042f90f990998a272387e371b893af52465b8/docs) to describe its functionality and no website to showcase any branding and highlight the logo. The task at hand was to turn these existing docs and logo into a website.
 
 <!--truncate-->
 

--- a/v1/website/core/Footer.js
+++ b/v1/website/core/Footer.js
@@ -117,7 +117,7 @@ class Footer extends React.Component {
           <SocialFooter config={this.props.config} />
         </section>
         <a
-          href="https://code.facebook.com/projects/"
+          href="https://opensource.facebook.com/"
           target="_blank"
           rel="noreferrer noopener"
           className="fbOpenSource">

--- a/v1/website/pages/en/users.js
+++ b/v1/website/pages/en/users.js
@@ -30,7 +30,7 @@ class Users extends React.Component {
               </h1>
               <p>
                 Docusaurus powers some of Facebook&apos;s popular{' '}
-                <a href="https://code.facebook.com/projects/">
+                <a href="https://opensource.facebook.com/">
                   open source projects
                 </a>
                 .


### PR DESCRIPTION
This site mostly doesn't exist anymore, so we should just link to the new
locations. The exception is that the CLA is still there.