### PR TITLE
fix: wrong `relativeHref` in next/prev button

### DIFF
--- a/packages/docusaurus-1.x/lib/core/DocsLayout.js
+++ b/packages/docusaurus-1.x/lib/core/DocsLayout.js
@@ -24,11 +24,11 @@ const {idx, getGitLastUpdatedTime, getGitLastUpdatedBy} = require('./utils.js');
 class DocsLayout extends React.Component {
   getRelativeURL = (from, to) => {
     const extension = this.props.config.cleanUrl ? '' : '.html';
-    const relativeHref =
-      path
-        .relative(from, to)
-        .replace('\\', '/')
-        .replace(/^\.\.\//, '') + extension;
+    const relativeHref = path
+      .relative(`${from}.html`, `${to}.html`)
+      .replace('\\', '/')
+      .replace(/^\.\.\//, '')
+      .replace(/\.html$/, extension);
     return url.resolve(
       `${this.props.config.baseUrl}${this.props.metadata.permalink}`,
       relativeHref,


### PR DESCRIPTION
## Motivation

Resolved #1344

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- I clone https://github.com/reduxjs/redux and install all dependencies
- Use this commit for `node_modules/docusaurus`
- Run `yarn start`
- Go to `http://localhost:3000/faq`
- Go to the bottom of the page and click on "General" and it goes to `http://localhost:3000/faq/general`
- Go to the bottom of the page and click on "FAQ Index" and it goes to `http://localhost:3000/faq` (it goes to `http://localhost:3000/` without this commit)

You can see the preview in https://hongarc.github.io/redux/faq

