### PR TITLE
fix(v2): hash-link should not be cut-off in doc container

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -4,6 +4,7 @@
 
 - **HOTFIX for 2.0.0-alpha.32** - Fix build compilation if exists only one code tab.
 - Add table of contents highlighting on scroll.
+- Add minor padding to docs container so that hash-link won't be cut off.
 - **BREAKING** `prismTheme` is renamed to `theme` as part new `prism` object in `themeConfig` field in your `docusaurus.config.js`. Eg: 
   ```diff
    themeConfig: {

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -19,6 +19,7 @@
 
 .docItemContainer {
   margin: 0 auto;
+  padding: 0 0.5rem;
   max-width: 45em;
 }
 
@@ -34,4 +35,8 @@
   .tableOfContents {
     display: none;
   }
+
+  .docItemContainer {
+  padding: 0 0.3rem;
+}
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -37,6 +37,6 @@
   }
 
   .docItemContainer {
-  padding: 0 0.3rem;
-}
+    padding: 0 0.3rem;
+  }
 }


### PR DESCRIPTION
## Motivation

Hash link is cut off especially on left side. Not sure what's the best padding value should be. Or should we use margin instead ? Do we need to pad right too ?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Mobile
Before vs After
<img width="294" alt="before-mobile" src="https://user-images.githubusercontent.com/17883920/68273519-3d7fbf80-0099-11ea-9900-6bd656fa2392.PNG"> <img width="257" alt="after-mobile" src="https://user-images.githubusercontent.com/17883920/68273524-46709100-0099-11ea-8eeb-5599824d7c52.PNG">

Desktop

Before

<img width="935" alt="before-desktop" src="https://user-images.githubusercontent.com/17883920/68273518-3d7fbf80-0099-11ea-8414-a87729aeefff.png">

After
<img width="931" alt="after-padding" src="https://user-images.githubusercontent.com/17883920/68273525-46709100-0099-11ea-9f64-f29b8594de22.png">
