### PR TITLE
refactor(v2): change plugin format within `docusaurus.config.js` to be like plugins

### DIFF
--- a/packages/docusaurus-preset-classic/src/index.js
+++ b/packages/docusaurus-preset-classic/src/index.js
@@ -8,31 +8,14 @@
 module.exports = function preset(context, opts = {}) {
   return {
     themes: [
-      {
-        module: '@docusaurus/theme-classic',
-        options: opts.theme,
-      },
-      {
-        module: '@docusaurus/theme-search-algolia',
-      },
+      ['@docusaurus/theme-classic', opts.theme],
+      '@docusaurus/theme-search-algolia',
     ],
     plugins: [
-      {
-        module: '@docusaurus/plugin-content-docs',
-        options: opts.docs,
-      },
-      {
-        module: '@docusaurus/plugin-content-blog',
-        options: opts.blog,
-      },
-      {
-        module: '@docusaurus/plugin-content-pages',
-        options: opts.pages,
-      },
-      {
-        module: '@docusaurus/plugin-sitemap',
-        options: opts.sitemap,
-      },
+      ['@docusaurus/plugin-content-docs', opts.docs],
+      ['@docusaurus/plugin-content-blog', opts.blog],
+      ['@docusaurus/plugin-content-pages', opts.pages],
+      ['@docusaurus/plugin-sitemap', opts.sitemap],
     ],
   };
 };

--- a/packages/docusaurus/CHANGELOG.md
+++ b/packages/docusaurus/CHANGELOG.md
@@ -11,7 +11,22 @@
   - Changed plugin definitions from classes to functions. Refer to the new plugin docs.
   - Implement Clients module API.
   - Change format within `docusaurus.config.js` to be like presets.
-- Infima CSS is now locked down on certain versions and not relying upon the CDN which reads from trunk.
+- Infima CSS is now locked down to specific versions and not relying upon the CDN which reads from trunk.
+- Customize the CSS by passing options into the classic preset:
+
+```
+presets: [
+  [
+    '@docusaurus/preset-classic',
+    {
+      theme: {
+        customCss: require.resolve('./css/custom.css'),
+      },
+      ...
+    },
+  ],
+],
+```
 
 ## V2 Changelog
 

--- a/packages/docusaurus/CHANGELOG.md
+++ b/packages/docusaurus/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## 2.0.0-alpha.19
 
-- Changed plugin definitions from classes to functions. Refer to the new plugin docs.
-- Added sun and moon emoji to the dark mode toggle.
 - Add a sensible default for browserslist config.
