### PR TITLE
misc(v1): use primary color for hovered items in table of contents

### DIFF
--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -1982,6 +1982,11 @@ input::placeholder {
   color: $primaryColor;
 }
 
+.onPageNav .toc-headings > li > a:hover {
+  font-weight: 600;
+  color: $primaryColor;
+}
+
 .onPageNav ul {
   list-style: none;
 }

--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -1977,12 +1977,8 @@ input::placeholder {
   color: #717171;
 }
 
-.onPageNav .toc-headings > li > a.active {
-  font-weight: 600;
-  color: $primaryColor;
-}
-
-.onPageNav .toc-headings > li > a:hover {
+.onPageNav .toc-headings > li > a.active,
+.onPageNav .toc-headings > li > a.hover {
   font-weight: 600;
   color: $primaryColor;
 }


### PR DESCRIPTION
when element in side nav is hovered over the color changes.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
