### PR TITLE
refactor(v2): return value instead of Promise in async

### DIFF
--- a/packages/docusaurus-plugin-content-pages/src/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/index.js
@@ -49,23 +49,15 @@ class DocusaurusPluginContentPages {
       cwd: pagesDir,
     });
 
-    // Prepare metadata container.
-    const pagesMetadatas = [];
-
-    await Promise.all(
-      pagesFiles.map(async relativeSource => {
-        const source = path.join(pagesDir, relativeSource);
-        const pathName = encodePath(fileToPath(relativeSource));
-        // Default Language.
-        const metadata = {
-          permalink: pathName.replace(/^\//, baseUrl),
-          source,
-        };
-        pagesMetadatas.push(metadata);
-      }),
-    );
-
-    return pagesMetadatas;
+    return pagesFiles.map(relativeSource => {
+      const source = path.join(pagesDir, relativeSource);
+      const pathName = encodePath(fileToPath(relativeSource));
+      // Default Language.
+      return {
+        permalink: pathName.replace(/^\//, baseUrl),
+        source,
+      };
+    });
   }
 
   async contentLoaded({content, actions}) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Old way:
 - Convert each element to `Promise` (`['elem1', 'elem2']` => `Promise {<resolved>: 'elem1'}`, `Promise {<resolved>: 'elem2'}`, )
 - Use `Promise.all` convert all of that `Promise` to one `Promise` return array have all element (`Promise {<resolved>: 'elem1'}`, `Promise {<resolved>: 'elem2'}` => `Promise {<resolved>: ['elem1', 'elem2']}`)

My way:
 - Just return that array (inside `async` function, we can return value instead of `Promise`)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

[Small test](https://repl.it/@Hongarc/async):
 - value of them is the same
 - this change is simple and faster
