### PR TITLE
fix: docusaurus fails to parse numeric id values

### DIFF
--- a/v1/lib/server/__tests__/__snapshots__/blog.test.js.snap
+++ b/v1/lib/server/__tests__/__snapshots__/blog.test.js.snap
@@ -3,7 +3,7 @@
 exports[`getMetadata blog file 1`] = `
 Object {
   "author": "Endilie",
-  "authorFBID": 100000251103620,
+  "authorFBID": "100000251103620",
   "authorTwitter": "endiliey",
   "authorURL": "https://github.com/endiliey",
   "content": "

--- a/v1/lib/server/metadataUtils.js
+++ b/v1/lib/server/metadataUtils.js
@@ -58,7 +58,7 @@ function extractMetadata(content) {
     } catch (err) {
       // Ignore the error as it means it's not a JSON value.
     }
-    metadata[key] = value;
+    metadata[key] = typeof value === 'number' ? `${value}` : value;
   }
   return {metadata, rawContent: both.content};
 }


### PR DESCRIPTION
Hi, so this is my second attempt at fixing this bug, the issue is that if you use a numeric id in the markdown declaration, Docusaurus crashes with the error `metadata.id.includes is not a function`, and in case of versioned docs it will crash on `metadata.id.indexOf`, after my fix is applied it crashes properly notifying the user that its not using the right id format.
Now since Docusaurus testing env is a website with versioned docs, I cant really provide a test but if you try it like so: 
```markdown
---
id: 1234
title: numeric-id
original_id: m000
---

testing

```

you'll see whats happening.

Cheers @yangshun !