### PR TITLE
feat(v2): better twitter preview meta tag

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -66,10 +66,7 @@ function Layout(props) {
           <meta name="twitter:image:alt" content={`Image for ${metaTitle}`} />
         )}
         {permalink && <meta property="og:url" content={siteUrl + permalink} />}
-        <meta
-          name="twitter:card"
-          content={image || favicon ? 'summary_large_image' : 'summary'}
-        />
+        <meta name="twitter:card" content="summary" />
       </Head>
       <Navbar />
       {children}

--- a/packages/docusaurus/src/client/templates/index.html.template.ejs
+++ b/packages/docusaurus/src/client/templates/index.html.template.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -10,7 +10,7 @@ module.exports = `
 <html <%= htmlAttributes %>>
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width">
     <%- chunkManifestScript %>
     <% metaAttributes.forEach((metaAttribute) => { %>
       <%- metaAttribute %>


### PR DESCRIPTION
## Motivation

- remove unwanted initial-scale viewport meta tag
- use twitter summary tag https://stackoverflow.com/questions/47578130/twitter-card-summary-vs-summary-large-image

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

https://cards-dev.twitter.com/validator

Previously
<img width="932" alt="initial-scale" src="https://user-images.githubusercontent.com/17883920/61478797-87df1280-a9bc-11e9-8a8d-d2f3f1363a6c.PNG">

Now
![image](https://user-images.githubusercontent.com/17883920/61479796-c83f9000-a9be-11e9-967c-6178c3d33a08.png)
