### PR TITLE
docs: updating configcat user link

### DIFF
--- a/website-1.x/data/users.js
+++ b/website-1.x/data/users.js
@@ -143,7 +143,7 @@ module.exports = [
   {
     caption: 'ConfigCat',
     image: '/img/users/configcat.svg',
-    infoLink: 'https://docs.configcat.com',
+    infoLink: 'https://configcat.com/docs',
     fbOpenSource: false,
     pinned: false,
   },


### PR DESCRIPTION
## Motivation

The Docs URL has been changed at Configcat.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yepp

## Test Plan

Just click the link within users page under ConfigCat.

## Related PRs

