### PR TITLE
perf(v2): add link rel preconnect for GA & google tag plugin

### DIFF
--- a/packages/docusaurus-plugin-google-analytics/src/index.js
+++ b/packages/docusaurus-plugin-google-analytics/src/index.js
@@ -14,5 +14,19 @@ module.exports = function() {
     getClientModules() {
       return [path.resolve(__dirname, './analytics')];
     },
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: 'https://www.google-analytics.com',
+            },
+          },
+        ],
+      };
+    },
   };
 };

--- a/packages/docusaurus-plugin-google-gtag/src/index.js
+++ b/packages/docusaurus-plugin-google-gtag/src/index.js
@@ -14,5 +14,26 @@ module.exports = function() {
     getClientModules() {
       return [path.resolve(__dirname, './gtag')];
     },
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: 'https://www.google-analytics.com',
+            },
+          },
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: 'https://www.googletagmanager.com',
+            },
+          },
+        ],
+      };
+    },
   };
 };


### PR DESCRIPTION
## Motivation

This PR requires #2057 to be looked first It's a PR for a PR. Just so that lerna changelog can pick it up

https://css-tricks.com/using-relpreconnect-to-establish-network-connections-early-and-increase-performance/

As suggested by lighthouse, can save few seconds
<img width="655" alt="preconnect tips" src="https://user-images.githubusercontent.com/17883920/69744348-97444880-1172-11ea-908a-d32cf3334fc9.PNG">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

![image](https://user-images.githubusercontent.com/17883920/69744570-05890b00-1173-11ea-87dd-3229830d9528.png)
