### PR TITLE
docs: normalized spelling of `web server`

### DIFF
--- a/docs/getting-started-docker.md
+++ b/docs/getting-started-docker.md
@@ -5,11 +5,11 @@ title: Docker
 
 [Docker](https://www.docker.com/) is a tool that enables you to create, deploy, and manage lightweight, stand-alone packages that contain everything needed to run an application. It can help us to avoid conflicting dependencies & unwanted behavior when running Docusaurus.
 
-## Run the local webserver in docker
+## Run the local web server in docker
 
 Ensure you have previously installed [docker](https://www.docker.com/get-started).
 
-To run the local webserver:
+To run the local web server:
 
 1. **Build the docker image** -- Enter the folder where you have Docusaurus installed. Run `docker build -t docusaurus-doc .`
 
@@ -23,7 +23,7 @@ To run the local webserver:
 
 ## Use docker-compose
 
-We can also use `docker-compose` to configure our application. This feature of docker allows you to run the webserver and any additional services with a single command.
+We can also use `docker-compose` to configure our application. This feature of docker allows you to run the web server and any additional services with a single command.
 
 > Compose is a tool for defining and running multi-container Docker applications. With Compose, you use a YAML file to configure your application’s services. Then, with a single command, you create and start all the services from your configuration.
 
@@ -58,6 +58,6 @@ services:
 
 ```
 
-To run a local webserver with `docker-compose` run `docker-compose up`.
+To run a local web server with `docker-compose` run `docker-compose up`.
 
 To build static HTML pages for publishing run `docker-compose run docusaurus bash -c 'yarn publish-gh-pages'`

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -63,7 +63,7 @@ described in the [Installation](#installing-docusaurus) section, you will have a
 runnable, example website to use as your site's base. To run:
 
 1.  `cd website`
-1.  From within the `website` directory, run the local webserver using
+1.  From within the `website` directory, run the local web server using
     `yarn start` or `npm start`.
 1.  Load the example site at http://localhost:3000 if it did not already open
     automatically. If port 3000 has already been taken, another port will be used. Look at the console messages to see which.

--- a/docs/tutorial-create-pages.md
+++ b/docs/tutorial-create-pages.md
@@ -88,7 +88,7 @@ I can write content using [GitHub-flavored Markdown syntax](https://github.githu
 }
 ```
 
-4. Kill your webserver (<kbd>Cmd</kbd> + <kbd>C</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>) and restart it (with `npm run start`) because a server restart is needed for sidebar changes.
+4. Kill your web server (<kbd>Cmd</kbd> + <kbd>C</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>) and restart it (with `npm run start`) because a server restart is needed for sidebar changes.
 5. Navigate to http://localhost:3000/docs/doc4.
 
 You've created your first documentation page on Docusaurus! The `sidebars.json` is where you specify the order of your documentation pages and in the front matter of the Markdown file is where you provide metadata about that page.

--- a/docs/tutorial-publish-site.md
+++ b/docs/tutorial-publish-site.md
@@ -9,7 +9,7 @@ Next we'll learn how to publish the site to the WWW for everyone to browse! For 
 
 ## Put the Site Online
 
-Kill the webserver first by pressing Cmd + C or Ctrl + C depending on your operating system.
+Kill the web server first by pressing Cmd + C or Ctrl + C depending on your operating system.
 
 In `website/siteConfig.js`, fill in the following fields:
 

--- a/website-1.x/versioned_docs/version-1.0.x/getting-started-installation.md
+++ b/website-1.x/versioned_docs/version-1.0.x/getting-started-installation.md
@@ -48,7 +48,7 @@ Running the Docusaurus initialization script, `docusaurus-init`, produces a runn
 1. In your root, rename `docs-examples-from-docusaurus` to `docs`.
 1. `cd website`
 1. Rename `blog-examples-from-docusaurus` to `blog`.
-1. Run the local webserver via `yarn start` or `npm start`.
+1. Run the local web server via `yarn start` or `npm start`.
 1. Load the example site at http://localhost:3000. You should see the example site loaded in your web browser.
 
 ![](/img/getting-started-preparation-verify.png)

--- a/website-1.x/versioned_docs/version-1.1.x/getting-started-installation.md
+++ b/website-1.x/versioned_docs/version-1.1.x/getting-started-installation.md
@@ -50,7 +50,7 @@ Running the Docusaurus initialization script, `docusaurus-init`, produces a runn
 1. In your root, rename `docs-examples-from-docusaurus` to `docs`.
 1. `cd website`
 1. Rename `blog-examples-from-docusaurus` to `blog`.
-1. Run the local webserver via `yarn start` or `npm start`.
+1. Run the local web server via `yarn start` or `npm start`.
 1. Load the example site at http://localhost:3000. You should see the example site loaded in your web browser.
 
 ![](/img/getting-started-preparation-verify.png)

--- a/website-1.x/versioned_docs/version-1.2.x/getting-started-installation.md
+++ b/website-1.x/versioned_docs/version-1.2.x/getting-started-installation.md
@@ -48,7 +48,7 @@ Running the Docusaurus initialization script, `docusaurus-init`, produces a runn
 1.  In your root, rename `docs-examples-from-docusaurus` to `docs`.
 1.  `cd website`
 1.  Rename `blog-examples-from-docusaurus` to `blog`.
-1.  Run the local webserver via `yarn start` or `npm start`.
+1.  Run the local web server via `yarn start` or `npm start`.
 1.  Load the example site at http://localhost:3000. You should see the example site loaded in your web browser. There's also a LiveReload server running and any changes made to the docs and files in the `website` directory will cause the page to refresh.
 
 ![](/img/getting-started-preparation-verify.png)

--- a/website-1.x/versioned_docs/version-1.3.x/getting-started-installation.md
+++ b/website-1.x/versioned_docs/version-1.3.x/getting-started-installation.md
@@ -63,7 +63,7 @@ runnable, example website to use as your site's base. To run:
 1.  In your root, rename `docs-examples-from-docusaurus` to `docs`.
 1.  `cd website`
 1.  Rename `blog-examples-from-docusaurus` to `blog`.
-1.  From within the `website` directory, run the local webserver using 
+1.  From within the `website` directory, run the local web server using 
     `yarn start` or `npm start`.
 1.  Load the example site at http://localhost:3000 if it did not already open
     automatically.

--- a/website-1.x/versioned_docs/version-1.4.x/getting-started-docker.md
+++ b/website-1.x/versioned_docs/version-1.4.x/getting-started-docker.md
@@ -6,11 +6,11 @@ original_id: docker
 
 [Docker](https://www.docker.com/) is a tool that enables you to create, deploy, and manage lightweight, stand-alone packages that contain everything needed to run an application. It can help us to avoid conflicting dependencies & unwanted behavior when running Docusaurus.
 
-## Run the local webserver in docker
+## Run the local web server in docker
 
 Ensure you have previously installed [docker](https://www.docker.com/get-started).
 
-To run the local webserver:
+To run the local web server:
 
 1. **Build the docker image** -- Enter the folder where you have Docusaurus installed. Run `docker build -t docusaurus-doc .`
 
@@ -24,7 +24,7 @@ To run the local webserver:
 
 ## Use docker-compose
 
-We can also use `docker-compose` to configure our application. This feature of docker allows you to run the webserver and any additional services with a single command.
+We can also use `docker-compose` to configure our application. This feature of docker allows you to run the web server and any additional services with a single command.
 
 > Compose is a tool for defining and running multi-container Docker applications. With Compose, you use a YAML file to configure your application’s services. Then, with a single command, you create and start all the services from your configuration.
 
@@ -59,6 +59,6 @@ services:
 
 ```
 
-To run a local webserver with `docker-compose` run `docker-compose up`.
+To run a local web server with `docker-compose` run `docker-compose up`.
 
 To build static HTML pages for publishing run `docker-compose run docusaurus bash -c 'yarn publish-gh-pages'`

--- a/website-1.x/versioned_docs/version-1.5.x/getting-started-installation.md
+++ b/website-1.x/versioned_docs/version-1.5.x/getting-started-installation.md
@@ -63,7 +63,7 @@ runnable, example website to use as your site's base. To run:
 1.  In your root, rename `docs-examples-from-docusaurus` to `docs`.
 1.  `cd website`
 1.  Rename `blog-examples-from-docusaurus` to `blog`.
-1.  From within the `website` directory, run the local webserver using 
+1.  From within the `website` directory, run the local web server using 
     `yarn start` or `npm start`.
 1.  Load the example site at http://localhost:3000 if it did not already open
     automatically.

--- a/website-1.x/versioned_docs/version-1.8.0/getting-started-installation.md
+++ b/website-1.x/versioned_docs/version-1.8.0/getting-started-installation.md
@@ -63,7 +63,7 @@ runnable, example website to use as your site's base. To run:
 1.  In your root, rename `docs-examples-from-docusaurus` to `docs`.
 1.  `cd website`
 1.  Rename `blog-examples-from-docusaurus` to `blog`.
-1.  From within the `website` directory, run the local webserver using
+1.  From within the `website` directory, run the local web server using
     `yarn start` or `npm start`.
 1.  Load the example site at http://localhost:3000 if it did not already open
     automatically.

--- a/website-1.x/versioned_docs/version-1.9.0/getting-started-installation.md
+++ b/website-1.x/versioned_docs/version-1.9.0/getting-started-installation.md
@@ -64,7 +64,7 @@ described in the [Installation](#installing-docusaurus) section, you will have a
 runnable, example website to use as your site's base. To run:
 
 1.  `cd website`
-1.  From within the `website` directory, run the local webserver using
+1.  From within the `website` directory, run the local web server using
     `yarn start` or `npm start`.
 1.  Load the example site at http://localhost:3000 if it did not already open
     automatically. If port 3000 has already been taken, another port will be used. Look at the console messages to see which.

--- a/website-1.x/versioned_docs/version-1.9.0/tutorial-create-pages.md
+++ b/website-1.x/versioned_docs/version-1.9.0/tutorial-create-pages.md
@@ -82,7 +82,7 @@ In this session, we learned how Docusaurus makes it really simple to create a we
 }
 ```
 
-4. Kill your webserver (<kbd>Cmd</kbd> + <kbd>C</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>) and restart it (with `npm run start`) because a server restart is needed for sidebar changes.
+4. Kill your web server (<kbd>Cmd</kbd> + <kbd>C</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd>) and restart it (with `npm run start`) because a server restart is needed for sidebar changes.
 5. Navigate to http://localhost:3000/docs/f8.
 
 You've created your first documentation page on Docusaurus! The `sidebars.json` is where you specify the order of your documentation pages and in the front matter of the Markdown file is where you provide metadata about that page.

--- a/website-1.x/versioned_docs/version-1.9.0/tutorial-publish-site.md
+++ b/website-1.x/versioned_docs/version-1.9.0/tutorial-publish-site.md
@@ -10,7 +10,7 @@ Next we'll learn how to publish the site to the WWW for everyone to browse! For 
 
 ## Put the Site Online
 
-Kill the webserver first by pressing Cmd + C or Ctrl + C depending on your operating system.
+Kill the web server first by pressing Cmd + C or Ctrl + C depending on your operating system.
 
 In `website/siteConfig.js`, fill in the following fields:
 


### PR DESCRIPTION
I found **webserver vs web server**, and I saw all of them use *web server* instead of *webserver*

Example: https://en.wikipedia.org/wiki/Web_server

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

