### PR TITLE
fix: remove the `Container` component from the `docsNavContainer`

### DIFF
--- a/packages/docusaurus-1.x/lib/core/BlogSidebar.js
+++ b/packages/docusaurus-1.x/lib/core/BlogSidebar.js
@@ -6,7 +6,6 @@
  */
 
 const React = require('react');
-const Container = require('./Container.js');
 const SideNav = require('./nav/SideNav.js');
 
 const MetadataBlog = require('./MetadataBlog.js');
@@ -42,7 +41,7 @@ class BlogSidebar extends React.Component {
       category: blogSidebarTitle,
     };
     return (
-      <Container className="docsNavContainer" id="docsNav" wrapper={false}>
+      <div className="docsNavContainer" id="docsNav">
         <SideNav
           language={this.props.language}
           root={`${this.props.config.baseUrl}blog/`}
@@ -50,7 +49,7 @@ class BlogSidebar extends React.Component {
           contents={contents}
           current={current}
         />
-      </Container>
+      </div>
     );
   }
 }

--- a/packages/docusaurus-1.x/lib/core/DocsSidebar.js
+++ b/packages/docusaurus-1.x/lib/core/DocsSidebar.js
@@ -7,7 +7,6 @@
 
 const React = require('react');
 const fs = require('fs');
-const Container = require('./Container.js');
 const SideNav = require('./nav/SideNav.js');
 const Metadata = require('../core/metadata.js');
 
@@ -38,7 +37,7 @@ class DocsSidebar extends React.Component {
     }
 
     return (
-      <Container className="docsNavContainer" id="docsNav" wrapper={false}>
+      <div className="docsNavContainer" id="docsNav">
         <SideNav
           collapsible={this.props.collapsible}
           language={this.props.metadata.language}
@@ -47,7 +46,7 @@ class DocsSidebar extends React.Component {
           contents={docsCategories[this.props.metadata.language]}
           current={this.props.metadata}
         />
-      </Container>
+      </div>
     );
   }
 }


### PR DESCRIPTION
In this case, the `docsNavContainer` does not pick up any styles or attributes from the `container` component it is wrapped in.

It does however pick up the pesky `.container` className, which when paired with bootstrap, messes up the styling of the top navigation in mobile.

This change is completely non-destructive, but helps enable the use of bootstrap on top of Docusaurus.