+- UI
+  - Added sun and moon emoji to the dark mode toggle.
+  - Mobile responsive menu.
+  - Right table of contents for docs is now sticky.
+- Plugins
+  - Changed plugin definitions from classes to functions. Refer to the new plugin docs.
+  - Implement Clients module API.
+  - Change format within `docusaurus.config.js` to be like presets.
+- Infima CSS is now locked down on certain versions and not relying upon the CDN which reads from trunk.
 
 ## V2 Changelog
 

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
@@ -14,15 +14,13 @@ module.exports = {
   url: 'https://docusaurus.io',
   favicon: 'img/docusaurus.ico',
   plugins: [
-    {
-      module: '@docusaurus/plugin-content-docs',
-      options: {
+    [
+      '@docusaurus/plugin-content-docs',
+      {
         path: '../docs',
         sidebarPath: require.resolve('./sidebars.json'),
       },
-    },
-    {
-      module: '@docusaurus/plugin-content-pages',
-    },
+    ],
+    '@docusaurus/plugin-content-pages',
   ],
 };

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -14,15 +14,13 @@ module.exports = {
   url: 'https://docusaurus.io',
   favicon: 'img/docusaurus.ico',
   plugins: [
-    {
-      module: '@docusaurus/plugin-content-docs',
-      options: {
+    [
+      '@docusaurus/plugin-content-docs',
+      {
         path: '../docs',
         sidebarPath: require.resolve('./sidebars.json'),
       },
-    },
-    {
-      module: '@docusaurus/plugin-content-pages',
-    },
+    ],
+    '@docusaurus/plugin-content-pages',
   ],
 };

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-bar.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-bar.js
@@ -1,14 +1,8 @@
 module.exports = function preset(context, opts = {}) {
   return {
     plugins: [
-      {
-        name: '@docusaurus/plugin-content-docs',
-        options: opts.docs,
-      },
-      {
-        name: '@docusaurus/plugin-content-blog',
-        options: opts.blog,
-      },
+      ['@docusaurus/plugin-content-docs', opts.docs],
+      ['@docusaurus/plugin-content-blog', opts.blog],
     ],
   };
 };

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-foo.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-foo.js
@@ -1,14 +1,8 @@
 module.exports = function preset(context, opts = {}) {
   return {
     plugins: [
-      {
-        name: '@docusaurus/plugin-content-pages',
-        options: opts.pages,
-      },
-      {
-        name: '@docusaurus/plugin-sitemap',
-        options: opts.sitemap,
-      },
+      ['@docusaurus/plugin-content-pages', opts.pages],
+      ['@docusaurus/plugin-sitemap', opts.sitemap],
     ],
   };
 };

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-qux.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-qux.js
@@ -1,16 +1,6 @@
 module.exports = function preset(context, opts = {}) {
   return {
-    themes: [
-      {
-        name: '@docusaurus/theme-classic',
-        options: opts.test,
-      },
-    ],
-    plugins: [
-      {
-        name: '@docusaurus/plugin-test',
-        options: opts.test,
-      },
-    ],
+    themes: [['@docusaurus/theme-classic', opts.test]],
+    plugins: [['@docusaurus/plugin-test', opts.test]],
   };
 };

--- a/packages/docusaurus/src/server/presets/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/presets/__tests__/index.test.ts
@@ -15,11 +15,11 @@ describe('loadPresets', () => {
     const context = {siteConfig: {}} as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [],
-  "themes": Array [],
-}
-`);
+      Object {
+        "plugins": Array [],
+        "themes": Array [],
+      }
+    `);
   });
 
   test('string form', () => {
@@ -30,20 +30,20 @@ Object {
     } as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-blog",
-      "options": undefined,
-    },
-  ],
-  "themes": Array [],
-}
-`);
+      Object {
+        "plugins": Array [
+          Array [
+            "@docusaurus/plugin-content-docs",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-content-blog",
+            undefined,
+          ],
+        ],
+        "themes": Array [],
+      }
+    `);
   });
 
   test('string form composite', () => {
@@ -57,28 +57,28 @@ Object {
     } as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-blog",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-pages",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-sitemap",
-      "options": undefined,
-    },
-  ],
-  "themes": Array [],
-}
-`);
+      Object {
+        "plugins": Array [
+          Array [
+            "@docusaurus/plugin-content-docs",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-content-blog",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-content-pages",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-sitemap",
+            undefined,
+          ],
+        ],
+        "themes": Array [],
+      }
+    `);
   });
 
   test('array form', () => {
@@ -89,20 +89,20 @@ Object {
     } as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-blog",
-      "options": undefined,
-    },
-  ],
-  "themes": Array [],
-}
-`);
+      Object {
+        "plugins": Array [
+          Array [
+            "@docusaurus/plugin-content-docs",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-content-blog",
+            undefined,
+          ],
+        ],
+        "themes": Array [],
+      }
+    `);
   });
 
   test('array form with options', () => {
@@ -118,22 +118,22 @@ Object {
     } as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": Object {
-        "path": "../",
-      },
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-blog",
-      "options": undefined,
-    },
-  ],
-  "themes": Array [],
-}
-`);
+      Object {
+        "plugins": Array [
+          Array [
+            "@docusaurus/plugin-content-docs",
+            Object {
+              "path": "../",
+            },
+          ],
+          Array [
+            "@docusaurus/plugin-content-blog",
+            undefined,
+          ],
+        ],
+        "themes": Array [],
+      }
+    `);
   });
 
   test('array form composite', () => {
@@ -153,32 +153,32 @@ Object {
     } as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": Object {
-        "path": "../",
-      },
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-blog",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-pages",
-      "options": Object {
-        "path": "../",
-      },
-    },
-    Object {
-      "name": "@docusaurus/plugin-sitemap",
-      "options": undefined,
-    },
-  ],
-  "themes": Array [],
-}
-`);
+      Object {
+        "plugins": Array [
+          Array [
+            "@docusaurus/plugin-content-docs",
+            Object {
+              "path": "../",
+            },
+          ],
+          Array [
+            "@docusaurus/plugin-content-blog",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-content-pages",
+            Object {
+              "path": "../",
+            },
+          ],
+          Array [
+            "@docusaurus/plugin-sitemap",
+            undefined,
+          ],
+        ],
+        "themes": Array [],
+      }
+    `);
   });
 
   test('mixed form', () => {
@@ -195,30 +195,30 @@ Object {
     } as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": Object {
-        "path": "../",
-      },
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-blog",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-pages",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-sitemap",
-      "options": undefined,
-    },
-  ],
-  "themes": Array [],
-}
-`);
+      Object {
+        "plugins": Array [
+          Array [
+            "@docusaurus/plugin-content-docs",
+            Object {
+              "path": "../",
+            },
+          ],
+          Array [
+            "@docusaurus/plugin-content-blog",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-content-pages",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-sitemap",
+            undefined,
+          ],
+        ],
+        "themes": Array [],
+      }
+    `);
   });
 
   test('mixed form with themes', () => {
@@ -236,38 +236,38 @@ Object {
     } as LoadContext;
     const presets = loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
-Object {
-  "plugins": Array [
-    Object {
-      "name": "@docusaurus/plugin-content-docs",
-      "options": Object {
-        "path": "../",
-      },
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-blog",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-content-pages",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-sitemap",
-      "options": undefined,
-    },
-    Object {
-      "name": "@docusaurus/plugin-test",
-      "options": undefined,
-    },
-  ],
-  "themes": Array [
-    Object {
-      "name": "@docusaurus/theme-classic",
-      "options": undefined,
-    },
-  ],
-}
-`);
+      Object {
+        "plugins": Array [
+          Array [
+            "@docusaurus/plugin-content-docs",
+            Object {
+              "path": "../",
+            },
+          ],
+          Array [
+            "@docusaurus/plugin-content-blog",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-content-pages",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-sitemap",
+            undefined,
+          ],
+          Array [
+            "@docusaurus/plugin-test",
+            undefined,
+          ],
+        ],
+        "themes": Array [
+          Array [
+            "@docusaurus/theme-classic",
+            undefined,
+          ],
+        ],
+      }
+    `);
   });
 });

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -16,7 +16,7 @@ export interface Preset {
   themes?: PluginConfig[];
 }
 
