### PR TITLE
docs: add Render hosting guide

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -27,6 +27,7 @@ At this point, you can grab all of the files inside the `website/build` director
 
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
+* [Render](#hosting-on-render)
 
 ### Using GitHub Pages
 
@@ -232,6 +233,33 @@ Steps to configure your Docusaurus-powered site on Netlify.
 1.  Click **Deploy site**
 
 You can also configure Netlify to rebuild on every commit to your repository, or only `master` branch commits.
+
+### Hosting on Render
+
+Render offers free [static site](https://render.com/docs/static-sites) hosting with fully managed SSL, custom domains, a global CDN and continuous auto deploys from your Git repo. Deploy your app in just a few minutes by following these steps.
+
+1. Create a new **Web Service** on Render, and give Render's GitHub app permission to access your Docusaurus repo.
+
+2. Select the branch to deploy. The default is `master`.
+
+2. Enter the following values during creation.
+
+    |  Field  |  Value |
+    | ------- | ----- |
+    | **Environment** | `Static Site` |
+    | **Build Command** | `cd website; yarn install; yarn build` |
+    | **Publish Directory** | `website/build/<projectName>` |
+
+    `projectName` is the value you defined in your `siteConfig.js`.
+
+    ```javascript{7}
+    const siteConfig = {
+      // ...
+      projectName: 'your-project-name',
+      // ...
+    ```
+
+That's it! Your app will be live on your Render URL as soon as the build finishes.
 
 ### Publishing to GitHub Enterprise
 

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -11,7 +11,7 @@ npm build
 
 Once it finishes, you should see the production build under the `build/` directory.
 
-You can deploy your site to static site hosting services such as [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are server rendered so they work without JavaScript too!
+You can deploy your site to static site hosting services such as [GitHub Pages](https://pages.github.com/), [Render](https://render.com/static-sites), and [Netlify](https://www.netlify.com/). Docusaurus sites are server rendered so they work without JavaScript too!
 
 ## Deploying to GitHub Pages
 
@@ -78,9 +78,9 @@ References:
 
 ## Deploying to Render
 
-Render offers free [static site](https://render.com/docs/static-sites) hosting with fully managed SSL, custom domains, a global CDN and continuous auto deploys from your Git repo. Deploy your app in just a few minutes by following these steps.
+Render offers [free static site hosting](https://render.com/docs/static-sites) with fully managed SSL, custom domains, a global CDN and continuous auto deploys from your Git repo. Deploy your app in just a few minutes by following these steps.
 
-1. Create a new **Web Service** on Render, and give Render's GitHub app permission to access your Docusaurus repo.
+1. Create a new **Web Service** on Render, and give Render permission to access your Docusaurus repo.
 
 2. Select the branch to deploy. The default is `master`.
 
@@ -89,17 +89,8 @@ Render offers free [static site](https://render.com/docs/static-sites) hosting w
     |  Field  |  Value |
     | ------- | ----- |
     | **Environment** | `Static Site` |
-    | **Build Command** | `cd website; yarn install; yarn build` |
-    | **Publish Directory** | `website/build/<projectName>` |
-
-    `projectName` is the value you defined in your `siteConfig.js`.
-
-    ```javascript{7}
-    const siteConfig = {
-      // ...
-      projectName: 'your-project-name',
-      // ...
-    ```
+    | **Build Command** | `yarn build` |
+    | **Publish Directory** | `build` |
 
 That's it! Your app will be live on your Render URL as soon as the build finishes.
 

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -76,6 +76,33 @@ References:
 
 -->
 
+## Deploying to Render
+
+Render offers free [static site](https://render.com/docs/static-sites) hosting with fully managed SSL, custom domains, a global CDN and continuous auto deploys from your Git repo. Deploy your app in just a few minutes by following these steps.
+
+1. Create a new **Web Service** on Render, and give Render's GitHub app permission to access your Docusaurus repo.
+
+2. Select the branch to deploy. The default is `master`.
+
+2. Enter the following values during creation.
+
+    |  Field  |  Value |
+    | ------- | ----- |
+    | **Environment** | `Static Site` |
+    | **Build Command** | `cd website; yarn install; yarn build` |
+    | **Publish Directory** | `website/build/<projectName>` |
+
+    `projectName` is the value you defined in your `siteConfig.js`.
+
+    ```javascript{7}
+    const siteConfig = {
+      // ...
+      projectName: 'your-project-name',
+      // ...
+    ```
+
+That's it! Your app will be live on your Render URL as soon as the build finishes.
+
 ## Deployment with Netlify
 
 _This section is a work in progress. [Welcoming PRs](https://github.com/facebook/docusaurus/issues/1640)._

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -11,7 +11,7 @@ npm build
 
 Once it finishes, you should see the production build under the `build/` directory.
 
-You can deploy your site to static site hosting services such as [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/). Docusaurus sites are server rendered so they work without JavaScript too!
+You can deploy your site to static site hosting services such as [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are server rendered so they work without JavaScript too!
 
 ## Deploying to GitHub Pages
 


### PR DESCRIPTION
## Motivation

[Render](https://render.com) is an official deployment option for [create-react-app](https://facebook.github.io/create-react-app/docs/deployment#render-https-rendercom), [gatsby](https://www.gatsbyjs.org/docs/deploying-to-render/), and [hugo](https://gohugo.io/hosting-and-deployment/hosting-on-render/). This PR adds a guide for Docusaurus users who may want to host their site on Render.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan
- [x] `yarn prettier && yarn lint`
- [x] `yarn test`
- [x] Visual inspection of all doc versions.
