### PR TITLE
feat(v2): upgrade addRoutes API to introduce query

### DIFF
--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -2,10 +2,12 @@
   "name": "@docusaurus/plugin-content-blog",
   "version": "1.0.0",
   "description": "Blog plugin for Docusaurus",
-  "main": "index.js",
+  "main": "src/index.js",
   "license": "MIT",
   "dependencies": {
     "@docusaurus/utils": "^1.0.0",
+    "front-matter": "^3.0.1",
+    "loader-utils": "^1.2.3",
     "fs-extra": "^7.0.1",
     "globby": "^9.1.0"
   },

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.js
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const fm = require('front-matter');
+const {parseQuery} = require('loader-utils');
+
+const TRUNCATE_MARKER = /<!--\s*truncate\s*-->/;
+
+module.exports = async function(fileString) {
+  const callback = this.async();
+
+  // Extract content of markdown (without frontmatter).
+  let {body: content} = fm(fileString);
+
+  // Truncate content if requested (e.g: file.md?truncated=true)
+  const {truncated} = this.resourceQuery && parseQuery(this.resourceQuery);
+  if (truncated) {
+    if (TRUNCATE_MARKER.test(content)) {
+      // eslint-disable-next-line
+      content = content.split(TRUNCATE_MARKER)[0];
+    } else {
+      // Return first 4 lines of the content as summary
+      content = content
+        .split('\n')
+        .slice(0, 4)
+        .join('\n');
+    }
+  }
+  return callback(null, content);
+};

--- a/packages/docusaurus-plugin-content-docs/src/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/index.js
@@ -220,7 +220,7 @@ class DocusaurusPluginContentDocs {
     });
   }
 
-  configureWebpack(config, isServer) {
+  configureWebpack(config, isServer, {getBabelLoader, getCacheLoader}) {
     const versionedDir = path.join(this.context.siteDir, 'versioned_docs');
     const translatedDir = path.join(this.context.siteDir, 'translated_docs');
 
@@ -228,30 +228,12 @@ class DocusaurusPluginContentDocs {
       module: {
         rules: [
           {
-            test: /(\.mdx?)$/, // TODO: Read only this plugin's markdown files.
+            test: /(\.mdx?)$/,
+            include: [this.contentPath],
             use: [
-              // TODO: Add back cache loader and read babel loader from existing config
-              // instead of duplicating it.
-              {
-                loader: 'babel-loader',
-                options: {
-                  // ignore local project babel config (.babelrc)
-                  babelrc: false,
-                  // ignore local project babel config (babel.config.js)
-                  configFile: false,
-                  presets: ['@babel/env', '@babel/react'],
-                  plugins: [
-                    'react-hot-loader/babel', // To enable react-hot-loader
-                    isServer
-                      ? 'dynamic-import-node'
-                      : '@babel/syntax-dynamic-import',
-                    'react-loadable/babel',
-                  ],
-                },
-              },
-              {
-                loader: '@docusaurus/mdx-loader',
-              },
+              getCacheLoader(isServer),
+              getBabelLoader(isServer),
+              '@docusaurus/mdx-loader',
               {
                 loader: path.resolve(__dirname, './markdown/index.js'),
                 options: {

--- a/packages/docusaurus/lib/theme/BlogPage/index.js
+++ b/packages/docusaurus/lib/theme/BlogPage/index.js
@@ -30,10 +30,7 @@ function BlogPage(props) {
       </Head>
       <div>
         {BlogPosts.map((PostContent, index) => (
-          <Post
-            key={index}
-            truncated={posts[index].truncatedSource}
-            metadata={posts[index]}>
+          <Post key={index} truncated metadata={posts[index]}>
             <PostContent />
           </Post>
         ))}

--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -37,8 +37,8 @@ module.exports = function createBaseConfig(props, isServer) {
     resolve: {
       symlinks: true,
       alias: {
-        // https://github.com/gaearon/react-hot-loader#react--dom
         'react-dom': isProd ? 'react-dom' : '@hot-loader/react-dom',
+        ejs: 'ejs/ejs.min.js',
         '@theme': themePath,
         '@site': siteDir,
         '@build': outDir,

--- a/packages/docusaurus/lib/webpack/utils.js
+++ b/packages/docusaurus/lib/webpack/utils.js
@@ -9,20 +9,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const cacheLoaderVersion = require('cache-loader/package.json').version;
 const merge = require('webpack-merge');
 
-// Modify the generated webpack config with normal webpack config.
-function applyConfigureWebpack(userConfig, config, isServer) {
-  if (typeof userConfig === 'object') {
-    return merge(config, userConfig);
-  }
-  if (typeof userConfig === 'function') {
-    const res = userConfig(config, isServer);
-    if (res && typeof res === 'object') {
-      return merge(config, res);
-    }
-  }
-  return config;
-}
-
 // Utility method to get style loaders
 function getStyleLoaders(isServer, cssOptions) {
   const isProd = process.env.NODE_ENV === 'production';
@@ -71,6 +57,33 @@ function getBabelLoader(isServer, babelOptions) {
       babelOptions,
     ),
   };
+}
+
+/**
+ * Helper function to modify webpack config
+ * @param {Object | Function} configureWebpack a webpack config or a function to modify config
+ * @param {Object} config initial webpack config
+ * @param {Boolean} isServer indicates if this is a server webpack configuration
+ * @returns {Object} final/ modified webpack config
+ */
+function applyConfigureWebpack(configureWebpack, config, isServer) {
+  if (typeof configureWebpack === 'object') {
+    return merge(config, configureWebpack);
+  }
+
+  // Export some utility functions
+  const utils = {
+    getStyleLoaders,
+    getCacheLoader,
+    getBabelLoader,
+  };
+  if (typeof configureWebpack === 'function') {
+    const res = configureWebpack(config, isServer, utils);
+    if (res && typeof res === 'object') {
+      return merge(config, res);
+    }
+  }
+  return config;
 }
 
 module.exports = {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -51,7 +51,6 @@
     "globby": "^9.1.0",
     "html-webpack-plugin": "^3.2.0",
     "is-wsl": "^1.1.0",
-    "loader-utils": "^1.1.0",
     "lodash": "^4.17.11",
     "mini-css-extract-plugin": "^0.4.1",
     "portfinder": "^1.0.13",


### PR DESCRIPTION
## Motivation

Something to ponder: How do we apply different loaders for files with same extension?

Scenario
- I want to load 'blog-xxxx.md' but only want the content summary
- I want to load 'blog-xxxx.md', all of the content

The goal is to conditionally transform resources as needed just by appending a query parameter to the import statement. 

Example:
`import('blog/2018-09-11-Towards-Docusaurus-2.md?truncated=true')`

Previously, our addRoute API looks like this

```js

addRoute({
  // .....
  component: 'the/path/component/' // Only accepts string
})
```

Now we allow
```js

addRoute({
  // .....
  component: {
     path: // the import path
     query: {
        // the query
    }
  }
})
```

Changes:
- Blog plugin now no longer generates truncated version of blog (reduce bundle size). 
- Some code refactoring for readability (in particular: `routes.js`)
- Refactoring some common loaders to docs and blog plugin

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Locally everything still OK
- Netlify (TBD)