### PR TITLE
fix(v2): handle case when <code> children is not a string

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
@@ -10,7 +10,13 @@ import CodeBlock from '@theme/CodeBlock';
 import styles from './styles.module.css';
 
 export default {
-  code: CodeBlock,
+  code: props => {
+    const {children} = props;
+    if (typeof children === 'string') {
+      return <CodeBlock {...props} />;
+    }
+    return children;
+  },
   a: Link,
   pre: props => <pre className={styles.mdxCodeBlock} {...props} />,
 };


### PR DESCRIPTION
## Motivation

Fix #1581

We should only pass our codeblock component if it's content is a string.
Note that this bug is because MDX turns `<div>` or react component to real react element.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan
```md
import BrowserWindow from '../components/BrowserWindow';

<pre><code>
  <BrowserWindow url="http://localhost:3000" >
    Lol bro
  </BrowserWindow>
</code></pre>
```

**Before**
<img width="951" alt="before-error-codeblock" src="https://user-images.githubusercontent.com/17883920/59100789-af70a300-8959-11e9-8731-204d6faa6b85.PNG">

**After**
<img width="951" alt="fix-reactchildren on codeblock" src="https://user-images.githubusercontent.com/17883920/59100837-cca57180-8959-11e9-8957-00e02c1bd570.PNG">


