### PR TITLE
fix(v2): babel/env should pick correct browserslist config in dev

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix babel/env not picking the correct browserslist configuration during development. When running `docusaurus start`, process.env.NODE_ENV is now consistently set to `development` instead of `undefined` (previously).
 - Ensure routes config generation to be more consistent in ordering. Nested routes should be placed last in routes.js. This will allow user to create `src/pages/docs.js` to create custom docs page for `/docs` or even `src/pages/docs/super.js` to create page for `/docs/super/`;
 - Fix watcher does not trigger reload on windows.
 - Add feed for blog posts.

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix babel/env not picking the correct browserslist configuration during development. When running `docusaurus start`, process.env.NODE_ENV is now consistently set to `development` instead of `undefined` (previously).
+- Fix babel/env not picking the correct browserslist configuration during development. When running `docusaurus start`, `process.env.NODE_ENV` is now consistently set to `development`.
 - Ensure routes config generation to be more consistent in ordering. Nested routes should be placed last in routes.js. This will allow user to create `src/pages/docs.js` to create custom docs page for `/docs` or even `src/pages/docs/super.js` to create page for `/docs/super/`;
 - Fix watcher does not trigger reload on windows.
 - Add feed for blog posts.

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -48,6 +48,7 @@ export async function build(
   siteDir: string,
   cliOptions: Partial<BuildCLIOptions> = {},
 ): Promise<void> {
+  process.env.BABEL_ENV = 'production';
   process.env.NODE_ENV = 'production';
   console.log(chalk.blue('Creating an optimized production build...'));
 

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -40,6 +40,8 @@ export async function start(
   siteDir: string,
   cliOptions: Partial<StartCLIOptions> = {},
 ): Promise<void> {
+  process.env.NODE_ENV = 'development';
+  process.env.BABEL_ENV = 'development';
   console.log(chalk.blue('Starting the development server...'));
 
   // Process all related files as a prop.


### PR DESCRIPTION
## Motivation

- Fix babel/env not picking the correct browserslist configuration during development. When running `docusaurus start`, process.env.NODE_ENV is now consistently set to `development`.

This should remove unnecessary transform in dev, which means faster dev :)

This should also fix some edge cases behavior reported on Discord if user set their own NODE_ENV environment variable to production when running `docusaurus start` (they shouldn't do that).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Set babel/env options `debug` to true

Before. It uses production browserslist instead
<img width="640" alt="before" src="https://user-images.githubusercontent.com/17883920/68453821-456e6980-0229-11ea-9ff7-055090b0d8ce.PNG">

After
<img width="623" alt="after" src="https://user-images.githubusercontent.com/17883920/68453820-44d5d300-0229-11ea-84b2-942d1d0c6671.PNG">

PS: BABEL_ENV is also set. See https://github.com/facebook/create-react-app/pull/2382/