### PR TITLE
fix: fix PostCSS warning on `build` command

### DIFF
--- a/packages/docusaurus-1.x/lib/server/utils.js
+++ b/packages/docusaurus-1.x/lib/server/utils.js
@@ -53,6 +53,7 @@ function minifyCss(cssContent) {
     .process(cssContent, {
       preset: 'default',
       zindex: false,
+      from: undefined,
     })
     .then(result => result.css);
 }


### PR DESCRIPTION
## Motivation

The warning is produced on `cssnano` call. See below:

> Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.

I think the warning makes users confusing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The warning is produced already. See the [build log](https://circleci.com/gh/facebook/docusaurus/8313):

![image](https://user-images.githubusercontent.com/473530/61203893-a6c47700-a726-11e9-8dd6-c180bed8a46a.png)

Also, you can reproduce on your shell terminal. Run the following commands:

```shell
mkdir work
cd work
npx docusaurus-init
cd website
yarn install
yarn run build
```

![image](https://user-images.githubusercontent.com/473530/61203999-f7d46b00-a726-11e9-9b3f-afadd2b74835.png)

## Related PRs

None.

