### PR TITLE
feat(v1): allow specifying meta desc in front matter

### DIFF
--- a/docs/api-doc-markdown.md
+++ b/docs/api-doc-markdown.md
@@ -15,6 +15,8 @@ Documents use the following markdown header fields that are enclosed by a line `
 
 `title`: The title of your document. If this field is not present, the document's `title` will default to its `id`.
 
+`description`: The description of your document which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`. If this field is not present, it will default to the first line of the contents.
+
 `hide_title`: Whether to hide the title at the top of the doc.
 
 `sidebar_label`: The text shown in the document sidebar and in the next/previous button for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.

--- a/docs/api-doc-markdown.md
+++ b/docs/api-doc-markdown.md
@@ -11,15 +11,11 @@ Docusaurus uses [GitHub Flavored Markdown (GFM)](https://guides.github.com/featu
 
 Documents use the following markdown header fields that are enclosed by a line `---` on either side:
 
-`id`: A unique document id. If this field is not present, the document's `id` will default to its file name (without the extension).
-
-`title`: The title of your document. If this field is not present, the document's `title` will default to its `id`.
-
-`description`: The description of your document which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`. If this field is not present, it will default to the first line of the contents.
-
-`hide_title`: Whether to hide the title at the top of the doc.
-
-`sidebar_label`: The text shown in the document sidebar and in the next/previous button for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.
+- `id`: A unique document id. If this field is not present, the document's `id` will default to its file name (without the extension).
+- `title`: The title of your document. If this field is not present, the document's `title` will default to its `id`.
+- `hide_title`: Whether to hide the title at the top of the doc.
+- `description`: The description of your document which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. If this field is not present, it will default to the first line of the contents.
+- `sidebar_label`: The text shown in the document sidebar and in the next/previous button for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.
 
 For example:
 

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -1,6 +1,7 @@
 ---
 id: installation
 title: Installation
+description: Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly!
 ---
 
 Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.

--- a/packages/docusaurus-1.x/lib/core/DocsLayout.js
+++ b/packages/docusaurus-1.x/lib/core/DocsLayout.js
@@ -88,7 +88,7 @@ class DocsLayout extends React.Component {
           separateOnPageNav: hasOnPageNav,
         })}
         title={title}
-        description={content.trim().split('\n')[0]}
+        description={metadata.description || content.trim().split('\n')[0]}
         language={metadata.language}
         version={metadata.version}
         metadata={metadata}>

--- a/packages/docusaurus-1.x/lib/server/readMetadata.js
+++ b/packages/docusaurus-1.x/lib/server/readMetadata.js
@@ -36,6 +36,7 @@ const SupportedHeaderFields = new Set([
   'hide_title',
   'layout',
   'custom_edit_url',
+  'description',
 ]);
 
 let allSidebars;

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -101,8 +101,8 @@ Documents use the following markdown header fields that are enclosed by a line `
 - `hide_title`: Whether to hide the title at the top of the doc. By default it is `false`.
 - `sidebar_label`: The text shown in the document sidebar and in the next/previous button for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.
 - `custom_edit_url`: The URL for editing this document. If this field is not present, the document's edit URL will fall back to `editUrl` from options fields passed to `docusaurus-plugin-content-docs`.
-- `description`: Description meta tag for the document page, for search engines. If this field is not present, it will default to the first line of the contents.
 - `keywords`: Keywords meta tag for the document page, for search engines.
+- `description`: The description of your document, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. If this field is not present, it will default to the first line of the contents.
 - `image`: Cover or thumbnail image that will be used when displaying the link to your post.
 
 Example:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

RN docs wanted to be able to explicitly specify the description in the front matter.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
<img width="1552" alt="Screen Shot 2019-10-19 at 12 16 51 PM" src="https://user-images.githubusercontent.com/1315101/67150309-bb0a9980-f26a-11e9-90d9-184335901f83.png">


## Related PRs

NA
