### PR TITLE
fix(v2): don't run terser in parallel for WSL

### DIFF
--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -10,8 +10,8 @@ const CSSExtractPlugin = require('mini-css-extract-plugin');
 const rehypePrism = require('@mapbox/rehype-prism');
 const TerserPlugin = require('terser-webpack-plugin');
 const path = require('path');
-
 const isWsl = require('is-wsl');
+
 const mdLoader = require.resolve('./loaders/markdown');
 
 const CSS_REGEX = /\.css$/;

--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -11,6 +11,8 @@ const rehypePrism = require('@mapbox/rehype-prism');
 const TerserPlugin = require('terser-webpack-plugin');
 const path = require('path');
 
+const isWsl = require(`is-wsl`);
+
 const mdLoader = require.resolve('./loaders/markdown');
 
 const CSS_REGEX = /\.css$/;
@@ -189,7 +191,9 @@ module.exports = function createBaseConfig(props, isServer) {
     config.optimization.minimizer([
       new TerserPlugin({
         cache: true,
-        parallel: true,
+        // We can't run in parallel for WSL due to upstream bug
+        // https://github.com/webpack-contrib/terser-webpack-plugin/issues/21
+        parallel: !isWsl,
         sourceMap: true,
         terserOptions: {
           ecma: 6,

--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -11,7 +11,7 @@ const rehypePrism = require('@mapbox/rehype-prism');
 const TerserPlugin = require('terser-webpack-plugin');
 const path = require('path');
 
-const isWsl = require(`is-wsl`);
+const isWsl = require('is-wsl');
 const mdLoader = require.resolve('./loaders/markdown');
 
 const CSS_REGEX = /\.css$/;

--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -12,7 +12,6 @@ const TerserPlugin = require('terser-webpack-plugin');
 const path = require('path');
 
 const isWsl = require(`is-wsl`);
-
 const mdLoader = require.resolve('./loaders/markdown');
 
 const CSS_REGEX = /\.css$/;

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -50,6 +50,7 @@
     "fs-extra": "^7.0.0",
     "globby": "^9.1.0",
     "html-webpack-plugin": "^3.2.0",
+    "is-wsl": "^1.1.0",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.11",
     "mini-css-extract-plugin": "^0.4.1",


### PR DESCRIPTION
## Motivation

I use [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about).
Running `docusaurus build` for v2 always hang due to Terser-webpack-plugin bug of not being able to run in parallel (see https://github.com/webpack-contrib/terser-webpack-plugin/issues/21 - only on WSL)

Usually, I always manually set `parallel: false` to run `docusaurus build` in v2.

This PR attempt to disable parallel uglifying through terser (only disable in WSL) until that issue is fixed upstream

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```bash
cd website
yarn build
```

Works on WSL. No longer hangs

![image](https://user-images.githubusercontent.com/17883920/55285228-74328080-53ba-11e9-8036-423b7d504aaa.png)

