### PR TITLE
perf(v2): replace unnecessary json stringify(string) with inline string

### DIFF
--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -99,7 +99,7 @@ export async function load(siteDir: string): Promise<Props> {
     `export default [\n${clientModules
       // import() is async so we use require() because client modules can have
       // CSS and the order matters for loading CSS.
-      .map(module => `  require(${JSON.stringify(module)}),`)
+      .map(module => `  require("${module}"),`)
       .join('\n')}\n];\n`,
   );
 
@@ -119,9 +119,7 @@ ${Object.keys(registry)
   .sort()
   .map(
     key =>
-      `  '${key}': [${registry[key].loader}, ${JSON.stringify(
-        registry[key].modulePath,
-      )}, require.resolveWeak(${JSON.stringify(registry[key].modulePath)})],`,
+      `  '${key}': [${registry[key].loader}, "${registry[key].modulePath}", require.resolveWeak("${registry[key].modulePath}")],`,
   )
   .join('\n')}};\n`,
   );


### PR DESCRIPTION
## Motivation

Rather than doing stringify for simple string like below

```js
const a = `test${JSON.stringify(word)}`;
```

Better do
```js
const a = `test"${word}"`;
```

![image](https://user-images.githubusercontent.com/17883920/69480466-33501600-0e3a-11ea-9941-5c93d913bf0b.png)

https://jsperf.com/stringifyvsdirect/1

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
- [x] Locally everything still ok
- [ ] Netlify
- [ ] CI pass