### PR TITLE
fix(v2): do not escape html and body attributes

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Do not escape html and body attributes
 - Add `date` frontMatter support for blog plugin
 - Add `truncateMarker` option to blog plugin, support string or regex.
 - Webpack `optimization.removeAvailableModules` is now disabled for performance gain. See https://github.com/webpack/webpack/releases/tag/v4.38.0 for more context.

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -7,7 +7,7 @@
 
 module.exports = `
 <!DOCTYPE html>
-<html <%= htmlAttributes %>>
+<html <%- htmlAttributes %>>
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
@@ -19,7 +19,7 @@ module.exports = `
       <link rel="stylesheet" type="text/css" href="<%= baseUrl %><%= stylesheet %>" />
     <% }); %>
   </head>
-  <body <%= bodyAttributes %>>
+  <body <%- bodyAttributes %>>
     <div id="__docusaurus">
       <%- appHtml %>
     </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The attributes of html element and body element are escaped during SSR.

<img width="359" alt="Screenshot on Docusaurus rendered HTML document" src="https://user-images.githubusercontent.com/12539/62604318-c4a28780-b932-11e9-95f7-880e890ff73e.png">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Open the rendered HTML document.

<!--
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
-->

