### PR TITLE
fix: replace Boolean with boolean in typescript type annotation

### DIFF
--- a/packages/docusaurus/src/commands/init.ts
+++ b/packages/docusaurus/src/commands/init.ts
@@ -13,7 +13,7 @@ import path from 'path';
 import _ from 'lodash';
 import {execSync} from 'child_process';
 
-function hasYarn(): Boolean {
+function hasYarn(): boolean {
   try {
     execSync('yarnpkg --version', {stdio: 'ignore'});
     return true;
@@ -22,7 +22,7 @@ function hasYarn(): Boolean {
   }
 }
 
-function isValidGitRepoUrl(gitRepoUrl): Boolean {
+function isValidGitRepoUrl(gitRepoUrl): boolean {
   return gitRepoUrl.startsWith('https://') || gitRepoUrl.startsWith('git@');
 }
 


### PR DESCRIPTION
## Motivation

According to [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html), using `Boolean` is bad. Looking at the code, I don't think it requires the `Boolean` wrapper type.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

N/A