### PR TITLE
feat(v2): add meta generator docusaurus

### DIFF
--- a/packages/docusaurus/src/client/templates/index.html.template.ejs
+++ b/packages/docusaurus/src/client/templates/index.html.template.ejs
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
+    <meta name="generator" content="Docusaurus">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -11,6 +11,7 @@ module.exports = `
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
+    <meta name="generator" content="Docusaurus">
     <%- chunkManifestScript %>
     <% metaAttributes.forEach((metaAttribute) => { %>
       <%- metaAttribute %>


### PR DESCRIPTION
# Motivation

Add meta generator tag according to HTML5 spec like v1
https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names

Benefits:
- Wappalyzer chrome extension can detect us 
<img width="943" alt="wappalyzer" src="https://user-images.githubusercontent.com/17883920/69130714-94e34e00-0ae3-11ea-8013-6c410422a9f7.PNG">
- You can search for popular website created with docusaurus easily
eg: https://publicwww.com/websites/%22%3Cmeta+name%3Dgenerator+content%3DDocusaurus%3E%22/

![image](https://user-images.githubusercontent.com/17883920/69130835-cd832780-0ae3-11ea-818a-301dc6784ec3.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

