### PR TITLE
feat: Created copycode button in live code block based on legacy button.

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.module.css
@@ -1,8 +1,9 @@
 .mdxCodeBlock {
+  position: relative;
   background-color: transparent;
-  border: 0.5px solid rgba(31, 34, 39, .6);
+  border: 0.5px solid rgba(31, 34, 39, 0.6);
   border-radius: var(--ifm-global-radius);
-  box-shadow: rgba(0,0,0,.1) 1px 1px 4px 1px;
+  box-shadow: rgba(0, 0, 0, 0.1) 1px 1px 4px 1px;
   box-sizing: border-box;
   font-family: inherit;
   padding: 0;

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "^2.2.6",
+    "clipboard": "^2.0.4",
     "prism-react-renderer": "^0.1.6",
     "react-live": "^2.1.2",
     "react-loadable": "^5.5.0",

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -4,8 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-import React, {Component, Fragment} from 'react';
+import React, {Fragment, createRef, useState, useEffect} from 'react';
 import classnames from 'classnames';
 import LoadableVisibility from 'react-loadable-visibility/react-loadable';
 import Highlight, {defaultProps} from 'prism-react-renderer';
@@ -20,96 +19,86 @@ const Playground = LoadableVisibility({
   loading: Loading,
 });
 
-export default class CodeBlock extends Component {
-  constructor() {
-    super();
+export default ({children, className: languageClassName, live, ...props}) => {
+  const [copied, setCopied] = useState(false);
 
-    this.state = {
-      copied: false,
-    };
-  }
+  const button = createRef();
+  const target = createRef();
 
-  componentDidMount() {
-    const {button, input} = this;
-
-    this.clipboard = new Clipboard(button, {
-      target: () => input,
+  useEffect(() => {
+    const clipboard = new Clipboard(button.current, {
+      target: () => target.current,
     });
-  }
 
-  componentWillUnmount() {
-    this.clipboard.destroy();
-  }
+    return function cleanup() {
+      clipboard.destroy();
+    };
+  }, [button.current, target.current]);
 
-  render() {
-    const {children, className: languageClassName, live, ...props} = this.props;
-
-    if (live) {
-      return (
+  if (live) {
+    return (
+      <Fragment>
         <Playground
           scope={{...React}}
           code={children.trim()}
           theme={nightOwlTheme}
           {...props}
         />
-      );
-    }
-    const language =
-      languageClassName && languageClassName.replace(/language-/, '');
-    return (
-      <Highlight
-        {...defaultProps}
-        theme={nightOwlTheme}
-        code={children.trim()}
-        language={language}>
-        {({className, style, tokens, getLineProps, getTokenProps}) => (
-          <Fragment>
-            <pre
-              ref={element => {
-                this.input = element;
-              }}
-              className={classnames(className, styles.codeBlock)}
-              style={style}>
-              {tokens.map((line, i) => (
-                <div key={i} {...getLineProps({line, key: i})}>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({token, key})} />
-                  ))}
-                </div>
-              ))}
-            </pre>
-            <button
-              ref={element => {
-                this.button = element;
-              }}
-              type="button"
-              className={classnames(styles.btnCopy)}
-              aria-label="Copy code to clipboard"
-              onClick={() => {
-                window.getSelection().empty();
-                this.setState({copied: true});
-                setTimeout(() => this.setState({copied: false}), 2000);
-              }}>
-              <div className={classnames(styles.btnCopy__body)}>
-                <svg
-                  width="11"
-                  height="11"
-                  viewBox="340 364 14 15"
-                  xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    fill="currentColor"
-                    d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-                <strong className={classnames(styles.btnCopy__label)}>
-                  {this.state.copied ? 'Copied' : 'Copy'}
-                </strong>
-              </div>
-            </button>
-          </Fragment>
-        )}
-      </Highlight>
+      </Fragment>
     );
   }
-}
+
+  const language =
+    languageClassName && languageClassName.replace(/language-/, '');
+  return (
+    <Highlight
+      {...defaultProps}
+      theme={nightOwlTheme}
+      code={children.trim()}
+      language={language}>
+      {({className, style, tokens, getLineProps, getTokenProps}) => (
+        <Fragment>
+          <pre
+            ref={target}
+            className={classnames(className, styles.codeBlock)}
+            style={style}>
+            {tokens.map((line, i) => (
+              <div key={i} {...getLineProps({line, key: i})}>
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({token, key})} />
+                ))}
+              </div>
+            ))}
+          </pre>
+          <button
+            ref={button}
+            type="button"
+            className={classnames(styles.btnCopy)}
+            aria-label="Copy code to clipboard"
+            onClick={() => {
+              window.getSelection().empty();
+              setCopied(true);
+              setTimeout(() => setCopied(), 2000);
+            }}>
+            <div className={classnames(styles.btnCopy__body)}>
+              <svg
+                width="11"
+                height="11"
+                viewBox="340 364 14 15"
+                xmlns="http://www.w3.org/2000/svg">
+                <path
+                  fill="currentColor"
+                  d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              <strong className={classnames(styles.btnCopy__label)}>
+                {copied ? 'Copied' : 'Copy'}
+              </strong>
+            </div>
+          </button>
+        </Fragment>
+      )}
+    </Highlight>
+  );
+};

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {Component, Fragment} from 'react';
 import classnames from 'classnames';
 import LoadableVisibility from 'react-loadable-visibility/react-loadable';
 import Highlight, {defaultProps} from 'prism-react-renderer';
 import nightOwlTheme from 'prism-react-renderer/themes/nightOwl';
 import Loading from '@theme/Loading';
