### PR TITLE
doc: change tutorial git to suggest HTTPS

### DIFF
--- a/docs/tutorial-setup.md
+++ b/docs/tutorial-setup.md
@@ -55,9 +55,9 @@ We highly recommend you to install Yarn, an alternative package manager that has
 5. Clone your repository to your local machine:
 
 ```sh
-git clone git@github.com:USERNAME/docusaurus-tutorial.git ##SSH
-#or
-git clone https://github.com/USERNAME/docusaurus-tutorial.git #HTTPS
+git clone git@github.com:USERNAME/docusaurus-tutorial.git # SSH
+# or
+git clone https://github.com/USERNAME/docusaurus-tutorial.git # HTTPS
 ```
 
 6. `cd` into the repository which you just created.

--- a/docs/tutorial-setup.md
+++ b/docs/tutorial-setup.md
@@ -55,7 +55,9 @@ We highly recommend you to install Yarn, an alternative package manager that has
 5. Clone your repository to your local machine:
 
 ```sh
-git clone https://github.com/USERNAME/docusaurus-tutorial.git
+git clone git@github.com:USERNAME/docusaurus-tutorial.git ##SSH
+#or
+git clone https://github.com/USERNAME/docusaurus-tutorial.git #HTTPS
 ```
 
 6. `cd` into the repository which you just created.

--- a/docs/tutorial-setup.md
+++ b/docs/tutorial-setup.md
@@ -55,7 +55,7 @@ We highly recommend you to install Yarn, an alternative package manager that has
 5. Clone your repository to your local machine:
 
 ```sh
-git clone git@github.com:USERNAME/docusaurus-tutorial.git
+git clone https://github.com/USERNAME/docusaurus-tutorial.git
 ```
 
 6. `cd` into the repository which you just created.


### PR DESCRIPTION
Since we're instructing the user to create a new repository, it might be a safe bet to assume that they don't have their SSH keys set up. HTTPS might be a better option in this context.

## Motivation

The motivation is to make the tutorial stop-free for new users. If the user hasn't set up their SSH keys, this part of the tutorial presents a road block. If I understand correctly, using HTTPS instead, here, removes that possible road block.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Indeed.

## Test Plan
I tried using cloning with HTTPS on my Windows 7 Git Bash and it worked, when an SSH clone did not.

## Related PRs

This is related to issue #1469 
