### PR TITLE
fix(v2): docusaurus route config generation for empty path

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix docusaurus route config generation for certain edge case
+
 ## 2.0.0-alpha.22
 
 - Add missing dependencies on `@docusaurus/preset-classic`

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
@@ -147,3 +147,42 @@ export default [
   ],
 }
 `;
+
+exports[`loadRoutes route config with empty (but valid) path string 1`] = `
+Object {
+  "registry": Object {
+    "component---hello-world-jse-0-f-b6c": Object {
+      "importStatement": "() => import(/* webpackChunkName: 'component---hello-world-jse-0-f-b6c' */ \\"hello/world.js\\")",
+      "modulePath": "hello/world.js",
+    },
+  },
+  "routesChunkNames": Object {
+    "": Object {
+      "component": "component---hello-world-jse-0-f-b6c",
+    },
+  },
+  "routesConfig": "
+import React from 'react';
+import ComponentCreator from '@docusaurus/ComponentCreator';
+
+export default [
+  
+{
+  path: '',
+  component: ComponentCreator(''),
+  
+  
+},
+  
+  {
+    path: '*',
+    component: ComponentCreator('*')
+  }
+];
+",
+  "routesPaths": Array [
+    "404.html",
+    "",
+  ],
+}
+`;

--- a/packages/docusaurus/src/server/__tests__/routes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/routes.test.ts
@@ -73,9 +73,9 @@ describe('loadRoutes', () => {
     } as RouteConfig;
 
     expect(loadRoutes([routeConfigWithoutPath])).rejects.toMatchInlineSnapshot(`
-            [Error: Invalid routeConfig (Path and component is required) 
-            {"component":"hello/world.js"}]
-        `);
+      [Error: Invalid routeConfig (Path must be a string and component is required) 
+      {"component":"hello/world.js"}]
+    `);
 
     const routeConfigWithoutComponent = {
       path: '/hello/world',
@@ -83,8 +83,8 @@ describe('loadRoutes', () => {
 
     expect(loadRoutes([routeConfigWithoutComponent])).rejects
       .toMatchInlineSnapshot(`
-            [Error: Invalid routeConfig (Path and component is required) 
-            {"path":"/hello/world"}]
-        `);
+      [Error: Invalid routeConfig (Path must be a string and component is required) 
+      {"path":"/hello/world"}]
+    `);
   });
 });

--- a/packages/docusaurus/src/server/__tests__/routes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/routes.test.ts
@@ -73,9 +73,9 @@ describe('loadRoutes', () => {
     } as RouteConfig;
 
     expect(loadRoutes([routeConfigWithoutPath])).rejects.toMatchInlineSnapshot(`
-      [Error: Invalid routeConfig (Path must be a string and component is required) 
-      {"component":"hello/world.js"}]
-    `);
+            [Error: Invalid routeConfig (Path must be a string and component is required) 
+            {"component":"hello/world.js"}]
+        `);
 
     const routeConfigWithoutComponent = {
       path: '/hello/world',
@@ -83,8 +83,18 @@ describe('loadRoutes', () => {
 
     expect(loadRoutes([routeConfigWithoutComponent])).rejects
       .toMatchInlineSnapshot(`
-      [Error: Invalid routeConfig (Path must be a string and component is required) 
-      {"path":"/hello/world"}]
-    `);
+            [Error: Invalid routeConfig (Path must be a string and component is required) 
+            {"path":"/hello/world"}]
+        `);
+  });
+
+  test('route config with empty (but valid) path string', async () => {
+    const routeConfig = {
+      path: '',
+      component: 'hello/world.js',
+    } as RouteConfig;
+
+    const result = await loadRoutes([routeConfig]);
+    expect(result).toMatchSnapshot();
   });
 });

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -41,9 +41,9 @@ export async function loadRoutes(pluginsRouteConfigs: RouteConfig[]) {
       exact,
     } = routeConfig;
 
-    if (!routePath || !component) {
+    if (!_.isString(routePath) || !component) {
       throw new Error(
-        `Invalid routeConfig (Path and component is required) \n${JSON.stringify(
+        `Invalid routeConfig (Path must be a string and component is required) \n${JSON.stringify(
           routeConfig,
         )}`,
       );


### PR DESCRIPTION
## Motivation

fix an error where empty string path is not valid

![image](https://user-images.githubusercontent.com/17883920/61586791-59249000-aba6-11e9-9627-2c96be0bbc28.png) 

this makes some site cannot use `routebasepath` : '' and baseurl '/'

example: https://github.com/react-knowledgeable/notes/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

![q](https://user-images.githubusercontent.com/17883920/61586800-95f08700-aba6-11e9-82e6-c52c20fb3ca3.gif)

