### PR TITLE
refactor(v2): remove unused metadata for pages

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -4,6 +4,7 @@
 
 ## 2.0.0-alpha.24
 
+- Remove unused metadata for pages. This minimize number of http request & smaller bundle size.
 - Upgrade dependencies of css-loader from 2.x to 3.x. Css modules localIdentName hash now only use the last 4 characters instead of 8.
 - Fix broken markdown linking replacement for mdx files
 - Fix potential security vulnerability because we're exposing the directory structure of the host machine. Instead of absolute path, we use relative path from site directory. Resulting in shorter webpack chunk naming and smaller bundle size. 

--- a/packages/docusaurus-plugin-content-pages/src/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/index.js
@@ -8,7 +8,7 @@
 const globby = require('globby');
 const path = require('path');
 const fs = require('fs');
-const {encodePath, fileToPath, docuHash} = require('@docusaurus/utils');
+const {encodePath, fileToPath} = require('@docusaurus/utils');
 
 const DEFAULT_OPTIONS = {
   path: 'src/pages', // Path to data on filesystem, relative to site dir.
@@ -63,22 +63,15 @@ module.exports = function(context, opts) {
         return;
       }
 
-      const {addRoute, createData} = actions;
+      const {addRoute} = actions;
 
       await Promise.all(
         content.map(async metadataItem => {
           const {permalink, source} = metadataItem;
-          const metadataPath = await createData(
-            `${docuHash(permalink)}.json`,
-            JSON.stringify(metadataItem, null, 2),
-          );
           addRoute({
             path: permalink,
             component: source,
             exact: true,
-            modules: {
-              metadata: metadataPath,
-            },
           });
         }),
       );


### PR DESCRIPTION
## Motivation

Metadata for pages is too small and is actually unused. from lighthouae audit, it just create extra request. lets remove it

![image](https://user-images.githubusercontent.com/17883920/61728693-e848c800-ad9f-11e9-9e08-378d03531d8c.png)

the metadata is like this
```json
{
  "permalink": "/feedback/",
  "source": "@site/src/pages/feedback/index.js"
}
```


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yyes

## Test Plan

- ci
- netlify preview