### PR TITLE
misc(v2): v1 backward compatibility for USE_SSH env var

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -7,6 +7,7 @@
 - Convert sitemap plugin to TypeScript.
 - Significantly reduce main bundle size and initial HTML payload on production build. Generated JS files from webpack is also shorter in name.
 - Refactor dark toggle into a hook.
+- Changed the way we read the `USE_SSH` env variable during deployment to be the same as in v1.
 
 ## 2.0.0-alpha.31
 

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -67,9 +67,10 @@ export async function deploy(siteDir: string): Promise<void> {
     process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
 
   const useSSH = process.env.USE_SSH;
-  const remoteBranch = useSSH
-    ? `git@${githubHost}:${organizationName}/${projectName}.git`
-    : `https://${gitUser}@${githubHost}/${organizationName}/${projectName}.git`;
+  const remoteBranch =
+    useSSH && useSSH.toLowerCase() === 'true'
+      ? `git@${githubHost}:${organizationName}/${projectName}.git`
+      : `https://${gitUser}@${githubHost}/${organizationName}/${projectName}.git`;
 
   // Check if this is a cross-repo publish
   const currentRepoUrl = shell


### PR DESCRIPTION
## Motivation

Docusaurus 1.X treats any non-'true' value to be false, but Docusaurus 2.X currently treats any non-empty string to be truthy here. This change should unbreak projects that migrate from V1 to V2 with `USE_SSH=false` environment variables.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep!

## Test Plan

eyes
