### PR TITLE
h3 topics with Markdown formatting causes a glitch on mobile using css

### DIFF
--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -1993,6 +1993,19 @@ input::placeholder {
   padding-bottom: 5px;
 }
 
+.toc-headings a { 
+  position: relative;
+}
+
+.toc-headings a:after { 
+  position : absolute ;
+  content : "";
+  left : 0;
+  right : 0;
+  top : 0;
+  bottom: 0;
+}
+
 @media only screen and (min-width: 1024px) {
   .toc section .navGroups {
     display: block;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I have created a PR for the same issue which but it solves using JS but this solves the problem using CSS only.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have done Yarn test, and every test cases passed.
For verification of the code, I tried the following URL https://docusaurus.io/docs/en/commands/#docusaurus-build
and it's working as per expectation. In the preview build, please invalidate the CDN cache also, so that it gets the newer code.

## Related PRs

Related PR - https://github.com/facebook/Docusaurus/pull/1467
