### PR TITLE
refactor(v2): use copy webpack plugin instead of manual copy

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -42,6 +42,7 @@
     "classnames": "^2.2.6",
     "clean-webpack-plugin": "^2.0.1",
     "commander": "^2.16.0",
+    "copy-webpack-plugin": "^5.0.3",
     "css-loader": "^1.0.0",
     "ejs": "^2.6.1",
     "envinfo": "^7.2.0",

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -8,12 +8,12 @@
 import webpack, {Configuration, Plugin} from 'webpack';
 import merge from 'webpack-merge';
 import CleanWebpackPlugin from 'clean-webpack-plugin';
+import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ReactLoadableSSRAddon from 'react-loadable-ssr-addon';
 import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer';
 import path from 'path';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import globby from 'globby';
 import {load, CLIOptions, Props} from '../server';
 import {createClientConfig} from '../webpack/client';
 import {createServerConfig} from '../webpack/server';
@@ -67,7 +67,17 @@ export async function build(
     ].filter(Boolean) as Plugin[],
   });
 
-  let serverConfig: Configuration = createServerConfig(props);
+  const staticDir = path.resolve(siteDir, 'static');
+  let serverConfig: Configuration = merge(createServerConfig(props), {
+    plugins: [
+      new CopyWebpackPlugin([
+        {
+          from: staticDir,
+          to: 'static',
+        },
+      ]),
+    ],
+  });
 
   // Plugin lifecycle - configureWebpack
   plugins.forEach(plugin => {
@@ -94,21 +104,6 @@ export async function build(
   if (serverConfig.output && serverConfig.output.filename) {
     const serverBundle = path.join(outDir, serverConfig.output.filename);
     fs.existsSync(serverBundle) && fs.unlinkSync(serverBundle);
-  }
-
-  // Copy static files.
-  const staticDir = path.resolve(siteDir, 'static');
-  if (fs.existsSync(staticDir)) {
-    const staticFiles = await globby(['**'], {
-      cwd: staticDir,
-    });
-    await Promise.all(
-      staticFiles.map(async source => {
-        const fromPath = path.resolve(staticDir, source);
-        const toPath = path.resolve(outDir, source);
-        return fs.copy(fromPath, toPath);
-      }),
-    );
   }
 
   /* Plugin lifecycle - postBuild */

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -18,7 +18,7 @@ import {load, CLIOptions, Props} from '../server';
 import {createClientConfig} from '../webpack/client';
 import {createServerConfig} from '../webpack/server';
 import {applyConfigureWebpack} from '../webpack/utils';
-import { STATIC_DIR_NAME } from '../constants';
+import {STATIC_DIR_NAME} from '../constants';
 
 function compile(config: Configuration[]): Promise<any> {
   return new Promise((resolve, reject) => {

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -18,6 +18,7 @@ import {load, CLIOptions, Props} from '../server';
 import {createClientConfig} from '../webpack/client';
 import {createServerConfig} from '../webpack/server';
 import {applyConfigureWebpack} from '../webpack/utils';
+import { STATIC_DIR_NAME } from '../constants';
 
 function compile(config: Configuration[]): Promise<any> {
   return new Promise((resolve, reject) => {
@@ -67,13 +68,12 @@ export async function build(
     ].filter(Boolean) as Plugin[],
   });
 
-  const staticDir = path.resolve(siteDir, 'static');
   let serverConfig: Configuration = merge(createServerConfig(props), {
     plugins: [
       new CopyWebpackPlugin([
         {
-          from: staticDir,
-          to: 'static',
+          from: path.resolve(siteDir, STATIC_DIR_NAME),
+          to: STATIC_DIR_NAME,
         },
       ]),
     ],

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -20,7 +20,7 @@ import WebpackDevServer from 'webpack-dev-server';
 import merge from 'webpack-merge';
 import {normalizeUrl} from '@docusaurus/utils';
 import {load, CLIOptions} from '../server';
-import {CONFIG_FILE_NAME} from '../constants';
+import {CONFIG_FILE_NAME, STATIC_DIR_NAME} from '../constants';
 import {createClientConfig} from '../webpack/client';
 import {applyConfigureWebpack} from '../webpack/utils';
 
@@ -130,7 +130,7 @@ export async function start(
     overlay: true,
     host,
     before: app => {
-      app.use(baseUrl, express.static(path.resolve(siteDir, 'static')));
+      app.use(baseUrl, express.static(path.resolve(siteDir, STATIC_DIR_NAME)));
       // TODO: add plugins beforeDevServer and afterDevServer hook
     },
   };

--- a/packages/docusaurus/src/constants.ts
+++ b/packages/docusaurus/src/constants.ts
@@ -6,4 +6,5 @@
  */
 
 export const GENERATED_FILES_DIR_NAME = '.docusaurus';
+export const STATIC_DIR_NAME = 'static';
 export const CONFIG_FILE_NAME = 'docusaurus.config.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4282,6 +4282,24 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-webpack-plugin@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.3.tgz#2179e3c8fd69f13afe74da338896f1f01a875b5c"
+  integrity sha512-PlZRs9CUMnAVylZq+vg2Juew662jWtwOXOqH4lbQD9ZFhRG9R7tVStOgHt21CBGVq7k5yIJaz8TXDLSjV+Lj8Q==
+  dependencies:
+    cacache "^11.3.2"
+    find-cache-dir "^2.1.0"
+    glob-parent "^3.1.0"
+    globby "^7.1.1"
+    is-glob "^4.0.1"
+    loader-utils "^1.2.3"
+    minimatch "^3.0.4"
+    normalize-path "^3.0.0"
+    p-limit "^2.2.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
+    webpack-log "^2.0.0"
+
 core-js-compat@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.0.1.tgz#bff73ba31ca8687431b9c88f78d3362646fb76f0"
@@ -4946,7 +4964,7 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-dir-glob@^2.2.2:
+dir-glob@^2.0.0, dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
@@ -6153,7 +6171,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^2.0.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -6671,6 +6689,18 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 globule@^1.0.0:
   version "1.2.1"
@@ -10392,7 +10422,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==


### PR DESCRIPTION
## Motivation

Refactor the "static" files copying into using https://github.com/webpack-contrib/copy-webpack-plugin.

This has several advantages:
- We have less codes in `commands/build.ts`
- User can modify the copy behavior or even remove the copywebpackplugin behavior itself with `configureWebpack`
- We can use all the features from copy-webpack-plugin like transforming the copied files.

Disadvantage
- Tied to webpack

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local build

<img width="539" alt="build working" src="https://user-images.githubusercontent.com/17883920/58111196-9a8ad480-7c23-11e9-8a74-4bd8f2077681.PNG">
