### PR TITLE
fix(v2): should be able to build even if static folder doesnt exist

### DIFF
--- a/packages/docusaurus/src/commands/build.js
+++ b/packages/docusaurus/src/commands/build.js
@@ -92,16 +92,18 @@ module.exports = async function build(siteDir, cliOptions = {}) {
 
   // Copy static files.
   const staticDir = path.resolve(siteDir, 'static');
-  const staticFiles = await globby(['**'], {
-    cwd: staticDir,
-  });
-  await Promise.all(
-    staticFiles.map(async source => {
-      const fromPath = path.resolve(staticDir, source);
-      const toPath = path.resolve(outDir, source);
-      return fs.copy(fromPath, toPath);
-    }),
-  );
+  if (fs.existsSync(staticDir)) {
+    const staticFiles = await globby(['**'], {
+      cwd: staticDir,
+    });
+    await Promise.all(
+      staticFiles.map(async source => {
+        const fromPath = path.resolve(staticDir, source);
+        const toPath = path.resolve(outDir, source);
+        return fs.copy(fromPath, toPath);
+      }),
+    );
+  }
 
   /* Plugin lifecycle - postBuild */
   await Promise.all(


### PR DESCRIPTION
## Motivation

should be able to build even if static folder doesnt exist
![image](https://user-images.githubusercontent.com/17883920/57924290-54f2a280-78d7-11e9-9e37-d168bfaf8172.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![image](https://user-images.githubusercontent.com/17883920/57924314-65a31880-78d7-11e9-9833-465b94fa02cd.png)