-export type PresetConfig = [string, Object] | string;
+export type PresetConfig = [string, Object | undefined] | string;
 
 export function loadPresets(
   context: LoadContext,
@@ -34,7 +34,8 @@ export function loadPresets(
     if (typeof presetItem === 'string') {
       presetModuleImport = presetItem;
     } else if (Array.isArray(presetItem)) {
-      [presetModuleImport, presetOptions] = presetItem;
+      presetModuleImport = presetItem[0];
+      presetOptions = presetItem[1] || {};
     }
 
     const presetModule = importFresh(presetModuleImport);

--- a/website/docs/plugins-api.md
+++ b/website/docs/plugins-api.md
@@ -18,17 +18,15 @@ Then you add it in your site's `docusaurus.config.js` plugin arrays:
 ```jsx
 module.exports = {
   plugins: [
-    {
-      module: '@docusaurus/plugin-content-pages',
-    },
-    {
+    '@docusaurus/plugin-content-pages',
+    [
       // Plugin with options
-      module: '@docusaurus/plugin-content-blog',
-      options: {
+      '@docusaurus/plugin-content-blog',
+      {
         include: ['*.md', '*.mdx'],
         path: 'blog',
       },
-    },
+    ],
   ],
 };
 ```
@@ -39,11 +37,7 @@ Docusaurus can also load plugins from your local directory, you can do something
 const path = require('path');
 
 module.exports = {
-  plugins: [
-    {
-      module: path.resolve(__dirname, '/path/to/docusaurus-local-plugin'),
-    },
-  ],
+  plugins: [path.resolve(__dirname, '/path/to/docusaurus-local-plugin')],
 };
 ```
 


### PR DESCRIPTION
…e like presets

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

One consistent format for declaring plugins, themes and presets.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Site builds. Tests pass.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