+import Clipboard from 'clipboard';
 import styles from './styles.module.css';
 
 /* Live playground is not small in size, lazy load it is better */
@@ -19,36 +20,96 @@ const Playground = LoadableVisibility({
   loading: Loading,
 });
 
-export default ({children, className: languageClassName, live, ...props}) => {
-  if (live) {
+export default class CodeBlock extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      copied: false,
+    };
+  }
+
+  componentDidMount() {
+    const {button, input} = this;
+
+    this.clipboard = new Clipboard(button, {
+      target: () => input,
+    });
+  }
+
+  componentWillUnmount() {
+    this.clipboard.destroy();
+  }
+
+  render() {
+    const {children, className: languageClassName, live, ...props} = this.props;
+
+    if (live) {
+      return (
+        <Playground
+          scope={{...React}}
+          code={children.trim()}
+          theme={nightOwlTheme}
+          {...props}
+        />
+      );
+    }
+    const language =
+      languageClassName && languageClassName.replace(/language-/, '');
     return (
-      <Playground
-        scope={{...React}}
-        code={children.trim()}
+      <Highlight
+        {...defaultProps}
         theme={nightOwlTheme}
-        {...props}
-      />
+        code={children.trim()}
+        language={language}>
+        {({className, style, tokens, getLineProps, getTokenProps}) => (
+          <Fragment>
+            <pre
+              ref={element => {
+                this.input = element;
+              }}
+              className={classnames(className, styles.codeBlock)}
+              style={style}>
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({line, key: i})}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({token, key})} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+            <button
+              ref={element => {
+                this.button = element;
+              }}
+              type="button"
+              className={classnames(styles.btnCopy)}
+              aria-label="Copy code to clipboard"
+              onClick={() => {
+                window.getSelection().empty();
+                this.setState({copied: true});
+                setTimeout(() => this.setState({copied: false}), 2000);
+              }}>
+              <div className={classnames(styles.btnCopy__body)}>
+                <svg
+                  width="11"
+                  height="11"
+                  viewBox="340 364 14 15"
+                  xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    fill="currentColor"
+                    d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+                <strong className={classnames(styles.btnCopy__label)}>
+                  {this.state.copied ? 'Copied' : 'Copy'}
+                </strong>
+              </div>
+            </button>
+          </Fragment>
+        )}
+      </Highlight>
     );
   }
-  const language =
-    languageClassName && languageClassName.replace(/language-/, '');
-  return (
-    <Highlight
-      {...defaultProps}
-      theme={nightOwlTheme}
-      code={children.trim()}
-      language={language}>
-      {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <pre className={classnames(className, styles.codeBlock)} style={style}>
-          {tokens.map((line, i) => (
-            <div key={i} {...getLineProps({line, key: i})}>
-              {line.map((token, key) => (
-                <span key={key} {...getTokenProps({token, key})} />
-              ))}
-            </div>
-          ))}
-        </pre>
-      )}
-    </Highlight>
-  );
-};
+}

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .codeBlock__parent {
   position: relative;
 }

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -1,8 +1,50 @@
+.codeBlock__parent {
+  position: relative;
+}
+
 .codeBlock {
+  position: relative;
   border-radius: 0;
   font-size: inherit;
   margin-bottom: 0;
   overflow: hidden;
   overflow-wrap: break-word;
   white-space: pre-wrap;
+}
+
+pre .btnCopy {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 2;
+  cursor: pointer;
+  border: 1px solid transparent;
+  padding: 0;
+  color: rgb(214, 222, 235);
+  background-color: transparent;
+  height: 30px;
+  transition: all 0.25s ease-out;
+}
+
+pre .btnCopy:hover {
+  text-decoration: none;
+}
+
+.btnCopy__body {
+  align-items: center;
+  display: flex;
+}
+
+.btnCopy svg {
+  fill: currentColor;
+  margin-right: 0.4em;
+}
+
+.btnCopy__label {
+  font-size: 11px;
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.btnClipboard {
+  right: 0.4em;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3784,7 +3784,7 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-clipboard@^2.0.0:
+clipboard@^2.0.0, clipboard@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.4.tgz#836dafd66cf0fea5d71ce5d5b0bf6e958009112d"
   integrity sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==


### PR DESCRIPTION
## Motivation

I've migrated the copy code button from `website-1.x` to `live-code-block` package.

### RFC

* I converted `<CodeBlock />` into a class component in order to use lifecycle methods with the clipboard library. I though about refactoring it back into a sfc with hooks, but I haven't used the hooks API yet.
* I'd also consider moving the `<button>` JSX into its own component.
* Anything wrong with using `<Fragment />` inside <Highlight />? https://github.com/facebook/Docusaurus/commit/8d81436afb5c043adbac1d118b76eaa9571b4326?diff=unified#r33938022
* Anything wrong with using an setTimeout method to set the state? https://github.com/facebook/Docusaurus/commit/8d81436afb5c043adbac1d118b76eaa9571b4326?diff=unified#r33938067


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

```shell
# In project root
yarn install

# In website/
yarn start
```

Navigate to any code block in the application.

## Related PRs

Support copy codeblock button for Docusaurus 2 - #1578. 
