### PR TITLE
feat(v2): faster production server build

### DIFF
--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -83,7 +83,10 @@ module.exports = function createBaseConfig(props, isServer) {
       .use('babel')
       .loader('babel-loader')
       .options({
+        // ignore local project babel config (.babelrc)
         babelrc: false,
+        // ignore local project babel config (babel.config.js)
+        configFile: false,
         presets: ['@babel/env', '@babel/react'],
         plugins: [
           isServer ? 'dynamic-import-node' : '@babel/syntax-dynamic-import',

--- a/packages/docusaurus/lib/webpack/server.js
+++ b/packages/docusaurus/lib/webpack/server.js
@@ -18,6 +18,9 @@ module.exports = function createServerConfig(props) {
   config.target('node');
   config.output.filename('server.bundle.js').libraryTarget('commonjs2');
 
+  // no need to minimize server bundle since we only run server compilation to generate static html files
+  config.optimization.minimize(false);
+
   // Workaround for Webpack 4 Bug (https://github.com/webpack/webpack/issues/6522)
   config.output.globalObject('this');
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,5 +40,8 @@ module.exports = {
     {
       name: '@docusaurus/plugin-content-pages',
     },
+    {
+      name: '@docusaurus/plugin-sitemap',
+    },
   ],
 };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,8 +40,5 @@ module.exports = {
     {
       name: '@docusaurus/plugin-content-pages',
     },
-    {
-      name: '@docusaurus/plugin-sitemap',
-    },
   ],
 };


### PR DESCRIPTION
## Motivation

We're only running webpack server compilation in production to generate static html files (with static-site-generator-plugin). So the bundle is in fact no need to be minimized.

https://webpack.js.org/configuration/optimization/#optimizationminimize
This makes the production build even faster because we skip uglifying part (which usually takes long) on server-bundle.js

No impact on user other than faster build.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before

Usually server and client should have the same compilation time

![image](https://user-images.githubusercontent.com/17883920/54904109-8030c500-4f18-11e9-9309-044e0af92c17.png)

After

~60% faster time on server build

![image](https://user-images.githubusercontent.com/17883920/54904557-c63a5880-4f19-11e9-913f-be6ec7b381a2.png)
