### PR TITLE
doc: remove references to F8 in tutorial

### DIFF
--- a/docs/tutorial-create-pages.md
+++ b/docs/tutorial-create-pages.md
@@ -34,11 +34,11 @@ module.exports = HelloWorld;
 ```
 
 2. Go to http://localhost:3000/hello-world and you should be able to see the new page.
-1. Change the text within the `<p>...</p>` to "I'm at F8!". The browser should refresh automatically to reflect the changes.
+1. Change the text within the `<p>...</p>` to "I can write JSX here!". The browser should refresh automatically to reflect the changes.
 
 ```diff
 - <p>This is my first page!</p>
-+ <p>I'm at F8!</p>
++ <p>I can write JSX here!</p>
 ```
 
 React is being used as a templating engine for rendering static markup. You can leverage on the expressability of React to build rich web content. Learn more about creating pages [here](custom-pages).
@@ -47,30 +47,37 @@ React is being used as a templating engine for rendering static markup. You can 
 
 ## Create a Documentation Page
 
-1. Create a new file in the `docs` folder called `f8.md`.
+1. Create a new file in the `docs` folder called `doc4.md`.
 1. Paste the following contents:
 
 ```
 ---
-id: f8
-title: Hello F8
+id: doc4
+title: This is Doc 4
 ---
 
-Hello F8! I'm at the Docusaurus classroom session!
+I can write content using [GitHub-flavored Markdown syntax](https://github.github.com/gfm/).
 
-## Using Docusaurus to Create Open Source Websites
+## Markdown Syntax
 
-In this session, we learned how Docusaurus makes it really simple to create a website for open source project documentation and get hands on by creating a Docusaurus website.
+*Bold* _italic_ `code` [Links](#url)
+
+> Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
+> id sem consectetuer libero luctus adipiscing.
+
+* Hey
+* Ho
+* Let's Go
 ```
 
-3. Go to `sidebars.json` and add `"f8"` after `"doc1"`. This ID should be the same one as in the Markdown file above.
+3. Go to `sidebars.json` and add `"doc4"` after `"doc1"`. This ID should be the same one as in the Markdown file above.
 
 ```diff
 {
   "docs": {
     "Docusaurus": [
       "doc1",
-+     "f8"
++     "doc4"
     ],
     "First Category": ["doc2"],
     "Second Category": ["doc3"]

--- a/docs/tutorial-create-pages.md
+++ b/docs/tutorial-create-pages.md
@@ -89,7 +89,7 @@ I can write content using [GitHub-flavored Markdown syntax](https://github.githu
 ```
 
 4. Kill your webserver (<kbd>Cmd</kbd> + <kbd>C</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>) and restart it (with `npm run start`) because a server restart is needed for sidebar changes.
-5. Navigate to http://localhost:3000/docs/f8.
+5. Navigate to http://localhost:3000/docs/doc4.
 
 You've created your first documentation page on Docusaurus! The `sidebars.json` is where you specify the order of your documentation pages and in the front matter of the Markdown file is where you provide metadata about that page.
 

--- a/docs/tutorial-create-pages.md
+++ b/docs/tutorial-create-pages.md
@@ -60,7 +60,7 @@ I can write content using [GitHub-flavored Markdown syntax](https://github.githu
 
 ## Markdown Syntax
 
-*Bold* _italic_ `code` [Links](#url)
+**Bold** _italic_ `code` [Links](#url)
 
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
 > id sem consectetuer libero luctus adipiscing.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Mentioning F8 in the tutorial feels weird without context. Removing it to make it more general.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Netlify.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
