### PR TITLE
docs: add "Install Git" to the "Setting Up" page

### DIFF
--- a/docs/tutorial-setup.md
+++ b/docs/tutorial-setup.md
@@ -9,7 +9,7 @@ This tutorial is geared at first-time users who want detailed instructions on ho
 
 ## Install Git
 
-Git copies files between your local system and your online repository. If not already installed, see [Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+Git is a version control system for tracking changes in source code during software development and it can help you synchronize and version files between your local system and your online repository. If not already installed, see [Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 
 ## Install Node.js
 

--- a/docs/tutorial-setup.md
+++ b/docs/tutorial-setup.md
@@ -7,6 +7,10 @@ This tutorial is geared at first-time users who want detailed instructions on ho
 
 <img alt="Docusaurus campfire" src="/img/undraw_docusaurus_mountain.svg" class="docImage"/>
 
+## Install Git
+
+Git copies files between your local system and your online repository. If not already installed, see [Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+
 ## Install Node.js
 
 Node.js is an environment that can run JavaScript code outside of a web browser and is used to write and run server-side JavaScript apps.


### PR DESCRIPTION
Please add an **Install Git** section to the **[Setting Up](https://docusaurus.io/docs/en/next/tutorial-setup)** page with its "detailed instructions on how to go from zero." To me "zero" means only the operating system. 