### PR TITLE
feat(v2): shorter chunk naming for pages

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Shorter chunk naming for pages. Instead of absolute path, we use relative path from site directory
 - Use contenthash instead of chunkhash for better long term caching
 
 ## 2.0.0-alpha.23

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.js
@@ -22,15 +22,15 @@ describe('docusaurus-plugin-content-pages', () => {
       siteConfig,
     });
     const pagesMetadatas = await plugin.loadContent();
-    const pagesDir = plugin.contentPath;
+    const pagesPath = path.relative(siteDir, plugin.contentPath);
     expect(pagesMetadatas).toEqual([
       {
         permalink: '/',
-        source: path.join(pagesDir, 'index.js'),
+        source: path.join('@site', pagesPath, 'index.js'),
       },
       {
         permalink: '/hello/world',
-        source: path.join(pagesDir, 'hello', 'world.js'),
+        source: path.join('@site', pagesPath, 'hello', 'world.js'),
       },
     ]);
   });

--- a/packages/docusaurus-plugin-content-pages/src/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/index.js
@@ -33,7 +33,7 @@ module.exports = function(context, opts) {
 
     async loadContent() {
       const {include} = options;
-      const {siteConfig} = context;
+      const {siteConfig, siteDir} = context;
       const pagesDir = contentPath;
 
       if (!fs.existsSync(pagesDir)) {
@@ -47,11 +47,15 @@ module.exports = function(context, opts) {
 
       return pagesFiles.map(relativeSource => {
         const source = path.join(pagesDir, relativeSource);
+        const aliasedSource = path.join(
+          '@site',
+          path.relative(siteDir, source),
+        );
         const pathName = encodePath(fileToPath(relativeSource));
         // Default Language.
         return {
           permalink: pathName.replace(/^\//, baseUrl),
-          source,
+          source: aliasedSource,
         };
       });
     },


### PR DESCRIPTION
## Motivation

Minor refactoring on pages plugin. Make use of `@site` alias so that we dont need to expose whole absolute path and potentially make the chunk name shorter

before this pr, the component naming is component-opt-build-website-blablabla.
<img width="879" alt="source is exposed" src="https://user-images.githubusercontent.com/17883920/61622736-91f46000-ac9f-11e9-8cf2-9de386ef826f.PNG">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

shorter now. it become site-blablabla
the pages metadata is like this after this pr
```js
{
  "permalink": "/",
  "source": "@site/src/pages/index.js"
}
```
<img width="570" alt="after-path" src="https://user-images.githubusercontent.com/17883920/61622805-b5b7a600-ac9f-11e9-981d-25f21eec7d19.PNG">

