### PR TITLE
fix(v2): remove obsolete iframe attributes

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -85,11 +85,10 @@ function Home() {
               to={useBaseUrl('docs/introduction')}>
               Get Started
             </Link>
-            <span className={styles.indexCtasGitHubButton}>
+            <span className={styles.indexCtasGitHubButtonWrapper}>
               <iframe
+                className={styles.indexCtasGitHubButton}
                 src="https://ghbtns.com/github-btn.html?user=facebook&amp;repo=docusaurus&amp;type=star&amp;count=true&amp;size=large"
-                frameBorder={0}
-                scrolling={0}
                 width={160}
                 height={30}
                 title="GitHub Stars"

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -121,8 +121,13 @@
   padding: 18px 36px;
 }
 
-.indexCtasGitHubButton {
+.indexCtasGitHubButtonWrapper {
   vertical-align: sub;
+}
+
+.indexCtasGitHubButton {
+  border: none;
+  overflow: hidden;
 }
 
 @media only screen and (max-width: 768px) {


### PR DESCRIPTION
## Motivation

The `frameborder` and `scrolling` attributes on the `iframe` element is obsolete. Use CSS instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No UI changes.
