### PR TITLE
fix(v2): static phrasing content should be rendered correctly in TOC

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`non text phrasing content 1`] = `
+"export const rightToc = [
+	{
+		value: '<em>Emphasis</em>',
+		id: 'emphasis',
+		children: [
+			{
+				value: '<strong>Importance</strong>',
+				id: 'importance',
+				children: []
+			}
+		]
+	},
+	{
+		value: '<del>Strikethrough</del>',
+		id: 'strikethrough',
+		children: []
+	},
+	{
+		value: '<i>HTML</i>',
+		id: 'ihtmli',
+		children: []
+	},
+	{
+		value: '<code>inline.code()</code>',
+		id: 'inlinecode',
+		children: []
+	}
+];
+
+## _Emphasis_
+
+### **Importance**
+
+## ~~Strikethrough~~
+
+## <i>HTML</i>
+
+## \`inline.code()\`
+"
+`;

--- a/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/fixtures/non-text-content.mdx
+++ b/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/fixtures/non-text-content.mdx
@@ -1,0 +1,9 @@
+## *Emphasis*
+
+### **Importance**
+
+## ~~Strikethrough~~
+
+## <i>HTML</i>
+
+## `inline.code()`

--- a/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/index.test.js
+++ b/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/index.test.js
@@ -22,7 +22,12 @@ const processFixture = async (name, options) => {
   return result.toString();
 };
 
-test('no options', async () => {
+test('non text phrasing content', async () => {
+  const result = await processFixture('non-text-content');
+  expect(result).toMatchSnapshot();
+});
+
+test('text content', async () => {
   const result = await processFixture('just-content');
   expect(result).toMatchInlineSnapshot(`
 "export const rightToc = [

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -30,15 +30,18 @@ function DocTOC({headings}) {
   );
 }
 
+/* eslint-disable jsx-a11y/control-has-associated-label */
 function Headings({headings, isChild}) {
   if (!headings.length) return null;
   return (
     <ul className={isChild ? '' : 'contents contents__left-border'}>
       {headings.map(heading => (
         <li key={heading.id}>
-          <a href={`#${heading.id}`} className={LINK_CLASS_NAME}>
-            <div dangerouslySetInnerHTML={{__html: heading.value}} />
-          </a>
+          <a
+            href={`#${heading.id}`}
+            className={LINK_CLASS_NAME}
+            dangerouslySetInnerHTML={{__html: heading.value}}
+          />
           <Headings isChild headings={heading.children} />
         </li>
       ))}

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -37,7 +37,7 @@ function Headings({headings, isChild}) {
       {headings.map(heading => (
         <li key={heading.id}>
           <a href={`#${heading.id}`} className={LINK_CLASS_NAME}>
-            {heading.value}
+            <div dangerouslySetInnerHTML={{__html: heading.value}} />
           </a>
           <Headings isChild headings={heading.children} />
         </li>


### PR DESCRIPTION
## Motivation

TOC always render as string. Never putting the html markup.

Previously, only the textual content of headings was used to generate the entries in the Table of Contents. This lead to a bug (or feature?) where HTML in headings made entries in the TOC appear with literal HTML.

Example:
```md
## <i>hello</i>
```

Will be rendered as literal
![image](https://user-images.githubusercontent.com/17883920/68870619-bd5af900-072d-11ea-8bd7-3d1e1d19b477.png)

Other example is below. See that the right toc does not render the emphasis, etc

<img width="937" alt="before" src="https://user-images.githubusercontent.com/17883920/68870205-18d8b700-072d-11ea-99cf-8cb114fc40f7.PNG">

mdast has a concept of static phrasing content, which includes all the things that can appear in links. Instead of using just the textual content of a heading, this commit introduces a new behaviour where any static phrasing content, such as HTML, inline code, and emphasis, are copied over into the Table of Contents.


See test plan

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes


## Test Plan

After. See that its rendered correctly now
<img width="934" alt="after" src="https://user-images.githubusercontent.com/17883920/68870219-1f672e80-072d-11ea-95dd-78db64a40b5a.PNG">

- Newly added test passes
- Old test still passing
