### PR TITLE
fix(v2): don't render docs baseroute because its empty

### DIFF
--- a/packages/docusaurus/lib/server/load/routes.js
+++ b/packages/docusaurus/lib/server/load/routes.js
@@ -43,7 +43,9 @@ async function loadRoutes(pluginsRouteConfigs) {
       exact,
     } = routeConfig;
 
-    addRoutesPath(routePath);
+    if (!routes) {
+      addRoutesPath(routePath);
+    }
 
     // Given an input (object or string), get the import path str
     const getModulePath = target => {

--- a/packages/docusaurus/test/load/routes.test.js
+++ b/packages/docusaurus/test/load/routes.test.js
@@ -14,7 +14,6 @@ describe('loadRoutes', () => {
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
-  "/docs",
   "/docs/endiliey/permalink",
   "/docs/foo/bar",
   "/docs/foo/baz",
@@ -30,7 +29,6 @@ Array [
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
-  "/docs",
   "/docs/1.0.0/foo/bar",
   "/docs/1.0.0/foo/baz",
   "/docs/1.0.0/hello",
@@ -52,7 +50,6 @@ Array [
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
-  "/docs",
   "/docs/en/1.0.0/foo/bar",
   "/docs/en/1.0.0/foo/baz",
   "/docs/en/1.0.0/hello",
@@ -87,7 +84,6 @@ Array [
     expect(routesPaths.sort()).toMatchInlineSnapshot(`
 Array [
   "/",
-  "/docs",
   "/docs/en/endiliey/permalink",
   "/docs/en/foo/bar",
   "/docs/en/foo/baz",


### PR DESCRIPTION
## Motivation

No need to render https://docusaurus-2.netlify.com/docs/

Bug reported in https://docusaurus-2.netlify.com/feedback/p/intuitive-base-url

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Netlify doesnt render that
