### PR TITLE
fix(v2): remove accessible anchors  via keyboard

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.js
@@ -17,8 +17,8 @@ const Heading = Tag => ({id, ...props}) => {
   }
   return (
     <Tag {...props}>
-      <a aria-hidden="true" className="anchor" id={id} />
-      <a aria-hidden="true" className="hash-link" href={`#${id}`}>
+      <a aria-hidden="true" tabIndex="-1" className="anchor" id={id} />
+      <a aria-hidden="true" tabIndex="-1" className="hash-link" href={`#${id}`}>
         #
       </a>
       {props.children}


### PR DESCRIPTION
## Motivation

> ARIA hidden element must not contain focusable elements

Stop hidden anchors from being keyboard accessible, because now control via Tab is not obvious, since the anchors are hidden.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try switching to elements using Tab key, anchors should not get focus.