### PR TITLE
fix(v2): removes hardcoded sidebar width

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
@@ -36,7 +36,7 @@ function DocItem(props) {
       <Head>
         {metadata && metadata.title && <title>{metadata.title}</title>}
       </Head>
-      <div className="container margin-vert--lg">
+      <div className={`${styles.container} container margin-bottom--lg`}>
         <div className="row">
           <div className="col col--8">
             <header>

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
@@ -9,6 +9,16 @@
   min-height: calc(100vh - 50px);
 }
 
+.container {
+  padding-top: 2rem !important;
+}
+
+@media (min-width: 996px) {
+  .container {
+    padding-left: 2rem;
+  }
+}
+
 @media only screen and (min-width: 996px) {
   .tableOfContents {
     max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocPage/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocPage/index.js
@@ -12,6 +12,8 @@ import Layout from '@theme/Layout'; // eslint-disable-line
 
 import DocSidebar from '@theme/DocSidebar';
 
+import './styles.css';
+
 function DocPage(props) {
   const {route, docsMetadata, location} = props;
   const {permalinkToId} = docsMetadata;
@@ -24,11 +26,11 @@ function DocPage(props) {
   return (
     <Layout noFooter description={description}>
       <div className="container container--fluid">
-        <div className="row">
-          <div className="col col--3">
+        <div>
+          <div className="sidebar__container">
             <DocSidebar docsMetadata={docsMetadata} sidebar={sidebar} />
           </div>
-          <div className="col col--9">
+          <div className="content__container">
             {renderRoutes(route.routes, {docsMetadata})}
           </div>
         </div>

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocPage/styles.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocPage/styles.css
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ /**
+ * width 19rem is calculated according to (sidebarWidth - sidebarPadding)
+ * i.e 20rem - ( 0.5rem + 0.5rem )
+ * Todo - 0.5rem and 20rem should be a css variable
+ */
+
+ @media (min-width: 996px) {
+  .sidebar__container {
+    width: 19rem;
+    float: left;
+    min-height: calc(100vh - var(--ifm-navbar-height));
+  }
+  .content__container {
+    margin: 0 0 0 19rem;
+  }
+}

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocSidebar/styles.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocSidebar/styles.css
@@ -16,6 +16,5 @@
     overflow-x: hidden;
     overflow-y: auto;
     top: var(--ifm-navbar-height);
-    width: 20rem;
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocSidebar/styles.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocSidebar/styles.css
@@ -16,5 +16,6 @@
     overflow-x: hidden;
     overflow-y: auto;
     top: var(--ifm-navbar-height);
+    width: 20rem;
   }
 }


### PR DESCRIPTION
## Motivation

This PR removes the hardcoded `width:20rem` value in the sidebar css in D2. 

Also, it was brought up in [#1530](https://github.com/facebook/Docusaurus/issues/1530)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local Testing.

- #### Before removing sidebar width
![Before Removing Width](https://tusharf5.s3-us-west-2.amazonaws.com/images/before-removing-side-width.png)


- #### After removing sidebar width
![After Removing Width](https://tusharf5.s3-us-west-2.amazonaws.com/images/after-removing-side-width.png)

## Related PRs

None