### PR TITLE
misc: add ESLint rule to check for Facebook copyright headers in JS files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,5 @@ jest.transform.js
 website-1.x/
 website/
 scripts
+packages/docusaurus-1.x/lib/core/metadata.js
+packages/docusaurus-1.x/lib/core/MetadataBlog.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,20 +21,36 @@ module.exports = {
     allowImportExportEverywhere: true,
   },
   extends: ['airbnb', 'prettier', 'prettier/react'],
-  plugins: ['react-hooks'],
+  plugins: ['react-hooks', 'header'],
   rules: {
     'class-methods-use-this': OFF, // It's a way of allowing private variables.
-    'no-console': OFF,
     'func-names': OFF,
+    'import/no-unresolved': WARNING, // Because it couldn't resolve webpack alias.
+    'header/header': [
+      ERROR,
+      'block',
+      [
+        '*',
+        {
+          pattern:
+            ' \\* Copyright \\(c\\) \\d{4}-present\\, Facebook\\, Inc\\.',
+          template: ' * Copyright (c) 2017-present, Facebook, Inc.',
+        },
+        ' *',
+        ' * This source code is licensed under the MIT license found in the',
+        ' * LICENSE file in the root directory of this source tree.',
+        ' ',
+      ],
+    ],
     'jsx-a11y/click-events-have-key-events': OFF, // Revisit in future™
     'jsx-a11y/no-noninteractive-element-interactions': OFF, // Revisit in future™
+    'no-console': OFF,
     'react/jsx-closing-bracket-location': OFF, // Conflicts with Prettier.
     'react/jsx-filename-extension': OFF,
     'react/jsx-one-expression-per-line': OFF,
     'react/no-array-index-key': OFF, // Sometimes its ok, e.g. non-changing data.
     'react/prop-types': OFF,
     'react/destructuring-assignment': OFF, // Too many lines.
-    'import/no-unresolved': WARNING, // Because it couldn't resolve webpack alias.
     'react/prefer-stateless-function': WARNING,
     'react-hooks/rules-of-hooks': ERROR,
   },

--- a/package.json
+++ b/package.json
@@ -13,30 +13,35 @@
     "test": "jest"
   },
   "devDependencies": {
-    "lerna": "^3.13.1",
-    "husky": "^1.3.1",
-    "lint-staged": "^7.2.0",
-    "prettier": "^1.13.7",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "8",
     "eslint": "4.x",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-react-hooks": "^0.0.0",
-    "jest": "^24.1.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
     "filepath": "^1.1.0",
     "front-matter": "^2.3.0",
-    "rimraf": "^2.6.2",
-    "glob-promise": "^3.3.0"
+    "glob-promise": "^3.3.0",
+    "husky": "^1.3.1",
+    "jest": "^24.1.0",
+    "lerna": "^3.13.1",
+    "lint-staged": "^7.2.0",
+    "prettier": "^1.13.7",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4",
+    "rimraf": "^2.6.2"
   },
   "lint-staged": {
     "linters": {
-      "*.js": ["yarn lint --fix", "yarn prettier", "git add"]
+      "*.js": [
+        "yarn lint --fix",
+        "yarn prettier",
+        "git add"
+      ]
     }
   },
   "husky": {

--- a/packages/docusaurus-1.x/.eslintignore
+++ b/packages/docusaurus-1.x/.eslintignore
@@ -1,4 +1,0 @@
-static/**/*.js
-build
-node_modules
-v2

--- a/packages/docusaurus/lib/load/docs/metadata.js
+++ b/packages/docusaurus/lib/load/docs/metadata.js
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2017-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,6 +4915,11 @@ eslint-module-utils@^2.3.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-header@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz#0e048b5f0adfdd9754142d59d551ae6bfdaf90ad"
+  integrity sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==
+
 eslint-plugin-import@^2.14.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Internally the Open Source Eng teams has built tools to check for certain violations in FB OSS projects. Missing copyright headers in files is an example of a violation.

This ESLint rule I'm adding should help reduce cases of this happening again. We will need to find add a similar rule for CSS (probably using Stylelint) if we and when have more CSS in future.

Also removed the `.eslintignore` within `packages/docusaurus-1.x` as [ESLint only uses one `.eslintignore`](https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories) and it'll be the root one.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Netlify.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
