### PR TITLE
feat(v2): add cache-loader by default especially on babel-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 yarn-error.log
 build
 .docusaurus
+.cache-loader

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -45,9 +45,11 @@ program
     '--bundle-analyzer',
     'Visualize size of webpack output files with an interactive zoomable treemap (default = false)',
   )
-  .action((siteDir = '.', {bundleAnalyzer}) => {
+  .option('--no-cache-loader', 'Do not use cache-loader')
+  .action((siteDir = '.', {bundleAnalyzer, cacheLoader}) => {
     wrapCommand(build)(path.resolve(siteDir), {
       bundleAnalyzer,
+      cacheLoader,
     });
   });
 
@@ -78,8 +80,9 @@ program
   .option('-p, --port <port>', 'use specified port (default: 3000)')
   .option('-h, --host <host>', 'use specified host (default: localhost')
   .option('-nw, --no-watch <noWatch>', 'disable live reload (default: false)')
-  .action((siteDir = '.', {port, noWatch}) => {
-    wrapCommand(start)(path.resolve(siteDir), {port, noWatch});
+  .option('--no-cache-loader', 'Do not use cache-loader')
+  .action((siteDir = '.', {port, noWatch, cacheLoader}) => {
+    wrapCommand(start)(path.resolve(siteDir), {port, noWatch, cacheLoader});
   });
 
 program.parse(process.argv);

--- a/packages/docusaurus/lib/commands/start.js
+++ b/packages/docusaurus/lib/commands/start.js
@@ -36,7 +36,7 @@ module.exports = async function start(siteDir, cliOptions = {}) {
   console.log(chalk.blue('Starting the development server...'));
 
   // Process all related files as a prop.
-  const props = await load(siteDir);
+  const props = await load(siteDir, cliOptions);
 
   // Reload files processing.
   if (!cliOptions.noWatch) {

--- a/packages/docusaurus/lib/load/index.js
+++ b/packages/docusaurus/lib/load/index.js
@@ -113,6 +113,7 @@ module.exports = async function load(siteDir, cliOptions = {}) {
     generatedFilesDir,
     routesPaths,
     plugins,
+    cliOptions,
   };
 
   return props;

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -38,6 +38,7 @@
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
+    "cache-loader": "^2.0.1",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,6 +2969,17 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cache-loader@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-2.0.1.tgz#5758f41a62d7c23941e3c3c7016e6faeb03acb07"
+  integrity sha512-V99T3FOynmGx26Zom+JrVBytLBsmUCzVG2/4NnUKgvXN4bEV42R1ERl1IyiH/cvFIDA1Ytq2lPZ9tXDSahcQpQ==
+  dependencies:
+    loader-utils "^1.1.0"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.0"
+    normalize-path "^3.0.0"
+    schema-utils "^1.0.0"
+
 cacheable-request@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"


### PR DESCRIPTION
## Motivation

Add https://github.com/webpack-contrib/cache-loader/ by default especially on expensive loader like babel-loader.

Also add `--no-cache-loader` cli option if user don't want it.

How it works:
**Caches the result of following loaders on disk**

<img width="262" alt="cache-loader-3" src="https://user-images.githubusercontent.com/17883920/55504542-a75b6500-5683-11e9-8a1a-66bd9a7e7691.PNG">


See test plan for benefits

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

### Yarn start

With cache-loader. Subsequent build is faster due to reuse of cache

<img width="572" alt="cache-loader-2" src="https://user-images.githubusercontent.com/17883920/55504302-1e442e00-5683-11e9-9324-ff5004bed39f.PNG">

Without cache loader, roughly similar performance
<img width="623" alt="no-cache-loader" src="https://user-images.githubusercontent.com/17883920/55504390-577c9e00-5683-11e9-9021-35bbd411476b.PNG">

### Yarn build

With cache-loader
<img width="619" alt="yarn build cache-loader" src="https://user-images.githubusercontent.com/17883920/55504427-695e4100-5683-11e9-8bfe-8e40eecb03b4.PNG">


Without cache-loader
<img width="613" alt="yarn build no cache-loader" src="https://user-images.githubusercontent.com/17883920/55504434-6cf1c800-5683-11e9-82ab-1bb6bd125746.PNG">

## Notes:

Lot of possibility for improvement in the future. Just adding it for now