### PR TITLE
chore: optimize continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Test v1 static website Builds
           command: |
-            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(docusaurus-1.x\/.*)|(website-1.x\/.*)"; then
+            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(docusaurus-1\.x\/.*)|(website-1\.x\/.*)"; then
               echo "Skipping deploy & test. No relevant v1 website files have changed"
             else
               cd website-1.x && yarn build
@@ -86,10 +86,12 @@ jobs:
               echo "machine github.com login docusaurus-bot password $DOCUSAURUS_PUBLISH_TOKEN" > ~/.netrc
             fi
       - run:
-          name: Deploy Website
+          name: Deploy v1 Website
           # Skip the deploy if we don't have the right org (facebook), or if this is just a pull request
           command: |
-            if [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
+            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(docusaurus-1\.x\/.*)|(website-1\.x\/.*)"; then
+              echo "Skipping deploy. No relevant v1 website files have changed"
+            elif [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
               echo "Deploying website..."
               # install Docusaurus and generate file of English strings
               cd website-1.x && yarn run write-translations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,12 @@ jobs:
           command: yarn test
       - run:
           name: Test v1 static website Builds
-          command: cd website-1.x && yarn build
+          command: |
+            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(docusaurus-1.x\/.*)|(website-1.x\/.*)"; then
+              echo "Skipping deploy & test. No relevant v1 website files have changed"
+            else
+              cd website-1.x && yarn build
+            fi
       - run:
           name: Test v2 static website Builds
           command: cd website && yarn build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,17 +55,6 @@ jobs:
       - run:
           name: Run Test Suites
           command: yarn test
-      - run:
-          name: Test v1 static website Builds
-          command: |
-            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(docusaurus-1\.x\/.*)|(website-1\.x\/.*)"; then
-              echo "Skipping deploy & test. No relevant v1 website files have changed"
-            else
-              cd website-1.x && yarn build
-            fi
-      - run:
-          name: Test v2 static website Builds
-          command: cd website && yarn build
 
   # The CIRCLE_ variables are defined during the CircleCI build process
   # https://circleci.com/docs/1.0/environment-variables/

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -3,6 +3,7 @@ id: installation
 title: Installation
 ---
 
+nits only 
 Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.
 
 ## Installing Docusaurus

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -3,7 +3,6 @@ id: installation
 title: Installation
 ---
 
-nits only 
 Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.
 
 ## Installing Docusaurus


### PR DESCRIPTION
## Motivation

- Smarter CI to skip deploying v1 static website if there is no related changes.
Example scenario:
If we're modifying README.md, it doesn't make much sense to burden the CI to actually run the whole publish-gh-pages script
- We already have netlify build for v1 and v2, why do we need to build static website build of v1 and v2 on our CI

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Proof of concept with various test commits to check if bash logic is working
![image](https://user-images.githubusercontent.com/17883920/54907815-6c3d9100-4f21-11e9-8dca-8b8d1c534def.png)

![image](https://user-images.githubusercontent.com/17883920/54909201-9b093680-4f24-11e9-9858-dfb8bb938c2a.png)

