### PR TITLE
fix(v2): webpack modules resolve should prioritize @docusaurus/core own deps

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -10,6 +10,8 @@
 - Changed the way we read the `USE_SSH` env variable during deployment to be the same as in v1.
 - Add highlight specific lines in code blocks.
 - Fix accessing `docs/` or `/docs/xxxx` that does not match any existing doc page should return 404 (Not found) page, not blank page.
+- Prioritize `@docusaurus/core` dependencies/ node_modules over user's node_modules. This fix a bug whereby if user has core-js@3 on its own node_modules but docusaurus depends on core-js@2, we previously encounter `Module not found: core-js/modules/xxxx` (because core-js@3 doesn't have that).
+Another example is if user installed webpack@3 but docusaurus depends on webpack@4.
 
 ## 2.0.0-alpha.31
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -9,12 +9,9 @@
 - Refactor dark toggle into a hook.
 - Changed the way we read the `USE_SSH` env variable during deployment to be the same as in v1.
 - Fix accessing `docs/` or `/docs/xxxx` that does not match any existing doc page should return 404 (Not found) page, not blank page.
-<<<<<<< HEAD
 - Prioritize `@docusaurus/core` dependencies/ node_modules over user's node_modules. This fix a bug whereby if user has core-js@3 on its own node_modules but docusaurus depends on core-js@2, we previously encounter `Module not found: core-js/modules/xxxx` (because core-js@3 doesn't have that).
 Another example is if user installed webpack@3 but docusaurus depends on webpack@4.
-=======
 - Added code block line highlighting feature (thanks @lex111)! If you have previously swizzled the `CodeBlock` theme component, it is recommended to update your source code to have this feature.
->>>>>>> f635f9aba22895baca36d3af05c8b7cb3e46d13b
 
 ## 2.0.0-alpha.31
 

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -50,10 +50,13 @@ export function createBaseConfig(
         '@generated': generatedFilesDir,
         '@docusaurus': path.resolve(__dirname, '../client/exports'),
       },
-      modules: [
-        'node_modules',
+      // This allows you to set a fallback for where Webpack should look for modules.
+      // We want `@docusaurus/core` own dependencies/`node_modules` to "win" if there is conflict
+      // Example: if there is core-js@3 in user's own node_modules, but core depends on
+      // core-js@2, we should use core-js@2.
+      modules: module.paths.concat([
         path.resolve(fs.realpathSync(process.cwd()), 'node_modules'),
-      ],
+      ]),
     },
     optimization: {
       removeAvailableModules: false,


### PR DESCRIPTION
## Motivation

- Prioritize `@docusaurus/core` dependencies/ node_modules over user's node_modules. This fix a bug whereby if user has core-js@3 on its own node_modules but docusaurus depends on core-js@2, we previously encounter `Module not found: core-js/modules/xxxx` (because core-js@3 doesn't have that).
Another example is if user installed webpack@3 but docusaurus depends on webpack@4.

This is currently happening to docsearch. cc @s-pace

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Using newly init website, try to manually add core-js@3 on the site

Before

<a href="https://ibb.co/Mc2Sgwy"><img src="https://i.ibb.co/48mtFvw/core-js-wrong.png" alt="core-js-wrong" border="0"></a>
After

<a href="https://ibb.co/QjXjpV6"><img src="https://i.ibb.co/M595ZHR/prioritize-own-core-js.png" alt="prioritize-own-core-js" border="0"></a>
