### PR TITLE
fix(v2): window scrolling behavior

### DIFF
--- a/packages/docusaurus/src/client/PendingNavigation.js
+++ b/packages/docusaurus/src/client/PendingNavigation.js
@@ -28,8 +28,6 @@ class PendingNavigation extends React.Component {
     const {routes, delay = 1000} = this.props;
 
     if (navigated) {
-      window.scrollTo(0, 0);
-
       this.startProgressBar(delay);
       // save the location so we can render the old screen
       this.setState({
@@ -45,6 +43,7 @@ class PendingNavigation extends React.Component {
             },
             this.stopProgressBar,
           );
+          window.scrollTo(0, 0);
         })
         .catch(e => console.warn(e));
     }

--- a/packages/docusaurus/src/webpack/base.js
+++ b/packages/docusaurus/src/webpack/base.js
@@ -100,13 +100,10 @@ module.exports = function createBaseConfig(props, isServer) {
         {
           test: /\.jsx?$/,
           exclude(modulePath) {
-            // always transpile our own library
-            if (modulePath.startsWith(path.join(__dirname, '..'))) {
-              return false;
-            }
-
-            // Don't transpile node_modules
-            return /node_modules/.test(modulePath);
+            // Don't transpile node_modules except any docusaurus package
+            return (
+              /node_modules/.test(modulePath) && !/docusaurus/.test(modulePath)
+            );
           },
           use: [
             cacheLoader && getCacheLoader(isServer),

--- a/website-1.x/blog/2018-09-11-Towards-Docusaurus-2.md
+++ b/website-1.x/blog/2018-09-11-Towards-Docusaurus-2.md
@@ -17,7 +17,7 @@ There is a saying that the very best software is constantly evolving, and the ve
 
 It all started with this [RFC issue](https://github.com/facebook/Docusaurus/issues/789) opened by [Yangshun](https://github.com/yangshun) towards the end of June 2018.
 
-<blockquote class="embedly-card"><h4><a href="https://github.com/facebook/Docusaurus/issues/789">[RFC] Docusaurus v2 · Issue #789 · facebook/Docusaurus</a></h4><p>These are some of the problems I'm seeing in Docusaurus now and also how we can address them in v2. A number of the ideas here were inspired by VuePress and other static site generators. In the current static site generators ecosystem, t...</p></blockquote>
+<blockquote><h4><a href="https://github.com/facebook/Docusaurus/issues/789">[RFC] Docusaurus v2 · Issue #789 · facebook/Docusaurus</a></h4><p>These are some of the problems I'm seeing in Docusaurus now and also how we can address them in v2. A number of the ideas here were inspired by VuePress and other static site generators. In the current static site generators ecosystem, t...</p></blockquote>
 
 Most of the suggested improvements are mentioned in the issue; I will provide details on some of issues in Docusaurus 1 and how we are going to address them in Docusaurus 2.
 
@@ -132,4 +132,3 @@ If you are using Docusaurus, you are part of our community; keep letting us know
 
 Lastly, if you haven't done so already, click the **star** and **watch** button on [GitHub](https://github.com/facebook/Docusaurus), and follow us on [Twitter](https://twitter.com/docusaurus).
 
-<script async src="//cdn.embedly.com/widgets/platform.js" charset="UTF-8"></script>


### PR DESCRIPTION
## Motivation


- Fix weird window scrolling behavior. It shouldn't scroll to top until page is already loaded

Others:
- Webpack javascript rule should also transpile file that use `docusaurus` as its name. This is to make sure that shipped theme packages can be babel transformed
- Remove mdx incompatibility inside one of our blog

<img width="584" alt="error-1" src="https://user-images.githubusercontent.com/17883920/57605070-5c910f00-7598-11e9-8d33-378726f92f6a.PNG">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Throttle internet
Before (window already scroll to top even before loading is finished)

![before](https://user-images.githubusercontent.com/17883920/57605128-83e7dc00-7598-11e9-9712-bbf77d85bc3d.gif)

After
![after scroll](https://user-images.githubusercontent.com/17883920/57605134-86e2cc80-7598-11e9-9b09-87c605fa4da9.gif)