### PR TITLE
refactor(v2): plugins lifecycle

### DIFF
--- a/packages/docusaurus-plugin-content-blog/index.js
+++ b/packages/docusaurus-plugin-content-blog/index.js
@@ -41,7 +41,7 @@ class DocusaurusPluginContentBlog {
   }
 
   // Fetches blog contents and returns metadata for the contents.
-  async loadContents() {
+  async loadContent() {
     const {pageCount, include, routeBasePath} = this.options;
     const {env, siteConfig} = this.context;
     const blogDir = this.contentPath;
@@ -109,10 +109,10 @@ class DocusaurusPluginContentBlog {
     return blogMetadata;
   }
 
-  async generateRoutes({metadata, actions}) {
+  async contentLoaded({content, actions}) {
     const {blogPageComponent, blogPostComponent} = this.options;
     const {addRoute} = actions;
-    metadata.forEach(metadataItem => {
+    content.forEach(metadataItem => {
       const {isBlogPage, permalink} = metadataItem;
       if (isBlogPage) {
         addRoute({

--- a/packages/docusaurus-plugin-content-pages/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-content-pages/__tests__/index.test.js
@@ -11,7 +11,7 @@ import loadSetup from '../../docusaurus/test/loadSetup';
 import DocusaurusPluginContentPages from '../index';
 
 describe('docusaurus-plugin-content-pages', () => {
-  describe('loadContents', () => {
+  describe('loadContent', () => {
     test.each([
       [
         'simple',
@@ -116,7 +116,7 @@ describe('docusaurus-plugin-content-pages', () => {
         siteDir,
         siteConfig,
       });
-      const pagesMetadatas = await plugin.loadContents();
+      const pagesMetadatas = await plugin.loadContent();
       const pagesDir = plugin.contentPath;
 
       expect(pagesMetadatas).toEqual(expected(pagesDir));

--- a/packages/docusaurus-plugin-content-pages/index.js
+++ b/packages/docusaurus-plugin-content-pages/index.js
@@ -31,7 +31,7 @@ class DocusaurusPluginContentPages {
     return 'docusaurus-plugin-content-pages';
   }
 
-  async loadContents() {
+  async loadContent() {
     const {include} = this.options;
     const {env, siteConfig} = this.context;
     const pagesDir = this.contentPath;
@@ -88,11 +88,11 @@ class DocusaurusPluginContentPages {
     return pagesMetadatas;
   }
 
-  async generateRoutes({metadata, actions}) {
+  async contentLoaded({content, actions}) {
     const {component} = this.options;
     const {addRoute} = actions;
 
-    metadata.forEach(metadataItem => {
+    content.forEach(metadataItem => {
       const {permalink, source} = metadataItem;
       addRoute({
         path: permalink,

--- a/packages/docusaurus/lib/commands/start.js
+++ b/packages/docusaurus/lib/commands/start.js
@@ -77,7 +77,7 @@ module.exports = async function start(siteDir, cliOptions = {}) {
   // Create compiler from generated webpack config.
   let config = createClientConfig(props);
 
-  const {siteConfig} = props;
+  const {siteConfig, plugins = []} = props;
   config.plugin('html-webpack-plugin').use(HtmlWebpackPlugin, [
     {
       inject: false,
@@ -89,11 +89,13 @@ module.exports = async function start(siteDir, cliOptions = {}) {
   ]);
   config = config.toConfig();
 
-  // Apply user webpack config.
-  const {
-    siteConfig: {configureWebpack},
-  } = props;
-  config = applyConfigureWebpack(configureWebpack, config, false);
+  // Plugin lifecycle - configureWebpack
+  plugins.forEach(({configureWebpack}) => {
+    if (!configureWebpack) {
+      return;
+    }
+    config = applyConfigureWebpack(configureWebpack, config, false);
+  });
 
   const compiler = webpack(config);
 

--- a/packages/docusaurus/lib/load/plugins.js
+++ b/packages/docusaurus/lib/load/plugins.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const fs = require('fs-extra');
+
+module.exports = async function loadPlugins({pluginConfigs = [], context}) {
+  /* 1. Plugin Lifecycle - Initializiation/Constructor */
+  const plugins = pluginConfigs.map(({name, path: pluginPath, options}) => {
+    let Plugin;
+    if (pluginPath && fs.existsSync(pluginPath)) {
+      // eslint-disable-next-line
+      Plugin = require(pluginPath);
+    } else {
+      try {
+        // eslint-disable-next-line
+        Plugin = require(name);
+      } catch (e) {
+        throw new Error(`'${name}' plugin cannot be found.`);
+      }
+    }
+    return new Plugin(options, context);
+  });
+
+  /* 2. Plugin lifecycle - LoadContent */
+  const pluginsLoadedContent = {};
+  await Promise.all(
+    plugins.map(async plugin => {
+      if (!plugin.loadContent) {
+        return;
+      }
+      const name = plugin.getName();
+      pluginsLoadedContent[name] = await plugin.loadContent();
+    }),
+  );
+
+  /* 3. Plugin lifecycle - contentLoaded */
+  const pluginRouteConfigs = [];
+  const actions = {
+    addRoute: config => pluginRouteConfigs.push(config),
+  };
+
+  await Promise.all(
+    plugins.map(async plugin => {
+      if (!plugin.contentLoaded) {
+        return;
+      }
+      const name = plugin.getName();
+      const content = pluginsLoadedContent[name];
+      await plugin.contentLoaded({content, actions});
+    }),
+  );
+  return {
+    plugins,
+    pluginRouteConfigs,
+  };
+};

--- a/packages/docusaurus/lib/load/plugins.js
+++ b/packages/docusaurus/lib/load/plugins.js
@@ -25,6 +25,16 @@ module.exports = async function loadPlugins({pluginConfigs = [], context}) {
     return new Plugin(options, context);
   });
 
+  // Do not allow plugin with duplicate name
+  const pluginNames = new Set();
+  plugins.forEach(plugin => {
+    const name = plugin.getName();
+    if (pluginNames.has(name)) {
+      throw new Error(`Duplicate plugin with name '${name}' found`);
+    }
+    pluginNames.add(name);
+  });
+
   /* 2. Plugin lifecycle - LoadContent */
   const pluginsLoadedContent = {};
   await Promise.all(

--- a/packages/docusaurus/lib/theme/BlogPage/index.js
+++ b/packages/docusaurus/lib/theme/BlogPage/index.js
@@ -14,9 +14,12 @@ import DocusaurusContext from '@docusaurus/context';
 
 function BlogPage(props) {
   const context = useContext(DocusaurusContext);
-  const {blogMetadata, language, siteConfig = {}} = context;
+  const {language, siteConfig = {}} = context;
   const {baseUrl, favicon} = siteConfig;
-  const {modules: BlogPosts} = props;
+  const {
+    metadata: {posts = []},
+    modules: BlogPosts,
+  } = props;
 
   return (
     <Layout>
@@ -28,7 +31,7 @@ function BlogPage(props) {
       </Head>
       <div>
         <ul>
-          {blogMetadata.map(metadata => (
+          {posts.map(metadata => (
             <li key={metadata.permalink}>
               <Link to={metadata.permalink}>{metadata.permalink}</Link>
             </li>

--- a/packages/docusaurus/lib/theme/Footer/index.js
+++ b/packages/docusaurus/lib/theme/Footer/index.js
@@ -5,15 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useContext} from 'react';
-import Link from '@docusaurus/Link';
-
-import DocusaurusContext from '@docusaurus/context';
+import React from 'react';
 
 import styles from './styles.module.css';
 
 function Footer() {
-  const context = useContext(DocusaurusContext);
   return (
     <footer className={styles.footer}>
       <section className={styles.footerRow}>
@@ -75,19 +71,6 @@ function Footer() {
                 Twitter
               </a>
             </li>
-          </ul>
-        </div>
-        {/* This is for v2 development only to know the available pages. */}
-        <div className={styles.footerColumn}>
-          <h3 className={styles.footerColumnTitle}>Pages</h3>
-          <ul className={styles.footerList}>
-            {context.pagesMetadata.map(metadata => (
-              <li key={metadata.permalink} className={styles.footerListItem}>
-                <Link className={styles.footerLink} to={metadata.permalink}>
-                  {metadata.permalink}
-                </Link>
-              </li>
-            ))}
           </ul>
         </div>
       </section>

--- a/packages/docusaurus/plugins/README.md
+++ b/packages/docusaurus/plugins/README.md
@@ -4,7 +4,7 @@ Plugins are one of the best ways to add functionality to our Docusaurus. Plugins
 
 ## Installing a Plugin
 
-A plugin is usually a dependency, so you install them like other packages in node using NPM. However, you don't need to install official plugin provided by Docusaurus team because it comes by default.
+A plugin is usually a dependency, so you install them like other packages in node using NPM.
 
 ```bash
 yarn add docusaurus-plugin-name
@@ -16,14 +16,14 @@ Then you add it in your site's `docusaurus.config.js` plugin arrays:
 module.exports = {
   plugins: [
     {
-      name: 'docusaurus-plugin-content-pages',
+      name: '@docusaurus/plugin-content-pages',
     },
     {
       // Plugin with options
-      name: 'docusaurus-plugin-content-blog',
+      name: '@docusaurus/plugin-content-blog',
       options: {
         include: ['*.md', '*.mdx'],
-        path: '../v1/website/blog',
+        path: 'blog',
       },
     },
   ],
@@ -50,6 +50,7 @@ For examples, please refer to several official plugins created.
 // A JavaScript class
 class DocusaurusPlugin {
   constructor(options, context) {
+    // Initialization hook
       
     // options are the plugin options set on config file
     this.options = {...options};
@@ -62,13 +63,19 @@ class DocusaurusPlugin {
     // plugin name identifier
   }
 
-  async loadContents() {
-    // Content loading hook that runs the first time plugin is loaded
-    // expect a content data structure to be returned
+
+  async loadContent()) {
+    // The loadContent hook is executed after siteConfig and env has been loaded
+    // You can return a JavaScript object that will be passed to contentLoaded hook
   }
 
-  async generateRoutes({metadata, actions}) {
-    // This is routes generation hook
+  async contentLoaded({content, actions}) {
+    // loaded hook is done after load hook is done
+    // actions are set of functional API provided by Docusaurus. e.g: addRoute
+  }
+
+  configureWebpack(config, isServer) {
+    // Modify internal webpack config. If returned value is an Object, it will be merged into the final config using webpack-merge; If returned value is a function, it will receive the config as the 1st argument and an isServer flag as the 2nd argument.
   }
 
   getPathsToWatch() {


### PR DESCRIPTION
# Motivation

Changes
- Do not inject global metadata to context yet. Example: blogMetadata
- Refactor plugins loading process to `load/plugins`
- Simplify/ change the plugin lifecycles a bit.
- Add configureWebpack plugin lifecycle

See below:

```js
// A JavaScript class
class DocusaurusPlugin {
  constructor(options, context) {
    // Initialization hook
      
    // options are the plugin options set on config file
    this.options = {...options};
    
    // context are provided from docusaurus. Example: siteConfig can be accessed from context
    this.context = context;
  }

  getName() {
    // plugin name identifier
  }


  async loadContent()) {
    // The loadContent hook is executed after siteConfig and env has been loaded
    // You can return a JavaScript object 'content' that will be passed to contentLoaded hook
  }

  async contentLoaded({content, actions}) {
    // contentLoaded hook is done after loadContent hook is done
    // actions are set of functional API provided by Docusaurus. e.g: addRoute
  }

  configureWebpack(config, isServer) {
    // Modify internal webpack config. If returned value is an Object, it will be merged into the final config using webpack-merge; If returned value is a function, it will receive the config as the 1st argument and an isServer flag as the 2nd argument.
  }

  getPathsToWatch() {
    // path to watch
  }
}
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Locally nothing changes compared to before. 

Netlify should work as per usual too