### PR TITLE
perf(v2): reduce main bundle size ~7kbs by using es5 if possible

### DIFF
--- a/packages/docusaurus/src/client/PendingNavigation.js
+++ b/packages/docusaurus/src/client/PendingNavigation.js
@@ -63,7 +63,7 @@ class PendingNavigation extends React.Component {
           if (!hash) {
             window.scrollTo(0, 0);
           } else {
-            const id = hash.replace('#', '');
+            const id = hash.substring(1);
             const element = document.getElementById(id);
             if (element) element.scrollIntoView();
           }

--- a/packages/docusaurus/src/client/docusaurus.js
+++ b/packages/docusaurus/src/client/docusaurus.js
@@ -18,7 +18,7 @@ const isSlowConnection = () => {
   // if user is on slow or constrained connection
   if (`connection` in navigator) {
     if (
-      (navigator.connection.effectiveType || ``).includes(`2g`) &&
+      (navigator.connection.effectiveType || ``).indexOf(`2g`) !== -1 &&
       navigator.connection.saveData
     ) {
       return true;
@@ -55,8 +55,7 @@ const docusaurus = {
       const chunkAssets = window.__chunkMapping[chunkName] || [];
       return arr.concat(chunkAssets);
     }, []);
-    const dedupedChunkAssets = Array.from(new Set(chunkAssetsNeeded));
-    Promise.all(dedupedChunkAssets.map(prefetchHelper)).then(() => {
+    Promise.all(chunkAssetsNeeded.map(prefetchHelper)).then(() => {
       fetched[routePath] = true;
     });
     return true;


### PR DESCRIPTION
## Motivation

Smaller bundle size while achieving same functionality. Avoiding cool syntax in main bundle like es6.string.includes (use indexOf instead) and es6.regexp.replace etc. This is because core-js and babel will try to polyfill.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

**Before 228.21kb**
<img width="960" alt="228 21kb" src="https://user-images.githubusercontent.com/17883920/68741531-7501e500-0620-11ea-98f9-66669d69cf5a.PNG">

**After 221.36kb**
<img width="956" alt="after 221kb" src="https://user-images.githubusercontent.com/17883920/68741533-7501e500-0620-11ea-905c-cee607e1b7dd.PNG">