### PR TITLE
fix: wrong sidebar_label and title on versioned_docs

### DIFF
--- a/v1/lib/write-translations.js
+++ b/v1/lib/write-translations.js
@@ -144,8 +144,7 @@ function execute() {
   });
 
   // go through pages to look for text inside translate tags
-  const files = glob.sync(`${CWD}/pages/en/**`);
-  files.forEach(file => {
+  glob.sync(`${CWD}/pages/en/**`).forEach(file => {
     const extension = nodePath.extname(file);
     if (extension === '.js') {
       const ast = babylon.parse(fs.readFileSync(file, 'utf8'), {

--- a/v1/lib/write-translations.js
+++ b/v1/lib/write-translations.js
@@ -72,16 +72,13 @@ function execute() {
   // look through markdown headers of docs for titles and categories to translate
   const docsDir = nodePath.join(CWD, '../', readMetadata.getDocsPath());
   const versionedDocsDir = nodePath.join(CWD, 'versioned_docs');
-  let files = [
-    ...glob.sync(`${docsDir}/**`),
-    ...glob.sync(`${versionedDocsDir}/**`),
-  ];
-  files.forEach(file => {
+
+  const translateDoc = (file, refDir) => {
     const extension = nodePath.extname(file);
     if (extension === '.md' || extension === '.markdown') {
       let res;
       try {
-        res = readMetadata.processMetadata(file, docsDir);
+        res = readMetadata.processMetadata(file, refDir);
       } catch (e) {
         console.error(e);
         process.exit(1);
@@ -100,7 +97,12 @@ function execute() {
           metadata.sidebar_label;
       }
     }
-  });
+  };
+  glob.sync(`${docsDir}/**`).forEach(file => translateDoc(file, docsDir));
+  glob
+    .sync(`${versionedDocsDir}/**`)
+    .forEach(file => translateDoc(file, versionedDocsDir));
+
   // look through header links for text to translate
   siteConfig.headerLinks.forEach(link => {
     if (link.label) {
@@ -116,8 +118,7 @@ function execute() {
     });
   });
 
-  files = glob.sync(`${CWD}/versioned_sidebars/*`);
-  files.forEach(file => {
+  glob.sync(`${CWD}/versioned_sidebars/*`).forEach(file => {
     if (!file.endsWith('-sidebars.json')) {
       if (file.endsWith('-sidebar.json')) {
         console.warn(
@@ -143,7 +144,7 @@ function execute() {
   });
 
   // go through pages to look for text inside translate tags
-  files = glob.sync(`${CWD}/pages/en/**`);
+  const files = glob.sync(`${CWD}/pages/en/**`);
   files.forEach(file => {
     const extension = nodePath.extname(file);
     if (extension === '.js') {


### PR DESCRIPTION
## Motivation

Fix #1259 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Use this reproducible demo https://github.com/amimas/docusaurus-1259

Use this PR patch

Go to  `/docs/`.

Note that the v1.0.0 docs file is like this:
```md
---
id: version-1.0.0-index
title: This is main page
sidebar_label: Main page
original_id: index
---

## Mauris In Code

Mauris vestibulum ullamcorper nibh, ut semper purus pulvinar ut. Donec volutpat orci sit amet mauris malesuada, non pulvinar augue aliquam. Vestibulum ultricies at urna ut suscipit. Morbi iaculis, erat at imperdiet semper, ipsum nulla sodales erat, eget tincidunt justo dui quis justo. Pellentesque dictum bibendum diam at aliquet. Sed pulvinar, dolor quis finibus ornare, eros odio facilisis erat, eu rhoncus nunc dui sed ex. Nunc gravida dui massa, sed ornare arcu tincidunt sit amet. Maecenas efficitur sapien neque, a laoreet libero feugiat ut.
```


Before (wrong sidebar_label and title)
<img width="948" alt="before" src="https://user-images.githubusercontent.com/17883920/53900305-39695100-4077-11e9-8928-63b14930904f.PNG">


After
<img width="936" alt="after" src="https://user-images.githubusercontent.com/17883920/53900317-3cfcd800-4077-11e9-862d-d128ee386b16.PNG">