### PR TITLE
misc: use /usr/bin/env bash to increase portability

### DIFF
--- a/scripts/prerelease.sh
+++ b/scripts/prerelease.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##
 # Copyright (c) 2017-present, Facebook, Inc.


### PR DESCRIPTION
## Motivation

Using `/usr/bin/env bash` instead of `/usr/bin/bash` increases portability of the script, see e.g. [here](https://stackoverflow.com/questions/2429511/why-do-people-write-the-usr-bin-env-python-shebang-on-the-first-line-of-a-pyt) and [here](https://stackoverflow.com/questions/1352922/why-is-usr-bin-env-python-supposedly-more-correct-than-just-usr-bin-pyt) and probably countles more.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

N/A

## Related PRs

N/A


Please review.