### PR TITLE
add "cd to the repository" to "Scaffold the Site"

### DIFF
--- a/docs/tutorial-create-new-site.md
+++ b/docs/tutorial-create-new-site.md
@@ -9,7 +9,13 @@ In this section, we'll get our Docusaurus site up and running for local developm
 
 ## Scaffold the Site
 
-1. Execute the `docusaurus-init` command in your terminal.
+1. `cd` to the directory of your local repository.
+
+```sh
+cd docusaurus-tutorial
+```
+
+2. Execute the `docusaurus-init` command in your terminal.
 
 ```sh
 docusaurus-init


### PR DESCRIPTION
The step "`cd` to the directory of your local repository" was moved from **[Install the Docusaurus init command](https://docusaurus.io/docs/en/next/tutorial-setup#install-the-docusaurus-init-command)**. See the previous pull request.