### PR TITLE
feat(v2): hide scrollbar of sidebar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -13,6 +13,7 @@
   border-right: 1px solid var(--ifm-contents-border-color);
   box-sizing: border-box;
   width: 300px;
+  display: flex;
 }
 
 .docMainContainer {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -12,6 +12,12 @@
     padding: 0.5rem;
     position: sticky;
     top: var(--ifm-navbar-height);
+    flex: 0 0 300px;
+    scrollbar-width: none;
+  }
+
+  .sidebar::-webkit-scrollbar {
+    width: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Motivation

I suggest hiding the scrollbar at the sidebar. It seems pretty obvious to me that the sidebar is a scrollable element, there are examples like https://webpack.js.org/concepts/ or https://reactjs.org/docs/getting-started.html where it's done the same way. The UI becomes much cleaner, there is no distracting scrollbar, the end user hovering over the sidebar area can easily find out that the sidebar is scrollable and scroll through the menu.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![AwesomeScreenshot-2019-11-15-1573768822232](https://user-images.githubusercontent.com/4408379/68899823-93accc80-0743-11ea-97e9-e537350dfc60.gif)


