### PR TITLE
perf(v2): more performant gtag and analytics plugin

### DIFF
--- a/packages/docusaurus-plugin-google-analytics/src/analytics.js
+++ b/packages/docusaurus-plugin-google-analytics/src/analytics.js
@@ -5,56 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import siteConfig from '@generated/docusaurus.config';
-
-const {themeConfig} = siteConfig;
-
 export default (function() {
-  if (!themeConfig.googleAnalytics) {
+  if (typeof window === 'undefined') {
     return null;
   }
-
-  const {trackingID} = themeConfig.googleAnalytics;
-  if (process.env.NODE_ENV === 'development' && !trackingID) {
-    console.warn(
-      'You specified the `googleAnalytics` object in `themeConfig` but the `trackingID` field was missing. ' +
-        'Please ensure this is not a mistake.',
-    );
-    return null;
-  }
-
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    !trackingID ||
-    typeof window === 'undefined'
-  ) {
-    return null;
-  }
-
-  /* eslint-disable */
-  (function(i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r;
-    (i[r] =
-      i[r] ||
-      function() {
-        (i[r].q = i[r].q || []).push(arguments);
-      }),
-      (i[r].l = 1 * new Date());
-    (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m);
-  })(
-    window,
-    document,
-    'script',
-    'https://www.google-analytics.com/analytics.js',
-    'ga',
-  );
-  /* eslint-enable */
-
-  window.ga('create', trackingID, 'auto');
-  window.ga('send', 'pageview');
 
   return {
     onRouteUpdate({location}) {

--- a/packages/docusaurus-plugin-google-analytics/src/index.js
+++ b/packages/docusaurus-plugin-google-analytics/src/index.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
 
   if (!googleAnalytics) {
     throw new Error(
-      `You need to specify 'googleAnalytics' object in 'themeConfig' with 'trackingId' field in it to use docusaurus-plugin-google-gtag`,
+      `You need to specify 'googleAnalytics' object in 'themeConfig' with 'trackingId' field in it to use docusaurus-plugin-google-analytics`,
     );
   }
 

--- a/packages/docusaurus-plugin-google-analytics/src/index.js
+++ b/packages/docusaurus-plugin-google-analytics/src/index.js
@@ -14,5 +14,19 @@ module.exports = function() {
     getClientModules() {
       return [path.resolve(__dirname, './analytics')];
     },
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: 'https://www.google-analytics.com',
+            },
+          },
+        ],
+      };
+    },
   };
 };

--- a/packages/docusaurus-plugin-google-analytics/src/index.js
+++ b/packages/docusaurus-plugin-google-analytics/src/index.js
@@ -7,15 +7,37 @@
 
 const path = require('path');
 
