### PR TITLE
docs: suggest ZEIT Now for quick deployment of 2.0

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -239,6 +239,10 @@ script:
 
 Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and, if everything passes, your website will be deployed via the `publish-gh-pages` script.
 
+### Hosting on ZEIT Now
+
+With [ZEIT Now](#using-zeit-now), you can deploy your site easily and connect it to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
+
 ### Hosting on Netlify
 
 Steps to configure your Docusaurus-powered site on Netlify.

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -42,7 +42,7 @@ Most importantly, however, deploying a Docusaurus project only takes a couple se
 npm i -g now
 ```
 
-2. Run a single command inside the directory if your project:
+2. Run a single command inside the root directory of your project:
 
 ```bash
 now

--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -30,7 +30,7 @@ At this point, you can grab all of the files inside the `website/build` director
 * [Netlify](#hosting-on-netlify)
 * [Render](#hosting-on-render)
 
-## Using ZEIT Now
+### Using ZEIT Now
 
 Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
 

--- a/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
@@ -30,7 +30,7 @@ At this point, you can grab all of the files inside the `website/build` director
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
 
-## Using ZEIT Now
+### Using ZEIT Now
 
 Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
 

--- a/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
@@ -239,6 +239,10 @@ script:
 
 Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and, if everything passes, your website will be deployed via the `publish-gh-pages` script.
 
+### Hosting on ZEIT Now
+
+With [ZEIT Now](#using-zeit-now), you can deploy your site easily and connect it to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
+
 ### Hosting on Netlify
 
 Steps to configure your Docusaurus-powered site on Netlify.

--- a/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
@@ -42,7 +42,7 @@ Most importantly, however, deploying a Docusaurus project only takes a couple se
 npm i -g now
 ```
 
-2. Run a single command inside the directory if your project:
+2. Run a single command inside the root directory of your project:
 
 ```bash
 now

--- a/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
@@ -240,6 +240,10 @@ script:
 
 Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and, if everything passes, your website will be deployed via the `publish-gh-pages` script.
 
+### Hosting on ZEIT Now
+
+With [ZEIT Now](#using-zeit-now), you can deploy your site easily and connect it to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
+
 ### Hosting on Netlify
 
 Steps to configure your Docusaurus-powered site on Netlify.

--- a/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
@@ -43,7 +43,7 @@ Most importantly, however, deploying a Docusaurus project only takes a couple se
 npm i -g now
 ```
 
-2. Run a single command inside the directory if your project:
+2. Run a single command inside the root directory of your project:
 
 ```bash
 now

--- a/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
@@ -31,7 +31,7 @@ At this point, you can grab all of the files inside the `website/build` director
 * [Netlify](#hosting-on-netlify)
 * [Render](#hosting-on-render)
 
-## Using ZEIT Now
+### Using ZEIT Now
 
 Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
 

--- a/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
@@ -30,7 +30,7 @@ At this point, you can grab all of the files inside the `website/build` director
 * [GitHub Pages](#using-github-pages)
 * [Netlify](#hosting-on-netlify)
 
-## Using ZEIT Now
+### Using ZEIT Now
 
 Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
 

--- a/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
@@ -239,6 +239,10 @@ script:
 
 Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and, if everything passes, your website will be deployed via the `publish-gh-pages` script.
 
+### Hosting on ZEIT Now
+
+With [ZEIT Now](#using-zeit-now), you can deploy your site easily and connect it to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
+
 ### Hosting on Netlify
 
 Steps to configure your Docusaurus-powered site on Netlify.

--- a/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
@@ -42,7 +42,7 @@ Most importantly, however, deploying a Docusaurus project only takes a couple se
 npm i -g now
 ```
 
-2. Run a single command inside the directory if your project:
+2. Run a single command inside the root directory of your project:
 
 ```bash
 now

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -25,7 +25,7 @@ You can deploy your site to static site hosting services such as [ZEIT Now](http
 npm i -g now
 ```
 
- 2. Run a single command inside the directory if your project:
+2. Run a single command inside the root directory of your project:
 
  ```bash
 now

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -11,7 +11,27 @@ npm build
 
 Once it finishes, you should see the production build under the `build/` directory.
 
-You can deploy your site to static site hosting services such as [GitHub Pages](https://pages.github.com/), [Now](https://zeit.co/now), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are statically rendered so they work without JavaScript too!
+You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are statically rendered so they work without JavaScript too!
+
+## Deploying to ZEIT Now
+
+ Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
+
+ Most importantly, however, deploying a Docusaurus project only takes a couple seconds:
+
+ 1. First, install their [command-line interface](https://zeit.co/download):
+
+ ```bash
+npm i -g now
+```
+
+ 2. Run a single command inside the directory if your project:
+
+ ```bash
+now
+```
+
+ **That's all.** Your docs will automatically be deployed.
 
 ## Deploying to GitHub Pages
 
@@ -75,10 +95,6 @@ References:
 - https://www.gatsbyjs.org/docs/deploying-and-hosting/
 
 -->
-
-## Deploying to Now
-
-_This section is a work in progress. [Welcoming PRs](https://github.com/facebook/docusaurus/issues/1640)._
 
 ## Deploying to Netlify
 

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -15,11 +15,11 @@ You can deploy your site to static site hosting services such as [ZEIT Now](http
 
 ## Deploying to ZEIT Now
 
- Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
+Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
 
- Most importantly, however, deploying a Docusaurus project only takes a couple seconds:
+Most importantly, however, deploying a Docusaurus project only takes a couple seconds:
 
- 1. First, install their [command-line interface](https://zeit.co/download):
+1. First, install their [command-line interface](https://zeit.co/download):
 
  ```bash
 npm i -g now
@@ -31,7 +31,7 @@ npm i -g now
 now
 ```
 
- **That's all.** Your docs will automatically be deployed.
+**That's all.** Your docs will automatically be deployed.
  
 Now you can connect your site to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
 

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -21,13 +21,13 @@ Most importantly, however, deploying a Docusaurus project only takes a couple se
 
 1. First, install their [command-line interface](https://zeit.co/download):
 
- ```bash
+```bash
 npm i -g now
 ```
 
 2. Run a single command inside the root directory of your project:
 
- ```bash
+```bash
 now
 ```
 

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -32,6 +32,8 @@ now
 ```
 
  **That's all.** Your docs will automatically be deployed.
+ 
+Now you can connect your site to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
 
 ## Deploying to GitHub Pages
 


### PR DESCRIPTION
## Motivation

Me and @rauchg recently had a great call with @yangshun and @wgao19 about how [ZEIT Now](https://zeit.co/now) can deploy any Docusaurus project **without any configuration**.

We concluded that it would be a good idea to have users of Docusaurus take advantage of this right out of the box, so we added it to the docs.

It's basically as easy as this:

```
npx @docusaurus/init@next init my-website classic
npx now my-website                                            # will prompt for login
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I described the usage in the section above. It's really simple.

## Related PRs

The PR is a follow-up to this: https://github.com/facebook/docusaurus/pull/1690.
