### PR TITLE
fix(v2): @theme/heading should not create anchor if id is not defined

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -20,6 +20,7 @@ function Home() {
 ([#1860](https://github.com/facebook/Docusaurus/issues/1860))
 
 ### Bug Fixes
+- Fix MDX `@theme/Heading` component. If there is no id, it should not create anchor link.
 - Fixed a bug in which if `themeConfig.algolia` is not defined, the custom searchbar won't appear.
 If you've swizzled Algolia `SearchBar` component before, please update your source code otherwise CSS might break. See [#1909](https://github.com/facebook/docusaurus/pull/1909/files) for reference.
 ```js

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.js
@@ -11,14 +11,19 @@ import React from 'react';
 
 import './styles.css';
 
-const Heading = Tag => ({id, ...props}) => (
-  <Tag {...props}>
-    <a aria-hidden="true" className="anchor" id={id} />
-    <a aria-hidden="true" className="hash-link" href={`#${id}`}>
-      #
-    </a>
-    {props.children}
-  </Tag>
-);
+const Heading = Tag => ({id, ...props}) => {
+  if (!id) {
+    return <Tag {...props} />;
+  }
+  return (
+    <Tag {...props}>
+      <a aria-hidden="true" className="anchor" id={id} />
+      <a aria-hidden="true" className="hash-link" href={`#${id}`}>
+        #
+      </a>
+      {props.children}
+    </Tag>
+  );
+};
 
 export default Heading;


### PR DESCRIPTION
## Motivation

Fix MDX `@theme/Heading` component. If there is no id, it should not create anchor link.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Before
<img width="829" alt="before" src="https://user-images.githubusercontent.com/17883920/67966089-cdef7780-fc35-11e9-866a-868edae0940e.PNG">

After
<img width="825" alt="after" src="https://user-images.githubusercontent.com/17883920/67966096-d21b9500-fc35-11e9-9e19-13ae870c9f0b.PNG">
