### PR TITLE
feat(v2): don't output server.bundle.js to disk

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -55,6 +55,7 @@
     "html-webpack-plugin": "^3.2.0",
     "is-wsl": "^1.1.0",
     "lodash": "^4.17.11",
+    "memory-fs": "^0.4.1",
     "mini-css-extract-plugin": "^0.4.1",
     "portfinder": "^1.0.13",
     "react-dev-utils": "^8.0.0",


### PR DESCRIPTION
## Motivation

https://webpack.js.org/api/node/#custom-file-systems

Don't output server.bundle.js to disk. Use memory temporarily instead when running.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="633" alt="memory-fs" src="https://user-images.githubusercontent.com/17883920/56075481-004e9a00-5df6-11e9-8d3c-38dacd077c7a.PNG">

No more server.bundle.js in my build folder