### PR TITLE
docs: move a cd step to the start of the init task

### DIFF
--- a/docs/tutorial-setup.md
+++ b/docs/tutorial-setup.md
@@ -72,17 +72,17 @@ git clone git@github.com:USERNAME/docusaurus-tutorial.git # SSH
 git clone https://github.com/USERNAME/docusaurus-tutorial.git # HTTPS
 ```
 
-7. `cd` to the directory for the local clone.
+## Install the Docusaurus init command
+
+Docusaurus comes with a command line tool to help you scaffold a Docusaurus site with some example templates. Let's install the installer!
+
+1. `cd` to the directory of your local repository.
 
 ```sh
 cd docusaurus-tutorial
 ```
 
-## Install the Docusaurus init command
-
-Docusaurus comes with a command line tool to help you scaffold a Docusaurus site with some example templates. Let's install the installer!
-
-1. Run the following command:
+2. Run the following command:
 
 ```sh
 npm install --global docusaurus-init


### PR DESCRIPTION
The `cd` step seems like the first step of "Install the Docusaurus init command," instead of the last step of "Create a GitHub repository and local clone."
