### PR TITLE
docs(v2): make double nested sidebar entry thinner and smaller

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -31,3 +31,9 @@ html[data-theme='dark'] {
     --ifm-font-size-base: 17px;
   }
 }
+
+.menu__list .menu__list .menu__list .menu__link {
+  font-size: 0.75em;
+  font-weight: normal;
+  color: #999;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Sidebar currently has a consistent appearance on menu items on different levels. This makes it look a bit messy on the 2nd nested items:

<img width="456" alt="image" src="https://user-images.githubusercontent.com/2055384/62855234-42480800-bd24-11e9-8708-6011c8a48a8f.png">

This PR makes it looks like this:

<img width="447" alt="image" src="https://user-images.githubusercontent.com/2055384/62855265-5c81e600-bd24-11e9-8bfa-700445efa336.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs


