### PR TITLE
chore(v2): temporary hack to persist infima CSS

### DIFF
--- a/packages/docusaurus/lib/client/App.js
+++ b/packages/docusaurus/lib/client/App.js
@@ -9,6 +9,7 @@ import React, {useState} from 'react';
 import {renderRoutes} from 'react-router-config';
 import ReactListenerProvider from 'react-listener-provider';
 
+import Head from '@docusaurus/Head'; // eslint-disable-line
 import routes from '@generated/routes'; // eslint-disable-line
 import metadata from '@generated/metadata'; // eslint-disable-line
 import siteConfig from '@generated/docusaurus.config'; //eslint-disable-line
@@ -19,6 +20,22 @@ function App() {
   return (
     <DocusaurusContext.Provider
       value={{siteConfig, ...metadata, ...context, setContext}}>
+      {/* TODO: this link stylesheet to infima is temporary */}
+      <Head>
+        <link
+          crossOrigin="anonymous"
+          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+          preload
+          rel="stylesheet"
+        />
+        <link
+          href="https://infima-dev.netlify.com/css/default/default.min.css"
+          preload
+          rel="stylesheet"
+          type="text/css"
+        />
+      </Head>
       <ReactListenerProvider>{renderRoutes(routes)}</ReactListenerProvider>
     </DocusaurusContext.Provider>
   );

--- a/packages/docusaurus/lib/default-theme/Layout/index.js
+++ b/packages/docusaurus/lib/default-theme/Layout/index.js
@@ -6,8 +6,6 @@
  */
 
 import React from 'react';
-
-import Head from '@docusaurus/Head'; // eslint-disable-line
 import Navbar from '@theme/Navbar'; // eslint-disable-line
 
 import './styles.css';
@@ -15,21 +13,6 @@ import './styles.css';
 function Layout({children}) {
   return (
     <div>
-      <Head>
-        <link
-          crossOrigin="anonymous"
-          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
-          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
-          preload
-          rel="stylesheet"
-        />
-        <link
-          href="https://infima-dev.netlify.com/css/default/default.min.css"
-          preload
-          rel="stylesheet"
-          type="text/css"
-        />
-      </Head>
       <Navbar />
       {children}
     </div>


### PR DESCRIPTION
## Motivation

Temporary solution to persist infima css. Put the link on root App

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No more FOUC in local and css not keep getting fetched

Before
<img width="939" alt="all css and default min css keep getting downloaded" src="https://user-images.githubusercontent.com/17883920/56460489-210a8700-63d6-11e9-9f44-24531750019b.PNG">

After
![image](https://user-images.githubusercontent.com/17883920/56460494-2b2c8580-63d6-11e9-93fe-1ad20c818f49.png)

