### PR TITLE
feat(v2): add ability disable to open page in browser when start command

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -7,6 +7,7 @@
 - Add `extendCli` api for plugins. This will allow plugin to further extend Docusaurus CLI.
 - Fix `swizzle` command not being able to swizzle single js file.
 - Fix logo URL in footer to be appended with baseUrl automatically.
+- Add the option `--disable-open-browser` for `start` command.
 
 ## 2.0.0-alpha.27
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -7,7 +7,7 @@
 - Add `extendCli` api for plugins. This will allow plugin to further extend Docusaurus CLI.
 - Fix `swizzle` command not being able to swizzle single js file.
 - Fix logo URL in footer to be appended with baseUrl automatically.
-- Add the option `--disable-open-browser` for `start` command.
+- Add the option `--no-open` for `start` command.
 
 ## 2.0.0-alpha.27
 

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -49,7 +49,7 @@ export interface StartCLIOptions {
   port: string;
   host: string;
   hotOnly: boolean;
-  disableOpenBrowser: boolean;
+  noOpen: boolean;
 }
 
 export interface BuildCLIOptions {

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -49,6 +49,7 @@ export interface StartCLIOptions {
   port: string;
   host: string;
   hotOnly: boolean;
+  disableOpenBrowser: boolean;
 }
 
 export interface BuildCLIOptions {

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -49,7 +49,7 @@ export interface StartCLIOptions {
   port: string;
   host: string;
   hotOnly: boolean;
-  noOpen: boolean;
+  open: boolean;
 }
 
 export interface BuildCLIOptions {

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -71,12 +71,12 @@ cli
     'Do not fallback to page refresh if hot reload fails (default: false)',
   )
   .option('--no-open', 'Do not open page in the browser (default: false)')
-  .action((siteDir = '.', {port, host, hotOnly, noOpen}) => {
+  .action((siteDir = '.', {port, host, hotOnly, open}) => {
     wrapCommand(start)(path.resolve(siteDir), {
       port,
       host,
       hotOnly,
-      noOpen,
+      open,
     });
   });
 

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -70,16 +70,13 @@ cli
     '--hot-only',
     'Do not fallback to page refresh if hot reload fails (default: false)',
   )
-  .option(
-    '--disable-open-browser',
-    'Do not open page in the browser (default: false)',
-  )
-  .action((siteDir = '.', {port, host, hotOnly, disableOpenBrowser}) => {
+  .option('--no-open', 'Do not open page in the browser (default: false)')
+  .action((siteDir = '.', {port, host, hotOnly, noOpen}) => {
     wrapCommand(start)(path.resolve(siteDir), {
       port,
       host,
       hotOnly,
-      disableOpenBrowser,
+      noOpen,
     });
   });
 

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -70,11 +70,16 @@ cli
     '--hot-only',
     'Do not fallback to page refresh if hot reload fails (default: false)',
   )
-  .action((siteDir = '.', {port, host, hotOnly}) => {
+  .option(
+    '--disable-open-browser',
+    'Do not open page in the browser (default: false)',
+  )
+  .action((siteDir = '.', {port, host, hotOnly, disableOpenBrowser}) => {
     wrapCommand(start)(path.resolve(siteDir), {
       port,
       host,
       hotOnly,
+      disableOpenBrowser,
     });
   });
 

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -144,7 +144,7 @@ export async function start(
     if (err) {
       console.log(err);
     }
-    openBrowser(openUrl);
+    !cliOptions.disableOpenBrowser && openBrowser(openUrl);
   });
   ['SIGINT', 'SIGTERM'].forEach(sig => {
     process.on(sig as NodeJS.Signals, () => {

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -144,7 +144,7 @@ export async function start(
     if (err) {
       console.log(err);
     }
-    !cliOptions.disableOpenBrowser && openBrowser(openUrl);
+    !cliOptions.noOpen && openBrowser(openUrl);
   });
   ['SIGINT', 'SIGTERM'].forEach(sig => {
     process.on(sig as NodeJS.Signals, () => {

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -144,7 +144,7 @@ export async function start(
     if (err) {
       console.log(err);
     }
-    !cliOptions.noOpen && openBrowser(openUrl);
+    cliOptions.open && openBrowser(openUrl);
   });
   ['SIGINT', 'SIGTERM'].forEach(sig => {
     process.on(sig as NodeJS.Signals, () => {

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -48,7 +48,7 @@ Builds and serves the static site with [Webpack Dev Server](https://webpack.js.o
 |`--port`|`3000`|Specifies the port of the dev server|
 |`--host`|`localhost`|Specify a host to use. E.g., if you want your server to be accessible externally, you can use `--host 0.0.0.0`|
 |`--hot-only`|`false`|Enables Hot Module Replacement without page refresh as fallback in case of build failures. More information [here](https://webpack.js.org/configuration/dev-server/#devserverhotonly).|
-|`--disable-open-browser`|`false`|Automatically open the page in the browser.|
+|`--no-open`|`false`|Do not open automatically the page in the browser.|
 
 ### `docusaurus build`
 

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -48,6 +48,7 @@ Builds and serves the static site with [Webpack Dev Server](https://webpack.js.o
 |`--port`|`3000`|Specifies the port of the dev server|
 |`--host`|`localhost`|Specify a host to use. E.g., if you want your server to be accessible externally, you can use `--host 0.0.0.0`|
 |`--hot-only`|`false`|Enables Hot Module Replacement without page refresh as fallback in case of build failures. More information [here](https://webpack.js.org/configuration/dev-server/#devserverhotonly).|
+|`--disable-open-browser`|`false`|Automatically open the page in the browser.|
 
 ### `docusaurus build`
 


### PR DESCRIPTION
## Motivation

When developing docs site (`docusaurus start` command), it can be very convenient to turn off auto page opening in a browser.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- Run `yarn run start --disable-open-browser`
