### PR TITLE
fix(v2): fix chokidar/watcher does not trigger reload on windows

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix watcher does not trigger reload on windows.
 - Add feed for blog posts.
 - **HOTFIX for 2.0.0-alpha.32** - Fix build compilation if exists only one code tab.
 - Add table of contents highlighting on scroll.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jest": "^24.9.0",
     "lerna": "^3.18.1",
     "lint-staged": "^7.2.0",
+    "picomatch": "^2.1.0",
     "prettier": "^1.18.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -7,7 +7,7 @@
 import fs from 'fs-extra';
 import _ from 'lodash';
 import path from 'path';
-import {normalizeUrl, docuHash} from '@docusaurus/utils';
+import {normalizeUrl, docuHash, posixPath} from '@docusaurus/utils';
 
 import {
   PluginOptions,
@@ -399,10 +399,8 @@ export default function pluginContentBlog(
 
       await Promise.all(
         feedTypes.map(feedType => {
-          const feedPath = path.join(
-            outDir,
-            options.routeBasePath,
-            `${feedType}.xml`,
+          const feedPath = posixPath(
+            path.join(outDir, options.routeBasePath, `${feedType}.xml`),
           );
           const feedContent = feedType === 'rss' ? feed.rss2() : feed.atom1();
           return fs.writeFile(feedPath, feedContent, err => {

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -7,7 +7,7 @@
 import fs from 'fs-extra';
 import _ from 'lodash';
 import path from 'path';
-import {normalizeUrl, docuHash, posixPath} from '@docusaurus/utils';
+import {normalizeUrl, docuHash} from '@docusaurus/utils';
 
 import {
   PluginOptions,

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -399,8 +399,10 @@ export default function pluginContentBlog(
 
       await Promise.all(
         feedTypes.map(feedType => {
-          const feedPath = posixPath(
-            path.join(outDir, options.routeBasePath, `${feedType}.xml`),
+          const feedPath = path.join(
+            outDir,
+            options.routeBasePath,
+            `${feedType}.xml`,
           );
           const feedContent = feedType === 'rss' ? feed.rss2() : feed.atom1();
           return fs.writeFile(feedPath, feedContent, err => {

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -107,6 +107,8 @@ describe('simple website', () => {
     expect(isMatch('docs/mdx', matchPattern)).toEqual(false);
     expect(isMatch('sidebars.json', matchPattern)).toEqual(true);
     expect(isMatch('versioned_docs/hello.md', matchPattern)).toEqual(false);
+    expect(isMatch('hello.md', matchPattern)).toEqual(false);
+    expect(isMatch('super/docs/hello.md', matchPattern)).toEqual(false);
   });
 
   test('configureWebpack', async () => {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -36,7 +36,7 @@ import {Configuration} from 'webpack';
 const DEFAULT_OPTIONS: PluginOptions = {
   path: 'docs', // Path to data on filesystem, relative to site dir.
   routeBasePath: 'docs', // URL Route.
-  include: ['**/*.md', '**/*.mdx'], // Extensions to include.
+  include: ['**/*.{md,mdx}'], // Extensions to include.
   sidebarPath: '', // Path to sidebar configuration for showing a list of markdown pages.
   docLayoutComponent: '@theme/DocPage',
   docItemComponent: '@theme/DocItem',

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -25,6 +25,8 @@ describe('load utils', () => {
       '\\\\?\\c:\\aaaa\\bbbb': '\\\\?\\c:\\aaaa\\bbbb',
       'c:\\aaaa\\bbbb': 'c:/aaaa/bbbb',
       'foo\\bar': 'foo/bar',
+      'foo\\bar/lol': 'foo/bar/lol',
+      'website\\docs/**/*.{md,mdx}': 'website/docs/**/*.{md,mdx}',
     };
     Object.keys(asserts).forEach(file => {
       expect(posixPath(file)).toBe(asserts[file]);

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -21,6 +21,7 @@ import merge from 'webpack-merge';
 import HotModuleReplacementPlugin from 'webpack/lib/HotModuleReplacementPlugin';
 import {load} from '../server';
 import {StartCLIOptions} from '@docusaurus/types';
+import {posixPath} from '@docusaurus/utils';
 import {CONFIG_FILE_NAME, STATIC_DIR_NAME, DEFAULT_PORT} from '../constants';
 import {createClientConfig} from '../webpack/client';
 import {applyConfigureWebpack} from '../webpack/utils';
@@ -54,9 +55,9 @@ export async function start(
 
   const normalizeToSiteDir = filepath => {
     if (filepath && path.isAbsolute(filepath)) {
-      return path.relative(siteDir, filepath);
+      return posixPath(path.relative(siteDir, filepath));
     }
-    return filepath;
+    return posixPath(filepath);
   };
 
   const pluginPaths: string[] = _.compact(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11972,6 +11972,11 @@ picomatch@^2.0.4, picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
+picomatch@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.0.tgz#0fd042f568d08b1ad9ff2d3ec0f0bfb3cb80e177"
+  integrity sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw==
+
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"


### PR DESCRIPTION
## Motivation

Chokidar uses glob pattern, and glob pattern must not contain window backslashes

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Newly added tests pass. 
