### PR TITLE
feat(v2): add ability expand all items in doc sidebar

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -4,6 +4,7 @@
 
 - Add sticky footer.
 - Remove empty doc sidebar container
+- Add ability expand all doc items in sidebar (same as `docsSideNavCollapsible` field in v1)
 
 ## 2.0.0-alpha.30
 

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -44,6 +44,7 @@ const DEFAULT_OPTIONS: PluginOptions = {
   rehypePlugins: [],
   showLastUpdateTime: false,
   showLastUpdateAuthor: false,
+  sidebarCollapsible: true,
 };
 
 export default function pluginContentDocs(
@@ -76,6 +77,7 @@ export default function pluginContentDocs(
         editUrl,
         showLastUpdateAuthor,
         showLastUpdateTime,
+        sidebarCollapsible,
       } = options;
       const {siteConfig, siteDir} = context;
       const docsDir = contentPath;
@@ -110,7 +112,9 @@ export default function pluginContentDocs(
             editUrl,
             showLastUpdateAuthor,
             showLastUpdateTime,
+            sidebarCollapsible,
           });
+
           docsMetadataRaw[metadata.id] = metadata;
         }),
       );
@@ -204,6 +208,7 @@ export default function pluginContentDocs(
         docsSidebars,
         sourceToPermalink,
         permalinkToSidebar,
+        sidebarCollapsible,
       };
     },
 
