### PR TITLE
fix(v2): use fswatch instead of timeout polling to wait for client manifest

### DIFF
--- a/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
+++ b/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const fs = require('fs');
 const chokidar = require('chokidar');
 
 class WaitPlugin {
@@ -19,12 +20,13 @@ class WaitPlugin {
       const watcher = chokidar.watch(filepath, {
         awaitWriteFinish: true,
         disableGlobbing: true,
-        persistent: false,
       });
 
       watcher.on('add', () => {
-        watcher.close();
-        callback();
+        if (fs.existsSync(filepath)) {
+          watcher.close();
+          callback();
+        }
       });
     });
   }

--- a/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
+++ b/packages/docusaurus/lib/webpack/plugins/WaitPlugin.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const fs = require('fs');
+
 const chokidar = require('chokidar');
 
 class WaitPlugin {
@@ -16,25 +16,15 @@ class WaitPlugin {
     // Before finishing the compilation step
     compiler.hooks.make.tapAsync('WaitPlugin', (compilation, callback) => {
       const {filepath} = this;
-
       const watcher = chokidar.watch(filepath, {
         awaitWriteFinish: true,
         disableGlobbing: true,
         persistent: false,
       });
 
-      const checkCondition = () => {
-        if (Array.isArray(filepath)) {
-          return filepath.every(file => fs.existsSync(file));
-        }
-        return fs.existsSync(filepath);
-      };
-
       watcher.on('add', () => {
-        if (checkCondition()) {
-          watcher.close();
-          callback();
-        }
+        watcher.close();
+        callback();
       });
     });
   }

--- a/packages/docusaurus/lib/webpack/server.js
+++ b/packages/docusaurus/lib/webpack/server.js
@@ -32,12 +32,9 @@ module.exports = function createServerConfig(props) {
     // No need to bundle its node_modules dependencies since we're bundling for static html generation (backend)
     externals: [nodeExternals()],
     plugins: [
-      // Wait until client-manifest and chunk-map is generated
+      // Wait until manifest from client bundle is generated
       new WaitPlugin({
-        filepath: [
-          path.join(outDir, 'client-manifest.json'),
-          path.join(outDir, 'chunk-map.json'),
-        ],
+        filepath: path.join(outDir, 'client-manifest.json'),
       }),
 
       // Static site generator webpack plugin.

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "cache-loader": "^2.0.1",
     "chalk": "^2.4.1",
-    "chokidar": "^2.0.4",
+    "chokidar": "^2.1.5",
     "classnames": "^2.2.6",
     "clean-webpack-plugin": "^2.0.1",
     "commander": "^2.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,7 +3277,7 @@ cheerio@0.22.0, cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-chokidar@^2.0.0:
+chokidar@^2.0.0, chokidar@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.5.tgz#0ae8434d962281a5f56c72869e79cb6d9d86ad4d"
   integrity sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==
@@ -4595,10 +4595,10 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-docusaurus@^2.0.0-alpha.6:
-  version "2.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-2.0.0-alpha.6.tgz#3ea061ec8a6425cdb11ba6d839bb05a3d0aacbba"
-  integrity sha512-NjFsNyKDjPTu884sSIpGn3sHcfo85gsBtB9+Pm3HPuaj/gFu2EaNikIb9jvk4/EXyoZ4xnrU6Rtup4vdAxxfHQ==
+docusaurus@^2.0.0-alpha.10:
+  version "2.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-2.0.0-alpha.10.tgz#3759ccdf7403a58483b41fffb1cfe662e2b98fca"
+  integrity sha512-sucBSgmtCA+DOSYGdhXV3TmeBR6On2n/6BFQCJs3/if06W6DzLCLb2sC2Jo1PpXpopYvAjd9Sf91zwEvovLPIw==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"


### PR DESCRIPTION
## Motivation

Optimize implementation of `WaitPlugin`. It is better to use fs event system to wait for a file rather than using hacky polling timeout implementation with a timeout. Also, no need to wait for `chunk-map.json` because it is 100% guaranteed that `client-manifest.json` will be generated after `chunk-map.json` in client. So if manifest exist, chunk map will exist.

**This is an attempt to fix error due to timeout like below** 

```bash
> docs@ build ROOT/uniforms-2/website
> docusaurus build

Creating an optimized production build...

Compiling

● Client █████████████████████████ chunk asset optimization (92%) TerserPlugin 
 

● Server █████████████████████████ building (70%) 107/107 modules 0 active
 

ROOT/uniforms-2/website/node_modules/@docusaurus/core/lib/webpack/plugins/WaitPlugin.js:34
          throw Error("Maybe it just wasn't meant to be.");
          ^

Error: Maybe it just wasn't meant to be.
    at Timeout.poll [as _onTimeout] (ROOT/uniforms-2/website/node_modules/@docusaurus/core/lib/webpack/plugins/WaitPlugin.js:34:17)
    at listOnTimeout (timers.js:327:15)
    at processTimers (timers.js:271:5)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! docs@ build: `docusaurus build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the docs@ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     HOME/.npm/_logs/2019-04-24T07_07_05_219Z-debug.log
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Production build still works
<img width="266" alt="success" src="https://user-images.githubusercontent.com/17883920/56667824-1820fa80-66e1-11e9-8033-06f2afa1f2f3.PNG">
