### PR TITLE
fix: show `subcategory` if it is exist for title of nav

### DIFF
--- a/packages/docusaurus-1.x/lib/core/nav/SideNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/SideNav.js
@@ -143,7 +143,10 @@ class SideNav extends React.Component {
               <h2>
                 <i>›</i>
                 <span>
-                  {this.getLocalizedCategoryString(this.props.current.category)}
+                  {this.getLocalizedCategoryString(
+                    this.props.current.subcategory ||
+                      this.props.current.category,
+                  )}
                 </span>
               </h2>
               {siteConfig.onPageNav === 'separate' && (


### PR DESCRIPTION
## Motivation

Fixed #1338

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test with `testing-library`'s website.
Live preview in https://hongarc.github.io/testing-library-docs/

- Go to https://hongarc.github.io/testing-library-docs/
- View page as mobile (chrome dev tools)
- Click`docs` in nav-site
- Click `toggle of nav` click one item in `DOM Testing Library`


Before:
![image](https://user-images.githubusercontent.com/19208123/57977372-5334f600-7a21-11e9-8223-f5a619c54c35.png)


After:
It shows subcategory's title if it is a subcategory
![image](https://user-images.githubusercontent.com/19208123/57977375-62b43f00-7a21-11e9-9d62-f20a81c51f78.png)

and keep `category`'s title if it is a category
![image](https://user-images.githubusercontent.com/19208123/57977381-78296900-7a21-11e9-9ef6-b653ee7b0f46.png)
