### PR TITLE
fix(v2): fix hash-link css

### DIFF
--- a/packages/docusaurus/lib/default-theme/DocBody/styles.css
+++ b/packages/docusaurus/lib/default-theme/DocBody/styles.css
@@ -25,10 +25,10 @@
 
 @media only screen and (min-width: 736px) {
   .hash-link {
-    display: none;
+    opacity: 0;
   }
-  
+
   *:hover > .hash-link {
-    display: inherit;
+    opacity: 1;
   }
 }

--- a/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
+++ b/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
@@ -4,40 +4,30 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 const fs = require('fs');
+const chokidar = require('chokidar');
 
 class WaitPlugin {
   constructor(options) {
-    this.timeout = options.timeout || 60000;
-    this.interval = options.interval || 250;
     this.filepath = options.filepath;
   }
 
   apply(compiler) {
     // Before finishing the compilation step
     compiler.hooks.make.tapAsync('WaitPlugin', (compilation, callback) => {
-      const start = Date.now();
-      const {filepath, timeout, interval} = this;
+      const {filepath} = this;
+      const watcher = chokidar.watch(filepath, {
+        awaitWriteFinish: true,
+        disableGlobbing: true,
+      });
 
-      const checkCondition = () => {
-        if (Array.isArray(filepath)) {
-          return filepath.every(file => fs.existsSync(file));
-        }
-        return fs.existsSync(filepath);
-      };
-
-      // Poll until file exist
-      function poll() {
-        if (checkCondition()) {
+      watcher.on('add', () => {
+        if (fs.existsSync(filepath)) {
+          watcher.close();
           callback();
-        } else if (Date.now() - start > timeout) {
-          throw Error("Maybe it just wasn't meant to be.");
-        } else {
-          setTimeout(poll, interval);
         }
-      }
-
-      poll();
+      });
     });
   }
 }

--- a/packages/docusaurus/lib/webpack/server.js
+++ b/packages/docusaurus/lib/webpack/server.js
@@ -32,12 +32,9 @@ module.exports = function createServerConfig(props) {
     // No need to bundle its node_modules dependencies since we're bundling for static html generation (backend)
     externals: [nodeExternals()],
     plugins: [
-      // Wait until client-manifest and chunk-map is generated
+      // Wait until manifest from client bundle is generated
       new WaitPlugin({
-        filepath: [
-          path.join(outDir, 'client-manifest.json'),
-          path.join(outDir, 'chunk-map.json'),
-        ],
+        filepath: path.join(outDir, 'client-manifest.json'),
       }),
 
       // Static site generator webpack plugin.

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "cache-loader": "^2.0.1",
     "chalk": "^2.4.1",
-    "chokidar": "^2.0.4",
+    "chokidar": "^2.1.5",
     "classnames": "^2.2.6",
     "clean-webpack-plugin": "^2.0.1",
     "commander": "^2.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,7 +3277,7 @@ cheerio@0.22.0, cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-chokidar@^2.0.0:
+chokidar@^2.0.0, chokidar@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.5.tgz#0ae8434d962281a5f56c72869e79cb6d9d86ad4d"
   integrity sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==
@@ -4595,10 +4595,10 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-docusaurus@^2.0.0-alpha.6:
-  version "2.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-2.0.0-alpha.6.tgz#3ea061ec8a6425cdb11ba6d839bb05a3d0aacbba"
-  integrity sha512-NjFsNyKDjPTu884sSIpGn3sHcfo85gsBtB9+Pm3HPuaj/gFu2EaNikIb9jvk4/EXyoZ4xnrU6Rtup4vdAxxfHQ==
+docusaurus@^2.0.0-alpha.10:
+  version "2.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-2.0.0-alpha.10.tgz#3759ccdf7403a58483b41fffb1cfe662e2b98fca"
+  integrity sha512-sucBSgmtCA+DOSYGdhXV3TmeBR6On2n/6BFQCJs3/if06W6DzLCLb2sC2Jo1PpXpopYvAjd9Sf91zwEvovLPIw==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"


### PR DESCRIPTION
## Motivation

Currently, the hash-link is so hard to click.

See this gif or try it out at https://docusaurus-2.netlify.com/docs/installation/#launching-the-server-behind-a-proxy

Before I can click the hash, it already disappears
![so hard to click](https://user-images.githubusercontent.com/17883920/56652588-4b9e5d80-66be-11e9-9841-0e319d039fd2.gif)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before
![have to do it really fast](https://user-images.githubusercontent.com/17883920/56652733-a20b9c00-66be-11e9-92c9-dcae8ffc3541.gif)


After

![easier](https://user-images.githubusercontent.com/17883920/56652641-6ec90d00-66be-11e9-94fd-06e7f11bf051.gif)

## Related PRs

#1385