### PR TITLE
fix(v2): toc should not be broken for heading with html inline code

### DIFF
--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -12,6 +12,7 @@
     "@babel/traverse": "^7.7.4",
     "@mdx-js/mdx": "^1.5.1",
     "@mdx-js/react": "^1.5.1",
+    "escape-html": "^1.0.3",
     "github-slugger": "^1.2.1",
     "gray-matter": "^4.0.2",
     "loader-utils": "^1.2.3",

--- a/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`inline code should be escaped 1`] = `
+"export const rightToc = [
+	{
+		value: '<code>&lt;Head /&gt;</code>',
+		id: 'head-',
+		children: [
+			{
+				value: '<code>&lt;Head&gt;Test&lt;/Head&gt;</code>',
+				id: 'headtesthead',
+				children: []
+			}
+		]
+	},
+	{
+		value: '<code>&lt;div /&gt;</code>',
+		id: 'div-',
+		children: []
+	},
+	{
+		value: '<code>&lt;div&gt; Test &lt;/div&gt;</code>',
+		id: 'div-test-div',
+		children: []
+	},
+	{
+		value: '<code>&lt;div&gt;&lt;i&gt;Test&lt;/i&gt;&lt;/div&gt;</code>',
+		id: 'divitestidiv',
+		children: []
+	}
+];
+
+## \`<Head />\`
+
+### \`<Head>Test</Head>\`
+
+## \`<div />\`
+
+## \`<div> Test </div>\`
+
+## \`<div><i>Test</i></div>\`
+"
+`;
+
 exports[`non text phrasing content 1`] = `
 "export const rightToc = [
 	{

--- a/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/fixtures/inline-code.md
+++ b/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/fixtures/inline-code.md
@@ -1,0 +1,9 @@
+## `<Head />`
+
+### `<Head>Test</Head>`
+
+## `<div />`
+
+## `<div> Test </div>`
+
+## `<div><i>Test</i></div>`

--- a/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/index.test.js
+++ b/packages/docusaurus-mdx-loader/src/remark/rightToc/__tests__/index.test.js
@@ -27,6 +27,11 @@ test('non text phrasing content', async () => {
   expect(result).toMatchSnapshot();
 });
 
+test('inline code should be escaped', async () => {
+  const result = await processFixture('inline-code');
+  expect(result).toMatchSnapshot();
+});
+
 test('text content', async () => {
   const result = await processFixture('just-content');
   expect(result).toMatchInlineSnapshot(`

--- a/packages/docusaurus-mdx-loader/src/remark/rightToc/search.js
+++ b/packages/docusaurus-mdx-loader/src/remark/rightToc/search.js
@@ -7,6 +7,7 @@
 
 const toString = require('mdast-util-to-string');
 const visit = require('unist-util-visit');
+const escapeHtml = require('escape-html');
 const slugs = require('github-slugger')();
 
 // https://github.com/syntax-tree/mdast#heading
@@ -18,7 +19,7 @@ function toValue(node) {
       case 'heading':
         return node.children.map(toValue).join('');
       case 'inlineCode':
-        return `<code>${node.value}</code>`;
+        return `<code>${escapeHtml(node.value)}</code>`;
       case 'emphasis':
         return `<em>${node.children.map(toValue).join('')}</em>`;
       case 'strong':

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,7 +5939,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=


### PR DESCRIPTION
## Motivation

Fix broken TOC if heading has html inside inline code.
Value need to be escaped inside inline code so that it wont be mistaken as html

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Before
<img width="934" alt="before - broken toc" src="https://user-images.githubusercontent.com/17883920/69845269-a9bd9f80-12a2-11ea-937e-6052ad4af106.PNG">

After
<img width="950" alt="after - non broken toc" src="https://user-images.githubusercontent.com/17883920/69845272-ad512680-12a2-11ea-86ef-533ae479978e.PNG">

Newly added test passes, previous snapshot tests for mdx-loader rightTOC does not change