### PR TITLE
fix(v2): throw error if first level item of a sidebar is not category

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-first-level-not-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-first-level-not-category.js
@@ -1,0 +1,13 @@
+module.exports = {
+  docs: [
+    {
+      type: 'category',
+      label: 'Getting Started',
+      items: ['greeting'],
+    },
+    {
+      type: 'doc',
+      id: 'api',
+    },
+  ],
+};

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
@@ -34,6 +34,16 @@ describe('loadSidebars', () => {
     );
   });
 
+  test('sidebars with first level not a category', async () => {
+    const sidebarPath = path.join(
+      fixtureDir,
+      'sidebars-first-level-not-category',
+    );
+    expect(() => loadSidebars(sidebarPath)).toThrowErrorMatchingInlineSnapshot(
+      `"Error loading {\\"type\\":\\"doc\\",\\"id\\":\\"api\\"}. First level item of a sidebar must be a category"`,
+    );
+  });
+
   test('sidebars with unknown sidebar item type', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-unknown-type.json');
     expect(() => loadSidebars(sidebarPath)).toThrowErrorMatchingInlineSnapshot(

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -39,6 +39,13 @@ function normalizeCategory(
   category: SidebarItemCategoryRaw,
   level = 0,
 ): SidebarItemCategory {
+  if (level === 0 && category.type !== 'category') {
+    throw new Error(
+      `Error loading ${JSON.stringify(
+        category,
+      )}. First level item of a sidebar must be a category`,
+    );
+  }
   assertItem(category, ['items', 'label']);
 
   if (!Array.isArray(category.items)) {


### PR DESCRIPTION
## Motivation

Close #1993

See that issue for more context

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Newly added test passes

