### PR TITLE
fix: transpile static js to IE 10

### DIFF
--- a/packages/docusaurus-1.x/lib/static/js/codetabs.js
+++ b/packages/docusaurus-1.x/lib/static/js/codetabs.js
@@ -4,27 +4,27 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 // Turn off ESLint for this file because it's sent down to users as-is.
+
 /* eslint-disable */
 window.addEventListener('load', function() {
   // add event listener for all tab
   document.querySelectorAll('.nav-link').forEach(function(el) {
     el.addEventListener('click', function(e) {
-      const groupId = e.target.getAttribute('data-group');
+      var groupId = e.target.getAttribute('data-group');
       document
-        .querySelectorAll(`.nav-link[data-group=${groupId}]`)
+        .querySelectorAll('.nav-link[data-group='.concat(groupId, ']'))
         .forEach(function(el) {
           el.classList.remove('active');
         });
       document
-        .querySelectorAll(`.tab-pane[data-group=${groupId}]`)
+        .querySelectorAll('.tab-pane[data-group='.concat(groupId, ']'))
         .forEach(function(el) {
           el.classList.remove('active');
         });
       e.target.classList.add('active');
       document
-        .querySelector(`#${e.target.getAttribute('data-tab')}`)
+        .querySelector('#'.concat(e.target.getAttribute('data-tab')))
         .classList.add('active');
     });
   });

--- a/packages/docusaurus-1.x/lib/static/js/scrollSpy.js
+++ b/packages/docusaurus-1.x/lib/static/js/scrollSpy.js
@@ -5,50 +5,56 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable prefer-arrow-callback */
+/* eslint-disable */
 (function scrollSpy() {
-  const OFFSET = 10;
-  let timer;
-  let headingsCache;
-  const findHeadings = function findHeadings() {
+  var OFFSET = 10;
+  var timer;
+  var headingsCache;
+
+  var findHeadings = function findHeadings() {
     return headingsCache || document.querySelectorAll('.toc-headings > li > a');
   };
-  const onScroll = function onScroll() {
+
+  var onScroll = function onScroll() {
     if (timer) {
       // throttle
       return;
     }
+
     timer = setTimeout(function() {
       timer = null;
-      let activeNavFound = false;
-      const headings = findHeadings(); // toc nav anchors
+      var activeNavFound = false;
+      var headings = findHeadings(); // toc nav anchors
+
       /**
        * On every call, try to find header right after  <-- next header
        * the one whose content is on the current screen <-- highlight this
        */
-      for (let i = 0; i < headings.length; i++) {
+
+      for (var i = 0; i < headings.length; i++) {
         // headings[i] is current element
         // if an element is already active, then current element is not active
         // if no element is already active, then current element is active
-        let currNavActive = !activeNavFound;
+        var currNavActive = !activeNavFound;
         /**
          * Enter the following check up only when an active nav header is not yet found
          * Then, check the bounding rectangle of the next header
          * The headers that are scrolled passed will have negative bounding rect top
          * So the first one with positive bounding rect top will be the nearest next header
          */
+
         if (currNavActive && i < headings.length - 1) {
-          const heading = headings[i + 1];
-          const next = decodeURIComponent(heading.href.split('#')[1]);
-          const nextHeader = document.getElementById(next);
+          var heading = headings[i + 1];
+          var next = decodeURIComponent(heading.href.split('#')[1]);
+          var nextHeader = document.getElementById(next);
 
           if (nextHeader) {
-            const top = nextHeader.getBoundingClientRect().top;
+            var top = nextHeader.getBoundingClientRect().top;
             currNavActive = top > OFFSET;
           } else {
             console.error('Can not find header element', {
               id: next,
-              heading,
+              heading: heading,
             });
           }
         }
@@ -56,6 +62,7 @@
          * Stop searching once a first such header is found,
          * this makes sure the highlighted header is the most current one
          */
+
         if (currNavActive) {
           activeNavFound = true;
           headings[i].classList.add('active');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Transpile static JavaScript files to IE 10 support so that they does not bail on IE 10.

This Babel REPL is [broken](https://github.com/babel/website/issues/1627#issuecomment-559115705) on IE 11 due to the client JavaScript requires ES6. 

### Have you read the [Contributing Guidelines on pull requests] (https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)? 

Yep

## Test Plan

Manually testing the generated website.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
