### PR TITLE
fix(v2): remove empty doc sidebar container

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add sticky footer.
+- Remove empty doc sidebar container
 
 ## 2.0.0-alpha.30
 

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
@@ -23,13 +23,15 @@ function DocPage(props) {
   return (
     <Layout noFooter>
       <div className={styles.docPage}>
-        <div className={styles.docSidebarContainer}>
-          <DocSidebar
-            docsSidebars={docsSidebars}
-            location={location}
-            sidebar={sidebar}
-          />
-        </div>
+        {sidebar && (
+          <div className={styles.docSidebarContainer}>
+            <DocSidebar
+              docsSidebars={docsSidebars}
+              location={location}
+              sidebar={sidebar}
+            />
+          </div>
+        )}
         <main className={styles.docMainContainer}>
           <MDXProvider components={MDXComponents}>
             {renderRoutes(route.routes)}


### PR DESCRIPTION
## Motivation

Docusaurus may not have a sidebar, but in the second version an empty container is now displayed, it needs to be deleted (it creates an additional empty space).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/67349023-63f91300-f54f-11e9-8cf3-4389e2e448a8.png)| ![image](https://user-images.githubusercontent.com/4408379/67349032-69565d80-f54f-11e9-8351-40102da7e11b.png) |
