### PR TITLE
fix(v2): allows to create tabs with only one item

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
@@ -13,10 +13,6 @@ function Tabs(props) {
   const {block, children, defaultValue, values} = props;
   const [selectedValue, setSelectedValue] = useState(defaultValue);
 
-  const selectedTabItem = React.Children.toArray(children).filter(
-    child => child.props.value === selectedValue,
-  )[0];
-
   return (
     <div>
       <ul
@@ -34,7 +30,9 @@ function Tabs(props) {
           </li>
         ))}
       </ul>
-      <div className="margin-vert--md">{selectedTabItem}</div>
+      <div className="margin-vert--md">
+        {[...children].filter(child => child.props.value === selectedValue)[0]}
+      </div>
     </div>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
@@ -13,6 +13,10 @@ function Tabs(props) {
   const {block, children, defaultValue, values} = props;
   const [selectedValue, setSelectedValue] = useState(defaultValue);
 
+  const selectedTabItem = React.Children.toArray(children).filter(
+    child => child.props.value === selectedValue,
+  )[0];
+
   return (
     <div>
       <ul
@@ -30,9 +34,7 @@ function Tabs(props) {
           </li>
         ))}
       </ul>
-      <div className="margin-vert--md">
-        {children.filter(child => child.props.value === selectedValue)[0]}
-      </div>
+      <div className="margin-vert--md">{selectedTabItem}</div>
     </div>
   );
 }


### PR DESCRIPTION
It was not possible to have tabs containing only one tab item, so the code below crashed

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I want to have consistent code blocks around my docs (so that single-file code snippets have the same filename title as multi-file snippets).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1) Build
2) Create a new `md` file
3) Use `Tabs` with single child.

```
<Tabs
    defaultValue="SomeFile.js"
    values={[
        { label: "SomeFile.js", value: "SomeFile.js" }
    ]}
>
<TabItem value="SomeFile.js">
    Tab content
</TabItem>
</Tabs>
```
