### PR TITLE
change(v2): swap init parameter order for name and template

### DIFF
--- a/packages/docusaurus-init/bin/index.js
+++ b/packages/docusaurus-init/bin/index.js
@@ -39,9 +39,9 @@ program
   .usage('<command> [options]');
 
 program
-  .command('init [siteName] [template] [rootDir]')
+  .command('init [template] [siteName] [rootDir]')
   .description('Initialize website')
-  .action((siteName, template, rootDir = '.') => {
+  .action((template, siteName, rootDir = '.') => {
     wrapCommand(init)(path.resolve(rootDir), siteName, template);
   });
 

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -15,17 +15,28 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init@next init [template] [name]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init@next init classic my-website
 ```
 
+If you do not specify `name` or `template`, it will prompt you for them.
 
-If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
+### Docusaurus templates
+
+Templates are designed to help you get started quickly building your doc site.
+
+Docusaurus 2 now ships with a `classic` template that contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
+
+You may also use a custom template. In fact, any repo to a Docusaurus 2 site can be a template. To use a custom template from a GitHub repo, use the URL to the repo as template:
+
+```bash
+$ npx @docusaurus/init@next init https://github.com/wgao19/docusaurus-template-no-style.git [name]
+```
 
 ## Project structure
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Swap init command order for template and project name.

Previously our init command was

```shell
$ init [name] [template]
```

So in the doc we exemplify as 

```shell
$ npx @docusaurus/init@next init my-website classic
```

This is not too bad. But we also accept git url for template, in which case the template argument will be very long and people will nearly certainly copy and paste. 

```shell
$ npx @docusaurus/init@next init [name] https://github.com/wgao19/docusaurus-template-no-style.git
```

Then having template as the last argument is not as friendly as having it before the project name because people can copy and paste the whole thing and input a project name.

```shell
$ npx @docusaurus/init@next init https://github.com/wgao19/docusaurus-template-no-style.git [name]
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

NA

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)