### PR TITLE
fix(v2): wrong modules path on windows

### DIFF
--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -6,7 +6,7 @@
  */
 
 import path from 'path';
-import {generate} from '@docusaurus/utils';
+import {generate, posixPath} from '@docusaurus/utils';
 
 import {loadConfig, DocusaurusConfig} from './config';
 import {loadThemeAlias} from './themes';
@@ -107,8 +107,8 @@ ${Object.keys(registry)
   .map(
     key => `  '${key}': {
     'importStatement': ${registry[key].importStatement},
-    'module': '${registry[key].modulePath}',
-    'webpack': require.resolveWeak('${registry[key].modulePath}'),
+    'module': '${posixPath(registry[key].modulePath)}',
+    'webpack': require.resolveWeak('${posixPath(registry[key].modulePath)}'),
   },`,
   )
   .join('\n')}};\n`,

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -6,7 +6,7 @@
  */
 
 import path from 'path';
-import {generate, posixPath} from '@docusaurus/utils';
+import {generate} from '@docusaurus/utils';
 
 import {loadConfig, DocusaurusConfig} from './config';
 import {loadThemeAlias} from './themes';
@@ -107,8 +107,8 @@ ${Object.keys(registry)
   .map(
     key => `  '${key}': {
     'importStatement': ${registry[key].importStatement},
-    'module': '${posixPath(registry[key].modulePath)}',
-    'webpack': require.resolveWeak('${posixPath(registry[key].modulePath)}'),
+    'module': ${JSON.stringify(registry[key].modulePath)},
+    'webpack': require.resolveWeak(${JSON.stringify(registry[key].modulePath)}),
   },`,
   )
   .join('\n')}};\n`,


### PR DESCRIPTION
## Motivation

When we try to build the app on a windows pc, the modules path were wrong. Now with this tiny fix, the build run smoothly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

When we "yarn start" the app build is successful.

## Related PRs

Nothing change, just a fix