### PR TITLE
fix: pass the missing host option to start

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -86,9 +86,10 @@ program
     'Do not fallback to page refresh if hot reload fails (default: false)',
   )
   .option('--no-cache-loader', 'Do not use cache-loader')
-  .action((siteDir = '.', {port, noWatch, hotOnly, cacheLoader}) => {
+  .action((siteDir = '.', {port, host, noWatch, hotOnly, cacheLoader}) => {
     wrapCommand(start)(path.resolve(siteDir), {
       port,
+      host,
       noWatch,
       hotOnly,
       cacheLoader,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This small change makes sure that a host parameter can be passed to the webpack dev server.

All the underlying code exists, only the host option is not passed correctly, which is fixed in this PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manually tested that the host parameter is passed to the start command when `-h <address>` is used.

## Related PRs
No