### PR TITLE
fix(v2): remove empty containers when no data in blog pages

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.js
@@ -89,10 +89,10 @@ function BlogPostItem(props) {
       <article className="markdown">
         <MDXProvider components={MDXComponents}>{children}</MDXProvider>
       </article>
-      <div className="row margin-vert--lg">
-        <div className="col">
+      {(tags.length > 0 || truncated) && (
+        <div className="row margin-vert--lg">
           {tags.length > 0 && (
-            <>
+            <div className="col">
               <strong>Tags:</strong>
               {tags.map(({label, permalink: tagPermalink}) => (
                 <Link
@@ -102,17 +102,17 @@ function BlogPostItem(props) {
                   {label}
                 </Link>
               ))}
-            </>
+            </div>
           )}
-        </div>
-        <div className="col text--right">
           {truncated && (
-            <Link to={metadata.permalink}>
-              <strong>Read More</strong>
-            </Link>
+            <div className="col text--right">
+              <Link to={metadata.permalink}>
+                <strong>Read More</strong>
+              </Link>
+            </div>
           )}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.js
@@ -23,12 +23,14 @@ function BlogPostPage(props) {
               <BlogPostItem frontMatter={frontMatter} metadata={metadata}>
                 <BlogPostContents />
               </BlogPostItem>
-              <div className="margin-vert--xl">
-                <BlogPostPaginator
-                  nextItem={metadata.nextItem}
-                  prevItem={metadata.prevItem}
-                />
-              </div>
+              {(metadata.nextItem || metadata.prevItem) && (
+                <div className="margin-vert--xl">
+                  <BlogPostPaginator
+                    nextItem={metadata.nextItem}
+                    prevItem={metadata.prevItem}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Motivation

If there is no previous or next post, then extra space appears due to vertical margins. The same goes for the container with tags and read more link.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Extra spaces when empty content:

![image](https://user-images.githubusercontent.com/4408379/68631770-08da9080-04fd-11ea-8cbe-cd9277d4bc37.png)

![image](https://user-images.githubusercontent.com/4408379/68631784-1abc3380-04fd-11ea-8465-e3647725ef45.png)

No extra spaces:

![image](https://user-images.githubusercontent.com/4408379/68631797-2ad41300-04fd-11ea-8a0d-9d995f0e9b6e.png)

