### PR TITLE
feat(v2): render 404 html page

### DIFF
--- a/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
@@ -55,6 +55,7 @@ export default [
 ];
 ",
   "routesPaths": Array [
+    "404.html",
     "/blog",
   ],
 }
@@ -140,6 +141,7 @@ export default [
 ];
 ",
   "routesPaths": Array [
+    "404.html",
     "/docs/hello",
     "docs/foo/baz",
   ],

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -26,7 +26,7 @@ export async function loadRoutes(pluginsRouteConfigs: RouteConfig[]) {
   const registry: {
     [chunkName: string]: ChunkRegistry;
   } = {};
-  const routesPaths: string[] = [];
+  const routesPaths: string[] = ['404.html'];
   const routesChunkNames: {
     [routePath: string]: any;
   } = {};


### PR DESCRIPTION
## Motivation

Generate/ Render 404 html page as well. This opens up possibility for user to override `theme/NotFound` page and create ez redirect in the future.

https://github.com/facebook/docusaurus/blob/master/packages/docusaurus-theme-classic/src/theme/NotFound.js

Currently, https://v2.docusaurus.io/nothing yields
<img width="957" alt="404-before" src="https://user-images.githubusercontent.com/17883920/61170271-012bcf00-a591-11e9-89d4-cab0e514e609.PNG">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Local build(not dev)

localhost::5000/nothing
<img width="952" alt="404" src="https://user-images.githubusercontent.com/17883920/61170277-11dc4500-a591-11e9-9ece-e0721890a2d7.PNG">

https://deploy-preview-1652--docusaurus-2.netlify.com/nothing
![image](https://user-images.githubusercontent.com/17883920/61170298-99c24f00-a591-11e9-8218-c5367c880af2.png)
