### PR TITLE
fix(v2): enable plugin not having pathsToWatch

### DIFF
--- a/packages/docusaurus/lib/commands/start.js
+++ b/packages/docusaurus/lib/commands/start.js
@@ -47,8 +47,12 @@ module.exports = async function start(siteDir, cliOptions = {}) {
     };
     const {plugins} = props;
     const docsRelativeDir = props.siteConfig.customDocsPath;
-    const pluginPaths = _.flatten(
-      plugins.map(plugin => plugin.getPathsToWatch()),
+    const pluginPaths = _.compact(
+      _.flatten(
+        plugins.map(
+          plugin => plugin.getPathsToWatch && plugin.getPathsToWatch(),
+        ),
+      ),
     );
     const fsWatcher = chokidar.watch(
       [


### PR DESCRIPTION
## Motivation

Fix error caused by `plugins.map(plugin => plugin.getPathsToWatch())`

What if plugin does not have a path to watch ??

<img width="675" alt="errorfix" src="https://user-images.githubusercontent.com/17883920/54902724-1b27a000-4f15-11e9-8cd8-e06cb895f829.PNG">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Locally
![image](https://user-images.githubusercontent.com/17883920/54902711-14992880-4f15-11e9-98cc-a044ef8e54a5.png)