### PR TITLE
feat(v2): add tabs component for multi-language code

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -1,5 +1,9 @@
 # Docusaurus 2 Changelog
 
+## Unreleased
+
+- Add `@theme/Tabs` which can be used to implement multi-language code tabs
+
 ## 2.0.0-alpha.26
 
 - Docs, pages plugin is rewritten in TypeScript

--- a/packages/docusaurus-theme-classic/src/theme/TabItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/TabItem/index.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+function TabItem(props) {
+  return <div>{props.children}</div>;
+}
+
+export default TabItem;

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useState} from 'react';
+
+import classnames from 'classnames';
+
+function Tabs(props) {
+  const {block, children, defaultValue, values} = props;
+  const [selectedValue, setSelectedValue] = useState(defaultValue);
+
+  return (
+    <div>
+      <ul
+        className={classnames('tabs', {
+          'tabs--block': block,
+        })}>
+        {values.map(({value, label}) => (
+          <li
+            className={classnames('tab-item', {
+              'tab-item--active': selectedValue === value,
+            })}
+            key={value}
+            onClick={() => setSelectedValue(value)}>
+            {label}
+          </li>
+        ))}
+      </ul>
+      <div className="margin-vert--md">
+        {children.filter(child => child.props.value === selectedValue)[0]}
+      </div>
+    </div>
+  );
+}
+
+export default Tabs;

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -257,3 +257,97 @@ function Clock(props) {
   );
 }
 ```
+
+### Multi-language support code blocks
+
+With MDX, you can easily create interactive components within your documentation, for example, to display code in multiple programming languages and switching between them using a tabs component.
+
+Instead of implementing a dedicated component for multi-language support code blocks, we've implemented a generic Tabs component in the classic theme so that you can use it for other non-code scenarios as well.
+
+The following example is how you can have multi-language code tabs in your docs. Note that the empty lines above and below each language block is **intentional**. This is a current limitation of MDX, you have to leave empty lines around Markdown syntax for the MDX parser to know that it's Markdown syntax and not JSX.
+
+    import Tabs from '@theme/Tabs';
+    import TabItem from '@theme/TabItem';
+
+    <Tabs
+      defaultValue="js"
+      values={[
+        { label: 'JavaScript', value: 'js', },
+        { label: 'Python', value: 'py', },
+        { label: 'Java', value: 'java', },
+      ]
+    }>
+    <TabItem value="js">
+
+    ```js
+    function helloWorld() {
+      console.log('Hello, world!');
+    }
+    ```
+
+    </TabItem>
+    <TabItem value="py">
+
+    ```py
+    def hello_world():
+      print 'Hello, world!'
+    ```
+
+    </TabItem>
+    <TabItem value="java">
+
+    ```java
+    class HelloWorld {
+      public static void main(String args[]) {
+        System.out.println("Hello, World");
+      }
+    }
+    ```
+
+    </TabItem>
+    </Tabs>
+
+And you will get the following:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  defaultValue="js"
+  values={[
+    { label: 'JavaScript', value: 'js', },
+    { label: 'Python', value: 'py', },
+    { label: 'Java', value: 'java', },
+  ]
+}>
+<TabItem value="js">
+
+```js
+function helloWorld() {
+  console.log('Hello, world!');
+}
+```
+
+</TabItem>
+<TabItem value="py">
+
+```py
+def hello_world():
+  print 'Hello, world!'
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+class HelloWorld {
+  public static void main(String args[]) {
+    System.out.println("Hello, World");
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+You may want to implement your own `<MultiLanguageCode />` abstraction if you find the above approach too verbose. We might just implement one in future for convenience.

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -385,7 +385,7 @@ In Docusaurus 2, the markdown syntax has been changed to [MDX](https://mdxjs.com
 
 ### Language-specific Code Tabs
 
-Refer to the [multi-language support code blocks](/docs/markdown-features#multi-language-support-code-blocks) section.
+Refer to the [multi-language support code blocks](markdown-features.md#multi-language-support-code-blocks) section.
 
 ## Update `.gitignore`
 

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -385,7 +385,7 @@ In Docusaurus 2, the markdown syntax has been changed to [MDX](https://mdxjs.com
 
 ### Language-specific Code Tabs
 
-Not yet supported. Stay tuned.
+Refer to the [multi-language support code blocks](/docs/markdown-features#multi-language-support-code-blocks) section.
 
 ## Update `.gitignore`
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Backward-compatibility for multi-language code support. I implemented a very low-level tabs component so that it can be reused for other scenarios (e.g. different OS platform).

It's quite verbose to use now but I think users can implement their own higher level abstractions that is customized for their use case (e.g. fixed languages).

In future I'm thinking we could create a wrapper provider that syncs the value across all instances of that kind of tabs and switching the value on one would switch for the other tabs. This is inspired by [Google Cloud docs](https://cloud.google.com/functions/docs/tutorials/http#functions-prepare-environment-nodejs).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try it on https://deploy-preview-1836--docusaurus-2.netlify.com/docs/markdown-features#multi-language-support-code-blocks

![Screen Shot 2019-10-12 at 2 40 08 PM](https://user-images.githubusercontent.com/1315101/66707984-454c7e00-ecfe-11e9-86cf-0161a5b7cdc7.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
