### PR TITLE
docs: make it clear in the tutorial where the `docs` folder is

### DIFF
--- a/docs/tutorial-create-pages.md
+++ b/docs/tutorial-create-pages.md
@@ -47,7 +47,7 @@ React is being used as a templating engine for rendering static markup. You can 
 
 ## Create a Documentation Page
 
-1. Create a new file in the `docs` folder called `doc4.md`.
+1. Create a new file in the `docs` folder called `doc4.md`. (The `docs` folder is in the root of your docusaurus installation.)
 1. Paste the following contents:
 
 ```

--- a/docs/tutorial-create-pages.md
+++ b/docs/tutorial-create-pages.md
@@ -47,7 +47,7 @@ React is being used as a templating engine for rendering static markup. You can 
 
 ## Create a Documentation Page
 
-1. Create a new file in the `docs` folder called `doc4.md`. (The `docs` folder is in the root of your docusaurus installation.)
+1. Create a new file in the `docs` folder called `doc4.md`. The `docs` folder is in the root of your Docusaurus project, one level above `website`.
 1. Paste the following contents:
 
 ```


### PR DESCRIPTION
I'm afraid it was not clear, to the beginner user—who this tutorial [is for][1]—where the `docs` folder was . 

The only reason I know this is because I'm a beginner user and I tried for too many minutes to find the `docs` folder inside the `website` folder. :sweat_smile: 

I had this assumption because the [previous example][2] is offered under the assumption that you're in the `website` folder.

[1]: https://docusaurus.io/docs/en/next/tutorial-setup
[2]: https://docusaurus.io/docs/en/next/tutorial-create-pages#creating-a-regular-page

Feel free to change the wording, I just want to make it clear where you should be looking, if you're new.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
I'm new to Docusaurus and I want to make the tutorial clear for new users.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

I haven't... and now I have. Sorry about my commit not matching the style. I'm not sure how to fix that now.

## Test Plan

N/A, I'm pretty sure. :sweat_smile: 

## Related PRs

Also, N/A.
