### PR TITLE
fix(v2): missing scripts/css on statically rendered  html

### DIFF
--- a/packages/docusaurus/lib/core/serverEntry.js
+++ b/packages/docusaurus/lib/core/serverEntry.js
@@ -46,6 +46,8 @@ export default function render(locals) {
     const bundles = getBundles(reactLoadableStats, modules);
     const assets = [
       ...webpackClientStats.assetsByChunkName.main,
+      ...webpackClientStats.assetsByChunkName.common,
+      ...webpackClientStats.assetsByChunkName.vendors,
       ...bundles.map(bundle => bundle.file),
     ];
     const scripts = assets.filter(value => value.match(/\.js$/));


### PR DESCRIPTION
## Motivation

There is some regression due to some webpack optimization that I did on #1323 . Some common chunks is not included in the statically rendered html. 

Example: 
![image](https://user-images.githubusercontent.com/17883920/55311295-19ba2280-5495-11e9-80e2-1795a494919a.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Disable javascript, head over to /feedback/

<img width="947" alt="css loaded" src="https://user-images.githubusercontent.com/17883920/55311305-23438a80-5495-11e9-9b0a-cbf91ca8a333.PNG">

## Related PRs

#1323 
