### PR TITLE
fix(v2): remove invalid label attribute of footer links

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -18,7 +18,6 @@ function FooterLink({to, href, label, ...props}) {
   return (
     <Link
       className="footer__link-item"
-      {...props}
       {...(href
         ? {
             target: '_blank',
@@ -27,7 +26,8 @@ function FooterLink({to, href, label, ...props}) {
           }
         : {
             to: toUrl,
-          })}>
+          })}
+      {...props}>
       {label}
     </Link>
   );

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -13,22 +13,21 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
 
-function FooterLink({item}) {
-  const toUrl = useBaseUrl(item.to);
+function FooterLink({to, href, label}) {
+  const toUrl = useBaseUrl(to);
   return (
     <Link
       className="footer__link-item"
-      {...item}
-      {...(item.href
+      {...(href
         ? {
             target: '_blank',
             rel: 'noopener noreferrer',
-            href: item.href,
+            href,
           }
         : {
             to: toUrl,
           })}>
-      {item.label}
+      {label}
     </Link>
   );
 }
@@ -77,7 +76,7 @@ function Footer() {
                         />
                       ) : (
                         <li key={item.href || item.to} className="footer__item">
-                          <FooterLink item={item} />
+                          <FooterLink {...item} />
                         </li>
                       ),
                     )}

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -13,11 +13,12 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
 
-function FooterLink({to, href, label}) {
+function FooterLink({to, href, label, ...props}) {
   const toUrl = useBaseUrl(to);
   return (
     <Link
       className="footer__link-item"
+      {...props}
       {...(href
         ? {
             target: '_blank',


### PR DESCRIPTION
# Motivation

A continuation of #1974. This is relevant  only for external links.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before:

```html
<a class="footer__link-item" label="Stack Overflow" href="https://stackoverflow.com/questions/tagged/docusaurus" target="_blank" rel="noopener noreferrer">Stack Overflow</a>
```

After (without `label`):

```html
<a class="footer__link-item" target="_blank" rel="noopener noreferrer" href="https://stackoverflow.com/questions/tagged/docusaurus">Stack Overflow</a>
```
