### PR TITLE
chore: upgrade shelljs version

### DIFF
--- a/packages/docusaurus-1.x/package.json
+++ b/packages/docusaurus-1.x/package.json
@@ -67,7 +67,7 @@
     "react-dom": "^16.5.0",
     "remarkable": "^1.7.1",
     "request": "^2.87.0",
-    "shelljs": "^0.7.8",
+    "shelljs": "^0.8.3",
     "sitemap": "^1.13.0",
     "tcp-port-used": "^0.1.2",
     "tiny-lr": "^1.1.1",

--- a/packages/docusaurus-init-1.x/package.json
+++ b/packages/docusaurus-init-1.x/package.json
@@ -15,6 +15,6 @@
   },
   "dependencies": {
     "chalk": "^2.1.0",
-    "shelljs": "^0.7.8"
+    "shelljs": "^0.8.3"
   }
 }

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -63,7 +63,7 @@
     "react-router-config": "^5.0.0",
     "react-router-dom": "^5.0.0",
     "semver": "^6.0.0",
-    "shelljs": "^0.8.2",
+    "shelljs": "^0.8.3",
     "static-site-generator-webpack-plugin": "^3.4.2",
     "style-loader": "^0.22.1",
     "terser-webpack-plugin": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12664,16 +12664,7 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shelljs@^0.8.2:
+shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==


### PR DESCRIPTION
## Motivation

`shelljs` version in `docusaurus-init` is very old. That version is released 2 years ago, I suspect https://github.com/facebook/Docusaurus/issues/1330#issuecomment-494286733 is happening because of shelljs

There are lot of bug fixes done in the newer version https://github.com/shelljs/shelljs/blob/master/CHANGELOG.md

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Locally both development server v1 and v2 still works
- Netlify for both version 