### PR TITLE
docs: add hint for linking dependencies time

### DIFF
--- a/docs/tutorial-create-new-site.md
+++ b/docs/tutorial-create-new-site.md
@@ -15,6 +15,8 @@ In this section we'll get our Docusaurus site up and running for local developme
 docusaurus-init
 ```
 
+> The `Linking dependencies...` step might take a while, but it will finish eventually.
+
 The following contents will be created for you in the directory you are in.
 
 ```sh


### PR DESCRIPTION
In this tutorial we assume that the user may or may not have used Node.js. It would follow then, based on how long it takes the "Linking dependencies" step to complete—243.61s for me—that we give them a hint that it might take a minute.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Support users new to Node.js by assuring them that the "Linking dependencies" step takes time, and that the program has not frozen.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

:+1: 

## Test Plan

Just added a hint to the tutorial. No change in code.

## Related PRs

:no_good_man:  
