### PR TITLE
fix(v2): regression from prioritizing core node_modules logic

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -23,6 +23,7 @@ import styles from './styles.module.css';
 
 function NavLink(props) {
   const toUrl = useBaseUrl(props.to);
+  console.log(toUrl);
   return (
     <Link
       className="navbar__item navbar__link"

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -23,7 +23,6 @@ import styles from './styles.module.css';
 
 function NavLink(props) {
   const toUrl = useBaseUrl(props.to);
-  console.log(toUrl);
   return (
     <Link
       className="navbar__item navbar__link"

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -54,9 +54,11 @@ export function createBaseConfig(
       // We want `@docusaurus/core` own dependencies/`node_modules` to "win" if there is conflict
       // Example: if there is core-js@3 in user's own node_modules, but core depends on
       // core-js@2, we should use core-js@2.
-      modules: module.paths.concat([
+      modules: [
+        path.resolve(__dirname, '..', '..', 'node_modules'),
+        'node_modules',
         path.resolve(fs.realpathSync(process.cwd()), 'node_modules'),
-      ]),
+      ],
     },
     optimization: {
       removeAvailableModules: false,


### PR DESCRIPTION
## Motivation

Fix regression from #1907  

Accessing https://v2.docusaurus.io/docs/introduction won't make the current active navbar item to be highlighted
<a href="https://ibb.co/FBwS3s1"><img src="https://i.ibb.co/tbs7KZ6/image.png" alt="image" border="0"></a>

Instead of using `module.paths`, we should use just the `@docusaurus/core` hoisted node_modules.
Why ?
Because module.paths traverse up until the root, and this can cause picking the wrong dependencies.
Node_modules resolution is hard !!

Anyway, currently our modules resolve is this
```js
modules: [
        // @docusaurus/core own node_modules
        path.resolve(__dirname, '..', '..', 'node_modules'),
        // two lines below is same as CRA, razzle, etc
        'node_modules',
        path.resolve(fs.realpathSync(process.cwd()), 'node_modules'),
      ],
```




### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- NavLink is highlighted now
<a href="https://ibb.co/0y7v9TJ"><img src="https://i.ibb.co/r2jNpYy/highlighted.png" alt="highlighted" border="0"></a>

Before #1907 and this PR
```diff
modules: [
-       path.resolve(__dirname, '..', '..', 'node_modules'),
        'node_modules',
        path.resolve(fs.realpathSync(process.cwd()), 'node_modules'),
      ],
```
<a href="https://ibb.co/kykqXzz"><img src="https://i.ibb.co/W3qBf77/not-working-if-line-is-removed.png" alt="not-working-if-line-is-removed" border="0"></a>

- Using test plan from https://github.com/facebook/docusaurus/pull/1907, we still fix the issue if user install their own core-js@3
```diff
modules: [
+      path.resolve(__dirname, '..', '..', 'node_modules'),
        'node_modules',
        path.resolve(fs.realpathSync(process.cwd()), 'node_modules'),
      ],
```
<a href="https://ibb.co/VYL0ZZ0"><img src="https://i.ibb.co/jk89229/still-working.png" alt="still-working" border="0"></a>


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
