### PR TITLE
fix(v2): add missing key prop in footer items with HTML

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -62,9 +62,10 @@ function Footer() {
                 Array.isArray(linkItem.items) &&
                 linkItem.items.length > 0 ? (
                   <ul className="footer__items">
-                    {linkItem.items.map(item =>
+                    {linkItem.items.map((item, key) =>
                       item.html ? (
                         <div
+                          key={key}
                           dangerouslySetInnerHTML={{
                             __html: item.html,
                           }}


### PR DESCRIPTION
## Motivation

My fault, forgot to add this prop :man_facepalming: . _Since the associated change has not been released yet, there is no need to document it in the changelog_.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

React warnings removed.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
