### PR TITLE
fix(v2): useTOC hooks should not be called in each nested children

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -64,7 +64,7 @@ function DocItem(props) {
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
 
   return (
-    <div>
+    <>
       <Head>
         {title && <title>{title}</title>}
         {description && <meta name="description" content={description} />}
@@ -168,7 +168,7 @@ function DocItem(props) {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -19,9 +19,18 @@ const LINK_CLASS_NAME = 'contents__link';
 const ACTIVE_LINK_CLASS_NAME = 'contents__link--active';
 const TOP_OFFSET = 100;
 
-function Headings({headings, isChild}) {
+function RightTOC({headings}) {
   useTOCHighlight(LINK_CLASS_NAME, ACTIVE_LINK_CLASS_NAME, TOP_OFFSET);
+  return (
+    <div className="col col--3">
+      <div className={styles.tableOfContents}>
+        <Headings headings={headings} />
+      </div>
+    </div>
+  );
+}
 
+function Headings({headings, isChild}) {
   if (!headings.length) return null;
   return (
     <ul className={isChild ? '' : 'contents contents__left-border'}>
@@ -155,13 +164,7 @@ function DocItem(props) {
                 </div>
               </div>
             </div>
-            {DocContent.rightToc && (
-              <div className="col col--3">
-                <div className={styles.tableOfContents}>
-                  <Headings headings={DocContent.rightToc} />
-                </div>
-              </div>
-            )}
+            {DocContent.rightToc && <RightTOC headings={DocContent.rightToc} />}
           </div>
         </div>
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -19,7 +19,7 @@ const LINK_CLASS_NAME = 'contents__link';
 const ACTIVE_LINK_CLASS_NAME = 'contents__link--active';
 const TOP_OFFSET = 100;
 
-function RightTOC({headings}) {
+function DocTOC({headings}) {
   useTOCHighlight(LINK_CLASS_NAME, ACTIVE_LINK_CLASS_NAME, TOP_OFFSET);
   return (
     <div className="col col--3">
@@ -164,7 +164,7 @@ function DocItem(props) {
                 </div>
               </div>
             </div>
-            {DocContent.rightToc && <RightTOC headings={DocContent.rightToc} />}
+            {DocContent.rightToc && <DocTOC headings={DocContent.rightToc} />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Motivation

TOC hooks is called inside each nested children previously. See gif below on how many `getActiveHeader` which leads to document query calls.

See recursive headings
https://github.com/facebook/docusaurus/blob/3be2e8654620c5d9d1b1f02c480966bcb9559096/packages/docusaurus-theme-classic/src/theme/DocItem/index.js#L22-L38

We should also do better in future by doing some throttling, but that's out of scope of this PR. 
We can also split RightTOC component as another `@theme/RightTOC` component so its swizzle-able if needed (but better in future PR so that lerna autogenerated changelog can pick it better)

![before call](https://user-images.githubusercontent.com/17883920/68587104-d149f500-04b8-11ea-9149-6a086560cb5d.gif)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Netlify
right toc still highlighted on scroll
- Less number of getActiveHeader calls
![after](https://user-images.githubusercontent.com/17883920/68587181-05251a80-04b9-11ea-85b4-0f111181a3a7.gif)
