### PR TITLE
fix(v2): fix search input blur on desktop

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -48,15 +48,16 @@ const Search = props => {
     }
   }, []);
 
-  const toggleSearchIconClick = useCallback(() => {
-    props.handleSearchBarToggle(!props.isSearchBarExpanded);
-  }, [props.isSearchBarExpanded]);
+  const toggleSearchIconClick = useCallback(
+    e => {
+      if (!searchBarRef.current.contains(e.target)) {
+        searchBarRef.current.focus();
+      }
 
-  useEffect(() => {
-    if (props.isSearchBarExpanded) {
-      searchBarRef.current.focus();
-    }
-  }, [props.isSearchBarExpanded]);
+      props.handleSearchBarToggle(!props.isSearchBarExpanded);
+    },
+    [props.isSearchBarExpanded],
+  );
 
   return isEnabled ? (
     <Fragment>
@@ -78,6 +79,7 @@ const Search = props => {
           {'search-bar-expanded': props.isSearchBarExpanded},
           {'search-bar': !props.isSearchBarExpanded},
         )}
+        onFocus={toggleSearchIconClick}
         onBlur={toggleSearchIconClick}
         ref={searchBarRef}
       />


### PR DESCRIPTION
## Motivation

Currently, there is a small bug on the desktop - when you put the focus on search input, and after you remove it (touch on the outside of search area), this focus will remain as it was - this is incorrect behavior.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![AwesomeScreenshot-2019-10-23-1571823548390](https://user-images.githubusercontent.com/4408379/67380971-d25fc480-f593-11e9-89a5-566d17c86f30.gif) | ![AwesomeScreenshot-2019-10-23-1571823268706](https://user-images.githubusercontent.com/4408379/67380979-d855a580-f593-11e9-967c-862a37178ef4.gif)|
