### PR TITLE
fix(v2): do not show category with empty items

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -9,6 +9,7 @@
 - Fix search bar focus bug. When you put the focus on search input, previously the focus will remain although we have clicked to other area outside of the search input.
 - New themeConfig option `sidebarCollapsible`. It is on by default. If explicitly set to `false`, all doc items in sidebar is expanded. Otherwise, it will still be a collapsible sidebar.
 - Disable adding hashes to the generated class names of CSS modules in dev mode. Generating unique identifiers takes some time, which can be saved since including paths to files in class names is enough to avoid collisions.
+- Fix showing sidebar category with empty items.
 
 ## 2.0.0-alpha.30
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -30,31 +30,35 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
   switch (type) {
     case 'category':
       return (
-        <li
-          className={classnames('menu__list-item', {
-            'menu__list-item--collapsed': collapsed,
-          })}
-          key={label}>
-          <a
-            className={classnames('menu__link', {
-              'menu__link--sublist': collapsible,
-              'menu__link--active': collapsible && !item.collapsed,
+        items.length > 0 && (
+          <li
+            className={classnames('menu__list-item', {
+              'menu__list-item--collapsed': collapsed,
             })}
-            href="#!"
-            onClick={collapsible ? () => setCollapsed(!collapsed) : undefined}>
-            {label}
-          </a>
-          <ul className="menu__list">
-            {items.map(childItem => (
-              <DocSidebarItem
-                key={childItem.label}
-                item={childItem}
-                onItemClick={onItemClick}
-                collapsible={collapsible}
-              />
-            ))}
-          </ul>
-        </li>
+            key={label}>
+            <a
+              className={classnames('menu__link', {
+                'menu__link--sublist': collapsible,
+                'menu__link--active': collapsible && !item.collapsed,
+              })}
+              href="#!"
+              onClick={
+                collapsible ? () => setCollapsed(!collapsed) : undefined
+              }>
+              {label}
+            </a>
+            <ul className="menu__list">
+              {items.map(childItem => (
+                <DocSidebarItem
+                  key={childItem.label}
+                  item={childItem}
+                  onItemClick={onItemClick}
+                  collapsible={collapsible}
+                />
+              ))}
+            </ul>
+          </li>
+        )
       );
 
     case 'link':
@@ -164,16 +168,19 @@ function DocSidebar(props) {
           )}
         </button>
         <ul className="menu__list">
-          {sidebarData.map(item => (
-            <DocSidebarItem
-              key={item.label}
-              item={item}
-              onItemClick={() => {
-                setShowResponsiveSidebar(false);
-              }}
-              collapsible={sidebarCollapsible}
-            />
-          ))}
+          {sidebarData.map(
+            item =>
+              item.items.length > 0 && (
+                <DocSidebarItem
+                  key={item.label}
+                  item={item}
+                  onItemClick={() => {
+                    setShowResponsiveSidebar(false);
+                  }}
+                  collapsible={sidebarCollapsible}
+                />
+              ),
+          )}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Motivation

It happens that there is a category in the sidebar, but it does not have items (i.e., empty array). You can of course not skip such inputs and give the user an error (?), but this is not the best option, because in this way the user probably wants to hide the display of such a category (do not ask me why ¯\_(ツ)_/¯).

Yes, although the user can simply comment out such categories... In any case, this is the edge case that needs to be handled correctly - do not show categories like these. 

> For the record, in the first version, categories with empty items simply did not shown, so seems fair to bring back this behavior to the second version (see Test plan).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Let say we have this `sidebars.js` file: 

```diff
module.exports = {
  docs: {
    Docusaurus: [
      'introduction',
      /*'motivation', */ 'design-principles',
      'contributing',
    ],
-   'Getting Started': ['installation', 'configuration'],
+   'Getting Started': [],
    Guides: [
      'creating-pages',
      'styling-layout',
      'static-assets',
      {
        type: 'category',
        label: 'Docs',
-       items: ['markdown-features', 'sidebar'],
+       items: [],
      },
      'blog',
      'analytics',
...
    ],
```

In the sidebar, such categories will be displayed, although they should not:

![image](https://user-images.githubusercontent.com/4408379/67613098-1a5c3280-f7b2-11e9-8fd5-c5ea978f21a0.png)

But after accepting this PR, these categories will not displayed:

![image](https://user-images.githubusercontent.com/4408379/67613109-4bd4fe00-f7b2-11e9-8db3-9917f8726770.png)
