### PR TITLE
feat(v2): prefetch links on viewport with intersection observer

### DIFF
--- a/packages/docusaurus/lib/client/docusaurus.js
+++ b/packages/docusaurus/lib/client/docusaurus.js
@@ -53,7 +53,6 @@ const docusaurus = {
     if (!canPrefetchOrLoad(routePath)) {
       return false;
     }
-    fetched[routePath] = true;
 
     // Find all webpack chunk names needed
     const matches = matchRoutes(routes, routePath);
@@ -70,7 +69,9 @@ const docusaurus = {
       return arr.concat(chunkAssets);
     }, []);
     const dedupedChunkAssets = Array.from(new Set(chunkAssetsNeeded));
-    dedupedChunkAssets.map(prefetchHelper);
+    Promise.all(dedupedChunkAssets.map(prefetchHelper)).then(() => {
+      fetched[routePath] = true;
+    });
     return true;
   },
   preload: routePath => {

--- a/packages/docusaurus/lib/client/exports/Link.js
+++ b/packages/docusaurus/lib/client/exports/Link.js
@@ -20,7 +20,6 @@ const handleIntersection = (el, cb) => {
         // MSEdge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
         // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
         if (entry.isIntersecting || entry.intersectionRatio > 0) {
-          console.log(entry);
           io.unobserve(el);
           io.disconnect();
           cb();

--- a/packages/docusaurus/lib/client/exports/Link.js
+++ b/packages/docusaurus/lib/client/exports/Link.js
@@ -24,8 +24,7 @@ function Link(props) {
     io = new window.IntersectionObserver(entries => {
       entries.forEach(entry => {
         if (el === entry.target) {
-          // Check if element is within viewport, remove listener, destroy observer, and run link callback.
-          // MSEdge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
+          // If element is in viewport, stop listening/observing & run callback.
           // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
           if (entry.isIntersecting || entry.intersectionRatio > 0) {
             io.unobserve(el);

--- a/packages/docusaurus/lib/client/exports/Link.js
+++ b/packages/docusaurus/lib/client/exports/Link.js
@@ -17,8 +17,10 @@ const handleIntersection = (el, cb) => {
     entries.forEach(entry => {
       if (el === entry.target) {
         // Check if element is within viewport, remove listener, destroy observer, and run link callback.
-        // MSEdge doesn't currently support isIntersecting, so also test for  an intersectionRatio > 0
+        // MSEdge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
+        // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
         if (entry.isIntersecting || entry.intersectionRatio > 0) {
+          console.log(entry);
           io.unobserve(el);
           io.disconnect();
           cb();

--- a/packages/docusaurus/lib/client/exports/Link.js
+++ b/packages/docusaurus/lib/client/exports/Link.js
@@ -11,26 +11,6 @@ import {NavLink} from 'react-router-dom';
 
 const internalRegex = /^\/(?!\/)/;
 
-// Set up IntersectionObserver
-const handleIntersection = (el, cb) => {
-  const io = new window.IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (el === entry.target) {
-        // Check if element is within viewport, remove listener, destroy observer, and run link callback.
-        // MSEdge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
-        // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
-        if (entry.isIntersecting || entry.intersectionRatio > 0) {
-          io.unobserve(el);
-          io.disconnect();
-          cb();
-        }
-      }
-    });
-  });
-  // Add element to the observer
-  io.observe(el);
-};
-
 function Link(props) {
   const {to, href, preloadProximity = 20} = props;
   const targetLink = to || href;
@@ -39,13 +19,31 @@ function Link(props) {
   const IOSupported =
     typeof window !== 'undefined' && 'IntersectionObserver' in window;
 
+  let io;
+  const handleIntersection = (el, cb) => {
+    io = new window.IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (el === entry.target) {
+          // Check if element is within viewport, remove listener, destroy observer, and run link callback.
+          // MSEdge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
+          // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+          if (entry.isIntersecting || entry.intersectionRatio > 0) {
+            io.unobserve(el);
+            io.disconnect();
+            cb();
+          }
+        }
+      });
+    });
+    // Add element to the observer
+    io.observe(el);
+  };
+
   const handleRef = ref => {
-    if (IOSupported && ref) {
+    if (IOSupported && ref && isInternal) {
       // If IO supported and element reference found, setup Observer functionality
       handleIntersection(ref, () => {
-        if (isInternal) {
-          window.__docusaurus.prefetch(targetLink);
-        }
+        window.__docusaurus.prefetch(targetLink);
       });
     }
   };
@@ -55,7 +53,13 @@ function Link(props) {
     if (!IOSupported && isInternal) {
       window.__docusaurus.prefetch(targetLink);
     }
-  }, []);
+    // when unmount, stops intersection observer from watching
+    return () => {
+      if (IOSupported && io) {
+        io.disconnect();
+      }
+    };
+  }, [targetLink, IOSupported, isInternal]);
 
   return !targetLink || !isInternal ? (
     // eslint-disable-next-line jsx-a11y/anchor-has-content

--- a/packages/docusaurus/lib/client/exports/Link.js
+++ b/packages/docusaurus/lib/client/exports/Link.js
@@ -5,16 +5,57 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import Perimeter from 'react-perimeter';
 import {NavLink} from 'react-router-dom';
 
 const internalRegex = /^\/(?!\/)/;
 
+// Set up IntersectionObserver
+const handleIntersection = (el, cb) => {
+  const io = new window.IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (el === entry.target) {
+        // Check if element is within viewport, remove listener, destroy observer, and run link callback.
+        // MSEdge doesn't currently support isIntersecting, so also test for  an intersectionRatio > 0
+        if (entry.isIntersecting || entry.intersectionRatio > 0) {
+          io.unobserve(el);
+          io.disconnect();
+          cb();
+        }
+      }
+    });
+  });
+  // Add element to the observer
+  io.observe(el);
+};
+
 function Link(props) {
   const {to, href, preloadProximity = 20} = props;
   const targetLink = to || href;
   const isInternal = internalRegex.test(targetLink);
+
+  const IOSupported =
+    typeof window !== 'undefined' && 'IntersectionObserver' in window;
+
+  const handleRef = ref => {
+    if (IOSupported && ref) {
+      // If IO supported and element reference found, setup Observer functionality
+      handleIntersection(ref, () => {
+        if (isInternal) {
+          window.__docusaurus.prefetch(targetLink);
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    // If IO is not supported. We prefetch by default
+    if (!IOSupported && isInternal) {
+      window.__docusaurus.prefetch(targetLink);
+    }
+  }, []);
+
   return !targetLink || !isInternal ? (
     // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a {...props} href={targetLink} />
@@ -23,7 +64,7 @@ function Link(props) {
       padding={preloadProximity}
       onBreach={() => window.__docusaurus.preload(targetLink)}
       once>
-      <NavLink {...props} to={targetLink} />
+      <NavLink {...props} innerRef={handleRef} to={targetLink} />
     </Perimeter>
   );
 }

--- a/packages/docusaurus/lib/client/exports/Link.js
+++ b/packages/docusaurus/lib/client/exports/Link.js
@@ -51,7 +51,7 @@ function Link(props) {
   };
 
   useEffect(() => {
-    // If IO is not supported. We prefetch by default
+    // If IO is not supported. We prefetch by default (only once)
     if (!IOSupported && isInternal) {
       window.__docusaurus.prefetch(targetLink);
     }


### PR DESCRIPTION
## Motivation

- If intersection observer is supported:
Once the current page has loaded, looks for all links on **the viewport**, and for each starts prefetching the page that the link points to.

- If IO is not supported.
Once the current page has loaded, looks for all links on **the page**, and for each starts prefetching the page that the link points to.

Make our site blazingly fast like gatsby

https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![prefetch viewport](https://user-images.githubusercontent.com/17883920/56459796-7db47480-63cb-11e9-80eb-01c4208289f4.gif)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
