### PR TITLE
feat(v2): add ability specify link in footer logo

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -11,6 +11,7 @@ import classnames from 'classnames';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from './styles.module.css';
 
 function FooterLink({item}) {
   const toUrl = useBaseUrl(item.to);
@@ -86,7 +87,21 @@ function Footer() {
           <div className="text--center">
             {logo && logo.src && (
               <div className="margin-bottom--sm">
-                <img className="footer__logo" alt={logo.alt} src={logoUrl} />
+                {logo.href ? (
+                  <a
+                    href={logo.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.footerLogoLink}>
+                    <img
+                      className="footer__logo"
+                      alt={logo.alt}
+                      src={logoUrl}
+                    />
+                  </a>
+                ) : (
+                  <img className="footer__logo" alt={logo.alt} src={logoUrl} />
+                )}
               </div>
             )}
             {copyright}

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -33,6 +33,10 @@ function FooterLink({item}) {
   );
 }
 
+const FooterLogo = ({url, alt}) => (
+  <img className="footer__logo" alt={alt} src={url} />
+);
+
 function Footer() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
@@ -93,14 +97,10 @@ function Footer() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className={styles.footerLogoLink}>
-                    <img
-                      className="footer__logo"
-                      alt={logo.alt}
-                      src={logoUrl}
-                    />
+                    <FooterLogo alt={logo.alt} url={logoUrl} />
                   </a>
                 ) : (
-                  <img className="footer__logo" alt={logo.alt} src={logoUrl} />
+                  <FooterLogo alt={logo.alt} url={logoUrl} />
                 )}
               </div>
             )}

--- a/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
@@ -1,0 +1,8 @@
+.footerLogoLink {
+  opacity: 0.5;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.footerLogoLink:hover {
+  opacity: 1;
+}

--- a/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .footerLogoLink {
   opacity: 0.5;
   transition: opacity 0.15s ease-in-out;

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -175,6 +175,7 @@ module.exports = {
       logo: {
         alt: 'Facebook Open Source Logo',
         src: 'https://docusaurus.io/img/oss_logo.png',
+        href: 'https://opensource.facebook.com/',
       },
       copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
     },
@@ -274,7 +275,7 @@ Deprecated. Create a `CNAME` file in your `static` folder instead with your cust
 
 #### `customDocsPath`, `docsUrl`, `editUrl`, `enableUpdateBy`, `enableUpdateTime`
 
-**BREAKING**: `editUrl` should point to (website) docusaurus project instead of `docs` directory. 
+**BREAKING**: `editUrl` should point to (website) docusaurus project instead of `docs` directory.
 
 Deprecated. Pass it as an option to `@docusaurus/preset-classic` docs instead:
 
@@ -290,8 +291,7 @@ module.exports = {
           // Equivalent to `customDocsPath`.
           path: 'docs',
           // Equivalent to `editUrl` but should point to `website` dir instead of `website/docs`
-          editUrl:
-            'https://github.com/facebook/docusaurus/edit/master/website',
+          editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
           // Equivalent to `docsUrl`.
           routeBasePath: 'docs',
           // Remark and Rehype plugins passed to MDX. Replaces `markdownOptions` and `markdownPlugins`.


### PR DESCRIPTION
## Motivation

Often the logo in the footer points to the vendor of this site, so you need the ability to set a link. An example is React Native - https://facebook.github.io/react-native/
This PR implements the same behavior with opacity prop.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Set the external link in `themeConfig.footer.logo.href` and see that the logo has become clickable.
