### PR TITLE
fix(v2): fix incorrect keywords meta tag

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -53,6 +53,9 @@ function DocItem(props) {
         {description && (
           <meta property="og:description" content={description} />
         )}
+        {keywords && keywords.length && (
+          <meta name="keywords" content={keywords.join(',')} />
+        )}
         {metaImage && (
           <meta
             property="og:image"
@@ -69,9 +72,6 @@ function DocItem(props) {
           <meta name="twitter:image:alt" content={`Image for ${title}`} />
         )}
         {permalink && <meta property="og:url" content={siteUrl + permalink} />}
-        {keywords && keywords.length && (
-          <meta property="keywords" content={keywords.join(',')} />
-        )}
       </Head>
       <div className="padding-vert--lg">
         <div className="container">

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -48,7 +48,7 @@ function Layout(props) {
           <meta property="og:description" content={description} />
         )}
         {keywords && keywords.length && (
-          <meta property="keywords" content={keywords.join(',')} />
+          <meta name="keywords" content={keywords.join(',')} />
         )}
         {metaImage && (
           <meta


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It should be `<meta name="keywords">` instead of `<meta property="keywords">`.

Source: https://seo-hacker.com/what-are-meta-tags-and-why-are-they-important/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![Screen Shot 2019-10-20 at 11 55 37 AM](https://user-images.githubusercontent.com/1315101/67164546-8d882380-f330-11e9-9128-57a9df55beb0.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
