### PR TITLE
chore(v2): add sensible default browserlist

### DIFF
--- a/packages/docusaurus/templates/classic/package.json
+++ b/packages/docusaurus/templates/classic/package.json
@@ -15,5 +15,17 @@
     "classnames": "^2.2.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -14,5 +14,17 @@
     "classnames": "^2.2.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }


### PR DESCRIPTION
## Motivation

Not having browserslist means that anything not all browsers don't support will end up getting compiled by Babel. Which translates to literally every single feature that Babel supports.

This isn't a good practice, according to https://babeljs.io/docs/en/babel-preset-env#browserslist-integration. 

The browesrslist is taken from CRA

Especially on development, webpack-dev-server itself only guarantee supporting limited number of browsers, so it makes sense to add sensible default browserlist.

Note that this does not mean we lock user to these certain browser only, user of docusaurus can always override the browserlist in their package.json or creating a browserlistrc. It's just that we generate this sensible default on official template

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Local development still works
- Netlify preview still works
