### PR TITLE
fix: blog docs example as object property

### DIFF
--- a/docs/guides-blog.md
+++ b/docs/guides-blog.md
@@ -77,7 +77,7 @@ The available options are an integer representing the number of posts you wish t
 Example:
 
 ```js
-blogSidebarCount: 'ALL';
+blogSidebarCount: 'ALL',
 ```
 
 ## Changing The Sidebar Title


### PR DESCRIPTION
## Motivation

The property is part of `website/siteConfig.js` and the example looks like a sentence.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Not need it.

## Related PRs

No PRs related
