### PR TITLE
fix(v2): use Infima from npm instead of trunk CDN

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "docsearch.js": "^2.5.2",
+    "infima": "0.2.0-alpha.1",
     "react-toggle": "^4.0.2"
   },
   "peerDependencies": {

--- a/packages/docusaurus-theme-classic/src/infima.js
+++ b/packages/docusaurus-theme-classic/src/infima.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import 'infima/dist/css/default/default.css';

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -5,21 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* These rules should eventually go into Infima */
-
 body {
   margin: 0;
   padding-top: var(--ifm-navbar-height);
   transition: var(--ifm-transition-fast) ease color;
-}
-
-:root {
-  --ifm-color-primary: #25c2a0 !important;
-  --ifm-color-primary-dark: #21ad8e !important;
-  --ifm-color-primary-darker: #1d977d !important;
-  --ifm-color-primary-darkerer: #0c4236 !important;
-  --ifm-color-primary-light: #55dfc1 !important;
-  --ifm-color-primary-lighter: #55dfc1 !important;
 }
 
 .anchor {

--- a/packages/docusaurus/src/client/App.js
+++ b/packages/docusaurus/src/client/App.js
@@ -11,7 +11,6 @@ import {renderRoutes} from 'react-router-config';
 import routes from '@generated/routes';
 import siteConfig from '@generated/docusaurus.config';
 
-import Head from '@docusaurus/Head';
 import DocusaurusContext from '@docusaurus/context';
 import PendingNavigation from './PendingNavigation';
 
@@ -20,15 +19,6 @@ import '@generated/client-modules';
 function App() {
   return (
     <DocusaurusContext.Provider value={{siteConfig}}>
-      {/* TODO: this link stylesheet to infima is temporary */}
-      <Head>
-        <link
-          href="https://infima-dev.netlify.com/css/default/default.min.css"
-          preload
-          rel="stylesheet"
-          type="text/css"
-        />
-      </Head>
       <PendingNavigation routes={routes}>
         {renderRoutes(routes)}
       </PendingNavigation>

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -72,8 +72,9 @@ export async function load(
   // Plugins.
   const pluginConfigs: PluginConfig[] = [
     ...presetPlugins,
-    ...(siteConfig.plugins || []),
     ...presetThemes,
+    // Site config should the highest priority.
+    ...(siteConfig.plugins || []),
     ...(siteConfig.themes || []),
   ];
   const {plugins, pluginsRouteConfigs} = await loadPlugins({

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -109,4 +109,12 @@ module.exports = {
       },
     ],
   ],
+  plugins: [
+    {
+      module: require('path').resolve(
+        __dirname,
+        './plugins/plugin-infima-overrides',
+      ),
+    },
+  ],
 };

--- a/website/pages/styles.module.css
+++ b/website/pages/styles.module.css
@@ -55,7 +55,7 @@
 }
 
 .index-hero-project-keywords {
-  color: #25c2a0;
+  color: var(--ifm-color-primary);
 }
 
 @keyframes jackInTheBox {
@@ -65,15 +65,15 @@
     transform-origin: center bottom;
   }
 
-   50% {
+  50% {
     transform: rotate(-10deg);
   }
 
-   70% {
+  70% {
     transform: rotate(3deg);
   }
 
-   to {
+  to {
     opacity: 1;
     transform: scale(1);
   }
@@ -93,12 +93,12 @@
 }
 
 .index-ctas-get-started-button {
-  border: 1px solid #25c2a0;
+  border: 1px solid var(--ifm-color-primary);
   display: inline-block;
   line-height: 1.2em;
-  text-decoration: none!important;
+  text-decoration: none !important;
   text-transform: uppercase;
-  transition: background .3s,color .3s;
+  transition: background 0.3s, color 0.3s;
   border-radius: 8px;
   border-width: 2px;
   color: #fff;

--- a/website/plugins/plugin-infima-overrides/index.js
+++ b/website/plugins/plugin-infima-overrides/index.js
@@ -9,14 +9,9 @@ const path = require('path');
 
 module.exports = function() {
   return {
-    name: 'docusaurus-theme-classic',
-
-    getThemePath() {
-      return path.resolve(__dirname, './theme');
-    },
-
+    name: 'docusaurus-plugin-website-infima',
     getClientModules() {
-      return [path.resolve(__dirname, './infima')];
+      return [path.resolve(__dirname, './infima-overrides')];
     },
   };
 };

--- a/website/plugins/plugin-infima-overrides/infima-overrides.js
+++ b/website/plugins/plugin-infima-overrides/infima-overrides.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './infima-variables.css';

--- a/website/plugins/plugin-infima-overrides/infima-variables.css
+++ b/website/plugins/plugin-infima-overrides/infima-variables.css
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+:root {
+  --ifm-color-primary: #25c2a0;
+  --ifm-color-primary-dark: rgb(33, 175, 144);
+  --ifm-color-primary-darker: rgb(31, 165, 136);
+  --ifm-color-primary-darkest: rgb(26, 136, 112);
+  --ifm-color-primary-light: rgb(70, 203, 174);
+  --ifm-color-primary-lighter: rgb(102, 212, 189);
+  --ifm-color-primary-lightest: rgb(146, 224, 208);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7317,6 +7317,11 @@ indexof@0.0.1:
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
   integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
+infima@0.2.0-alpha.1:
+  version "0.2.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.1.tgz#f29ed163d84b3754788cc4a23fdbcc6fa96fdd1e"
+  integrity sha512-MkKiboxvTF1tSHQIuq5PquV2vrZ7gdPr9/VGxwVfN5/V814fIrzToiT7l5VYaqEJdMrMQ9EZNSds9IzbqwyESA==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Use the proper abstractions and engineer it right:

- Install Infima from npm (I just published `0.2.0-alpha.1`)
- Import Infima CSS from theme-classic.
- Move Infima variables override into `website` folder via a client module.

After this lands, we should publish new version asap and help existing users migrate asap. Loading Infima CSS from trunk is a ticking time bomb waiting to explode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Site looks the same!

## Related PRs

NA
