### PR TITLE
breaking(v2): editUrl should point to website instead of docsDir

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -80,7 +80,7 @@ describe('processMetadata', () => {
 
   test('docs with editUrl', async () => {
     const editUrl =
-      'https://github.com/facebook/docusaurus/edit/master/website/docs/';
+      'https://github.com/facebook/docusaurus/edit/master/website';
     const source = path.join('foo', 'baz.md');
     const data = await processMetadata({
       source,

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -7,7 +7,7 @@
 
 import fs from 'fs-extra';
 import path from 'path';
-import {parse, normalizeUrl} from '@docusaurus/utils';
+import {parse, normalizeUrl, posixPath} from '@docusaurus/utils';
 import {DocusaurusConfig} from '@docusaurus/types';
 
 import lastUpdate from './lastUpdate';
@@ -100,7 +100,10 @@ export default async function processMetadata({
   }
 
   if (editUrl) {
-    metadata.editUrl = normalizeUrl([editUrl, source]);
+    metadata.editUrl = normalizeUrl([
+      editUrl,
+      posixPath(path.relative(siteDir, filePath)),
+    ]);
   }
 
   if (metadata.custom_edit_url) {

--- a/website/docs/advanced-plugins.md
+++ b/website/docs/advanced-plugins.md
@@ -131,9 +131,9 @@ module.exports = {
          */
         path: 'docs',
         /**
-         * URL for editing docs, example: 'https://github.com/facebook/docusaurus/edit/master/website/docs/'
+         * URL for editing website repo, example: 'https://github.com/facebook/docusaurus/edit/master/website/'
          */
-        editUrl: 'https://github.com/repo/project/website/docs/',
+        editUrl: 'https://github.com/repo/project/website/',
         /**
          * URL route for the blog section of your site
          * do not include trailing slash

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -274,6 +274,8 @@ Deprecated. Create a `CNAME` file in your `static` folder instead with your cust
 
 #### `customDocsPath`, `docsUrl`, `editUrl`, `enableUpdateBy`, `enableUpdateTime`
 
+**BREAKING**: `editUrl` should point to (website) docusaurus project instead of `docs` directory. 
+
 Deprecated. Pass it as an option to `@docusaurus/preset-classic` docs instead:
 
 ```jsx {9-22}
@@ -287,9 +289,9 @@ module.exports = {
         docs: {
           // Equivalent to `customDocsPath`.
           path: 'docs',
-          // Equivalent to `editUrl`
+          // Equivalent to `editUrl` but should point to `website` dir instead of `website/docs`
           editUrl:
-            'https://github.com/facebook/docusaurus/edit/master/website/docs/',
+            'https://github.com/facebook/docusaurus/edit/master/website',
           // Equivalent to `docsUrl`.
           routeBasePath: 'docs',
           // Remark and Rehype plugins passed to MDX. Replaces `markdownOptions` and `markdownPlugins`.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -33,7 +33,7 @@ module.exports = {
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/facebook/docusaurus/edit/master/website/docs/',
+            'https://github.com/facebook/docusaurus/edit/master/website/',
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
         },


### PR DESCRIPTION
## Motivation

In v1, `editUrl` is pointing to `docsDir` and its always pointing to `next` for the edit.

Try https://docusaurus.io/docs/en/1.13.0/installation, notice the edit is for `next` docs only.

### This breaking changes makes people moving docs folder around easier. 
For example, if I renamed docs folder from `docs` to `document`. Before this PR i have to change the docs plugin path options from `docs` to `document` AND I HAVE to update my `editUrl` from https://github.com/facebook/docusaurus/edit/master/website/docs/ to https://github.com/facebook/docusaurus/edit/master/website/document/ as well. Double work.
After this PR, I only need to do it once

### It supports versioned_docs and translated_docs editUrl better in future
Since we can always resolve it based from website dir. Since we already have lot of aliasing through `@site`, it makes more sense to point it to `website` instead of `docsDir`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Updated test passes
- Netlify editUrl still works

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
