### PR TITLE
fix(v2): Trim code block before passing to prism react renderer

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/components/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/components/CodeBlock/index.js
@@ -23,7 +23,7 @@ export default ({children, className: languageClassName, live, ...props}) => {
     return (
       <Playground
         scope={{...React}}
-        code={children}
+        code={children.trim()}
         theme={nightOwlTheme}
         {...props}
       />
@@ -35,7 +35,7 @@ export default ({children, className: languageClassName, live, ...props}) => {
     <Highlight
       {...defaultProps}
       theme={nightOwlTheme}
-      code={children}
+      code={children.trim()}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <pre


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

There is a trailing newline in each code block passed to prism react renderer. This fix trims the string before passing them down.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

Before

<img width="765" alt="image" src="https://user-images.githubusercontent.com/2055384/58902052-f6318380-8734-11e9-9402-91fa6c54c2a4.png">


After

<img width="759" alt="image" src="https://user-images.githubusercontent.com/2055384/58902013-e4e87700-8734-11e9-9118-2f2ded27ab43.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
