### PR TITLE
docs(v2): add documentation on versioning

### DIFF
--- a/website/docs/versioning.md
+++ b/website/docs/versioning.md
@@ -6,51 +6,50 @@ You can use the version script to cut a new documentation version based on the l
 
 ## :warning: Disclaimer
 
-> Consider it really well before starting to version your documentation. 
+> Consider it really well before starting to version your documentation.
 
-Most of the times, you don't need versioning and it will just increase your build time and introduces complexity to your codebase. Versioning is **best suited for website with high-traffic & rapid changes in documentation between version**. If your documentation rarely changes, don't version. 
+Most of the times, you don't need versioning and it will just increase your build time and introduces complexity to your codebase. Versioning is **best suited for website with high-traffic and rapid changes in documentation between version**. If your documentation rarely changes, don't version.
 
 To better understand how versioning works and see if it suits your needs, you can read up below.
 
 ## Directory structure
+
 ```shell
-website/
-├── sidebars.json        # sidebar for master (next) version 
-├── docs/                # docs directory for master (next) version
-│   ├── foo/         
+website
+├── sidebars.json        # sidebar for master (next) version
+├── docs                 # docs directory for master (next) version
+│   ├── foo
 │   │   └── bar.md       # https://mysite.com/docs/next/foo/bar
-│   └── hello.md         # https://mysite.com/docs/next/hello  
-│
-├── versions.json             # file to indicate what versions are available 
-├── versioned_docs/               
+│   └── hello.md         # https://mysite.com/docs/next/hello
+├── versions.json        # file to indicate what versions are available
+├── versioned_docs
 │   ├── version-1.1.0
-│   │    ├── foo
-│   │    │   └── bar.md      # https://mysite.com/docs/foo/bar
-│   │    └── hello.md
-|   │    
+│   │   ├── foo
+│   │   │   └── bar.md   # https://mysite.com/docs/foo/bar
+│   │   └── hello.md
 │   └── version-1.0.0
-│        ├── foo
-│        │   └── bar.md      # https://mysite.com/docs/1.0.0/foo/bar
-│        └── hello.md
-├── versioned_sidebars/
+│       ├── foo
+│       │   └── bar.md   # https://mysite.com/docs/1.0.0/foo/bar
+│       └── hello.md
+├── versioned_sidebars
 │   ├── version-1.1.0-sidebars.json
 │   └── version-1.0.0-sidebars.json
-│
 ├── docusaurus.config.js
 └── package.json
 ```
 
-This table below summarizes Docusaurus versioning at a glance.
+The table below explains how a versioned file maps to its version and the generated URL.
 
-| Path                                    | Version         | URL                  |
-| --------------------------------------- | --------------- | -------------------- |
-| `versioned_docs/version-1.0.0/hello.md` | 1.0.0           | /docs/1.0.0/hello    |
-| `versioned_docs/version-1.1.0/hello.md` | 1.1.0 (latest)  | /docs/hello          |
-| `docs/guides/hello.md`                  | next            | /docs/next/hello     |
+| Path                                    | Version        | URL               |
+| --------------------------------------- | -------------- | ----------------- |
+| `versioned_docs/version-1.0.0/hello.md` | 1.0.0          | /docs/1.0.0/hello |
+| `versioned_docs/version-1.1.0/hello.md` | 1.1.0 (latest) | /docs/hello       |
+| `docs/guides/hello.md`                  | next           | /docs/next/hello  |
 
 ### Tagging a new version
