### PR TITLE
docs(v1): Add information for docsSideNavCollapsible in siteConfig.js

### DIFF
--- a/packages/docusaurus-1.x/examples/basics/siteConfig.js
+++ b/packages/docusaurus-1.x/examples/basics/siteConfig.js
@@ -94,7 +94,7 @@ const siteConfig = {
 
   // For sites with a sizable amount of content, set collapsible to true.
   // Expand/collapse the links and subcategories under categories.
-  // docsSideNavCollapsible: true
+  // docsSideNavCollapsible: true,
 
   // Show documentation's last contributor's name.
   // enableUpdateBy: true,

--- a/packages/docusaurus-1.x/examples/basics/siteConfig.js
+++ b/packages/docusaurus-1.x/examples/basics/siteConfig.js
@@ -92,6 +92,10 @@ const siteConfig = {
   ogImage: 'img/undraw_online.svg',
   twitterImage: 'img/undraw_tweetstorm.svg',
 
+  // For sites with a sizable amount of content, set collapsible to true.
+  // Expand/collapse the links and subcategories under categories.
+  // docsSideNavCollapsible: true
+
   // Show documentation's last contributor's name.
   // enableUpdateBy: true,
 


### PR DESCRIPTION
## Motivation

Collapsible categories are pretty useful and should be included in the basic siteConfig.js 

https://github.com/facebook/docusaurus/blob/master/docs/guides-navigation.md#collapsible-categories

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes