### PR TITLE
fix(v2): fix SSR mismatch location for non default baseurl

### DIFF
--- a/packages/docusaurus/lib/client/serverEntry.js
+++ b/packages/docusaurus/lib/client/serverEntry.js
@@ -22,12 +22,14 @@ import ssrTemplate from './templates/ssr.html.template';
 
 // Renderer for static-site-generator-webpack-plugin (async rendering via promises)
 export default function render(locals) {
-  return preload(routes, locals.path).then(() => {
+  const {routesLocation} = locals;
+  const location = routesLocation[locals.path];
+  return preload(routes, location).then(() => {
     const modules = new Set();
     const context = {};
     const appHtml = ReactDOMServer.renderToString(
       <Loadable.Capture report={moduleName => modules.add(moduleName)}>
-        <StaticRouter location={locals.path} context={context}>
+        <StaticRouter location={location} context={context}>
           <App />
         </StaticRouter>
       </Loadable.Capture>,

--- a/packages/docusaurus/lib/webpack/server.js
+++ b/packages/docusaurus/lib/webpack/server.js
@@ -18,9 +18,14 @@ module.exports = function createServerConfig(props) {
   const config = createBaseConfig(props, true);
   const isProd = process.env.NODE_ENV === 'production';
 
-  const routesRelativePaths = routesPaths.map(str =>
-    baseUrl === '/' ? str : str.replace(new RegExp(`^${baseUrl}`), '/'),
-  );
+  const routesLocation = {};
+  // Array of paths to be rendered. Relative to output directory
+  const ssgPaths = routesPaths.map(str => {
+    const ssgPath =
+      baseUrl === '/' ? str : str.replace(new RegExp(`^${baseUrl}`), '/');
+    routesLocation[ssgPath] = str;
+    return ssgPath;
+  });
   const serverConfig = merge(config, {
     entry: {
       main: path.resolve(__dirname, '../client/serverEntry.js'),
@@ -46,8 +51,9 @@ module.exports = function createServerConfig(props) {
         locals: {
           baseUrl,
           outDir,
+          routesLocation,
         },
-        paths: routesRelativePaths,
+        paths: ssgPaths,
       }),
 
       // Show compilation progress bar.


### PR DESCRIPTION
## Motivation

Fix SSR mismatch location for non default baseurl.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Set `baseUrl` to `/test` on `docusaurus.config.js`

```bash
cd website
yarn build
```

Notice that the `index.html` generated is Page Not Found

After this PR, the `index.html` generated is now correct.

## Related PRs

#1414 
