### PR TITLE
feat(v2): style sidebar on overflow

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -13,6 +13,24 @@
     position: sticky;
     top: var(--ifm-navbar-height);
   }
+
+  .sidebar::-webkit-scrollbar {
+    width: 7px;
+  }
+
+  .sidebar::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 10px;
+  }
+
+  .sidebar::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 10px;
+  }
+
+  .sidebar::-webkit-scrollbar-thumb:hover {
+    background: #555;
+  }
 }
 
 .sidebarMenuIcon {


### PR DESCRIPTION
## Motivation

This is continuation from #2017 but for left sidebar. Feel free to close if you think it's not looking nice

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

**Before**
<img width="959" alt="before dark" src="https://user-images.githubusercontent.com/17883920/69474876-121b0580-0df9-11ea-9a4c-4fbc45f4b445.PNG">
<img width="958" alt="before styling" src="https://user-images.githubusercontent.com/17883920/69474877-12b39c00-0df9-11ea-995e-80d19627ee67.PNG">
<img width="958" alt="before" src="https://user-images.githubusercontent.com/17883920/69474878-12b39c00-0df9-11ea-9c5f-98a39a4105cb.PNG">

**After**
<img width="960" alt="after dark" src="https://user-images.githubusercontent.com/17883920/69474879-18a97d00-0df9-11ea-9202-964607ff5a86.PNG">
<img width="958" alt="after styling" src="https://user-images.githubusercontent.com/17883920/69474880-18a97d00-0df9-11ea-99ae-55214d75431c.PNG">
<img width="956" alt="after" src="https://user-images.githubusercontent.com/17883920/69474881-18a97d00-0df9-11ea-9bc7-5cbb08128154.PNG">
