### PR TITLE
fix(v2): wrong head meta and title

### DIFF
--- a/packages/docusaurus/lib/client/exports/Head.js
+++ b/packages/docusaurus/lib/client/exports/Head.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import Helmet from 'react-helmet';
+import {Helmet} from 'react-helmet';
 
 function Head(props) {
   return <Helmet {...props} />;

--- a/packages/docusaurus/lib/client/serverEntry.js
+++ b/packages/docusaurus/lib/client/serverEntry.js
@@ -9,7 +9,7 @@ import ejs from 'ejs';
 import React from 'react';
 import {StaticRouter} from 'react-router-dom';
 import ReactDOMServer from 'react-dom/server';
-import Helmet from 'react-helmet';
+import {Helmet} from 'react-helmet';
 import {getBundles} from 'react-loadable-ssr-addon';
 import Loadable from 'react-loadable';
 

--- a/packages/docusaurus/lib/default-theme/Doc/index.js
+++ b/packages/docusaurus/lib/default-theme/Doc/index.js
@@ -19,19 +19,14 @@ import DocusaurusContext from '@docusaurus/context';
 import styles from './styles.module.css';
 
 function Doc(props) {
-  const {metadata = {}, siteConfig = {}} = useContext(DocusaurusContext);
+  const {siteConfig = {}} = useContext(DocusaurusContext);
   const {route} = props;
-  const {language, version} = metadata;
   const {baseUrl, favicon} = siteConfig;
-
   return (
     <Layout>
       <Head>
-        <title>{(metadata && metadata.title) || siteConfig.title}</title>
+        <title>{siteConfig.title}</title>
         {favicon && <link rel="shortcut icon" href={baseUrl + favicon} />}
-        {language && <html lang={language} />}
-        {language && <meta name="docsearch:language" content={language} />}
-        {version && <meta name="docsearch:version" content={version} />}
       </Head>
       <Sidebar />
       <div className={styles.mainContainer}>

--- a/packages/docusaurus/lib/default-theme/DocBody/index.js
+++ b/packages/docusaurus/lib/default-theme/DocBody/index.js
@@ -9,20 +9,27 @@ import React, {useContext, useEffect} from 'react';
 
 import DocsPaginator from '@theme/DocsPaginator'; // eslint-disable-line
 import DocusaurusContext from '@docusaurus/context';
+import Head from '@docusaurus/Head';
 
 import styles from './styles.module.css';
 
 function DocBody(props) {
   const {metadata, modules} = props;
+  const {language, version} = metadata;
   const context = useContext(DocusaurusContext);
   useEffect(() => {
     context.setContext({metadata});
   }, []);
 
   const DocContents = modules[0];
-
   return (
     <div className={styles.docBody}>
+      <Head>
+        {metadata && metadata.title && <title>{metadata.title}</title>}
+        {language && <html lang={language} />}
+        {language && <meta name="docsearch:language" content={language} />}
+        {version && <meta name="docsearch:version" content={version} />}
+      </Head>
       <div className="container margin-bottom-xl">
         <div className="row">
           <div className="col col-8 col-offset-2">

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -55,7 +55,7 @@
     "mini-css-extract-plugin": "^0.4.1",
     "portfinder": "^1.0.13",
     "react-dev-utils": "^8.0.0",
-    "react-helmet": "^5.2.0",
+    "react-helmet": "^6.0.0-beta",
     "react-hot-loader": "^4.8.2",
     "react-listener-provider": "^0.2.0",
     "react-loadable": "^5.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10874,14 +10874,19 @@ react-error-overlay@^5.1.4:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.4.tgz#88dfb88857c18ceb3b9f95076f850d7121776991"
   integrity sha512-fp+U98OMZcnduQ+NSEiQa4s/XMsbp+5KlydmkbESOw4P69iWZ68ZMFM5a2BuE0FgqPBKApJyRuYHR95jM8lAmg==
 
-react-helmet@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
-  integrity sha1-qBgR3yExOm1VxfBYxK66XW89l6c=
+react-fast-compare@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-helmet@^6.0.0-beta:
+  version "6.0.0-beta"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.0.0-beta.tgz#1f2ac04521951486e4fce3296d0c88aae8cabd5c"
+  integrity sha512-GnNWsokebTe7fe8MH2I/a2dl4THYWhthLBoMaQSRYqW5XbPo881WAJGi+lqRBjyOFryW6zpQluEkBy70zh+h9w==
   dependencies:
-    deep-equal "^1.0.1"
     object-assign "^4.1.1"
     prop-types "^15.5.4"
+    react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
 
 react-hot-loader@^4.8.2:


### PR DESCRIPTION
## Motivation

Problem

Wrong title in static html if javascript disabled
<img width="938" alt="before" src="https://user-images.githubusercontent.com/17883920/55868222-998f6d80-5bb6-11e9-81ed-998a98480088.PNG">

Others:
- Upgrade react-helmet to v6 beta. We need this because of potential critical bug https://github.com/nfl/react-helmet/issues/373 issue surfacing

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Correct meta tag on static html (even with JavaScript disabled)
<img width="928" alt="after" src="https://user-images.githubusercontent.com/17883920/55868238-a4e29900-5bb6-11e9-836a-c433899bfc5c.PNG">
