### PR TITLE
fix(v2): remove auto wrap for code blocks

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -63,43 +63,46 @@ export default ({children, className: languageClassName, metastring}) => {
   };
 
   return (
-    <Highlight
-      {...defaultProps}
-      theme={prism.theme || defaultTheme}
-      code={children.trim()}
-      language={language}>
-      {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <div className={styles.codeBlockWrapper}>
-          <pre
-            ref={target}
-            className={classnames(className, styles.codeBlock)}
-            style={style}>
-            {tokens.map((line, i) => {
-              const lineProps = getLineProps({line, key: i});
+    <div className={styles.codeBlockWrapper}>
+      <button
+        ref={button}
+        type="button"
+        aria-label="Copy code to clipboard"
+        className={styles.copyButton}
+        onClick={handleCopyCode}>
+        {showCopied ? 'Copied' : 'Copy'}
+      </button>
 
-              if (highlightLines.includes(i + 1)) {
-                lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-              }
+      <Highlight
+        {...defaultProps}
+        theme={prism.theme || defaultTheme}
+        code={children.trim()}
+        language={language}>
+        {({className, style, tokens, getLineProps, getTokenProps}) => (
+          <pre className={classnames(className, styles.codeBlock)}>
+            <code
+              ref={target}
+              className={classnames(className, styles.codeBlockLines)}
+              style={style}>
+              {tokens.map((line, i) => {
+                const lineProps = getLineProps({line, key: i});
 
-              return (
-                <div key={i} {...lineProps}>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({token, key})} />
-                  ))}
-                </div>
-              );
-            })}
+                if (highlightLines.includes(i + 1)) {
+                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+                }
+
+                return (
+                  <div key={i} {...lineProps}>
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({token, key})} />
+                    ))}
+                  </div>
+                );
+              })}
+            </code>
           </pre>
-          <button
-            ref={button}
-            type="button"
-            aria-label="Copy code to clipboard"
-            className={styles.copyButton}
-            onClick={handleCopyCode}>
-            {showCopied ? 'Copied' : 'Copy'}
-          </button>
-        </div>
-      )}
-    </Highlight>
+        )}
+      </Highlight>
+    </div>
   );
 };

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -1,11 +1,3 @@
-.codeBlock {
-  border-radius: 0;
-  margin-bottom: 0;
-  overflow: hidden;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
-}
-
 .codeBlockWrapper {
   position: relative;
 }
@@ -31,4 +23,19 @@
   visibility: hidden;
   transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
     bottom 200ms ease-in-out;
+}
+
+.codeBlock {
+  overflow: auto;
+  display: block;
+  padding: 0;
+  font-size: inherit;
+}
+
+.codeBlockLines {
+  border-radius: 0;
+  margin-bottom: 0;
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -94,7 +94,7 @@ function DocItem(props) {
       <div className="padding-vert--lg">
         <div className="container">
           <div className="row">
-            <div className="col">
+            <div className="col col--9">
               <div className={styles.docItemContainer}>
                 <article>
                   {version && (

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -81,43 +81,46 @@ export default ({
   };
 
   return (
-    <Highlight
-      {...defaultProps}
-      theme={prism.theme || defaultTheme}
-      code={children.trim()}
-      language={language}>
-      {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <div className={styles.codeBlockWrapper}>
-          <pre
-            ref={target}
-            className={classnames(className, styles.codeBlock)}
-            style={style}>
-            {tokens.map((line, i) => {
-              const lineProps = getLineProps({line, key: i});
+    <div className={styles.codeBlockWrapper}>
+      <button
+        ref={button}
+        type="button"
+        aria-label="Copy code to clipboard"
+        className={styles.copyButton}
+        onClick={handleCopyCode}>
+        {showCopied ? 'Copied' : 'Copy'}
+      </button>
 
-              if (highlightLines.includes(i + 1)) {
-                lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-              }
+      <Highlight
+        {...defaultProps}
+        theme={prism.theme || defaultTheme}
+        code={children.trim()}
+        language={language}>
+        {({className, style, tokens, getLineProps, getTokenProps}) => (
+          <pre className={classnames(className, styles.codeBlock)}>
+            <code
+              ref={target}
+              className={classnames(className, styles.codeBlockLines)}
+              style={style}>
+              {tokens.map((line, i) => {
+                const lineProps = getLineProps({line, key: i});
 
-              return (
-                <div key={i} {...lineProps}>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({token, key})} />
-                  ))}
-                </div>
-              );
-            })}
+                if (highlightLines.includes(i + 1)) {
+                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+                }
+
+                return (
+                  <div key={i} {...lineProps}>
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({token, key})} />
+                    ))}
+                  </div>
+                );
+              })}
+            </code>
           </pre>
-          <button
-            ref={button}
-            type="button"
-            aria-label="Copy code to clipboard"
-            className={styles.copyButton}
-            onClick={handleCopyCode}>
-            {showCopied ? 'Copied' : 'Copy'}
-          </button>
-        </div>
-      )}
-    </Highlight>
+        )}
+      </Highlight>
+    </div>
   );
 };

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -1,12 +1,3 @@
-.codeBlock {
-  border-radius: 0;
-  font-size: inherit;
-  margin-bottom: 0;
-  overflow: hidden;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
-}
-
 .codeBlockWrapper {
   position: relative;
 }
@@ -32,4 +23,19 @@
   visibility: hidden;
   transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
     bottom 200ms ease-in-out;
+}
+
+.codeBlock {
+  overflow: auto;
+  display: block;
+  padding: 0;
+  font-size: inherit;
+}
+
+.codeBlockLines {
+  border-radius: 0;
+  margin-bottom: 0;
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
 }


### PR DESCRIPTION
## Motivation

In v1, code blocks are displayed as is, without wrapping, in general, this is a very good UX, especially on mobile devices. This PR disables line wrapping instead of which scroll bar will be displayed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Desktop:

![image](https://user-images.githubusercontent.com/4408379/69523528-2552e000-0f75-11ea-91dd-d33e35468388.png)

Mobile:

![image](https://user-images.githubusercontent.com/4408379/69523485-0eac8900-0f75-11ea-9249-551201063602.png)
