### PR TITLE
feat(v2): code-split metadata out of routes

### DIFF
--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docusaurus/utils",
   "version": "2.0.0-alpha.5",
-  "description": "A set of utility functions for Docusaurus packages",
+  "description": "Node utility functions for Docusaurus packages",
   "main": "src/index.js",
   "publishConfig": {
     "access": "public"
@@ -11,6 +11,6 @@
     "escape-string-regexp": "^1.0.5",
     "front-matter": "^3.0.1",
     "fs-extra": "^7.0.0",
-    "kebab-hash": "^0.1.2"
+    "lodash": "^4.17.11"
   }
 }

--- a/packages/docusaurus-utils/src/__tests__/index.test.js
+++ b/packages/docusaurus-utils/src/__tests__/index.test.js
@@ -8,7 +8,8 @@
 import path from 'path';
 import {
   fileToPath,
-  fileToComponentName,
+  docuHash,
+  genComponentName,
   genChunkName,
   idx,
   getSubFolder,
@@ -30,21 +31,34 @@ describe('load utils', () => {
     });
   });
 
-  test('fileToComponentName', () => {
+  test('genComponentName', () => {
     const asserts = {
-      'index.md': 'MDIndex',
-      'hello/index.md': 'MDHelloIndex',
-      'foo.md': 'MDFoo',
-      'foo-bar.md': 'MDFooBar',
-      'index.js': 'JSIndex',
-      'foobar.js': 'JSFoobar',
-      'docusaurus/index.js': 'JSDocusaurusIndex',
-      '234.md': 'MD234',
-      '2018-07-08-test.md': 'MD20180708Test',
-      '%asd.md': 'MDAsd',
+      '/': 'Index',
+      '/foo-bar': 'FooBar096',
+      '/foo/bar': 'FooBar1Df',
+      '/blog/2017/12/14/introducing-docusaurus':
+        'Blog20171214IntroducingDocusaurus8D2',
+      '/blog/2017/12/14-introducing-docusaurus':
+        'Blog20171214IntroducingDocusaurus0Bc',
+      '/blog/201712/14-introducing-docusaurus':
+        'Blog20171214IntroducingDocusaurusA93',
     };
     Object.keys(asserts).forEach(file => {
-      expect(fileToComponentName(file)).toBe(asserts[file]);
+      expect(genComponentName(file)).toBe(asserts[file]);
+    });
+  });
+
+  test('docuHash', () => {
+    const asserts = {
+      '/foo-bar': 'foo-bar-096',
+      '/foo/bar': 'foo-bar-1df',
+      '/endi/lie': 'endi-lie-9fa',
+      '/endi-lie': 'endi-lie-fd3',
+      '/yangshun/tay': 'yangshun-tay-48d',
+      '/yangshun-tay': 'yangshun-tay-f3b',
+    };
+    Object.keys(asserts).forEach(file => {
+      expect(docuHash(file)).toBe(asserts[file]);
     });
   });
 

--- a/packages/docusaurus-utils/src/__tests__/index.test.js
+++ b/packages/docusaurus-utils/src/__tests__/index.test.js
@@ -50,6 +50,8 @@ describe('load utils', () => {
 
   test('docuHash', () => {
     const asserts = {
+      '': '-d41',
+      '/': 'Index',
       '/foo-bar': 'foo-bar-096',
       '/foo/bar': 'foo-bar-1df',
       '/endi/lie': 'endi-lie-9fa',

--- a/packages/docusaurus-utils/src/__tests__/index.test.js
+++ b/packages/docusaurus-utils/src/__tests__/index.test.js
@@ -9,7 +9,7 @@ import path from 'path';
 import {
   fileToPath,
   fileToComponentName,
-  generateChunkName,
+  genChunkName,
   idx,
   getSubFolder,
   normalizeUrl,
@@ -64,7 +64,7 @@ describe('load utils', () => {
     });
   });
 
-  test('generateChunkName', () => {
+  test('genChunkName', () => {
     const asserts = {
       '/docs/adding-blog': 'docs-adding-blog-062',
       '/docs/versioning': 'docs-versioning-8a8',
@@ -76,7 +76,7 @@ describe('load utils', () => {
       '/blog': 'blog-c06',
     };
     Object.keys(asserts).forEach(str => {
-      expect(generateChunkName(str)).toBe(asserts[str]);
+      expect(genChunkName(str)).toBe(asserts[str]);
     });
   });
 

--- a/packages/docusaurus-utils/src/index.js
+++ b/packages/docusaurus-utils/src/index.js
@@ -64,7 +64,7 @@ function posixPath(str) {
   return str.replace(/\\/g, '/');
 }
 
-function generateChunkName(str, prefix) {
+function genChunkName(str, prefix) {
   const name = str === '/' ? 'index' : kebabHash(str);
   return prefix ? `${prefix}---${name}` : name;
 }
@@ -163,7 +163,7 @@ module.exports = {
   generate,
   fileToPath,
   fileToComponentName,
-  generateChunkName,
+  genChunkName,
   getSubFolder,
   idx,
   normalizeUrl,

--- a/packages/docusaurus-utils/src/index.js
+++ b/packages/docusaurus-utils/src/index.js
@@ -7,8 +7,9 @@
 
 const path = require('path');
 const fm = require('front-matter');
+const {createHash} = require('crypto');
 
-const kebabHash = require('kebab-hash');
+const _ = require(`lodash`);
 const escapeStringRegexp = require('escape-string-regexp');
 const fs = require('fs-extra');
 
@@ -39,14 +40,34 @@ function encodePath(userpath) {
     .join('/');
 }
 
-function fileToComponentName(file) {
-  const ext = extRE.exec(file)[1];
-  let str = file.replace(extRE, '');
-  str = str.replace(/([A-Z])/g, ' $1');
-  str = str.replace(/^[\W_]+|[\W_]+$/g, '').toLowerCase();
-  str = str.charAt(0).toUpperCase() + str.slice(1);
-  str = str.replace(/[\W_]+(\w|$)/g, (_, ch) => ch.toUpperCase());
-  return ext ? ext.toUpperCase() + str : str;
+/**
+ * Given an input string, convert to kebab-case and append a hash. Avoid str collision
+ * @param {string} str input string
+ * @returns {string}
+ */
+function docuHash(str) {
+  const shortHash = createHash('md5')
+    .update(str)
+    .digest('hex')
+    .substr(0, 3);
+  return `${_.kebabCase(str)}-${shortHash}`;
+}
+
+/**
+ * Generate unique React Component Name. E.g: /foo-bar -> FooBar096
+ * @param {string} pagePath
+ * @returns {string} unique react component name
+ */
+function genComponentName(pagePath) {
+  if (pagePath === '/') {
+    return 'Index';
+  }
+  const pageHash = docuHash(pagePath);
+  const pascalCase = _.flow(
+    _.camelCase,
+    _.upperFirst,
+  );
+  return pascalCase(pageHash);
 }
 
 /**
@@ -65,7 +86,7 @@ function posixPath(str) {
 }
 
 function genChunkName(str, prefix) {
-  const name = str === '/' ? 'index' : kebabHash(str);
+  const name = str === '/' ? 'index' : docuHash(str);
   return prefix ? `${prefix}---${name}` : name;
 }
 
@@ -160,9 +181,10 @@ function normalizeUrl(rawUrls) {
 
 module.exports = {
   encodePath,
+  docuHash,
   generate,
   fileToPath,
-  fileToComponentName,
+  genComponentName,
   genChunkName,
   getSubFolder,
   idx,

--- a/packages/docusaurus-utils/src/index.js
+++ b/packages/docusaurus-utils/src/index.js
@@ -46,6 +46,9 @@ function encodePath(userpath) {
  * @returns {string}
  */
 function docuHash(str) {
+  if (str === '/') {
+    return 'Index';
+  }
   const shortHash = createHash('md5')
     .update(str)
     .digest('hex')

--- a/packages/docusaurus/lib/client/serverEntry.js
+++ b/packages/docusaurus/lib/client/serverEntry.js
@@ -13,7 +13,7 @@ import {Helmet} from 'react-helmet';
 import {getBundles} from 'react-loadable-ssr-addon';
 import Loadable from 'react-loadable';
 
-import manifest from '@build/assets-manifest.json'; //eslint-disable-line
+import manifest from '@generated/assets-manifest.json'; //eslint-disable-line
 import routes from '@generated/routes'; // eslint-disable-line
 import preload from './preload';
 import App from './App';
@@ -22,10 +22,10 @@ import ssrTemplate from './templates/ssr.html.template';
 // Renderer for static-site-generator-webpack-plugin (async rendering via promises)
 export default function render(locals) {
   return preload(routes, locals.path).then(() => {
-    const modules = [];
+    const modules = new Set();
     const context = {};
     const appHtml = ReactDOMServer.renderToString(
-      <Loadable.Capture report={moduleName => modules.push(moduleName)}>
+      <Loadable.Capture report={moduleName => modules.add(moduleName)}>
         <StaticRouter location={locals.path} context={context}>
           <App />
         </StaticRouter>

--- a/packages/docusaurus/lib/commands/start.js
+++ b/packages/docusaurus/lib/commands/start.js
@@ -42,8 +42,7 @@ module.exports = async function start(siteDir, cliOptions = {}) {
 
   // Reload files processing.
   if (!cliOptions.noWatch) {
-    const reload = filepath => {
-      console.log(`${filepath} has changed`);
+    const reload = () => {
       load(siteDir).catch(err => {
         console.error(chalk.red(err.stack));
       });
@@ -80,7 +79,6 @@ module.exports = async function start(siteDir, cliOptions = {}) {
   const urls = prepareUrls(protocol, host, port);
   const openUrl = normalizeUrl([urls.localUrlForBrowser, baseUrl]);
 
-  // Create compiler from generated webpack config.
   const {siteConfig, plugins = []} = props;
   let config = merge(createClientConfig(props), {
     plugins: [
@@ -132,7 +130,8 @@ module.exports = async function start(siteDir, cliOptions = {}) {
       rewrites: [{from: /\.html$/, to: '/'}],
     },
     disableHostCheck: true,
-    overlay: false,
+    // Enable overlay on browser. E.g: display errors
+    overlay: true,
     host,
     // https://webpack.js.org/configuration/dev-server/#devserverbefore
     // eslint-disable-next-line

--- a/packages/docusaurus/lib/server/load/index.js
+++ b/packages/docusaurus/lib/server/load/index.js
@@ -64,8 +64,6 @@ module.exports = async function load(siteDir, cliOptions = {}) {
     routesHashPathFileName,
     routesMetadata,
     routesMetadataFileName,
-    routesComponentStr,
-    routesComponentFileName,
     routesAsyncModules,
     routesAsyncModulesFileName,
   } = await loadRoutes(pluginsRouteConfigs);
@@ -90,9 +88,6 @@ module.exports = async function load(siteDir, cliOptions = {}) {
         JSON.stringify(metadata, null, 2),
       );
 
-      const componentStr = routesComponentStr[routesPath];
-      await generate(targetDir, routesComponentFileName, componentStr);
-
       const asyncModules = routesAsyncModules[routesPath] || [];
       await generate(
         targetDir,
@@ -105,6 +100,8 @@ module.exports = async function load(siteDir, cliOptions = {}) {
   await generate(generatedFilesDir, 'routes.js', routesConfig);
 
   // -------------------------- TBD (Experimental) ----------------------
+  // TODO: we always assume that plugin loaded content always wanted to be imported globally
+  // TODO: contentStore API
   // Generate contents metadata.
   const metadataTemplateFile = path.resolve(
     __dirname,

--- a/packages/docusaurus/lib/server/load/plugins.js
+++ b/packages/docusaurus/lib/server/load/plugins.js
@@ -42,7 +42,7 @@ module.exports = async function loadPlugins({pluginConfigs = [], context}) {
       const content = await plugin.loadContent();
       const pluginContentPath = path.join(name, metadataFileName);
       const pluginContentDir = path.join(context.generatedFilesDir, name);
-      fs.ensureDirSync(pluginContentDir);
+      await fs.ensureDir(pluginContentDir);
       await generate(
         pluginContentDir,
         metadataFileName,

--- a/packages/docusaurus/lib/server/load/routes.js
+++ b/packages/docusaurus/lib/server/load/routes.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const path = require('path');
 const {genChunkName, docuHash} = require('@docusaurus/utils');
 const {stringify} = require('querystring');
 
@@ -21,12 +20,12 @@ async function loadRoutes(pluginsRouteConfigs) {
   const addRoutesPath = routePath => {
     routesPaths.push(routePath);
   };
-  // Mapping of routePath -> generatedPath. Example: '/blog' -> '@generated/blog-c06'
-  const routesHashPath = {};
-  const addRoutesHashPath = routePath => {
-    routesHashPath[routePath] = `@generated/${docuHash(routePath)}`;
+  // Mapping of routePath -> metadataPath. Example: '/blog' -> '@generated/metadata/blog-c06.json'
+  const routesMetadataPath = {};
+  const addRoutesMetadataPath = routePath => {
+    const fileName = `${docuHash(routePath)}.json`;
+    routesMetadataPath[routePath] = `@generated/metadata/${fileName}`;
   };
-  const routesHashPathFileName = 'hashPath.json';
   // Mapping of routePath -> metadata. Example: '/blog' -> { isBlogPage: true, permalink: '/blog' }
   const routesMetadata = {};
   const addRoutesMetadata = (routePath, metadata) => {
@@ -34,7 +33,6 @@ async function loadRoutes(pluginsRouteConfigs) {
       routesMetadata[routePath] = metadata;
     }
   };
-  const routesMetadataFileName = 'metadata.json';
   // Mapping of routePath -> async imported modules. Example: '/blog' -> ['@theme/BlogPage']
   const routesAsyncModules = {};
   const addRoutesAsyncModule = (routePath, module) => {
@@ -43,7 +41,6 @@ async function loadRoutes(pluginsRouteConfigs) {
     }
     routesAsyncModules[routePath].push(module);
   };
-  const routesAsyncModulesFileName = 'asyncModules.json';
 
   // This is the higher level overview of route code generation
   function generateRouteCode(routeConfig) {
@@ -56,9 +53,8 @@ async function loadRoutes(pluginsRouteConfigs) {
     } = routeConfig;
 
     addRoutesPath(routePath);
-    addRoutesHashPath(routePath);
-    const hashPath = routesHashPath[routePath];
     addRoutesMetadata(routePath, metadata);
+    addRoutesMetadataPath(routePath);
 
     // Given an input (object or string), get the import path str
     const getModulePath = target => {
@@ -106,7 +102,7 @@ async function loadRoutes(pluginsRouteConfigs) {
 
     let metadataImportStr = '';
     if (metadata) {
-      const metadataPath = path.join(hashPath, routesMetadataFileName);
+      const metadataPath = routesMetadataPath[routePath];
       addRoutesAsyncModule(routePath, metadataPath);
       metadataImportStr = `metadata: ${genImportStr(
         metadataPath,
@@ -156,14 +152,11 @@ export default [
 ];\n`;
 
   return {
-    routesConfig,
-    routesPaths,
-    routesHashPath,
-    routesHashPathFileName,
-    routesMetadata,
-    routesMetadataFileName,
     routesAsyncModules,
-    routesAsyncModulesFileName,
+    routesConfig,
+    routesMetadata,
+    routesMetadataPath,
+    routesPaths,
   };
 }
 

--- a/packages/docusaurus/lib/server/load/routes.js
+++ b/packages/docusaurus/lib/server/load/routes.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {generateChunkName} = require('@docusaurus/utils');
+const {genChunkName} = require('@docusaurus/utils');
 const {stringify} = require('querystring');
 
 async function loadRoutes(pluginsRouteConfigs) {
@@ -33,7 +33,7 @@ async function loadRoutes(pluginsRouteConfigs) {
     const isObj = typeof target === 'object';
     const importStr = isObj ? target.path : target;
     const queryStr = target.query ? `?${stringify(target.query)}` : '';
-    const chunkName = generateChunkName(name || importStr, prefix);
+    const chunkName = genChunkName(name || importStr, prefix);
     const finalStr = JSON.stringify(importStr + queryStr);
     return `() => import(/* webpackChunkName: '${chunkName}' */ ${finalStr})`;
   }

--- a/packages/docusaurus/lib/server/load/routes.js
+++ b/packages/docusaurus/lib/server/load/routes.js
@@ -5,98 +5,191 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {genChunkName} = require('@docusaurus/utils');
+const path = require('path');
+const {genChunkName, genComponentName, docuHash} = require('@docusaurus/utils');
 const {stringify} = require('querystring');
 
 async function loadRoutes(pluginsRouteConfigs) {
-  const imports = [
+  const componentImports = [
     `import React from 'react';`,
     `import Loadable from 'react-loadable';`,
     `import Loading from '@theme/Loading';`,
+  ];
+  const routesImports = [
+    `import React from 'react';`,
     `import NotFound from '@theme/NotFound';`,
   ];
-
+  const addRoutesImport = importStr => {
+    routesImports.push(importStr);
+  };
+  // Routes paths. Example: ['/', '/docs', '/blog/2017/09/03/test']
   const routesPaths = [];
-  const addRoutesPath = permalink => {
-    if (permalink && !/:|\*/.test(permalink)) {
-      routesPaths.push(permalink);
+  const addRoutesPath = routePath => {
+    routesPaths.push(routePath);
+  };
+  // Mapping of routePath -> generatedPath. Example: '/blog' -> '@generated/blog-c06'
+  const routesHashPath = {};
+  const addRoutesHashPath = routePath => {
+    routesHashPath[routePath] = `@generated/${docuHash(routePath)}`;
+  };
+  const routesHashPathFileName = 'hashPath.json';
+  // Mapping of routePath -> metadata. Example: '/blog' -> { isBlogPage: true, permalink: '/blog' }
+  const routesMetadata = {};
+  const addRoutesMetadata = (routePath, metadata) => {
+    if (metadata) {
+      routesMetadata[routePath] = metadata;
     }
   };
+  const routesMetadataFileName = 'metadata.json';
+  // Mapping of routePath -> async imported modules. Example: '/blog' -> ['@theme/BlogPage']
+  const routesAsyncModules = {};
+  const addRoutesAsyncModule = (routePath, module) => {
+    if (!routesAsyncModules[routePath]) {
+      routesAsyncModules[routePath] = [];
+    }
+    routesAsyncModules[routePath].push(module);
+  };
+  const routesAsyncModulesFileName = 'asyncModules.json';
+  // Mapping of routePath -> generated component code. Example: '/blog' -> `export default () => .....`;
+  const routesComponentStr = {};
+  const addRoutesComponentStr = (routePath, componentStr) => {
+    routesComponentStr[routePath] = componentStr;
+  };
+  const routesComponentFileName = 'component.js';
 
-  const notFoundRoute = `
-{
-  path: '*',
-  component: NotFound,
-}`;
+  // This is the higher level overview of route code generation
+  function generateRouteCode(routeConfig) {
+    const {
+      path: routePath,
+      component,
+      metadata,
+      modules = [],
+      routes,
+    } = routeConfig;
 
-  function genImportStr(target, prefix, name) {
-    const isObj = typeof target === 'object';
-    const importStr = isObj ? target.path : target;
-    const queryStr = target.query ? `?${stringify(target.query)}` : '';
-    const chunkName = genChunkName(name || importStr, prefix);
-    const finalStr = JSON.stringify(importStr + queryStr);
-    return `() => import(/* webpackChunkName: '${chunkName}' */ ${finalStr})`;
-  }
+    addRoutesPath(routePath);
+    addRoutesHashPath(routePath);
+    const hashPath = routesHashPath[routePath];
+    addRoutesMetadata(routePath, metadata);
 
-  function generateRouteCode(pluginRouteConfig) {
-    const {path, component, metadata, modules, routes} = pluginRouteConfig;
+    const getModulePath = target => {
+      const isObj = typeof target === 'object';
+      const importStr = isObj ? target.path : target;
+      const queryStr = target.query ? `?${stringify(target.query)}` : '';
+      return `${importStr}${queryStr}`;
+    };
+
+    if (!component) {
+      throw new Error(`path: ${routePath} need a component`);
+    }
+    const componentPath = getModulePath(component);
+    addRoutesAsyncModule(routePath, componentPath);
+
+    const genImportStr = (modulePath, prefix, name) => {
+      const chunkName = genChunkName(name || modulePath, prefix);
+      const finalStr = JSON.stringify(modulePath);
+      return `() => import(/* webpackChunkName: '${chunkName}' */ ${finalStr})`;
+    };
+
+    const componentName = genComponentName(routePath);
+    const importStr = `import ${componentName} from '${hashPath}/${routesComponentFileName}'`;
+    addRoutesImport(importStr);
+
     if (routes) {
+      const componentStr = `
+${componentImports.join('\n')}
+export default Loadable({
+  loader: ${genImportStr(componentPath, 'component')},
+  loading: Loading,
+});
+`;
+      addRoutesComponentStr(routePath, componentStr);
+
       return `
 {
-  path: '${path}',
-  component: Loadable({
-    loader: ${genImportStr(component, 'component')},
-    loading: Loading,
-  }),
+  path: '${routePath}',
+  component: ${componentName},
   routes: [${routes.map(generateRouteCode).join(',')}],
 }`;
     }
 
-    addRoutesPath(path);
-    const genModulesImportStr = `${modules
-      .map((mod, i) => `Mod${i}: ${genImportStr(mod, i, path)},`)
-      .join('\n')}`;
-    const genModulesLoadedStr = `[${modules
-      .map((mod, i) => `loaded.Mod${i}.default,`)
-      .join('\n')}]`;
+    const modulesImportStr = modules
+      .map((module, i) => {
+        const modulePath = getModulePath(module);
+        addRoutesAsyncModule(routePath, modulePath);
+        return `Mod${i}: ${genImportStr(modulePath, i, routePath)},`;
+      })
+      .join('\n');
+    const modulesLoadedStr = modules
+      .map((module, i) => `loaded.Mod${i}.default,`)
+      .join('\n');
+
+    let metadataImportStr = '';
+    if (metadata) {
+      const metadataPath = path.join(hashPath, routesMetadataFileName);
+      addRoutesAsyncModule(routePath, metadataPath);
+      metadataImportStr = `metadata: ${genImportStr(
+        metadataPath,
+        'metadata',
+        routePath,
+      )},`;
+    }
+
+    const componentStr = `
+${componentImports.join('\n')}
+export default Loadable.Map({
+  loader: {
+    ${modulesImportStr}
+    ${metadataImportStr}
+    Component: ${genImportStr(componentPath, 'component')},
+  },
+  loading: Loading,
+  render(loaded, props) {
+    const Component = loaded.Component.default;
+    const metadata = loaded.metadata || {};
+    const modules = [${modulesLoadedStr}];
+    return (
+      <Component {...props} metadata={metadata} modules={modules}/>
+    );
+  }
+});\n`;
+    addRoutesComponentStr(routePath, componentStr);
 
     return `
-{
-  path: '${path}',
-  exact: true,
-  component: Loadable.Map({
-    loader: {
-      ${genModulesImportStr}
-      Component: ${genImportStr(component, 'component')},
-    },
-    loading: Loading,
-    render(loaded, props) {
-      const Component = loaded.Component.default;
-      const modules = ${genModulesLoadedStr};
-      return (
-        <Component {...props} metadata={${JSON.stringify(
-          metadata,
-        )}} modules={modules}/>
-      );
-    }
-  })
-}`;
+    {
+      path: '${routePath}',
+      exact: true,
+      component: ${componentName}
+    }`;
   }
 
   const routes = pluginsRouteConfigs.map(generateRouteCode);
+  const notFoundRoute = `
+  {
+    path: '*',
+    component: NotFound
+  }`;
 
   const routesConfig = `
-${imports.join('\n')}
+${routesImports.join('\n')}
 
-const routes = [
-// Plugins.${routes.join(',')},
+export default [
+  ${routes.join(',')},
+  ${notFoundRoute}
+];\n`;
 
-// Not Found.${notFoundRoute},
-];
-
-export default routes;\n`;
-
-  return {routesConfig, routesPaths};
+  return {
+    routesConfig,
+    routesPaths,
+    routesHashPath,
+    routesHashPathFileName,
+    routesMetadata,
+    routesMetadataFileName,
+    routesComponentStr,
+    routesComponentFileName,
+    routesAsyncModules,
+    routesAsyncModulesFileName,
+  };
 }
 
 module.exports = loadRoutes;

--- a/packages/docusaurus/lib/webpack/client.js
+++ b/packages/docusaurus/lib/webpack/client.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 const path = require('path');
 const WebpackNiceLog = require('webpack-nicelog');
 const ReactLoadableSSRAddon = require('react-loadable-ssr-addon');
@@ -16,6 +15,7 @@ module.exports = function createClientConfig(props) {
   const isProd = process.env.NODE_ENV === 'production';
   const config = createBaseConfig(props);
 
+  const {generatedFilesDir} = props;
   const clientConfig = merge(config, {
     entry: {
       main: path.resolve(__dirname, '../client/clientEntry.js'),
@@ -28,7 +28,7 @@ module.exports = function createClientConfig(props) {
     plugins: [
       // Generate manifests file
       new ReactLoadableSSRAddon({
-        filename: 'assets-manifest.json',
+        filename: path.resolve(generatedFilesDir, 'assets-manifest.json'),
       }),
       // Show compilation progress bar and build time.
       new WebpackNiceLog({

--- a/packages/docusaurus/test/load/routes.test.js
+++ b/packages/docusaurus/test/load/routes.test.js
@@ -14,6 +14,7 @@ describe('loadRoutes', () => {
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
+  "/docs",
   "/docs/endiliey/permalink",
   "/docs/foo/bar",
   "/docs/foo/baz",
@@ -29,6 +30,7 @@ Array [
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
+  "/docs",
   "/docs/1.0.0/foo/bar",
   "/docs/1.0.0/foo/baz",
   "/docs/1.0.0/hello",
@@ -50,6 +52,7 @@ Array [
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
+  "/docs",
   "/docs/en/1.0.0/foo/bar",
   "/docs/en/1.0.0/foo/baz",
   "/docs/en/1.0.0/hello",
@@ -84,6 +87,7 @@ Array [
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
+  "/docs",
   "/docs/en/endiliey/permalink",
   "/docs/en/foo/bar",
   "/docs/en/foo/baz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8081,13 +8081,6 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
-kebab-hash@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/kebab-hash/-/kebab-hash-0.1.2.tgz#dfb7949ba34d8e70114ea7d83e266e5e2a4abaac"
-  integrity sha512-BTZpq3xgISmQmAVzkISy4eUutsUA7s4IEFlCwOBJjvSFOwyR7I+fza+tBc/rzYWK/NrmFHjfU1IhO3lu29Ib/w==
-  dependencies:
-    lodash.kebabcase "^4.1.1"
-
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -8416,11 +8409,6 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
-lodash.kebabcase@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
-  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
 lodash.map@^4.4.0:
   version "4.6.0"


### PR DESCRIPTION
## Motivation

See http://www.evernote.com/l/AqrzyoEn5d5BZ6z4HbV0YVcaulCnOF0blOk/ for initial idea
Initially I wanted to code-split it such that we have component.js as well for each route

Example:
For /blog/2017/12/14/introducing-docusaurus, we will create 3 new files
- .docusaurus/blog-2017-12-14-introducing-docusaurus-8d2/component.js
- .docusaurus/blog-2017-12-14-introducing-docusaurus-8d2/metadata.json
- .docusaurus/blog-2017-12-14-introducing-docusaurus-8d2/modules.json

But after implementing it, I found that it makes us having to generate a lot of files and the bundle size actually become bigger due to module concatenation, files overhead, etc. Turns out that having one big single routes.js file is better than having small routes.js file + a lot of component.js file

<img width="960" alt="code split component string" src="https://user-images.githubusercontent.com/17883920/56051342-da3ae280-5d80-11e9-985c-abdef758fc40.png">

So instead of that,

What I did in this PR is to make metadata as standalone modules. Allow possibility of reusing data.
For each route, the data is saved in a unique json path.

The algorithm is kebab case the url and append a hash to it. Very unlikely to have collision

Example: **@generated/metadata/docs-commands-445.json**
```
{
  "id": "commands",
  "title": "CLI Commands",
  "language": null,
  "version": null,
  "source": "/mnt/c/Users/endij/Desktop/Linux/Docusaurus/docs/api-commands.md",
  "permalink": "/docs/commands",
  "localized_id": "commands",
  "sidebar": "docs",
  "category": "API",
  "next_id": "doc-markdown",
  "next": "doc-markdown",
  "previous_id": "versioning",
  "previous": "versioning",
  "previous_title": "Versioning",
  "next_title": "Markdown Features"
}
```

We also have a json mapping file called **routesMetadataPath.json**
Mapping of routePath -> metadataPath. Example: '/blog' -> '@generated/metadata/blog-c06.json'
Very useful to know which json metadata file is related to certain route
```json
{
  "/docs/versioning": "@generated/metadata/docs-versioning-8a8.json",
  "/docs/search": "@generated/metadata/docs-search-6da.json",
  "/blog": "@generated/metadata/blog-c06.json",
  "/": "@generated/metadata/-666.json",
  "/youtube": "@generated/metadata/youtube-429.json",
  "/feedback/": "@generated/metadata/feedback-7c7.json"
}
```



Extra:


**routesAsyncModules.json**
Mapping of routePath -> async imported modules. Example: '/blog' -> ['@theme/BlogPage']
Very useful to know what modules are async imported in a route

This will be used for my future use, like constructing prefetching based on viewport with intersection observer API 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Locally still works
![image](https://user-images.githubusercontent.com/17883920/56051030-099d1f80-5d80-11e9-9e4d-3f16da03b802.png)

- There is a lot of new JSON file in `.docusaurus/metadata`
![image](https://user-images.githubusercontent.com/17883920/56051071-20dc0d00-5d80-11e9-9fde-a8dcdc42d7e7.png)

Production client bundle seems to be OK. Metadata are code splitted
This one also has lower main bundle size than the initial idea and before the code split
<img width="956" alt="final bundle size after metadata codesplit" src="https://user-images.githubusercontent.com/17883920/56051761-4bc76080-5d82-11e9-9b35-c0e32da019aa.PNG">

<img width="954" alt="final bundle size 2" src="https://user-images.githubusercontent.com/17883920/56051116-3c471800-5d80-11e9-934b-074fcaadcdec.PNG">


According to netlify, 

Before:
![image](https://user-images.githubusercontent.com/17883920/56052748-d4470080-5d84-11e9-8264-e6db1eb5577e.png)


After:
![image](https://user-images.githubusercontent.com/17883920/56052730-c6917b00-5d84-11e9-8b1a-e6fc11c927a2.png)



