### PR TITLE
fix(v2): remove duplicate meta tags

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -39,9 +39,7 @@ function Layout(props) {
   return (
     <>
       <Head>
-        <meta charSet="utf-8" />
         <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-        <meta name="viewport" content="width=device-width" />
         {metaTitle && <title>{metaTitle}</title>}
         {metaTitle && <meta property="og:title" content={metaTitle} />}
         {favicon && <link rel="shortcut icon" href={faviconUrl} />}


### PR DESCRIPTION
## Motivation

These two meta tags are already defined in the template:

https://github.com/facebook/docusaurus/blob/b027db1b346d928255d3f0205059f9cab10417b0/packages/docusaurus/src/client/templates/ssr.html.template.js#L12-L13

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See build.
