### PR TITLE
Fix bug where a numeric id would cause a failure

### DIFF
--- a/v1/lib/server/metadataUtils.js
+++ b/v1/lib/server/metadataUtils.js
@@ -58,7 +58,7 @@ function extractMetadata(content) {
     } catch (err) {
       // Ignore the error as it means it's not a JSON value.
     }
-    metadata[key] = value;
+    metadata[key] = isNaN(value) ? value : value+'';
   }
   return {metadata, rawContent: both.content};
 }


### PR DESCRIPTION


## Motivation

This is so that later in the parsing when include is used on an expected string value of `metadata.id` and fails because of type mismatch.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes
