### PR TITLE
fix(v1): apply negative margin to docs heading only

### DIFF
--- a/packages/docusaurus-1.x/lib/core/DocsLayout.js
+++ b/packages/docusaurus-1.x/lib/core/DocsLayout.js
@@ -97,7 +97,7 @@ class DocsLayout extends React.Component {
             collapsible={this.props.config.docsSideNavCollapsible}
             metadata={metadata}
           />
-          <Container className="mainContainer">
+          <Container className="mainContainer docsContainer">
             <DocComponent
               metadata={metadata}
               content={content}

--- a/packages/docusaurus-1.x/lib/static/css/main.css
+++ b/packages/docusaurus-1.x/lib/static/css/main.css
@@ -653,12 +653,12 @@ blockquote {
   padding: 0;
 }
 
-.mainContainer .wrapper .post .postHeader:before,
-.mainContainer .wrapper .post .postHeaderTitle:before {
-  content: "";
+.docsContainer .wrapper .post .postHeader:before,
+.docsContainer .wrapper .post .postHeaderTitle:before {
+  content: '';
   display: block;
   height: 90px; /* fixed header height and empty space below it */
-  margin-top: -90px;  /* negative fixed header height and empty space below it  */
+  margin-top: -90px; /* negative fixed header height and empty space below it  */
   visibility: hidden;
   pointer-events: none;
 }
@@ -726,12 +726,12 @@ blockquote {
 }
 
 @media only screen and (max-width: 1023px) {
-  .mainContainer .wrapper .post .postHeader:before,
-  .mainContainer .wrapper .post .postHeaderTitle:before {
-    content: "";
+  .docsContainer .wrapper .post .postHeader:before,
+  .docsContainer .wrapper .post .postHeaderTitle:before {
+    content: '';
     display: block;
     height: 200px; /* fixed header height and empty space below it */
-    margin-top: -200px;  /* negative fixed header height and empty space below it  */
+    margin-top: -200px; /* negative fixed header height and empty space below it  */
     visibility: hidden;
     pointer-events: none;
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

facebook/docusaurus#1869 added negative margins to all headings including those on the blog and it made the "Read more" links hidden behind the heading. Let's only target the headings on the docs and not the blog.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Can click on blog.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
