### PR TITLE
fix(v2): move header inside article tag in doc page

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -86,12 +86,13 @@ function DocItem(props) {
           <div className="row">
             <div className="col">
               <div className={styles.docItemContainer}>
-                {!metadata.hide_title && (
-                  <header>
-                    <h1 className={styles.docTitle}>{metadata.title}</h1>
-                  </header>
-                )}
                 <article>
+                  {!metadata.hide_title && (
+                    <header>
+                      <h1 className={styles.docTitle}>{metadata.title}</h1>
+                    </header>
+                  )}
+
                   <div className="markdown">
                     <DocContent />
                   </div>


### PR DESCRIPTION
## Motivation

In terms of _semantics_, the `header` tag should be inside the `article` tag, rather not outside it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See HTML markup, no UI changes.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
