### PR TITLE
fix(v2): clicking logo on mobile sidebar should go to homepage

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -165,11 +165,7 @@ function Navbar() {
         />
         <div className="navbar__sidebar">
           <div className="navbar__sidebar__brand">
-            <a
-              className="navbar__brand"
-              href="#!"
-              role="button"
-              onClick={hideSidebar}>
+            <Link className="navbar__brand" onClick={hideSidebar} to={baseUrl}>
               {logo != null && (
                 <img
                   className="navbar__logo"
@@ -178,7 +174,7 @@ function Navbar() {
                 />
               )}
               {title != null && <strong>{title}</strong>}
-            </a>
+            </Link>
             {sidebarShown && (
               <Toggle
                 aria-label="Dark mode toggle in sidebar"


### PR DESCRIPTION
## Motivation

- Shouldnt clicking the logo in navbar points to home? Currently it closes navbar ![](https://i.imgur.com/J6ytQFF.png)

![before-logo](https://user-images.githubusercontent.com/17883920/61174356-1b819f00-a5c9-11e9-8af3-abb622c2a41a.gif)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

![after-logo1](https://user-images.githubusercontent.com/17883920/61174364-22a8ad00-a5c9-11e9-92d0-af8944164897.gif)


