### PR TITLE
move "cd to the repository" to "Scaffold the Site"

### DIFF
--- a/docs/tutorial-setup.md
+++ b/docs/tutorial-setup.md
@@ -76,13 +76,7 @@ git clone https://github.com/USERNAME/docusaurus-tutorial.git # HTTPS
 
 Docusaurus comes with a command line tool to help you scaffold a Docusaurus site with some example templates. Let's install the installer!
 
-1. `cd` to the directory of your local repository.
-
-```sh
-cd docusaurus-tutorial
-```
-
-2. Run the following command:
+Run the following command:
 
 ```sh
 npm install --global docusaurus-init


### PR DESCRIPTION
The folder isn't important for the command `npm install --global docusaurus-init`. 

However, it is important to run `docusaurus-init` in the repository folder. The next pull request moves the step to **[Scaffold the Site](https://docusaurus.io/docs/en/next/tutorial-create-new-site#scaffold-the-site).**