### PR TITLE
feat(v2): add support for authenticating with a GitHub token

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -72,12 +72,14 @@ export async function deploy(siteDir: string): Promise<void> {
   const useSSH = process.env.USE_SSH;
   const remoteBranch = useSSH
     ? `git@${githubHost}:${organizationName}/${projectName}.git`
-    : `https://${gitUser}${gitToken ? `:${gitToken}` : ''}@${githubHost}/${organizationName}/${projectName}.git`;
+    : `https://${gitUser}${
+        gitToken ? `:${gitToken}` : ''
+      }@${githubHost}/${organizationName}/${projectName}.git`;
 
   // Set Git identity if a token is used for auth
-  if (gitToken && gitName && gitEmail) {
-    shell.exec(`git config  user.name "${gitName}"`);
-    shell.exec(`git config  user.email "${gitEmail}"`);
+  if (gitToken && gitName) {
+    shell.exec(`git config --global user.name "${gitName}"`);
+    shell.exec(`git config  --global user.email "${gitEmail || ''}"`);
   }
 
   // Check if this is a cross-repo publish

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -22,6 +22,9 @@ export async function deploy(siteDir: string): Promise<void> {
     throw new Error('Sorry, this script requires git');
   }
 
+  const gitName = process.env.GIT_NAME;
+  const gitEmail = process.env.GIT_EMAIL;
+  const gitToken = process.env.GIT_TOKEN;
   const gitUser = process.env.GIT_USER;
   if (!gitUser) {
     throw new Error(`Please set the GIT_USER`);
@@ -69,7 +72,13 @@ export async function deploy(siteDir: string): Promise<void> {
   const useSSH = process.env.USE_SSH;
   const remoteBranch = useSSH
     ? `git@${githubHost}:${organizationName}/${projectName}.git`
-    : `https://${gitUser}@${githubHost}/${organizationName}/${projectName}.git`;
+    : `https://${gitUser}${gitToken ? `:${gitToken}` : ''}@${githubHost}/${organizationName}/${projectName}.git`;
+
+  // Set Git identity if a token is used for auth
+  if (gitToken && gitName && gitEmail) {
+    shell.exec(`git config  user.name "${gitName}"`);
+    shell.exec(`git config  user.email "${gitEmail}"`);
+  }
 
   // Check if this is a cross-repo publish
   const currentRepoUrl = shell

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -81,6 +81,7 @@ There are two more optional parameters that are set as environment variables:
 | --- | --- |
 | `USE_SSH` | Set to `true` to use SSH instead of the default HTTPS for the connection to the GitHub repo. |
 | `CURRENT_BRANCH` | The branch that contains the latest docs changes that will be deployed. Usually, the branch will be `master`, but it could be any branch (default or otherwise) except for `gh-pages`. If nothing is set for this variable, then the current branch will be used. |
+| `GIT_TOKEN` | To authenticate with a Github token. |
 
 ### Deploy
 


### PR DESCRIPTION
## Motivation

While integrating Docusaurus into a CI system that relies on Github access tokens for authenticating, I realized that the current deploy command does not support this workflow.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Ran the linter
- Ran unit tests
- Ran the build
- Executed the command ```GIT_TOKEN="..." GIT_USER=husman npx docusaurus deploy``` successfully. The static files were pushed to the **gh-pages** branch in my repository.

## Related PRs

- https://github.com/facebook/docusaurus/issues/1778
