### PR TITLE
refactor(v2): hydrate on server existing markup instead of full rerender

### DIFF
--- a/packages/docusaurus/lib/core/clientEntry.js
+++ b/packages/docusaurus/lib/core/clientEntry.js
@@ -6,8 +6,8 @@
  */
 
 import React from 'react';
+import {hydrate, render} from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
-import ReactDOM from 'react-dom';
 
 import App from './App';
 import preload from './preload';
@@ -15,8 +15,12 @@ import routes from '@generated/routes'; // eslint-disable-line
 
 // Client-side render (e.g: running in browser) to become single-page application (SPA).
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  // For production, attempt to hydrate existing markup for performant first-load experience.
+  // For development, there is no existing markup so we had to render it.
+  // Note that we also preload async component to avoid first-load loading screen.
+  const renderMethod = process.env.NODE_ENV === 'production' ? hydrate : render;
   preload(routes, window.location.pathname).then(() => {
-    ReactDOM.render(
+    renderMethod(
       <BrowserRouter>
         <App />
       </BrowserRouter>,

--- a/packages/docusaurus/lib/core/preload.js
+++ b/packages/docusaurus/lib/core/preload.js
@@ -8,11 +8,15 @@
 import {matchRoutes} from 'react-router-config';
 
 /**
- * This helps us to make sure all the async component for that particular route
- * is loaded before rendering. This is to avoid loading screens on first page load
+ * Helper function to make sure all async component for that particular route
+ * is preloaded before rendering. This is especially useful to avoid loading screens
+ *
+ * @param {Array<RouteConfig>} routes react-router-config
+ * @param {string} pathname the route pathname, example: /docs/installation
+ * @returns {Promise} Promise object represents whether pathname
  */
-export default function preload(routeConfig, providedLocation) {
-  const matches = matchRoutes(routeConfig, providedLocation);
+export default function preload(routes, pathname) {
+  const matches = matchRoutes(routes, pathname);
   return Promise.all(
     matches.map(match => {
       const {component} = match.route;


### PR DESCRIPTION
## Motivation

ReactDOM.render is slower than ReactDOM.hydrate. Since we already server render in production, we can just try to hydrate the existing container without rerendering it completely client-side.

References:

https://reactjs.org/docs/react-dom-server.html#rendertostring

> If you call ReactDOM.hydrate() on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.

https://reactjs.org/docs/react-dom.html#render
> Using ReactDOM.render() to hydrate a server-rendered container is deprecated and will be removed in React 17. Use hydrate() instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Locally development still works
![image](https://user-images.githubusercontent.com/17883920/55495206-fba81a00-566e-11e9-9bf6-33efeac838a2.png)

2. Locally production build also works. No HTML mismatch
<img width="960" alt="no html mismatch" src="https://user-images.githubusercontent.com/17883920/55495193-f3e87580-566e-11e9-9a6d-4eead84ce407.PNG">
