### PR TITLE
 fix(v2): handle non existent blog, docs, pages

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/index.js
@@ -56,6 +56,10 @@ class DocusaurusPluginContentBlog {
     const {siteConfig} = this.context;
     const blogDir = this.contentPath;
 
+    if (!fs.existsSync(blogDir)) {
+      return null;
+    }
+
     const {baseUrl} = siteConfig;
     const blogFiles = await globby(include, {
       cwd: blogDir,
@@ -158,6 +162,10 @@ class DocusaurusPluginContentBlog {
   }
 
   async contentLoaded({content: blogContents, actions}) {
+    if (!blogContents) {
+      return;
+    }
+
     const {
       blogListComponent,
       blogPostComponent,

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.js
@@ -12,18 +12,18 @@ import loadSidebars from '../sidebars';
 
 describe('loadSidebars', () => {
   test('normal site with sidebars', async () => {
-    const sidebar = require(path.join(
+    const sidebarPath = path.join(
       __dirname,
       '__fixtures__',
       'website',
       'sidebars.json',
-    ));
-    const result = loadSidebars({sidebar});
+    );
+    const result = loadSidebars(sidebarPath);
     expect(result).toMatchSnapshot();
   });
 
   test('site without sidebars', () => {
-    const result = loadSidebars({sidebar: {}});
+    const result = loadSidebars(null);
     expect(result).toMatchSnapshot();
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/index.js
@@ -6,7 +6,7 @@
  */
 
 const globby = require('globby');
-const importFresh = require('import-fresh');
+const fs = require('fs');
 const path = require('path');
 const {idx, normalizeUrl, docuHash} = require('@docusaurus/utils');
 
@@ -48,14 +48,16 @@ class DocusaurusPluginContentDocs {
   // Fetches blog contents and returns metadata for the contents.
   async loadContent() {
     const {include, routeBasePath, sidebarPath} = this.options;
-    const {siteDir, siteConfig} = this.context;
+    const {siteConfig} = this.context;
     const docsDir = this.contentPath;
 
-    // We don't want sidebars to be cached because of hotreloading.
-    const sidebar = importFresh(sidebarPath);
-    const docsSidebars = loadSidebars({siteDir, sidebar});
+    if (!fs.existsSync(docsDir)) {
+      return null;
+    }
 
-    // @tested - build the docs ordering such as next, previous, category and sidebar
+    const docsSidebars = loadSidebars(sidebarPath);
+
+    // Build the docs ordering such as next, previous, category and sidebar
     const order = createOrder(docsSidebars);
 
     // Prepare metadata container.
@@ -113,6 +115,10 @@ class DocusaurusPluginContentDocs {
   async contentLoaded({content, actions}) {
     const {docLayoutComponent, docItemComponent, routeBasePath} = this.options;
     const {addRoute, createData} = actions;
+
+    if (!content) {
+      return;
+    }
 
     const routes = await Promise.all(
       Object.values(content.docs).map(async metadataItem => {

--- a/packages/docusaurus-plugin-content-docs/src/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/index.js
@@ -113,12 +113,11 @@ class DocusaurusPluginContentDocs {
   }
 
   async contentLoaded({content, actions}) {
-    const {docLayoutComponent, docItemComponent, routeBasePath} = this.options;
-    const {addRoute, createData} = actions;
-
     if (!content) {
       return;
     }
+    const {docLayoutComponent, docItemComponent, routeBasePath} = this.options;
+    const {addRoute, createData} = actions;
 
     const routes = await Promise.all(
       Object.values(content.docs).map(async metadataItem => {

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.js
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const fs = require('fs');
+const importFresh = require('import-fresh');
+
 /**
  * Check that item contains only allowed keys
  *
@@ -109,7 +112,11 @@ function normalizeSidebar(sidebars) {
   }, {});
 }
 
-module.exports = function loadSidebars({sidebar}) {
-  const allSidebars = sidebar;
+module.exports = function loadSidebars(sidebarPath) {
+  // We don't want sidebars to be cached because of hotreloading.
+  let allSidebars = {};
+  if (sidebarPath && fs.existsSync(sidebarPath)) {
+    allSidebars = importFresh(sidebarPath);
+  }
   return normalizeSidebar(allSidebars);
 };

--- a/packages/docusaurus-plugin-content-pages/src/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/index.js
@@ -7,6 +7,7 @@
 
 const globby = require('globby');
 const path = require('path');
+const fs = require('fs');
 const {encodePath, fileToPath, docuHash} = require('@docusaurus/utils');
 
 const DEFAULT_OPTIONS = {
@@ -39,6 +40,10 @@ class DocusaurusPluginContentPages {
     const {siteConfig} = this.context;
     const pagesDir = this.contentPath;
 
+    if (!fs.existsSync(pagesDir)) {
+      return null;
+    }
+
     const {baseUrl} = siteConfig;
     const pagesFiles = await globby(include, {
       cwd: pagesDir,
@@ -65,6 +70,10 @@ class DocusaurusPluginContentPages {
 
   async contentLoaded({content, actions}) {
     const {addRoute, createData} = actions;
+
+    if (!content) {
+      return;
+    }
 
     await Promise.all(
       content.map(async metadataItem => {

--- a/packages/docusaurus-plugin-content-pages/src/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/index.js
@@ -69,11 +69,11 @@ class DocusaurusPluginContentPages {
   }
 
   async contentLoaded({content, actions}) {
-    const {addRoute, createData} = actions;
-
     if (!content) {
       return;
     }
+
+    const {addRoute, createData} = actions;
 
     await Promise.all(
       content.map(async metadataItem => {


### PR DESCRIPTION
## Motivation

handle non existent blog, docs, pages

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

Before (bunch of errors)
<img width="630" alt="before-pages" src="https://user-images.githubusercontent.com/17883920/57754384-e10e9980-7720-11e9-9a84-d8c7735d9109.PNG">

After
No error even if pages/docs/blog is empty
<img width="579" alt="after-pages" src="https://user-images.githubusercontent.com/17883920/57754399-e8ce3e00-7720-11e9-874a-1ba65d15ecd5.PNG">
