### PR TITLE
fix: wrong bootstrapped footer social links

### DIFF
--- a/packages/docusaurus-1.x/examples/basics/core/Footer.js
+++ b/packages/docusaurus-1.x/examples/basics/core/Footer.js
@@ -80,6 +80,30 @@ class Footer extends React.Component {
               aria-label="Star this project on GitHub">
               Star
             </a>
+            {this.props.config.twitterUsername && (
+              <div className="social">
+                <a
+                  href={`https://twitter.com/${
+                    this.props.config.twitterUsername
+                  }`}
+                  className="twitter-follow-button">
+                  Follow @{this.props.config.twitterUsername}
+                </a>
+              </div>
+            )}
+            {this.props.config.facebookAppId && (
+              <div className="social">
+                <div
+                  className="fb-like"
+                  data-href={this.props.config.url}
+                  data-colorscheme="dark"
+                  data-layout="standard"
+                  data-share="true"
+                  data-width="225"
+                  data-show-faces="false"
+                />
+              </div>
+            )}
           </div>
         </section>
 


### PR DESCRIPTION
## Motivation

fix #1644 

the bootstrapped footer code doesnt include social links

wrong (outdated?) component is being created during bootstrapping.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

<img width="955" alt="after" src="https://user-images.githubusercontent.com/17883920/60987638-3dcab100-a36c-11e9-9884-30e65cd0d8a5.PNG">

