### PR TITLE
fix(v2): fix browser window menu icon on smaller screen

### DIFF
--- a/website/src/components/BrowserWindow/styles.module.css
+++ b/website/src/components/BrowserWindow/styles.module.css
@@ -27,7 +27,7 @@
 }
 
 .browserWindowAddressBar {
-  flex: 1 0 auto;
+  flex: 1 0;
   margin-left: 0.5rem;
   margin-right: 1rem;
 }


### PR DESCRIPTION
## Motivation

On small screens (<360px), the browser window menu icon goes beyond the parent container.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/68998113-0e4e2700-08bf-11ea-8adf-4dc26b77a540.png) | ![image](https://user-images.githubusercontent.com/4408379/68998094-d810a780-08be-11ea-8db8-74657ffad81c.png) |