### PR TITLE
docs: suggest ZEIT Now for quick deployment

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -25,12 +25,12 @@ At this point, you can grab all of the files inside the `website/build` director
 
 ### Hosting on a Service:
 
-* [ZEIT Now](#hosting-on-now)
+* [ZEIT Now](#using-zeit-now)
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
 * [Render](#hosting-on-render)
 
-## Hosting on ZEIT Now
+## Using ZEIT Now
 
 Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
 

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -25,9 +25,30 @@ At this point, you can grab all of the files inside the `website/build` director
 
 ### Hosting on a Service:
 
+* [ZEIT Now](#hosting-on-now)
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
 * [Render](#hosting-on-render)
+
+## Hosting on ZEIT Now
+
+Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
+
+Most importantly, however, deploying a Docusaurus project only takes a couple seconds:
+
+1. First, install their [command-line interface](https://zeit.co/download):
+
+```bash
+npm i -g now
+```
+
+2. Run a single command inside the directory if your project:
+
+```bash
+now
+```
+
+**That's all.** Your docs will automatically be deployed.
 
 ### Using GitHub Pages
 

--- a/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
@@ -26,8 +26,29 @@ At this point, you can grab all of the files inside the `website/build` director
 
 ### Hosting on a Service:
 
+* [ZEIT Now](#using-zeit-now)
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
+
+## Using ZEIT Now
+
+Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
+
+Most importantly, however, deploying a Docusaurus project only takes a couple seconds:
+
+1. First, install their [command-line interface](https://zeit.co/download):
+
+```bash
+npm i -g now
+```
+
+2. Run a single command inside the directory if your project:
+
+```bash
+now
+```
+
+**That's all.** Your docs will automatically be deployed.
 
 ### Using GitHub Pages
 

--- a/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
@@ -26,9 +26,30 @@ At this point, you can grab all of the files inside the `website/build` director
 
 ### Hosting on a Service:
 
+* [ZEIT Now](#using-zeit-now)
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
 * [Render](#hosting-on-render)
+
+## Using ZEIT Now
+
+Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
+
+Most importantly, however, deploying a Docusaurus project only takes a couple seconds:
+
+1. First, install their [command-line interface](https://zeit.co/download):
+
+```bash
+npm i -g now
+```
+
+2. Run a single command inside the directory if your project:
+
+```bash
+now
+```
+
+**That's all.** Your docs will automatically be deployed.
 
 ### Using GitHub Pages
 

--- a/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
@@ -26,8 +26,29 @@ At this point, you can grab all of the files inside the `website/build` director
 
 ### Hosting on a Service:
 
+* [ZEIT Now](#using-zeit-now)
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
+
+## Using ZEIT Now
+
+Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
+
+Most importantly, however, deploying a Docusaurus project only takes a couple seconds:
+
+1. First, install their [command-line interface](https://zeit.co/download):
+
+```bash
+npm i -g now
+```
+
+2. Run a single command inside the directory if your project:
+
+```bash
+now
+```
+
+**That's all.** Your docs will automatically be deployed.
 
 ### Using GitHub Pages
 


### PR DESCRIPTION
## Motivation

Me and @rauchg recently had a great call with @yangshun and @wgao19 about how [ZEIT Now](https://zeit.co/now) can deploy any Docusaurus project **without any configuration**.

We concluded that it would be a good idea to have users of Docusaurus take advantage of this right out of the box, so we added it to the docs.

It's basically as easy as this:

```
npx docusaurus-init
npx now                     # will prompt for login
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I described the usage in the section above. It's really simple.

## Related PRs

No related PRs. I will soon create a new PR for Docusaurus 2.0, however.
