### PR TITLE
feat: use primary color for highlighted items in table of contents

### DIFF
--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -1979,6 +1979,7 @@ input::placeholder {
 
 .onPageNav .toc-headings > li > a.active {
   font-weight: 600;
+  color: $primaryColor;
 }
 
 .onPageNav ul {


### PR DESCRIPTION
Currently the items in table of contents are highlighted as bold based on items being
viewed on the screen or as the user scrolls up/down on a page. Added the `primaryColor`
of the site's configuration to make the current section being viewed standout more
in the table of content.

closes #1608

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I can easily apply necessary changes so that items in table of contents are highlighted using the primary colour, but I think this is something others may find useful also.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before the `css` change:

![image](https://user-images.githubusercontent.com/2721901/60200631-7d45b900-9814-11e9-883e-f3420dcb6a5f.png)

After the `css` change:

![image](https://user-images.githubusercontent.com/2721901/60200646-85055d80-9814-11e9-9652-11a7f5f9af68.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
