### PR TITLE
docs: add v2 roadmap to landing page

### DIFF
--- a/v1/website/pages/en/index.js
+++ b/v1/website/pages/en/index.js
@@ -73,6 +73,17 @@ class Index extends React.Component {
       <div>
         <HomeSplash siteConfig={siteConfig} language={language} />
         <div className="mainContainer">
+          <div className="announcement">
+            <div className="announcement-inner">
+              We're working on{' '}
+              <a href="https://github.com/facebook/Docusaurus/issues/789">
+                Docusaurus 2
+              </a>
+              , contribute to its roadmap by suggesting features or giving
+              feedback{' '}
+              <a href="https://munseo-preview.netlify.com/feedback/">here</a>!
+            </div>
+          </div>
           <Container padding={['bottom', 'top']} background="light">
             <GridBlock
               align="center"

--- a/v1/website/static/css/custom.css
+++ b/v1/website/static/css/custom.css
@@ -57,3 +57,17 @@ table td:first-child > code {
     width: 64px;
   }
 }
+
+.announcement {
+  background-color: #20232a;
+  color: #fff;
+  font-weight: bold;
+  font-size: 24px;
+  padding: 48px;
+  text-align: center;
+}
+
+.announcement-inner {
+  margin: 0 auto;
+  max-width: 768px;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

More widely announce v2 and its roadmap.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="1552" alt="Screen Shot 2019-03-20 at 12 08 07 AM" src="https://user-images.githubusercontent.com/1315101/54665496-7df7e200-4aa4-11e9-953a-a35c5dcde059.png">


## Related PRs

NA
