### PR TITLE
feat(v2): add aria-label to read more links for a11y

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.js
@@ -106,7 +106,9 @@ function BlogPostItem(props) {
           )}
           {truncated && (
             <div className="col text--right">
-              <Link to={metadata.permalink}>
+              <Link
+                to={metadata.permalink}
+                aria-label={`Read more about ${title}`}>
                 <strong>Read More</strong>
               </Link>
             </div>


### PR DESCRIPTION
## Motivation

Screen readers need a more descriptive link name.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

