### PR TITLE
fix(v2): fix browser window background

### DIFF
--- a/website/src/components/BrowserWindow/styles.module.css
+++ b/website/src/components/BrowserWindow/styles.module.css
@@ -1,12 +1,12 @@
 .browserWindow {
-  border: 3px solid var(--ifm-color-emphasis-alpha-10);
+  border: 3px solid var(--ifm-color-emphasis-200);
   border-top-left-radius: var(--ifm-global-radius);
   border-top-right-radius: var(--ifm-global-radius);
 }
 
 .browserWindowHeader {
   align-items: center;
-  background: var(--ifm-color-emphasis-alpha-10);
+  background: var(--ifm-color-emphasis-200);
   display: flex;
   padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
## Motivation

Probably some custom properties have been removed due to the Infima update, so the browser window lost the background on website of v2.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/68094459-9e4ca380-feb1-11e9-8dca-2c833f7ade54.png) |  ![image](https://user-images.githubusercontent.com/4408379/68094458-9bea4980-feb1-11e9-8c45-ea22d5dac55e.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
