### PR TITLE
fix: right TOC should not strip special chars

### DIFF
--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -22,6 +22,9 @@ The same script can be invoked using npm:
 npm run start
 ```
 
+
+### `/<context>/status`
+
 To run a particular script, just replace the `start` command in the examples above with the command associated with your script.
 
 ## Using arguments

--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -22,9 +22,6 @@ The same script can be invoked using npm:
 npm run start
 ```
 
-
-### `/<context>/status`
-
 To run a particular script, just replace the `start` command in the examples above with the command associated with your script.
 
 ## Using arguments

--- a/packages/docusaurus-1.x/lib/core/toc.js
+++ b/packages/docusaurus-1.x/lib/core/toc.js
@@ -38,7 +38,7 @@ function getTOC(content, headingTags = 'h2', subHeadingTags = 'h3') {
     if (!allowedHeadingLevels.includes(heading.lvl)) {
       return;
     }
-    const rawContent = mdToc.titleize(heading.content);
+    const rawContent = heading.content;
     const entry = {
       hashLink,
       rawContent,


### PR DESCRIPTION
## Motivation

Fix #1457. See that issue for more description.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```md
### `/<context>/status`
```

Before

Wrong TOC
![image](https://user-images.githubusercontent.com/17883920/57715944-6f940400-76aa-11e9-9611-1e6330e09448.png)



After
<img width="886" alt="rightTOC" src="https://user-images.githubusercontent.com/17883920/57715823-2f348600-76aa-11e9-805b-48f2248270f9.PNG">

![image](https://user-images.githubusercontent.com/17883920/57715966-80447a00-76aa-11e9-9cad-fd0e3de385a7.png)

