### PR TITLE
fix(v2): custom searchbar should appear even if themeconfig.algolia is undefined

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 - Fixed a bug in which if `themeConfig.algolia` is not defined, the custom searchbar won't appear.
+If you've swizzled Algolia `SearchBar` component before, please update your source code otherwise CSS might break
+```js
+- <Fragment>
++ <div className="navbar__search" key="search-box">
+```
 - Reduce memory usage consumption.
 - Slightly adjust search icon position to be more aligned on small width device.
 - Convert sitemap plugin to TypeScript.

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug in which if `themeConfig.algolia` is not defined, the custom searchbar won't appear.
 - Reduce memory usage consumption.
 - Slightly adjust search icon position to be more aligned on small width device.
 - Convert sitemap plugin to TypeScript.

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fixed a bug in which if `themeConfig.algolia` is not defined, the custom searchbar won't appear.
-If you've swizzled Algolia `SearchBar` component before, please update your source code otherwise CSS might break
+If you've swizzled Algolia `SearchBar` component before, please update your source code otherwise CSS might break. See [#1909](https://github.com/facebook/docusaurus/pull/1909/files) for reference.
 ```js
 - <Fragment>
 + <div className="navbar__search" key="search-box">

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -137,12 +137,10 @@ function Navbar() {
                 unchecked: <Sun />,
               }}
             />
-            <div className="navbar__search" key="search-box">
-              <SearchBar
-                handleSearchBarToggle={setIsSearchBarExpanded}
-                isSearchBarExpanded={isSearchBarExpanded}
-              />
-            </div>
+            <SearchBar
+              handleSearchBarToggle={setIsSearchBarExpanded}
+              isSearchBarExpanded={isSearchBarExpanded}
+            />
           </div>
         </div>
         <div

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -52,7 +52,7 @@ function Navbar() {
   const [theme, setTheme] = useTheme();
   const {siteConfig = {}} = context;
   const {baseUrl, themeConfig = {}} = siteConfig;
-  const {algolia, navbar = {}} = themeConfig;
+  const {navbar = {}} = themeConfig;
   const {title, logo = {}, links = []} = navbar;
 
   const showSidebar = useCallback(() => {
@@ -137,14 +137,12 @@ function Navbar() {
                 unchecked: <Sun />,
               }}
             />
-            {algolia && (
-              <div className="navbar__search" key="search-box">
-                <SearchBar
-                  handleSearchBarToggle={setIsSearchBarExpanded}
-                  isSearchBarExpanded={isSearchBarExpanded}
-                />
-              </div>
-            )}
+            <div className="navbar__search" key="search-box">
+              <SearchBar
+                handleSearchBarToggle={setIsSearchBarExpanded}
+                isSearchBarExpanded={isSearchBarExpanded}
+              />
+            </div>
           </div>
         </div>
         <div

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -8,7 +8,6 @@
 import React, {
   useState,
   useEffect,
-  Fragment,
   useContext,
   useRef,
   useCallback,
@@ -60,7 +59,7 @@ const Search = props => {
   );
 
   return isEnabled ? (
-    <Fragment>
+    <div className="navbar__search" key="search-box">
       <span
         role="button"
         className={classnames('search-icon', {
@@ -84,7 +83,7 @@ const Search = props => {
         onBlur={toggleSearchIconClick}
         ref={searchBarRef}
       />
-    </Fragment>
+    </div>
   ) : null;
 };
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -47,3 +47,5 @@ yarn swizzle @docusaurus/theme-classic SearchBar
 ```
 
 This will create a `src/themes/SearchBar` file in your project folder. Restart your dev server and edit the component, you will see that Docusaurus uses your own `SearchBar` component now.
+
+**Notes**: You can alternatively [swizzle from Algolia SearchBar](#customizing-the-algolia-search-bar) and create your own search component from there.

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -1,0 +1,51 @@
+---
+id: theme-classic
+title: Classic Theme Configuration
+---
+
+_This section is a work in progress._
+
+## Navbar
+
+### Navbar Title & Logo
+
+You can add a logo and title to the navbar via `themeConfig.navbar`. Logo can be placed in [static folder](static-assets.md).
+
+```js
+// docusaurus.config.js
+module.exports = {
+  themeConfig: {
+    navbar: {
+      title: 'Site Title',
+      logo: {
+        alt: 'Site Logo',
+        src: 'img/logo.svg',
+      },
+    }
+}
+```
+
+### Navbar Links
+
+You can add links to the navbar via `themeConfig.navbar.links`:
+
+```js
+// docusaurus/config.js
+module.exports = {
+  themeConfig: {
+    navbar: {
+      links: [
+        {
+          to: 'docs/docusaurus.config.js',
+          label: 'docusaurus.config.js',
+          position: 'left',
+        },
+        // ... other links
+      ],
+    }
+}
+```
+
+Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes:
+
+## Footer

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -46,6 +46,6 @@ module.exports = {
 }
 ```
 
-Outbound links automatically get `target="_blank" rel="noopener noreferrer"`. You can offer `target` and `rel` to customize the attributes:
+Outbound links automatically get `target="_blank" rel="noopener noreferrer"`.
 
 ## Footer

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -34,7 +34,7 @@ module.exports = {
       {
         type: 'category',
         label: 'Themes',
-        items: ['using-themes', 'advanced-themes'],
+        items: ['using-themes', 'advanced-themes', 'theme-classic'],
       },
       'presets',
     ],


### PR DESCRIPTION
## Motivation

Found a bug on our navbar code while documenting. -Previously, if `themeConfig.algolia` is not defined, the custom searchbar won't appear.

Also added WIP documentation on theme-classic configuration. Better than nothing.  cc @wgao19 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

1. Swizzle searchbar
2. Remove themeconfig.algolia
3. Custom searchbar does appear
