### PR TITLE
fix(v2): use regular div instead of main tag for wrapper layout page

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -59,7 +59,7 @@ function Layout(props) {
         <meta name="twitter:card" content="summary" />
       </Head>
       <Navbar />
-      <main className="main">{children}</main>
+      <div className="main-wrapper">{children}</div>
       {!noFooter && <Footer />}
     </>
   );

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -22,6 +22,6 @@ body > div {
   flex-direction: column;
 }
 
-.main {
+.main-wrapper {
   flex: 1 0 auto;
 }


### PR DESCRIPTION
## Motivation

Now I just noticed that the `main` tag is already used in the [template](https://github.com/facebook/docusaurus/blob/7714afb00f837ebead0328526779bc20f3b6885f/packages/docusaurus-theme-classic/src/theme/DocPage/index.js), so it makes sense to replace it with a regular div.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See HTML markup, no changes UI.