-module.exports = function() {
+module.exports = function(context) {
+  const {siteConfig} = context;
+  const {themeConfig} = siteConfig;
+  const {googleAnalytics} = themeConfig || {};
+
+  if (!googleAnalytics) {
+    throw new Error(
+      `You need to specify 'googleAnalytics' object in 'themeConfig' with 'trackingId' field in it to use docusaurus-plugin-google-gtag`,
+    );
+  }
+
+  const {trackingID} = googleAnalytics;
+
+  if (!trackingID) {
+    throw new Error(
+      'You specified the `googleAnalytics` object in `themeConfig` but the `trackingID` field was missing. ' +
+        'Please ensure this is not a mistake.',
+    );
+  }
+  const isProd = process.env.NODE_ENV === 'production';
   return {
     name: 'docusaurus-plugin-google-analytics',
 
     getClientModules() {
-      return [path.resolve(__dirname, './analytics')];
+      return isProd ? [path.resolve(__dirname, './analytics')] : [];
     },
 
     injectHtmlTags() {
+      if (!isProd) {
+        return {};
+      }
       return {
         headTags: [
           {
@@ -23,6 +45,22 @@ module.exports = function() {
             attributes: {
               rel: 'preconnect',
               href: 'https://www.google-analytics.com',
+            },
+          },
+          // https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tag
+          {
+            tagName: 'script',
+            innerHTML: `
+              window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+              ga('create', '${trackingID}', 'auto');
+              ga('send', 'pageview');
+            `,
+          },
+          {
+            tagName: 'script',
+            attributes: {
+              async: true,
+              src: 'https://www.google-analytics.com/analytics.js',
             },
           },
         ],

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.js
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.js
@@ -32,11 +32,6 @@ export default (function() {
   }
 
   /* eslint-disable */
-  const $scriptEl = window.document.createElement('script');
-  $scriptEl.async = 1;
-  $scriptEl.src = `https://www.googletagmanager.com/gtag/js?id=${trackingID}`;
-  window.document.head.appendChild($scriptEl);
-
   window.dataLayer = window.dataLayer || [];
   function gtag() {
     // Have to use `arguments` instead of spreading as there are

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.js
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.js
@@ -7,29 +7,16 @@
 
 import siteConfig from '@generated/docusaurus.config';
 
-const {themeConfig} = siteConfig;
-
 export default (function() {
-  if (!themeConfig.gtag) {
+  if (typeof window === 'undefined') {
     return null;
   }
 
-  const {trackingID} = themeConfig.gtag;
-  if (process.env.NODE_ENV === 'development' && !trackingID) {
-    console.warn(
-      'You specified the `gtag` object in `themeConfig` but the `trackingID` field was missing. ' +
-        'Please ensure this is not a mistake.',
-    );
-    return null;
-  }
-
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    !trackingID ||
-    typeof window === 'undefined'
-  ) {
-    return null;
-  }
+  const {
+    themeConfig: {
+      gtag: {trackingID},
+    },
+  } = siteConfig;
 
   return {
     onRouteUpdate({location}) {

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.js
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.js
@@ -31,20 +31,6 @@ export default (function() {
     return null;
   }
 
-  /* eslint-disable */
-  window.dataLayer = window.dataLayer || [];
-  function gtag() {
-    // Have to use `arguments` instead of spreading as there are
-    // other properties attached to it e.g. callee.
-    // The GA library requires usage of `arguments.
-    window.dataLayer.push(arguments);
-  }
-  // Expose globally.
-  window.gtag = gtag;
-  gtag('js', new Date());
-  gtag('config', trackingID);
-  /* eslint-enable */
-
   return {
     onRouteUpdate({location}) {
       // Always refer to the variable on window in-case it gets overridden elsewhere.

--- a/packages/docusaurus-plugin-google-gtag/src/index.js
+++ b/packages/docusaurus-plugin-google-gtag/src/index.js
@@ -35,6 +35,11 @@ module.exports = function(context) {
     },
 
     injectHtmlTags() {
+      const innerHTML = `window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', ${trackingID});`;
+
       return {
         headTags: [
           {
@@ -57,6 +62,10 @@ module.exports = function(context) {
               async: true,
               src: `https://www.googletagmanager.com/gtag/js?id=${trackingID}`,
             },
+          },
+          {
+            tagName: 'script',
+            innerHTML,
           },
         ],
       };

--- a/packages/docusaurus-plugin-google-gtag/src/index.js
+++ b/packages/docusaurus-plugin-google-gtag/src/index.js
@@ -27,19 +27,18 @@ module.exports = function(context) {
     );
   }
 
+  const isProd = process.env.NODE_ENV === 'production';
   return {
     name: 'docusaurus-plugin-google-gtag',
 
     getClientModules() {
-      return [path.resolve(__dirname, './gtag')];
+      return isProd ? [path.resolve(__dirname, './gtag')] : [];
     },
 
     injectHtmlTags() {
-      const innerHTML = `window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', ${trackingID});`;
-
+      if (!isProd) {
+        return {};
+      }
       return {
         headTags: [
           {
@@ -56,6 +55,7 @@ module.exports = function(context) {
               href: 'https://www.googletagmanager.com',
             },
           },
+          // https://developers.google.com/analytics/devguides/collection/gtagjs/#install_the_global_site_tag
           {
             tagName: 'script',
             attributes: {
@@ -65,7 +65,11 @@ module.exports = function(context) {
           },
           {
             tagName: 'script',
-            innerHTML,
+            innerHTML: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${trackingID}');`,
           },
         ],
       };

--- a/packages/docusaurus-plugin-google-gtag/src/index.js
+++ b/packages/docusaurus-plugin-google-gtag/src/index.js
@@ -7,12 +7,59 @@
 
 const path = require('path');
 
-module.exports = function() {
+module.exports = function(context) {
+  const {siteConfig} = context;
+  const {themeConfig} = siteConfig;
+  const {gtag} = themeConfig || {};
+
+  if (!gtag) {
+    throw new Error(
+      `You need to specify 'gtag' object in 'themeConfig' with 'trackingId' field in it to use docusaurus-plugin-google-gtag`,
+    );
+  }
+
+  const {trackingID} = gtag;
+
+  if (!trackingID) {
+    throw new Error(
+      'You specified the `gtag` object in `themeConfig` but the `trackingID` field was missing. ' +
+        'Please ensure this is not a mistake.',
+    );
+  }
+
   return {
     name: 'docusaurus-plugin-google-gtag',
 
     getClientModules() {
       return [path.resolve(__dirname, './gtag')];
+    },
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: 'https://www.google-analytics.com',
+            },
+          },
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'preconnect',
+              href: 'https://www.googletagmanager.com',
+            },
+          },
+          {
+            tagName: 'script',
+            attributes: {
+              async: true,
+              src: `https://www.googletagmanager.com/gtag/js?id=${trackingID}`,
+            },
+          },
+        ],
+      };
     },
   };
 };

--- a/packages/docusaurus-plugin-google-gtag/src/index.js
+++ b/packages/docusaurus-plugin-google-gtag/src/index.js
@@ -40,6 +40,7 @@ module.exports = function(context) {
         return {};
       }
       return {
+        // Gtag includes GA by default, so we also preconnect to google-analytics.
         headTags: [
           {
             tagName: 'link',


### PR DESCRIPTION
## Motivation

I merged https://github.com/facebook/docusaurus/pull/2062#issuecomment-559917005 to wrong branch. But anyway I added some more optimization here

**Gtag**
We use inject head html hooks, so that the script head is not appended after JS load. [Removing this code](https://github.com/facebook/docusaurus/blob/522dd2d206900c74cbae03cc03974a6652e19218/packages/docusaurus-plugin-google-gtag/src/gtag.js#L35)

We should move this https://github.com/facebook/docusaurus/blob/61551152805aa53b1a50abf307ed6491ff3ab742/packages/docusaurus-plugin-google-gtag/src/gtag.js#L40-L51 to head like what https://developers.google.com/analytics/devguides/collection/gtagjs/ recommend.

Doing it via client modules previously will put it in main bundle.

**Google analytics**
Instead of old https://developers.google.com/analytics/devguides/collection/analyticsjs/#the_google_analytics_tag

We use the async tag https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tag since our user is mostly not on IE9 or older browser

**Summary**
- Also tried to leverage more on build time for checking instead of doing it client side
- Try to be more spec compliant

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

**Gtag**
Production build
![image](https://user-images.githubusercontent.com/17883920/69900365-c7732d80-13a4-11ea-8de7-bd18f6647a21.png)

Also spec compliant with 
https://developers.google.com/analytics/devguides/collection/gtagjs/
![image](https://user-images.githubusercontent.com/17883920/69900538-305ba500-13a7-11ea-88ec-f27a2a398681.png)


**Google analytics**

![image](https://user-images.githubusercontent.com/17883920/69900533-18842100-13a7-11ea-8f7a-17a45626c720.png)


https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tag
![image](https://user-images.githubusercontent.com/17883920/69900519-fe4a4300-13a6-11ea-9767-a3d554403f8f.png)
