### PR TITLE
feat(v2): only create one css file to avoid code-split css loading problem

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -117,7 +117,7 @@ export function createBaseConfig(
               },
               // Only create one CSS file to avoid
               // problems with code-split CSS loading in different orders
-              // causing inconsistent/non-determanistic styling
+              // causing inconsistent/non-deterministic styling
               // See https://github.com/facebook/docusaurus/issues/2006
               styles: {
                 name: 'styles',

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -102,19 +102,32 @@ export function createBaseConfig(
             }),
           ]
         : undefined,
-      splitChunks: {
-        // Since the chunk name includes all origin chunk names it’s recommended for production builds with long term caching to NOT include [name] in the filenames
-        name: false,
-        cacheGroups: {
-          // disable the built-in cacheGroups
-          default: false,
-          common: {
-            name: 'common',
-            minChunks: totalPages > 2 ? totalPages * 0.5 : 2,
-            priority: 40,
+      splitChunks: isServer
+        ? false
+        : {
+            // Since the chunk name includes all origin chunk names it’s recommended for production builds with long term caching to NOT include [name] in the filenames
+            name: false,
+            cacheGroups: {
+              // disable the built-in cacheGroups
+              default: false,
+              common: {
+                name: 'common',
+                minChunks: totalPages > 2 ? totalPages * 0.5 : 2,
+                priority: 40,
+              },
+              // Only create one CSS file to avoid
+              // problems with code-split CSS loading in different orders
+              // causing inconsistent/non-determanistic styling
+              // See https://github.com/facebook/docusaurus/issues/2006
+              styles: {
+                name: 'styles',
+                test: /\.css$/,
+                chunks: `all`,
+                enforce: true,
+                priority: 50,
+              },
+            },
           },
-        },
-      },
     },
     module: {
       rules: [
@@ -163,7 +176,6 @@ export function createBaseConfig(
     plugins: [
       new MiniCssExtractPlugin({
         filename: isProd ? '[name].[contenthash:8].css' : '[name].css',
-        chunkFilename: isProd ? '[name].[contenthash:8].css' : '[name].css',
       }),
     ],
   };


### PR DESCRIPTION
## Motivation

Close #2006 

See issue for reasoning

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- yarn build, only one css file is created
- netlify ???
- no css break on local build

caveat:
- dont know how big is our css 😭 