### PR TITLE
fix(v2): windows compatibility

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/index.test.js
+++ b/packages/docusaurus-utils/src/__tests__/index.test.js
@@ -13,9 +13,23 @@ import {
   idx,
   getSubFolder,
   normalizeUrl,
+  posixPath,
 } from '../index';
 
 describe('load utils', () => {
+  test('posixPath', () => {
+    const asserts = {
+      'c:/aaaa\\bbbb': 'c:/aaaa/bbbb',
+      'c:\\aaaa\\bbbb\\★': 'c:\\aaaa\\bbbb\\★',
+      '\\\\?\\c:\\aaaa\\bbbb': '\\\\?\\c:\\aaaa\\bbbb',
+      'c:\\aaaa\\bbbb': 'c:/aaaa/bbbb',
+      'foo\\bar': 'foo/bar',
+    };
+    Object.keys(asserts).forEach(file => {
+      expect(posixPath(file)).toBe(asserts[file]);
+    });
+  });
+
   test('fileToComponentName', () => {
     const asserts = {
       'index.md': 'MDIndex',

--- a/packages/docusaurus-utils/src/index.js
+++ b/packages/docusaurus-utils/src/index.js
@@ -49,6 +49,21 @@ function fileToComponentName(file) {
   return ext ? ext.toUpperCase() + str : str;
 }
 
+/**
+ * Convert Windows backslash paths to posix style paths. E.g: endi\\lie -> endi/lie
+ * @param {string} str windows backslash paths
+ * @returns {string} posix-style path
+ */
+function posixPath(str) {
+  const isExtendedLengthPath = /^\\\\\?\\/.test(str);
+  const hasNonAscii = /[^\u0000-\u0080]+/.test(str); // eslint-disable-line
+
+  if (isExtendedLengthPath || hasNonAscii) {
+    return str;
+  }
+  return str.replace(/\\/g, '/');
+}
+
 function generateChunkName(str, prefix) {
   const name = str === '/' ? 'index' : kebabHash(str);
   return prefix ? `${prefix}---${name}` : name;
@@ -153,4 +168,5 @@ module.exports = {
   idx,
   normalizeUrl,
   parse,
+  posixPath,
 };

--- a/packages/docusaurus/lib/server/load/plugins.js
+++ b/packages/docusaurus/lib/server/load/plugins.js
@@ -7,7 +7,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const {generate} = require('@docusaurus/utils');
+const {generate, posixPath} = require('@docusaurus/utils');
 
 module.exports = async function loadPlugins({pluginConfigs = [], context}) {
   // 1. Plugin Lifecycle - Initialization/Constructor
@@ -48,7 +48,10 @@ module.exports = async function loadPlugins({pluginConfigs = [], context}) {
         metadataFileName,
         JSON.stringify(content, null, 2),
       );
-      const contentPath = path.join('@generated', pluginContentPath);
+      // Note that we need to convert it into POSIX format because
+      // import XXXXX from '@generated\this-is\my\path' is incorrect
+      // import XXXXX from '@generated/this-is/my/path' is correct
+      const contentPath = posixPath(path.join('@generated', pluginContentPath));
 
       return {
         metadataKey,

--- a/packages/docusaurus/lib/server/load/routes.js
+++ b/packages/docusaurus/lib/server/load/routes.js
@@ -34,7 +34,8 @@ async function loadRoutes(pluginsRouteConfigs) {
     const importStr = isObj ? target.path : target;
     const queryStr = target.query ? `?${stringify(target.query)}` : '';
     const chunkName = generateChunkName(name || importStr, prefix);
-    return `() => import(/* webpackChunkName: '${chunkName}' */ '${importStr}${queryStr}')`;
+    const finalStr = JSON.stringify(importStr + queryStr);
+    return `() => import(/* webpackChunkName: '${chunkName}' */ ${finalStr})`;
   }
 
   function generateRouteCode(pluginRouteConfig) {


### PR DESCRIPTION
## Motivation

Fix #1350

The problem

`import XXXXX from '@generated\this-is\my\path' is incorrect`
`import XXXXX from '@generated/this-is/my/path' is correct`

<img width="588" alt="The problem" src="https://user-images.githubusercontent.com/17883920/55863149-8d061780-5bac-11e9-9f89-938bfe5afdd7.png">

We need to escape `backslashes` for windows path.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before

<img width="960" alt="previous" src="https://user-images.githubusercontent.com/17883920/55863100-72cc3980-5bac-11e9-8c2f-a5c67320b68f.PNG">

After

Windows
<img width="443" alt="after" src="https://user-images.githubusercontent.com/17883920/55863111-76f85700-5bac-11e9-902a-1745dff5f262.PNG">

Linux
<img width="551" alt="linux still ok" src="https://user-images.githubusercontent.com/17883920/55863480-30efc300-5bad-11e9-9347-c9953dde3ba2.PNG">


<img width="955" alt="after-fix" src="https://user-images.githubusercontent.com/17883920/55863119-79f34780-5bac-11e9-9230-38c5d48a3fac.PNG">
