### PR TITLE
refactor(v2): blog data revamp

### DIFF
--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -14,6 +14,7 @@
     "@mdx-js/mdx": "^1.0.18",
     "@mdx-js/react": "^1.0.16",
     "github-slugger": "^1.2.1",
+    "gray-matter": "^4.0.2",
     "loader-utils": "^1.2.3",
     "mdast-util-to-string": "^1.0.5",
     "prism-themes": "^1.1.0",

--- a/packages/docusaurus-mdx-loader/src/index.js
+++ b/packages/docusaurus-mdx-loader/src/index.js
@@ -10,6 +10,8 @@ const mdx = require('@mdx-js/mdx');
 const rehypePrism = require('@mapbox/rehype-prism');
 const emoji = require('remark-emoji');
 const slug = require('rehype-slug');
+const matter = require('gray-matter');
+const stringifyObject = require('stringify-object');
 const linkHeadings = require('./linkHeadings');
 const rightToc = require('./rightToc');
 
@@ -19,9 +21,10 @@ const DEFAULT_OPTIONS = {
   prismTheme: 'prism-themes/themes/prism-atom-dark.css',
 };
 
-module.exports = async function(content) {
+module.exports = async function(fileString) {
   const callback = this.async();
 
+  const {data, content} = matter(fileString);
   const options = Object.assign(DEFAULT_OPTIONS, getOptions(this), {
     filepath: this.resourcePath,
   });
@@ -43,6 +46,7 @@ module.exports = async function(content) {
   import React from 'react';
   import { mdx } from '@mdx-js/react';
   ${importStr}
+  export const frontMatter = ${stringifyObject(data)};
   ${result}
   `;
 

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -12,7 +12,6 @@
     "@docusaurus/utils": "^2.0.0-alpha.13",
     "fs-extra": "^7.0.1",
     "globby": "^9.1.0",
-    "gray-matter": "^4.0.2",
     "loader-utils": "^1.2.3"
   },
   "peerDependencies": {

--- a/packages/docusaurus-plugin-content-blog/src/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/index.js
@@ -23,7 +23,7 @@ const DEFAULT_OPTIONS = {
   path: 'blog', // Path to data on filesystem, relative to site dir.
   routeBasePath: 'blog', // URL Route.
   include: ['*.md', '*.mdx'], // Extensions to include.
-  pageCount: 10, // How many entries per page.
+  postsPerPage: 10, // How many posts per page.
   blogListComponent: '@theme/BlogListPage',
   blogPostComponent: '@theme/BlogPostPage',
 };
@@ -49,7 +49,7 @@ class DocusaurusPluginContentBlog {
 
   // Fetches blog contents and returns metadata for the necessary routes.
   async loadContent() {
-    const {pageCount, include, routeBasePath} = this.options;
+    const {postsPerPage, include, routeBasePath} = this.options;
     const {siteConfig} = this.context;
     const blogDir = this.contentPath;
 
@@ -96,8 +96,8 @@ class DocusaurusPluginContentBlog {
 
     // Blog pagination routes.
     // Example: `/blog`, `/blog/page/1`, `/blog/page/2`
-    const numOfPosts = blogPosts.length;
-    const numberOfPages = Math.ceil(numOfPosts / pageCount);
+    const totalCount = blogPosts.length;
+    const numberOfPages = Math.ceil(totalCount / postsPerPage);
     const basePageUrl = normalizeUrl([baseUrl, routeBasePath]);
 
     const blogListPaginated = [];
@@ -113,14 +113,15 @@ class DocusaurusPluginContentBlog {
         metadata: {
           permalink: blogPaginationPermalink(page),
           page: page + 1,
-          pageCount,
-          totalCount: numberOfPages,
+          postsPerPage,
+          totalPages: numberOfPages,
+          totalCount,
           previousPage: page !== 0 ? blogPaginationPermalink(page - 1) : null,
           nextPage:
             page < numberOfPages - 1 ? blogPaginationPermalink(page + 1) : null,
         },
         items: blogPosts
-          .slice(page * pageCount, (page + 1) * pageCount)
+          .slice(page * postsPerPage, (page + 1) * postsPerPage)
           .map(item => item.id),
       });
     }

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.js
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const matter = require('gray-matter');
 const {parseQuery} = require('loader-utils');
 
 const TRUNCATE_MARKER = /<!--\s*truncate\s*-->/;
@@ -13,22 +12,13 @@ const TRUNCATE_MARKER = /<!--\s*truncate\s*-->/;
 module.exports = async function(fileString) {
   const callback = this.async();
 
-  // Extract content of markdown (without frontmatter).
-  let {content} = matter(fileString);
+  let finalContent = fileString;
 
   // Truncate content if requested (e.g: file.md?truncated=true)
   const {truncated} = this.resourceQuery && parseQuery(this.resourceQuery);
-  if (truncated) {
-    if (TRUNCATE_MARKER.test(content)) {
-      // eslint-disable-next-line
-      content = content.split(TRUNCATE_MARKER)[0];
-    } else {
-      // Return first 4 lines of the content as summary
-      content = content
-        .split('\n')
-        .slice(0, 4)
-        .join('\n');
-    }
+  if (truncated && TRUNCATE_MARKER.test(fileString)) {
+    // eslint-disable-next-line
+    finalContent = fileString.split(TRUNCATE_MARKER)[0];
   }
-  return callback(null, content);
+  return callback(null, finalContent);
 };

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogListPage/index.js
@@ -9,25 +9,35 @@ import React from 'react';
 
 import Layout from '@theme/Layout'; // eslint-disable-line
 import BlogPostItem from '@theme/BlogPostItem';
+import BlogListPaginator from '@theme/BlogListPaginator';
 
 function BlogListPage(props) {
-  const {
-    metadata: {posts = []},
-    entries: BlogPosts,
-  } = props;
+  const {metadata, items} = props;
 
   return (
     <Layout title="Blog" description="Blog">
       <div className="container margin-vert--xl">
         <div className="row">
           <div className="col col--6 col--offset-3">
-            {BlogPosts.map((PostContent, index) => (
-              <div className="margin-bottom--xl" key={index}>
-                <BlogPostItem truncated metadata={posts[index]}>
-                  <PostContent />
-                </BlogPostItem>
-              </div>
-            ))}
+            {items.map(
+              ({
+                content: BlogPostContent,
+                frontMatter,
+                metadata: blogPostMetadata,
+              }) => (
+                <div
+                  className="margin-bottom--xl"
+                  key={blogPostMetadata.permalink}>
+                  <BlogPostItem
+                    frontMatter={frontMatter}
+                    metadata={blogPostMetadata}
+                    truncated>
+                    <BlogPostContent />
+                  </BlogPostItem>
+                </div>
+              ),
+            )}
+            <BlogListPaginator metadata={metadata} />
           </div>
         </div>
       </div>

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogListPage/index.js
@@ -20,16 +20,12 @@ function BlogListPage(props) {
         <div className="row">
           <div className="col col--8 col--offset-2">
             {items.map(
-              ({
-                content: BlogPostContent,
-                frontMatter,
-                metadata: blogPostMetadata,
-              }) => (
+              ({content: BlogPostContent, metadata: blogPostMetadata}) => (
                 <div
                   className="margin-bottom--xl"
                   key={blogPostMetadata.permalink}>
                   <BlogPostItem
-                    frontMatter={frontMatter}
+                    frontMatter={BlogPostContent.frontMatter}
                     metadata={blogPostMetadata}
                     truncated>
                     <BlogPostContent />

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogListPage/index.js
@@ -18,7 +18,7 @@ function BlogListPage(props) {
     <Layout title="Blog" description="Blog">
       <div className="container margin-vert--xl">
         <div className="row">
-          <div className="col col--6 col--offset-3">
+          <div className="col col--8 col--offset-2">
             {items.map(
               ({
                 content: BlogPostContent,

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogListPaginator/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogListPaginator/index.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Link from '@docusaurus/Link';
+
+function BlogListPaginator(props) {
+  const {metadata} = props;
+  const {previousPage, nextPage} = metadata;
+
+  return (
+    <div className="row">
+      <div className="col col--6">
+        {previousPage && (
+          <Link className="button button--secondary" to={previousPage}>
+            Newer entries
+          </Link>
+        )}
+      </div>
+      <div className="col col--6 text--right">
+        {nextPage && (
+          <Link className="button button--secondary" to={nextPage}>
+            Older entries
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BlogListPaginator;

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogPostItem/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogPostItem/index.js
@@ -9,20 +9,11 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 
 function BlogPostItem(props) {
-  const {metadata, children, truncated} = props;
+  const {children, frontMatter, metadata, truncated} = props;
+
   const renderPostHeader = () => {
-    if (!metadata) {
-      return null;
-    }
-    const {
-      date,
-      author,
-      authorURL,
-      authorTitle,
-      authorFBID,
-      permalink,
-      title,
-    } = metadata;
+    const {author, authorURL, authorTitle, authorFBID, title} = frontMatter;
+    const {date, permalink} = metadata;
 
     const blogPostDate = new Date(date);
     const month = [
@@ -39,9 +30,10 @@ function BlogPostItem(props) {
       'November',
       'December',
     ];
+
     const authorImageURL = authorFBID
       ? `https://graph.facebook.com/${authorFBID}/picture/?height=200&width=200`
-      : metadata.authorImageURL;
+      : frontMatter.authorImageURL;
 
     return (
       <header>
@@ -88,10 +80,8 @@ function BlogPostItem(props) {
       {renderPostHeader()}
       <article className="markdown">{children}</article>
       {truncated && (
-        <div className="text--right">
-          <Link className="button button--secondary" to={metadata.permalink}>
-            Read More
-          </Link>
+        <div className="text--right margin-vert--md">
+          <Link to={metadata.permalink}>Read More</Link>
         </div>
       )}
     </div>

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPage/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPage/index.js
@@ -19,7 +19,7 @@ function BlogPostPage(props) {
     nextItem,
     prevItem,
   } = props;
-  console.log(props);
+
   return (
     <Layout title={frontMatter.title} description={frontMatter.description}>
       {BlogPostContents && (

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPage/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPage/index.js
@@ -12,16 +12,10 @@ import BlogPostItem from '@theme/BlogPostItem';
 import BlogPostPaginator from '../BlogPostPaginator';
 
 function BlogPostPage(props) {
-  const {
-    content: BlogPostContents,
-    frontMatter,
-    metadata,
-    nextItem,
-    prevItem,
-  } = props;
-
+  const {content: BlogPostContents, metadata, nextItem, prevItem} = props;
+  const {frontMatter} = BlogPostContents;
   return (
-    <Layout title={frontMatter.title} description={frontMatter.description}>
+    <Layout title={metadata.title} description={metadata.description}>
       {BlogPostContents && (
         <div className="container margin-vert--xl">
           <div className="row">

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPage/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPage/index.js
@@ -9,19 +9,29 @@ import React from 'react';
 
 import Layout from '@theme/Layout'; // eslint-disable-line
 import BlogPostItem from '@theme/BlogPostItem';
+import BlogPostPaginator from '../BlogPostPaginator';
 
 function BlogPostPage(props) {
-  const {content: BlogPostContents, metadata} = props;
-
+  const {
+    content: BlogPostContents,
+    frontMatter,
+    metadata,
+    nextItem,
+    prevItem,
+  } = props;
+  console.log(props);
   return (
-    <Layout title={metadata.title} description={metadata.description}>
+    <Layout title={frontMatter.title} description={frontMatter.description}>
       {BlogPostContents && (
         <div className="container margin-vert--xl">
           <div className="row">
-            <div className="col col--6 col--offset-3">
-              <BlogPostItem metadata={metadata}>
+            <div className="col col--8 col--offset-2">
+              <BlogPostItem frontMatter={frontMatter} metadata={metadata}>
                 <BlogPostContents />
               </BlogPostItem>
+              <div className="margin-vert--lg">
+                <BlogPostPaginator nextItem={nextItem} prevItem={prevItem} />
+              </div>
             </div>
           </div>
         </div>

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPaginator/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPaginator/index.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Link from '@docusaurus/Link';
+
+function BlogPostPaginator(props) {
+  const {nextItem, prevItem} = props;
+
+  return (
+    <div className="row">
+      <div className="col col--6">
+        {prevItem && (
+          <Link
+            className="button button--secondary"
+            to={prevItem.metadata.permalink}>
+            {prevItem.frontMatter.title}
+          </Link>
+        )}
+      </div>
+      <div className="col col--6 text--right">
+        {nextItem && (
+          <Link
+            className="button button--secondary"
+            to={nextItem.metadata.permalink}>
+            {nextItem.frontMatter.title}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BlogPostPaginator;

--- a/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPaginator/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/theme/BlogPostPaginator/index.js
@@ -15,19 +15,15 @@ function BlogPostPaginator(props) {
     <div className="row">
       <div className="col col--6">
         {prevItem && (
-          <Link
-            className="button button--secondary"
-            to={prevItem.metadata.permalink}>
-            {prevItem.frontMatter.title}
+          <Link className="button button--secondary" to={prevItem.permalink}>
+            {prevItem.title}
           </Link>
         )}
       </div>
       <div className="col col--6 text--right">
         {nextItem && (
-          <Link
-            className="button button--secondary"
-            to={nextItem.metadata.permalink}>
-            {nextItem.frontMatter.title}
+          <Link className="button button--secondary" to={nextItem.permalink}>
+            {nextItem.title}
           </Link>
         )}
       </div>

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -13,7 +13,6 @@
     "@docusaurus/utils": "^2.0.0-alpha.13",
     "fs-extra": "^7.0.1",
     "globby": "^9.1.0",
-    "gray-matter": "^4.0.2",
     "import-fresh": "^3.0.0",
     "loader-utils": "^1.2.3"
   },

--- a/packages/docusaurus-plugin-content-docs/src/markdown/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/index.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const matter = require('gray-matter');
 const {getOptions} = require('loader-utils');
 const {resolve} = require('url');
 
@@ -16,15 +15,14 @@ module.exports = async function(fileString) {
   });
   const {docsDir, sourceToPermalink} = options;
 
-  // Extract content of markdown (without frontmatter).
-  let {content} = matter(fileString);
-
   // Determine the source dir. e.g: /docs, /website/versioned_docs/version-1.0.0
   let sourceDir;
   const thisSource = this.resourcePath;
   if (thisSource.startsWith(docsDir)) {
     sourceDir = docsDir;
   }
+
+  let content = fileString;
 
   // Replace internal markdown linking (except in fenced blocks).
   if (sourceDir) {

--- a/packages/docusaurus-plugin-content-docs/src/metadata.js
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.js
@@ -18,70 +18,66 @@ module.exports = async function processMetadata(
 ) {
   const filepath = path.resolve(refDir, source);
   const fileString = await fs.readFile(filepath, 'utf-8');
-  const {frontMatter = {}, excerpt} = parse(fileString);
+  const {frontMatter: metadata = {}, excerpt} = parse(fileString);
 
   // Default id is the file name.
-  if (!frontMatter.id) {
-    frontMatter.id = path.basename(source, path.extname(source));
+  if (!metadata.id) {
+    metadata.id = path.basename(source, path.extname(source));
   }
-  if (frontMatter.id.includes('/')) {
+  if (metadata.id.includes('/')) {
     throw new Error('Document id cannot include "/".');
   }
 
   // Default title is the id.
-  if (!frontMatter.title) {
-    frontMatter.title = frontMatter.id;
+  if (!metadata.title) {
+    metadata.title = metadata.id;
   }
 
-  if (!frontMatter.description) {
-    frontMatter.description = excerpt;
+  if (!metadata.description) {
+    metadata.description = excerpt;
   }
 
   const dirName = path.dirname(source);
   if (dirName !== '.') {
     const prefix = dirName;
     if (prefix) {
-      frontMatter.id = `${prefix}/${frontMatter.id}`;
+      metadata.id = `${prefix}/${metadata.id}`;
     }
   }
 
   // The docs absolute file source.
   // e.g: `/end/docs/hello.md` or `/end/website/versioned_docs/version-1.0.0/hello.md`
-  frontMatter.source = path.join(refDir, source);
+  metadata.source = path.join(refDir, source);
 
   // Build the permalink.
   const {baseUrl} = siteConfig;
 
   // If user has own custom permalink defined in frontmatter
   // e.g: :baseUrl:docsUrl/:langPart/:versionPart/endiliey/:id
-  if (frontMatter.permalink) {
-    frontMatter.permalink = path.resolve(
-      frontMatter.permalink
+  if (metadata.permalink) {
+    metadata.permalink = path.resolve(
+      metadata.permalink
         .replace(/:baseUrl/, baseUrl)
         .replace(/:docsUrl/, docsBasePath)
-        .replace(/:id/, frontMatter.id),
+        .replace(/:id/, metadata.id),
     );
   } else {
-    frontMatter.permalink = normalizeUrl([
-      baseUrl,
-      docsBasePath,
-      frontMatter.id,
-    ]);
+    metadata.permalink = normalizeUrl([baseUrl, docsBasePath, metadata.id]);
   }
 
   // Determine order.
-  const {id} = frontMatter;
+  const {id} = metadata;
   if (order[id]) {
-    frontMatter.sidebar = order[id].sidebar;
-    frontMatter.category = order[id].category;
-    frontMatter.subCategory = order[id].subCategory;
+    metadata.sidebar = order[id].sidebar;
+    metadata.category = order[id].category;
+    metadata.subCategory = order[id].subCategory;
     if (order[id].next) {
-      frontMatter.next = order[id].next;
+      metadata.next = order[id].next;
     }
     if (order[id].previous) {
-      frontMatter.previous = order[id].previous;
+      metadata.previous = order[id].previous;
     }
   }
 
-  return frontMatter;
+  return metadata;
 };

--- a/packages/docusaurus-plugin-content-docs/src/metadata.js
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.js
@@ -18,66 +18,70 @@ module.exports = async function processMetadata(
 ) {
   const filepath = path.resolve(refDir, source);
   const fileString = await fs.readFile(filepath, 'utf-8');
-  const {metadata = {}, excerpt} = parse(fileString);
+  const {frontMatter = {}, excerpt} = parse(fileString);
 
   // Default id is the file name.
-  if (!metadata.id) {
-    metadata.id = path.basename(source, path.extname(source));
+  if (!frontMatter.id) {
+    frontMatter.id = path.basename(source, path.extname(source));
   }
-  if (metadata.id.includes('/')) {
+  if (frontMatter.id.includes('/')) {
     throw new Error('Document id cannot include "/".');
   }
 
   // Default title is the id.
-  if (!metadata.title) {
-    metadata.title = metadata.id;
+  if (!frontMatter.title) {
+    frontMatter.title = frontMatter.id;
   }
 
-  if (!metadata.description) {
-    metadata.description = excerpt;
+  if (!frontMatter.description) {
+    frontMatter.description = excerpt;
   }
 
   const dirName = path.dirname(source);
   if (dirName !== '.') {
     const prefix = dirName;
     if (prefix) {
-      metadata.id = `${prefix}/${metadata.id}`;
+      frontMatter.id = `${prefix}/${frontMatter.id}`;
     }
   }
 
   // The docs absolute file source.
   // e.g: `/end/docs/hello.md` or `/end/website/versioned_docs/version-1.0.0/hello.md`
-  metadata.source = path.join(refDir, source);
+  frontMatter.source = path.join(refDir, source);
 
   // Build the permalink.
   const {baseUrl} = siteConfig;
 
   // If user has own custom permalink defined in frontmatter
   // e.g: :baseUrl:docsUrl/:langPart/:versionPart/endiliey/:id
-  if (metadata.permalink) {
-    metadata.permalink = path.resolve(
-      metadata.permalink
+  if (frontMatter.permalink) {
+    frontMatter.permalink = path.resolve(
+      frontMatter.permalink
         .replace(/:baseUrl/, baseUrl)
         .replace(/:docsUrl/, docsBasePath)
-        .replace(/:id/, metadata.id),
+        .replace(/:id/, frontMatter.id),
     );
   } else {
-    metadata.permalink = normalizeUrl([baseUrl, docsBasePath, metadata.id]);
+    frontMatter.permalink = normalizeUrl([
+      baseUrl,
+      docsBasePath,
+      frontMatter.id,
+    ]);
   }
 
   // Determine order.
-  const {id} = metadata;
+  const {id} = frontMatter;
   if (order[id]) {
-    metadata.sidebar = order[id].sidebar;
-    metadata.category = order[id].category;
-    metadata.subCategory = order[id].subCategory;
+    frontMatter.sidebar = order[id].sidebar;
+    frontMatter.category = order[id].category;
+    frontMatter.subCategory = order[id].subCategory;
     if (order[id].next) {
-      metadata.next = order[id].next;
+      frontMatter.next = order[id].next;
     }
     if (order[id].previous) {
-      metadata.previous = order[id].previous;
+      frontMatter.previous = order[id].previous;
     }
   }
 
-  return metadata;
+  return frontMatter;
 };

--- a/packages/docusaurus-utils/src/index.js
+++ b/packages/docusaurus-utils/src/index.js
@@ -166,7 +166,7 @@ function getSubFolder(file, refDir) {
  * @returns {Object}
  */
 function parse(fileString) {
-  const {data: metadata, content, excerpt} = matter(fileString, {
+  const {data: frontMatter, content, excerpt} = matter(fileString, {
     excerpt(file) {
       // eslint-disable-next-line no-param-reassign
       file.excerpt = file.content
@@ -175,7 +175,7 @@ function parse(fileString) {
         .shift();
     },
   });
-  return {metadata, content, excerpt};
+  return {frontMatter, content, excerpt};
 }
 
 /**

--- a/packages/docusaurus/src/client/exports/ComponentCreator.js
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.js
@@ -28,7 +28,7 @@ function ComponentCreator(path) {
   /* Prepare opts data that react-loadable needs
   https://github.com/jamiebuilds/react-loadable#declaring-which-modules-are-being-loaded
   Example:
-  - optsLoader: 
+  - optsLoader:
   {
     component: () => import('./Pages.js'),
     content.foo: () => import('./doc1.md'),
@@ -41,6 +41,10 @@ function ComponentCreator(path) {
       target.forEach((value, index) => {
         traverseChunk(value, [...keys, index]);
       });
+      return;
+    }
+
+    if (target == null) {
       return;
     }
 

--- a/packages/docusaurus/src/server/load/routes.js
+++ b/packages/docusaurus/src/server/load/routes.js
@@ -49,6 +49,10 @@ async function loadRoutes(pluginsRouteConfigs) {
 
     // Given an input (object or string), get the import path str
     const getModulePath = target => {
+      if (!target) {
+        return null;
+      }
+
       const importStr = _.isObject(target) ? target.path : target;
       const queryStr = target.query ? `?${stringify(target.query)}` : '';
       return `${importStr}${queryStr}`;
@@ -57,9 +61,14 @@ async function loadRoutes(pluginsRouteConfigs) {
     if (!component) {
       throw new Error(`path: ${routePath} need a component`);
     }
+
     const componentPath = getModulePath(component);
 
     const genImportChunk = (modulePath, prefix, name) => {
+      if (!modulePath) {
+        return null;
+      }
+
       const chunkName = genChunkName(modulePath, prefix, name);
       const finalStr = JSON.stringify(modulePath);
       return {
@@ -90,6 +99,11 @@ async function loadRoutes(pluginsRouteConfigs) {
         prefix,
         routePath,
       );
+
+      if (!importChunk) {
+        return null;
+      }
+
       registry[importChunk.chunkName] = {
         importStatement: importChunk.importStatement,
         modulePath: importChunk.modulePath,

--- a/website-1.x/blog/2018-12-14-Happy-First-Birthday-Slash.md
+++ b/website-1.x/blog/2018-12-14-Happy-First-Birthday-Slash.md
@@ -11,6 +11,8 @@ authorTwitter: JoelMarcey
 
 Docusaurus [went live](https://docusaurus.io/blog/2017/12/14/introducing-docusaurus) on December 14, 2017. At the time, we had [8 early adopters](https://docusaurus.io/blog/2017/12/14/introducing-docusaurus#acknowledgements).
 
+<!--truncate-->
+
 We now have nearly [60 known users of Docusaurus](https://docusaurus.io/en/users), and probably more that we don't know about. We have [9K GitHub stars](https://github.com/facebook/docusaurus) and an active community, particularly [Yangshun Tay](https://twitter.com/yangshunz) and [Endilie Yacop Sucipto](https://twitter.com/endiliey), both of whom are the lead maintainers helping keep this project [moving forward](https://docusaurus.io/blog/2018/09/11/Towards-Docusaurus-2).
 
 Thank you to everyone for your support and use of this project! I am super proud of how far this project has come in just a year.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,6 +36,7 @@ module.exports = {
         },
         blog: {
           path: '../website-1.x/blog',
+          pageCount: 2,
         },
       },
     ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,7 +36,7 @@ module.exports = {
         },
         blog: {
           path: '../website-1.x/blog',
-          pageCount: 2,
+          postsPerPage: 3,
         },
       },
     ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make blogs great again

- Clean up blog data props structure by splitting metadata and front matter into two separate props. This is helpful in letting users add whatever they want to the front matter and have it being referenced in blog posts. Metadata is something that is controlled by the plugin. There will not be collisions if we split it up. For blog list pages, I've also cleaned them up a bit and reused the blog item metadata and front matter. It was being duplicated in the list's metadata and the entries 😓 
- Remove use of `isBlogPage` and distinguish between blog list and blog posts.
- Add prev/next for blog list pages (new `BlogListPaginator` component)
- Add prev/next for blog item pages (new `BlogItemPaginator` component)

The blog plugin code is a little harder to read now, but still acceptable IMO. Having types will definitely help in refactoring and understanding the code.

Here's how `routesChunkNames.json` looks like for blog now.

```js
{
  "/blog/2018/12/14/Happy-First-Birthday-Slash": {
    "component": "component---theme-blog-post-page-ccc",
    "content": "content---blog-2018-12-14-happy-first-birthday-slash-260-b8c",
    "frontMatter": "frontMatter---blog-2018-12-14-happy-first-birthday-slashb-8-a-d30",
    "metadata": "metadata---blog-2018-12-14-happy-first-birthday-slasha-11-124",
    "prevItem": null,
    "nextItem": {
      "metadata": "metadata---blog-2018-12-14-happy-first-birthday-slashef-5-827",
      "frontMatter": "frontMatter---blog-2018-12-14-happy-first-birthday-slashe-67-ac6"
    }
  },
  "/blog/2018/09/11/Towards-Docusaurus-2": {
    "component": "component---theme-blog-post-page-ccc",
    "content": "content---blog-2018-09-11-towards-docusaurus-2-b-0-b-dfe",
    "frontMatter": "frontMatter---blog-2018-12-14-happy-first-birthday-slashe-67-ac6",
    "metadata": "metadata---blog-2018-12-14-happy-first-birthday-slashef-5-827",
    "prevItem": {
      "metadata": "metadata---blog-2018-12-14-happy-first-birthday-slasha-11-124",
      "frontMatter": "frontMatter---blog-2018-12-14-happy-first-birthday-slashb-8-a-d30"
    },
    "nextItem": {
      "metadata": "metadata---blog-2018-09-11-towards-docusaurus-2-d-5-f-74d",
      "frontMatter": "frontMatter---blog-2018-09-11-towards-docusaurus-2119-372"
    }
  },
  "/blog/2018/04/30/How-I-Converted-Profilo-To-Docusaurus": {
    "component": "component---theme-blog-post-page-ccc",
    "content": "content---blog-2018-04-30-how-i-converted-profilo-to-docusaurusba-6-241",
    "frontMatter": "frontMatter---blog-2018-09-11-towards-docusaurus-2119-372",
    "metadata": "metadata---blog-2018-09-11-towards-docusaurus-2-d-5-f-74d",
    "prevItem": {
      "metadata": "metadata---blog-2018-12-14-happy-first-birthday-slashef-5-827",
      "frontMatter": "frontMatter---blog-2018-12-14-happy-first-birthday-slashe-67-ac6"
    },
    "nextItem": {
      "metadata": "metadata---blog-2018-04-30-how-i-converted-profilo-to-docusaurusadf-fc6",
      "frontMatter": "frontMatter---blog-2018-04-30-how-i-converted-profilo-to-docusaurus-09-b-868"
    }
  },
  "/blog/2017/12/14/introducing-docusaurus": {
    "component": "component---theme-blog-post-page-ccc",
    "content": "content---blog-2017-12-14-introducing-docusaurus-4-f-2-24f",
    "frontMatter": "frontMatter---blog-2018-04-30-how-i-converted-profilo-to-docusaurus-09-b-868",
    "metadata": "metadata---blog-2018-04-30-how-i-converted-profilo-to-docusaurusadf-fc6",
    "prevItem": {
      "metadata": "metadata---blog-2018-09-11-towards-docusaurus-2-d-5-f-74d",
      "frontMatter": "frontMatter---blog-2018-09-11-towards-docusaurus-2119-372"
    },
    "nextItem": null
  },
  ...
```

I might add tags and categories features next.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Netlify preview. I set the blog page count to 2 in the meanwhile. We can set it back to 5/10 later.

## Related PRs

NA.