### PR TITLE
feat(v2): local plugin path resolve

### DIFF
--- a/v2/lib/load/config.js
+++ b/v2/lib/load/config.js
@@ -25,8 +25,6 @@ const REQUIRED_FIELDS = [
 
 const OPTIONAL_FIELDS = [
   'algolia',
-  'chainWebpack',
-  'configureWebpack',
   'customDocsPath',
   'customFields',
   'defaultLanguage',

--- a/v2/lib/load/index.js
+++ b/v2/lib/load/index.js
@@ -79,7 +79,7 @@ module.exports = async function load(siteDir) {
   const plugins = pluginConfigs.map(
     ({name, path: pluginPath = path.join(pluginDir, name), options}) => {
       let Plugin;
-      // If it exist in provided path or Docusaurus official plugin path
+      // If it exist in provided path or official plugin directory
       if (pluginPath && fs.existsSync(pluginPath)) {
         // eslint-disable-next-line
         Plugin = require(pluginPath);

--- a/v2/lib/load/index.js
+++ b/v2/lib/load/index.js
@@ -75,12 +75,26 @@ module.exports = async function load(siteDir) {
   const context = {env, siteDir, siteConfig};
 
   // Initialize plugins.
-  const plugins = pluginConfigs.map(({name, options}) => {
-    // TODO: Resolve using node_modules as well.
-    // eslint-disable-next-line
-    const Plugin = require(path.resolve(__dirname, '../../plugins', name));
-    return new Plugin(options, context);
-  });
+  const pluginDir = path.resolve(__dirname, '../../plugins');
+  const plugins = pluginConfigs.map(
+    ({name, path: pluginPath = path.join(pluginDir, name), options}) => {
+      let Plugin;
+      // If it exist in provided path or Docusaurus official plugin path
+      if (pluginPath && fs.existsSync(pluginPath)) {
+        // eslint-disable-next-line
+        Plugin = require(pluginPath);
+      } else {
+        // Resolve using node_modules as well.
+        try {
+          // eslint-disable-next-line
+          Plugin = require(name);
+        } catch (e) {
+          throw new Error(`'${name}' plugin cannot be found.`);
+        }
+      }
+      return new Plugin(options, context);
+    },
+  );
 
   // Plugin lifecycle - loadContents().
   // Currently plugins run lifecycle in parallel and are not order-dependent. We could change

--- a/v2/plugins/README.md
+++ b/v2/plugins/README.md
@@ -1,0 +1,80 @@
+# Docusaurus Plugin
+
+Plugin is one of the best way to add functionality to our Docusaurus. Plugin allows third-party developers to extend or modify just what Docusaurus does.
+
+## Installing a Plugin
+
+A plugin is usually a dependency, so you install them like other packages in node using NPM. However, you don't need to install official plugin provided by Docusaurus team because it came by default.
+
+Example:
+```bash
+npm install --save docusaurus-plugin-name
+```
+
+Then you add it in your site's `docusaurus.config.js` plugin arrays
+
+Example:
+```js
+module.exports = {
+  plugins: [
+    {
+      name: 'docusaurus-plugin-content-pages',
+    },
+    {
+      // Plugin with options
+      name: 'docusaurus-plugin-content-blog',
+      options: {
+        include: ['*.md', '*.mdx'],
+        path: '../v1/website/blog',
+      },
+    },
+  ],
+};
+```
+
+Docusaurus can also load plugins from your local folder, you can do something like below:
+
+```js
+module.exports = {
+  plugins: [
+    {
+      path: `/path/to/docusaurus-local-plugin`,
+    },
+  ],
+}
+```
+
+## Basic Plugin Architecture
+
+For examples, please refer to several official plugins created.
+
+```js
+// A JavaScript class
+class DocusaurusPlugin {
+  constructor(options, context) {
+      
+    // options are the plugin options set on config file
+    this.options = {...options};
+    
+    // context are provided from docusaurus. Example: siteConfig can be accessed from context
+    this.context = context;
+  }
+
+  getName() {
+    // plugin name identifier
+  }
+
+  async loadContents() {
+    // Content loading hook that runs the first time plugin is loaded
+    // expect a content data structure to be returned
+  }
+
+  async generateRoutes({metadata, actions}) {
+    // This is routes generation hook
+  }
+
+  getPathsToWatch() {
+    // path to watch
+  }
+}
+```

--- a/v2/plugins/README.md
+++ b/v2/plugins/README.md
@@ -1,19 +1,17 @@
-# Docusaurus Plugin
+# Docusaurus Plugins
 
-Plugin is one of the best way to add functionality to our Docusaurus. Plugin allows third-party developers to extend or modify just what Docusaurus does.
+Plugins are one of the best ways to add functionality to our Docusaurus. Plugins allow third-party developers to extend or modify the default functionality that Docusaurus provides.
 
 ## Installing a Plugin
 
-A plugin is usually a dependency, so you install them like other packages in node using NPM. However, you don't need to install official plugin provided by Docusaurus team because it came by default.
+A plugin is usually a dependency, so you install them like other packages in node using NPM. However, you don't need to install official plugin provided by Docusaurus team because it comes by default.
 
-Example:
 ```bash
-npm install --save docusaurus-plugin-name
+yarn add docusaurus-plugin-name
 ```
 
-Then you add it in your site's `docusaurus.config.js` plugin arrays
+Then you add it in your site's `docusaurus.config.js` plugin arrays:
 
-Example:
 ```js
 module.exports = {
   plugins: [
@@ -38,7 +36,7 @@ Docusaurus can also load plugins from your local folder, you can do something li
 module.exports = {
   plugins: [
     {
-      path: `/path/to/docusaurus-local-plugin`,
+      path: '/path/to/docusaurus-local-plugin',
     },
   ],
 }


### PR DESCRIPTION
## Motivation

- **Wrote some documentation 😄** 

https://github.com/endiliey/Docusaurus/blob/plugin/v2/plugins/README.md

![image](https://user-images.githubusercontent.com/17883920/54751938-5b3a0a80-4c17-11e9-959c-926558e1b525.png)

- Add extra plugin API to install from local path

Example
```js
module.exports = {
  plugins: [
    {
      path: `/path/to/docusaurus-local-plugin`,
    },
  ],
}
```

- Also resolve plugins from official docusaurus plugin directory and/or npm dependency



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

### Test 1
```md
module.exports = {
  plugins: [
    {
      name: 'docusaurus-plugin-content-blog',
      options: {
        include: ['*.md', '*.mdx'],
        path: '../v1/website/blog',
      },
    },
    {
      name: 'docusaurus-plugin-content-pages',
    },
  ],
};
```

No error

### Test 2
```js
module.exports = {
  plugins: [
    {
      path: require.resolve('../v2/plugins/docusaurus-plugin-content-pages')
    },
  ],
}
```

No error


### Test 3
```js
module.exports = {
  plugins: [
    {
      name: 'docusaurus-nothing',
    },
  ],
}
```
Error case:
<img width="620" alt="error" src="https://user-images.githubusercontent.com/17883920/54751569-51fc6e00-4c16-11e9-8a94-386e55322e9c.PNG">
