### PR TITLE
docs: revert a link to localhost:3000

### DIFF
--- a/docs/tutorial-create-new-site.md
+++ b/docs/tutorial-create-new-site.md
@@ -68,6 +68,6 @@ The following contents will be created in your current directory. Some example d
 3. Run `cd website` to go into the `website` directory.
 4. Run `npm start` or `yarn start`.
 
-A browser window will open up at http://localhost:3000/docusaurus-tutorial/.
+A browser window will open up at http://localhost:3000.
 
 Congratulations, you have just made your first Docusaurus site! Click around the pages to get a feel for it.


### PR DESCRIPTION
@yangshun You're right. I removed `docusaurus-tutorial/` from the links. 
Reverts facebook/docusaurus#1715 
