### PR TITLE
fix: bug fix for `Show HTML tag on TOC, not escaping them`

### DIFF
--- a/packages/docusaurus-1.x/lib/core/nav/OnPageNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/OnPageNav.js
@@ -25,7 +25,7 @@ const Headings = ({headings}) => {
     <ul className="toc-headings">
       {headings.map(heading => (
         <li key={heading.hashLink}>
-          <Link hashLink={heading.hashLink} content={heading.content} />
+          <Link hashLink={heading.hashLink} content={heading.rawContent} />
           <Headings headings={heading.children} />
         </li>
       ))}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Long time no see.
I found very easy bug on issue.

But, this PR cause broken old style. And I don't know all side effect.
We need a explicitly way to show the HTML sentence or add the HTML tag in the TOC.
If you suggest a good way, I will update this PR.

It's simple training for me.
I want more contribution for V2 from now.
Because I love TypeScript & Docusarus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

It's simple change.

## Related PRs

Nope.
