### PR TITLE
feat(v2): add scripts and stylesheets field to config

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -4,6 +4,7 @@
 
 - Docs, pages plugin is rewritten in TypeScript
 - Docs improvements and tweaks
+  - Improved metadata which results in smaller bundle size.
   - Docs sidebar can now be more than one level deep, theoretically up to infinity
   - Collapsible docs sidebar!
   - Make doc page title larger
@@ -13,6 +14,7 @@
 - Code Blocks
   - Change default theme from Night Owl to Palenight
   - Slight tweaks to playground/preview components
+  - Add `scripts` and `stylesheets` field to docusaurus.config.
 
 ## 2.0.0-alpha.25
 

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -19,6 +19,18 @@ export interface DocusaurusConfig {
   customFields?: {
     [key: string]: any;
   };
+  scripts?: (
+    | string
+    | {
+        src: string;
+        [key: string]: any;
+      })[];
+  stylesheets?: (
+    | string
+    | {
+        href: string;
+        [key: string]: any;
+      })[];
 }
 
 export interface DocusaurusContext {

--- a/packages/docusaurus/src/client/App.js
+++ b/packages/docusaurus/src/client/App.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 
+import Head from '@docusaurus/Head';
 import routes from '@generated/routes';
 import siteConfig from '@generated/docusaurus.config';
 import renderRoutes from '@docusaurus/renderRoutes';
@@ -16,8 +17,29 @@ import PendingNavigation from './PendingNavigation';
 import './client-lifecycles-dispatcher';
 
 function App() {
+  const {stylesheets, scripts} = siteConfig;
   return (
     <DocusaurusContext.Provider value={{siteConfig}}>
+      {(stylesheets || scripts) && (
+        <Head>
+          {stylesheets &&
+            stylesheets.map(source =>
+              source.href ? (
+                <link rel="stylesheet" key={source.href} {...source} />
+              ) : (
+                <link rel="stylesheet" key={source} href={source} />
+              ),
+            )}
+          {scripts &&
+            scripts.map(source =>
+              source.src ? (
+                <script type="text/javascript" key={source.src} {...source} />
+              ) : (
+                <script type="text/javascript" src={source} key={source} />
+              ),
+            )}
+        </Head>
+      )}
       <PendingNavigation routes={routes}>
         {renderRoutes(routes)}
       </PendingNavigation>

--- a/packages/docusaurus/src/client/App.js
+++ b/packages/docusaurus/src/client/App.js
@@ -24,18 +24,18 @@ function App() {
         <Head>
           {stylesheets &&
             stylesheets.map(source =>
-              source.href ? (
-                <link rel="stylesheet" key={source.href} {...source} />
-              ) : (
+              typeof source === 'string' ? (
                 <link rel="stylesheet" key={source} href={source} />
+              ) : (
+                <link rel="stylesheet" key={source.href} {...source} />
               ),
             )}
           {scripts &&
             scripts.map(source =>
-              source.src ? (
-                <script type="text/javascript" key={source.src} {...source} />
-              ) : (
+              typeof source === 'string' ? (
                 <script type="text/javascript" src={source} key={source} />
+              ) : (
+                <script type="text/javascript" key={source.src} {...source} />
               ),
             )}
         </Head>

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -23,6 +23,8 @@ const OPTIONAL_FIELDS = [
   'themes',
   'presets',
   'themeConfig',
+  'scripts',
+  'stylesheets',
 ];
 
 const DEFAULT_CONFIG: {

--- a/website/docs/docusaurus.config.js.md
+++ b/website/docs/docusaurus.config.js.md
@@ -253,7 +253,9 @@ Error: The field(s) 'foo', 'bar' are not recognized in docusaurus.config.js
 
 ### `scripts`
 
-An array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. The script tag will be inserted in the HTML head.
+An array of scripts to load. The values can be either strings or plain objects of attribute-value maps. The `<script>` tags will be inserted in the HTML `<head>`.
+
+Note that `<script>` added here are render-blocking so you might want to add `async: true`/`defer: true` to the objects.
 
 - Type: `(string | Object)[]`
 
@@ -263,10 +265,11 @@ Example:
 // docusaurus.config.js
 module.exports = {
   scripts: [
-    'https://docusaurus.io/slash.js',
+    // String format.
+    'https://docusaurus.io/script.js',
+    // Object format.
     {
-      src:
-        'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
+      src: 'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
       async: true,
     },
   ],
@@ -275,7 +278,7 @@ module.exports = {
 
 ### `stylesheets`
 
-An array of CSS sources to load. The values can be either strings or plain objects of attribute-value maps. The link tag will be inserted in the HTML head.
+An array of CSS sources to load. The values can be either strings or plain objects of attribute-value maps. The `<link>` tags will be inserted in the HTML `<head>`.
 
 - Type: `(string | Object)[]`
 
@@ -285,9 +288,11 @@ Example:
 // docusaurus.config.js
 module.exports = {
   stylesheets: [
+    // String format.
     'https://docusaurus.io/style.css',
-    {
-      href: 'http://css.link',
+    // Object format.
+    { 
+      href: 'http://mydomain.com/style.css',
       type: 'text/css',
     },
   ],

--- a/website/docs/docusaurus.config.js.md
+++ b/website/docs/docusaurus.config.js.md
@@ -250,3 +250,46 @@ Attempting to add unknown field in the config will lead to error in build time:
 ```bash
 Error: The field(s) 'foo', 'bar' are not recognized in docusaurus.config.js
 ```
+
+### `scripts`
+
+An array of JavaScript sources to load. The values can be either strings or plain objects of attribute-value maps. The script tag will be inserted in the HTML head.
+
+- Type: `(string | Object)[]`
+
+Example:
+
+```js
+// docusaurus.config.js
+module.exports = {
+  scripts: [
+    'https://docusaurus.io/slash.js',
+    {
+      src:
+        'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
+      async: true,
+    },
+  ],
+};
+```
+
+### `stylesheets`
+
+An array of CSS sources to load. The values can be either strings or plain objects of attribute-value maps. The link tag will be inserted in the HTML head.
+
+- Type: `(string | Object)[]`
+
+Example:
+
+```js
+// docusaurus.config.js
+module.exports = {
+  stylesheets: [
+    'https://docusaurus.io/style.css',
+    {
+      href: 'http://css.link',
+      type: 'text/css',
+    },
+  ],
+};
+```

--- a/website/docs/migration-from-v1-to-v2.md
+++ b/website/docs/migration-from-v1-to-v2.md
@@ -117,7 +117,7 @@ module.exports = {
 
 Refer to migration guide below for each field in `siteConfig.js`.
 
-#### `baseUrl`, `tagline`, `title`, `url`, `favicon`, `organizationName`, `projectName`, `githubHost`
+#### `baseUrl`, `tagline`, `title`, `url`, `favicon`, `organizationName`, `projectName`, `githubHost`, `scripts`, `stylesheets`
 
 No actions needed.
 
@@ -324,8 +324,6 @@ module.exports = {
 
 - `enableUpdateBy`
 - `enableUpdateTime`
-- `scripts`
-- `stylesheets`
 
 ### Removed fields
 


### PR DESCRIPTION
## Motivation

 Add `scripts` and `stylesheets` field to docusaurus.config. for v1 parity and enable user to use external resources script or stylesheets

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Add random scripts and stylesheets into config
```js
  scripts: [
    'https://docusaurus.io/slash.js',
    {
      src:
        'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
      async: true,
    },
  ],
  stylesheets: [
    'https://docusaurus.io/style.css',
    {
      href: 'http://css.link',
      type: 'text/css',
    },
  ],
```

<img width="459" alt="1" src="https://user-images.githubusercontent.com/17883920/66626648-36dd6400-ec23-11e9-84c5-9a483105185f.PNG">
<img width="443" alt="2" src="https://user-images.githubusercontent.com/17883920/66626649-36dd6400-ec23-11e9-984a-6f1c9e8cac1d.PNG">
