### PR TITLE
refactor(v2): load sidebars from docs plugin

### DIFF
--- a/packages/docusaurus-plugin-content-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-content-docs/__tests__/index.test.js
@@ -10,16 +10,14 @@ import path from 'path';
 import loadSetup from '../../docusaurus/test/loadSetup';
 import DocusaurusPluginContentDocs from '../index';
 
-/* eslint-disable global-require, import/no-dynamic-require */
-
 describe('loadDocs', () => {
   test('simple website', async () => {
     const {env, siteDir, siteConfig} = await loadSetup('simple');
-    const sidebar = require(path.join(siteDir, 'sidebars.json'));
+    const sidebarPath = path.join(siteDir, 'sidebars.json');
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
-        sidebar,
+        sidebarPath,
       },
       {
         env,
@@ -64,11 +62,11 @@ describe('loadDocs', () => {
     const {env, siteDir, siteConfig, versionedDir} = await loadSetup(
       'versioned',
     );
-    const sidebar = require(path.join(siteDir, 'sidebars.json'));
+    const sidebarPath = path.join(siteDir, 'sidebars.json');
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
-        sidebar,
+        sidebarPath,
       },
       {
         env,
@@ -117,11 +115,11 @@ describe('loadDocs', () => {
       translatedDir,
       versionedDir,
     } = await loadSetup('transversioned');
-    const sidebar = require(path.join(siteDir, 'sidebars.json'));
+    const sidebarPath = path.join(siteDir, 'sidebars.json');
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
-        sidebar,
+        sidebarPath,
       },
       {
         env,
@@ -183,11 +181,11 @@ describe('loadDocs', () => {
     const {env, siteDir, siteConfig, translatedDir} = await loadSetup(
       'translated',
     );
-    const sidebar = require(path.join(siteDir, 'sidebars.json'));
+    const sidebarPath = path.join(siteDir, 'sidebars.json');
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
-        sidebar,
+        sidebarPath,
       },
       {
         env,
@@ -235,11 +233,11 @@ describe('loadDocs', () => {
     const {env, siteDir, siteConfig, versionedDir} = await loadSetup(
       'versioned',
     );
-    const sidebar = require(path.join(siteDir, 'sidebars.json'));
+    const sidebarPath = path.join(siteDir, 'sidebars.json');
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
-        sidebar,
+        sidebarPath,
       },
       {
         cliOptions: {

--- a/packages/docusaurus-plugin-content-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-content-docs/__tests__/index.test.js
@@ -10,12 +10,16 @@ import path from 'path';
 import loadSetup from '../../docusaurus/test/loadSetup';
 import DocusaurusPluginContentDocs from '../index';
 
+/* eslint-disable global-require, import/no-dynamic-require */
+
 describe('loadDocs', () => {
-  test.only('simple website', async () => {
+  test('simple website', async () => {
     const {env, siteDir, siteConfig} = await loadSetup('simple');
+    const sidebar = require(path.join(siteDir, 'sidebars.json'));
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
+        sidebar,
       },
       {
         env,
@@ -60,9 +64,11 @@ describe('loadDocs', () => {
     const {env, siteDir, siteConfig, versionedDir} = await loadSetup(
       'versioned',
     );
+    const sidebar = require(path.join(siteDir, 'sidebars.json'));
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
+        sidebar,
       },
       {
         env,
@@ -111,9 +117,11 @@ describe('loadDocs', () => {
       translatedDir,
       versionedDir,
     } = await loadSetup('transversioned');
+    const sidebar = require(path.join(siteDir, 'sidebars.json'));
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
+        sidebar,
       },
       {
         env,
@@ -175,9 +183,11 @@ describe('loadDocs', () => {
     const {env, siteDir, siteConfig, translatedDir} = await loadSetup(
       'translated',
     );
+    const sidebar = require(path.join(siteDir, 'sidebars.json'));
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
+        sidebar,
       },
       {
         env,
@@ -225,15 +235,19 @@ describe('loadDocs', () => {
     const {env, siteDir, siteConfig, versionedDir} = await loadSetup(
       'versioned',
     );
+    const sidebar = require(path.join(siteDir, 'sidebars.json'));
     const plugin = new DocusaurusPluginContentDocs(
       {
         path: '../docs',
+        sidebar,
       },
       {
+        cliOptions: {
+          skipNextRelease: true,
+        },
         env,
         siteDir,
         siteConfig,
-        cliOptions: {skipNextRelease: true},
       },
     );
     const {docs: docsMetadata} = await plugin.loadContent();

--- a/packages/docusaurus-plugin-content-docs/__tests__/sidebars.test.js
+++ b/packages/docusaurus-plugin-content-docs/__tests__/sidebars.test.js
@@ -9,24 +9,29 @@ import path from 'path';
 import loadSidebars from '../src/sidebars';
 import loadSetup from '../../docusaurus/test/loadSetup';
 
+/* eslint-disable global-require, import/no-dynamic-require */
+
 describe('loadSidebars', () => {
   const fixtures = path.join(__dirname, '..', '__fixtures__');
+
   test('normal site with sidebars', async () => {
     const {env, siteDir} = await loadSetup('simple');
-    const result = loadSidebars({siteDir, env});
+    const sidebar = require(path.join(siteDir, 'sidebars.json'));
+    const result = loadSidebars({siteDir, env, sidebar});
     expect(result).toMatchSnapshot();
   });
 
   test('site without sidebars', () => {
     const env = {};
     const siteDir = path.join(fixtures, 'bad-site');
-    const result = loadSidebars({siteDir, env});
+    const result = loadSidebars({siteDir, env, sidebar: {}});
     expect(result).toMatchSnapshot();
   });
 
   test('site with sidebars & versioned sidebars', async () => {
     const {env, siteDir} = await loadSetup('versioned');
-    const result = loadSidebars({siteDir, env});
+    const sidebar = require(path.join(siteDir, 'sidebars.json'));
+    const result = loadSidebars({siteDir, env, sidebar});
     expect(result).toMatchSnapshot();
   });
 
@@ -39,7 +44,7 @@ describe('loadSidebars', () => {
     };
     const {siteDir} = await loadSetup('versioned');
     expect(() => {
-      loadSidebars({siteDir, env});
+      loadSidebars({siteDir, env, sidebar: {}});
     }).toThrowErrorMatchingInlineSnapshot(
       `"Failed to load versioned_sidebars/version-2.0.0-sidebars.json. It does not exist."`,
     );

--- a/packages/docusaurus-plugin-content-docs/index.js
+++ b/packages/docusaurus-plugin-content-docs/index.js
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const path = require('path');
 const globby = require('globby');
+const importFresh = require('import-fresh');
+const path = require('path');
 const {getSubFolder, idx, normalizeUrl} = require('@docusaurus/utils');
+
 const createOrder = require('./src/order');
 const loadSidebars = require('./src/sidebars');
 const processMetadata = require('./src/metadata');
@@ -19,7 +21,7 @@ const DEFAULT_OPTIONS = {
   routeBasePath: 'docs', // URL Route.
   include: ['**/*.md', '**/*.mdx'], // Extensions to include.
   // TODO: Change format to array.
-  sidebar: {}, // Sidebar configuration for showing a list of documentation pages.
+  sidebarPath: '', // Path to sidebar configuration for showing a list of markdown pages.
   // TODO: Settle themeing.
   docLayoutComponent: '@theme/Doc',
   docItemComponent: '@theme/DocBody',
@@ -37,17 +39,18 @@ class DocusaurusPluginContentDocs {
   }
 
   getPathsToWatch() {
-    return [this.contentPath];
+    return [this.contentPath, this.options.sidebarPath];
   }
 
   // Fetches blog contents and returns metadata for the contents.
   async loadContent() {
-    const {include, routeBasePath, sidebar} = this.options;
+    const {include, routeBasePath, sidebarPath} = this.options;
     const {siteDir, env, siteConfig, cliOptions = {}} = this.context;
     const {skipNextRelease} = cliOptions;
     const docsDir = this.contentPath;
 
-    // @tested - load all sidebars including versioned sidebars
+    // We don't want sidebars to be cached because of hotreloading.
+    const sidebar = importFresh(sidebarPath);
     const docsSidebars = loadSidebars({siteDir, env, sidebar});
 
     // @tested - build the docs ordering such as next, previous, category and sidebar

--- a/packages/docusaurus-plugin-content-docs/index.js
+++ b/packages/docusaurus-plugin-content-docs/index.js
@@ -18,8 +18,8 @@ const DEFAULT_OPTIONS = {
   path: 'docs', // Path to data on filesystem, relative to site dir.
   routeBasePath: 'docs', // URL Route.
   include: ['**/*.md', '**/*.mdx'], // Extensions to include.
-  // TODO: Read from props rather than hardcoded sidebar.json.
-  sidebar: [], // Sidebar configuration for showing a list of documentation pages.
+  // TODO: Change format to array.
+  sidebar: {}, // Sidebar configuration for showing a list of documentation pages.
   // TODO: Settle themeing.
   docLayoutComponent: '@theme/Doc',
   docItemComponent: '@theme/DocBody',
@@ -42,13 +42,13 @@ class DocusaurusPluginContentDocs {
 
   // Fetches blog contents and returns metadata for the contents.
   async loadContent() {
-    const {include, routeBasePath} = this.options;
+    const {include, routeBasePath, sidebar} = this.options;
     const {siteDir, env, siteConfig, cliOptions = {}} = this.context;
     const {skipNextRelease} = cliOptions;
     const docsDir = this.contentPath;
 
     // @tested - load all sidebars including versioned sidebars
-    const docsSidebars = loadSidebars({siteDir, env});
+    const docsSidebars = loadSidebars({siteDir, env, sidebar});
 
     // @tested - build the docs ordering such as next, previous, category and sidebar
     const order = createOrder(docsSidebars);

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -8,7 +8,8 @@
     "@babel/polyfill": "^7.4.0",
     "@docusaurus/utils": "^1.0.0",
     "fs-extra": "^7.0.1",
-    "globby": "^9.1.0"
+    "globby": "^9.1.0",
+    "import-fresh": "^3.0.0"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0"

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.js
@@ -113,19 +113,10 @@ function normalizeSidebar(sidebars) {
   }, {});
 }
 
-module.exports = function loadSidebars({siteDir, env}, deleteCache = true) {
-  let allSidebars = {};
+module.exports = function loadSidebars({siteDir, env, sidebar}) {
+  const allSidebars = sidebar;
 
-  // current sidebars
-  const sidebarsJSONFile = path.join(siteDir, 'sidebars.json');
-  if (deleteCache) {
-    delete require.cache[sidebarsJSONFile];
-  }
-  if (fs.existsSync(sidebarsJSONFile)) {
-    allSidebars = require(sidebarsJSONFile); // eslint-disable-line
-  }
-
-  // versioned sidebars
+  // Versioned sidebars.
   if (idx(env, ['versioning', 'enabled'])) {
     const versions = idx(env, ['versioning', 'versions']);
     if (Array.isArray(versions)) {

--- a/packages/docusaurus/CHANGES.md
+++ b/packages/docusaurus/CHANGES.md
@@ -4,5 +4,6 @@
 
 - `siteConfig.js` renamed to `docusaurus.config.js`.
 - Removed the following config options:
-  - `docsUrl`. Use the plugin option on `docusaurus-plugin-content-blog` instead.
-  - `customDocsPath`. Use the plugin option on `docusaurus-plugin-content-blog` instead.
+  - `docsUrl`. Use the plugin option on `docusaurus-plugin-content-docs` instead.
+  - `customDocsPath`. Use the plugin option on `docusaurus-plugin-content-docs` instead.
+  - `sidebars.json` now has to be explicitly loaded by users and passed into the the plugin option on `docusaurus-plugin-content-docs`.

--- a/packages/docusaurus/lib/commands/start.js
+++ b/packages/docusaurus/lib/commands/start.js
@@ -54,7 +54,7 @@ module.exports = async function start(siteDir, cliOptions = {}) {
       ),
     );
     const fsWatcher = chokidar.watch(
-      [...pluginPaths, loadConfig.configFileName, 'sidebars.json'],
+      [...pluginPaths, loadConfig.configFileName],
       {
         cwd: siteDir,
         ignoreInitial: true,

--- a/packages/docusaurus/test/__fixtures__/custom-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/custom-site/docusaurus.config.js
@@ -23,6 +23,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
+        sidebar: require('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/custom-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/custom-site/docusaurus.config.js
@@ -23,7 +23,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
-        sidebar: require('./sidebars.json'),
+        sidebarPath: require.resolve('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/simple-site/docusaurus.config.js
@@ -23,6 +23,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
+        sidebar: require('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/simple-site/docusaurus.config.js
@@ -23,7 +23,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
-        sidebar: require('./sidebars.json'),
+        sidebarPath: require.resolve('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/translated-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/translated-site/docusaurus.config.js
@@ -24,6 +24,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
+        sidebar: require('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/translated-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/translated-site/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
-        sidebar: require('./sidebars.json'),
+        sidebarPath: require.resolve('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/transversioned-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/transversioned-site/docusaurus.config.js
@@ -24,6 +24,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
+        sidebar: require('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/transversioned-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/transversioned-site/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
-        sidebar: require('./sidebars.json'),
+        sidebarPath: require.resolve('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/versioned-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/versioned-site/docusaurus.config.js
@@ -23,6 +23,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
+        sidebar: require('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/__fixtures__/versioned-site/docusaurus.config.js
+++ b/packages/docusaurus/test/__fixtures__/versioned-site/docusaurus.config.js
@@ -23,7 +23,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
-        sidebar: require('./sidebars.json'),
+        sidebarPath: require.resolve('./sidebars.json'),
       },
     },
     {

--- a/packages/docusaurus/test/load/config.test.js
+++ b/packages/docusaurus/test/load/config.test.js
@@ -37,6 +37,17 @@ Object {
       "name": "@docusaurus/plugin-content-docs",
       "options": Object {
         "path": "../docs",
+        "sidebar": Object {
+          "docs": Object {
+            "Guides": Array [
+              "hello",
+            ],
+            "Test": Array [
+              "foo/bar",
+              "foo/baz",
+            ],
+          },
+        },
       },
     },
     Object {

--- a/packages/docusaurus/test/load/config.test.js
+++ b/packages/docusaurus/test/load/config.test.js
@@ -13,7 +13,11 @@ describe('loadConfig', () => {
   test('website with valid siteConfig', async () => {
     const {siteDir} = await loadSetup('simple');
     const config = loadConfig(siteDir);
-    expect(config).toMatchInlineSnapshot(`
+    expect(config).toMatchInlineSnapshot(
+      {
+        plugins: expect.any(Array),
+      },
+      `
 Object {
   "baseUrl": "/",
   "favicon": "img/docusaurus.ico",
@@ -32,34 +36,14 @@ Object {
     },
   ],
   "organizationName": "endiliey",
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": Object {
-        "path": "../docs",
-        "sidebar": Object {
-          "docs": Object {
-            "Guides": Array [
-              "hello",
-            ],
-            "Test": Array [
-              "foo/bar",
-              "foo/baz",
-            ],
-          },
-        },
-      },
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-pages",
-    },
-  ],
+  "plugins": Any<Array>,
   "projectName": "hello",
   "tagline": "Hello World",
   "title": "Hello",
   "url": "https://docusaurus.io",
 }
-`);
+`,
+    );
     expect(config).not.toEqual({});
   });
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -33,6 +33,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
+        sidebar: require('./sidebars.json'),
       },
     },
     {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -33,7 +33,7 @@ module.exports = {
       name: '@docusaurus/plugin-content-docs',
       options: {
         path: '../docs',
-        sidebar: require('./sidebars.json'),
+        sidebarPath: require.resolve('./sidebars.json'),
       },
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6698,6 +6698,14 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 import-lazy@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
@@ -9771,6 +9779,13 @@ param-case@2.1.x, param-case@^2.1.0:
   integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
   dependencies:
     no-case "^2.2.0"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-asn1@^5.0.0:
   version "5.1.4"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change. This allows people to write sidebars in normal JS format, which allows for reusing and writing inline comments. That could be helpful!

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Reduce hidden magic by requiring a sidebars file to be passed into the docs plugin.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Updated Jest tests.

## Related PRs

#1327 
