### PR TITLE
fix (v1): fix broken relative links related to `--skip-next-release` build option

### DIFF
--- a/packages/docusaurus-1.x/lib/server/docs.js
+++ b/packages/docusaurus-1.x/lib/server/docs.js
@@ -69,9 +69,7 @@ function mdToHtmlify(oldContent, mdToHtml, metadata, siteConfig) {
     let mdMatch = mdRegex.exec(modifiedLine);
     while (mdMatch !== null) {
       /* Replace it to correct html link */
-      const docsSource = metadata.version
-        ? metadata.source.replace(/version-.*?\//, '')
-        : metadata.source;
+      const docsSource = metadata.source;
       let htmlLink =
         mdToHtml[resolve(docsSource, mdMatch[1])] || mdToHtml[mdMatch[1]];
       if (htmlLink) {

--- a/packages/docusaurus-1.x/lib/server/docs.js
+++ b/packages/docusaurus-1.x/lib/server/docs.js
@@ -79,27 +79,53 @@ function mdToHtmlify(oldContent, mdToHtml, metadata, siteConfig) {
         htmlLink =
           mdToHtml[resolve(docsSource, mdMatch[1])] || mdToHtml[mdMatch[1]];
       } else {
-        /*
-         * Check if the target file exists in the versioned doc.
-         * If it exists with the versioned doc, resolve the link.
-         * If it does not exist with the versioned doc,
-         * check if it exists at the directory where the version
-         *  was created from. If yes, resolve the link. Otherwise,
-         * this is a broken link.
+        /**
+         * When the very first version is created, all source/markdown files from next release docs
+         * are copied to the directory corresponding to that version. For subsequent versiones being
+         * created, source/markdown files are copied to the corresponding version directory, if and
+         * only if that file had changed in the next release docs. This is how the source files are
+         * maintained when versions are created.
+         *
+         * During build time those files that were not copied to the versioned docs source, are copied
+         * to the build output.
+         *
+         * When `--skip-next-release` build option is used, we need to verify whether the target file path
+         * exists with the "versioned docs" or at the next release docs. If it does, that file will be
+         * available in the build output and the link will be valid. So, update the link from `.md` to
+         * `.html` accordingly.
          */
         const originalFilePath = metadata.original_id.match('.+/')
           ? metadata.original_id.match('.+/')[0]
           : '';
+
+        const targetFileAtVersionedDoc =
+          'versioned_docs/version-' +
+          metadata.version +
+          '/' +
+          resolve(docsSource, mdMatch[1]);
+
         const targetFileAtRoot =
           '../' + siteConfig.docsUrl + '/' + originalFilePath + mdMatch[1];
 
-        if (fs.existsSync(mdMatch[1])) {
-          htmlLink = resolve(docsSource, mdMatch[1]).replace('.md', '.html');
-        } else if (fs.existsSync(targetFileAtRoot)) {
-          htmlLink = resolve(docsSource, mdMatch[1]).replace('.md', '.html');
+        if (
+          fs.existsSync(targetFileAtVersionedDoc) ||
+          fs.existsSync(targetFileAtRoot)
+        ) {
+          if (siteConfig.cleanUrl) {
+            htmlLink = docsSource.endsWith('index.md')
+              ? mdMatch[1].replace('.md', '.html')
+              : '../' + mdMatch[1].replace('.md', '.html');
+          } else {
+            htmlLink = mdMatch[1].replace('.md', '.html');
+          }
         }
       }
 
+      /**
+       * If there is a valid target link, sanitize the URL according to various configuration
+       * options such as: `clearnUrl`, versions, language, etc. Otherwise, store the target so
+       * that it can be reported as a broken link.
+       */
       if (htmlLink) {
         htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
         htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);

--- a/packages/docusaurus-1.x/lib/server/docs.js
+++ b/packages/docusaurus-1.x/lib/server/docs.js
@@ -69,9 +69,19 @@ function mdToHtmlify(oldContent, mdToHtml, metadata, siteConfig) {
     let mdMatch = mdRegex.exec(modifiedLine);
     while (mdMatch !== null) {
       /* Replace it to correct html link */
-      const docsSource = metadata.source;
+      let docsSource;
+      if (readMetadata.shouldGenerateNextReleaseDocs()) {
+        docsSource = metadata.version
+          ? metadata.source.replace(/version-.*?\//, '')
+          : metadata.source;
+      } else {
+        docsSource = metadata.source;
+      }
       let htmlLink =
-        mdToHtml[resolve(docsSource, mdMatch[1])] || mdToHtml[mdMatch[1]];
+        mdToHtml[resolve(docsSource, mdMatch[1])] ||
+        mdToHtml[mdMatch[1]] ||
+        resolve(docsSource, mdMatch[1]).replace('.md', '.html');
+
       if (htmlLink) {
         htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
         htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);

--- a/packages/docusaurus-1.x/lib/server/metadataUtils.js
+++ b/packages/docusaurus-1.x/lib/server/metadataUtils.js
@@ -70,7 +70,7 @@ function mdToHtml(Metadata, siteConfig) {
   const result = {};
   Object.keys(Metadata).forEach(id => {
     const metadata = Metadata[id];
-    if (metadata.language !== 'en' || metadata.original_id) {
+    if (metadata.language !== 'en') {
       return;
     }
     let htmlLink = baseUrl + metadata.permalink.replace('/next/', '/');

--- a/packages/docusaurus-1.x/lib/server/readMetadata.js
+++ b/packages/docusaurus-1.x/lib/server/readMetadata.js
@@ -405,4 +405,5 @@ module.exports = {
   processMetadata,
   generateMetadataDocs,
   generateMetadataBlog,
+  shouldGenerateNextReleaseDocs,
 };


### PR DESCRIPTION
The problem is described in issue #1805 and it seems to have existed for a long time.
Given versioning is enabled and the repository contains versioned docs, if the build
option `--skip-next-release` is used when building the static site, the versioned
docs contains a lot of broken links. The generator is not able to locate the targetted
file for the relative link and so it leaves the html links as ".md" instead of ".html".

The issue appears to be isolated to `website/versioned-docs/` only and only if the above
mentioned build option is used.

This change fixes this issue and allows for generating site with appropriate relative
links.

closes #1805 

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I have used Docusaurus in several of my work related documentation sites. We've recently published our documentation sites and found out about this bug. Currently our production sites has lot of broken links in our "versioned docs".

I wanted to see a proper fix that will work for everyone instead of coming up with a workaround or hacking our sites post-build to address this issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

The changes in this PR is relatively small. So, I applied these changes to my documentation projects where I have the bugs. Then:

1. Generate a site using the command `yarn build`
2. Serve the generated site using a webserver locally and verified that everything still works as usual and relative links in both next release and versioned docs are working
3. Generate a site using the command `yarn build --skip-next-release`
4. Repeat step 2 mentioned above

I know that V2 is still under development but I wasn't able to find any code related to this feature.


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
