### PR TITLE
fix(v2): prefetch only existing chunks

### DIFF
--- a/packages/docusaurus/lib/client/docusaurus.js
+++ b/packages/docusaurus/lib/client/docusaurus.js
@@ -35,9 +35,12 @@ const docusaurus = {
     // Find all webpack chunk names needed
     const matches = matchRoutes(routes, routePath);
     const chunkNamesNeeded = matches.reduce((arr, match) => {
-      const chunkNames = Object.values(
-        flat(routesChunkNames[match.route.path]),
-      );
+      const chunk = routesChunkNames[match.route.path];
+      if (!chunk) {
+        return arr;
+      }
+
+      const chunkNames = Object.values(flat(chunk));
       return arr.concat(chunkNames);
     }, []);
 


### PR DESCRIPTION
## Motivation

While developing I've noticed a lot of errors (counted in hundreds) coming from the `flat` function. It turned out that the prefetching was trying to load some non-existing pages (some docs page in my case). It's _rather_ not possible to encounter it in a finished and working page, but having fewer errors during development is always better.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Add a non-prefetchable link on your site (e.g. non-existing yet docs site). With this change, it should not throw an error while prefetching it.
