### PR TITLE
fix(v2): swizzle should be able to handle single js file

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -4,6 +4,7 @@
 - Further reduce memory usage to avoid heap memory allocation failure.
 - Fix `keywords` frontmatter for SEO not working properly.
 - Add `extendCli` api for plugins. This will allow plugin to further extend Docusaurus CLI.
+- Fix `swizzle` command not being able to swizzle single js file.
 
 ## 2.0.0-alpha.27
 

--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -26,6 +26,12 @@ export async function swizzle(
     if (componentName) {
       fromPath = path.join(fromPath, componentName);
       toPath = path.join(toPath, componentName);
+
+      // Handle single js file only.
+      // E.g: if <fromPath> does not exist, we try to swizzle <fromPath>.js instead
+      if (!fs.existsSync(fromPath) && fs.existsSync(`${fromPath}.js`)) {
+        [fromPath, toPath] = [`${fromPath}.js`, `${toPath}.js`];
+      }
     }
     await fs.copy(fromPath, toPath);
 

--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -37,7 +37,7 @@ export async function swizzle(
 
     const relativeDir = path.relative(process.cwd(), toPath);
     const fromMsg = chalk.blue(
-      componentName ? `${themeName}/${componentName}` : themeName,
+      componentName ? `${themeName} ${chalk.yellow(componentName)}` : themeName,
     );
     const toMsg = chalk.cyan(relativeDir);
     console.log(


### PR DESCRIPTION
## Motivation

Minor bug found from https://v2.docusaurus.io/docs/search/#using-your-own-search and discord report

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Before
<img width="670" alt="before" src="https://user-images.githubusercontent.com/17883920/66898503-85c03a80-f023-11e9-8c94-c6cca6d808a9.PNG">


After
![image](https://user-images.githubusercontent.com/17883920/66903757-3e3eac00-f02d-11e9-9693-900d8e8ac3e8.png)

