### PR TITLE
fix(v1): docusaurus-start should work even if path contain 'pages' word

### DIFF
--- a/packages/docusaurus-1.x/lib/server/server.js
+++ b/packages/docusaurus-1.x/lib/server/server.js
@@ -276,7 +276,7 @@ function execute(port, host) {
       fs.existsSync((userFile = englishFile))
     ) {
       // copy into docusaurus so require paths work
-      const userFileParts = userFile.split(`pages${sep}`);
+      const userFileParts = userFile.split(join(CWD, `pages${sep}`));
       let tempFile = join(__dirname, '..', 'pages', userFileParts[1]);
       tempFile = tempFile.replace(
         path.basename(file),


### PR DESCRIPTION
## Motivation

Close #2016 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Follow instruction in #2016 

<img width="958" alt="dev working" src="https://user-images.githubusercontent.com/17883920/69257665-03acce00-0bee-11ea-8312-d649947ec4b5.PNG">
