### PR TITLE
fix(v2): make friendlier title on home page for SEO

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,13 +9,16 @@ const versions = require('./versions.json');
 
 module.exports = {
   title: 'Docusaurus',
-  tagline:
-    'An optimized site generator in React. Docusaurus helps you to move fast and write content. Build documentation websites, blogs, marketing pages, and more.',
+  tagline: 'Build optimized websites quickly, focus on your content',
   organizationName: 'facebook',
   projectName: 'docusaurus',
   baseUrl: '/',
   url: 'https://v2.docusaurus.io',
   favicon: 'img/docusaurus.ico',
+  customFields: {
+    description:
+      'An optimized site generator in React. Docusaurus helps you to move fast and write content. Build documentation websites, blogs, marketing pages, and more.',
+  },
   themes: ['@docusaurus/theme-live-codeblock'],
   plugins: [
     [

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -61,10 +61,10 @@ const QUOTES = [
 
 function Home() {
   const context = useDocusaurusContext();
-  const {siteConfig = {}} = context;
+  const {siteConfig: {customFields = {}} = {}} = context;
 
   return (
-    <Layout permalink="/" description={siteConfig.tagline}>
+    <Layout permalink="/" description={customFields.description}>
       <div className={styles.hero}>
         <div className={styles.heroInner}>
           <h1 className={styles.heroProjectTagline}>


### PR DESCRIPTION
## Motivation

Currently, the tagline is very long, it is in both the title and description metas, I do not think that this is normal.

> Google typically displays the first 50–60 characters of a title tag. If you keep your titles under 60 characters, our research suggests that you can expect about 90% of your titles to display properly.

Be that as it may, but for SEO such a long title (>160 chars) has a not good effect, and in general the headline should not be like that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See browser window title and meta description.
