### PR TITLE
fix(v2): check static dir exist before copying

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -68,16 +68,21 @@ export async function build(
     ].filter(Boolean) as Plugin[],
   });
 
-  let serverConfig: Configuration = merge(createServerConfig(props), {
-    plugins: [
-      new CopyWebpackPlugin([
-        {
-          from: path.resolve(siteDir, STATIC_DIR_NAME),
-          to: outDir,
-        },
-      ]),
-    ],
-  });
+  let serverConfig: Configuration = createServerConfig(props);
+
+  const staticDir = path.resolve(siteDir, STATIC_DIR_NAME);
+  if (fs.existsSync(staticDir)) {
+    serverConfig = merge(serverConfig, {
+      plugins: [
+        new CopyWebpackPlugin([
+          {
+            from: staticDir,
+            to: outDir,
+          },
+        ]),
+      ],
+    });
+  }
 
   // Plugin lifecycle - configureWebpack
   plugins.forEach(plugin => {


### PR DESCRIPTION
## Motivation

Regression from https://github.com/facebook/Docusaurus/commit/e4de7c3ed43b839cc69dca6560d7c912aeba2cdd

That kinda reverted the static dir fix from
https://github.com/facebook/Docusaurus/commit/05ba7d835dc316b8f981e137e3935a51128ad2e4
<img width="631" alt="before" src="https://user-images.githubusercontent.com/17883920/58541987-3c677e00-822f-11e9-9f20-3590d81887c4.PNG">

Although there is no build error now, it just output some warning

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="498" alt="after" src="https://user-images.githubusercontent.com/17883920/58542054-6456e180-822f-11e9-8bb5-82d481b1e393.PNG">

