### PR TITLE
fix: add support for non-latin characters in scrollSpy ToC highlighter

### DIFF
--- a/packages/docusaurus-1.x/lib/static/js/scrollSpy.js
+++ b/packages/docusaurus-1.x/lib/static/js/scrollSpy.js
@@ -38,10 +38,19 @@
          * So the first one with positive bounding rect top will be the nearest next header
          */
         if (currNavActive && i < headings.length - 1) {
-          const next = headings[i + 1].href.split('#')[1];
+          const heading = headings[i + 1];
+          const next = decodeURIComponent(heading.href.split('#')[1]);
           const nextHeader = document.getElementById(next);
-          const top = nextHeader.getBoundingClientRect().top;
-          currNavActive = top > OFFSET;
+
+          if (nextHeader) {
+            const top = nextHeader.getBoundingClientRect().top;
+            currNavActive = top > OFFSET;
+          } else {
+            console.error('Can not find header element', {
+              id: next,
+              heading,
+            });
+          }
         }
         /**
          * Stop searching once a first such header is found,
@@ -56,6 +65,7 @@
       }
     }, 100);
   };
+
   document.addEventListener('scroll', onScroll);
   document.addEventListener('resize', onScroll);
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Motivation

fix #1569

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Just add:

```md
## Привет, мир
```

You should see something like this:

![image](https://user-images.githubusercontent.com/2536916/59013159-fbc8bf80-8841-11e9-9de8-065d10533d20.png)

