### PR TITLE
fix: removing margin left for gridblock

### DIFF
--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -1010,12 +1010,8 @@ input::placeholder {
     margin: 0 12px;
   }
 
-  .gridBlock > *:first-child {
-    margin-left: 0;
-  }
-
-  .gridBlock > *:last-child {
-    margin-right: 0;
+  .gridBlock > .blockElement {
+    margin: 0 24px 0 0;
   }
 
   .gridBlock .twoByGridBlock {


### PR DESCRIPTION
## Motivation

https://github.com/facebook/docusaurus/issues/1632

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![Screenshot from 2019-07-23 20-44-16](https://user-images.githubusercontent.com/39810304/61758552-cabd3380-ad8a-11e9-8b94-a5d2bab01807.png)
