### PR TITLE
docs: fix documented type for the `cleanUrl` option

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -102,7 +102,7 @@ Control the number of blog posts that show up in the sidebar. See the [adding a 
 
 Control the title of the blog sidebar. See the [adding a blog docs](guides-blog.md#changing-the-sidebar-title) for more information.
 
-#### `cleanUrl` [string]
+#### `cleanUrl` [boolean]
 
 If `true`, allow URLs with no `HTML` extension. For example, a request to URL https://docusaurus.io/docs/installation will return the same result as https://docusaurus.io/docs/installation.html.
 


### PR DESCRIPTION
## Motivation

The documented type was wrong, I think.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Well, I have now.

## Test Plan

I must admit I haven't verified it because it's so trivial, but build the docs and visit /docs/en/site-config#cleanurl-string.

## Related PRs

\-