### PR TITLE
feat: add "unlisted" front matter option for blog posts

### DIFF
--- a/packages/docusaurus-1.x/lib/core/BlogPageLayout.js
+++ b/packages/docusaurus-1.x/lib/core/BlogPageLayout.js
@@ -10,6 +10,8 @@ const BlogPost = require('./BlogPost.js');
 const BlogSidebar = require('./BlogSidebar.js');
 const Container = require('./Container.js');
 const MetadataBlog = require('./MetadataBlog.js');
+
+const MetadataPublicBlog = MetadataBlog.filter(item => item.unlisted !== true);
 const Site = require('./Site.js');
 const utils = require('./utils.js');
 
@@ -40,27 +42,28 @@ class BlogPageLayout extends React.Component {
           />
           <Container className="mainContainer postContainer blogContainer">
             <div className="posts">
-              {MetadataBlog.slice(page * perPage, (page + 1) * perPage).map(
-                post => (
-                  <BlogPost
-                    post={post}
-                    content={post.content}
-                    truncate
-                    key={
-                      utils.getPath(post.path, this.props.config.cleanUrl) +
-                      post.title
-                    }
-                    config={this.props.config}
-                  />
-                ),
-              )}
+              {MetadataPublicBlog.slice(
+                page * perPage,
+                (page + 1) * perPage,
+              ).map(post => (
+                <BlogPost
+                  post={post}
+                  content={post.content}
+                  truncate
+                  key={
+                    utils.getPath(post.path, this.props.config.cleanUrl) +
+                    post.title
+                  }
+                  config={this.props.config}
+                />
+              ))}
               <div className="docs-prevnext">
                 {page > 0 && (
                   <a className="docs-prev" href={this.getPageURL(page - 1)}>
                     ← Prev
                   </a>
                 )}
-                {MetadataBlog.length > (page + 1) * perPage && (
+                {MetadataPublicBlog.length > (page + 1) * perPage && (
                   <a className="docs-next" href={this.getPageURL(page + 1)}>
                     Next →
                   </a>

--- a/packages/docusaurus-1.x/lib/core/BlogPageLayout.js
+++ b/packages/docusaurus-1.x/lib/core/BlogPageLayout.js
@@ -11,7 +11,7 @@ const BlogSidebar = require('./BlogSidebar.js');
 const Container = require('./Container.js');
 const MetadataBlog = require('./MetadataBlog.js');
 
-const MetadataPublicBlog = MetadataBlog.filter(item => item.unlisted !== true);
+const MetadataPublicBlog = MetadataBlog.filter(item => !item.draft);
 const Site = require('./Site.js');
 const utils = require('./utils.js');
 

--- a/packages/docusaurus-1.x/lib/core/BlogSidebar.js
+++ b/packages/docusaurus-1.x/lib/core/BlogSidebar.js
@@ -11,7 +11,7 @@ const SideNav = require('./nav/SideNav.js');
 
 const MetadataBlog = require('./MetadataBlog.js');
 
-const MetadataPublicBlog = MetadataBlog.filter(item => item.unlisted !== true);
+const MetadataPublicBlog = MetadataBlog.filter(item => !item.draft);
 
 class BlogSidebar extends React.Component {
   render() {

--- a/packages/docusaurus-1.x/lib/core/BlogSidebar.js
+++ b/packages/docusaurus-1.x/lib/core/BlogSidebar.js
@@ -11,6 +11,8 @@ const SideNav = require('./nav/SideNav.js');
 
 const MetadataBlog = require('./MetadataBlog.js');
 
+const MetadataPublicBlog = MetadataBlog.filter(item => item.unlisted !== true);
+
 class BlogSidebar extends React.Component {
   render() {
     let blogSidebarCount = 5;
@@ -18,7 +20,7 @@ class BlogSidebar extends React.Component {
     let blogSidebarTitle = blogSidebarTitleConfig.default || 'Recent Posts';
     if (this.props.config.blogSidebarCount) {
       if (this.props.config.blogSidebarCount === 'ALL') {
-        blogSidebarCount = MetadataBlog.length;
+        blogSidebarCount = MetadataPublicBlog.length;
         blogSidebarTitle = blogSidebarTitleConfig.all || 'All Blog Posts';
       } else {
         blogSidebarCount = this.props.config.blogSidebarCount;
@@ -29,7 +31,7 @@ class BlogSidebar extends React.Component {
       {
         type: 'CATEGORY',
         title: blogSidebarTitle,
-        children: MetadataBlog.slice(0, blogSidebarCount).map(item => ({
+        children: MetadataPublicBlog.slice(0, blogSidebarCount).map(item => ({
           type: 'LINK',
           item,
         })),

--- a/packages/docusaurus-1.x/lib/core/__tests__/__fixtures__/blog-post-with-draft.md
+++ b/packages/docusaurus-1.x/lib/core/__tests__/__fixtures__/blog-post-with-draft.md
@@ -1,0 +1,5 @@
+---
+title: Draft Example
+draft: true
+---
+This blog post should not appear in the sidebar or the blog feed because it is a draft.

--- a/packages/docusaurus-1.x/lib/core/__tests__/__fixtures__/blog-post-with-unlisted.md
+++ b/packages/docusaurus-1.x/lib/core/__tests__/__fixtures__/blog-post-with-unlisted.md
@@ -1,0 +1,5 @@
+---
+title: Truncation Example
+unlisted: true
+---
+This blog post should not appear in the sidebar or the blog feed.

--- a/packages/docusaurus-1.x/lib/core/__tests__/__fixtures__/blog-post-with-unlisted.md
+++ b/packages/docusaurus-1.x/lib/core/__tests__/__fixtures__/blog-post-with-unlisted.md
@@ -1,5 +1,0 @@
----
-title: Truncation Example
-unlisted: true
----
-This blog post should not appear in the sidebar or the blog feed.

--- a/packages/docusaurus-1.x/lib/server/feed.js
+++ b/packages/docusaurus-1.x/lib/server/feed.js
@@ -28,9 +28,7 @@ module.exports = function(type) {
 
   readMetadata.generateMetadataBlog();
   const MetadataBlog = require('../core/MetadataBlog.js');
-  const MetadataPublicBlog = MetadataBlog.filter(
-    item => item.unlisted !== true,
-  );
+  const MetadataPublicBlog = MetadataBlog.filter(item => !item.draft);
 
   const feed = new Feed({
     title: `${siteConfig.title} Blog`,

--- a/packages/docusaurus-1.x/lib/server/feed.js
+++ b/packages/docusaurus-1.x/lib/server/feed.js
@@ -28,6 +28,9 @@ module.exports = function(type) {
 
   readMetadata.generateMetadataBlog();
   const MetadataBlog = require('../core/MetadataBlog.js');
+  const MetadataPublicBlog = MetadataBlog.filter(
+    item => item.unlisted !== true,
+  );
 
   const feed = new Feed({
     title: `${siteConfig.title} Blog`,
@@ -38,10 +41,10 @@ module.exports = function(type) {
     link: blogRootURL,
     image: siteImageURL,
     copyright: siteConfig.copyright,
-    updated: new Date(MetadataBlog[0].date),
+    updated: new Date(MetadataPublicBlog[0].date),
   });
 
-  MetadataBlog.forEach(post => {
+  MetadataPublicBlog.forEach(post => {
     const url = `${blogRootURL}/${post.path}`;
     const description = utils.blogPostHasTruncateMarker(post.content)
       ? renderMarkdown(utils.extractBlogPostBeforeTruncate(post.content))


### PR DESCRIPTION
Previously, the blog sidebar listed the most recent blog posts sorted by
their publish date. This commit adds the ability to hide a specific blog
post from the sidebar and the feed of all blog posts by adding the
`unlisted: true` header option.

Fixes #1393.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation


The motivation for this feature is to make it possible to change dates of published posts without breaking the old URL (which might be widely shared).


Concrete example, we published a blog post two weeks ago that is dated for 2020 (https://scalameta.org/metals/blog/2020/04/12/mercury.html). We have closed three PRs fixing the date (https://github.com/scalameta/metals/pull/683, https://github.com/scalameta/metals/pull/670, https://github.com/scalameta/metals/pull/656) but they have all been closed because changing the date of the post would turn the old URL into a 404.

With the ability to unlist posts, I could unlist the 2020 post, create a new posts dated in 2019 and update the unlisted 2020 post to forward to the new 2019 post.

I'm open for alternative solutions to fix that particular problem. I think unlisting is a flexible solution that could be useful in other situations as well, for example when writing a draft post.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I would appreciate help for testing this change since I'm unfamiliar with jest (and JavaScript in general 😅 ). I created a blog post in `__test__/__fixtures__` using `unlisted: true` and ran `yarn test` and everything passed but I expected some snapshot tests to fail.

I tested the change manually on our website and it seems to work as expected:

![2019-04-26 11 04 57](https://user-images.githubusercontent.com/1408093/56797045-186de280-6814-11e9-880a-b185b78a8ac5.gif)

Observe that uncommenting `unlisted: true` makes the post disappear from both the sidebar and the list of all blog posts while the post is still published under the unchanged URL.

## Related PRs

I'm not aware of any.
