### PR TITLE
Allowing you to set a site level description property

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -76,6 +76,10 @@ Project name. This must match your GitHub repository project name (case-sensitiv
 
 The tagline for your website.
 
+#### `description` [string]
+
+Site level description for your website. Used in generating the description metadata tag. Can be overridden for specific pages by setting a description property on the exported React component. 
+
 #### `title` [string]
 
 Title for your website.

--- a/packages/docusaurus-1.x/lib/core/Site.js
+++ b/packages/docusaurus-1.x/lib/core/Site.js
@@ -40,7 +40,7 @@ class Site extends React.Component {
       : (!this.props.config.disableTitleTagline &&
           `${this.props.config.title} · ${tagline}`) ||
         this.props.config.title;
-    const description = this.props.description || tagline;
+    const description = this.props.description || this.props.config.description || tagline;
     const path = getPath(
       this.props.config.baseUrl + (this.props.url || 'index.html'),
       this.props.config.cleanUrl,

--- a/packages/docusaurus-1.x/lib/core/Site.js
+++ b/packages/docusaurus-1.x/lib/core/Site.js
@@ -40,7 +40,8 @@ class Site extends React.Component {
       : (!this.props.config.disableTitleTagline &&
           `${this.props.config.title} · ${tagline}`) ||
         this.props.config.title;
-    const description = this.props.description || this.props.config.description || tagline;
+    const description =
+      this.props.description || this.props.config.description || tagline;
     const path = getPath(
       this.props.config.baseUrl + (this.props.url || 'index.html'),
       this.props.config.cleanUrl,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When creating a documentation site, there are times your want to add a  site description that can be used throughout the site (as a meta tag). This is particularly useful when sharing links to your site. 

As it is, you currently have to go to each page and set the description property on the exported React component for it to be used in the description meta tag. If you do not specify this, your configured tagline will be used (which might not be the desired result)

This change allow you to specify a description property in your site config. This description property is then used if you do not specify the description at the page level. If this is not specified then the tagline is used (like the current behavior).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Linked to the Docusaurus project, and built a test site  (`docusaurus-build` command) with the description property set. Checked the meta tags produced.
