### PR TITLE
fix: don't collapse the blog navigation even if collapsible is true

### DIFF
--- a/packages/docusaurus-1.x/lib/core/DocsLayout.js
+++ b/packages/docusaurus-1.x/lib/core/DocsLayout.js
@@ -94,7 +94,10 @@ class DocsLayout extends React.Component {
         version={metadata.version}
         metadata={metadata}>
         <div className="docMainWrapper wrapper">
-          <DocsSidebar metadata={metadata} />
+          <DocsSidebar
+            collapsible={this.props.config.docsSideNavCollapsible}
+            metadata={metadata}
+          />
           <Container className="mainContainer">
             <DocComponent
               metadata={metadata}

--- a/packages/docusaurus-1.x/lib/core/DocsSidebar.js
+++ b/packages/docusaurus-1.x/lib/core/DocsSidebar.js
@@ -11,7 +11,6 @@ const Container = require('./Container.js');
 const SideNav = require('./nav/SideNav.js');
 const Metadata = require('../core/metadata.js');
 
-const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 const readCategories = require('../server/readCategories.js');
 
 let languages;
@@ -41,7 +40,7 @@ class DocsSidebar extends React.Component {
     return (
       <Container className="docsNavContainer" id="docsNav" wrapper={false}>
         <SideNav
-          collapsible={siteConfig.docsSideNavCollapsible}
+          collapsible={this.props.collapsible}
           language={this.props.metadata.language}
           root={this.props.root}
           title={this.props.title}

--- a/packages/docusaurus-1.x/lib/core/DocsSidebar.js
+++ b/packages/docusaurus-1.x/lib/core/DocsSidebar.js
@@ -10,6 +10,8 @@ const fs = require('fs');
 const Container = require('./Container.js');
 const SideNav = require('./nav/SideNav.js');
 const Metadata = require('../core/metadata.js');
+
+const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 const readCategories = require('../server/readCategories.js');
 
 let languages;
@@ -39,6 +41,7 @@ class DocsSidebar extends React.Component {
     return (
       <Container className="docsNavContainer" id="docsNav" wrapper={false}>
         <SideNav
+          collapsible={siteConfig.docsSideNavCollapsible}
           language={this.props.metadata.language}
           root={this.props.root}
           title={this.props.title}

--- a/packages/docusaurus-1.x/lib/core/nav/SideNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/SideNav.js
@@ -66,7 +66,7 @@ class SideNav extends React.Component {
     let categoryClassName = 'navGroupCategoryTitle';
     let arrow;
 
-    if (siteConfig.docsSideNavCollapsible) {
+    if (this.props.collapsible) {
       categoryClassName += ' collapsible';
       ulClassName = 'hide';
       arrow = (
@@ -227,6 +227,7 @@ class SideNav extends React.Component {
 }
 
 SideNav.defaultProps = {
+  collapsible: false,
   contents: [],
 };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Addresses issue on RN website where collapsible sidebar also appears on the Blog:

> I just noticed that this also collapses the sidebar in the blog section. Is it possible to always expand it there?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Docs show collapsing but blog doesn't.

![Screen Shot 2019-05-26 at 11 07 32 AM](https://user-images.githubusercontent.com/1315101/58385521-825de100-7fa6-11e9-8d96-8d680ffccdc4.png)
![Screen Shot 2019-05-26 at 11 07 29 AM](https://user-images.githubusercontent.com/1315101/58385522-82f67780-7fa6-11e9-8e3f-a967eef224e3.png)


## Related PRs

https://github.com/facebook/react-native-website/pull/934