@@ -238,6 +243,7 @@ export default function pluginContentDocs(
       const docsBaseMetadata: DocsBaseMetadata = {
         docsSidebars: content.docsSidebars,
         permalinkToSidebar: content.permalinkToSidebar,
+        sidebarCollapsible: content.sidebarCollapsible,
       };
 
       const docsBaseRoute = normalizeUrl([

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -23,6 +23,7 @@ type Args = {
   editUrl?: string;
   showLastUpdateAuthor?: boolean;
   showLastUpdateTime?: boolean;
+  sidebarCollapsible?: boolean;
 };
 
 export default async function processMetadata({
@@ -35,6 +36,7 @@ export default async function processMetadata({
   editUrl,
   showLastUpdateAuthor,
   showLastUpdateTime,
+  sidebarCollapsible,
 }: Args): Promise<MetadataRaw> {
   const filePath = path.join(docsDir, source);
 
@@ -129,6 +131,8 @@ export default async function processMetadata({
       }
     }
   }
+
+  metadata.sidebarCollapsible = sidebarCollapsible;
 
   return metadata as MetadataRaw;
 }

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -17,6 +17,7 @@ export interface PluginOptions {
   editUrl?: string;
   showLastUpdateTime?: boolean;
   showLastUpdateAuthor?: boolean;
+  sidebarCollapsible?: boolean;
 }
 
 export type SidebarItemDoc = {
@@ -95,6 +96,7 @@ export interface MetadataRaw extends OrderMetadata {
   lastUpdatedAt?: number;
   lastUpdatedBy?: string;
   hide_title?: boolean;
+  sidebarCollapsible?: boolean;
   [key: string]: any;
 }
 
@@ -126,9 +128,10 @@ export interface LoadedContent {
   docsSidebars: Sidebar;
   sourceToPermalink: SourceToPermalink;
   permalinkToSidebar: PermalinkToSidebar;
+  sidebarCollapsible?: boolean;
 }
 
 export type DocsBaseMetadata = Pick<
   LoadedContent,
-  'docsSidebars' | 'permalinkToSidebar'
+  'docsSidebars' | 'permalinkToSidebar' | 'sidebarCollapsible'
 >;

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
@@ -17,7 +17,7 @@ import styles from './styles.module.css';
 
 function DocPage(props) {
   const {route, docsMetadata, location} = props;
-  const {permalinkToSidebar, docsSidebars} = docsMetadata;
+  const {permalinkToSidebar, docsSidebars, sidebarCollapsible} = docsMetadata;
   const sidebar = permalinkToSidebar[location.pathname.replace(/\/$/, '')];
 
   return (
@@ -29,6 +29,7 @@ function DocPage(props) {
               docsSidebars={docsSidebars}
               location={location}
               sidebar={sidebar}
+              sidebarCollapsible={sidebarCollapsible}
             />
           </div>
         )}

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -14,7 +14,7 @@ import styles from './styles.module.css';
 
 const MOBILE_TOGGLE_SIZE = 24;
 
-function DocSidebarItem({item, onItemClick}) {
+function DocSidebarItem({item, onItemClick, collapsible}) {
   const {items, href, label, type} = item;
   const [collapsed, setCollapsed] = useState(item.collapsed);
   const [prevCollapsedProp, setPreviousCollapsedProp] = useState(null);
@@ -36,11 +36,12 @@ function DocSidebarItem({item, onItemClick}) {
           })}
           key={label}>
           <a
-            className={classnames('menu__link', 'menu__link--sublist', {
-              'menu__link--active': !item.collapsed,
+            className={classnames('menu__link', {
+              'menu__link--sublist': collapsible,
+              'menu__link--active': collapsible && !item.collapsed,
             })}
             href="#!"
-            onClick={() => setCollapsed(!collapsed)}>
+            onClick={collapsible ? () => setCollapsed(!collapsed) : undefined}>
             {label}
           </a>
           <ul className="menu__list">
@@ -49,6 +50,7 @@ function DocSidebarItem({item, onItemClick}) {
                 key={childItem.label}
                 item={childItem}
                 onItemClick={onItemClick}
+                collapsible={collapsible}
               />
             ))}
           </ul>
@@ -95,7 +97,12 @@ function mutateSidebarCollapsingState(item, location) {
 function DocSidebar(props) {
   const [showResponsiveSidebar, setShowResponsiveSidebar] = useState(false);
 
-  const {docsSidebars, location, sidebar: currentSidebar} = props;
+  const {
+    docsSidebars,
+    location,
+    sidebar: currentSidebar,
+    sidebarCollapsible,
+  } = props;
 
   if (!currentSidebar) {
     return null;
@@ -109,9 +116,11 @@ function DocSidebar(props) {
     );
   }
 
-  sidebarData.forEach(sidebarItem =>
-    mutateSidebarCollapsingState(sidebarItem, location),
-  );
+  if (sidebarCollapsible) {
+    sidebarData.forEach(sidebarItem =>
+      mutateSidebarCollapsingState(sidebarItem, location),
+    );
+  }
 
   return (
     <div className={styles.sidebar}>
@@ -162,6 +171,7 @@ function DocSidebar(props) {
               onItemClick={() => {
                 setShowResponsiveSidebar(false);
               }}
+              collapsible={sidebarCollapsible}
             />
           ))}
         </ul>

--- a/website/docs/advanced-plugins.md
+++ b/website/docs/advanced-plugins.md
@@ -108,18 +108,19 @@ module.exports = {
 
 <!--
 #### Options
-| Option | Default | Notes |
-| :-- | :-- | :-- |
-| `path` | `'blog'` | Path to data on filesystem, relative to site dir |
-| `routeBasePath` | `'blog'` | URL Route |
-| `include` | `['*.md', '*.mdx']` | Extensions to include |
-| `postsPerPage` | `10` | How many posts per page |
-| `blogListComponent` | `'@theme/BlogListPage'` | Theme component used for the blog listing page |
-| `blogPostComponent` | `'@theme/BlogPostPage'` | Theme component used for the blog post page |
-| `blogTagsListComponent` | `'@theme/BlogTagsListPage'` | Theme component used for the blog tags list page |
+| Option                   | Default                      | Notes                                            |
+|--------------------------|------------------------------|--------------------------------------------------|
+| :--                      | :--                          | :--                                              |
+| `path`                   | `'blog'`                     | Path to data on filesystem, relative to site dir |
+| `routeBasePath`          | `'blog'`                     | URL Route                                        |
+| `include`                | `['*.md', '*.mdx']`          | Extensions to include                            |
+| `postsPerPage`           | `10`                         | How many posts per page                          |
+| `blogListComponent`      | `'@theme/BlogListPage'`      | Theme component used for the blog listing page   |
+| `blogPostComponent`      | `'@theme/BlogPostPage'`      | Theme component used for the blog post page      |
+| `blogTagsListComponent`  | `'@theme/BlogTagsListPage'`  | Theme component used for the blog tags list page |
 | `blogTagsPostsComponent` | `'@theme/BlogTagsPostsPage'` | Theme component used for the blog tags post page |
-| `remarkPlugins` | `[]` | Plugins for remark |
-| `rehypePlugins` | `[]` | Plugins for rehype |
+| `remarkPlugins`          | `[]`                         | Plugins for remark                               |
+| `rehypePlugins`          | `[]`                         | Plugins for rehype                               |
 commenting out because charts look less direct than code example
 -->
 
@@ -172,6 +173,11 @@ module.exports = {
          * Whether to display the last date the doc was updated.
          * /
         showLastUpdateTime: false,
+        /**
+         * For sites with a sizable amount of content, set collapsible to true.
+         * Expand/collapse the links and subcategories under categories.
+         * /
+        sidebarCollapsible: true,
       },
     ],
   ],

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -290,6 +290,8 @@ module.exports = {
           showLastUpdateAuthor: true,
           // Equivalent to `enableUpdateTime`.
           showLastUpdateTime: true,
+          // Equivalent to `docsSideNavCollapsible`.
+          sidebarCollapsible: true,
         },
         ...
       },


### PR DESCRIPTION
## Motivation

In v1 it was possible to choose whether to expand (or collapse)  by default nav elements in the doc sidebar.

This behavior was set by optional `docsSideNavCollapsible` field and defaulted to `false` value (*all nav elements were expanded*).

In the new v2 - nav elements are collapsed and this can not be overridden, except to swizzle the component... this is really bad.

At least [34 sites](https://github.com/search?q=filename%3AsiteConfig.js+%22docsSideNavCollapsible%3A+false%22) explicitly indicated `docsSideNavCollapsible: false`, despite being the default value, which means that sites using this field with the value `false` are **much larger**! Although I understand that this is not very much in demand!

I tried to bring back this useful field/feature, as it was in the v1 - as a result `docsSideNavCollapsible` -> `sidebarCollapsible` (see screenshots below).

I don’t know how correct implementation it is, but it works, therefore I ask you to accept this feature request, it is the useful feature for small docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| `sidebarCollapsible: true` (default)   | `sidebarCollapsible: false` (new!)    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/67427723-5aba8580-f5e5-11e9-9375-282b0365db35.png) | ![image](https://user-images.githubusercontent.com/4408379/67427745-66a64780-f5e5-11e9-8b5b-c0b38eba36d1.png) |
