### PR TITLE
fix(v1): markdown content and toc should render the same

### DIFF
--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -4,6 +4,10 @@ title: Installation
 description: Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly!
 ---
 
+## function1 [array\<string>]
+
+## <a name="foo"></a> _Foo_
+
 Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.
 
 ## Installing Docusaurus

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -4,10 +4,6 @@ title: Installation
 description: Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly!
 ---
 
-## function1 [array\<string>]
-
-## <a name="foo"></a> _Foo_
-
 Docusaurus was designed from the ground up to be easily installed and used to get your website up and running quickly.
 
 ## Installing Docusaurus

--- a/packages/docusaurus-1.x/lib/core/__tests__/toc.test.js
+++ b/packages/docusaurus-1.x/lib/core/__tests__/toc.test.js
@@ -39,22 +39,35 @@ describe('getTOC', () => {
     expect(headingsJson).toContain('4th level headings');
   });
 
-  describe('stripping of HTML', () => {
-    test('correctly removes', () => {
-      const headings = getTOC(`## <a name="foo"></a> Foo`, 'h2', []);
+  test('html tag in source', () => {
+    const headings = getTOC(`## <a name="foo"></a> Foo`, 'h2', []);
 
-      expect(headings[0].hashLink).toEqual('a-namefooa-foo');
-      expect(headings[0].rawContent).toEqual(`<a name="foo"></a> Foo`);
-      expect(headings[0].content).toEqual('Foo');
-    });
+    expect(headings[0].hashLink).toEqual('a-namefooa-foo');
+    expect(headings[0].rawContent).toEqual(`<a name="foo"></a> Foo`);
+    expect(headings[0].content).toEqual(`<a name="foo"></a> Foo`);
+  });
 
-    test('retains formatting from Markdown', () => {
-      const headings = getTOC(`## <a name="foo"></a> _Foo_`, 'h2', []);
+  test('transform markdown syntax to html syntax', () => {
+    const headings = getTOC(`## <a name="foo"></a> _Foo_`, 'h2', []);
 
-      expect(headings[0].hashLink).toEqual('a-namefooa-_foo_');
-      expect(headings[0].rawContent).toEqual(`<a name="foo"></a> _Foo_`);
-      expect(headings[0].content).toEqual('<em>Foo</em>');
-    });
+    expect(headings[0].hashLink).toEqual('a-namefooa-_foo_');
+    expect(headings[0].rawContent).toEqual(`<a name="foo"></a> _Foo_`);
+    expect(headings[0].content).toEqual(`<a name="foo"></a> <em>Foo</em>`);
+
+    const headings2 = getTOC(`## **Foo**`, 'h2', []);
+
+    expect(headings2[0].hashLink).toEqual('foo');
+    expect(headings2[0].rawContent).toEqual(`**Foo**`);
+    expect(headings2[0].content).toEqual(`<strong>Foo</strong>`);
+  });
+
+  test('does not strip tags randomly', () => {
+    // eslint-disable-next-line no-useless-escape
+    const headings = getTOC(`## function1 [array\<string>]`, 'h2', []);
+
+    expect(headings[0].hashLink).toEqual('function1-arraystring');
+    expect(headings[0].rawContent).toEqual(`function1 [array<string>]`);
+    expect(headings[0].content).toEqual(`function1 [array<string>]`);
   });
 });
 

--- a/packages/docusaurus-1.x/lib/core/toc.js
+++ b/packages/docusaurus-1.x/lib/core/toc.js
@@ -7,7 +7,6 @@
 
 const {Remarkable} = require('remarkable');
 const mdToc = require('markdown-toc');
-const striptags = require('striptags');
 const GithubSlugger = require('github-slugger');
 const toSlug = require('./toSlug');
 
@@ -27,7 +26,10 @@ function getTOC(content, headingTags = 'h2', subHeadingTags = 'h3') {
     ? [].concat(subHeadingTags).map(tagToLevel)
     : [];
   const allowedHeadingLevels = headingLevels.concat(subHeadingLevels);
-  const md = new Remarkable();
+  const md = new Remarkable({
+    // Enable HTML tags in source (same as './renderMarkdown.js')
+    html: true,
+  });
   const headings = mdToc(content).json;
   const toc = [];
   const slugger = new GithubSlugger();
@@ -35,8 +37,7 @@ function getTOC(content, headingTags = 'h2', subHeadingTags = 'h3') {
 
   headings.forEach(heading => {
     const rawContent = heading.content;
-    const safeContent = striptags(rawContent);
-    const rendered = md.renderInline(safeContent);
+    const rendered = md.renderInline(rawContent);
 
     const hashLink = toSlug(rawContent, slugger);
     if (!allowedHeadingLevels.includes(heading.lvl)) {

--- a/packages/docusaurus-1.x/package.json
+++ b/packages/docusaurus-1.x/package.json
@@ -70,7 +70,6 @@
     "request": "^2.88.0",
     "shelljs": "^0.8.3",
     "sitemap": "^3.2.2",
-    "striptags": "^3.1.1",
     "tcp-port-used": "^1.0.1",
     "tiny-lr": "^1.1.1",
     "tree-node-cli": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15225,11 +15225,6 @@ strip-outer@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
-striptags@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.1.tgz#c8c3e7fdd6fb4bb3a32a3b752e5b5e3e38093ebd"
-  integrity sha1-yMPn/db7S7OjKjt1LltePjgJPr0=
-
 strong-log-transformer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"


### PR DESCRIPTION
## Motivation

Close #2021 

Sort of continuation from #2019 but this is dealing with consistent rendered content. That PR is consistent hash-link and slug

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Added test passes
- 

```md

## function1 [array\<string>]

## <a name="foo"></a> _Foo_
```
<img width="941" alt="render same" src="https://user-images.githubusercontent.com/17883920/69304552-9fbcf080-0c53-11ea-9711-4042772a2d0a.PNG">

