### PR TITLE
refactor(v2): make better a11y for tabs

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
@@ -9,28 +9,77 @@ import React, {useState, Children} from 'react';
 
 import classnames from 'classnames';
 
+import styles from './styles.module.css';
+
+const keys = {
+  left: 37,
+  right: 39,
+};
+
 function Tabs(props) {
   const {block, children, defaultValue, values} = props;
   const [selectedValue, setSelectedValue] = useState(defaultValue);
+  const tabRefs = [];
+
+  const focusNextTab = (tabs, target) => {
+    const next = tabs.indexOf(target) + 1;
+
+    if (!tabs[next]) {
+      tabs[0].focus();
+    } else {
+      tabs[next].focus();
+    }
+  };
+
+  const focusPreviousTab = (tabs, target) => {
+    const prev = tabs.indexOf(target) - 1;
+
+    if (!tabs[prev]) {
+      tabs[tabs.length - 1].focus();
+    } else {
+      tabs[prev].focus();
+    }
+  };
+
+  const handleKeydown = (tabs, target, event) => {
+    switch (event.keyCode) {
+      case keys.right:
+        focusNextTab(tabs, target);
+        break;
+      case keys.left:
+        focusPreviousTab(tabs, target);
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
     <div>
       <ul
+        role="tablist"
+        aria-orientation="horizontal"
         className={classnames('tabs', {
           'tabs--block': block,
         })}>
         {values.map(({value, label}) => (
           <li
-            className={classnames('tab-item', {
+            role="tab"
+            tabIndex="0"
+            aria-selected={selectedValue === value}
+            className={classnames('tab-item', styles.tabItem, {
               'tab-item--active': selectedValue === value,
             })}
             key={value}
+            ref={tabControl => tabRefs.push(tabControl)}
+            onKeyDown={event => handleKeydown(tabRefs, event.target, event)}
+            onFocus={() => setSelectedValue(value)}
             onClick={() => setSelectedValue(value)}>
             {label}
           </li>
         ))}
       </ul>
-      <div className="margin-vert--md">
+      <div role="tabpanel" className="margin-vert--md">
         {
           Children.toArray(children).filter(
             child => child.props.value === selectedValue,

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
@@ -1,0 +1,9 @@
+.tabItem:hover,
+.tabItem:active,
+.tabItem:focus {
+  outline: 0;
+}
+
+.tabItem:focus {
+  background-color: var(--ifm-hover-overlay);
+}

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
@@ -1,8 +1,9 @@
-.tabItem:hover,
-.tabItem:active,
-.tabItem:focus {
-  outline: 0;
-}
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 .tabItem:focus {
   background-color: var(--ifm-hover-overlay);


### PR DESCRIPTION
## Motivation

Tabs cannot be controlled from the keyboard at the moment, this is very bad for a11y.

This PR implements tab switching by Tab/Tab+Shift and arrow keys (left and right).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Additionally, I added an `onFocus` handler so as not to press the Enter button to open the content of the focusable tab. Because that the contents of all the tabs are already loaded, we can _immediately_ display the contents of focusable tab, it's very cool.

![AwesomeScreenshot-2019-11-14-1573727789043](https://user-images.githubusercontent.com/4408379/68852181-6f6fd200-06e8-11ea-9efd-baa39900d920.gif)

For comparison, an example without `onFocus`, where the user needs to press Enter to display the contents of focusable tab. I think in this case it is not very good for UX.

![AwesomeScreenshot-2019-11-14-1573728450969](https://user-images.githubusercontent.com/4408379/68852183-71399580-06e8-11ea-81a7-b17fe649f4fa.gif)

