### PR TITLE
fix(v2): fix babel transpilation include/exclude logic

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -1,7 +1,7 @@
 # Docusaurus 2 Changelog
 
 ## 2.0.0-alpha.30
-- Fix babel transpilation include/exclude logic to be more efficient.
+- Fix babel transpilation include/exclude logic to be more efficient. This also fix a very weird bug `TypeError: Cannot assign to read only property 'exports' of object '#<Object>'` if your website path contains `docusaurus` word in it.
 
 ## 2.0.0-alpha.29
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -1,5 +1,8 @@
 # Docusaurus 2 Changelog
 
+## 2.0.0-alpha.30
+- Fix babel transpilation include/exclude logic to be more efficient.
+
 ## 2.0.0-alpha.29
 
 **HOTFIX for 2.0.0-alpha.28**. 

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -24,6 +24,7 @@ export function createBaseConfig(
 ): Configuration {
   const {outDir, siteDir, baseUrl, generatedFilesDir, routesPaths} = props;
 
+  const clientDir = path.join(__dirname, '..', 'client');
   const totalPages = routesPaths.length;
   const isProd = process.env.NODE_ENV === 'production';
   return {
@@ -115,10 +116,16 @@ export function createBaseConfig(
         {
           test: /\.jsx?$/,
           exclude: modulePath => {
-            // Don't transpile node_modules except any docusaurus package
-            return (
-              /node_modules/.test(modulePath) && !/docusaurus/.test(modulePath)
-            );
+            // always transpile client dir
+            if (modulePath.startsWith(clientDir)) {
+              return false;
+            }
+            // transpile docusaurus npm packages, except its nested dependencies
+            if (/(docusaurus)((?!node_modules).)*\.jsx?$/.test(modulePath)) {
+              return false;
+            }
+            // Don't transpile node_modules
+            return /node_modules/.test(modulePath);
           },
           use: [getCacheLoader(isServer), getBabelLoader(isServer)].filter(
             Boolean,

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -120,12 +120,11 @@ export function createBaseConfig(
             if (modulePath.startsWith(clientDir)) {
               return false;
             }
-            // transpile docusaurus npm packages, except its nested dependencies
-            if (/(docusaurus)((?!node_modules).)*\.jsx?$/.test(modulePath)) {
-              return false;
-            }
-            // Don't transpile node_modules
-            return /node_modules/.test(modulePath);
+            // Don't transpile node_modules except any docusaurus npm package
+            return (
+              /node_modules/.test(modulePath) &&
+              !/(docusaurus)((?!node_modules).)*\.jsx?$/.test(modulePath)
+            );
           },
           use: [getCacheLoader(isServer), getBabelLoader(isServer)].filter(
             Boolean,

--- a/packages/docusaurus/src/webpack/plugins/LogPlugin.js
+++ b/packages/docusaurus/src/webpack/plugins/LogPlugin.js
@@ -16,9 +16,13 @@ class LogPlugin extends WebpackBar {
     super.apply(compiler);
 
     compiler.hooks.done.tap('WebpackNiceLog', stats => {
-      const messages = formatWebpackMessages(stats.toJson('errors-only', true));
-      if (messages.errors.length) {
-        showError(messages.errors);
+      if (stats.hasErrors()) {
+        const messages = formatWebpackMessages(
+          stats.toJson('errors-only', true),
+        );
+        if (messages.errors.length) {
+          showError(messages.errors);
+        }
       }
     });
   }

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -90,7 +90,14 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
         configFile: false,
         presets: [
           isServer
-            ? '@babel/env'
+            ? [
+                '@babel/env',
+                {
+                  targets: {
+                    node: 'current',
+                  },
+                },
+              ]
             : [
                 '@babel/env',
                 {

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -37,8 +37,8 @@ Meanwhile, the default doc site functionalities provided by Docusaurus 1 are now
 {
   dependencies: {
 -    "docusaurus": "^1.x.x",
-+    "@docusaurus/core": "^2.0.0-alpha.29",
-+    "@docusaurus/preset-classic": "^2.0.0-alpha.29",
++    "@docusaurus/core": "^2.0.0-alpha.30",
++    "@docusaurus/preset-classic": "^2.0.0-alpha.30",
   }
 }
 ```
@@ -71,8 +71,8 @@ A typical Docusaurus 2 `package.json` may look like this:
     "deploy": "docusaurus deploy"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-alpha.29",
-    "@docusaurus/preset-classic": "^2.0.0-alpha.29",
+    "@docusaurus/core": "^2.0.0-alpha.30",
+    "@docusaurus/preset-classic": "^2.0.0-alpha.30",
     "classnames": "^2.2.6",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4410,20 +4410,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000971:
-  version "1.0.30000974"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
-  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
-
-caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000984:
-  version "1.0.30000984"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz#dc96c3c469e9bcfc6ad5bdd24c77ec918ea76fe0"
-  integrity sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA==
-
-caniuse-lite@^1.0.30000989:
-  version "1.0.30000989"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
-  integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000971, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000984, caniuse-lite@^1.0.30000989:
+  version "1.0.30001002"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz#ba999a737b1abd5bf0fd47efe43a09b9cadbe9b0"
+  integrity sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Motivation

Previously, there is an edge case bug in which if website path contains `docusaurus` in its name, all the node_modules js file will be transpiled.

Example: /mnt/c/Users/endij/Desktop/Linux/test/docusaurus_crash/website/node_modules/@docusaurus/core/node_modules/core-js/modules/_descriptors.js will match the regex

Due to babel smart polyfilling, transpiling files like above that uses commonjs will cause  https://github.com/webpack/webpack/issues/4039#issuecomment-477779322

```TypeError: Cannot assign to read only property 'exports' of object '#<Object>' ```

![image](https://user-images.githubusercontent.com/17883920/67218881-53627300-f451-11e9-8f87-85fad3983fe9.png)

![image](https://user-images.githubusercontent.com/17883920/67218972-74c35f00-f451-11e9-8112-04b73c92e525.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Using regextester. Only docusaurus npm package that are transpiled.

![image](https://user-images.githubusercontent.com/17883920/67218507-adaf0400-f450-11e9-99fb-8eaa041d73f5.png)

Manually patch new inited site with `docusaurus` on its name
![image](https://user-images.githubusercontent.com/17883920/67219191-ca980700-f451-11e9-905f-87438a8afc43.png)
