### PR TITLE
Fix modules path on windows

### DIFF
--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -107,8 +107,8 @@ ${Object.keys(registry)
   .map(
     key => `  '${key}': {
     'importStatement': ${registry[key].importStatement},
-    'module': '${registry[key].modulePath}',
-    'webpack': require.resolveWeak('${registry[key].modulePath}'),
+    'module': '${registry[key].modulePath.replace(/\\/g, '/')}',
+    'webpack': require.resolveWeak('${registry[key].modulePath.replace(/\\/g, '/')}'),
   },`,
   )
   .join('\n')}};\n`,


### PR DESCRIPTION

## Motivation

When we try to build the app on a windows pc, the modules path were wrong. Now with this tiny fix, the build run smoothly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

When we "yarn start" the app build is successful.

## Related PRs

Nothing change, just a fix