### PR TITLE
refactor(v2): improve PendingNavigation to not use componentWillReceiveProps

### DIFF
--- a/packages/docusaurus/src/client/PendingNavigation.js
+++ b/packages/docusaurus/src/client/PendingNavigation.js
@@ -17,29 +17,43 @@ class PendingNavigation extends React.Component {
   constructor(props) {
     super(props);
 
+    // previousLocation doesn't affect rendering, hence not stored in state.
+    this.previousLocation = null;
     this.progressBarTimeout = null;
     this.state = {
-      previousLocation: null,
+      nextRouteHasLoaded: true,
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    const navigated = nextProps.location !== this.props.location;
+  // Intercept location update and still show current route until next route
+  // is done loading.
+  shouldComponentUpdate(nextProps, nextState) {
+    const routeDidChange = nextProps.location !== this.props.location;
     const {routes, delay = 1000} = this.props;
 
-    if (navigated) {
+    // If `routeDidChange` is true, means the router is trying to navigate to a new
+    // route. We will preload the new route.
+    if (routeDidChange) {
       this.startProgressBar(delay);
-      // save the location so we can render the old screen
+      // Save the location first
+      this.previousLocation = this.props.location;
       this.setState({
-        previousLocation: this.props.location,
+        nextRouteHasLoaded: false,
       });
 
-      // load data while the old screen remains
+      // Load data while the old screen remains.
       preload(routes, nextProps.location.pathname)
         .then(() => {
+          // TODO: Implement browser lifecycle.
+          // onRouteUpdate({
+          //   previousLocation: this.previousLocation,
+          //   location: nextProps.location,
+          // });
+          // Route has loaded, we can reset previousLocation.
+          this.previousLocation = null;
           this.setState(
             {
-              previousLocation: null,
+              nextRouteHasLoaded: true,
             },
             this.stopProgressBar,
           );
@@ -53,7 +67,16 @@ class PendingNavigation extends React.Component {
           }
         })
         .catch(e => console.warn(e));
+      return false;
     }
+
+    // There's a pending route transition. Don't update until it's done.
+    if (!nextState.nextRouteHasLoaded) {
+      return false;
+    }
+
+    // Route has loaded, we can update now.
+    return true;
   }
 
   clearProgressBarTimeout() {
@@ -77,13 +100,7 @@ class PendingNavigation extends React.Component {
 
   render() {
     const {children, location} = this.props;
-    const {previousLocation} = this.state;
-
-    // use a controlled <Route> to trick all descendants into
-    // rendering the old location
-    return (
-      <Route location={previousLocation || location} render={() => children} />
-    );
+    return <Route location={location} render={() => children} />;
   }
 }
 

--- a/packages/docusaurus/src/client/PendingNavigation.js
+++ b/packages/docusaurus/src/client/PendingNavigation.js
@@ -35,7 +35,7 @@ class PendingNavigation extends React.Component {
     // route. We will preload the new route.
     if (routeDidChange) {
       this.startProgressBar(delay);
-      // Save the location first
+      // Save the location first.
       this.previousLocation = this.props.location;
       this.setState({
         nextRouteHasLoaded: false,
@@ -89,6 +89,8 @@ class PendingNavigation extends React.Component {
   startProgressBar(delay) {
     this.clearProgressBarTimeout();
     this.progressBarTimeout = setTimeout(() => {
+      // TODO: Implement browser lifecycle.
+      // onRouteUpdateDelayed()
       nprogress.start();
     }, delay);
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

To better prepare for implementing `onRouteUpdate` and `onRouteUpdateDelayed` browser APIs, here are a few improvements to `PendingNavigation`:

- Don't trick React into rendering the same location just to preserve the current route. Use `shouldComponentUpdate` for those purposes. With this, `render()` is only called once - when it's ready to transition
- Save previous location on `this` since it doesn't affect the rendering
- Make it very clear where to call `onRouteUpdate` and `onRouteUpdateDelayed`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test with slow 3G throttling in Netlify preview.

To get around the `prefetch`, replace `preload` with this locally:

```
export default function preload(routes, pathname) {
  const matches = matchRoutes(routes, pathname);
  return Promise.all(
    [...matches.map(match => {
      const {component} = match.route;
      if (component && component.preload) {
        return component.preload();
      }
      return undefined;
    }), new Promise((resolve) => {
      setTimeout(resolve, 2000);
    })],
  );
}
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
