### PR TITLE
chore(v2): update dependencies

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -69,7 +69,7 @@
     "static-site-generator-webpack-plugin": "^3.4.2",
     "style-loader": "^0.22.1",
     "terser-webpack-plugin": "^1.2.4",
-    "wait-on": "endiliey/wait-on#master",
+    "wait-file": "^1.0.1",
     "webpack": "^4.30.0",
     "webpack-bundle-analyzer": "^3.1.0",
     "webpack-dev-server": "^3.4.1",

--- a/packages/docusaurus/src/webpack/plugins/WaitPlugin.js
+++ b/packages/docusaurus/src/webpack/plugins/WaitPlugin.js
@@ -7,7 +7,7 @@
 
 const path = require('path');
 const fs = require('fs-extra');
-const waitOn = require('wait-on');
+const {waitFile} = require('wait-file');
 
 class WaitPlugin {
   constructor(options) {
@@ -17,11 +17,11 @@ class WaitPlugin {
   apply(compiler) {
     // Before finishing the compilation step
     compiler.hooks.make.tapAsync('WaitPlugin', (compilation, callback) => {
-      // To prevent 'waitOn' error on waiting non-existing directory
+      // To prevent 'waitFile' error on waiting non-existing directory
       fs.ensureDirSync(path.dirname(this.filepath));
 
       // Wait until file exist
-      waitOn({
+      waitFile({
         resources: [this.filepath],
         interval: 300,
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6223,6 +6223,15 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
+  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
@@ -12028,7 +12037,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.53.0, request@^2.87.0, request@^2.88.0:
+request@^2.53.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -14052,14 +14061,13 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-wait-on@endiliey/wait-on#master:
-  version "3.2.0"
-  resolved "https://codeload.github.com/endiliey/wait-on/tar.gz/fb9b97c8e314b2d74573be8e5cd0c2ae88b0e4ec"
+wait-file@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wait-file/-/wait-file-1.0.1.tgz#8b9a7479e4bc1d518e516789796ad2d963ab9a95"
+  integrity sha512-A/5EGp+9LshI6dv8Vq3vLVCk30H2komd1iNhddS9MDUr15l5rQJup/oLNRVNv3bH9h/vKUwEilL/vDrt6OIJcQ==
   dependencies:
     "@hapi/joi" "^15.0.3"
-    core-js "^2.6.5"
-    minimist "^1.2.0"
-    request "^2.88.0"
+    fs-extra "^8.0.1"
     rx "^4.1.0"
 
 walker@^1.0.7, walker@~1.0.5:


### PR DESCRIPTION
## Motivation

Update dependencies so that it can point the npm version instead of my GitHub

Because in some cases, it can error out to install from GitHub
<img width="664" alt="git clone failed" src="https://user-images.githubusercontent.com/17883920/58602597-1f2ec000-82c0-11e9-9cfb-5f0bc6f85bbd.PNG">



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="544" alt="build ok" src="https://user-images.githubusercontent.com/17883920/58602584-13db9480-82c0-11e9-985e-b7256a6a5f1c.PNG">
