### PR TITLE
refactor(v2): simplify blog truncate function

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -7,11 +7,7 @@ import {parse, normalizeUrl} from '@docusaurus/utils';
 import {LoadContext} from '@docusaurus/types';
 
 export function truncate(fileString: string, truncateMarker: RegExp | string) {
-  const truncated =
-    typeof truncateMarker === 'string'
-      ? fileString.includes(truncateMarker)
-      : truncateMarker.test(fileString);
-  return truncated ? fileString.split(truncateMarker)[0] : fileString;
+  return fileString.split(truncateMarker, 1).shift() || fileString;
 }
 
 // YYYY-MM-DD-{name}.mdx?

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -7,7 +7,7 @@ import {parse, normalizeUrl} from '@docusaurus/utils';
 import {LoadContext} from '@docusaurus/types';
 
 export function truncate(fileString: string, truncateMarker: RegExp | string) {
-  return fileString.split(truncateMarker, 1).shift() || fileString;
+  return fileString.split(truncateMarker, 1).shift()!;
 }
 
 // YYYY-MM-DD-{name}.mdx?


### PR DESCRIPTION
## Motivation

Simplify blog truncate function. This should be faster because we're passing `limit` to split function and less code to execute lol

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Edit blog file

With truncate marker, read more still showed
<img width="775" alt="read more" src="https://user-images.githubusercontent.com/17883920/68648618-5eda2300-0553-11ea-989b-73786b0253ed.PNG">

Without truncate marker, show all
<img width="772" alt="remove truncate marker" src="https://user-images.githubusercontent.com/17883920/68648619-5eda2300-0553-11ea-9723-db018e127ee5.PNG">
