### PR TITLE
Header theme for next versioned pages

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -373,6 +373,8 @@ const siteConfig = {
   colors: {
     primaryColor: '#2E8555',
     secondaryColor: '#205C3B',
+    currentVersionHeaderColor: '#D50000',
+    currentVersionTextColor: '#FFFFFF',
   },
   editUrl: 'https://github.com/facebook/docusaurus/edit/master/docs/',
   // Users variable set above

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -28,6 +28,8 @@ Color configurations for the site.
 - `primaryColor` is the color used the header navigation bar and sidebars.
 - `secondaryColor` is the color seen in the second row of the header navigation bar when the site window is narrow (including on mobile).
 - Custom color configurations can also be added. For example, if user styles are added with colors specified as `$myColor`, then adding a `myColor` field to `colors` will allow you to easily configure this color.
+- `currentVersionHeaderColor` is the color used the header navigation bar and sidebars when user is seeing the unreleased version of the app. _(Optional)_
+- `currentVersionTextColor` is the text color for header navigation bar and sidebars when user is seeing the unreleased version of the app. _(Optional)_
 
 #### `copyright` [string]
 

--- a/packages/docusaurus-1.x/examples/basics/siteConfig.js
+++ b/packages/docusaurus-1.x/examples/basics/siteConfig.js
@@ -56,6 +56,10 @@ const siteConfig = {
   colors: {
     primaryColor: '{{primaryColor}}',
     secondaryColor: '{{secondaryColor}}',
+    /*
+    currentVersionHeaderColor: '{{currentVersionHeaderColor}}',
+    currentVersionTextColor: '{{currentVersionTextColor}}',
+    */
   },
 
   /* Custom fonts for website */

--- a/packages/docusaurus-1.x/lib/core/nav/HeaderNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/HeaderNav.js
@@ -299,8 +299,11 @@ class HeaderNav extends React.Component {
       (env.translation.enabled
         ? `${this.props.language}/versions${extension}`
         : `versions${extension}`);
+    const isNextVersion =
+      env.versioning.enabled && this.props.version === 'next';
+    const headerNextVersionClass = isNextVersion ? 'nextVersion' : '';
     return (
-      <div className="fixedHeaderContainer">
+      <div className={`fixedHeaderContainer ${headerNextVersionClass}`}>
         <div className="headerWrapper wrapper">
           <header>
             <a

--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -728,6 +728,11 @@ blockquote {
   transform: translate3d(0, 0, 0);
 }
 
+.nextVersion {
+  background: $currentVersionHeaderColor;
+  color: $currentVersionTextColor;
+}
+
 @media only screen and (min-width: 1024px) {
   .fixedHeaderContainer {
     flex-shrink: 0;
@@ -776,6 +781,10 @@ blockquote {
   margin: 0;
   margin-left: 10px;
   text-decoration: underline;
+}
+
+.nextVersion header h3, .nextVersion a {
+  color: $currentVersionTextColor;
 }
 
 @media (max-width: 480px) {

--- a/website-1.x/siteConfig.js
+++ b/website-1.x/siteConfig.js
@@ -42,6 +42,8 @@ const siteConfig = {
   colors: {
     primaryColor: '#2E8555',
     secondaryColor: '#205C3B',
+    currentVersionHeaderColor: '#D50000',
+    currentVersionTextColor: '#FFFFFF',
   },
   translationRecruitingLink: 'https://crowdin.com/project/docusaurus',
   copyright: `Copyright © ${new Date().getFullYear()} Facebook Inc.`,


### PR DESCRIPTION
## Motivation

A different look for on-going development changes for docs site.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Configure color code for `currentVersionHeaderColor` and `currentVersionTextColor` into `colors` block of `siteConfig.js`.
<img width="480" alt="siteConfig.js changes" src="https://user-images.githubusercontent.com/10116103/62185874-af9d8580-b381-11e9-99ec-a0f4b7cf3906.png">

Then you need to start the 1.x application on your local and follow the journey.
![docusaurus-next-theme-recording](https://user-images.githubusercontent.com/10116103/62186458-01470f80-b384-11e9-8b89-1dda82eac279.gif)


The doc `(api-site-config.md)` is also updated and added along with this PR.