### PR TITLE
perf(v2): use webpack future version of asset emitting logic to free memory

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -42,6 +42,8 @@ export function createBaseConfig(
   return {
     mode: isProd ? 'production' : 'development',
     output: {
+      // Use future version of asset emitting logic, which allows freeing memory of assets after emitting.
+      futureEmitAssets: true,
       pathinfo: false,
       path: outDir,
       filename: isProd ? '[name].[contenthash:8].js' : '[name].js',


### PR DESCRIPTION
## Motivation

Implement https://github.com/webpack/webpack/pull/8642 which is webpack@5 default behavior to emit assets.

Nextjs, nuxtjs set this option too for memory friendly performance.

Inspired from https://nextjs.org/blog/webpack-memory

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- [x] Local dev ok
- [] Netlify
- [] CI