### PR TITLE
chore: don't need ignore `node_modules`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 __fixtures__
 dist
-node_modules
 build
 jest.config.js
 jest.transform.js


### PR DESCRIPTION
`node_modules` is ignored by default so we don't need it
