### PR TITLE
feat(v2): allow plugins to specify paths to watch

### DIFF
--- a/v2-website/docusaurus.config.js
+++ b/v2-website/docusaurus.config.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   plugins: [
     {
-      name: 'docusaurus-content-blog',
+      name: 'docusaurus-plugin-content-blog',
       options: {
         include: ['*.md', '*.mdx'],
         path: '../v1/website/blog',

--- a/v2/.eslintrc.js
+++ b/v2/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   extends: ['airbnb', 'prettier', 'prettier/react'],
   plugins: ['react-hooks'],
   rules: {
+    'class-methods-use-this': OFF, // It's a way of allowing private variables.
     'no-console': OFF,
     'func-names': OFF,
     'jsx-a11y/click-events-have-key-events': OFF, // Revisit in future™

--- a/v2/lib/commands/start.js
+++ b/v2/lib/commands/start.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const _ = require('lodash');
 const path = require('path');
 const fs = require('fs-extra');
 const chalk = require('chalk');
@@ -46,10 +47,14 @@ module.exports = async function start(siteDir, cliOptions = {}) {
         console.error(chalk.red(err.stack));
       });
     };
+    const {plugins} = props;
     const docsRelativeDir = props.siteConfig.customDocsPath;
+    const pluginPaths = _.flatten(
+      plugins.map(plugin => plugin.getPathsToWatch()),
+    );
     const fsWatcher = chokidar.watch(
       [
-        // TODO: Watch plugin paths (e.g. blog)
+        ...pluginPaths,
         `../${docsRelativeDir}/**/*.md`,
         loadConfig.configFileName,
         'sidebars.json',

--- a/v2/lib/core/App.js
+++ b/v2/lib/core/App.js
@@ -10,7 +10,7 @@ import {renderRoutes} from 'react-router-config';
 
 import routes from '@generated/routes'; // eslint-disable-line
 // TODO: Generalize for blog plugin.
-import blogMetadata from '@generated/docusaurus-content-blog/blogMetadata.json'; // eslint-disable-line
+import blogMetadata from '@generated/docusaurus-plugin-content-blog/blogMetadata.json'; // eslint-disable-line
 import docsMetadatas from '@generated/docsMetadatas'; // eslint-disable-line
 import env from '@generated/env'; // eslint-disable-line
 import docsSidebars from '@generated/docsSidebars'; // eslint-disable-line

--- a/v2/lib/load/index.js
+++ b/v2/lib/load/index.js
@@ -88,11 +88,7 @@ module.exports = async function load(siteDir) {
     // TODO: Resolve using node_modules as well.
     // eslint-disable-next-line
     const Plugin = require(path.resolve(__dirname, '../../plugins', name));
-    const plugin = new Plugin(opts, context);
-    return {
-      name,
-      plugin,
-    };
+    return new Plugin(opts, context);
   });
 
   // Plugin lifecycle - loadContents().
@@ -102,11 +98,12 @@ module.exports = async function load(siteDir) {
   // this in future if there are plugins which need to run in certain order or depend on
   // others for data.
   const pluginsLoadedContents = await Promise.all(
-    plugins.map(async ({plugin, name}) => {
+    plugins.map(async plugin => {
       if (!plugin.loadContents) {
         return null;
       }
 
+      const name = plugin.getName();
       const {options} = plugin;
       const contents = await plugin.loadContents();
       const pluginContents = {
@@ -132,7 +129,7 @@ module.exports = async function load(siteDir) {
     addRoute: config => pluginRouteConfigs.push(config),
   };
   await Promise.all(
-    plugins.map(async ({plugin}, index) => {
+    plugins.map(async (plugin, index) => {
       if (!plugin.generateRoutes) {
         return;
       }
@@ -181,6 +178,7 @@ module.exports = async function load(siteDir) {
     generatedFilesDir,
     contentsStore,
     routesPaths,
+    plugins,
   };
 
   return props;

--- a/v2/plugins/docusaurus-plugin-content-blog.js
+++ b/v2/plugins/docusaurus-plugin-content-blog.js
@@ -34,14 +34,19 @@ class DocusaurusContentBlogPlugin {
   constructor(opts, context) {
     this.options = {...DEFAULT_OPTIONS, ...opts};
     this.context = context;
+    this.contentPath = path.resolve(this.context.siteDir, this.options.path);
+  }
+
+  getName() {
+    return 'docusaurus-plugin-content-blog';
   }
 
   async loadContents() {
-    const {pageCount, path: filePath, include, routeBasePath} = this.options;
-    const {env, siteConfig, siteDir} = this.context;
-    const blogDir = path.resolve(siteDir, filePath);
-    const {baseUrl} = siteConfig;
+    const {pageCount, include, routeBasePath} = this.options;
+    const {env, siteConfig} = this.context;
+    const blogDir = this.contentPath;
 
+    const {baseUrl} = siteConfig;
     const blogFiles = await globby(include, {
       cwd: blogDir,
     });
@@ -126,6 +131,10 @@ class DocusaurusContentBlogPlugin {
         modules: [metadata.source],
       });
     });
+  }
+
+  getPathsToWatch() {
+    return [this.contentPath];
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Reduce hardcoding of certain paths and add a method to plugins to allow them to specify which paths it wants the Docusaurus runtime to watch for changes so that we can rebuild those parts if there are updates.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- Include the paths to watch -> Update blog post -> Page refreshes
- Do not include the paths to watch -> Update blog post -> Page doesn't refresh

## Related PRs

NA.
