### PR TITLE
docs(v2): fix syntax highlighting for YML code blocks

### DIFF
--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -23,7 +23,7 @@ To publish in the blog, create a file within the blog directory with a formatted
 
 For example, at `my-website/blog/2019-09-05-hello-docusaurus-v2.md`:
 
-```md
+```yml
 ---
 title: Welcome Docusaurus v2
 author: Dattatreya Tripathy
@@ -32,7 +32,6 @@ authorURL: https://github.com/dt97
 authorTwitter: CuriousDT
 tags: [hello, docusaurus-v2]
 ---
-
 Welcome to this blog. This blog is created with [**Docusaurus 2 alpha**](https://v2.docusaurus.io/).
 
 <!--truncate-->
@@ -56,11 +55,10 @@ The only required field is `title`; however, we provide options to add author in
 
 Use the `<!--truncate-->` marker in your blog post to represent what will be shown as the summary when viewing all published blog posts. Anything above `<!--truncate-->` will be part of the summary. For example:
 
-```md {9}
+```yml
 ---
 title: Truncation Example
 ---
-
 All this will be part of the blog post summary.
 
 Even this.
@@ -101,7 +99,7 @@ module.exports = {
         blog: {
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`
+            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
           },
         },
       },

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -38,7 +38,7 @@ website # root directory of your site
 
 In the top of the file, specify `id` the `title` in the front matter, so that Docusaurus will pick them up correctly when generating your site.
 
-```markdown
+```yml
 ---
 id: greeting
 title: Hello
@@ -107,7 +107,7 @@ Documents use the following markdown header fields that are enclosed by a line `
 
 Example:
 
-```md
+```yml
 ---
 id: doc-markdown
 title: Markdown Features

--- a/website/docs/sidebar.md
+++ b/website/docs/sidebar.md
@@ -91,11 +91,10 @@ website # root directory of your site
 
 However, the last part of the `id` can be defined by user in the frontmatter. For example, if `guide/hello.md` content is defined as below, it's final `id` is `guide/part1`.
 
-```md
+```yml
 ---
 id: part1
 ---
-
 Lorem ipsum
 ```
 


### PR DESCRIPTION
## Motivation

Some blocks of code with YML are marked as Markdown-code, which is incorrect and needs to be fixed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

