### PR TITLE
feat(v2): create useDocusaurusContext

### DIFF
--- a/packages/docusaurus/lib/client/exports/useDocusaurusContext.js
+++ b/packages/docusaurus/lib/client/exports/useDocusaurusContext.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useContext} from 'react';
+import DocusaurusContext from '@docusaurus/context';
+
+function useDocusaurusContext() {
+  return useContext(DocusaurusContext);
+}
+
+export default useDocusaurusContext;

--- a/packages/docusaurus/lib/default-theme/BlogPage/index.js
+++ b/packages/docusaurus/lib/default-theme/BlogPage/index.js
@@ -5,15 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useContext} from 'react';
+import React from 'react';
+
 import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'; // eslint-disable-line
+
 import Footer from '@theme/Footer'; // eslint-disable-line
 import Layout from '@theme/Layout'; // eslint-disable-line
-import DocusaurusContext from '@docusaurus/context';
 import Post from '../Post';
 
 function BlogPage(props) {
-  const context = useContext(DocusaurusContext);
+  const context = useDocusaurusContext();
   const {language, siteConfig = {}} = context;
   const {baseUrl, favicon} = siteConfig;
   const {

--- a/packages/docusaurus/lib/default-theme/BlogPost/index.js
+++ b/packages/docusaurus/lib/default-theme/BlogPost/index.js
@@ -5,18 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useContext} from 'react';
+import React from 'react';
 
 import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'; // eslint-disable-line
+
 import Layout from '@theme/Layout'; // eslint-disable-line
 import Footer from '@theme/Footer'; // eslint-disable-line
-import DocusaurusContext from '@docusaurus/context';
+
 import Post from '../Post';
 
 function BlogPost(props) {
-  const {metadata: contextMetadata = {}, siteConfig = {}} = useContext(
-    DocusaurusContext,
-  );
+  const {
+    metadata: contextMetadata = {},
+    siteConfig = {},
+  } = useDocusaurusContext();
   const {baseUrl, favicon} = siteConfig;
   const {language, title} = contextMetadata;
   const {content, metadata} = props;

--- a/packages/docusaurus/lib/default-theme/Doc/index.js
+++ b/packages/docusaurus/lib/default-theme/Doc/index.js
@@ -5,19 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useContext} from 'react';
+import React from 'react';
 import {renderRoutes} from 'react-router-config';
+
 import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'; // eslint-disable-line
 
 import Layout from '@theme/Layout'; // eslint-disable-line
 import Footer from '@theme/Footer'; // eslint-disable-line
 import Navbar from '@theme/Navbar'; // eslint-disable-line
 import Sidebar from '@theme/Sidebar'; // eslint-disable-line
 
-import DocusaurusContext from '@docusaurus/context';
-
 function Doc(props) {
-  const {siteConfig = {}} = useContext(DocusaurusContext);
+  const {siteConfig = {}} = useDocusaurusContext();
   const {route, docsMetadata, location} = props;
   const {baseUrl, favicon} = siteConfig;
   return (

--- a/packages/docusaurus/lib/default-theme/Markdown/index.js
+++ b/packages/docusaurus/lib/default-theme/Markdown/index.js
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useContext} from 'react';
-import Head from '@docusaurus/Head';
+import React from 'react';
 
-import DocusaurusContext from '@docusaurus/context';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 function Markdown(props) {
-  const context = useContext(DocusaurusContext);
+  const context = useDocusaurusContext();
   const {siteConfig} = context;
   const highlight = Object.assign(
     {},

--- a/packages/docusaurus/lib/default-theme/Navbar/index.js
+++ b/packages/docusaurus/lib/default-theme/Navbar/index.js
@@ -5,14 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useContext} from 'react';
+import React from 'react';
 
 import Link from '@docusaurus/Link';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
 import Search from '@theme/Search';
-import DocusaurusContext from '@docusaurus/context';
 
 function Navbar(props) {
-  const context = useContext(DocusaurusContext);
+  const context = useDocusaurusContext();
   const {siteConfig = {}, env = {}, metadata = {}} = context;
   // TODO: navbar headerlinks should depends on theme, not siteConfig;
   const {

--- a/packages/docusaurus/lib/default-theme/Pages/index.js
+++ b/packages/docusaurus/lib/default-theme/Pages/index.js
@@ -5,15 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useContext} from 'react';
+import React from 'react';
+
 import Head from '@docusaurus/Head'; // eslint-disable-line
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'; // eslint-disable-line
+
 import Footer from '@theme/Footer'; // eslint-disable-line
 import Layout from '@theme/Layout'; // eslint-disable-line
 
-import DocusaurusContext from '@docusaurus/context';
-
 function Pages({content}) {
-  const context = useContext(DocusaurusContext);
+  const context = useDocusaurusContext();
   const {metadata = {}, siteConfig = {}} = context;
   const {baseUrl, favicon} = siteConfig;
   const {language} = metadata;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Create a wrapper context function that allows access to context easily. It's quite troublesome now to have to import `useContext` and `@docusaurus/context`. Bundle them together as `useDocusaurusContext`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Site still builds and can navigate each page.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
