### PR TITLE
fix(v2): keywords frontmatter should work properly

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0-alpha.28
 - Further reduce memory usage to avoid heap memory allocation failure.
+- Fix `keywords` frontmatter for SEO not working properly.
 
 ## 2.0.0-alpha.27
 

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -42,6 +42,7 @@ function DocItem(props) {
     editUrl,
     lastUpdatedAt,
     lastUpdatedBy,
+    keywords,
   } = metadata;
 
   return (
@@ -68,6 +69,9 @@ function DocItem(props) {
           <meta name="twitter:image:alt" content={`Image for ${title}`} />
         )}
         {permalink && <meta property="og:url" content={siteUrl + permalink} />}
+        {keywords && keywords.length && (
+          <meta property="keywords" content={keywords.join(',')} />
+        )}
       </Head>
       <div className="padding-vert--lg">
         <div className="container">

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -48,7 +48,7 @@ function Layout(props) {
           <meta property="og:description" content={description} />
         )}
         {keywords && keywords.length && (
-          <meta property="keywords" content={keywords} />
+          <meta property="keywords" content={keywords.join(',')} />
         )}
         {metaImage && (
           <meta

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -2,9 +2,6 @@
 id: introduction
 title: Introduction
 description: Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.
-keywords:
-    - test 
-    - wkwk
 ---
 
 #### :warning: Disclaimers

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -2,6 +2,9 @@
 id: introduction
 title: Introduction
 description: Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.
+keywords:
+    - test 
+    - wkwk
 ---
 
 #### :warning: Disclaimers

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -101,6 +101,9 @@ Documents use the following markdown header fields that are enclosed by a line `
 - `hide_title`: Whether to hide the title at the top of the doc. By default it is `false`.
 - `sidebar_label`: The text shown in the document sidebar and in the next/previous button for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.
 - `custom_edit_url`: The URL for editing this document. If this field is not present, the document's edit URL will fall back to `editUrl` from options fields passed to `docusaurus-plugin-content-docs`.
+- `description`: Description of this document page. 
+- `image`: Cover or thumbnail image that will be used when displaying the link to your post. 
+- `keywords`: Keywords for search engines.
 
 Example:
 
@@ -110,6 +113,11 @@ id: doc-markdown
 title: Markdown Features
 sidebar_label: Markdown :)
 custom_edit_url: https://github.com/facebook/docusaurus/edit/master/docs/api-doc-markdown.md
+keywords:
+  - docs
+  - docusaurus
+description: How do I find you when I cannot solve this problem
+image: https://i.imgur.com/mErPwqL.png
 ---
 
 ```

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -32,7 +32,7 @@ This provides a clear distinction between Docusaurus' official packages and comm
 
 Meanwhile, the default doc site functionalities provided by Docusaurus 1 are now provided by `@docusaurus/preset-classic`. Therefore, we need to add this dependency as well:
 
-```diff
+```json
 // package.json
 {
   dependencies: {

--- a/website/docs/seo.md
+++ b/website/docs/seo.md
@@ -39,7 +39,7 @@ module.exports = {
 };
 ```
 
-## Page specific SEO
+## Document Page specific SEO
 
 To add SEO to your doc, use the following fields in your doc's front matter:
 
@@ -80,15 +80,15 @@ Note that the file of this image cannot be SVG.
 
 To add customized SEO, use the `Head` component from `@docusaurus/Head`.
 
+Example:
+
 ```js
 import Head from '@docusaurus/Head';
 
 const MySEO = () => (
   <>
     <Head>
-      <meta charSet="utf-8" />
-      <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-      <meta name="viewport" content="width=device-width" />
+      <meta property="og:description" content={'My custom description'} />
     </Head>
   </>
 );


### PR DESCRIPTION
## Motivation

Keywords seo in https://v2.docusaurus.io/docs/seo#keywords is not working

- Add more documentation on markdown frontmatter

P.S: I think we can remove https://v2.docusaurus.io/docs/seo docs in the future because it kinda duplicates with markdown-features

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

```md
---
id: introduction
title: Introduction
description: Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.
keywords:
    - test 
    - wkwk
---
```
![image](https://user-images.githubusercontent.com/17883920/66798496-5d0f4680-ef38-11e9-903a-f0a281de2db1.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
