### PR TITLE
docs: change parameter type for separateCss from string to array

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -269,7 +269,7 @@ If you want a visible navigation option for representing topics on the current p
 
 Array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. Refer to the example below. The script tag will be inserted in the HTML head.
 
-#### `separateCss` [string]
+#### `separateCSS` [array]
 
 Directories inside which any `css` files will not be processed and concatenated to Docusaurus' styles. This is to support static `html` pages that may be separate from Docusaurus with completely separate styles.
 

--- a/website-1.x/versioned_docs/version-1.5.x/api-site-config.md
+++ b/website-1.x/versioned_docs/version-1.5.x/api-site-config.md
@@ -261,7 +261,7 @@ If you want a visible navigation option for representing topics on the current p
 
 Array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. Refer to the example below. The script tag will be inserted in the HTML head.
 
-#### `separateCss` [string]
+#### `separateCSS` [array]
 
 Directories inside which any `css` files will not be processed and concatenated to Docusaurus' styles. This is to support static `html` pages that may be separate from Docusaurus with completely separate styles.
 

--- a/website-1.x/versioned_docs/version-1.6.x/api-site-config.md
+++ b/website-1.x/versioned_docs/version-1.6.x/api-site-config.md
@@ -266,7 +266,7 @@ If you want a visible navigation option for representing topics on the current p
 
 Array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. Refer to the example below. The script tag will be inserted in the HTML head.
 
-#### `separateCss` [string]
+#### `separateCSS` [array]
 
 Directories inside which any `css` files will not be processed and concatenated to Docusaurus' styles. This is to support static `html` pages that may be separate from Docusaurus with completely separate styles.
 

--- a/website-1.x/versioned_docs/version-1.7.3/api-site-config.md
+++ b/website-1.x/versioned_docs/version-1.7.3/api-site-config.md
@@ -270,7 +270,7 @@ If you want a visible navigation option for representing topics on the current p
 
 Array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. Refer to the example below. The script tag will be inserted in the HTML head.
 
-#### `separateCss` [string]
+#### `separateCSS` [array]
 
 Directories inside which any `css` files will not be processed and concatenated to Docusaurus' styles. This is to support static `html` pages that may be separate from Docusaurus with completely separate styles.
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The parameter type was wrong, as explained in [this issue](https://github.com/facebook/Docusaurus/issues/1357). yangshun accepted the solution and asked me to create the pull request. 😊

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No test plan required for a docs change (I think)

## Related PRs

n/a
