### PR TITLE
fix(v2): markdown reference to file should not be page not found

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
@@ -19,7 +19,13 @@ export default {
     }
     return children;
   },
-  a: Link,
+  a: props => {
+    if (/\.[^./]+$/.test(props.href)) {
+      // eslint-disable-next-line jsx-a11y/anchor-has-content
+      return <a {...props} />;
+    }
+    return <Link {...props} />;
+  },
   pre: props => <pre className={styles.mdxCodeBlock} {...props} />,
   h1: Heading('h1'),
   h2: Heading('h2'),


### PR DESCRIPTION
## Motivation

See https://v2.docusaurus.io/feedback/p/ability-to-download-static-assets-such-as-pdfs

In v1 it was possible to link to pdfs and other non-img static files in markdown using the syntax [file name] (/path/to/asset.pdf). When the user would click this link, the browser would trigger a download. In v2, docusaurus routing does not allow this and results in a 404, even though hitting my-site.com/path/to/asset.pdf directly will download the file just fine.

It's because we replace all `a` in MDX with `Link`. But we should've checked if its a file first. 99.99% webpage url that links to file will have `.xxx` notation in last part of URL

There might be edge cases like where some bad user has a url like `/docs/docusaurus.png` in which its a valid internal URL (not a file), its still OK to use <a> as it only causes page refresh.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Before
![before - static assets](https://user-images.githubusercontent.com/17883920/69780551-2d618880-11de-11ea-8a2c-b68657c1a2cf.gif)

After

![after](https://user-images.githubusercontent.com/17883920/69780548-2aff2e80-11de-11ea-9b35-f98e98a45c52.gif)
