### PR TITLE
fix(v2): remove hashbang when click on category

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import classnames from 'classnames';
 
 import Link from '@docusaurus/Link';
@@ -27,6 +27,11 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
     setCollapsed(item.collapsed);
   }
 
+  const handleClickItem = useCallback(e => {
+    e.preventDefault();
+    setCollapsed(state => !state);
+  });
+
   switch (type) {
     case 'category':
       return (
@@ -42,9 +47,7 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
                 'menu__link--active': collapsible && !item.collapsed,
               })}
               href="#!"
-              onClick={
-                collapsible ? () => setCollapsed(!collapsed) : undefined
-              }>
+              onClick={collapsible ? handleClickItem : undefined}>
               {label}
             </a>
             <ul className="menu__list">

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -27,7 +27,7 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
     setCollapsed(item.collapsed);
   }
 
-  const handleClickItem = useCallback(e => {
+  const handleItemClick = useCallback(e => {
     e.preventDefault();
     setCollapsed(state => !state);
   });
@@ -47,7 +47,7 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
                 'menu__link--active': collapsible && !item.collapsed,
               })}
               href="#!"
-              onClick={collapsible ? handleClickItem : undefined}>
+              onClick={collapsible ? handleItemClick : undefined}>
               {label}
             </a>
             <ul className="menu__list">


### PR DESCRIPTION
## Motivation

Currently, when you click on a category in the browser address bar, two characters "#!" (known as the hashbang) are added to the end of the URL. This is somewhat annoying and clogs the browser history.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Click on a category to expand it.
1. Look at the browser bar, the URL should **not** change
