### PR TITLE
 chore: remove `@types/chalk` and `@types/globby`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,9 @@
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/preset-typescript": "^7.3.3",
-    "@types/chalk": "^2.2.0",
     "@types/escape-string-regexp": "^1.0.0",
     "@types/express": "^4.16.1",
     "@types/fs-extra": "7.0.0",
-    "@types/globby": "9.1.0",
     "@types/jest": "^24.0.13",
     "@types/lodash": "^4.14.129",
     "@types/node": "^12.0.2",

--- a/packages/docusaurus-1.x/package.json
+++ b/packages/docusaurus-1.x/package.json
@@ -37,7 +37,7 @@
     "@babel/types": "^7.1.2",
     "autoprefixer": "^9.1.5",
     "babylon": "^6.17.4",
-    "chalk": "^2.1.0",
+    "chalk": "^2.4.2",
     "classnames": "^2.2.6",
     "color": "^2.0.1",
     "commander": "^2.18.0",

--- a/packages/docusaurus-init-1.x/package.json
+++ b/packages/docusaurus-init-1.x/package.json
@@ -14,7 +14,7 @@
     "docusaurus-init": "initialize.js"
   },
   "dependencies": {
-    "chalk": "^2.1.0",
+    "chalk": "^2.4.2",
     "shelljs": "^0.8.3"
   }
 }

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -11,7 +11,7 @@
     "@docusaurus/mdx-loader": "^2.0.0-alpha.18",
     "@docusaurus/utils": "^2.0.0-alpha.18",
     "fs-extra": "^7.0.1",
-    "globby": "^9.1.0",
+    "globby": "^9.2.0",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.11"
   },

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -11,7 +11,7 @@
     "@docusaurus/mdx-loader": "^2.0.0-alpha.18",
     "@docusaurus/utils": "^2.0.0-alpha.18",
     "fs-extra": "^7.0.1",
-    "globby": "^9.1.0",
+    "globby": "^9.2.0",
     "import-fresh": "^3.0.0",
     "loader-utils": "^1.2.3"
   },

--- a/packages/docusaurus-plugin-content-pages/package.json
+++ b/packages/docusaurus-plugin-content-pages/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@docusaurus/utils": "^2.0.0-alpha.18",
-    "globby": "^9.1.0"
+    "globby": "^9.2.0"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -48,7 +48,7 @@
     "envinfo": "^7.2.0",
     "express": "^4.16.4",
     "fs-extra": "^7.0.0",
-    "globby": "^9.1.0",
+    "globby": "^9.2.0",
     "html-webpack-plugin": "^4.0.0-beta.5",
     "import-fresh": "^3.0.0",
     "inquirer": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6568,7 +6568,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globby@^9.1.0:
+globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
   integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,13 +1846,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/chalk@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
-  integrity sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==
-  dependencies:
-    chalk "*"
-
 "@types/cheerio@^0.22.8":
   version "0.22.11"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.11.tgz#61c0facf9636d14ba5f77fc65ed8913aa845d717"
@@ -1929,13 +1922,6 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
-
-"@types/globby@9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@types/globby/-/globby-9.1.0.tgz#08e2cf99c64f8e45c6cfbe05e9d8ac763aca6482"
-  integrity sha512-9du/HCA71EBz7syHRnM4Q/u4Fbx3SyN/Uu+4Of9lyPX4A6Xi+A8VMxvx8j5/CMTfrae2Zwdwg0fAaKvKXfRbAw==
-  dependencies:
-    globby "*"
 
 "@types/html-minifier@*":
   version "3.5.3"
@@ -3563,15 +3549,6 @@ ccount@^1.0.0, ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
-chalk@*, chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -3582,6 +3559,15 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 change-case@^3.0.2:
   version "3.1.0"
@@ -6546,20 +6532,6 @@ globals@^11.0.1, globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globby@*, globby@^9.1.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
-  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
-  dependencies:
-    "@types/glob" "^7.1.1"
-    array-union "^1.0.2"
-    dir-glob "^2.2.2"
-    fast-glob "^2.2.6"
-    glob "^7.1.3"
-    ignore "^4.0.3"
-    pify "^4.0.1"
-    slash "^2.0.0"
-
 globby@8.0.2, globby@^8.0.1:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
@@ -6595,6 +6567,20 @@ globby@^7.1.1:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+globby@^9.1.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
+  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^1.0.2"
+    dir-glob "^2.2.2"
+    fast-glob "^2.2.6"
+    glob "^7.1.3"
+    ignore "^4.0.3"
+    pify "^4.0.1"
+    slash "^2.0.0"
 
 globule@^1.0.0:
   version "1.2.1"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

`@types/globby@9.1.0` and `@types/chalk@2.2.0` are two stub types definition, so I removed them in `package.json`.

By the way, I updated `globby` and `chalk` (`chalk@2.1` don't have `index.d.ts`).


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

You can see `index.d.ts`:
 - [chalk's `index.d.ts`](https://github.com/chalk/chalk/blob/master/index.d.ts)
 - [globby's `index.d.ts`](https://github.com/sindresorhus/globby/blob/master/index.d.ts)

## Related PRs

