### PR TITLE
fix: make referenced links work with code block tabs

### DIFF
--- a/v1/lib/core/Doc.js
+++ b/v1/lib/core/Doc.js
@@ -6,6 +6,7 @@
  */
 
 const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
 const MarkdownBlock = require('./MarkdownBlock.js');
 const CodeTabsMarkdownBlock = require('./CodeTabsMarkdownBlock.js');
 
@@ -31,6 +32,28 @@ const splitTabsToTitleAndContent = content => {
   }));
 };
 
+const cleanTheCodeTag = content => {
+  const contents = content.split(
+    /(<pre>)(.*?)(<\/pre>)/gms,
+  );
+  let inCodeBlock = false;
+  const cleanContents = contents.map((c) => {
+    if (c === '<pre>') {
+      inCodeBlock = true;
+      return c;
+    } if (c === '</pre>') {
+      inCodeBlock = false;
+      return c;
+    } if (inCodeBlock) {
+      return c.replace(/\n/g, "<br />");
+    }
+      return c;
+
+
+  });
+  return cleanContents.join('');
+};
+
 // inner doc component for article itself
 class Doc extends React.Component {
   renderContent() {
@@ -40,26 +63,27 @@ class Doc extends React.Component {
       /(<!--DOCUSAURUS_CODE_TABS-->\n)(.*?)(\n<!--END_DOCUSAURUS_CODE_TABS-->)/gms,
     );
 
-    const renderResult = contents.map((c, index) => {
+    const renderResult = contents.map((c) => {
       if (c === '<!--DOCUSAURUS_CODE_TABS-->\n') {
         inCodeTabs = true;
-        return null;
+        return '';
       }
       if (c === '\n<!--END_DOCUSAURUS_CODE_TABS-->') {
         inCodeTabs = false;
-        return null;
+        return '';
       }
       if (inCodeTabs) {
-        return (
+        const codeTabsMarkdownBlock = renderToStaticMarkup(
           <CodeTabsMarkdownBlock>
             {splitTabsToTitleAndContent(c)}
           </CodeTabsMarkdownBlock>
         );
+        return cleanTheCodeTag(codeTabsMarkdownBlock);
       }
-      return <MarkdownBlock key={index}>{c}</MarkdownBlock>;
+      return c;
     });
 
-    return renderResult;
+    return renderResult.join('');
   }
 
   render() {
@@ -110,7 +134,9 @@ class Doc extends React.Component {
             <h1 className="postHeaderTitle">{this.props.title}</h1>
           )}
         </header>
-        <article>{this.renderContent()}</article>
+        <article>
+          <MarkdownBlock>{this.renderContent()}</MarkdownBlock>
+        </article>
       </div>
     );
   }

--- a/v1/lib/core/Doc.js
+++ b/v1/lib/core/Doc.js
@@ -6,7 +6,7 @@
  */
 
 const React = require('react');
-const { renderToStaticMarkup } = require('react-dom/server');
+const {renderToStaticMarkup} = require('react-dom/server');
 const MarkdownBlock = require('./MarkdownBlock.js');
 const CodeTabsMarkdownBlock = require('./CodeTabsMarkdownBlock.js');
 
@@ -33,23 +33,21 @@ const splitTabsToTitleAndContent = content => {
 };
 
 const cleanTheCodeTag = content => {
-  const contents = content.split(
-    /(<pre>)(.*?)(<\/pre>)/gms,
-  );
+  const contents = content.split(/(<pre>)(.*?)(<\/pre>)/gms);
   let inCodeBlock = false;
-  const cleanContents = contents.map((c) => {
+  const cleanContents = contents.map(c => {
     if (c === '<pre>') {
       inCodeBlock = true;
       return c;
-    } if (c === '</pre>') {
+    }
+    if (c === '</pre>') {
       inCodeBlock = false;
       return c;
-    } if (inCodeBlock) {
-      return c.replace(/\n/g, "<br />");
     }
-      return c;
-
-
+    if (inCodeBlock) {
+      return c.replace(/\n/g, '<br />');
+    }
+    return c;
   });
   return cleanContents.join('');
 };
@@ -63,7 +61,7 @@ class Doc extends React.Component {
       /(<!--DOCUSAURUS_CODE_TABS-->\n)(.*?)(\n<!--END_DOCUSAURUS_CODE_TABS-->)/gms,
     );
 
-    const renderResult = contents.map((c) => {
+    const renderResult = contents.map(c => {
       if (c === '<!--DOCUSAURUS_CODE_TABS-->\n') {
         inCodeTabs = true;
         return '';
@@ -76,7 +74,7 @@ class Doc extends React.Component {
         const codeTabsMarkdownBlock = renderToStaticMarkup(
           <CodeTabsMarkdownBlock>
             {splitTabsToTitleAndContent(c)}
-          </CodeTabsMarkdownBlock>
+          </CodeTabsMarkdownBlock>,
         );
         return cleanTheCodeTag(codeTabsMarkdownBlock);
       }


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
- The reason for this bug that the previous Codeblock implementation separates
the tabs, the markdown before tabs, and the markdown after tabs into
separate Remarkable component, thus they don't share information
regarding the reference link
- To solve this, change the Doc implementation so that one Doc
have only one Remarkable component by transforming the codeblock
into html string and add it as part of the markdown, letting the
Remarkable take care of the html string
- However, this approach made us need to ensure that there is no
newline in the codetab, otherwise, the formatting inside the
code will be broken. Thus, I replace every newline inside the
code tag with a br tag

Fix #1215 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Create a referenced link with the reference located separately (one above the Codeblock tab, one below the Codeblock tab), e.g:
1. Add `[You can use numbers for reference-style link definitions][1]` anywhere above the Codeblock tab
2. Add `[1]: http://slashdot.org` anywhere below the Codeblock tab

## Related PRs
 None