### PR TITLE
feat(v2): add ability to set custom HTML in footer items

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -10,6 +10,7 @@
 - Changed the way we read the `USE_SSH` env variable during deployment to be the same as in v1.
 - Add highlight specific lines in code blocks.
 - Fix accessing `docs/` or `/docs/xxxx` that does not match any existing doc page should return 404 (Not found) page, not blank page.
+- Allow user to add custom HTML to footer items.
 
 ## 2.0.0-alpha.31
 

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -62,11 +62,19 @@ function Footer() {
                 Array.isArray(linkItem.items) &&
                 linkItem.items.length > 0 ? (
                   <ul className="footer__items">
-                    {linkItem.items.map(item => (
-                      <li key={item.href || item.to} className="footer__item">
-                        <FooterLink item={item} />
-                      </li>
-                    ))}
+                    {linkItem.items.map(item =>
+                      item.html ? (
+                        <div
+                          dangerouslySetInnerHTML={{
+                            __html: item.html,
+                          }}
+                        />
+                      ) : (
+                        <li key={item.href || item.to} className="footer__item">
+                          <FooterLink item={item} />
+                        </li>
+                      ),
+                    )}
                   </ul>
                 ) : null}
               </div>


### PR DESCRIPTION
## Motivation

Often, the GitHub stars button is added to the footer, to do this in v2 you need to swizzle the Footer component, just to insert such a button. It seems to me that you can simplify this action by simply giving the opportunity to provide custom HTML for the link (see Test plan).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

In file `docusaurus.config.js`:

```js
// ...
scripts: ['https://buttons.github.io/buttons.js'],
// ...
footer: {
  links: {
    {
      title: 'Social',
      items: [
        // ...
        {
          html:
            '<a class="github-button" href="https://github.com/facebook/docusaurus" data-icon="octicon-star" data-show-count="true" aria-label="Star facebook/docusaurus on GitHub">Star</a>',
        },
      ],
    },    
  }
}
//...
```

As result:

![image](https://user-images.githubusercontent.com/4408379/67737446-4844af80-fa1c-11e9-89bf-a9895889f9ac.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
