### PR TITLE
fix(v2): remove invalid attributes of nav links

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -21,23 +21,22 @@ import useTheme from '@theme/hooks/useTheme';
 
 import styles from './styles.module.css';
 
-function NavLink(props) {
-  const toUrl = useBaseUrl(props.to);
+function NavLink({to, href, label}) {
+  const toUrl = useBaseUrl(to);
   return (
     <Link
       className="navbar__item navbar__link"
-      {...props}
-      {...(props.href
+      {...(href
         ? {
             target: '_blank',
             rel: 'noopener noreferrer',
-            href: props.href,
+            href,
           }
         : {
             activeClassName: 'navbar__link--active',
             to: toUrl,
           })}>
-      {props.label}
+      {label}
     </Link>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -21,7 +21,7 @@ import useTheme from '@theme/hooks/useTheme';
 
 import styles from './styles.module.css';
 
-function NavLink({to, href, label}) {
+function NavLink({to, href, label, position, ...props}) {
   const toUrl = useBaseUrl(to);
   return (
     <Link
@@ -35,7 +35,8 @@ function NavLink({to, href, label}) {
         : {
             activeClassName: 'navbar__link--active',
             to: toUrl,
-          })}>
+          })}
+      {...props}>
       {label}
     </Link>
   );


### PR DESCRIPTION
## Motivation

Currently, because that all props are passed to `NavLink`, navigation links have two invalid attributes - `label` and `position`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before:

```html
<a class="navbar__item navbar__link" label="Docs" position="left" href="/docs/introduction">Docs</a>
```

After:

```html
<a class="navbar__item navbar__link" href="/docs/introduction">Docs</a>
```