### PR TITLE
fix(v2): fix link to logo in footer

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -6,7 +6,7 @@
 - Fix `swizzle` command not passing context properly to theme packages.
 - Add `extendCli` api for plugins. This will allow plugin to further extend Docusaurus CLI.
 - Fix `swizzle` command not being able to swizzle single js file.
-- Fix logo URL in footer to use absolute path.
+- Fix logo URL in footer to be appended with baseUrl automatically.
 
 ## 2.0.0-alpha.27
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -6,6 +6,7 @@
 - Fix `swizzle` command not passing context properly to theme packages.
 - Add `extendCli` api for plugins. This will allow plugin to further extend Docusaurus CLI.
 - Fix `swizzle` command not being able to swizzle single js file.
+- Fix logo URL in footer to use absolute path.
 
 ## 2.0.0-alpha.27
 

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -69,7 +69,11 @@ function Footer() {
           <div className="text--center">
             {logo && logo.src && (
               <div className="margin-bottom--sm">
-                <img className="footer__logo" alt={logo.alt} src={logo.src} />
+                <img
+                  className="footer__logo"
+                  alt={logo.alt}
+                  src={withBaseUrl(logo.src)}
+                />
               </div>
             )}
             {copyright}


### PR DESCRIPTION
## Motivation

If the target URL contains a slash at the end, the logo will not be displayed,
For example, the target URL is http://localhost:3000/blog/, then the logo URL will be http://localhost:3000/blog/img/logo.svg, not http://localhost:3000/img/logo.svg.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan



## Related PRs


