### PR TITLE
docs(v2): add windows batch instructions for publishing to gh pages

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -97,11 +97,17 @@ __Note:__ Not setting the `url` and `baseUrl` of your project might result in in
 
 To run the script directly from the command-line, you can use the following, filling in the parameter values as appropriate.
 
+**Bash**
 ```bash
 GIT_USER=<GIT_USER> \
   CURRENT_BRANCH=master \
   USE_SSH=true \
   yarn run publish-gh-pages # or `npm run publish-gh-pages`
+```
+
+**Windows**
+```batch
+cmd /C "set GIT_USER=<GIT_USER> && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
 ```
 
 There are also two optional parameters that are set as environment variables:


### PR DESCRIPTION
## Motivation

Closes #1749. Informs users how to run the `publish-gh-pages` command on Windows, as the Linux command is incompatible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes. One question - do I need to update the versioned document version with this change?

## Test Plan

Here's how the change looks in the VS Code markdown viewer:
![a preview of the fix contained in this PR](https://user-images.githubusercontent.com/7024578/67781253-1b65bc00-fa5f-11e9-9d3f-8685c6605e7f.png)


## Related PRs

n/a
