### PR TITLE
feat(v2): webpack multicompile client & server

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/index.js
+++ b/packages/docusaurus-plugin-sitemap/src/index.js
@@ -55,7 +55,11 @@ class DocusaurusPluginSitemap {
 
     // Write sitemap file
     const sitemapPath = path.join(outDir, 'sitemap.xml');
-    return fs.writeFile(sitemapPath, generatedSitemap);
+    fs.writeFile(sitemapPath, generatedSitemap, err => {
+      if (err) {
+        throw new Error(`Sitemap error: ${err}`);
+      }
+    });
   }
 }
 

--- a/packages/docusaurus/lib/client/serverEntry.js
+++ b/packages/docusaurus/lib/client/serverEntry.js
@@ -13,7 +13,8 @@ import {Helmet} from 'react-helmet';
 import {getBundles} from 'react-loadable-ssr-addon';
 import Loadable from 'react-loadable';
 
-import manifest from '@generated/assets-manifest.json'; //eslint-disable-line
+import path from 'path';
+import fs from 'fs';
 import routes from '@generated/routes'; // eslint-disable-line
 import preload from './preload';
 import App from './App';
@@ -41,6 +42,10 @@ export default function render(locals) {
       helmet.link.toString(),
     ];
     const metaAttributes = metaStrings.filter(Boolean);
