### PR TITLE
refactor(v2): simplify & faster last updated logic for docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/preset-typescript": "^7.3.3",
+    "@types/cross-spawn": "^6.0.1",
     "@types/express": "^4.17.0",
     "@types/fs-extra": "8.0.0",
     "@types/inquirer": "^6.0.3",

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@docusaurus/mdx-loader": "^2.0.0-alpha.25",
     "@docusaurus/utils": "^2.0.0-alpha.25",
+    "cross-spawn": "^7.0.1",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
     "import-fresh": "^3.1.0",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -7,9 +7,10 @@
 
 import fs from 'fs';
 import path from 'path';
-import shell from 'shelljs';
+import spawn from 'cross-spawn';
 
 import lastUpdate from '../lastUpdate';
+import {SpawnSyncReturns} from 'child_process';
 
 describe('lastUpdate', () => {
   test('existing test file in repository with Git timestamp', () => {
@@ -44,44 +45,5 @@ describe('lastUpdate', () => {
     fs.writeFileSync(tempFilePath, 'Lorem ipsum :)');
     expect(lastUpdate(tempFilePath)).toBeNull();
     fs.unlinkSync(tempFilePath);
-  });
-
-  test('test renaming and moving file', () => {
-    const mock = jest.spyOn(shell, 'exec');
-    mock
-      .mockImplementationOnce(() => ({
-        stdout:
-          '1539502055, Yangshun Tay\n' +
-          '\n' +
-          ' create mode 100644 v1/lib/core/__tests__/__fixtures__/.temp2\n',
-      }))
-      .mockImplementationOnce(() => ({
-        stdout:
-          '1539502056, Joel Marcey\n' +
-          '\n' +
-          ' rename v1/lib/core/__tests__/__fixtures__/{.temp2 => test/.temp3} (100%)\n' +
-          '1539502055, Yangshun Tay\n' +
-          '\n' +
-          ' create mode 100644 v1/lib/core/__tests__/__fixtures__/.temp2\n',
-      }));
-    const tempFilePath2 = path.join(__dirname, '__fixtures__', '.temp2');
-    const tempFilePath3 = path.join(
-      __dirname,
-      '__fixtures__',
-      'test',
-      '.temp3',
-    );
-
-    // Create new file.
-    const createData = lastUpdate(tempFilePath2);
-    expect(createData.timestamp).not.toBeNull();
-
-    // Rename/move the file.
-    const updateData = lastUpdate(tempFilePath3);
-    expect(updateData.timestamp).not.toBeNull();
-    // Should only consider file content change.
-    expect(updateData.timestamp).toEqual(createData.timestamp);
-
-    mock.mockRestore();
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -7,7 +7,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import spawn from 'cross-spawn';
 
 import lastUpdate from '../lastUpdate';
 import {SpawnSyncReturns} from 'child_process';

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -9,7 +9,6 @@ import fs from 'fs';
 import path from 'path';
 
 import lastUpdate from '../lastUpdate';
-import {SpawnSyncReturns} from 'child_process';
 
 describe('lastUpdate', () => {
   test('existing test file in repository with Git timestamp', () => {

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -104,7 +104,14 @@ export default async function processMetadata({
   }
 
   if (showLastUpdateAuthor || showLastUpdateTime) {
-    const fileLastUpdateData = lastUpdate(filePath);
+    // Use fake data in dev for faster development
+    const fileLastUpdateData =
+      process.env.NODE_ENV === 'production'
+        ? lastUpdate(filePath)
+        : {
+            author: 'Author',
+            timestamp: '1539502055',
+          };
 
     if (fileLastUpdateData) {
       const {author, timestamp} = fileLastUpdateData;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,6 +2355,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cross-spawn@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.1.tgz#60fa0c87046347c17d9735e5289e72b804ca9b63"
+  integrity sha512-MtN1pDYdI6D6QFDzy39Q+6c9rl2o/xN7aWGe6oZuzqq5N6+YuwFsWiEAv3dNzvzN9YzU+itpN8lBzFpphQKLAw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint@*":
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-4.16.6.tgz#96d4ecddbea618ab0b55eaf0dffedf387129b06c"
@@ -5011,6 +5018,15 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crowdin-cli@^0.3.0:
   version "0.3.0"
@@ -11705,6 +11721,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
+  integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -14181,10 +14202,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@1.6.1:
   version "1.6.1"
@@ -16157,6 +16190,13 @@ which@1, which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
+  integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
## Motivation

The last updated time took too long. It took ~250ms for one doc.

For docusaurus own docs, it took 7-8s while webpack compilation is only 9s
<img width="628" alt="dev2" src="https://user-images.githubusercontent.com/17883920/66640340-fd1c5580-ec42-11e9-85d8-07b83a45b2ec.PNG">

Improvement:
- Use cross-spawn (faster than shelljs)
- No need to make the last updated logic too complex (just find last commit like vuepress)
- Disable it in dev (use fake timestamp instead) since production is the one who really need this feature

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Much faster now ~100ms

<img width="596" alt="cross-spawn" src="https://user-images.githubusercontent.com/17883920/66640709-a5cab500-ec43-11e9-8854-fc0898602f69.PNG">

Netlify still have last updated info
![image](https://user-images.githubusercontent.com/17883920/66641331-bd566d80-ec44-11e9-85df-3fa1fe00f15f.png)
