### PR TITLE
fix(v2): nested routes should have wildcard/ not found page too

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -9,6 +9,7 @@
 - Refactor dark toggle into a hook.
 - Changed the way we read the `USE_SSH` env variable during deployment to be the same as in v1.
 - Add highlight specific lines in code blocks.
+- Accessing `docs/` or `/docs/xxxx` should return not found page, not blank page.
 
 ## 2.0.0-alpha.31
 

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
@@ -131,7 +131,11 @@ export default [
   component: ComponentCreator('docs/foo/baz'),
   
   
-}],
+}, 
+  {
+    path: '*',
+    component: ComponentCreator('*')
+  }],
 },
   
   {

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -15,6 +15,12 @@ import {
   RouteModule,
 } from '@docusaurus/types';
 
+const notFoundRoute = `
+  {
+    path: '*',
+    component: ComponentCreator('*')
+  }`;
+
 function getModulePath(target: Module): string {
   if (typeof target === 'string') {
     return target;
@@ -102,7 +108,9 @@ export async function loadRoutes(pluginsRouteConfigs: RouteConfig[]) {
     );
 
     const routesStr = routes
-      ? `routes: [${routes.map(generateRouteCode).join(',')}],`
+      ? `routes: [${routes
+          .map(generateRouteCode)
+          .join(',')}, ${notFoundRoute}],`
       : '';
     const exactStr = exact ? `exact: true,` : '';
 
@@ -116,12 +124,6 @@ export async function loadRoutes(pluginsRouteConfigs: RouteConfig[]) {
   }
 
   const routes = pluginsRouteConfigs.map(generateRouteCode);
-  const notFoundRoute = `
-  {
-    path: '*',
-    component: ComponentCreator('*')
-  }`;
-
   const routesConfig = `
 ${routesImports.join('\n')}
 


### PR DESCRIPTION
## Motivation

When accessing https://v2.docusaurus.io/docs or https://v2.docusaurus.io/docs/xxxxx we'll see only blank page because it match `@theme/DocPage`

We should have fall back wildcard for nested routes.

Before this PR, our generated routes look like this
```js
export default [
  {
    path: "/",
    component: ComponentCreator("/"),
    exact: true
  },
  {
    path: "/docs",
    component: ComponentCreator("/docs"),
    routes: [
      {
        path: "/docs/advanced-themes",
        component: ComponentCreator("/docs/advanced-themes"),
        exact: true
      },
      {
        path: "/docs/advanced-plugins",
        component: ComponentCreator("/docs/advanced-plugins"),
        exact: true
      },
    ]
  },
  {
    path: "*",
    component: ComponentCreator("*")
  }
];
``` 

After this PR, we add fallback notfound route too
```js
export default [
  {
    path: "/",
    component: ComponentCreator("/"),
    exact: true
  },
  {
    path: "/docs",
    component: ComponentCreator("/docs"),
    routes: [
      {
        path: "/docs/advanced-themes",
        component: ComponentCreator("/docs/advanced-themes"),
        exact: true
      },
      {
        path: "/docs/advanced-plugins",
        component: ComponentCreator("/docs/advanced-plugins"),
        exact: true
      },
      {
        path: "*",
        component: ComponentCreator("*")
      }
    ]
  },
  {
    path: "*",
    component: ComponentCreator("*")
  }
];
```

So 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Locally access /docs/ and /docs/xxx i find not found page
- Netlify
