### PR TITLE
feat(v2): postcss should only use stage 3 features instead of stage 2

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -4,6 +4,7 @@
 
 - Add sticky footer.
 - Remove empty doc sidebar container
+- PostCSS preset env now only polyfills Stage 3 features (previously it was stage 2) like Create React App. Stage 2 CSS is considered relatively unstable and subject to change while Stage 3 features will likely become a standard.
 
 ## 2.0.0-alpha.30
 

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -54,6 +54,7 @@ export function getStyleLoaders(
             autoprefixer: {
               flexbox: 'no-2009',
             },
+            stage: 3,
           }),
         ],
       },


### PR DESCRIPTION
## Motivation

By default postcss preset env use stage 2, i think its better to use stage 3 like CRA because stage 2 CSS is considered relatively unstable and subject to change while Stage 3 features will likely become a standard.

https://github.com/facebook/create-react-app/blob/9788522d8747b506f469d2fcb6ff696332271ab9/packages/react-scripts/config/webpack.config.js#L119

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Manually navigate locally, page seems to be OK.

P.S Feel free to close this PR if we do want stage 2 features