### PR TITLE
perf(v2): disable hash for css modules localident in dev

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -6,6 +6,7 @@
 - Remove empty doc sidebar container
 - PostCSS preset env now only polyfills Stage 3 features (previously it was stage 2) like Create React App. Stage 2 CSS is considered relatively unstable and subject to change while Stage 3 features will likely become a standard.
 - Add ability expand all doc items in sidebar (same as `docsSideNavCollapsible` field in v1)
+- Disable adding hashes to the generated class names of CSS modules in dev mode. Generating unique identifiers takes some time, which can be saved since including paths to files in class names is enough to avoid collisions.
 
 ## 2.0.0-alpha.30
 

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -144,7 +144,9 @@ export function createBaseConfig(
           test: CSS_MODULE_REGEX,
           use: getStyleLoaders(isServer, {
             modules: {
-              localIdentName: `[local]_[hash:base64:4]`,
+              localIdentName: isProd
+                ? `[local]_[hash:base64:4]`
+                : `[local]_[path]`,
             },
             importLoaders: 1,
             sourceMap: !isProd,


### PR DESCRIPTION
## Motivation

Disable adding hashes to the generated class names of CSS modules in dev mode. Generating unique identifiers takes some time, which can be saved since including paths to files in class names is enough to avoid collisions.

Recommended by https://github.com/webpack-contrib/css-loader#localidentname

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Verify locally in dev
- [x] Hot reload still working
- [x] css classname has path embedded to it it avoid collision