### PR TITLE
fix(v2): wrong copy static files target directory

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -73,7 +73,7 @@ export async function build(
       new CopyWebpackPlugin([
         {
           from: path.resolve(siteDir, STATIC_DIR_NAME),
-          to: STATIC_DIR_NAME,
+          to: outDir,
         },
       ]),
     ],


### PR DESCRIPTION
## Motivation

<img width="954" alt="broke" src="https://user-images.githubusercontent.com/17883920/58144885-cb4e2680-7c82-11e9-90c3-3e358da31061.PNG">

Static files was copied to wrong place.
 It was copied to https://docusaurus-2.netlify.com/static/img/docusaurus_keytar.svg
but not https://docusaurus-2.netlify.com/img/docusaurus_keytar.svg

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Build locally and test it with python http server

<img width="946" alt="before" src="https://user-images.githubusercontent.com/17883920/58144909-e28d1400-7c82-11e9-9d95-4d3f345b02f1.PNG">

<img width="959" alt="after" src="https://user-images.githubusercontent.com/17883920/58144912-e456d780-7c82-11e9-98e8-bfc31f30bbd0.PNG">