+
+    const {outDir} = locals;
+    const manifestPath = path.join(outDir, 'client-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
     // Get all required assets for this particular page based on client manifest information
     const modulesToBeLoaded = [...manifest.entrypoints, ...Array.from(modules)];

--- a/packages/docusaurus/lib/commands/build.js
+++ b/packages/docusaurus/lib/commands/build.js
@@ -81,10 +81,7 @@ module.exports = async function build(siteDir, cliOptions = {}) {
   // Build the client bundles first.
   // We cannot run them in parallel because the server needs to know
   // the correct client bundle name.
-  await compile(clientConfig);
-
-  // Build the server bundles (render the static HTML and pick client bundle),
-  await compile(serverConfig);
+  await compile([clientConfig, serverConfig]);
 
   // Copy static files.
   const staticDir = path.resolve(siteDir, 'static');

--- a/packages/docusaurus/lib/webpack/client.js
+++ b/packages/docusaurus/lib/webpack/client.js
@@ -15,7 +15,6 @@ module.exports = function createClientConfig(props) {
   const isProd = process.env.NODE_ENV === 'production';
   const config = createBaseConfig(props);
 
-  const {generatedFilesDir} = props;
   const clientConfig = merge(config, {
     entry: {
       main: path.resolve(__dirname, '../client/clientEntry.js'),
@@ -26,9 +25,9 @@ module.exports = function createClientConfig(props) {
       runtimeChunk: true,
     },
     plugins: [
-      // Generate manifests file
+      // Generate client manifests file
       new ReactLoadableSSRAddon({
-        filename: path.resolve(generatedFilesDir, 'assets-manifest.json'),
+        filename: 'client-manifest.json',
       }),
       // Show compilation progress bar and build time.
       new WebpackNiceLog({

--- a/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
+++ b/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
@@ -4,31 +4,34 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const WebpackBeforeBuildPlugin = require('before-build-webpack');
 const fs = require('fs');
 
-class WaitPlugin extends WebpackBeforeBuildPlugin {
-  constructor(file, interval = 300, timeout = 30000) {
-    super(
-      (stats, callback) => {
-        const start = Date.now();
-        fs.writeFileSync('start.js', new Date().toString());
+class WaitPlugin {
+  constructor(options) {
+    this.timeout = options.timeout || 60000;
+    this.interval = options.interval || 250;
+    this.filepath = options.filepath;
+  }
 
-        function poll() {
-          if (fs.existsSync(file)) {
-            fs.writeFileSync('stop.js', new Date().toString());
-            callback();
-          } else if (Date.now() - start > timeout) {
-            throw Error("Maybe it just wasn't meant to be.");
-          } else {
-            setTimeout(poll, interval);
-          }
+  apply(compiler) {
+    // Before finishing the compilation step
+    compiler.hooks.make.tapAsync('WaitPlugin', (compilation, callback) => {
+      const start = Date.now();
+      const {filepath, timeout, interval} = this;
+
+      // Poll until file exist
+      function poll() {
+        if (fs.existsSync(filepath)) {
+          callback();
+        } else if (Date.now() - start > timeout) {
+          throw Error("Maybe it just wasn't meant to be.");
+        } else {
+          setTimeout(poll, interval);
         }
+      }
 
-        poll();
-      },
-      ['make'],
-    );
+      poll();
+    });
   }
 }
 

--- a/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
+++ b/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const WebpackBeforeBuildPlugin = require('before-build-webpack');
+const fs = require('fs');
+
+class WaitPlugin extends WebpackBeforeBuildPlugin {
+  constructor(file, interval = 300, timeout = 30000) {
+    super(
+      (stats, callback) => {
+        const start = Date.now();
+        fs.writeFileSync('start.js', new Date().toString());
+
+        function poll() {
+          if (fs.existsSync(file)) {
+            fs.writeFileSync('stop.js', new Date().toString());
+            callback();
+          } else if (Date.now() - start > timeout) {
+            throw Error("Maybe it just wasn't meant to be.");
+          } else {
+            setTimeout(poll, interval);
+          }
+        }
+
+        poll();
+      },
+      ['make'],
+    );
+  }
+}
+
+module.exports = WaitPlugin;

--- a/packages/docusaurus/lib/webpack/server.js
+++ b/packages/docusaurus/lib/webpack/server.js
@@ -11,9 +11,10 @@ const StaticSiteGeneratorPlugin = require('static-site-generator-webpack-plugin'
 const WebpackNiceLog = require('webpack-nicelog');
 const merge = require('webpack-merge');
 const createBaseConfig = require('./base');
+const WaitPlugin = require('./plugins/WaitPlugin');
 
 module.exports = function createServerConfig(props) {
-  const {baseUrl, routesPaths} = props;
+  const {baseUrl, routesPaths, outDir} = props;
   const config = createBaseConfig(props, true);
   const isProd = process.env.NODE_ENV === 'production';
 
@@ -31,11 +32,15 @@ module.exports = function createServerConfig(props) {
     // No need to bundle its node_modules dependencies since we're bundling for static html generation (backend)
     externals: [nodeExternals()],
     plugins: [
+      // Wait until client-manifest is generated
+      new WaitPlugin(path.join(outDir, 'client-manifest.json')),
+
       // Static site generator webpack plugin.
       new StaticSiteGeneratorPlugin({
         entry: 'main',
         locals: {
           baseUrl,
+          outDir,
         },
         paths: routesPaths,
       }),

--- a/packages/docusaurus/lib/webpack/server.js
+++ b/packages/docusaurus/lib/webpack/server.js
@@ -33,7 +33,9 @@ module.exports = function createServerConfig(props) {
     externals: [nodeExternals()],
     plugins: [
       // Wait until client-manifest is generated
-      new WaitPlugin(path.join(outDir, 'client-manifest.json')),
+      new WaitPlugin({
+        filepath: path.join(outDir, 'client-manifest.json'),
+      }),
 
       // Static site generator webpack plugin.
       new StaticSiteGeneratorPlugin({

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -39,6 +39,7 @@
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
+    "before-build-webpack": "^0.2.8",
     "cache-loader": "^2.0.1",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -39,7 +39,6 @@
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
-    "before-build-webpack": "^0.2.8",
     "cache-loader": "^2.0.1",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,11 +2625,6 @@ before-after-hook@^1.4.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
   integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
-before-build-webpack@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/before-build-webpack/-/before-build-webpack-0.2.8.tgz#6db62350c909e0de6aec962ed89bbedc89645847"
-  integrity sha512-RgKHL4VGFqJSJuT6jZZXHQOGMq5ri5iECHVI9RlPutdyTTmNssOEKZ7WJ1yVSbZTN/4kjpzU5RHMgOtAvs7HQg==
-
 bfj@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.1.tgz#05a3b7784fbd72cfa3c22e56002ef99336516c48"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,6 +2625,11 @@ before-after-hook@^1.4.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
   integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
+before-build-webpack@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/before-build-webpack/-/before-build-webpack-0.2.8.tgz#6db62350c909e0de6aec962ed89bbedc89645847"
+  integrity sha512-RgKHL4VGFqJSJuT6jZZXHQOGMq5ri5iECHVI9RlPutdyTTmNssOEKZ7WJ1yVSbZTN/4kjpzU5RHMgOtAvs7HQg==
+
 bfj@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.1.tgz#05a3b7784fbd72cfa3c22e56002ef99336516c48"


### PR DESCRIPTION
## Motivation

Try to run in one instance

Edit: The idea here is to wait at **`make`** webpack compilation hook (https://webpack.js.org/api/compiler-hooks/#make) which is done before finishing the compilation.
This is roughly before static-site-generator-webpack-plugin begins to execute its function. 

Note that we cannot do `import manifest from XXXXX` because at that time, the manifest still doesn't exist until client bundle finish serving.

We can however, do fs.existSync first at webpack level using our newly created `WaitPlugin` and then fs.readFileSync(manifest) later on.

Either way, it feels nicer to see the client and server bundle being run together

Others:
- Fix sitemap plugin to remove annoying callback deprecation warning

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

**Before**
![image](https://user-images.githubusercontent.com/17883920/56081328-a6be8d80-5e3e-11e9-98d5-31079ef334b5.png)

![image](https://user-images.githubusercontent.com/17883920/56081335-b50ca980-5e3e-11e9-8182-95bfb9350abd.png)


**After**
<img width="656" alt="multicompiler" src="https://user-images.githubusercontent.com/17883920/56079426-db264f80-5e26-11e9-9bd5-ac65e14a0c8d.PNG">

![image](https://user-images.githubusercontent.com/17883920/56081311-8393de00-5e3e-11e9-8067-696739f8afec.png)

The performance gain is not so much actually (around 2-3s gain in my pc, my total build time is 12s). Because the server actually compiles really fast even if compiled sequentially (~5s only). But for long term it is definitely better to run it together

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
