### PR TITLE
feat(v2): display footer in docs page for consistency

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,12 +2,12 @@
 
 ## Unreleased
 
-- Footer is now sticky/ pinned to the bottom of the viewport in desktop browsers.
+- Footer is now sticky/ pinned to the bottom of the viewport in desktop browsers. 
+- Footer is now also displayed in docs page for consistency.
 - Remove empty doc sidebar container if sidebar for a particular doc page does not exist. Otherwise, it will cause an additional empty space.
 - Default PostCSS loader now only polyfills stage 3+ features (previously it was stage 2) like Create React App. Stage 2 CSS is considered relatively unstable and subject to change while Stage 3 features will likely become a standard. 
 - Fix search bar focus bug. When you put the focus on search input, previously the focus will remain although we have clicked to other area outside of the search input.
 - New themeConfig option `sidebarCollapsible`. It is on by default. If explicitly set to `false`, all doc items in sidebar is expanded. Otherwise, it will still be a collapsible sidebar.
-- Footer is now also displayed in docs page for consistency.
 
 ## 2.0.0-alpha.30
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -7,6 +7,7 @@
 - Default PostCSS loader now only polyfills stage 3+ features (previously it was stage 2) like Create React App. Stage 2 CSS is considered relatively unstable and subject to change while Stage 3 features will likely become a standard. 
 - Fix search bar focus bug. When you put the focus on search input, previously the focus will remain although we have clicked to other area outside of the search input.
 - New themeConfig option `sidebarCollapsible`. It is on by default. If explicitly set to `false`, all doc items in sidebar is expanded. Otherwise, it will still be a collapsible sidebar.
+- Footer is now also displayed in docs page for consistency.
 
 ## 2.0.0-alpha.30
 

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
@@ -24,7 +24,7 @@ function DocPage(props) {
   const {sidebarCollapsible = true} = themeConfig;
 
   return (
-    <Layout noFooter>
+    <Layout>
       <div className={styles.docPage}>
         {sidebar && (
           <div className={styles.docSidebarContainer}>

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -20,11 +20,18 @@ function Layout(props) {
     favicon,
     tagline,
     title: defaultTitle,
-    noFooter,
     themeConfig: {image: defaultImage},
     url: siteUrl,
   } = siteConfig;
-  const {children, title, description, image, keywords, permalink} = props;
+  const {
+    children,
+    title,
+    noFooter,
+    description,
+    image,
+    keywords,
+    permalink,
+  } = props;
   const metaTitle = title || `${defaultTitle} · ${tagline}`;
   const metaImage = image || defaultImage;
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -20,6 +20,7 @@ function Layout(props) {
     favicon,
     tagline,
     title: defaultTitle,
+    noFooter,
     themeConfig: {image: defaultImage},
     url: siteUrl,
   } = siteConfig;
@@ -54,7 +55,7 @@ function Layout(props) {
       </Head>
       <Navbar />
       <main className="main">{children}</main>
-      <Footer />
+      {!noFooter && <Footer />}
     </React.Fragment>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -23,15 +23,7 @@ function Layout(props) {
     themeConfig: {image: defaultImage},
     url: siteUrl,
   } = siteConfig;
-  const {
-    children,
-    title,
-    noFooter,
-    description,
-    image,
-    keywords,
-    permalink,
-  } = props;
+  const {children, title, description, image, keywords, permalink} = props;
   const metaTitle = title || `${defaultTitle} · ${tagline}`;
   const metaImage = image || defaultImage;
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
@@ -62,7 +54,7 @@ function Layout(props) {
       </Head>
       <Navbar />
       <main className="main">{children}</main>
-      {!noFooter && <Footer />}
+      <Footer />
     </React.Fragment>
   );
 }


### PR DESCRIPTION
## Motivation

Previously, the sticky stuff on the docs page might not play well with a Footer underneath so we chose to leave it out. But since #1855, it is now possible to have consistent look like v1.

See https://github.com/facebook/docusaurus/issues/1598



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

[Imgur](https://imgur.com/y7tU7F8)

[Imgur](https://imgur.com/ypMb6QO)
