### PR TITLE
fix(v2): fix js-loader not transpiling own library

### DIFF
--- a/packages/docusaurus/lib/webpack/base.js
+++ b/packages/docusaurus/lib/webpack/base.js
@@ -99,7 +99,15 @@ module.exports = function createBaseConfig(props, isServer) {
       rules: [
         {
           test: /\.jsx?$/,
-          exclude: /node_modules/,
+          exclude(modulePath) {
+            // always transpile our own library
+            if (modulePath.startsWith(path.join(__dirname, '..'))) {
+              return false;
+            }
+
+            // Don't transpile node_modules
+            return /node_modules/.test(modulePath);
+          },
           use: [
             cacheLoader && getCacheLoader(isServer),
             getBabelLoader(isServer),

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.0",
+    "@docusaurus/plugin-content-docs": "^2.0.0-alpha.0",
     "@docusaurus/plugin-content-blog": "^2.0.0-alpha.0",
     "@docusaurus/plugin-content-pages": "^2.0.0-alpha.0",
+    "@docusaurus/plugin-sitemap": "^2.0.0-alpha.0",
     "classnames": "^2.2.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",


### PR DESCRIPTION
## Motivation

Fix stuff that prevents v2 being installed as a package

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before

<img width="745" alt="fail alpha" src="https://user-images.githubusercontent.com/17883920/55896919-070cbf80-5bf2-11e9-9f0b-2fda36741ed8.PNG">

After

Can use it as 3rd party package
![image](https://user-images.githubusercontent.com/17883920/55896940-1b50bc80-5bf2-11e9-9bef-f9d504e56a3f.png)

<img width="956" alt="1" src="https://user-images.githubusercontent.com/17883920/55896949-20157080-5bf2-11e9-9298-c5943347a917.PNG">
<img width="938" alt="2" src="https://user-images.githubusercontent.com/17883920/55896957-2277ca80-5bf2-11e9-99a1-ec64c0c1df31.PNG">
