### PR TITLE
refactor(v2): move headerLinks -> themeConfig & rm dead code

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -15,12 +15,10 @@ import SearchBar from '@theme/SearchBar';
 function Navbar() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
-  // TODO: navbar headerlinks should depends on theme, not siteConfig;
   const {
     baseUrl,
-    headerLinks,
     headerIcon,
-    themeConfig: {algolia},
+    themeConfig: {algolia, headerLinks = []},
     title,
     disableHeaderTitle,
   } = siteConfig;

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -20,8 +20,7 @@ class Search extends React.Component {
   }
 
   componentDidMount() {
-    const {siteConfig = {}, metadata = {}} = this.context;
-    const {version: thisVersion, language: thisLanguage} = metadata;
+    const {siteConfig = {}} = this.context;
     const {
       themeConfig: {algolia},
     } = siteConfig;
@@ -35,11 +34,7 @@ class Search extends React.Component {
           apiKey: algolia.apiKey,
           indexName: algolia.indexName,
           inputSelector: '#search_input_react',
-          algoliaOptions: JSON.parse(
-            JSON.stringify(algolia.algoliaOptions)
-              .replace('VERSION', thisVersion)
-              .replace('LANGUAGE', thisLanguage),
-          ),
+          algoliaOptions: algolia.algoliaOptions,
         });
       });
     } else {
@@ -55,8 +50,8 @@ class Search extends React.Component {
       <input
         id="search_input_react"
         type="search"
-        placeholder="Search docs"
-        aria-label="Search docs"
+        placeholder="Search"
+        aria-label="Search"
       />
     ) : null;
   }

--- a/packages/docusaurus/CHANGES.md
+++ b/packages/docusaurus/CHANGES.md
@@ -18,6 +18,8 @@ headerLinks: [
 ],
 ```
 
+- `headerLinks` is now moved to themeConfig
+
 # Additions
 
 ### Presets

--- a/packages/docusaurus/lib/server/load/__tests__/__fixtures__/custom-site/docusaurus.config.js
+++ b/packages/docusaurus/lib/server/load/__tests__/__fixtures__/custom-site/docusaurus.config.js
@@ -12,10 +12,6 @@ module.exports = {
   projectName: 'sakura',
   baseUrl: '/sakura/',
   url: 'https://docusaurus.io',
-  headerLinks: [
-    {doc: 'foo/bar', label: 'Docs'},
-    {page: 'hello/world', label: 'Hello'},
-  ],
   headerIcon: 'img/docusaurus.svg',
   favicon: 'img/docusaurus.ico',
   plugins: [

--- a/packages/docusaurus/lib/server/load/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus/lib/server/load/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -12,10 +12,6 @@ module.exports = {
   projectName: 'hello',
   baseUrl: '/',
   url: 'https://docusaurus.io',
-  headerLinks: [
-    {doc: 'foo/bar', label: 'Docs'},
-    {page: 'hello/world', label: 'Hello'},
-  ],
   headerIcon: 'img/docusaurus.svg',
   favicon: 'img/docusaurus.ico',
   plugins: [

--- a/packages/docusaurus/lib/server/load/__tests__/config.test.js
+++ b/packages/docusaurus/lib/server/load/__tests__/config.test.js
@@ -22,19 +22,6 @@ Object {
   "baseUrl": "/",
   "favicon": "img/docusaurus.ico",
   "headerIcon": "img/docusaurus.svg",
-  "headerLinks": Array [
-    Object {
-      "doc": "foo/bar",
-      "label": "Docs",
-    },
-    Object {
-      "label": "Hello",
-      "page": "hello/world",
-    },
-    Object {
-      "languages": true,
-    },
-  ],
   "organizationName": "endiliey",
   "plugins": Any<Array>,
   "projectName": "hello",
@@ -52,7 +39,7 @@ Object {
     expect(() => {
       loadConfig(siteDir);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"The required field(s) 'favicon', 'headerLinks', 'headerIcon', 'organizationName', 'projectName', 'tagline', 'url' are missing from docusaurus.config.js"`,
