### PR TITLE
Add --skip-next-release option to yarn build

### DIFF
--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -59,6 +59,7 @@ Alias: `build`.
 | Options                    | Default | Description                                                                                                           |
 | -------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
 | `--skip-image-compression` | `false` | Skip compression of image assets. You usually won't want to skip this unless your images have already been optimized. |
+| `--skip-next-release` | `false` | Skip the next release documents when versioning is enabled. This will not build HTML files for documents in `/docs` directory.|
 
 Generates the static website, applying translations if necessary. Useful for building the website prior to deployment.
 

--- a/packages/docusaurus-1.x/lib/__tests__/build-files.test.js
+++ b/packages/docusaurus-1.x/lib/__tests__/build-files.test.js
@@ -94,3 +94,20 @@ describe('Build files', () => {
     });
   });
 });
+
+describe('Build files but skip next release', () => {
+  beforeAll(() => {
+    shell.cd('website-1.x');
+    shell.exec('yarn build --skip-next-release', {silent: true});
+  });
+
+  afterAll(() => {
+    clearBuildFolder();
+  });
+
+  test('Did not generate HTML files from markdown files for next release', () => {
+    expect(
+      glob.sync(`${buildDir}/${siteConfig.projectName}/docs/**/next`).length,
+    ).toBe(0);
+  });
+});

--- a/packages/docusaurus-1.x/lib/server/__tests__/start.test.js
+++ b/packages/docusaurus-1.x/lib/server/__tests__/start.test.js
@@ -18,7 +18,7 @@ const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 // siteConfig virtually.
 jest.mock(`${process.cwd()}/siteConfig.js`, () => jest.fn(), {virtual: true});
 
-jest.mock('commander');
+jest.genMockFromModule('commander');
 jest.mock('react-dev-utils/openBrowser');
 jest.mock('portfinder');
 jest.mock('../liveReloadServer.js');

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -45,8 +45,12 @@ program
     '-sic, --skip-image-compression <skipImageCompression>',
     'Skip compression of image assets (default: false)',
   )
-  .action((siteDir = '.', {skipImageCompression}) => {
-    wrapCommand(build)(path.resolve(siteDir), {skipImageCompression});
+  .option('--skip-next-release', 'Skip documents from next release')
+  .action((siteDir = '.', {skipImageCompression, skipNextRelease}) => {
+    wrapCommand(build)(path.resolve(siteDir), {
+      skipImageCompression,
+      skipNextRelease,
+    });
   });
 
 program

--- a/packages/docusaurus/lib/commands/build.js
+++ b/packages/docusaurus/lib/commands/build.js
@@ -38,11 +38,11 @@ function compile(config) {
   });
 }
 
-module.exports = async function build(siteDir) {
+module.exports = async function build(siteDir, options) {
   process.env.NODE_ENV = 'production';
   console.log('Build command invoked ...');
 
-  const props = await load(siteDir);
+  const props = await load(siteDir, options.skipNextRelease);
 
   // Apply user webpack config.
   const {outDir, plugins} = props;

--- a/packages/docusaurus/lib/load/index.js
+++ b/packages/docusaurus/lib/load/index.js
@@ -17,7 +17,7 @@ const loadRoutes = require('./routes');
 const loadPlugins = require('./plugins');
 const constants = require('../constants');
 
-module.exports = async function load(siteDir) {
+module.exports = async function load(siteDir, skipNextRelease = false) {
   const generatedFilesDir = path.resolve(
     siteDir,
     constants.GENERATED_FILES_DIR_NAME,
@@ -42,12 +42,15 @@ module.exports = async function load(siteDir) {
 
   // Docs
   const docsDir = path.resolve(siteDir, '..', siteConfig.customDocsPath);
-  const {docsMetadatas, docsSidebars} = await loadDocs({
-    siteDir,
-    docsDir,
-    env,
-    siteConfig,
-  });
+  const {docsMetadatas, docsSidebars} = await loadDocs(
+    {
+      siteDir,
+      docsDir,
+      env,
+      siteConfig,
+    },
+    skipNextRelease,
+  );
   await generate(
     generatedFilesDir,
     'docsMetadatas.js',

--- a/packages/docusaurus/test/load/docs/index.test.js
+++ b/packages/docusaurus/test/load/docs/index.test.js
@@ -173,4 +173,28 @@ describe('loadDocs', () => {
       version: null,
     });
   });
+
+  test('versioned website with skip next release', async () => {
+    const props = await loadSetup('versioned');
+    const {siteDir, docsDir, versionedDir, env, siteConfig} = props;
+    const {docsMetadatas} = await loadDocs(
+      {siteDir, docsDir, env, siteConfig},
+      true,
+    );
+    expect(docsMetadatas['version-1.0.0-foo/bar']).toEqual({
+      category: 'Test',
+      id: 'version-1.0.0-foo/bar',
+      language: null,
+      localized_id: 'version-1.0.0-foo/bar',
+      next: 'version-1.0.0-foo/baz',
+      next_id: 'version-1.0.0-foo/baz',
+      next_title: 'Baz',
+      permalink: '/docs/1.0.0/foo/bar',
+      sidebar: 'version-1.0.0-docs',
+      source: path.join(versionedDir, 'version-1.0.0/foo/bar.md'),
+      title: 'Bar',
+      version: '1.0.0',
+    });
+    expect(docsMetadatas['foo/bar']).toBeUndefined();
+  });
 });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
This patch resolves #1243. Docusaurus CLI command for building `HTML` files from `MarkDown` is `docusaurus-build`.  After deploying the static website as a result of this build, the documentation for the next release can be accessed by visiting `**/next*`. This is ideal for open source projects because it enables transperancy and encourages contribution. However, a closed source project will appreciate an option to skip building and deploying the next version documents. The proposed feature adds an option to `docusaurus-build` command to skip the build for documents of the next release. Thus, when `docusaurus-build --skip-next-release` is executed, the resulting `HTML` files are only for the already released version.
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have added test case for the build option. In addition to that, I have done some manual testing. Please follow the ReadMe file in this [demo repository](https://github.com/parthpp/SkipNextRelease) to try it yourself.