### PR TITLE
perf/fix(v2): more efficient hot reload & consistent filegen

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - More efficient hot reload & consistent generated file. 
+- Set babel `compact` options to `true` which removes "superfluous whitespace characters and line terminators.
 
 ## 2.0.0-alpha.33
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -1,6 +1,7 @@
 # Docusaurus 2 Changelog
 
 ## Unreleased
+- More efficient hot reload & consistent generated file. 
 
 ## 2.0.0-alpha.33
 

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -18,9 +18,6 @@ import {posixPath} from '@docusaurus/utils';
 const createFakeActions = (routeConfigs: RouteConfig[], contentDir) => {
   return {
     addRoute: (config: RouteConfig) => {
-      config.routes.sort((a, b) =>
-        a.path > b.path ? 1 : b.path > a.path ? -1 : 0,
-      );
       routeConfigs.push(config);
     },
     createData: async (name, _content) => {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -8,7 +8,12 @@
 import globby from 'globby';
 import fs from 'fs-extra';
 import path from 'path';
-import {idx, normalizeUrl, docuHash} from '@docusaurus/utils';
+import {
+  idx,
+  normalizeUrl,
+  docuHash,
+  objectWithKeySorted,
+} from '@docusaurus/utils';
 import {LoadContext, Plugin} from '@docusaurus/types';
 
 import createOrder from './order';
@@ -202,7 +207,7 @@ export default function pluginContentDocs(
         docsDir,
         docsSidebars,
         sourceToPermalink,
-        permalinkToSidebar,
+        permalinkToSidebar: objectWithKeySorted(permalinkToSidebar),
       };
     },
 
@@ -252,7 +257,9 @@ export default function pluginContentDocs(
       addRoute({
         path: docsBaseRoute,
         component: docLayoutComponent,
-        routes,
+        routes: routes.sort((a, b) =>
+          a.path > b.path ? 1 : b.path > a.path ? -1 : 0,
+        ),
         modules: {
           docsMetadata: aliasedSource(docsBaseMetadataPath),
         },

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -15,6 +15,7 @@ import {
   getSubFolder,
   normalizeUrl,
   posixPath,
+  objectWithKeySorted,
 } from '../index';
 
 describe('load utils', () => {
@@ -80,6 +81,41 @@ describe('load utils', () => {
     Object.keys(asserts).forEach(file => {
       expect(fileToPath(file)).toBe(asserts[file]);
     });
+  });
+
+  test('objectWithKeySorted', () => {
+    const obj = {
+      '/docs/adding-blog': '4',
+      '/docs/versioning': '5',
+      '/': '1',
+      '/blog/2018': '3',
+      '/youtube': '7',
+      '/users/en/': '6',
+      '/blog': '2',
+    };
+    expect(objectWithKeySorted(obj)).toMatchInlineSnapshot(`
+      Object {
+        "/": "1",
+        "/blog": "2",
+        "/blog/2018": "3",
+        "/docs/adding-blog": "4",
+        "/docs/versioning": "5",
+        "/users/en/": "6",
+        "/youtube": "7",
+      }
+    `);
+    const obj2 = {
+      b: 'foo',
+      c: 'bar',
+      a: 'baz',
+    };
+    expect(objectWithKeySorted(obj2)).toMatchInlineSnapshot(`
+      Object {
+        "a": "baz",
+        "b": "foo",
+        "c": "bar",
+      }
+    `);
   });
 
   test('genChunkName', () => {

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -31,6 +31,15 @@ export async function generate(
   }
 }
 
+export function objectWithKeySorted(obj: Object) {
+  // https://github.com/lodash/lodash/issues/1459#issuecomment-253969771
+  return _(obj)
+    .toPairs()
+    .sortBy(0)
+    .fromPairs()
+    .value();
+}
+
 const indexRE = /(^|.*\/)index\.(md|js)$/i;
 const extRE = /\.(md|js)$/;
 

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -116,6 +116,7 @@ export async function load(siteDir: string): Promise<Props> {
     'registry.js',
     `export default {
 ${Object.keys(registry)
+  .sort()
   .map(
     key =>
       `  '${key}': [${registry[key].loader}, ${JSON.stringify(

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -89,6 +89,8 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
       {
         babelrc: false,
         configFile: false,
+        // All optional newlines and whitespace will be omitted when generating code in compact mode
+        compact: true,
         presets: [
           isServer
             ? [


### PR DESCRIPTION
## Motivation

More efficient hot reload & consistent generated file

Note that I set `clientLogLevel` to `info` in devserver config.

Previously, if we start development server and go to home page. We can go to `src/pages/index.js` and just 'save' without changing anything

<img width="323" alt="many are recompiled" src="https://user-images.githubusercontent.com/17883920/68463451-3a273800-0241-11ea-95e9-84e93a397255.PNG">

GIF Preview
![Nothing changed but lot of recompile](https://user-images.githubusercontent.com/17883920/68463640-b0c43580-0241-11ea-912e-4fd5c9d4aeaf.gif)


Note that there are several files that got disposed by WDS. This is because our generated files (although we have caching in https://github.com/facebook/docusaurus/blob/87f864e5bafb25debc9aafbd16cb51e051ec7e4b/packages/docusaurus-utils/src/index.ts#L15-L32), is re-written due to different object keys ordering.

Explanation
```js
{
'a': 'foo',
'b': 'bar',
}
```

Is considered different from
```js
{
'b': 'bar',
'a': 'foo',
}
```

The generated files can be different because of async nature and keys ordering. We should always provide consistent file generation.

Others:
- set babel compact to true which removes "superfluous whitespace characters and line terminators  https://stackoverflow.com/questions/35192796/babel-note-the-code-generator-has-deoptimised-the-styling-of-app-js-as-it-exc/36880182

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

After this PR
<img width="342" alt="consistent" src="https://user-images.githubusercontent.com/17883920/68463664-bd488e00-0241-11ea-8ce6-c116e8d0802b.png">

GIF preview
![Nothing changed](https://user-images.githubusercontent.com/17883920/68463660-bae63400-0241-11ea-8eff-17215d2fb36d.gif)

I tried editing the src/pages/index.js for real and its the right behavior
<img width="331" alt="correct behavior" src="https://user-images.githubusercontent.com/17883920/68463808-04cf1a00-0242-11ea-84e9-c245d8d6d3b3.PNG">

Index.js is detected to have changed, so it is disposed. Registry need to be dispsoed because index.js has changed, and so on.

## Extra: Notice the hot reload performance is much faster :)
