### PR TITLE
docs: add more info on cleanUrl siteconfig

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -106,6 +106,8 @@ Control the title of the blog sidebar. See the [adding a blog docs](guides-blog.
 
 If `true`, allow URLs with no `HTML` extension. For example, a request to URL https://docusaurus.io/docs/installation will return the same result as https://docusaurus.io/docs/installation.html.
 
+***Note:*** If users intend for this website to be used exclusively offline, this value must be set to 'False.' By default it is set to 'True,' which will cause an offline site to route to the parent folder of the linked page.
+
 #### `cname` [string]
 
 The CNAME for your website. It will go into a `CNAME` file when your site is built.

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ---
 id: site-config
 title: siteConfig.js
@@ -113,7 +106,7 @@ Control the title of the blog sidebar. See the [adding a blog docs](guides-blog.
 
 If `true`, allow URLs with no `HTML` extension. For example, a request to URL https://docusaurus.io/docs/installation will return the same result as https://docusaurus.io/docs/installation.html.
 
-***Note:*** If users intend for this website to be used exclusively offline, this value must be set to 'False.' By default it is set to 'True,' which will cause an offline site to route to the parent folder of the linked page.
+***Note:*** If users intend for this website to be used exclusively offline, this value must be set to 'false.' Otherwise, it will cause an offline site to route to the parent folder of the linked page.
 
 #### `cname` [string]
 

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 ---
 id: site-config
 title: siteConfig.js


### PR DESCRIPTION
Added a clarification to the cleanUrl property to set it false if the users intend to use docusaurus only offline.

close #1824 

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Clarify specific use cases issues.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Just text.