### PR TITLE
fix(v1): fix page title render issue when referred by search result

### DIFF
--- a/packages/docusaurus-1.x/lib/core/Doc.js
+++ b/packages/docusaurus-1.x/lib/core/Doc.js
@@ -238,7 +238,9 @@ class Doc extends React.Component {
         <header className="postHeader">
           {editLink}
           {!this.props.hideTitle && (
-            <h1 className="postHeaderTitle">{this.props.title}</h1>
+            <h1 id="__docusaurus" className="postHeaderTitle">
+              {this.props.title}
+            </h1>
           )}
         </header>
         <article>

--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -653,7 +653,8 @@ blockquote {
   padding: 0;
 }
 
-.mainContainer .wrapper .post .postHeader:before, .mainContainer .wrapper .post .postHeaderTitle:before {
+.mainContainer .wrapper .post .postHeader:before,
+.mainContainer .wrapper .post .postHeaderTitle:before {
   content: "";
   display: block;
   height: 90px; /* fixed header height and empty space below it */
@@ -725,7 +726,8 @@ blockquote {
 }
 
 @media only screen and (max-width: 1023px) {
-  .mainContainer .wrapper .post .postHeader:before, .mainContainer .wrapper .post .postHeaderTitle:before {
+  .mainContainer .wrapper .post .postHeader:before,
+  .mainContainer .wrapper .post .postHeaderTitle:before {
     content: "";
     display: block;
     height: 200px; /* fixed header height and empty space below it */

--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -653,6 +653,15 @@ blockquote {
   padding: 0;
 }
 
+.mainContainer .wrapper .post .postHeader:before, .mainContainer .wrapper .post .postHeaderTitle:before {
+  content: "";
+  display: block;
+  height: 90px; /* fixed header height and empty space below it */
+  margin-top: -90px;  /* negative fixed header height and empty space below it  */
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .mainContainer .wrapper .post .postSocialPlugins {
   padding-top: 1em;
 }
@@ -712,6 +721,17 @@ blockquote {
 
   .mainContainer .wrapper .posts .post {
     width: 100%;
+  }
+}
+
+@media only screen and (max-width: 1023px) {
+  .mainContainer .wrapper .post .postHeader:before, .mainContainer .wrapper .post .postHeaderTitle:before {
+    content: "";
+    display: block;
+    height: 200px; /* fixed header height and empty space below it */
+    margin-top: -200px;  /* negative fixed header height and empty space below it  */
+    visibility: hidden;
+    pointer-events: none;
   }
 }
 /* End of Main Container */


### PR DESCRIPTION
When Algolia DocSearch query finds a match for a page's title, it attempts to generate
a permalink. Because the page title element (`h1`) does not have an `id`, Algolia
generates uses the `id` from closes parent element. Because of this, the page title
scrolls to a position that is slightly overlayed by the fixed top navigation bar.

This fix sets an `id` for the page title so that the search result is able to generate
a more accurate permalink.

closes #1828 

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This is a wide-spread bug that is affecting everyone and the required change is relatively small.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The original issue is caused by algolia attempting to auto generate a permalink for the page title that does not actually have a specific `id`. That's why it's not possible to test this change locally and verify the fix. But, based on discussions in #1828, it's recommended by algolia docsearch to have an `id` for the page title so that algolia can produce the best redirect/link for the search result.


@endiliey - As per your comment in the above mentioned issue, I didn't make changes in V2 code, but I still see the same issue in V2 doc site used for Docusaurus documentation. I'm not fully clear on why we don't want this fix in V2 code. Please feel free to let me know if you'd like me to make any changes.


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
