### PR TITLE
feat(v2): enable user to analyze production bundle size

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.js
@@ -238,11 +238,9 @@ describe('loadDocs', () => {
       {
         path: '../docs',
         sidebarPath,
+        skipNextRelease: true,
       },
       {
-        cliOptions: {
-          skipNextRelease: true,
-        },
         env,
         siteDir,
         siteConfig,

--- a/packages/docusaurus-plugin-content-docs/src/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/index.js
@@ -25,6 +25,7 @@ const DEFAULT_OPTIONS = {
   // TODO: Settle themeing.
   docLayoutComponent: '@theme/Doc',
   docItemComponent: '@theme/DocBody',
+  skipNextRelease: false, // Skip documents from next release (default = false)
 };
 
 class DocusaurusPluginContentDocs {
@@ -44,9 +45,8 @@ class DocusaurusPluginContentDocs {
 
   // Fetches blog contents and returns metadata for the contents.
   async loadContent() {
-    const {include, routeBasePath, sidebarPath} = this.options;
-    const {siteDir, env, siteConfig, cliOptions = {}} = this.context;
-    const {skipNextRelease} = cliOptions;
+    const {include, routeBasePath, sidebarPath, skipNextRelease} = this.options;
+    const {siteDir, env, siteConfig} = this.context;
     const docsDir = this.contentPath;
 
     // We don't want sidebars to be cached because of hotreloading.

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -42,12 +42,12 @@ program
   .command('build [siteDir]')
   .description('Build website')
   .option(
-    '--skip-next-release',
-    'Skip documents from next release (default = false)',
+    '--bundle-analyzer',
+    'Visualize size of webpack output files with an interactive zoomable treemap (default = false)',
   )
-  .action((siteDir = '.', {skipNextRelease}) => {
+  .action((siteDir = '.', {bundleAnalyzer}) => {
     wrapCommand(build)(path.resolve(siteDir), {
-      skipNextRelease,
+      bundleAnalyzer,
     });
   });
 

--- a/packages/docusaurus/lib/commands/build.js
+++ b/packages/docusaurus/lib/commands/build.js
@@ -41,7 +41,7 @@ function compile(config) {
 
 module.exports = async function build(siteDir, cliOptions = {}) {
   process.env.NODE_ENV = 'production';
-  console.log(chalk.blue('Creating an optimized production build...\n'));
+  console.log(chalk.blue('Creating an optimized production build...'));
 
   const props = await load(siteDir, cliOptions);
 

--- a/packages/docusaurus/lib/commands/build.js
+++ b/packages/docusaurus/lib/commands/build.js
@@ -7,6 +7,7 @@
 
 const webpack = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 const path = require('path');
 const chalk = require('chalk');
 const fs = require('fs-extra');
@@ -40,7 +41,7 @@ function compile(config) {
 
 module.exports = async function build(siteDir, cliOptions = {}) {
   process.env.NODE_ENV = 'production';
-  console.log('Build command invoked ...');
+  console.log(chalk.blue('Creating an optimized production build...\n'));
 
   const props = await load(siteDir, cliOptions);
 
@@ -50,8 +51,13 @@ module.exports = async function build(siteDir, cliOptions = {}) {
   const clientConfigObj = createClientConfig(props);
   // Remove/clean build folders before building bundles.
   clientConfigObj.plugin('clean').use(CleanWebpackPlugin, [{verbose: false}]);
-  let serverConfig = createServerConfig(props).toConfig();
+  // Visualize size of webpack output files with an interactive zoomable treemap.
+  if (cliOptions.bundleAnalyzer) {
+    clientConfigObj.plugin('bundleAnalyzer').use(BundleAnalyzerPlugin);
+  }
+
   let clientConfig = clientConfigObj.toConfig();
+  let serverConfig = createServerConfig(props).toConfig();
 
   // Plugin lifecycle - configureWebpack
   plugins.forEach(({configureWebpack}) => {

--- a/packages/docusaurus/lib/commands/start.js
+++ b/packages/docusaurus/lib/commands/start.js
@@ -33,7 +33,7 @@ async function getPort(reqPort) {
 }
 
 module.exports = async function start(siteDir, cliOptions = {}) {
-  console.log(chalk.blue('Starting the development server...\n'));
+  console.log(chalk.blue('Starting the development server...'));
 
   // Process all related files as a prop.
   const props = await load(siteDir);

--- a/packages/docusaurus/lib/load/index.js
+++ b/packages/docusaurus/lib/load/index.js
@@ -23,7 +23,6 @@ module.exports = async function load(siteDir, cliOptions = {}) {
     siteDir,
     constants.GENERATED_FILES_DIR_NAME,
   );
-  fs.ensureDirSync(generatedFilesDir);
 
   // Site Config
   const siteConfig = loadConfig.loadConfig(siteDir);

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -70,6 +70,7 @@
     "style-loader": "^0.22.1",
     "terser-webpack-plugin": "^1.2.3",
     "webpack": "^4.26.0",
+    "webpack-bundle-analyzer": "^3.1.0",
     "webpack-chain": "^4.9.0",
     "webpack-dev-server": "^3.2.1",
     "webpack-merge": "^4.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,7 +1965,7 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn-walk@^6.0.1:
+acorn-walk@^6.0.1, acorn-walk@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
   integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
@@ -1980,7 +1980,7 @@ acorn@^5.5.0, acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.1, acorn@^6.0.5:
+acorn@^6.0.1, acorn@^6.0.5, acorn@^6.0.7:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
@@ -2564,6 +2564,16 @@ before-after-hook@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
   integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
+
+bfj@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.1.tgz#05a3b7784fbd72cfa3c22e56002ef99336516c48"
+  integrity sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==
+  dependencies:
+    bluebird "^3.5.1"
+    check-types "^7.3.0"
+    hoopy "^0.1.2"
+    tryer "^1.0.0"
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -3168,6 +3178,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-types@^7.3.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.4.0.tgz#0378ec1b9616ec71f774931a3c6516fad8c152f4"
+  integrity sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==
 
 cheerio@0.22.0, cheerio@^0.22.0:
   version "0.22.0"
@@ -5216,7 +5231,7 @@ expect@^24.5.0:
     jest-message-util "^24.5.0"
     jest-regex-util "^24.3.0"
 
-express@^4.15.3, express@^4.16.2:
+express@^4.15.3, express@^4.16.2, express@^4.16.3:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
   integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
@@ -5506,7 +5521,7 @@ filesize@3.5.11:
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
   integrity sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==
 
-filesize@3.6.1:
+filesize@3.6.1, filesize@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
   integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
@@ -6149,7 +6164,7 @@ gzip-size@3.0.0:
   dependencies:
     duplexer "^0.1.1"
 
-gzip-size@5.0.0:
+gzip-size@5.0.0, gzip-size@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
   integrity sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==
@@ -6407,6 +6422,11 @@ homedir-polyfill@^1.0.1:
   integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   dependencies:
     parse-passwd "^1.0.0"
+
+hoopy@^0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
+  integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   version "2.7.1"
@@ -9484,6 +9504,11 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 opn@5.2.0:
   version "5.2.0"
@@ -12806,6 +12831,11 @@ truncate-html@^1.0.1:
     "@types/cheerio" "^0.22.8"
     cheerio "0.22.0"
 
+tryer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
+  integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -13307,6 +13337,25 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-bundle-analyzer@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.1.0.tgz#2f19cbb87bb6d4f3cb4e59cb67c837bd9436e89d"
+  integrity sha512-nyDyWEs7C6DZlgvu1pR1zzJfIWSiGPbtaByZr8q+Fd2xp70FuM/8ngCJzj3Er1TYRLSFmp1F1OInbEm4DZH8NA==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-walk "^6.1.1"
+    bfj "^6.1.1"
+    chalk "^2.4.1"
+    commander "^2.18.0"
+    ejs "^2.6.1"
+    express "^4.16.3"
+    filesize "^3.6.1"
+    gzip-size "^5.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    opener "^1.5.1"
+    ws "^6.0.0"
+
 webpack-chain@^4.9.0:
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-4.12.1.tgz#6c8439bbb2ab550952d60e1ea9319141906c02a6"
@@ -13623,6 +13672,13 @@ ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
## Motivation

I think it's a good cliOptions for user to enable them analyze their bundle size especially in production.

![image](https://user-images.githubusercontent.com/17883920/55499857-91e13d80-5679-11e9-880b-2ba95fe67384.png)

https://github.com/webpack-contrib/webpack-bundle-analyzer - Over 1.4 million downloads on NPM /week

I personally like it to make my debugging/ web performance optimizing life easier

Other Changes:
1. Move skipNextRelease to be part of the docs plugin, instead of docusaurus-core cli
2. Remove ensureDirSync seen generate command already have an inbuilt async `fs.ensureDir`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
cd website
yarn build --bundle-analyzer
```

<img width="955" alt="bundle-analyzer" src="https://user-images.githubusercontent.com/17883920/55499755-56df0a00-5679-11e9-92f0-6f505a0de125.PNG">

