### PR TITLE
Use clean url for og:url when cleanUrl is true

### DIFF
--- a/v1/lib/core/Site.js
+++ b/v1/lib/core/Site.js
@@ -16,7 +16,7 @@ const Footer = require(`${process.cwd()}/core/Footer.js`);
 const translation = require('../server/translation.js');
 const env = require('../server/env.js');
 const liveReloadServer = require('../server/liveReloadServer.js');
-const {idx} = require('./utils.js');
+const {idx, getPath} = require('./utils.js');
 
 const CWD = process.cwd();
 
@@ -41,10 +41,11 @@ class Site extends React.Component {
           `${this.props.config.title} · ${tagline}`) ||
         this.props.config.title;
     const description = this.props.description || tagline;
-    const url =
-      this.props.config.url +
-      this.props.config.baseUrl +
-      (this.props.url || 'index.html');
+    const path = getPath(
+      this.props.config.baseUrl + (this.props.url || 'index.html'),
+      this.props.config.cleanUrl,
+    );
+    const url = this.props.config.url + path;
     let docsVersion = this.props.version;
 
     const liveReloadScriptUrl = liveReloadServer.getReloadScriptUrl();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #1233.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Set `cleanUrl` to `true` in `siteConfig.js`. Check the `og:url` meta tag. The value should be the clean url.
