### PR TITLE
fix(v2): only show the Git requirement message for the docs last update feature once

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
+++ b/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
@@ -11,6 +11,8 @@ type FileLastUpdateData = {timestamp?: number; author?: string};
 
 const GIT_COMMIT_TIMESTAMP_AUTHOR_REGEX = /^(\d+), (.+)$/;
 
+let showedGitRequirementError = false;
+
 export default function getFileLastUpdate(
   filePath: string,
 ): FileLastUpdateData | null {
@@ -32,9 +34,14 @@ export default function getFileLastUpdate(
   // Wrap in try/catch in case the shell commands fail (e.g. project doesn't use Git, etc).
   try {
     if (!shell.which('git')) {
-      console.log('Sorry, the docs plugin last update options require Git.');
+      if (!showedGitRequirementError) {
+        showedGitRequirementError = true;
+        console.log('Sorry, the docs plugin last update options require Git.');
+      }
+
       return null;
     }
+
     // To differentiate between content change and file renaming/moving, use --summary
     // To follow the file history until before it is moved (when we create new version), use
     // --follow.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Only show the Git requirement message for the docs last update feature once so that we don't spam users with `console.log()`s when they have many docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Mocked the condition to pass and see that we only print that message once.

```
> @ start /Users/yangshun/Developer/docusaurus_users/docusaurus
> yarn tsc && yarn start:v2

yarn run v1.16.0
$ lerna run tsc --no-private
lerna notice cli v3.14.1
lerna info Executing command in 6 packages: "yarn run tsc"
lerna info run Ran npm script 'tsc' in '@docusaurus/init' in 2.7s:
$ tsc
lerna info run Ran npm script 'tsc' in '@docusaurus/utils' in 2.7s:
$ tsc
lerna info run Ran npm script 'tsc' in '@docusaurus/plugin-content-blog' in 3.6s:
$ tsc
lerna info run Ran npm script 'tsc' in '@docusaurus/plugin-content-pages' in 3.6s:
$ tsc
lerna info run Ran npm script 'tsc' in '@docusaurus/plugin-content-docs' in 3.8s:
$ tsc
lerna info run Ran npm script 'tsc' in '@docusaurus/core' in 4.0s:
$ tsc && node copyUntypedFiles.js
lerna success run Ran npm script 'tsc' in 6 packages in 6.7s:
lerna success - @docusaurus/init
lerna success - @docusaurus/plugin-content-blog
lerna success - @docusaurus/plugin-content-docs
lerna success - @docusaurus/plugin-content-pages
lerna success - @docusaurus/utils
lerna success - @docusaurus/core
✨  Done in 7.38s.
yarn run v1.16.0
$ yarn workspace docusaurus-2-website start
$ docusaurus start
Starting the development server...
Sorry, the docs plugin last update options require Git.
Your site will be accessible at http://localhost:3000/
✅  [22:01:01] Build 2325a46f finished in 8000 ms!
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
