### PR TITLE
fix(v2): add `ts,tsx` to `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "lint-staged": {
     "linters": {
-      "*.js": [
+      "*.{js,jsx,ts,tsx}": [
         "yarn lint --fix",
         "yarn prettier",
         "git add"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I found a missing configuration of `lint-staged` on `pacakge.json`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No

## Related PRs

#1785
