### PR TITLE
chore(v2): improve a11y & tweak eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,11 @@ module.exports = {
   rules: {
     'class-methods-use-this': OFF, // It's a way of allowing private variables.
     'func-names': OFF,
-    'import/no-unresolved': WARNING, // Because it couldn't resolve webpack alias.
+    // Ignore certain webpack alias because it can't be resolved
+    'import/no-unresolved': [
+      ERROR,
+      {ignore: ['^@theme', '^@docusaurus', '^@generated']},
+    ],
     'header/header': [
       ERROR,
       'block',
@@ -42,8 +46,8 @@ module.exports = {
         ' ',
       ],
     ],
-    'jsx-a11y/click-events-have-key-events': OFF, // Revisit in future™
-    'jsx-a11y/no-noninteractive-element-interactions': OFF, // Revisit in future™
+    'jsx-a11y/click-events-have-key-events': WARNING,
+    'jsx-a11y/no-noninteractive-element-interactions': WARNING,
     'no-console': OFF,
     'no-underscore-dangle': OFF,
     'react/jsx-closing-bracket-location': OFF, // Conflicts with Prettier.

--- a/packages/docusaurus/src/client/App.js
+++ b/packages/docusaurus/src/client/App.js
@@ -8,10 +8,10 @@
 import React from 'react';
 import {renderRoutes} from 'react-router-config';
 
-import Head from '@docusaurus/Head'; // eslint-disable-line
-import routes from '@generated/routes'; // eslint-disable-line
-import siteConfig from '@generated/docusaurus.config'; //eslint-disable-line
-import DocusaurusContext from '@docusaurus/context'; // eslint-disable-line
+import Head from '@docusaurus/Head';
+import routes from '@generated/routes';
+import siteConfig from '@generated/docusaurus.config';
+import DocusaurusContext from '@docusaurus/context';
 import PendingNavigation from './PendingNavigation';
 
 function App() {

--- a/packages/docusaurus/src/client/clientEntry.js
+++ b/packages/docusaurus/src/client/clientEntry.js
@@ -9,10 +9,10 @@ import React from 'react';
 import {hydrate, render} from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 
+import routes from '@generated/routes';
 import App from './App';
 import preload from './preload';
 import docusaurus from './docusaurus';
-import routes from '@generated/routes'; // eslint-disable-line
 
 // Client-side render (e.g: running in browser) to become single-page application (SPA).
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {

--- a/packages/docusaurus/src/client/docusaurus.js
+++ b/packages/docusaurus/src/client/docusaurus.js
@@ -6,7 +6,7 @@
  */
 import {matchRoutes} from 'react-router-config';
 import routesChunkNames from '@generated/routesChunkNames';
-import routes from '@generated/routes'; // eslint-disable-line
+import routes from '@generated/routes';
 import prefetchHelper from './prefetch';
 import preloadHelper from './preload';
 import flat from './flat';

--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -15,7 +15,7 @@ import Loadable from 'react-loadable';
 
 import path from 'path';
 import fs from 'fs';
-import routes from '@generated/routes'; // eslint-disable-line
+import routes from '@generated/routes';
 import preload from './preload';
 import App from './App';
 import ssrTemplate from './templates/ssr.html.template';

--- a/packages/docusaurus/src/client/theme-fallback/Layout/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Layout/index.js
@@ -6,8 +6,8 @@
  */
 
 import React from 'react';
-import Head from '@docusaurus/Head'; // eslint-disable-line
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext'; // eslint-disable-line
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 function Layout(props) {
   const context = useDocusaurusContext();

--- a/website/pages/index.js
+++ b/website/pages/index.js
@@ -125,6 +125,7 @@ function Home() {
             <div className="col">
               <img
                 className={styles.featureImage}
+                alt={'Powered by Markdown'}
                 src={`${siteConfig.baseUrl}img/undraw_typewriter.svg`}
               />
               <h3>Powered by Markdown</h3>
@@ -136,6 +137,7 @@ function Home() {
             </div>
             <div className="col">
               <img
+                alt={'Built Using React'}
                 className={styles.featureImage}
                 src={`${siteConfig.baseUrl}img/undraw_react.svg`}
               />
@@ -148,6 +150,7 @@ function Home() {
             </div>
             <div className="col">
               <img
+                alt={'Ready for Translations'}
                 className={styles.featureImage}
                 src={`${siteConfig.baseUrl}img/undraw_around_the_world.svg`}
               />
@@ -163,6 +166,7 @@ function Home() {
           <div className="row">
             <div className="col col--4 col--offset-2">
               <img
+                alt={'Document Versioning'}
                 className={styles.featureImage}
                 src={`${siteConfig.baseUrl}img/undraw_version_control.svg`}
               />
@@ -175,6 +179,7 @@ function Home() {
             </div>
             <div className="col col--4">
               <img
+                alt={'Document Search'}
                 className={styles.featureImage}
                 src={`${siteConfig.baseUrl}img/undraw_algolia.svg`}
               />


### PR DESCRIPTION
## Motivation

- Remove all `eslint-disable-lines` due to no import resolve on webpack alias.
- Tweak eslintrc a little bit
- Improve a11y

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Locally website still works
- Netlify builds

