### PR TITLE
fix: change regex to match index.html

### DIFF
--- a/packages/docusaurus-1.x/lib/server/readMetadata.js
+++ b/packages/docusaurus-1.x/lib/server/readMetadata.js
@@ -143,7 +143,7 @@ function processMetadata(file, refDir) {
   const rawContent = result.rawContent;
 
   if (!metadata.id) {
-    metadata.id = path.basename(file, path.extname(file));
+    metadata.id = path.parse(file).name;
   }
   if (metadata.id.includes('/')) {
     throw new Error('Document id cannot include "/".');

--- a/packages/docusaurus-1.x/lib/server/readMetadata.js
+++ b/packages/docusaurus-1.x/lib/server/readMetadata.js
@@ -374,10 +374,7 @@ function generateMetadataBlog() {
       }
       const metadata = blog.getMetadata(file);
       // Extract, YYYY, MM, DD from the file name
-      const filePathDateArr = path
-        .basename(file)
-        .toString()
-        .split('-');
+      const filePathDateArr = path.basename(file).split('-');
       metadata.date = new Date(
         `${filePathDateArr[0]}-${filePathDateArr[1]}-${
           filePathDateArr[2]


### PR DESCRIPTION
## Motivation

- `path.basename` return `string`, don't need using `toString`
- I think `path.parse` is better(don't sure)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

| file                  | path.basename(file, path.extname(file)) | path.parse(file).name |
|-----------------------|-----------------------------------------|-----------------------|
| /path/to/filename.ext | filename                                | filename              |
| /path/to/filename2    | filename2                               | filename2             |

`path.basename` return string so I think we don't need to check `'somestring'.toString()` (actually, I tested this change and one more PR for Redux's website and I didn't any error)