### PR TITLE
 fix(v2): right toc should be sticky

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
@@ -53,7 +53,11 @@ function DocItem(props) {
             <DocPaginator docsMetadata={docsMetadata} metadata={metadata} />
           </div>
           <div className="col col--3 col--offset-1">
-            {DocContent.rightToc && <Headings headings={DocContent.rightToc} />}
+            {DocContent.rightToc && (
+              <div className={styles.onPageNav}>
+                <Headings headings={DocContent.rightToc} />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
@@ -8,7 +8,6 @@
 import React from 'react';
 
 import Head from '@docusaurus/Head';
-
 import DocPaginator from '@theme/DocPaginator';
 
 import styles from './styles.module.css';

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/index.js
@@ -53,7 +53,7 @@ function DocItem(props) {
           </div>
           <div className="col col--3 col--offset-1">
             {DocContent.rightToc && (
-              <div className={styles.onPageNav}>
+              <div className={styles.tableOfContents}>
                 <Headings headings={DocContent.rightToc} />
               </div>
             )}

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
@@ -13,7 +13,6 @@
   .onPageNav {
     max-height: calc(100vh - 90px);
     overflow-y: auto;
-    position: -webkit-sticky;
     position: sticky;
     top: 90px;
   }

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
@@ -10,10 +10,10 @@
 }
 
 @media only screen and (min-width: 996px) {
-  .onPageNav {
-    max-height: calc(100vh - 90px);
+  .tableOfContents {
+    max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
     overflow-y: auto;
     position: sticky;
-    top: 90px;
+    top: calc(var(--ifm-navbar-height) + 2rem);
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
@@ -8,3 +8,13 @@
 .docBody {
   min-height: calc(100vh - 50px);
 }
+
+@media only screen and (min-width: 1024px) {
+  .onPageNav {
+    max-height: calc(100vh - 90px);
+    overflow-y: auto;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 90px;
+  }
+}

--- a/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-plugin-content-docs/src/theme/DocItem/styles.module.css
@@ -9,7 +9,7 @@
   min-height: calc(100vh - 50px);
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 996px) {
   .onPageNav {
     max-height: calc(100vh - 90px);
     overflow-y: auto;


### PR DESCRIPTION
## Motivation

if you open https://v2.docusaurus.io/, the right table of content is not sticky/ does not follow viewport like v1. 

Check, https://reasonml.github.io/docs/en/what-and-why in desktop, try to scroll and see that the right toc is following viewport

![](https://i.imgur.com/hIj9WZG.png)

Go to https://v2.docusaurus.io/docs/introduction, try to scroll and see that the right toc is not sticky

P.S: The right toc still need a lot of kwork, especially on mobile. But this Pr only aim to solve the sticky position on large viewport

![](https://i.imgur.com/l2IJV8Q.png)
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

![sticky](https://user-images.githubusercontent.com/17883920/58796679-918d0080-8630-11e9-90d0-ca762c76ebe0.gif)

