### PR TITLE
perf(v2): significantly reduce bundle size & initial html payload

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Convert sitemap plugin to TypeScript
+- Significantly reduce main bundle size and initial HTML payload on production build.
 
 ## 2.0.0-alpha.31
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Convert sitemap plugin to TypeScript
-- Significantly reduce main bundle size and initial HTML payload on production build.
+- Significantly reduce main bundle size and initial HTML payload on production build. Generated JS files from webpack is also shorter in name.
 
 ## 2.0.0-alpha.31
 

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -108,6 +108,22 @@ describe('load utils', () => {
     Object.keys(secondAssert).forEach(str => {
       expect(genChunkName(str, undefined, 'blog')).toBe(secondAssert[str]);
     });
+
+    // Only generate short unique id
+    const thirdAssert = {
+      a: '1',
+      b: '2',
+      c: '3',
+      d: '4',
+    };
+    Object.keys(thirdAssert).forEach(str => {
+      expect(genChunkName(str, undefined, undefined, true)).toBe(
+        thirdAssert[str],
+      );
+    });
+
+    expect(genChunkName('e', undefined, undefined, true)).toBe('5');
+    expect(genChunkName('d', undefined, undefined, true)).toBe('4');
   });
 
   test('idx', () => {

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -111,19 +111,17 @@ describe('load utils', () => {
 
     // Only generate short unique id
     const thirdAssert = {
-      a: '1',
-      b: '2',
-      c: '3',
-      d: '4',
+      a: '0cc175b9',
+      b: '92eb5ffe',
+      c: '4a8a08f0',
+      d: '8277e091',
     };
     Object.keys(thirdAssert).forEach(str => {
       expect(genChunkName(str, undefined, undefined, true)).toBe(
         thirdAssert[str],
       );
     });
-
-    expect(genChunkName('e', undefined, undefined, true)).toBe('5');
-    expect(genChunkName('d', undefined, undefined, true)).toBe('4');
+    expect(genChunkName('d', undefined, undefined, true)).toBe('8277e091');
   });
 
   test('idx', () => {

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -101,19 +101,24 @@ export function genChunkName(
   modulePath: string,
   prefix?: string,
   preferredName?: string,
+  shortId?: boolean,
 ): string {
   let chunkName: string | undefined = chunkNameCache.get(modulePath);
   if (!chunkName) {
-    let str = modulePath;
-    if (preferredName) {
-      const shortHash = createHash('md5')
-        .update(modulePath)
-        .digest('hex')
-        .substr(0, 3);
-      str = `${preferredName}${shortHash}`;
+    if (shortId) {
+      chunkName = _.uniqueId();
+    } else {
+      let str = modulePath;
+      if (preferredName) {
+        const shortHash = createHash('md5')
+          .update(modulePath)
+          .digest('hex')
+          .substr(0, 3);
+        str = `${preferredName}${shortHash}`;
+      }
+      const name = str === '/' ? 'index' : docuHash(str);
+      chunkName = prefix ? `${prefix}---${name}` : name;
     }
-    const name = str === '/' ? 'index' : docuHash(str);
-    chunkName = prefix ? `${prefix}---${name}` : name;
     chunkNameCache.set(modulePath, chunkName);
   }
   return chunkName;

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -106,7 +106,10 @@ export function genChunkName(
   let chunkName: string | undefined = chunkNameCache.get(modulePath);
   if (!chunkName) {
     if (shortId) {
-      chunkName = _.uniqueId();
+      chunkName = createHash('md5')
+        .update(modulePath)
+        .digest('hex')
+        .substr(0, 8);
     } else {
       let str = modulePath;
       if (preferredName) {

--- a/packages/docusaurus/src/client/exports/ComponentCreator.js
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.js
@@ -56,9 +56,11 @@ function ComponentCreator(path) {
     }
 
     const chunkRegistry = registry[target] || {};
-    optsLoader[keys.join('.')] = chunkRegistry.loader;
-    optsModules.push(chunkRegistry.module);
-    optsWebpack.push(chunkRegistry.webpack);
+    /* eslint-disable prefer-destructuring */
+    optsLoader[keys.join('.')] = chunkRegistry[0];
+    optsModules.push(chunkRegistry[1]);
+    optsWebpack.push(chunkRegistry[2]);
+    /* eslint-enable prefer-destructuring */
   }
 
   traverseChunk(chunkNames, []);

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -117,11 +117,10 @@ export async function load(siteDir: string): Promise<Props> {
     `export default {
 ${Object.keys(registry)
   .map(
-    key => `  '${key}': {
-    'loader': ${registry[key].loader},
-    'module': ${JSON.stringify(registry[key].modulePath)},
-    'webpack': require.resolveWeak(${JSON.stringify(registry[key].modulePath)}),
-  },`,
+    key =>
+      `  '${key}': [${registry[key].loader}, ${JSON.stringify(
+        registry[key].modulePath,
+      )}, require.resolveWeak(${JSON.stringify(registry[key].modulePath)})],`,
   )
   .join('\n')}};\n`,
   );

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -24,6 +24,7 @@ function getModulePath(target: Module): string {
 }
 
 export async function loadRoutes(pluginsRouteConfigs: RouteConfig[]) {
+  const isProd = process.env.NODE_ENV === 'production';
   const routesImports = [
     `import React from 'react';`,
     `import ComponentCreator from '@docusaurus/ComponentCreator';`,
@@ -82,7 +83,7 @@ export async function loadRoutes(pluginsRouteConfigs: RouteConfig[]) {
       }
 
       const modulePath = getModulePath(value as Module);
-      const chunkName = genChunkName(modulePath, prefix, name);
+      const chunkName = genChunkName(modulePath, prefix, name, isProd);
       const loader = `() => import(/* webpackChunkName: '${chunkName}' */ ${JSON.stringify(
         modulePath,
       )})`;

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -32,8 +32,8 @@ export function createBaseConfig(
     output: {
       pathinfo: false,
       path: outDir,
-      filename: isProd ? '[name].[contenthash].js' : '[name].js',
-      chunkFilename: isProd ? '[name].[contenthash].js' : '[name].js',
+      filename: isProd ? '[name].[contenthash:8].js' : '[name].js',
+      chunkFilename: isProd ? '[name].[contenthash:8].js' : '[name].js',
       publicPath: baseUrl,
     },
     // Don't throw warning when asset created is over 250kb
@@ -157,8 +157,8 @@ export function createBaseConfig(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: isProd ? '[name].[contenthash].css' : '[name].css',
-        chunkFilename: isProd ? '[name].[contenthash].css' : '[name].css',
+        filename: isProd ? '[name].[contenthash:8].css' : '[name].css',
+        chunkFilename: isProd ? '[name].[contenthash:8].css' : '[name].css',
       }),
     ],
   };


### PR DESCRIPTION
## Motivation

### Update: used alphanumeric id from hash so that the same module path always have same chunk name. For better long term caching. 

I think it's quite straightforward that **SPEED** is everything in web development. Saving 0.3s or even 0.5s in page loading is **HUGE**.
This PR attempts to reduce our bundle size by changing the registry.js structure a little bit (using array instead of object) and using short alphanumeric id for our webpack chunk name in production.

So in development
```js
// registry.js
export default {
  'component---site-src-pages-help-js-7-e-3-222': [() => import(/* webpackChunkName: 'component---site-src-pages-help-js-7-e-3-222' */ "@site/src/pages/help.js"), "@site/src/pages/help.js", require.resolveWeak("@site/src/pages/help.js")],
  'component---site-src-pages-index-jsc-4-f-f99': [() => import(/* webpackChunkName: 'component---site-src-pages-index-jsc-4-f-f99' */ "@site/src/pages/index.js"), "@site/src/pages/index.js", require.resolveWeak("@site/src/pages/index.js")],
}
```

While production
```js
// registry.js
export default {
  '17896441': [() => import(/* webpackChunkName: '17896441' */ "@site/src/pages/help.js"), "@site/src/pages/help.js", require.resolveWeak("@site/src/pages/help.js")],
  '7e37206e': [() => import(/* webpackChunkName: '7e37206e' */ "@site/src/pages/index.js"), "@site/src/pages/index.js", require.resolveWeak("@site/src/pages/index.js")],
}
```

So the main caveat of this PR is obvious, when looking at the network tab, the JS file name is not so easy to determine like before. 

<a href="https://ibb.co/kJJJfdc"><img src="https://i.ibb.co/4222GQN/image.png" alt="image" border="0"></a>

See how the js file name in production is previously `component---theme-doc-item-178-a40.8e48729024944b887b6d.js`. After this PR, you should only see something like `7e37206e.8e487290.js`. 

But I believe **easy to debug** JS name should be done in development (for **developer**), and we should prioritize sending the lowest byte as possible to docusaurus's website visitor. Our neighbor SSG also used numeric id and doesnt seem to have complains though. Seeing huge website like Facebook/ Instagram, their JS file naming is even more randomized (use alphanumeric like ours for long term caching)

<a href="https://ibb.co/J55j7yD"><img src="https://i.ibb.co/KFFxqLT/vuepress.png" alt="vuepress" border="0"></a>
<a href="https://ibb.co/DkvMLW8"><img src="https://i.ibb.co/vmTdDqQ/webpack.png" alt="webpack" border="0"></a><br /><a target='_blank' href='https://imgbb.com/'>upload image</a><br />
<a href="https://ibb.co/0XWn0cK"><img src="https://i.ibb.co/TTnwQk1/facebook.png" alt="facebook" border="0"></a><br /><a target='_blank' href='https://imgbb.com/'>free image hosting</a><br />

This also makes our HTML payload smaller because the inlined chunk-mapping is shorter in string length

See Test Plan for more obvious benefit especially on scaling.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

I used 225 valid markdown files for the stress test. The markdown file is generated with this script https://gist.github.com/endiliey/8970281b25b125747c27d8d2be9260f1

Before
Main bundle ~349kb
HTML is ~81kb
<a href="https://ibb.co/1nRCtCr"><img src="https://i.ibb.co/VNMFcFg/225-docs-before-html-81kb.png" alt="225-docs-before-html-81kb" border="0"></a>
<a href="https://ibb.co/z4Yg48R"><img src="https://i.ibb.co/LZWyZQt/225-docs-before-main-bundle-349-kb.png" alt="225-docs-before-main-bundle-349-kb" border="0"></a>

After
Main bundle ~295kb
HTML is ~47kb
<a href="https://ibb.co/LvPGYPc"><img src="https://i.ibb.co/7bz9jzZ/225-docs-after-html-47kb.png" alt="225-docs-after-html-47kb" border="0"></a>
<a href="https://ibb.co/QbZXFZB"><img src="https://i.ibb.co/2nw57w2/225-docs-after-main-bundle-295kb.png" alt="225-docs-after-main-bundle-295kb" border="0"></a>

That's almost ~100kb difference saved on initial payload.

Even with current docu v2 docs, we have saved ~10kb on main bundle and ~8kb/html
Before
<a href="https://ibb.co/vmxbcpK"><img src="https://i.ibb.co/GkvXdyb/1-before.png" alt="1-before" border="0"></a>
After
<a href="https://ibb.co/M6pvt6J"><img src="https://i.ibb.co/QdngTdx/3-supershortchunkname-save-20kb.png" alt="3-supershortchunkname-save-20kb" border="0"></a>1

P.S: For user like me who has potato internet, few KBs saving can be worth a lot
