### PR TITLE
perf(v2): unblock metadata processing when possible

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -59,30 +59,11 @@ export default async function processMetadata({
   const {versioning} = env;
   const filePath = path.join(refDir, source);
 
-  const fileString = await fs.readFile(filePath, 'utf-8');
-  const {frontMatter = {}, excerpt} = parse(fileString);
-
-  // Default id is the file name.
-  const baseID: string =
-    frontMatter.id || path.basename(source, path.extname(source));
-  if (baseID.includes('/')) {
-    throw new Error('Document id cannot include "/".');
-  }
-
-  // Default title is the id.
-  const title: string = frontMatter.title || baseID;
-
-  const description: string = frontMatter.description || excerpt;
+  const fileStringPromise = fs.readFile(filePath, 'utf-8');
+  const lastUpdatedPromise = lastUpdated(filePath, options);
 
   let version;
-  let id = baseID;
-
-  // Append subdirectory as part of id.
   const dirName = path.dirname(source);
-  if (dirName !== '.') {
-    id = `${dirName}/${baseID}`;
-  }
-
   if (versioning.enabled) {
     if (/^version-/.test(dirName)) {
       const inferredVersion = dirName
@@ -101,6 +82,34 @@ export default async function processMetadata({
   const versionPath =
     version && version !== versioning.latestVersion ? version : '';
 
+  const relativePath = path.relative(siteDir, filePath);
+
+  // Cannot use path.join() as it resolves '../' and removes the '@site'. Let webpack loader resolve it.
+  const aliasedPath = `@site/${relativePath}`;
+
+  const docsEditUrl = editUrl
+    ? normalizeUrl([editUrl, posixPath(relativePath)])
+    : undefined;
+
+  const {frontMatter = {}, excerpt} = parse(await fileStringPromise);
+  const {sidebar_label, custom_edit_url} = frontMatter;
+
+  // Default base id is the file name.
+  const baseID: string =
+    frontMatter.id || path.basename(source, path.extname(source));
+
+  if (baseID.includes('/')) {
+    throw new Error('Document id cannot include "/".');
+  }
+
+  // Append subdirectory as part of id.
+  const id = dirName !== '.' ? `${dirName}/${baseID}` : baseID;
+
+  // Default title is the id.
+  const title: string = frontMatter.title || baseID;
+
+  const description: string = frontMatter.description || excerpt;
+
   // The last portion of the url path. Eg: 'foo/bar', 'bar'
   const routePath =
     version && version !== 'next'
@@ -113,18 +122,7 @@ export default async function processMetadata({
     routePath,
   ]);
 
-  const {sidebar_label, custom_edit_url} = frontMatter;
-
-  const relativePath = path.relative(siteDir, filePath);
-
-  // Cannot use path.join() as it resolves '../' and removes the '@site'. Let webpack loader resolve it.
-  const aliasedPath = `@site/${relativePath}`;
-
-  const docsEditUrl = editUrl
-    ? normalizeUrl([editUrl, posixPath(relativePath)])
-    : undefined;
-
-  const {lastUpdatedAt, lastUpdatedBy} = await lastUpdated(filePath, options);
+  const {lastUpdatedAt, lastUpdatedBy} = await lastUpdatedPromise;
 
   // Assign all of object properties during instantiation (if possible) for NodeJS optimization
   // Adding properties to object after instantiation will cause hidden class transitions.


### PR DESCRIPTION
## Motivation

Await pauses the execution of current async function and waits for the passed Promise's resolution, and then resumes the async function's execution

In `metadata.ts`, we can actually increase the performance a little bit by making the readFile as promise, then continue resuming the function execution, only when we then really need the data. we await the promise.

I created a simple benchmark to sort of describe the situation
https://runkit.com/endiliey/await-readfile-vs-readfile-as-promise/1.0.0

![image](https://user-images.githubusercontent.com/17883920/69540680-cfecf200-0fb9-11ea-9e32-c5cbb5822c5c.png)


Old approach is something like
```js
async function oldApproach(source) {
  const {id, title} = await fakeReadFile(source);
  const version = getVersion(source);

  // do something else
  
  return {
    id,
    title,
    version,
  }
}
```

Now it's like
```js
async function newApproach(source) {
  const frontMatterPromise = fakeReadFile(source);
  const version = getVersion(source);

  // do something else
  
  const {id, title} = await frontMatterPromise;
  
  return {
    id,
    title,
    version,
  }
}
```



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Docs plugin is covered by tests, so since it passes, regression is less likely
<img width="662" alt="passing test" src="https://user-images.githubusercontent.com/17883920/69540205-aaabb400-0fb8-11ea-8ba9-e30c6d8a9630.PNG">
