### PR TITLE
chore(v2): make feedback page accessible, not 404

### DIFF
--- a/website/src/theme/NotFound.js
+++ b/website/src/theme/NotFound.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Layout from '@theme/Layout';
+import Feedback from '../pages/feedback';
+
+function NotFound({location}) {
+  if (/^\/feedback/.test(location.pathname)) {
+    return <Feedback />;
+  }
+
+  return (
+    <Layout title="Page Not Found">
+      <div className="container margin-vert--xl">
+        <div className="row">
+          <div className="col col--6 col--offset-3">
+            <h1 className="hero__title">Page Not Found</h1>
+            <p>We could not find what you were looking for.</p>
+            <p>
+              Please contact the owner of the site that linked you to the
+              original URL and let them know their link is broken.
+            </p>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export default NotFound;

--- a/website/src/theme/NotFound.js
+++ b/website/src/theme/NotFound.js
@@ -16,7 +16,7 @@ function NotFound({location}) {
 
   return (
     <Layout title="Page Not Found">
-      <div className="container margin-vert--xl">
+      <div className="container margin-vert--xl" data-canny>
         <div className="row">
           <div className="col col--6 col--offset-3">
             <h1 className="hero__title">Page Not Found</h1>


### PR DESCRIPTION
## Motivation

try going to any feedback page directly

https://v2.docusaurus.io/feedback/p/hamburger

it will be 404. user have to go to feedback page directly and click on the page
<img width="951" alt="error" src="https://user-images.githubusercontent.com/17883920/61731784-6dcf7680-ada6-11e9-8863-4b2d235d7144.PNG">

this pr swizzle our 404 page so that it wont 404 when going to feedback page

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- directly go to feedback page
![image](https://user-images.githubusercontent.com/17883920/61731932-b9822000-ada6-11e9-884a-d2a8253ae1ba.png)
