### PR TITLE
fix(v2): specify own CSS class for code tabs

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
@@ -14,7 +14,7 @@ function Tabs(props) {
   const [selectedValue, setSelectedValue] = useState(defaultValue);
 
   return (
-    <div>
+    <div className="docusaurus-code-tabs">
       <ul
         className={classnames('tabs', {
           'tabs--block': block,


### PR DESCRIPTION
## Motivation

Tabs must have its own CSS class so that the end user can customize it.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![image](https://user-images.githubusercontent.com/4408379/67737667-3283ba00-fa1d-11e9-87db-2185be85e390.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
