### PR TITLE
fix(v2): fix docs sidebar highlighting if link is partially matched

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -71,6 +71,7 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
           <Link
             activeClassName="menu__link--active"
             className="menu__link"
+            exact
             to={href}
             onClick={onItemClick}>
             {label}


### PR DESCRIPTION
## Motivation

Close #2059 

For sidebar, we should pass `exact` to `Link` component so that it will only match if its exact

https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md#exact-bool

So if current page is `/blog/test`, it won't match `/blog`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Before
<img width="942" alt="before" src="https://user-images.githubusercontent.com/17883920/69741815-4894af80-116e-11ea-9d16-16ed22f2fbdf.PNG">

After
<img width="951" alt="after" src="https://user-images.githubusercontent.com/17883920/69741818-4af70980-116e-11ea-9899-5e3d821432a4.PNG">
