### PR TITLE
fix(v2): fix scrolling problem for location with hash

### DIFF
--- a/packages/docusaurus/src/client/PendingNavigation.js
+++ b/packages/docusaurus/src/client/PendingNavigation.js
@@ -43,7 +43,14 @@ class PendingNavigation extends React.Component {
             },
             this.stopProgressBar,
           );
-          window.scrollTo(0, 0);
+          const {hash} = nextProps.location;
+          if (!hash) {
+            window.scrollTo(0, 0);
+          } else {
+            const id = hash.replace('#', '');
+            const element = document.getElementById(id);
+            if (element) element.scrollIntoView();
+          }
         })
         .catch(e => console.warn(e));
     }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -43,9 +43,9 @@ Deployment configurations are used when you deploy your site with Docusaurus' de
 <!-- TODO: currently these fields are only used in GH Pages, what about other deployment services such as Netlify -->
 
 - [url](docusaurus.config.js.md#url)
-- [baseUrl](docusaurus.config.js.md#baseUrl)
+- [baseUrl](docusaurus.config.js.md#baseurl)
 - [organizationName](docusaurus.config.js.md#organizationname)
-- [projectName](docusaurus.config.js.md#projectName)
+- [projectName](docusaurus.config.js.md#projectname)
 
 You may also check the doc for [Deployment](deployment.md) for more information about the fields.
 
@@ -53,7 +53,7 @@ You may also check the doc for [Deployment](deployment.md) for more information 
 
 <!-- TODO: More explanation from these docs, respectively -->
 
-- [themeConfig](docusaurus.config.js.md#themeConfig)
+- [themeConfig](docusaurus.config.js.md#themeconfig)
 - [presets](docusaurus.config.js.md#presets)
 - [plugins](docusaurus.config.js.md#plugins)
 
@@ -61,7 +61,7 @@ You may also check the doc for [Deployment](deployment.md) for more information 
 
 Docusaurus guards `docusaurus.config.js` from unknown fields. To add a custom field, define it on `customFields`
 
-- [customFields](docusaurus.config.js.md#customFields)
+- [customFields](docusaurus.config.js.md#customfields)
 
 Example:
 


### PR DESCRIPTION
## Motivation

In-page hash anchors are behaving weirdly. Clicking on them first time will go to the top of the page, the second time will go to the anchor scroll location. Try the four links on the second section of [this page](https://deploy-preview-1539--docusaurus-2.netlify.com/docs/configuration)

See this
![before-cant scroll](https://user-images.githubusercontent.com/17883920/59048441-661c4700-88b8-11e9-90cf-439db9c29868.gif)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Locally
![after anchor](https://user-images.githubusercontent.com/17883920/59048457-6fa5af00-88b8-11e9-8842-b0edba1d956c.gif)

Netlify test
![right scrolling behavior](https://user-images.githubusercontent.com/17883920/59048806-3a4d9100-88b9-11e9-928d-8c70bebf5fb8.gif)
