### PR TITLE
docs: add the repository name to the localhost:3000 link

### DIFF
--- a/docs/tutorial-create-new-site.md
+++ b/docs/tutorial-create-new-site.md
@@ -62,6 +62,6 @@ The following contents will be created in your current directory. Some example d
 2. Run `cd website` to go into the `website` directory.
 1. Run `npm start` or `yarn start`.
 
-A browser window will open up at http://localhost:3000.
+A browser window will open up at http://localhost:3000/docusaurus-tutorial/.
 
 Congratulations, you have just made your first Docusaurus site! Click around the pages to get a feel for it.


### PR DESCRIPTION
Change the link from `http://localhost:3000` to `http://localhost:3000/docusaurus-tutorial/` in **[Scaffold the Site](https://docusaurus.io/docs/en/next/tutorial-create-new-site#scaffold-the-site)**.
