### PR TITLE
fix: relative path markdown linking on versioned docs

### DIFF
--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -73,8 +73,11 @@ function mdToHtmlify(oldContent, mdToHtml, metadata) {
     let mdMatch = mdRegex.exec(modifiedLine);
     while (mdMatch !== null) {
       /* Replace it to correct html link */
+      const docsSource = metadata.version
+        ? metadata.source.replace(/version-.*?\//, '')
+        : metadata.source;
       let htmlLink =
-        mdToHtml[resolve(metadata.source, mdMatch[1])] || mdToHtml[mdMatch[1]];
+        mdToHtml[resolve(docsSource, mdMatch[1])] || mdToHtml[mdMatch[1]];
       if (htmlLink) {
         htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
         htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);

--- a/v1/lib/version.js
+++ b/v1/lib/version.js
@@ -53,6 +53,15 @@ if (env.versioning.missingVersionsPage) {
   process.exit(1);
 }
 
+if (version.includes('/')) {
+  console.error(
+    `${chalk.red(
+      'Invalid version number specified! Do not include slash (/). Try something like: 1.0.0',
+    )}`,
+  );
+  process.exit(1);
+}
+
 if (typeof version === 'undefined') {
   console.error(
     `${chalk.yellow(


### PR DESCRIPTION
## Motivation

Fix #1271 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Follow this repo https://github.com/parthpp/Docusaurus-Broken-Links

Before:
<img width="653" alt="before" src="https://user-images.githubusercontent.com/17883920/54340296-0411c400-4672-11e9-8b92-dceda6d71655.png">

After:
<img width="958" alt="after" src="https://user-images.githubusercontent.com/17883920/54340252-ee9c9a00-4671-11e9-93c6-7a7075b78309.png">

Also strictly enforce docusaurus-version to use X.Y.Z format like Semver, does not allow `/`
