### PR TITLE
fix(v2): adjust first-level heading offset

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -12,7 +12,6 @@ body {
 
 body {
   margin: 0;
-  padding-top: var(--ifm-navbar-height);
   transition: var(--ifm-transition-fast) ease color;
 }
 
@@ -24,4 +23,5 @@ body > div {
 
 .main-wrapper {
   flex: 1 0 auto;
+  margin-top: var(--ifm-navbar-height);
 }


### PR DESCRIPTION
## Motivation

Currently, the same problem is observed as in [v1](https://github.com/facebook/docusaurus/pull/1869
) (take this opportunity, look at that PR and merge it please!). If during the search we click the page itself (i.e. first-level heading or h1), then we get a URL of the form https://v2.docusaurus.io/docs/introduction/#__docusaurus and the heading is incorrectly positioned (see Plan)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/69006033-d4226b00-093a-11ea-8c69-232192859da1.png) | ![image](https://user-images.githubusercontent.com/4408379/69006040-e43a4a80-093a-11ea-874f-3431efba509d.png) |
