### PR TITLE
feat(v2): style right sidebar scrollbar when overflow

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -30,6 +30,24 @@
   top: calc(var(--ifm-navbar-height) + 2rem);
 }
 
+.tableOfContents::-webkit-scrollbar {
+  width: 7px;
+}
+
+.tableOfContents::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 10px;
+}
+
+.tableOfContents::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 10px;
+}
+
+.tableOfContents::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
 @media only screen and (max-width: 996px) {
   .tableOfContents {
     display: none;


### PR DESCRIPTION
## Motivation

CSS Tweaks to be consistent like v1. see Test Plan. Feel free to close if its not a good idea

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Before
<img width="188" alt="before-light" src="https://user-images.githubusercontent.com/17883920/69216029-b7d23880-0b9d-11ea-8ba9-9f2ed0407a7c.PNG">
<img width="193" alt="before-dark" src="https://user-images.githubusercontent.com/17883920/69216028-b7d23880-0b9d-11ea-899b-21cb9a04bd3a.PNG">

After
<img width="224" alt="after-dark" src="https://user-images.githubusercontent.com/17883920/69216042-c0c30a00-0b9d-11ea-91a2-6b9a2c200b33.PNG">
<img width="205" alt="after-light" src="https://user-images.githubusercontent.com/17883920/69216044-c1f43700-0b9d-11ea-9f34-646daa923222.PNG">
