### PR TITLE
fix(v1): mobile safari search input misalignment in header

### DIFF
--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -843,7 +843,7 @@ input[type='search'] {
   padding-left: 10px;
   position: absolute;
   right: 10px;
-  top: 15px;
+  top: 10px;
 }
 
 .navSearchWrapper:before {
@@ -1382,6 +1382,7 @@ input::placeholder {
     transition: background-color 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55),
       width 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55), color 0.2s ease;
     width: 100%;
+    height: 30px;
   }
 
   .reactNavSearchWrapper input#search_input_react:focus,


### PR DESCRIPTION
Resolves #254 

## Motivation

The thing was that the search input was sized differently on Mobile Safari / Chrome browsers which caused in a misalignment like described in the #254 bug report. I've unified the height of the input and aligned it properly, so it looks good on Chrome/Firefox as well as on Safari / Mobile Safari.

### Have you read the [Contributing Guidelines on pull requests]

Yes.

## Test Plan

I've tested locally on given browsers:

### Chrome desktop:

![image](https://user-images.githubusercontent.com/11553624/67624017-36041f00-f82c-11e9-89eb-3e1b66b45be7.png)

### Firefox desktop:

![image](https://user-images.githubusercontent.com/11553624/67624037-53d18400-f82c-11e9-911d-a4c4c0e16a7e.png)

### Safari desktop:

![image](https://user-images.githubusercontent.com/11553624/67624041-63e96380-f82c-11e9-82a3-99a3450abf63.png)

### Chrome iPhone 8

![image](https://user-images.githubusercontent.com/11553624/67624064-9b581000-f82c-11e9-8501-c9e7b46ed677.png)

### Safari iPhone 8

![image](https://user-images.githubusercontent.com/11553624/67624074-b3c82a80-f82c-11e9-8490-1390099fa3cc.png)

### Chrome Google Pixel 3

![image](https://user-images.githubusercontent.com/11553624/67624086-cfcbcc00-f82c-11e9-8843-70017ef9d6a5.png)