### PR TITLE
feat(v2): live playground should be lazily loaded on visibility

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -12,9 +12,11 @@
     "@mdx-js/react": "^1.0.20",
     "classnames": "^2.2.6",
     "docsearch.js": "^2.5.2",
+    "infima": "0.2.0-alpha.1",
     "prism-react-renderer": "^0.1.6",
     "react-live": "^2.1.2",
-    "infima": "0.2.0-alpha.1",
+    "react-loadable": "^5.5.0",
+    "react-loadable-visibility": "^2.5.1",
     "react-toggle": "^4.0.2"
   },
   "peerDependencies": {

--- a/packages/docusaurus-theme-classic/src/theme/components/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/components/CodeBlock/index.js
@@ -6,10 +6,17 @@
  */
 
 import React from 'react';
+import LoadableVisibility from 'react-loadable-visibility/react-loadable';
 import Highlight, {defaultProps} from 'prism-react-renderer';
 import nightOwlTheme from 'prism-react-renderer/themes/nightOwl';
 
-import Playground from '@theme/components/Playground';
+import Loading from '@theme/Loading';
+
+/* Live playground is not small in size, lazy load it is better */
+const Playground = LoadableVisibility({
+  loader: () => import('@theme/components/Playground'),
+  loading: Loading,
+});
 
 export default ({children, className: languageClassName, live, ...props}) => {
   if (live) {

--- a/website/docs/writing-documentation.md
+++ b/website/docs/writing-documentation.md
@@ -97,3 +97,77 @@ TODO: Talk more about using the official docs plugin and how to configure the si
 References:
 - https://docusaurus.io/docs/en/navigation
 -->
+
+If you're writing technical documentation you may want a way to delineate blocks of 
+code, sometimes known as a *code fence*. The result is also known as a *code block*.
+
+### Creating a code block, aka code fence with syntax highlighting
+
+The simplest way to show code is to wrap it between two lines consisting of 3 backticks in a row.
+
+### Highlighting code
+
+Example:
+
+    ```jsx
+	  console.log("Hello world");
+    ```
+
+And the result would be:
+
+```jsx
+console.log("Hello world");
+```
+
+## Live Editor
+
+You can also create live code editors with a code block `live` meta string.
+
+Example:
+
+    ```jsx live
+    function Clock(props) {
+      const [date, setDate] = useState(new Date());
+      useEffect(() => {
+        var timerID = setInterval(() => tick(), 1000);
+
+        return function cleanup() {
+          clearInterval(timerID);
+        };
+      });
+
+      function tick() {
+        setDate(new Date());
+      }
+
+      return (
+        <div>
+          <h2>It is {date.toLocaleTimeString()}.</h2>
+        </div>
+      );
+    }
+    ```
+And the result would be:
+
+```jsx live
+function Clock(props) {
+  const [date, setDate] = useState(new Date());
+  useEffect(() => {
+    var timerID = setInterval(() => tick(), 1000);
+
+    return function cleanup() {
+      clearInterval(timerID);
+    };
+  });
+
+  function tick() {
+    setDate(new Date());
+  }
+
+  return (
+    <div>
+      <h2>It is {date.toLocaleTimeString()}.</h2>
+    </div>
+  );
+}
+```

--- a/website/docs/writing-documentation.md
+++ b/website/docs/writing-documentation.md
@@ -101,11 +101,9 @@ References:
 If you're writing technical documentation you may want a way to delineate blocks of 
 code, sometimes known as a *code fence*. The result is also known as a *code block*.
 
-### Creating a code block, aka code fence with syntax highlighting
+## Syntax highlighting
 
 The simplest way to show code is to wrap it between two lines consisting of 3 backticks in a row.
-
-### Highlighting code
 
 Example:
 

--- a/website/docs/writing-documentation.md
+++ b/website/docs/writing-documentation.md
@@ -98,11 +98,10 @@ References:
 - https://docusaurus.io/docs/en/navigation
 -->
 
-If you're writing technical documentation you may want a way to delineate blocks of 
-code, sometimes known as a *code fence*. The result is also known as a *code block*.
-
 ## Syntax highlighting
 
+If you're writing technical documentation you may want a way to delineate blocks of 
+code, sometimes known as a *code fence*. The result is also known as a *code block*.
 The simplest way to show code is to wrap it between two lines consisting of 3 backticks in a row.
 
 Example:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11546,6 +11546,11 @@ react-loadable-ssr-addon@^0.1.8:
   resolved "https://registry.yarnpkg.com/react-loadable-ssr-addon/-/react-loadable-ssr-addon-0.1.9.tgz#c134275fd36637a554f6438a0b78e0d1f70a8260"
   integrity sha512-mjk0ykDmmgPvkoFVwjbhev/VtarlpdR7B9FzuFFxtviFWVjaL8ddw4J89uFvUkC1KtFmXdQ6BF7yzUB54QqmXg==
 
+react-loadable-visibility@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/react-loadable-visibility/-/react-loadable-visibility-2.5.1.tgz#713ad70967865a0db1f4dc918228a29a59a593d5"
+  integrity sha512-rIwqjznjAi7i9K+BF/SUCcQZaiIhoPbbMj9aLceHeH093kL4aJ0bdj/iUG6E+ohIkKliKgKB2RKSai0MwNH51g==
+
 react-loadable@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-5.5.0.tgz#582251679d3da86c32aae2c8e689c59f1196d8c4"


### PR DESCRIPTION
## Motivation

Live playground makes the TTI (time to interactive) slower and reduce our lighthouse performance score. Most of the time ppl dont need playground. We should lazy load the playground component

Live playground is not small in size, lazy load it is better. This does not effect normal syntax highlighting (not playground)

note that reacjs org is kinda doing a similar stuff ??
![image](https://user-images.githubusercontent.com/17883920/58872135-f9f1e580-86f5-11e9-81cc-4963e07b67f7.png)

also added docs for the feature

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

real world test in production (its almost unnoticeable)
![testtt](https://user-images.githubusercontent.com/17883920/58873630-599dc000-86f9-11e9-8a59-6e412370a4ea.gif)

try it here: https://deploy-preview-1557--docusaurus-2.netlify.com/docs/writing-documentation/ and scroll down to bottom