### PR TITLE
feat(v2): support prefers-color-scheme & fix dark mode FOUC on refresh

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -8,9 +8,9 @@
 const path = require('path');
 
 // Need to be inlined to prevent dark mode FOUC
+// Make sure that the 'storageKey' is the same as the one in `/theme/hooks/useTheme.js`
+const storageKey = 'theme';
 const noFlash = `(function() {
-  var storageKey = 'theme';
-
   function setDataThemeAttribute(theme) {
     document.querySelector('html').setAttribute('data-theme', theme);
   }
@@ -20,15 +20,14 @@ const noFlash = `(function() {
   var supportsColorSchemeQuery = mql.media === preferDarkQuery;
   var localStorageTheme = null;
   try {
-    localStorageTheme = localStorage.getItem(storageKey);
+    localStorageTheme = localStorage.getItem('${storageKey}');
   } catch (err) {}
   var localStorageExists = localStorageTheme !== null;
 
   if (localStorageExists) {
     setDataThemeAttribute(localStorageTheme);
-  } else if (supportsColorSchemeQuery) {
-    var theme = mql.matches ? 'dark' : '';
-    setDataThemeAttribute(theme);
+  } else if (supportsColorSchemeQuery && mql.matches) {
+    setDataThemeAttribute('dark');
   }
 })();`;
 

--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -7,6 +7,39 @@
 
 const path = require('path');
 
+const noFlash = `(function() {
+  // Change these if you use something different in your hook.
+  var storageKey = 'theme';
+
+  function setDataThemeAttribute(theme) {
+    document.querySelector('html').setAttribute('data-theme', theme);
+  }
+  
+  var preferDarkQuery = '(prefers-color-scheme: dark)';
+  var mql = window.matchMedia(preferDarkQuery);
+  var supportsColorSchemeQuery = mql.media === preferDarkQuery;
+  var localStorageTheme = null;
+  try {
+    localStorageTheme = localStorage.getItem(storageKey);
+  } catch (err) {}
+  var localStorageExists = localStorageTheme !== null;
+
+  // Determine the source of truth
+  if (localStorageExists) {
+    // source of truth from localStorage
+    setDataThemeAttribute(localStorageTheme);
+  } else if (supportsColorSchemeQuery) {
+    // source of truth from system
+    var theme = mql.matches ? 'dark' : '';
+    setDataThemeAttribute(theme);
+    localStorage.setItem(storageKey, theme);
+  } else {
+    // source of truth from document
+    var theme = document.querySelector('html').getAttribute('data-theme');
+    localStorage.setItem(storageKey, theme);
+  }
+})();`;
+
 module.exports = function(context, options) {
   const {customCss} = options || {};
   return {
@@ -18,6 +51,20 @@ module.exports = function(context, options) {
 
     getClientModules() {
       return ['infima/dist/css/default/default.css', customCss];
+    },
+
+    injectHtmlTags() {
+      return {
+        preBodyTags: [
+          {
+            tagName: 'script',
+            attributes: {
+              type: 'text/javascript',
+            },
+            innerHTML: noFlash,
+          },
+        ],
+      };
     },
   };
 };

--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -7,8 +7,8 @@
 
 const path = require('path');
 
+// Need to be inlined to prevent dark mode FOUC
 const noFlash = `(function() {
-  // Change these if you use something different in your hook.
   var storageKey = 'theme';
 
   function setDataThemeAttribute(theme) {
@@ -24,23 +24,19 @@ const noFlash = `(function() {
   } catch (err) {}
   var localStorageExists = localStorageTheme !== null;
 
-  // Determine the source of truth
   if (localStorageExists) {
-    // source of truth from localStorage
     setDataThemeAttribute(localStorageTheme);
   } else if (supportsColorSchemeQuery) {
-    // source of truth from system
     var theme = mql.matches ? 'dark' : '';
     setDataThemeAttribute(theme);
-    localStorage.setItem(storageKey, theme);
-  } else {
-    // source of truth from document
-    var theme = document.querySelector('html').getAttribute('data-theme');
-    localStorage.setItem(storageKey, theme);
   }
 })();`;
 
 module.exports = function(context, options) {
+  const {
+    siteConfig: {themeConfig},
+  } = context;
+  const {disableDarkMode = false} = themeConfig || {};
   const {customCss} = options || {};
   return {
     name: 'docusaurus-theme-classic',
@@ -54,6 +50,9 @@ module.exports = function(context, options) {
     },
 
     injectHtmlTags() {
+      if (disableDarkMode) {
+        return {};
+      }
       return {
         preBodyTags: [
           {

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.js
@@ -8,6 +8,8 @@
 import React from 'react';
 import Toggle from 'react-toggle';
 
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
 import classnames from 'classnames';
 import styles from './styles.module.css';
 
@@ -15,8 +17,10 @@ const Moon = () => <span className={classnames(styles.toggle, styles.moon)} />;
 const Sun = () => <span className={classnames(styles.toggle, styles.sun)} />;
 
 export default function(props) {
+  const {isClient} = useDocusaurusContext();
   return (
     <Toggle
+      disabled={!isClient}
       icons={{
         checked: <Moon />,
         unchecked: <Sun />,

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
@@ -26,6 +26,7 @@
 /**
  * styles for React Toggle
  * copied over because we want to allow user to swizzle it and modify the css
+ * and also to make sure its compatible with our dark mode
  * https://github.com/aaronshaf/react-toggle/blob/master/style.css
  */
 :global(.react-toggle) {
@@ -62,9 +63,6 @@
 
 :global(.react-toggle--disabled) {
   cursor: not-allowed;
-  opacity: 0.5;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s;
 }
 
 :global(.react-toggle-track) {
@@ -94,6 +92,7 @@
   transition: opacity 0.25s ease;
 }
 
+:global([data-theme="dark"] .react-toggle .react-toggle-track-check),
 :global(.react-toggle--checked .react-toggle-track-check) {
   opacity: 1;
   -webkit-transition: opacity 0.25s ease;
@@ -117,6 +116,7 @@
   transition: opacity 0.25s ease;
 }
 
+:global([data-theme="dark"] .react-toggle .react-toggle-track-x),
 :global(.react-toggle--checked .react-toggle-track-x) {
   opacity: 0;
 }
@@ -141,6 +141,7 @@
   transition: all 0.25s ease;
 }
 
+:global([data-theme="dark"] .react-toggle .react-toggle-thumb),
 :global(.react-toggle--checked .react-toggle-thumb) {
   left: 27px;
   border-color: #19ab27;

--- a/packages/docusaurus/src/client/App.js
+++ b/packages/docusaurus/src/client/App.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import Head from '@docusaurus/Head';
 import routes from '@generated/routes';
@@ -18,8 +18,14 @@ import './client-lifecycles-dispatcher';
 
 function App() {
   const {stylesheets, scripts} = siteConfig;
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
   return (
-    <DocusaurusContext.Provider value={{siteConfig}}>
+    <DocusaurusContext.Provider value={{siteConfig, isClient}}>
       {(stylesheets || scripts) && (
         <Head>
           {stylesheets &&

--- a/packages/docusaurus/src/server/html-tags/index.ts
+++ b/packages/docusaurus/src/server/html-tags/index.ts
@@ -28,7 +28,8 @@ export function loadHtmlTags(plugins: Plugin<any>[]): InjectedHtmlTags {
       if (!plugin.injectHtmlTags) {
         return acc;
       }
-      const {headTags, preBodyTags, postBodyTags} = plugin.injectHtmlTags();
+      const {headTags, preBodyTags, postBodyTags} =
+        plugin.injectHtmlTags() || {};
       return {
         headTags: headTags
           ? acc.headTags + '\n' + createHtmlTagsString(headTags)


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/1995

Before this PR, notice the FOUC
![before](https://user-images.githubusercontent.com/17883920/69896656-73e8eb80-1374-11ea-9b72-6bd72bb37484.gif)

Also have prefer color scheme.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Build production locally
- Serve it locally
- Go dark mode and refresh
![persistent toggle](https://user-images.githubusercontent.com/17883920/69896502-d214cf00-1372-11ea-9d77-a6836d91ac95.gif)

You can also try it on netlify :)

https://deploy-preview-2069--docusaurus-2.netlify.com/

cc @lex111 in case you want to give this a try. Seems that this should fit all of our use case

## Extra notes

`isClient` context is needed because we need to do **two pass rendering**
Why do we need two pass rendering ? 
For full reasoning, please check the whole thread starting from this comment https://github.com/facebook/docusaurus/pull/2057#issuecomment-559137084

I tweaked the CSS such that it looks very perfect now.