### PR TITLE
docs(v1): document how to include Google Fonts

### DIFF
--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -337,6 +337,23 @@ Boolean flag to indicate whether `HTML` files in `/pages` should be wrapped with
 
 Users can also add their own custom fields if they wish to provide some data across different files.
 
+## Adding Google Fonts
+
+Google Fonts offers faster load times by caching fonts without forcing users to sacrifice privacy. For more information on Google Fonts, see the [**Google Fonts**](https://fonts.google.com/#) documentation.
+
+To add Google Fonts to your Docusaurus deployment, open the **siteConfig.js** file located in the */docusaurus/website-1.x/* directory. In this file, add the following property:
+
+```css
+stylesheets: [
+    "https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700",
+    "/css/code-block-buttons.css"
+  ],
+```
+
+Once saved, your Docusaurus instance will use Google Fonts.
+
+> Using this method of implementing Google Fonts is the correct method. Using`@import` will not function as expected.
+
 ## Example siteConfig.js with many available fields
 
 ```js

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -347,7 +347,7 @@ To add Google Fonts to your Docusaurus deployment, add the font path to the `sit
 
 ```js
 stylesheets: [
-  "https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700",
+  'https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700',
 ],
 ```
 

--- a/docs/api-site-config.md
+++ b/docs/api-site-config.md
@@ -339,20 +339,17 @@ Users can also add their own custom fields if they wish to provide some data acr
 
 ## Adding Google Fonts
 
-Google Fonts offers faster load times by caching fonts without forcing users to sacrifice privacy. For more information on Google Fonts, see the [**Google Fonts**](https://fonts.google.com/#) documentation.
+<!-- TODO: Shift this into a dedicated styling section in future -->
 
-To add Google Fonts to your Docusaurus deployment, open the **siteConfig.js** file located in the */docusaurus/website-1.x/* directory. In this file, add the following property:
+Google Fonts offers faster load times by caching fonts without forcing users to sacrifice privacy. For more information on Google Fonts, see the [Google Fonts](https://fonts.google.com/) documentation.
 
-```css
+To add Google Fonts to your Docusaurus deployment, add the font path to the `siteConfig.js` under `stylesheets`:
+
+```js
 stylesheets: [
-    "https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700",
-    "/css/code-block-buttons.css"
-  ],
+  "https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700",
+],
 ```
-
-Once saved, your Docusaurus instance will use Google Fonts.
-
-> Using this method of implementing Google Fonts is the correct method. Using`@import` will not function as expected.
 
 ## Example siteConfig.js with many available fields
 


### PR DESCRIPTION
Added a piece of text from the set-up guide to enable Google Fonts.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensuring that users can find information on adding Google Fonts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

Fixes #1169 