### PR TITLE
feat(cli v2): Added new environment info command

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -106,7 +106,7 @@ program
           System: ['OS', 'CPU'],
           Binaries: ['Node', 'Yarn', 'npm'],
           Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-          npmPackages: ['/**/{@docusaurus/*/}'],
+          npmPackages: ['@docusaurus/*/'],
         },
         {
           showNotFound: true,

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -101,15 +101,13 @@ program
   .action(() => {
     console.log(chalk.bold('\nEnvironment Info:'));
     envinfo
-      .run(
-        {
-          System: ['OS', 'CPU'],
-          Binaries: ['Node', 'Yarn', 'npm'],
-          Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-          npmPackages: '?(@)docusaurus{*,/**,*/**}',
-          npmGlobalPackages: '?(@)docusaurus{*,/**,*/**}',
-        }
-      )
+      .run({
+        System: ['OS', 'CPU'],
+        Binaries: ['Node', 'Yarn', 'npm'],
+        Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
+        npmPackages: '?(@)docusaurus{*,/**,*/**}',
+        npmGlobalPackages: '?(@)docusaurus{*,/**,*/**}',
+      })
       .then(console.log);
   });
 

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -106,13 +106,9 @@ program
           System: ['OS', 'CPU'],
           Binaries: ['Node', 'Yarn', 'npm'],
           Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-          npmPackages: ['@docusaurus/**'],
-        },
-        {
-          showNotFound: true,
-          duplicates: true,
-          fullTree: true,
-        },
+          npmPackages: '?(@)docusaurus{*,/**,*/**}',
+          npmGlobalPackages: '?(@)docusaurus{*,/**,*/**}',
+        }
       )
       .then(console.log);
   });

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -105,8 +105,8 @@ program
         System: ['OS', 'CPU'],
         Binaries: ['Node', 'Yarn', 'npm'],
         Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-        npmPackages: '?(@)docusaurus{*,/**,*/**}',
-        npmGlobalPackages: '?(@)docusaurus{*,/**,*/**}',
+        npmPackages: '?(@)docusaurus{*,*/**}',
+        npmGlobalPackages: '?(@)docusaurus{*,*/**}',
       })
       .then(console.log);
   });

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -106,7 +106,7 @@ program
           System: ['OS', 'CPU'],
           Binaries: ['Node', 'Yarn', 'npm'],
           Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-          npmPackages: ['@docusaurus/*/'],
+          npmPackages: ['@docusaurus/**'],
         },
         {
           showNotFound: true,

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -8,6 +8,7 @@
  */
 
 const chalk = require('chalk');
+const envinfo = require('envinfo');
 const semver = require('semver');
 const path = require('path');
 const program = require('commander');
@@ -92,6 +93,28 @@ program
       hotOnly,
       cacheLoader,
     });
+  });
+
+program
+  .command('info')
+  .description('Shows debugging information about the local environment')
+  .action(() => {
+    console.log(chalk.bold('\nEnvironment Info:'));
+    envinfo
+      .run(
+        {
+          System: ['OS', 'CPU'],
+          Binaries: ['Node', 'Yarn', 'npm'],
+          Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
+          npmGlobalPackages: ['@docusaurus'],
+        },
+        {
+          showNotFound: true,
+          duplicates: true,
+          fullTree: true,
+        },
+      )
+      .then(console.log);
   });
 
 program.arguments('<command>').action(cmd => {

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -106,7 +106,7 @@ program
           System: ['OS', 'CPU'],
           Binaries: ['Node', 'Yarn', 'npm'],
           Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-          npmPackages: ['@docusaurus'],
+          npmPackages: ['/**/{@docusaurus/*/}'],
         },
         {
           showNotFound: true,

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -106,7 +106,7 @@ program
           System: ['OS', 'CPU'],
           Binaries: ['Node', 'Yarn', 'npm'],
           Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-          npmGlobalPackages: ['docusaurus'],
+          npmPackages: ['@docusaurus'],
         },
         {
           showNotFound: true,

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -106,7 +106,7 @@ program
           System: ['OS', 'CPU'],
           Binaries: ['Node', 'Yarn', 'npm'],
           Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-          npmGlobalPackages: ['@docusaurus'],
+          npmGlobalPackages: ['docusaurus'],
         },
         {
           showNotFound: true,

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -47,6 +47,7 @@
     "css-loader": "^1.0.0",
     "docsearch.js": "^2.5.2",
     "ejs": "^2.6.1",
+    "envinfo": "^7.2.0",
     "express": "^4.16.4",
     "front-matter": "^3.0.1",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
Added a dedicated command which will print debugging information about the local environment.

`docusaurus info` results in :-

```bash
Environment Info:

  System:
    OS: Linux 4.18 Ubuntu 18.10 (Cosmic Cuttlefish)
    CPU: (4) x64 Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz
  Binaries:
    Node: 8.11.4 - /usr/bin/node
    Yarn: 1.16.0-0 - /usr/local/bin/yarn
    npm: 6.9.0 - /usr/local/bin/npm
  Browsers:
    Chrome: 74.0.3729.108
    Firefox: 63.0
  npmGlobalPackages:
    @docusaurus: 1.8.3
```