-1. First, finsh your work on `docs` . A version always should be based from master.
-2. Enter a new version number
+
+1. First, make sure your content in the `docs` directory is ready to be frozen as a version. A version always should be based from master.
+1. Enter a new version number.
 
 ```bash npm2yarn
 npm run docusaurus docs:version 1.1.0
@@ -58,62 +57,71 @@ npm run docusaurus docs:version 1.1.0
 
 When tagging a new version, the document versioning mechanism will:
 
-* Copy full `docs/` folder contents into a new `versioned_docs/version-<version>/` folder.
-* Create a versioned sidebars file based from your current [sidebar](sidebar.md) configuration (if exists). Saved as `versioned_sidebars/version-<version>-sidebars.json`.
-* Place a new version number in `versions.json`
+- Copy the full `docs/` folder contents into a new `versioned_docs/version-<version>/` folder.
+- Create a versioned sidebars file based from your current [sidebar](sidebar.md) configuration (if it exists). Saved it as `versioned_sidebars/version-<version>-sidebars.json`.
+- Append the new version number into `versions.json`.
 
 ## Files
-### Creating new files
-1. Place the new file into correspondent version folder.
-2. Include the reference for the new file into correspondent sidebar file, according version number.
 
-Master docs
+### Creating new files
+
+1. Place the new file into the corresponding version folder.
+1. Include the reference for the new file into the corresponding sidebar file, according to version number.
+
+**Master docs**
+
 ```shell
-# the new file
+# The new file.
 docs/new.md
 
-# edit the correspondent sidebar
+# Edit the corresponding sidebar file.
 sidebar.js
 ```
 
-Older docs
+**Older docs**
+
 ```shell
-# the new file
+# The new file.
 versioned_docs/version-1.0.0/new.md
 
-# edit the correspondent sidebar
+# Edit the corresponding sidebar file.
 versioned_sidebars/version-1.0.0-sidebars.json
 ```
 
 ### Linking files
-* Remember to include the `.md` extension.
-* Files will be linked to correct corresponding version
-* Relative paths work as well
 
-```lisp
+- Remember to include the `.md` extension.
+- Files will be linked to correct corresponding version.
+- Relative paths work as well.
+
+```md
 The [@hello](hello.md#paginate) document is great!
 
 See the [Tutorial](../getting-started/tutorial.md) for more info.
 ```
 
 ## Versions
-Each subfolder in `versioned_docs/` will represent a documentation version
 
-### Updating an existent version
-You can update multiples docs versions at the same time. Because each `docs/` subfolder represents specifics routes when published.
+Each directory in `versioned_docs/` will represent a documentation version.
+
+### Updating an existing version
+
+You can update multiple docs versions at the same time. Because each directory in `versioned_docs/` represents specific routes when published.
 
 1. Edit any file.
-2. Commit and push changes.
-3. It will be published to the correspondent version.
+1. Commit and push changes.
+1. It will be published to the version.
 
-**Example:** When you change any file from `versioned_docs/version-2.6/`, it will publish changes only for `2.6` docs version.
+**Example:** When you change any file in `versioned_docs/version-2.6/`, it will only affect the docs for version `2.6`.
 
-### Deleting an existent version
-You can delete/remove version as well.
+### Deleting an existing version
 
-1. Remove the version from `versions.json`
+You can delete/remove versions as well.
+
+1. Remove the version from `versions.json`.
 
 Example:
+
 ```diff {4}
 [
   "2.0.0",
@@ -122,17 +130,17 @@ Example:
 ]
 ```
 
-2. Delete the versioned docs. Example: `versioned_docs/version-1.8.0`.
-3. Delete the versioned sidebars. Example: `versioned_sidebars/version-1.8.0-sidebars.json`.
+2. Delete the versioned docs directory. Example: `versioned_docs/version-1.8.0`.
+3. Delete the versioned sidebars file. Example: `versioned_sidebars/version-1.8.0-sidebars.json`.
 
-## Best Practices Recommendation
+## Recommended practices
 
 ### Version your documentation only when needed
 
-For example, you are building a documentation for your npm package `foo` and you are currently in version 1.0.0. You then release a patch version for a minor bug fix and it's now 1.0.1. 
+For example, you are building a documentation for your npm package `foo` and you are currently in version 1.0.0. You then release a patch version for a minor bug fix and it's now 1.0.1.
 
-Should you cut a new documentation version 1.0.1? **You shouldn't**. 1.0.1 and 1.0.0 docs shouldn't differ according to semver because there is no new feature !. Cutting a new version for it will only just create unnecessary duplicated files.
+Should you cut a new documentation version 1.0.1? **You probably shouldn't**. 1.0.1 and 1.0.0 docs shouldn't differ according to semver because there are no new features!. Cutting a new version for it will only just create unnecessary duplicated files.
 
