### PR TITLE
fix(v2): plugins not watching the correct files

### DIFF
--- a/packages/docusaurus-plugin-content-blog/index.js
+++ b/packages/docusaurus-plugin-content-blog/index.js
@@ -44,7 +44,11 @@ class DocusaurusPluginContentBlog {
   }
 
   getPathsToWatch() {
-    return [this.contentPath];
+    const {include = []} = this.options;
+    const globPattern = include.map(
+      pattern => `${this.contentPath}/${pattern}`,
+    );
+    return [...globPattern];
   }
 
   // Fetches blog contents and returns metadata for the contents.

--- a/packages/docusaurus-plugin-content-docs/src/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/index.js
@@ -41,7 +41,11 @@ class DocusaurusPluginContentDocs {
   }
 
   getPathsToWatch() {
-    return [this.contentPath, this.options.sidebarPath];
+    const {include = []} = this.options;
+    const globPattern = include.map(
+      pattern => `${this.contentPath}/${pattern}`,
+    );
+    return [...globPattern, this.options.sidebarPath];
   }
 
   // Fetches blog contents and returns metadata for the contents.

--- a/packages/docusaurus-plugin-content-pages/src/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/index.js
@@ -30,7 +30,11 @@ class DocusaurusPluginContentPages {
   }
 
   getPathsToWatch() {
-    return [this.contentPath];
+    const {include = []} = this.options;
+    const globPattern = include.map(
+      pattern => `${this.contentPath}/${pattern}`,
+    );
+    return [...globPattern];
   }
 
   async loadContent() {

--- a/packages/docusaurus/lib/commands/start.js
+++ b/packages/docusaurus/lib/commands/start.js
@@ -41,19 +41,28 @@ module.exports = async function start(siteDir, cliOptions = {}) {
 
   // Reload files processing.
   if (!cliOptions.noWatch) {
-    const reload = () => {
+    const reload = filepath => {
+      console.log(`${filepath} has changed`);
       load(siteDir).catch(err => {
         console.error(chalk.red(err.stack));
       });
     };
     const {plugins} = props;
+
+    const normalizeToSiteDir = filepath => {
+      if (filepath && path.isAbsolute(filepath)) {
+        return path.relative(siteDir, filepath);
+      }
+      return filepath;
+    };
+
     const pluginPaths = _.compact(
       _.flatten(
         plugins.map(
           plugin => plugin.getPathsToWatch && plugin.getPathsToWatch(),
         ),
       ),
-    );
+    ).map(normalizeToSiteDir);
     const fsWatcher = chokidar.watch(
       [...pluginPaths, loadConfig.configFileName],
       {


### PR DESCRIPTION
## Motivation

We should use glob pattern for the paths to watch in plugins. It's also more performant to watch the correct extension files, see https://github.com/facebook/Docusaurus/pull/1327#discussion_r270658141

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

**Before**

It doesn't trigger load() due to wrong glob pattern
![before](https://user-images.githubusercontent.com/17883920/55673488-3b733980-58db-11e9-909e-57419c85239b.gif)

**After**

It triggers load() after this PR.

![chokidar](https://user-images.githubusercontent.com/17883920/55673495-45953800-58db-11e9-83e3-ec2b3332b592.gif)

