### PR TITLE
fix(v2): fix hot reload sometimes not working due to altered modules

### DIFF
--- a/packages/docusaurus/lib/client/exports/ComponentCreator.js
+++ b/packages/docusaurus/lib/client/exports/ComponentCreator.js
@@ -13,7 +13,6 @@ import registry from '@generated/registry';
 
 function ComponentCreator(path) {
   const modules = routesAsyncModules[path];
-  const originalModules = modules;
   const optsModules = [];
   const optsWebpack = [];
   const mappedModules = {};
@@ -63,8 +62,8 @@ function ComponentCreator(path) {
     modules: optsModules,
     webpack: () => optsWebpack,
     render: (loaded, props) => {
-      // Transform back loaded modules back into the original structure.
-      const loadedModules = originalModules;
+      // clone the original object since we don't want to alter the original.
+      const loadedModules = JSON.parse(JSON.stringify(modules));
       Object.keys(loaded).forEach(key => {
         let val = loadedModules;
         const keyPath = key.split('.');


### PR DESCRIPTION
## Motivation

Sometimes hot reload not working because we alter the modules object. 

Try to deep clone the object with json clone trick. Lodash cloneDeep would do the job but lodash cloneDeep can make our bundle size bigger :| and according to https://github.com/lodash/lodash/issues/1984#issue-133070711 it is also slower than simple JSON clone trick.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```bash
yarn start --hot-only
```

Hot reload working
![image](https://user-images.githubusercontent.com/17883920/56356686-2b792500-620c-11e9-99ef-3a6492cc6efb.png)


## Related PRs

#1366 #1367 