-### Keep the number of versions low 
+### Keep the number of versions small
 
-As a good rule of thumb, try to maintain the number of your versions below 10. **It is very likely** that you have a lot of obsolete versioned documentation that nobody even read anymore. [Babel](https://babeljs.io/versions) for example is currently in version `7.X`, and it no longer maintains documentation for version `<= 6.X`. Keep it low :)
+As a good rule of thumb, try to keep the number of your versions below 10. **It is very likely** that you will have a lot of obsolete versioned documentation that nobody even reads anymore. For example, [Babel](https://babeljs.io/versions) for example is currently in version `7.x`, and it no longer maintains documentation for version `<= 6.x`. Keep it small 😊

--- a/website/docs/versioning.md
+++ b/website/docs/versioning.md
@@ -143,4 +143,13 @@ Should you cut a new documentation version 1.0.1? **You probably shouldn't**. 1.
 
 ### Keep the number of versions small
 
-As a good rule of thumb, try to keep the number of your versions below 10. **It is very likely** that you will have a lot of obsolete versioned documentation that nobody even reads anymore. For example, [Babel](https://babeljs.io/versions) for example is currently in version `7.x`, and it no longer maintains documentation for version `<= 6.x`. Keep it small 😊
+As a good rule of thumb, try to keep the number of your versions below 10. **It is very likely** that you will have a lot of obsolete versioned documentation that nobody even reads anymore. For example, [Jest](https://jestjs.io/versions) for example is currently in version `24.9`, and only maintains several latest documentation version with the lowest being `22.X`. Keep it small 😊
+
+### Use absolute import within the docs
+
+Don't use relative paths import within the docs. Because when we cut a version the paths no longer work (the nesting level is different, among other reasons). You can utilize the `@site` alias provided by docusaurus, that points to the `website` directory. Example:
+
+```diff
+- import Foo from '../src/components/Foo';
++ import Foo from '@site/src/components/Foo';
+```

--- a/website/docs/versioning.md
+++ b/website/docs/versioning.md
@@ -1,0 +1,138 @@
+---
+title: Versioning
+---
+
+You can use the version script to cut a new documentation version based on the latest content in the `docs` directory. That specific set of documentation will then be preserved and accessible even as the documentation in the `docs` directory changes moving forward.
+
+## :warning: Disclaimer
+
+> Consider it really well before starting to version your documentation. 
+
+Most of the times, you don't need versioning and it will just increase your build time and introduces complexity to your codebase. Versioning is **best suited for website with high-traffic & rapid changes in documentation between version**. If your documentation rarely changes, don't version. 
+
+To better understand how versioning works and see if it suits your needs, you can read up below.
+
+## Directory structure
+```shell
+website/
+├── sidebars.json        # sidebar for master (next) version 
+├── docs/                # docs directory for master (next) version
+│   ├── foo/         
+│   │   └── bar.md       # https://mysite.com/docs/next/foo/bar
+│   └── hello.md         # https://mysite.com/docs/next/hello  
+│
+├── versions.json             # file to indicate what versions are available 
+├── versioned_docs/               
+│   ├── version-1.1.0
+│   │    ├── foo
+│   │    │   └── bar.md      # https://mysite.com/docs/foo/bar
+│   │    └── hello.md
+|   │    
+│   └── version-1.0.0
+│        ├── foo
+│        │   └── bar.md      # https://mysite.com/docs/1.0.0/foo/bar
+│        └── hello.md
+├── versioned_sidebars/
+│   ├── version-1.1.0-sidebars.json
+│   └── version-1.0.0-sidebars.json
+│
+├── docusaurus.config.js
+└── package.json
+```
+
+This table below summarizes Docusaurus versioning at a glance.
+
+| Path                                    | Version         | URL                  |
+| --------------------------------------- | --------------- | -------------------- |
+| `versioned_docs/version-1.0.0/hello.md` | 1.0.0           | /docs/1.0.0/hello    |
+| `versioned_docs/version-1.1.0/hello.md` | 1.1.0 (latest)  | /docs/hello          |
+| `docs/guides/hello.md`                  | next            | /docs/next/hello     |
+
+### Tagging a new version
+1. First, finsh your work on `docs` . A version always should be based from master.
+2. Enter a new version number
+
+```bash npm2yarn
+npm run docusaurus docs:version 1.1.0
+```
+
+When tagging a new version, the document versioning mechanism will:
+
+* Copy full `docs/` folder contents into a new `versioned_docs/version-<version>/` folder.
+* Create a versioned sidebars file based from your current [sidebar](sidebar.md) configuration (if exists). Saved as `versioned_sidebars/version-<version>-sidebars.json`.
+* Place a new version number in `versions.json`
+
+## Files
+### Creating new files
+1. Place the new file into correspondent version folder.
+2. Include the reference for the new file into correspondent sidebar file, according version number.
+
+Master docs
+```shell
+# the new file
+docs/new.md
+
+# edit the correspondent sidebar
+sidebar.js
+```
+
+Older docs
+```shell
+# the new file
+versioned_docs/version-1.0.0/new.md
+
+# edit the correspondent sidebar
+versioned_sidebars/version-1.0.0-sidebars.json
+```
+
+### Linking files
+* Remember to include the `.md` extension.
+* Files will be linked to correct corresponding version
+* Relative paths work as well
+
+```lisp
+The [@hello](hello.md#paginate) document is great!
+
+See the [Tutorial](../getting-started/tutorial.md) for more info.
+```
+
+## Versions
+Each subfolder in `versioned_docs/` will represent a documentation version
+
+### Updating an existent version
+You can update multiples docs versions at the same time. Because each `docs/` subfolder represents specifics routes when published.
+
+1. Edit any file.
+2. Commit and push changes.
+3. It will be published to the correspondent version.
+
+**Example:** When you change any file from `versioned_docs/version-2.6/`, it will publish changes only for `2.6` docs version.
+
+### Deleting an existent version
+You can delete/remove version as well.
+
+1. Remove the version from `versions.json`
+
+Example:
+```diff {4}
+[
+  "2.0.0",
+  "1.9.0",
+- "1.8.0"
+]
+```
+
+2. Delete the versioned docs. Example: `versioned_docs/version-1.8.0`.
+3. Delete the versioned sidebars. Example: `versioned_sidebars/version-1.8.0-sidebars.json`.
+
+## Best Practices Recommendation
+
+### Version your documentation only when needed
+
+For example, you are building a documentation for your npm package `foo` and you are currently in version 1.0.0. You then release a patch version for a minor bug fix and it's now 1.0.1. 
+
+Should you cut a new documentation version 1.0.1? **You shouldn't**. 1.0.1 and 1.0.0 docs shouldn't differ according to semver because there is no new feature !. Cutting a new version for it will only just create unnecessary duplicated files.
+
+### Keep the number of versions low 
+
+As a good rule of thumb, try to maintain the number of your versions below 10. **It is very likely** that you have a lot of obsolete versioned documentation that nobody even read anymore. [Babel](https://babeljs.io/versions) for example is currently in version `7.X`, and it no longer maintains documentation for version `<= 6.X`. Keep it low :)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -16,7 +16,7 @@ module.exports = {
       {
         type: 'category',
         label: 'Docs',
-        items: ['markdown-features', 'sidebar'],
+        items: ['markdown-features', 'sidebar', 'versioning'],
       },
       'blog',
       'analytics',


### PR DESCRIPTION
## Motivation

Write documentation on versioning. Feel free to edit :)

Don't merge till #2030 is merged please, because versioning hasn't been released yet

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

<img width="954" alt="versioning docs" src="https://user-images.githubusercontent.com/17883920/69477666-7fd82900-0e1b-11ea-8ad2-c570c2c4ebe8.PNG">

Use netlify
