### PR TITLE
feat(v2): allow hiding docs table of contents

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -111,6 +111,11 @@ export default async function processMetadata({
     delete metadata.custom_edit_url;
   }
 
+  if (metadata.hide_table_of_contents) {
+    metadata.hideTableOfContents = Boolean(metadata.hide_table_of_contents);
+    delete metadata.hide_table_of_contents;
+  }
+
   if (showLastUpdateAuthor || showLastUpdateTime) {
     // Use fake data in dev for faster development
     const fileLastUpdateData =

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -111,11 +111,6 @@ export default async function processMetadata({
     delete metadata.custom_edit_url;
   }
 
-  if (metadata.hide_table_of_contents) {
-    metadata.hideTableOfContents = Boolean(metadata.hide_table_of_contents);
-    delete metadata.hide_table_of_contents;
-  }
-
   if (showLastUpdateAuthor || showLastUpdateTime) {
     // Use fake data in dev for faster development
     const fileLastUpdateData =

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -95,6 +95,7 @@ export interface MetadataRaw extends OrderMetadata {
   lastUpdatedAt?: number;
   lastUpdatedBy?: string;
   hide_title?: boolean;
+  hide_table_of_contents?: boolean;
   [key: string]: any;
 }
 

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -94,8 +94,6 @@ export interface MetadataRaw extends OrderMetadata {
   editUrl?: string;
   lastUpdatedAt?: number;
   lastUpdatedBy?: string;
-  hide_title?: boolean;
-  hide_table_of_contents?: boolean;
   [key: string]: any;
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -62,6 +62,7 @@ function DocItem(props) {
     lastUpdatedAt,
     lastUpdatedBy,
     keywords,
+    hideTableOfContents,
   } = metadata;
 
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
@@ -172,7 +173,9 @@ function DocItem(props) {
                 </div>
               </div>
             </div>
-            {DocContent.rightToc && <DocTOC headings={DocContent.rightToc} />}
+            {!hideTableOfContents && DocContent.rightToc && (
+              <DocTOC headings={DocContent.rightToc} />
+            )}
           </div>
         </div>
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -62,8 +62,13 @@ function DocItem(props) {
     lastUpdatedAt,
     lastUpdatedBy,
     keywords,
-    hideTableOfContents,
   } = metadata;
+  const {
+    frontMatter: {
+      hide_title: hideTitle,
+      hide_table_of_contents: hideTableOfContents,
+    },
+  } = DocContent;
 
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
 
@@ -91,7 +96,7 @@ function DocItem(props) {
             <div className="col">
               <div className={styles.docItemContainer}>
                 <article>
-                  {!metadata.hide_title && (
+                  {!hideTitle && (
                     <header>
                       <h1 className={styles.docTitle}>{metadata.title}</h1>
                     </header>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -20,7 +20,6 @@
 .docItemContainer {
   margin: 0 auto;
   padding: 0 0.5rem;
-  max-width: 45em;
 }
 
 .tableOfContents {

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -99,6 +99,7 @@ Documents use the following markdown header fields that are enclosed by a line `
 - `id`: A unique document id. If this field is not present, the document's `id` will default to its file name (without the extension).
 - `title`: The title of your document. If this field is not present, the document's `title` will default to its `id`.
 - `hide_title`: Whether to hide the title at the top of the doc. By default it is `false`.
+- `hide_table_of_contents`: Whether to hide the table of contents to the right. By default it is `false`.
 - `sidebar_label`: The text shown in the document sidebar and in the next/previous button for this document. If this field is not present, the document's `sidebar_label` will default to its `title`.
 - `custom_edit_url`: The URL for editing this document. If this field is not present, the document's edit URL will fall back to `editUrl` from options fields passed to `docusaurus-plugin-content-docs`.
 - `keywords`: Keywords meta tag for the document page, for search engines.
@@ -112,6 +113,7 @@ Example:
 id: doc-markdown
 title: Markdown Features
 hide_title: false
+hide_table_of_contents: false
 sidebar_label: Markdown :)
 custom_edit_url: https://github.com/facebook/docusaurus/edit/master/docs/api-doc-markdown.md
 description: How do I find you when I cannot solve this problem


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I want to be able to hide the table of contents for Infima docs where the main content width is not wide enough. Example: https://facebookincubator.github.io/infima/docs/layout/grid

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="1552" alt="Screen Shot 2019-11-18 at 9 38 06 PM" src="https://user-images.githubusercontent.com/1315101/69119553-e04a1d80-0a4b-11ea-87ed-b3034b47a062.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
