### PR TITLE
feat(v2): improve @docusaurus/plugin-content-blog

### DIFF
--- a/packages/docusaurus-plugin-content-blog/components/BlogPage/index.js
+++ b/packages/docusaurus-plugin-content-blog/components/BlogPage/index.js
@@ -6,11 +6,10 @@
  */
 
 import React, {useContext} from 'react';
-import Link from '@docusaurus/Link';
 import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout'; // eslint-disable-line
-
 import DocusaurusContext from '@docusaurus/context';
+import Post from '../Post';
 
 function BlogPage(props) {
   const context = useContext(DocusaurusContext);
@@ -30,15 +29,13 @@ function BlogPage(props) {
         {language && <meta name="docsearch:language" content={language} />}
       </Head>
       <div>
-        <ul>
-          {posts.map(metadata => (
-            <li key={metadata.permalink}>
-              <Link to={metadata.permalink}>{metadata.permalink}</Link>
-            </li>
-          ))}
-        </ul>
-        {BlogPosts.map((BlogPost, index) => (
-          <BlogPost key={index} />
+        {BlogPosts.map((PostContent, index) => (
+          <Post
+            key={index}
+            truncated={posts[index].truncatedSource}
+            metadata={posts[index]}>
+            <PostContent />
+          </Post>
         ))}
       </div>
     </Layout>

--- a/packages/docusaurus-plugin-content-blog/components/BlogPost/index.js
+++ b/packages/docusaurus-plugin-content-blog/components/BlogPost/index.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Head from '@docusaurus/Head';
+import Layout from '@theme/Layout'; // eslint-disable-line
+
+import DocusaurusContext from '@docusaurus/context';
+import Post from '../Post';
+import styles from './styles.module.css';
+
+class BlogPost extends React.Component {
+  render() {
+    const {metadata: contextMetadata = {}, siteConfig = {}} = this.context;
+    const {baseUrl, favicon} = siteConfig;
+    const {language, title} = contextMetadata;
+    const {modules, metadata} = this.props;
+    const BlogPostContents = modules[0];
+
+    return (
+      <Layout>
+        <Head defaultTitle={siteConfig.title}>
+          {title && <title>{title}</title>}
+          {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
+          {language && <html lang={language} />}
+        </Head>
+        <div className={styles.blogPostContainer}>
+          <Post metadata={metadata}>
+            <BlogPostContents />
+          </Post>
+        </div>
+      </Layout>
+    );
+  }
+}
+
+BlogPost.contextType = DocusaurusContext;
+
+export default BlogPost;

--- a/packages/docusaurus-plugin-content-blog/components/BlogPost/index.js
+++ b/packages/docusaurus-plugin-content-blog/components/BlogPost/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useContext} from 'react';
 import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout'; // eslint-disable-line
 
@@ -13,31 +13,31 @@ import DocusaurusContext from '@docusaurus/context';
 import Post from '../Post';
 import styles from './styles.module.css';
 
-class BlogPost extends React.Component {
-  render() {
-    const {metadata: contextMetadata = {}, siteConfig = {}} = this.context;
-    const {baseUrl, favicon} = siteConfig;
-    const {language, title} = contextMetadata;
-    const {modules, metadata} = this.props;
-    const BlogPostContents = modules[0];
+function BlogPost(props) {
+  const {metadata: contextMetadata = {}, siteConfig = {}} = useContext(
+    DocusaurusContext,
+  );
+  const {baseUrl, favicon} = siteConfig;
+  const {language, title} = contextMetadata;
+  const {modules, metadata} = props;
+  const BlogPostContents = modules[0];
 
-    return (
-      <Layout>
-        <Head defaultTitle={siteConfig.title}>
-          {title && <title>{title}</title>}
-          {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
-          {language && <html lang={language} />}
-        </Head>
+  return (
+    <Layout>
+      <Head defaultTitle={siteConfig.title}>
+        {title && <title>{title}</title>}
+        {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
+        {language && <html lang={language} />}
+      </Head>
+      {BlogPostContents && (
         <div className={styles.blogPostContainer}>
           <Post metadata={metadata}>
             <BlogPostContents />
           </Post>
         </div>
-      </Layout>
-    );
-  }
+      )}
+    </Layout>
+  );
 }
-
-BlogPost.contextType = DocusaurusContext;
 
 export default BlogPost;

--- a/packages/docusaurus-plugin-content-blog/components/BlogPost/styles.module.css
+++ b/packages/docusaurus-plugin-content-blog/components/BlogPost/styles.module.css
@@ -7,9 +7,9 @@
 
 .blogPostContainer {
   border-bottom: 1px solid #e0e0e0;
-    border-radius: 3px;
-    padding-bottom: 20px;
-    margin: 50px auto;
-    text-align: left;
-    max-width: 1100px;
+  border-radius: 3px;
+  padding-bottom: 20px;
+  margin: 50px auto;
+  text-align: left;
+  max-width: 1100px;
 }

--- a/packages/docusaurus-plugin-content-blog/components/BlogPost/styles.module.css
+++ b/packages/docusaurus-plugin-content-blog/components/BlogPost/styles.module.css
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.blogPostContainer {
+  border-bottom: 1px solid #e0e0e0;
+    border-radius: 3px;
+    padding-bottom: 20px;
+    margin: 50px auto;
+    text-align: left;
+    max-width: 1100px;
+}

--- a/packages/docusaurus-plugin-content-blog/components/Post/index.js
+++ b/packages/docusaurus-plugin-content-blog/components/Post/index.js
@@ -11,13 +11,12 @@ import classnames from 'classnames'; // eslint-disable-line
 
 import styles from './styles.module.css';
 
-class Post extends React.Component {
-  renderPostHeader() {
-    const {metadata} = this.props;
+function Post(props) {
+  const {metadata, children, truncated} = props;
+  const renderPostHeader = () => {
     if (!metadata) {
       return null;
     }
-
     const {
       date,
       author,
@@ -78,25 +77,21 @@ class Post extends React.Component {
         </div>
       </header>
     );
-  }
+  };
 
-  render() {
-    return (
-      <div className={styles.postContainer}>
-        {this.renderPostHeader()}
-        {this.props.children}
-        {this.props.truncated && (
-          <div className={styles.readMoreContainer}>
-            <Link
-              className={styles.readMoreLink}
-              to={this.props.metadata.permalink}>
-              Read More
-            </Link>
-          </div>
-        )}
-      </div>
-    );
-  }
+  return (
+    <div className={styles.postContainer}>
+      {renderPostHeader()}
+      {children}
+      {truncated && (
+        <div className={styles.readMoreContainer}>
+          <Link className={styles.readMoreLink} to={metadata.permalink}>
+            Read More
+          </Link>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default Post;

--- a/packages/docusaurus-plugin-content-blog/components/Post/index.js
+++ b/packages/docusaurus-plugin-content-blog/components/Post/index.js
@@ -7,15 +7,11 @@
 
 import React from 'react';
 import Link from '@docusaurus/Link';
-import Head from '@docusaurus/Head';
-import classnames from 'classnames';
-import Layout from '@theme/Layout'; // eslint-disable-line
-
-import DocusaurusContext from '@docusaurus/context';
+import classnames from 'classnames'; // eslint-disable-line
 
 import styles from './styles.module.css';
 
-class BlogPost extends React.Component {
+class Post extends React.Component {
   renderPostHeader() {
     const {metadata} = this.props;
     if (!metadata) {
@@ -85,26 +81,22 @@ class BlogPost extends React.Component {
   }
 
   render() {
-    const {metadata = {}, siteConfig = {}} = this.context;
-    const {baseUrl, favicon} = siteConfig;
-    const {language, title} = metadata;
-    const {modules} = this.props;
-    const BlogPostContents = modules[0];
-
     return (
-      <Layout>
-        <Head defaultTitle={siteConfig.title}>
-          {title && <title>{title}</title>}
-          {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
-          {language && <html lang={language} />}
-        </Head>
+      <div className={styles.postContainer}>
         {this.renderPostHeader()}
-        <BlogPostContents />
-      </Layout>
+        {this.props.children}
+        {this.props.truncated && (
+          <div className={styles.readMoreContainer}>
+            <Link
+              className={styles.readMoreLink}
+              to={this.props.metadata.permalink}>
+              Read More
+            </Link>
+          </div>
+        )}
+      </div>
     );
   }
 }
 
-BlogPost.contextType = DocusaurusContext;
-
-export default BlogPost;
+export default Post;

--- a/packages/docusaurus-plugin-content-blog/components/Post/styles.module.css
+++ b/packages/docusaurus-plugin-content-blog/components/Post/styles.module.css
@@ -45,3 +45,38 @@
   height: 50px;
   width: 50px;
 }
+
+.readMoreContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.readMoreLink {
+  border: 1px solid #2e8555;
+  border-radius: 3px;
+  color: #2e8555;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.2em;
+  padding: 10px;
+  text-decoration: none!important;
+  text-transform: uppercase;
+  transition: background .3s,color .3s;
+}
+
+.readMoreLink:hover {
+  background-color: #00a388;
+  color: #fff;
+}
+
+.postContainer {
+  border-bottom: 1px solid #e0e0e0;
+    border-radius: 3px;
+    padding-bottom: 20px;
+    margin: 50px auto;
+    text-align: left;
+    width: 600px;
+    max-width: 1100px;
+}

--- a/packages/docusaurus-plugin-content-blog/components/Post/styles.module.css
+++ b/packages/docusaurus-plugin-content-blog/components/Post/styles.module.css
@@ -73,10 +73,10 @@
 
 .postContainer {
   border-bottom: 1px solid #e0e0e0;
-    border-radius: 3px;
-    padding-bottom: 20px;
-    margin: 50px auto;
-    text-align: left;
-    width: 600px;
-    max-width: 1100px;
+  border-radius: 3px;
+  padding-bottom: 20px;
+  margin: 50px auto;
+  text-align: left;
+  width: 600px;
+  max-width: 1100px;
 }

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -3,10 +3,15 @@
   "version": "1.0.0",
   "description": "Blog content plugin for Docusaurus",
   "main": "index.js",
+  "files": [
+    "components"
+  ],
   "license": "MIT",
   "dependencies": {
     "@docusaurus/utils": "^1.0.0",
+    "classnames": "^2.2.6",
     "fs-extra": "^7.0.1",
-    "globby": "^9.1.0"
+    "globby": "^9.1.0",
+    "react": "^16.8.5"
   }
 }

--- a/packages/docusaurus-utils/index.js
+++ b/packages/docusaurus-utils/index.js
@@ -14,6 +14,7 @@ const genCache = new Map();
 async function generate(generatedFilesDir, file, content) {
   const cached = genCache.get(file);
   if (cached !== content) {
+    await fs.ensureDir(generatedFilesDir);
     await fs.writeFile(path.join(generatedFilesDir, file), content);
     genCache.set(file, content);
   }

--- a/packages/docusaurus/lib/load/index.js
+++ b/packages/docusaurus/lib/load/index.js
@@ -73,7 +73,7 @@ module.exports = async function load(siteDir) {
 
   // Process plugins.
   const pluginConfigs = siteConfig.plugins || [];
-  const context = {env, siteDir, siteConfig};
+  const context = {env, siteDir, generatedFilesDir, siteConfig};
   const {plugins, pluginRouteConfigs} = await loadPlugins({
     pluginConfigs,
     context,

--- a/packages/docusaurus/lib/load/theme.js
+++ b/packages/docusaurus/lib/load/theme.js
@@ -16,8 +16,6 @@ module.exports = function loadConfig(siteDir) {
 
   const themeComponents = [
     'Doc',
-    'BlogPost',
-    'BlogPage',
     'Pages',
     'Loading',
     'NotFound',
@@ -26,7 +24,9 @@ module.exports = function loadConfig(siteDir) {
   ];
 
   themeComponents.forEach(component => {
-    if (!require.resolve(path.join(themePath, component))) {
+    try {
+      require.resolve(path.join(themePath, component));
+    } catch (e) {
       throw new Error(
         `Failed to load ${themePath}/${component}. It does not exist.`,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10736,7 +10736,7 @@ react-youtube@^7.9.0:
     prop-types "^15.5.3"
     youtube-player "^5.5.1"
 
-react@^16.5.0, react@^16.8.4:
+react@^16.5.0, react@^16.8.4, react@^16.8.5:
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
   integrity sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==


### PR DESCRIPTION
## Motivation

Improve @docusaurus/plugin-content-blog plugin to be more like v1. There are some room for improvements (sidebar, CSS, etc). Maybe future PR will improve that.

Others:
- Components should be part of plugin package. Not in docusaurus own package
- Fix some minor bugs

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- `/blog` now display truncated content only with readmore button

Before
![image](https://user-images.githubusercontent.com/17883920/54944000-80a77b00-4f6d-11e9-8329-7e05858fb321.png)

After
<img width="933" alt="blogpage" src="https://user-images.githubusercontent.com/17883920/54943824-17c00300-4f6d-11e9-9bec-2d39db9478e9.PNG">

- BlogPost
<img width="897" alt="blogpost" src="https://user-images.githubusercontent.com/17883920/54943802-0aa31400-4f6d-11e9-95a5-0430ad457005.PNG">

- https://deploy-preview-1311--docusaurus-2.netlify.com/blog
