### PR TITLE
fix: h3 topics with Markdown formatting causes a glitch on mobile

### DIFF
--- a/packages/docusaurus-1.x/lib/core/nav/SideNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/SideNav.js
@@ -189,8 +189,14 @@ class SideNav extends React.Component {
 
               const headings = document.querySelector('.toc-headings');
               headings && headings.addEventListener('click', function(event) {
-                if (event.target.tagName === 'A') {
-                  document.body.classList.remove('tocActive');
+                let el = event.target;
+                while(el !== event.currentTarget){
+                  if (el.tagName === 'A') {
+                    document.body.classList.remove('tocActive');
+                    break;
+                  } else{
+                    el = el.parentNode;
+                  }
                 }
               }, false);
 

--- a/packages/docusaurus-1.x/lib/core/nav/SideNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/SideNav.js
@@ -190,7 +190,7 @@ class SideNav extends React.Component {
               const headings = document.querySelector('.toc-headings');
               headings && headings.addEventListener('click', function(event) {
                 let el = event.target;
-                while(el !== event.currentTarget){
+                while(el !== headings){
                   if (el.tagName === 'A') {
                     document.body.classList.remove('tocActive');
                     break;

--- a/packages/docusaurus-1.x/lib/core/nav/SideNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/SideNav.js
@@ -187,9 +187,9 @@ class SideNav extends React.Component {
               createToggler('#navToggler', '#docsNav', 'docsSliderActive');
               createToggler('#tocToggler', 'body', 'tocActive');
 
-              const headings = document.querySelector('.toc-headings');
+              var headings = document.querySelector('.toc-headings');
               headings && headings.addEventListener('click', function(event) {
-                let el = event.target;
+                var el = event.target;
                 while(el !== headings){
                   if (el.tagName === 'A') {
                     document.body.classList.remove('tocActive');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

we are adding click listener on ".toc-headings" and removing toActive class if the target is "A" tag, Where in case of this issue the target is actually Code tag. 
Look at the below code.
```html
<li><a href="#docusaurus-build"><code>docusaurus-build</code></a></li>
```
Because of this "toActive" class is not getting removed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have done Yarn test, and every test cases passed. 
For verification of the code, I tried the following URL  https://docusaurus.io/docs/en/commands/#docusaurus-build
and it's working as per expectation.

## Edit from maintainer:

Close #1254
Close #1485