### PR TITLE
docs: fix reference to publishing steps

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -152,7 +152,7 @@ workflows:
 
 Make sure to replace all `<....>` in the `command:` sequence with appropriate values. For `<GIT_USER>`, it should be a GitHub account that has access to push documentation to your GitHub repository. Many times `<GIT_USER>` and `<GITHUB_USERNAME>` will be the same.
 
-**DO NOT** place the actual value of `$GITHUB_TOKEN` in `circle.yml`. We already configured that as an environment variable back in Step 3.
+**DO NOT** place the actual value of `$GITHUB_TOKEN` in `circle.yml`. We already configured that as an environment variable back in Step 5.
 
 > If you want to use SSH for your GitHub repository connection, you can set `USE_SSH=true`. So the above command would look something like: `cd website && npm install && GIT_USER=<GIT_USER> USE_SSH=true npm run publish-gh-pages`.
 


### PR DESCRIPTION
## Motivation

I believe the reference to step 3 should actually be to step 5.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

No. I don't think it would be necessary for such a small change.

## Test Plan

None needed. Just need an authorized maintainer to confirm that the step should be 5.
