### PR TITLE
refactor(v2): move typing to types.ts

### DIFF
--- a/packages/docusaurus/src/client/exports/context.ts
+++ b/packages/docusaurus/src/client/exports/context.ts
@@ -6,10 +6,6 @@
  */
 
 import * as React from 'react';
-import {DocusaurusConfig} from '../../server/config';
-
-export interface DocusaurusContext {
-  siteConfig?: DocusaurusConfig;
-}
+import { DocusaurusContext } from '../types';
 
 export default React.createContext<DocusaurusContext>({});

--- a/packages/docusaurus/src/client/exports/context.ts
+++ b/packages/docusaurus/src/client/exports/context.ts
@@ -6,6 +6,6 @@
  */
 
 import * as React from 'react';
-import { DocusaurusContext } from '../types';
+import {DocusaurusContext} from '../types';
 
 export default React.createContext<DocusaurusContext>({});

--- a/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
+++ b/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
@@ -6,10 +6,11 @@
  */
 
 import {useContext} from 'react';
-import DocusaurusContext from './context';
+import context from './context';
+import { DocusaurusContext } from '../types';
 
-function useDocusaurusContext() {
-  return useContext(DocusaurusContext);
+function useDocusaurusContext(): DocusaurusContext {
+  return useContext(context);
 }
 
 export default useDocusaurusContext;

--- a/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
+++ b/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
@@ -7,7 +7,7 @@
 
 import {useContext} from 'react';
 import context from './context';
-import { DocusaurusContext } from '../types';
+import {DocusaurusContext} from '../types';
 
 function useDocusaurusContext(): DocusaurusContext {
   return useContext(context);

--- a/packages/docusaurus/src/client/types.ts
+++ b/packages/docusaurus/src/client/types.ts
@@ -1,0 +1,5 @@
+import { DocusaurusConfig } from '../server/types';
+
+export interface DocusaurusContext {
+  siteConfig?: DocusaurusConfig;
+}

--- a/packages/docusaurus/src/client/types.ts
+++ b/packages/docusaurus/src/client/types.ts
@@ -1,4 +1,4 @@
-import { DocusaurusConfig } from '../server/types';
+import {DocusaurusConfig} from '../server/types';
 
 export interface DocusaurusContext {
   siteConfig?: DocusaurusConfig;

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -5,20 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import webpack, {Configuration, Plugin} from 'webpack';
-import merge from 'webpack-merge';
+import chalk from 'chalk';
 import CleanWebpackPlugin from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-import ReactLoadableSSRAddon from 'react-loadable-ssr-addon';
-import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer';
-import path from 'path';
-import chalk from 'chalk';
 import fs from 'fs-extra';
-import {load, CLIOptions, Props} from '../server';
+import path from 'path';
+import ReactLoadableSSRAddon from 'react-loadable-ssr-addon';
+import webpack, {Configuration, Plugin} from 'webpack';
+import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer';
+import merge from 'webpack-merge';
+import {STATIC_DIR_NAME} from '../constants';
+import {load} from '../server';
+import {CLIOptions, Props} from '../server/types';
 import {createClientConfig} from '../webpack/client';
 import {createServerConfig} from '../webpack/server';
 import {applyConfigureWebpack} from '../webpack/utils';
-import {STATIC_DIR_NAME} from '../constants';
 
 function compile(config: Configuration[]): Promise<any> {
   return new Promise((resolve, reject) => {

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs-extra';
 import path from 'path';
 import shell from 'shelljs';
-import fs from 'fs-extra';
-import {build} from './build';
-import {loadConfig} from '../server/config';
 import {CONFIG_FILE_NAME} from '../constants';
+import {loadConfig} from '../server/config';
+import {build} from './build';
 
 export async function deploy(siteDir: string): Promise<void> {
   console.log('Deploy command invoked ...');

--- a/packages/docusaurus/src/commands/init.ts
+++ b/packages/docusaurus/src/commands/init.ts
@@ -6,12 +6,12 @@
  */
 
 import chalk from 'chalk';
-import fs from 'fs-extra';
-import shell from 'shelljs';
-import inquirer from 'inquirer';
-import path from 'path';
-import _ from 'lodash';
 import {execSync} from 'child_process';
+import fs from 'fs-extra';
+import inquirer from 'inquirer';
+import _ from 'lodash';
+import path from 'path';
+import shell from 'shelljs';
 
 function hasYarn(): boolean {
   try {

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -5,22 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import _ from 'lodash';
-import path from 'path';
-import webpack from 'webpack';
-import express from 'express';
+import {normalizeUrl} from '@docusaurus/utils';
 import chalk from 'chalk';
 import chokidar from 'chokidar';
+import express from 'express';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import _ from 'lodash';
+import path from 'path';
 import portfinder from 'portfinder';
 import openBrowser from 'react-dev-utils/openBrowser';
 import {prepareUrls} from 'react-dev-utils/WebpackDevServerUtils';
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-import HotModuleReplacementPlugin from 'webpack/lib/HotModuleReplacementPlugin';
+import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import merge from 'webpack-merge';
-import {normalizeUrl} from '@docusaurus/utils';
-import {load, CLIOptions} from '../server';
+import HotModuleReplacementPlugin from 'webpack/lib/HotModuleReplacementPlugin';
 import {CONFIG_FILE_NAME, STATIC_DIR_NAME} from '../constants';
+import {load} from '../server';
+import {CLIOptions} from '../server/types';
 import {createClientConfig} from '../webpack/client';
 import {applyConfigureWebpack} from '../webpack/utils';
 

--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs-extra';
 import chalk from 'chalk';
-import path from 'path';
+import fs from 'fs-extra';
 import importFresh from 'import-fresh';
+import path from 'path';
 
 export async function swizzle(
   siteDir: string,

--- a/packages/docusaurus/src/server/client-modules/index.ts
+++ b/packages/docusaurus/src/server/client-modules/index.ts
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Plugin} from '../plugins';
-
 import _ from 'lodash';
+import {Plugin} from '../types';
 
 export function loadClientModules(plugins: Plugin<any>[]): string[] {
   return _.compact(

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -5,34 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {PluginConfig} from './plugins';
-
 import fs from 'fs-extra';
-import _ from 'lodash';
 import importFresh from 'import-fresh';
+import _ from 'lodash';
 import path from 'path';
 import {CONFIG_FILE_NAME} from '../constants';
-import {PresetConfig} from './presets';
-
-export interface DocusaurusConfig {
-  baseUrl: string;
-  favicon: string;
-  tagline: string;
-  title: string;
-  url: string;
-  organizationName?: string;
-  projectName?: string;
-  githubHost?: string;
-  plugins?: PluginConfig[];
-  themes?: PluginConfig[];
-  presets?: PresetConfig[];
-  themeConfig?: {
-    [key: string]: any;
-  };
-  customFields?: {
-    [key: string]: any;
-  };
-}
+import {DocusaurusConfig, PluginConfig} from './types';
 
 const REQUIRED_FIELDS = ['baseUrl', 'favicon', 'tagline', 'title', 'url'];
 

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -5,38 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {PluginConfig, Plugin} from './plugins';
-
-import path from 'path';
-import _ from 'lodash';
-
 import {generate} from '@docusaurus/utils';
-
-import {loadConfig, DocusaurusConfig} from './config';
-import {loadThemeAlias} from './themes';
-import {loadPlugins} from './plugins';
-import {loadRoutes} from './routes';
-import {loadPresets} from './presets';
+import _ from 'lodash';
+import path from 'path';
+import {CONFIG_FILE_NAME, GENERATED_FILES_DIR_NAME} from '../constants';
 import {loadClientModules} from './client-modules';
-
-import {GENERATED_FILES_DIR_NAME, CONFIG_FILE_NAME} from '../constants';
-
-export interface CLIOptions {
-  [option: string]: any;
-}
-
-export interface LoadContext {
-  siteDir: string;
-  generatedFilesDir: string;
-  siteConfig: DocusaurusConfig;
-  cliOptions: CLIOptions;
-  outDir: string;
-  baseUrl: string;
-}
-export interface Props extends LoadContext {
-  routesPaths: string[];
-  plugins: Plugin<any>[];
-}
+import {loadConfig} from './config';
+import {loadPlugins} from './plugins';
+import {loadPresets} from './presets';
+import {loadRoutes} from './routes';
+import {loadThemeAlias} from './themes';
+import {
+  CLIOptions,
+  DocusaurusConfig,
+  LoadContext,
+  PluginConfig,
+  Props,
+} from './types';
 
 export async function load(
   siteDir: string,

--- a/packages/docusaurus/src/server/loadSetup.ts
+++ b/packages/docusaurus/src/server/loadSetup.ts
@@ -6,7 +6,8 @@
  */
 
 import path from 'path';
-import {load, Props} from './index';
+import {load} from './index';
+import {Props} from './types';
 
 // Helper methods to setup dummy/fake projects
 export const loadSetup = async (name: string): Promise<Props> => {

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -5,36 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {LoadContext, Props} from '..';
-import {RouteConfig} from '../routes';
-
+import {generate} from '@docusaurus/utils';
 import fs from 'fs-extra';
 import importFresh from 'import-fresh';
 import path from 'path';
-import {generate} from '@docusaurus/utils';
-import {Configuration} from 'webpack';
-
-export interface Plugin<T> {
-  name: string;
-  loadContent?(): T;
-  contentLoaded?({
-    content: T,
-    actions: DocusaurusPluginContentLoadedActions,
-  }): void;
-  postBuild?(props: Props): void;
-  postStart?(props: Props): void;
-  configureWebpack?(config: Configuration, isServer: boolean): Configuration;
-  getThemePath?(): string;
-  getPathsToWatch?(): string[];
-  getClientModules?(): string[];
-}
-
-export type PluginConfig = [string, Object | undefined] | string;
-
-export interface PluginContentLoadedActions {
-  addRoute(config: RouteConfig): void;
-  createData(name: string, data: Object): Promise<string>;
-}
+import {
+  LoadContext,
+  Plugin,
+  PluginConfig,
+  PluginContentLoadedActions,
+  RouteConfig,
+} from '../types';
 
 export async function loadPlugins({
   pluginConfigs,

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -5,18 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {LoadContext} from '../index';
-import {PluginConfig} from '../plugins';
-
 import importFresh from 'import-fresh';
 import _ from 'lodash';
-
-export interface Preset {
-  plugins?: PluginConfig[];
-  themes?: PluginConfig[];
-}
-
-export type PresetConfig = [string, Object | undefined] | string;
+import {LoadContext, PluginConfig, Preset, PresetConfig} from '../types';
 
 export function loadPresets(
   context: LoadContext,

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -6,33 +6,9 @@
  */
 
 import {genChunkName} from '@docusaurus/utils';
-import {stringify, ParsedUrlQueryInput} from 'querystring';
 import _ from 'lodash';
-
-interface ChunkRegistry {
-  importStatement: string;
-  modulePath: string;
-}
-
-type Module =
-  | {
-      path: string;
-      __import?: boolean;
-      query?: ParsedUrlQueryInput;
-    }
-  | string;
-
-interface RouteModule {
-  [module: string]: Module | RouteModule | RouteModule[];
-}
-
-export interface RouteConfig {
-  path: string;
-  component: string;
-  modules?: RouteModule;
-  routes?: RouteConfig[];
-  exact?: boolean;
-}
+import {stringify} from 'querystring';
+import {ChunkRegistry, Module, RouteConfig, RouteModule} from './types';
 
 function getModulePath(target: Module): string {
   if (typeof target === 'string') {

--- a/packages/docusaurus/src/server/themes/alias.ts
+++ b/packages/docusaurus/src/server/themes/alias.ts
@@ -9,10 +9,7 @@ import globby from 'globby';
 import fs from 'fs-extra';
 import path from 'path';
 import {fileToPath, posixPath, normalizeUrl} from '@docusaurus/utils';
-
-export interface ThemeAlias {
-  [alias: string]: string;
-}
+import {ThemeAlias} from '../types';
 
 export function themeAlias(themePath: string): ThemeAlias {
   if (!fs.pathExistsSync(themePath)) {

--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {themeAlias, ThemeAlias} from './alias';
-
-export {ThemeAlias} from './alias';
+import {ThemeAlias} from '../types';
+import {themeAlias} from './alias';
 
 export function loadThemeAlias(themePaths: string[]): ThemeAlias {
   return themePaths.reduce(

--- a/packages/docusaurus/src/server/types.ts
+++ b/packages/docusaurus/src/server/types.ts
@@ -1,0 +1,100 @@
+import {ParsedUrlQueryInput} from 'querystring';
+import {Configuration} from 'webpack';
+
+export interface DocusaurusConfig {
+  baseUrl: string;
+  favicon: string;
+  tagline: string;
+  title: string;
+  url: string;
+  organizationName?: string;
+  projectName?: string;
+  githubHost?: string;
+  plugins?: PluginConfig[];
+  themes?: PluginConfig[];
+  presets?: PresetConfig[];
+  themeConfig?: {
+    [key: string]: any;
+  };
+  customFields?: {
+    [key: string]: any;
+  };
+}
+
+export interface Preset {
+  plugins?: PluginConfig[];
+  themes?: PluginConfig[];
+}
+
+export type PresetConfig = [string, Object | undefined] | string;
+
+export interface CLIOptions {
+  [option: string]: any;
+}
+
+export interface LoadContext {
+  siteDir: string;
+  generatedFilesDir: string;
+  siteConfig: DocusaurusConfig;
+  cliOptions: CLIOptions;
+  outDir: string;
+  baseUrl: string;
+}
+
+export interface Props extends LoadContext {
+  routesPaths: string[];
+  plugins: Plugin<any>[];
+}
+
+export interface PluginContentLoadedActions {
+  addRoute(config: RouteConfig): void;
+  createData(name: string, data: Object): Promise<string>;
+}
+
+export interface Plugin<T> {
+  name: string;
+  loadContent?(): T;
+  contentLoaded?({
+    content,
+    actions,
+  }: {
+    content: T;
+    actions: PluginContentLoadedActions;
+  }): void;
+  postBuild?(props: Props): void;
+  postStart?(props: Props): void;
+  configureWebpack?(config: Configuration, isServer: boolean): Configuration;
+  getThemePath?(): string;
+  getPathsToWatch?(): string[];
+  getClientModules?(): string[];
+}
+export type PluginConfig = [string, Object | undefined] | string;
+
+export interface ChunkRegistry {
+  importStatement: string;
+  modulePath: string;
+}
+
+export type Module =
+  | {
+      path: string;
+      __import?: boolean;
+      query?: ParsedUrlQueryInput;
+    }
+  | string;
+
+export interface RouteModule {
+  [module: string]: Module | RouteModule | RouteModule[];
+}
+
+export interface RouteConfig {
+  path: string;
+  component: string;
+  modules?: RouteModule;
+  routes?: RouteConfig[];
+  exact?: boolean;
+}
+
+export interface ThemeAlias {
+  [alias: string]: string;
+}

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -5,14 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs-extra';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import OptimizeCSSAssetsPlugin from 'optimize-css-assets-webpack-plugin';
-import TerserPlugin from 'terser-webpack-plugin';
 import path from 'path';
-import fs from 'fs-extra';
+import TerserPlugin from 'terser-webpack-plugin';
 import {Configuration} from 'webpack';
+
+import {Props} from '../server/types';
 import {getBabelLoader, getCacheLoader, getStyleLoaders} from './utils';
-import {Props} from '../server';
 
 const CSS_REGEX = /\.css$/;
 const CSS_MODULE_REGEX = /\.module\.css$/;

--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -6,12 +6,12 @@
  */
 import path from 'path';
 import {Configuration} from 'webpack';
-import WebpackNiceLog from 'webpack-nicelog';
 import merge from 'webpack-merge';
-import ChunkManifestPlugin from './plugins/ChunkManifestPlugin';
+import WebpackNiceLog from 'webpack-nicelog';
 
+import {Props} from '../server/types';
 import {createBaseConfig} from './base';
-import {Props} from '../server';
+import ChunkManifestPlugin from './plugins/ChunkManifestPlugin';
 
 export function createClientConfig(props: Props): Configuration {
   const isProd = process.env.NODE_ENV === 'production';

--- a/packages/docusaurus/src/webpack/server.ts
+++ b/packages/docusaurus/src/webpack/server.ts
@@ -7,13 +7,13 @@
 
 import path from 'path';
 import StaticSiteGeneratorPlugin from 'static-site-generator-webpack-plugin';
-import WebpackNiceLog from 'webpack-nicelog';
-import merge from 'webpack-merge';
 import {Configuration} from 'webpack';
+import merge from 'webpack-merge';
+import WebpackNiceLog from 'webpack-nicelog';
 
+import {Props} from '../server/types';
 import {createBaseConfig} from './base';
 import WaitPlugin from './plugins/WaitPlugin';
-import {Props} from '../server';
 
 export function createServerConfig(props: Props): Configuration {
   const {baseUrl, routesPaths, outDir} = props;


### PR DESCRIPTION
## Motivation

Just moving interfaces to a dedicated types file. it's not a good idea to keep interfaces on the real code as it make the code very intimidating to the reader. Having `types.ts`  also makes it clear that it is a typescript types.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Nothing broke
<img width="959" alt="development" src="https://user-images.githubusercontent.com/17883920/59105499-a0442200-8966-11e9-8a1f-a2edc50505f3.PNG">

Netlify and CI should pass

