### PR TITLE
refactor(v2): replace h1 tag with h2 in blog list pages

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.js
@@ -26,6 +26,7 @@ function BlogPostItem(props) {
   const {author, authorURL, authorTitle, authorFBID, title} = frontMatter;
 
   const renderPostHeader = () => {
+    const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
     const match = date.substring(0, 10).split('-');
     const year = match[0];
     const month = [
@@ -50,9 +51,10 @@ function BlogPostItem(props) {
 
     return (
       <header>
-        <h1 className={classnames('margin-bottom--sm', styles.blogPostTitle)}>
+        <TitleHeading
+          className={classnames('margin-bottom--sm', styles.blogPostTitle)}>
           {isBlogPostPage ? title : <Link to={permalink}>{title}</Link>}
-        </h1>
+        </TitleHeading>
         <div className="margin-bottom--sm">
           <time dateTime={date} className={styles.blogPostDate}>
             {month} {day}, {year}


### PR DESCRIPTION

## Motivation

A continuation of #1962. 

The `h1` tag should always be one on a page, so only `h2` should be used in posts lists.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See HTML markup, no UI changes.
