### PR TITLE
Warn the user if unknown arguments are provided

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -94,6 +94,12 @@ program
     });
   });
 
+program.arguments('<command>').action(cmd => {
+  program.outputHelp();
+  console.log(`  ${chalk.red(`\n  Unknown command ${chalk.yellow(cmd)}.`)}`);
+  console.log();
+});
+
 program.parse(process.argv);
 
 if (!process.argv.slice(2).length) {


### PR DESCRIPTION
Closes #1398 

Shows up a suitable message if the user fires in unknown commands:-

> docusaurus run

```bash
Usage: docusaurus <command> [options]

Options:
  -V, --version              output the version number
  -h, --help                 output usage information

Commands:
  build [options] [siteDir]  Build website
  eject [siteDir]            copy the default theme into website folder for customization.
  init [projectDir]          Initialize website
  deploy [siteDir]           deploy website
  start [options] [siteDir]  Start development server
  
  Unknown command run.
```
