### PR TITLE
refactor(v2): move unused generated files out from build folder

### DIFF
--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -45,12 +45,12 @@ export default async function render(locals) {
   ];
   const metaAttributes = metaStrings.filter(Boolean);
 
-  const {outDir} = locals;
-  const manifestPath = path.join(outDir, 'client-manifest.json');
+  const {generatedFilesDir} = locals;
+  const manifestPath = path.join(generatedFilesDir, 'client-manifest.json');
   const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
 
   // chunkName -> chunkAssets mapping.
-  const chunkManifestPath = path.join(outDir, 'chunk-map.json');
+  const chunkManifestPath = path.join(generatedFilesDir, 'chunk-map.json');
   const chunkManifest = JSON.parse(
     await fs.readFile(chunkManifestPath, 'utf8'),
   );

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -55,7 +55,7 @@ export async function build(
   const props: Props = await load(siteDir);
 
   // Apply user webpack config.
-  const {outDir, plugins} = props;
+  const {outDir, generatedFilesDir, plugins} = props;
 
   let clientConfig: Configuration = merge(createClientConfig(props), {
     plugins: [
@@ -65,7 +65,7 @@ export async function build(
       cliOptions.bundleAnalyzer && new BundleAnalyzerPlugin(),
       // Generate client manifests file that will be used for server bundle
       new ReactLoadableSSRAddon({
-        filename: 'client-manifest.json',
+        filename: path.join(generatedFilesDir, 'client-manifest.json'),
       }),
     ].filter(Boolean) as Plugin[],
   });

--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -30,6 +30,7 @@ export function createClientConfig(props: Props): Configuration {
       // Generate chunk-map.json (mapping of chunk names to their corresponding chunk assets)
       new ChunkManifestPlugin({
         filename: 'chunk-map.json',
+        outputPath: props.generatedFilesDir,
         manifestVariable: '__chunkMapping',
         inlineManifest: !isProd,
       }),

--- a/packages/docusaurus/src/webpack/plugins/ChunkManifestPlugin.js
+++ b/packages/docusaurus/src/webpack/plugins/ChunkManifestPlugin.js
@@ -15,6 +15,7 @@ class ChunkManifestPlugin {
   constructor(options) {
     this.options = {
       filename: 'manifest.json',
+      outputPath: null,
       manifestVariable: 'webpackManifest',
       inlineManifest: false,
       ...options,
@@ -23,7 +24,7 @@ class ChunkManifestPlugin {
 
   apply(compiler) {
     let chunkManifest;
-    const {path: outputPath, publicPath} = compiler.options.output;
+    const {path: defaultOutputPath, publicPath} = compiler.options.output;
 
     // Build the chunk mapping
     compiler.hooks.afterCompile.tapAsync(pluginName, (compilation, done) => {
@@ -49,6 +50,7 @@ class ChunkManifestPlugin {
       }
       chunkManifest = assetsMap;
       if (!this.options.inlineManifest) {
+        const outputPath = this.options.outputPath || defaultOutputPath;
         const finalPath = path.resolve(outputPath, this.options.filename);
         fs.ensureDir(path.dirname(finalPath), () => {
           fs.writeFile(finalPath, JSON.stringify(chunkManifest, null, 2), done);

--- a/packages/docusaurus/src/webpack/server.ts
+++ b/packages/docusaurus/src/webpack/server.ts
@@ -16,7 +16,7 @@ import WaitPlugin from './plugins/WaitPlugin';
 import LogPlugin from './plugins/LogPlugin';
 
 export function createServerConfig(props: Props): Configuration {
-  const {baseUrl, routesPaths, outDir} = props;
+  const {baseUrl, routesPaths, generatedFilesDir} = props;
   const config = createBaseConfig(props, true);
 
   const routesLocation = {};
@@ -41,7 +41,7 @@ export function createServerConfig(props: Props): Configuration {
     plugins: [
       // Wait until manifest from client bundle is generated
       new WaitPlugin({
-        filepath: path.join(outDir, 'client-manifest.json'),
+        filepath: path.join(generatedFilesDir, 'client-manifest.json'),
       }),
 
       // Static site generator webpack plugin.
@@ -49,7 +49,7 @@ export function createServerConfig(props: Props): Configuration {
         entry: 'main',
         locals: {
           baseUrl,
-          outDir,
+          generatedFilesDir,
           routesLocation,
         },
         paths: ssgPaths,


### PR DESCRIPTION
## Motivation

chunk-map and client-manifest.json is actually not useful in build folder. We shouldn't put it in build folder, but put it in generated folder instead.

The benefit of this is that less space is used for build artifacts. (eg: if pushing to github pages or aws-bucket, these files are not uploaded)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

dev chunk map still working
<img width="931" alt="dev - chunkmap" src="https://user-images.githubusercontent.com/17883920/69474693-a8016100-0df6-11ea-8eb2-0d6797ca61f3.PNG">

its now moved to generated dir
<img width="722" alt="moved to generated dir" src="https://user-images.githubusercontent.com/17883920/69474694-a899f780-0df6-11ea-9005-342fe3802d9b.PNG">
