### PR TITLE
feat(v2): allow plugin to extendCli

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,6 +3,7 @@
 ## 2.0.0-alpha.28
 - Further reduce memory usage to avoid heap memory allocation failure.
 - Fix `keywords` frontmatter for SEO not working properly.
+- Add `extendCli` api for plugins. This will allow plugin to further extend Docusaurus CLI.
 
 ## 2.0.0-alpha.27
 

--- a/packages/docusaurus-types/package.json
+++ b/packages/docusaurus-types/package.json
@@ -9,6 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "commander": "^2.20.0",
     "@types/webpack": "^4.32.0",
     "querystring": "0.2.0"
   }

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -1,4 +1,5 @@
 import {Loader, Configuration} from 'webpack';
+import {CommanderStatic} from 'commander';
 import {ParsedUrlQueryInput} from 'querystring';
 
 export interface DocusaurusConfig {
@@ -92,6 +93,7 @@ export interface Plugin<T> {
   getThemePath?(): string;
   getPathsToWatch?(): string[];
   getClientModules?(): string[];
+  extendCli?(cli: CommanderStatic): any;
 }
 
 export type PluginConfig = [string, Object] | [string] | string;

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -11,7 +11,7 @@ const chalk = require('chalk');
 const semver = require('semver');
 const path = require('path');
 const cli = require('commander');
-const {build, swizzle, deploy, start, unknownCommand} = require('../lib');
+const {build, swizzle, deploy, start, externalCommand} = require('../lib');
 const requiredVersion = require('../package.json').engines.node;
 
 if (!semver.satisfies(process.version, requiredVersion)) {
@@ -86,12 +86,12 @@ cli.arguments('<command>').action(cmd => {
   console.log();
 });
 
-function isKnownCommand(argv) {
-  return ['start', 'build', 'swizzle', 'deploy'].includes(argv[0]);
+function isInternalCommand(command) {
+  return ['start', 'build', 'swizzle', 'deploy'].includes(command);
 }
 
-if (!isKnownCommand(process.argv.slice(2))) {
-  unknownCommand(cli, path.resolve('.'));
+if (!isInternalCommand(process.argv.slice(2)[0])) {
+  externalCommand(cli, path.resolve('.'));
 }
 
 cli.parse(process.argv);

--- a/packages/docusaurus/src/commands/external.ts
+++ b/packages/docusaurus/src/commands/external.ts
@@ -9,7 +9,7 @@ import {CommanderStatic} from 'commander';
 import {loadContext, loadPluginConfigs} from '../server';
 import {initPlugins} from '../server/plugins/init';
 
-export function unknownCommand(cli: CommanderStatic, siteDir: string): void {
+export function externalCommand(cli: CommanderStatic, siteDir: string): void {
   const context = loadContext(siteDir);
   const pluginConfigs = loadPluginConfigs(context);
   const plugins = initPlugins({pluginConfigs, context});

--- a/packages/docusaurus/src/commands/unknown.ts
+++ b/packages/docusaurus/src/commands/unknown.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {CommanderStatic} from 'commander';
+import {loadContext, loadPluginConfigs} from '../server';
+import {initPlugins} from '../server/plugins/init';
+
+export function unknownCommand(cli: CommanderStatic, siteDir: string): void {
+  const context = loadContext(siteDir);
+  const pluginConfigs = loadPluginConfigs(context);
+  const plugins = initPlugins({pluginConfigs, context});
+
+  // Plugin lifecycle - extendCli
+  plugins.forEach(plugin => {
+    const {extendCli} = plugin;
+    if (!extendCli) {
+      return;
+    }
+    extendCli(cli);
+  });
+}

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -9,3 +9,4 @@ export {build} from './commands/build';
 export {start} from './commands/start';
 export {swizzle} from './commands/swizzle';
 export {deploy} from './commands/deploy';
+export {unknownCommand} from './commands/unknown';

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -9,4 +9,4 @@ export {build} from './commands/build';
 export {start} from './commands/start';
 export {swizzle} from './commands/swizzle';
 export {deploy} from './commands/deploy';
-export {unknownCommand} from './commands/unknown';
+export {externalCommand} from './commands/external';

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import _ from 'lodash';
 import {generate} from '@docusaurus/utils';
 import fs from 'fs-extra';
-import importFresh from 'import-fresh';
 import path from 'path';
 import {
   LoadContext,
@@ -17,6 +15,7 @@ import {
   PluginContentLoadedActions,
   RouteConfig,
 } from '@docusaurus/types';
+import {initPlugins} from './init';
 
 export async function loadPlugins({
   pluginConfigs,
@@ -29,30 +28,7 @@ export async function loadPlugins({
   pluginsRouteConfigs: RouteConfig[];
 }> {
   // 1. Plugin Lifecycle - Initialization/Constructor
-  const plugins: Plugin<any>[] = _.compact(
-    pluginConfigs.map(pluginItem => {
-      let pluginModuleImport;
-      let pluginOptions = {};
-      if (!pluginItem) {
-        return null;
-      }
-
-      if (typeof pluginItem === 'string') {
-        pluginModuleImport = pluginItem;
-      } else if (Array.isArray(pluginItem)) {
-        pluginModuleImport = pluginItem[0];
-        pluginOptions = pluginItem[1] || {};
-      }
-
-      if (!pluginModuleImport) {
-        return null;
-      }
-
-      // module is any valid module identifier - npm package or locally-resolved path.
-      const pluginModule: any = importFresh(pluginModuleImport);
-      return (pluginModule.default || pluginModule)(context, pluginOptions);
-    }),
-  );
+  const plugins: Plugin<any>[] = initPlugins({pluginConfigs, context});
 
   // 2. Plugin lifecycle - loadContent
   // Currently plugins run lifecycle in parallel and are not order-dependent. We could change

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import _ from 'lodash';
+import importFresh from 'import-fresh';
+import {LoadContext, Plugin, PluginConfig} from '@docusaurus/types';
+
+export function initPlugins({
+  pluginConfigs,
+  context,
+}: {
+  pluginConfigs: PluginConfig[];
+  context: LoadContext;
+}): Plugin<any>[] {
+  const plugins: Plugin<any>[] = _.compact(
+    pluginConfigs.map(pluginItem => {
+      let pluginModuleImport;
+      let pluginOptions = {};
+      if (!pluginItem) {
+        return null;
+      }
+
+      if (typeof pluginItem === 'string') {
+        pluginModuleImport = pluginItem;
+      } else if (Array.isArray(pluginItem)) {
+        pluginModuleImport = pluginItem[0];
+        pluginOptions = pluginItem[1] || {};
+      }
+
+      if (!pluginModuleImport) {
+        return null;
+      }
+
+      // module is any valid module identifier - npm package or locally-resolved path.
+      const pluginModule: any = importFresh(pluginModuleImport);
+      return (pluginModule.default || pluginModule)(context, pluginOptions);
+    }),
+  );
+
+  return plugins;
+}

--- a/website/docs/lifecycle-apis.md
+++ b/website/docs/lifecycle-apis.md
@@ -130,6 +130,23 @@ configureWebpack(config, isServer, {getBabelLoader, getCacheLoader}) {
 },
 ```
 
+## extendCli(cli)
+
+Register an extra command to enhance the CLI of docusaurus. `cli` is [commander](https://www.npmjs.com/package/commander) object.
+
+Example:
+
+```js
+extendCli(cli) {
+  cli
+    .command('roll')
+    .description('Roll a random number between 1 and 1000')
+    .action(() => {
+      console.log(Math.floor(Math.random() * 1000 + 1));
+  });
+},
+```
+
 <!--
 For example, the in docusaurus-plugin-content-docs:
 
@@ -209,6 +226,10 @@ module.exports = function(context, opts) {
       // Return an array of paths to the modules that are to be imported
       // in the client bundle. These modules are imported globally before
       // React even renders the initial UI.
+    },
+
+    extendCli(cli) {
+      // Register an extra command to enhance the CLI of docusaurus
     },
   };
 };


### PR DESCRIPTION
## Motivation

Register an extra command to enhance the CLI of docusaurus. `cli` is [commander](https://www.npmjs.com/package/commander) object..

Need this before working on docs versioning

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Modify any plugin and add an experimental command `roll` through `extendCli`
```js
    extendCli(cli) {
      cli
        .command('roll')
        .description('Roll a random number between 1 and 1000')
        .action(() => {
          console.log(Math.floor(Math.random() * 1000 + 1));
        });
    },
```

![extend cli](https://user-images.githubusercontent.com/17883920/66852215-a5654d80-efa6-11e9-9651-1134cf5daec0.gif)
