### PR TITLE
feat(v2): webpack chunk naming & splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "workspaces": [
-    "packages/docusaurus-1.x",
+    "packages/*",
     "website",
     "website-1.x"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "workspaces": [
-    "packages/*",
+    "packages/docusaurus-1.x",
     "website",
     "website-1.x"
   ],

--- a/packages/docusaurus-utils/index.js
+++ b/packages/docusaurus-utils/index.js
@@ -7,6 +7,8 @@
 
 const path = require('path');
 const fm = require('front-matter');
+
+const kebabHash = require(`kebab-hash`);
 const escapeStringRegexp = require('escape-string-regexp');
 const fs = require('fs-extra');
 
@@ -45,6 +47,11 @@ function fileToComponentName(file) {
   str = str.charAt(0).toUpperCase() + str.slice(1);
   str = str.replace(/[\W_]+(\w|$)/g, (_, ch) => ch.toUpperCase());
   return ext ? ext.toUpperCase() + str : str;
+}
+
+function generateChunkName(str, prefix) {
+  const name = str === `/` ? `index` : kebabHash(str);
+  return prefix ? `${prefix}---${name}` : name;
 }
 
 function idx(target, keyPaths) {
@@ -141,6 +148,7 @@ module.exports = {
   generate,
   fileToPath,
   fileToComponentName,
+  generateChunkName,
   getSubFolder,
   idx,
   normalizeUrl,

--- a/packages/docusaurus-utils/index.js
+++ b/packages/docusaurus-utils/index.js
@@ -8,7 +8,7 @@
 const path = require('path');
 const fm = require('front-matter');
 
-const kebabHash = require(`kebab-hash`);
+const kebabHash = require('kebab-hash');
 const escapeStringRegexp = require('escape-string-regexp');
 const fs = require('fs-extra');
 
@@ -50,7 +50,7 @@ function fileToComponentName(file) {
 }
 
 function generateChunkName(str, prefix) {
-  const name = str === `/` ? `index` : kebabHash(str);
+  const name = str === '/' ? 'index' : kebabHash(str);
   return prefix ? `${prefix}---${name}` : name;
 }
 

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
     "front-matter": "^3.0.1",
-    "fs-extra": "^7.0.0"
+    "fs-extra": "^7.0.0",
+    "kebab-hash": "^0.1.2"
   }
 }

--- a/packages/docusaurus-utils/test/index.test.js
+++ b/packages/docusaurus-utils/test/index.test.js
@@ -9,6 +9,7 @@ import path from 'path';
 import {
   fileToPath,
   fileToComponentName,
+  generateChunkName,
   idx,
   getSubFolder,
   normalizeUrl,
@@ -46,6 +47,22 @@ describe('load utils', () => {
     };
     Object.keys(asserts).forEach(file => {
       expect(fileToPath(file)).toBe(asserts[file]);
+    });
+  });
+
+  test('generateChunkName', () => {
+    const asserts = {
+      '/docs/adding-blog': 'docs-adding-blog-062',
+      '/docs/versioning': 'docs-versioning-8a8',
+      '/': 'index',
+      '/blog/2018/04/30/How-I-Converted-Profilo-To-Docusaurus':
+        'blog-2018-04-30-how-i-converted-profilo-to-docusaurus-4f2',
+      '/youtube': 'youtube-429',
+      '/users/en/': 'users-en-f7a',
+      '/blog': 'blog-c06',
+    };
+    Object.keys(asserts).forEach(str => {
+      expect(generateChunkName(str)).toBe(asserts[str]);
     });
   });
 

--- a/packages/docusaurus/lib/load/routes.js
+++ b/packages/docusaurus/lib/load/routes.js
@@ -38,9 +38,9 @@ async function loadRoutes({
   path: '${permalink}',
   exact: true,
   component: Loadable({
-    loader: () => import(/* webpackChunkName: "${generateChunkName(
+    loader: () => import(/* webpackChunkName: '${generateChunkName(
       permalink,
-    )}" */ '${source}'),
+    )}' */ '${source}'),
     loading: Loading,
     render(loaded, props) {
       let Content = loaded.default;
@@ -82,16 +82,16 @@ async function loadRoutes({
 ${modules
   .map(
     (module, index) =>
-      `      Module${index}: () => import(/* webpackChunkName: "${generateChunkName(
+      `      Module${index}: () => import(/* webpackChunkName: '${generateChunkName(
         path,
         `module${index}`,
-      )}" */'${module}'),`,
+      )}' */'${module}'),`,
   )
   .join('\n')}
-      Component: () => import(/* webpackChunkName: "${generateChunkName(
+      Component: () => import(/* webpackChunkName: '${generateChunkName(
         component,
         'component',
-      )}" */'${component}'),
+      )}' */'${component}'),
     },
     loading: Loading,
     render(loaded, props) {

--- a/packages/docusaurus/lib/load/routes.js
+++ b/packages/docusaurus/lib/load/routes.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {normalizeUrl} = require('@docusaurus/utils');
+const {normalizeUrl, generateChunkName} = require('@docusaurus/utils');
 
 async function loadRoutes({
   siteConfig = {},
@@ -38,7 +38,9 @@ async function loadRoutes({
   path: '${permalink}',
   exact: true,
   component: Loadable({
-    loader: () => import('${source}'),
+    loader: () => import(/* webpackChunkName: "${generateChunkName(
+      permalink,
+    )}" */ '${source}'),
     loading: Loading,
     render(loaded, props) {
       let Content = loaded.default;
@@ -78,9 +80,18 @@ async function loadRoutes({
   component: Loadable.Map({
     loader: {
 ${modules
-  .map((module, index) => `      Module${index}: () => import('${module}'),`)
+  .map(
+    (module, index) =>
+      `      Module${index}: () => import(/* webpackChunkName: "${generateChunkName(
+        path,
+        `module${index}`,
+      )}" */'${module}'),`,
+  )
   .join('\n')}
-      Component: () => import('${component}'),
+      Component: () => import(/* webpackChunkName: "${generateChunkName(
+        path,
+        'component',
+      )}" */'${component}'),
     },
     loading: Loading,
     render(loaded, props) {

--- a/packages/docusaurus/lib/load/routes.js
+++ b/packages/docusaurus/lib/load/routes.js
@@ -89,7 +89,7 @@ ${modules
   )
   .join('\n')}
       Component: () => import(/* webpackChunkName: "${generateChunkName(
-        path,
+        component,
         'component',
       )}" */'${component}'),
     },

--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -155,7 +155,7 @@ module.exports = function createBaseConfig(props, isServer) {
   config.plugin('extractCSS').use(CSSExtractPlugin, [
     {
       filename: isProd ? '[name].[chunkhash].css' : '[name].css',
-      chunkFilename: isProd ? '[id].[chunkhash].css' : '[id].css',
+      chunkFilename: isProd ? '[name].[chunkhash].css' : '[name].css',
     },
   ]);
 

--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -55,6 +55,7 @@ module.exports = function createBaseConfig(props, isServer) {
     .mode(isProd ? 'production' : 'development')
     .output.path(outDir)
     .filename(isProd ? '[name].[chunkhash].js' : '[name].js')
+    .chunkFilename(isProd ? '[name].[chunkhash].js' : '[name].js')
     .publicPath(baseUrl);
 
   if (!isProd) {
@@ -157,6 +158,32 @@ module.exports = function createBaseConfig(props, isServer) {
       chunkFilename: isProd ? '[id].[chunkhash].css' : '[id].css',
     },
   ]);
+
+  // https://webpack.js.org/plugins/split-chunks-plugin/
+  config.optimization.splitChunks({
+    // We set max requests to Infinity because of HTTP/2
+    maxInitialRequests: Infinity,
+    maxAsyncRequests: Infinity,
+    cacheGroups: {
+      // disable the built-in cacheGroups
+      default: false,
+      vendors: {
+        test: /[\\/]node_modules[\\/]/,
+        name: 'vendors',
+        priority: 20,
+        // create chunk regardless of the size of the chunk
+        enforce: true,
+      },
+      common: {
+        name: 'common',
+        chunks: 'all',
+        minChunks: 2,
+        priority: 10,
+        reuseExistingChunk: true,
+        enforce: true,
+      },
+    },
+  });
 
   if (isProd) {
     config.optimization.minimizer([

--- a/yarn.lock
+++ b/yarn.lock
@@ -7992,6 +7992,13 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+kebab-hash@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/kebab-hash/-/kebab-hash-0.1.2.tgz#dfb7949ba34d8e70114ea7d83e266e5e2a4abaac"
+  integrity sha512-BTZpq3xgISmQmAVzkISy4eUutsUA7s4IEFlCwOBJjvSFOwyR7I+fza+tBc/rzYWK/NrmFHjfU1IhO3lu29Ib/w==
+  dependencies:
+    lodash.kebabcase "^4.1.1"
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -8320,6 +8327,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
 lodash.map@^4.4.0:
   version "4.6.0"
@@ -10853,7 +10865,7 @@ react-youtube@^7.9.0:
     prop-types "^15.5.3"
     youtube-player "^5.5.1"
 
-react@^16.5.0, react@^16.8.4, react@^16.8.5:
+react@^16.5.0, react@^16.8.4:
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
   integrity sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==


### PR DESCRIPTION
## Motivation

- Optimize webpack chunks splitting by adding vendors (for node_modules) and common (for code that is reused) cacheGroups
- Add webpackChunkNaming so that generated modules file names is easier to read. It's not a good idea to see "1.js", "2.js", "3.js". It will be better to see "component--theme-BlogPost.js", "module-blog-introducing-docusaurus.js" and/or "docs--installation.js"

I recommend checking the netlify and use your Network Tab to better understand the situation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![chunk name](https://user-images.githubusercontent.com/17883920/55277041-9aaed800-5336-11e9-9d05-3d2f21af4c97.gif)

