### PR TITLE
feat(v2): blog and docs support mdxLoaderOptions option, mdx-loader support per input preprocess and plugins

### DIFF
--- a/packages/docusaurus-mdx-loader/src/index.js
+++ b/packages/docusaurus-mdx-loader/src/index.js
@@ -37,27 +37,31 @@ module.exports = async function(fileString) {
     onRehypePlugins,
     ...reqOptions
   } = {...DEFAULT_OPTIONS, ...getOptions(this)};
-  const input = await onInput(matter(fileString));
 
-  const options = {
-    ...reqOptions,
-    remarkPlugins: [
-      ...PERSIST_OPTIONS.remarkPlugins,
-      ...(remarkPlugins || []),
-      ...((await onRemarkPlugins(input)) || []),
-    ],
-    rehypePlugins: [
-      ...PERSIST_OPTIONS.rehypePlugins,
-      ...(rehypePlugins || []),
-      ...((await onRemarkPlugins(input)) || []),
-    ],
-    filepath: this.resourcePath,
-  };
-
-  const {data, content} = input;
   let result;
+  let data;
 
   try {
+    const input = await onInput(matter(fileString));
+
+    const options = {
+      ...reqOptions,
+      remarkPlugins: [
+        ...PERSIST_OPTIONS.remarkPlugins,
+        ...(remarkPlugins || []),
+        ...((await onRemarkPlugins(input)) || []),
+      ],
+      rehypePlugins: [
+        ...PERSIST_OPTIONS.rehypePlugins,
+        ...(rehypePlugins || []),
+        ...((await onRemarkPlugins(input)) || []),
+      ],
+      filepath: this.resourcePath,
+    };
+
+    const {data: frontMatter, content} = input;
+    data = frontMatter;
+
     result = await mdx(content, options);
   } catch (err) {
     return callback(err);

--- a/packages/docusaurus-mdx-loader/src/index.js
+++ b/packages/docusaurus-mdx-loader/src/index.js
@@ -37,19 +37,19 @@ module.exports = async function(fileString) {
     onRehypePlugins,
     ...reqOptions
   } = {...DEFAULT_OPTIONS, ...getOptions(this)};
-  const input = onInput(matter(fileString));
+  const input = await onInput(matter(fileString));
 
   const options = {
     ...reqOptions,
     remarkPlugins: [
       ...PERSIST_OPTIONS.remarkPlugins,
       ...(remarkPlugins || []),
-      ...(onRemarkPlugins(input) || []),
+      ...((await onRemarkPlugins(input)) || []),
     ],
     rehypePlugins: [
       ...PERSIST_OPTIONS.rehypePlugins,
       ...(rehypePlugins || []),
-      ...(onRemarkPlugins(input) || []),
+      ...((await onRemarkPlugins(input)) || []),
     ],
     filepath: this.resourcePath,
   };

--- a/packages/docusaurus-plugin-content-blog/src/index.js
+++ b/packages/docusaurus-plugin-content-blog/src/index.js
@@ -33,6 +33,7 @@ const DEFAULT_OPTIONS = {
   blogTagsPostsComponent: '@theme/BlogTagsPostsPage',
   remarkPlugins: [],
   rehypePlugins: [],
+  mdxLoaderOptions: {},
   truncateMarker: /<!--\s*(truncate)\s*-->/, // string or regex
 };
 
@@ -353,7 +354,12 @@ module.exports = function(context, opts) {
     },
 
     configureWebpack(config, isServer, {getBabelLoader, getCacheLoader}) {
-      const {rehypePlugins, remarkPlugins, truncateMarker} = options;
+      const {
+        rehypePlugins,
+        remarkPlugins,
+        mdxLoaderOptions,
+        truncateMarker,
+      } = options;
       return {
         module: {
           rules: [
@@ -368,6 +374,7 @@ module.exports = function(context, opts) {
                   options: {
                     remarkPlugins,
                     rehypePlugins,
+                    ...mdxLoaderOptions,
                   },
                 },
                 {

--- a/packages/docusaurus-plugin-content-docs-legacy/src/index.js
+++ b/packages/docusaurus-plugin-content-docs-legacy/src/index.js
@@ -25,6 +25,7 @@ const DEFAULT_OPTIONS = {
   docItemComponent: '@theme/DocLegacyItem',
   remarkPlugins: [],
   rehypePlugins: [],
+  mdxLoaderOptions: {},
 };
 
 module.exports = function(context, opts) {
@@ -157,7 +158,7 @@ module.exports = function(context, opts) {
     },
 
     configureWebpack(config, isServer, {getBabelLoader, getCacheLoader}) {
-      const {rehypePlugins, remarkPlugins} = options;
+      const {rehypePlugins, remarkPlugins, mdxLoaderOptions} = options;
       return {
         module: {
           rules: [
@@ -172,6 +173,7 @@ module.exports = function(context, opts) {
                   options: {
                     remarkPlugins,
                     rehypePlugins,
+                    ...mdxLoaderOptions,
                   },
                 },
                 {


### PR DESCRIPTION
…support per input preprocess and plugins

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

* add extension point for per input mdx process
* so add mdxLoaderOptions to pass down options

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

non break change, dog-feed first,

[this](https://github.com/wenerme/wener/blob/master/story/project/bbvm.md) doc use [these](https://github.com/wenerme/docusaurus/tree/wenerme/my/extensions) extension to generate this page https://wener.me/blog/bbvm/

* import content from external
* change image baseUrl

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

no