+      `"The required field(s) 'favicon', 'headerIcon', 'organizationName', 'projectName', 'tagline', 'url' are missing from docusaurus.config.js"`,
     );
   });
 
@@ -61,7 +48,7 @@ Object {
     expect(() => {
       loadConfig(siteDir);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"The required field(s) 'favicon', 'headerLinks', 'headerIcon' are missing from docusaurus.config.js"`,
+      `"The required field(s) 'favicon', 'headerIcon' are missing from docusaurus.config.js"`,
     );
   });
 
@@ -70,7 +57,7 @@ Object {
     expect(() => {
       loadConfig(siteDir);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"The required field(s) 'baseUrl', 'favicon', 'headerLinks', 'headerIcon', 'organizationName', 'projectName', 'tagline', 'title', 'url' are missing from docusaurus.config.js"`,
+      `"The required field(s) 'baseUrl', 'favicon', 'headerIcon', 'organizationName', 'projectName', 'tagline', 'title', 'url' are missing from docusaurus.config.js"`,
     );
   });
 });

--- a/packages/docusaurus/lib/server/load/config.js
+++ b/packages/docusaurus/lib/server/load/config.js
@@ -23,7 +23,6 @@ const REQUIRED_FIELDS = [
 
 const OPTIONAL_FIELDS = [
   'customFields',
-  'disableHeaderTitle',
   'githubHost',
   'plugins',
   'presets',

--- a/packages/docusaurus/lib/server/load/config.js
+++ b/packages/docusaurus/lib/server/load/config.js
@@ -13,7 +13,6 @@ const {CONFIG_FILE_NAME} = require('../../constants');
 const REQUIRED_FIELDS = [
   'baseUrl',
   'favicon',
-  'headerLinks',
   'headerIcon',
   'organizationName',
   'projectName',
@@ -24,11 +23,8 @@ const REQUIRED_FIELDS = [
 
 const OPTIONAL_FIELDS = [
   'customFields',
-  'defaultLanguage',
   'disableHeaderTitle',
   'githubHost',
-  'highlight',
-  'markdownPlugins',
   'plugins',
   'presets',
   'themeConfig',
@@ -65,31 +61,6 @@ function loadConfig(siteDir, deleteCache = true) {
 
   // Merge default config with loaded config.
   const config = {...DEFAULT_CONFIG, ...loadedConfig};
-
-  // Build final headerLinks based on siteConfig.
-  const {headerLinks} = config;
-
-  // Add language dropdown to end if location not specified.
-  let languages = false;
-  headerLinks.forEach(link => {
-    if (link.languages) {
-      languages = true;
-    }
-  });
-  if (!languages) {
-    headerLinks.push({languages: true});
-  }
-  let search = false;
-  headerLinks.forEach(link => {
-    // Append search bar if location not specified.
-    if (link.search) {
-      search = true;
-    }
-  });
-  if (!search && config.algolia) {
-    headerLinks.push({search: true});
-  }
-  config.headerLinks = headerLinks;
 
   // User's own array of custom fields/
   // e.g: if they want to include some.field so they can access it later from `props.siteConfig`.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,11 +12,6 @@ module.exports = {
   projectName: 'docusaurus',
   baseUrl: '/',
   url: 'https://docusaurus-2.netlify.com',
-  headerLinks: [
-    {url: 'docs/introduction', label: 'Docs'},
-    {url: 'blog', label: 'Blog'},
-    {url: 'feedback/', label: 'Feedback'},
-  ],
   headerIcon: 'img/docusaurus.svg',
   favicon: 'img/docusaurus.ico',
   themeConfig: {
@@ -25,6 +20,11 @@ module.exports = {
       indexName: 'docusaurus-2',
       algoliaOptions: {},
     },
+    headerLinks: [
+      {url: 'docs/introduction', label: 'Docs'},
+      {url: 'blog', label: 'Blog'},
+      {url: 'feedback/', label: 'Feedback'},
+    ],
   },
   presets: [
     [


### PR DESCRIPTION
## Motivation

Move headerLinks as themeConfig stuff. 

Remove old and dead code

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Locally headerlinks still work
- Netlify
