### PR TITLE
refactor(v2): convert `@docusaurus/plugin-content-blog` to TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,4 +13,4 @@ packages/docusaurus-1.x/lib/core/__tests__/split-tab.test.js
 packages/docusaurus-utils/lib/
 packages/docusaurus/lib/
 packages/docusaurus-init/lib/
-
+packages/docusaurus-plugin-content-blog/lib/

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ types
 packages/docusaurus-utils/lib/
 packages/docusaurus/lib/
 packages/docusaurus-init/lib/
-
-
+packages/docusaurus-plugin-content-blog/lib/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ build
 packages/docusaurus-utils/lib/
 packages/docusaurus/lib/
 packages/docusaurus-init/lib/
+packages/docusaurus-plugin-content-blog/lib/

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
     '__fixtures__',
     '/packages/docusaurus/lib',
     '/packages/docusaurus-utils/lib',
+    '/packages/docusaurus-plugin-content-blog/lib',
   ],
   transform: {
     '^.+\\.[jt]sx?$': 'babel-jest',

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -2,7 +2,10 @@
   "name": "@docusaurus/plugin-content-blog",
   "version": "2.0.0-alpha.24",
   "description": "Blog plugin for Docusaurus",
-  "main": "src/index.js",
+  "main": "lib/index.js",
+  "scripts": {
+    "tsc": "tsc"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -8,11 +8,12 @@
 import fs from 'fs-extra';
 import path from 'path';
 import pluginContentBlog from '../index';
+import {DocusaurusConfig} from '../typesDocusaurus';
 
 describe('loadBlog', () => {
   test('simple website', async () => {
     const siteDir = path.join(__dirname, '__fixtures__', 'website');
-    const siteConfig = {
+    const siteConfig: DocusaurusConfig = {
       title: 'Hello',
       baseUrl: '/',
       url: 'https://docusaurus.io',

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -6,8 +6,9 @@
  */
 
 const {parseQuery, getOptions} = require('loader-utils');
+import {loader} from 'webpack';
 
-module.exports = async function(fileString) {
+export = function(fileString: string) {
   const callback = this.async();
 
   const {truncateMarker} = getOptions(this);
@@ -25,5 +26,5 @@ module.exports = async function(fileString) {
     // eslint-disable-next-line
     finalContent = fileString.split(truncateMarker)[0];
   }
-  return callback(null, finalContent);
-};
+  return callback && callback(null, finalContent);
+} as loader.Loader;

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -1,0 +1,93 @@
+import {Loader} from 'webpack';
+
+export interface BlogContent {
+  blogPosts: BlogPost[];
+  blogListPaginated: BlogPaginated[];
+  blogTags: BlogTags;
+  blogTagsListPath: string;
+}
+
+export interface DateLink {
+  date: Date;
+  link: string;
+}
+
+export interface PluginOptions {
+  path: string;
+  routeBasePath: string;
+  include: string[];
+  postsPerPage: number;
+  blogListComponent: string;
+  blogPostComponent: string;
+  blogTagsListComponent: string;
+  blogTagsPostsComponent: string;
+  remarkPlugins: string[];
+  rehypePlugins: string[];
+  truncateMarker: RegExp | string;
+}
+
+export interface BlogTags {
+  [key: string]: BlogTag;
+}
+
+export interface BlogTag {
+  name: string;
+  items: string[];
+  permalink: string;
+}
+
+export interface BlogPost {
+  id: string;
+  metadata: MetaData;
+}
+
+export interface BlogPaginated {
+  metadata: MetaData;
+  items: string[];
+}
+
+export interface MetaData {
+  permalink: string;
+  source: string;
+  description: string;
+  date: Date;
+  tags: (Tag | string)[];
+  title: string;
+}
+
+export interface Tag {
+  label: string;
+  permalink: string;
+}
+
+export interface BlogItemsToModules {
+  [key: string]: MetaDataWithPath;
+}
+
+export interface MetaDataWithPath {
+  metadata: MetaData;
+  metadataPath: string;
+}
+
+export interface TagsModule {
+  [key: string]: TagModule;
+}
+
+export interface TagModule {
+  allTagsPath: string;
+  slug: string;
+  name: string;
+  count: number;
+  permalink: string;
+}
+
+export interface ConfigureWebpackUtils {
+  getStyleLoaders: (
+    isServer: boolean,
+    cssOptions: {
+      [key: string]: any;
+    },
+  ) => Loader[];
+  getCacheLoader: (isServer: boolean, cacheOptions?: {}) => Loader | null;
+  getBabelLoader: (isServer: boolean, babelOptions?: {}) => Loader;
+}

--- a/packages/docusaurus-plugin-content-blog/src/typesDocusaurus.ts
+++ b/packages/docusaurus-plugin-content-blog/src/typesDocusaurus.ts
@@ -1,0 +1,63 @@
+import {ParsedUrlQueryInput} from 'querystring';
+
+export interface DocusaurusConfig {
+  baseUrl: string;
+  favicon?: string;
+  tagline?: string;
+  title: string;
+  url: string;
+  organizationName?: string;
+  projectName?: string;
+  githubHost?: string;
+  plugins?: PluginConfig[];
+  themes?: PluginConfig[];
+  presets?: PresetConfig[];
+  themeConfig?: {
+    [key: string]: any;
+  };
+  customFields?: {
+    [key: string]: any;
+  };
+}
+
+export type PluginConfig = [string, Object | undefined] | string;
+
+export type PresetConfig = [string, Object | undefined] | string;
+
+export interface CLIOptions {
+  [option: string]: any;
+}
+
+export interface LoadContext {
+  siteDir: string;
+  generatedFilesDir?: string;
+  siteConfig: DocusaurusConfig;
+  cliOptions?: CLIOptions;
+  outDir?: string;
+  baseUrl?: string;
+}
+
+export interface PluginContentLoadedActions {
+  addRoute(config: RouteConfig): void;
+  createData(name: string, data: Object): Promise<string>;
+}
+
+export type Module =
+  | {
+      path: string;
+      __import?: boolean;
+      query?: ParsedUrlQueryInput;
+    }
+  | string;
+
+export interface RouteModule {
+  [module: string]: Module | RouteModule | RouteModule[];
+}
+
+export interface RouteConfig {
+  path: string;
+  component: string;
+  modules?: RouteModule;
+  routes?: RouteConfig[];
+  exact?: boolean;
+}

--- a/packages/docusaurus-plugin-content-blog/tsconfig.json
+++ b/packages/docusaurus-plugin-content-blog/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./lib/.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "lib",
+  }
+}

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -50,7 +50,7 @@ export async function loadPlugins({
 
       // module is any valid module identifier - npm package or locally-resolved path.
       const pluginModule = importFresh(pluginModuleImport);
-      return pluginModule(context, pluginOptions);
+      return (pluginModule.default || pluginModule)(context, pluginOptions);
     }),
   );
 

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -30,7 +30,7 @@ export function loadPresets(
     }
 
     const presetModule = importFresh(presetModuleImport);
-    const preset: Preset = presetModule(context, presetOptions);
+    const preset: Preset = (presetModule.default || presetModule)(context, presetOptions);
 
     preset.plugins && unflatPlugins.push(preset.plugins);
     preset.themes && unflatThemes.push(preset.themes);

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -30,7 +30,10 @@ export function loadPresets(
     }
 
     const presetModule = importFresh(presetModuleImport);
-    const preset: Preset = (presetModule.default || presetModule)(context, presetOptions);
+    const preset: Preset = (presetModule.default || presetModule)(
+      context,
+      presetOptions,
+    );
 
     preset.plugins && unflatPlugins.push(preset.plugins);
     preset.themes && unflatThemes.push(preset.themes);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

https://github.com/facebook/docusaurus/issues/1698
I want to contribute to this issue.
Before that, I want to convert plugin code to TypeScript.

I want many opinions.
And I think we need a common type definition module that includes `DocusaurusConfig, LoadContext, PluginContent`, and so on.
So, I have collected these definitions in `typesDocusaurus.ts`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Convert test codes to TypeScript also.

## Related PRs

None
