### PR TITLE
refactor(v2): use hash to compare generated content

### DIFF
--- a/packages/docusaurus-utils/src/index.js
+++ b/packages/docusaurus-utils/src/index.js
@@ -13,13 +13,18 @@ const _ = require(`lodash`);
 const escapeStringRegexp = require('escape-string-regexp');
 const fs = require('fs-extra');
 
-const genCache = new Map();
+const fileHash = new Map();
 async function generate(generatedFilesDir, file, content) {
-  const cached = genCache.get(file);
-  if (cached !== content) {
-    await fs.ensureDir(generatedFilesDir);
-    await fs.writeFile(path.join(generatedFilesDir, file), content);
-    genCache.set(file, content);
+  const filepath = path.join(generatedFilesDir, file);
+  const lastHash = fileHash.get(filepath);
+  const currentHash = createHash('md5')
+    .update(content)
+    .digest('hex');
+
+  if (lastHash !== currentHash) {
+    await fs.ensureDir(path.dirname(filepath));
+    await fs.writeFile(filepath, content);
+    fileHash.set(filepath, currentHash);
   }
 }
 


### PR DESCRIPTION
## Motivation

Minor refactoring. Instead of comparing old file string and new file string when deciding whether to `writeFile`, we can save the hash of old file and compare it to the hash of new file. While `md5` is not a 100% perfect hash, its still almost impossible to get a collision and this is more of to optimize our fs operation. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Locally still OK. No problem in development. 