### PR TITLE
feat(v2): add help page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -92,6 +92,10 @@ module.exports = {
               label: 'Installation',
               to: 'docs/installation',
             },
+            {
+              label: 'Migration from v1 to v2',
+              to: 'docs/migration-from-v1-to-v2',
+            },
           ],
         },
         {
@@ -108,6 +112,10 @@ module.exports = {
             {
               label: 'Discord',
               href: 'https://discordapp.com/invite/docusaurus',
+            },
+            {
+              label: 'Help',
+              to: 'help',
             },
           ],
         },

--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useEffect} from 'react';
+import Layout from '@theme/Layout';
+
+import Link from '@docusaurus/Link';
+import withBaseUrl from '@docusaurus/withBaseUrl';
+
+function Help() {
+  return (
+    <Layout permalink="/help" description="Docusaurus 2 Help page">
+      <div className="container margin-vert--xl">
+        <div className="text--center margin-bottom--xl">
+          <h1>Need Help?</h1>
+          <p>
+            If you need help with Docusaurus 2, you can try one of the
+            mechanisms below.
+          </p>
+        </div>
+        <div className="row">
+          <div className="col">
+            <h2>Browse the docs</h2>
+            <p>
+              Learn more about Docusaurus using the{' '}
+              <Link to={withBaseUrl('docs/introduction')}>
+                official documentation
+              </Link>
+            </p>
+          </div>
+          <div className="col">
+            <h2>Discord</h2>
+            <p>
+              You can join the conversation on{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://discord.gg/docusaurus">
+                Discord
+              </a>{' '}
+              on one of our two text channels:{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://discord.gg/7wjJ9yH">
+                #docusaurus-2-dogfooding
+              </a>{' '}
+              for user help and{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://discord.gg/6g6ASPA">
+                #docusaurus-2-dev
+              </a>{' '}
+              for contributing help.
+            </p>
+          </div>
+          <div className="col">
+            <h2>Twitter</h2>
+            <p>
+              You can follow and contact us on{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://twitter.com/docusaurus">
+                Twitter
+              </a>
+              .
+            </p>
+          </div>
+          <div className="col">
+            <h2>GitHub</h2>
+            <p>
+              At our{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://github.com/facebook/docusaurus">
+                GitHub repo
+              </a>{' '}
+              Browse and submit{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://github.com/facebook/docusaurus/issues">
+                issues
+              </a>{' '}
+              or{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://github.com/facebook/docusaurus/pulls">
+                pull requests
+              </a>{' '}
+              for bugs you find or any new features you may want implemented. Be
+              sure to also check out our{' '}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md">
+                contributing guide
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export default Help;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Create a help page that's similar to v1's [Help page](https://docusaurus.io/en/help)
- So that users doing #1834 have a v2 implementation to refer to. Many FB websites have that Help page

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="1552" alt="Screen Shot 2019-10-12 at 12 50 01 AM" src="https://user-images.githubusercontent.com/1315101/66697450-9de23380-ec8a-11e9-8fe4-382f3c9020d2.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
