### PR TITLE
docs: update TypeGraphQL showcase url

### DIFF
--- a/website-1.x/data/users.js
+++ b/website-1.x/data/users.js
@@ -718,7 +718,7 @@ module.exports = [
   {
     caption: 'TypeGraphQL',
     image: '/img/users/type-graphql.png',
-    infoLink: 'https://19majkel94.github.io/type-graphql/',
+    infoLink: 'https://typegraphql.ml/',
     fbOpenSource: false,
     pinned: false,
   },


### PR DESCRIPTION
## Motivation

After changing my account name, the old link no longer works:
https://github.com/facebook/docusaurus/pull/1174#issuecomment-536184353