### PR TITLE
Revert "fix(v2): remove auto wrap for code blocks (#2048)"

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -63,46 +63,43 @@ export default ({children, className: languageClassName, metastring}) => {
   };
 
   return (
-    <div className={styles.codeBlockWrapper}>
-      <button
-        ref={button}
-        type="button"
-        aria-label="Copy code to clipboard"
-        className={styles.copyButton}
-        onClick={handleCopyCode}>
-        {showCopied ? 'Copied' : 'Copy'}
-      </button>
+    <Highlight
+      {...defaultProps}
+      theme={prism.theme || defaultTheme}
+      code={children.trim()}
+      language={language}>
+      {({className, style, tokens, getLineProps, getTokenProps}) => (
+        <div className={styles.codeBlockWrapper}>
+          <pre
+            ref={target}
+            className={classnames(className, styles.codeBlock)}
+            style={style}>
+            {tokens.map((line, i) => {
+              const lineProps = getLineProps({line, key: i});
 
-      <Highlight
-        {...defaultProps}
-        theme={prism.theme || defaultTheme}
-        code={children.trim()}
-        language={language}>
-        {({className, style, tokens, getLineProps, getTokenProps}) => (
-          <pre className={classnames(className, styles.codeBlock)}>
-            <code
-              ref={target}
-              className={classnames(className, styles.codeBlockLines)}
-              style={style}>
-              {tokens.map((line, i) => {
-                const lineProps = getLineProps({line, key: i});
+              if (highlightLines.includes(i + 1)) {
+                lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+              }
 
-                if (highlightLines.includes(i + 1)) {
-                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-                }
-
-                return (
-                  <div key={i} {...lineProps}>
-                    {line.map((token, key) => (
-                      <span key={key} {...getTokenProps({token, key})} />
-                    ))}
-                  </div>
-                );
-              })}
-            </code>
+              return (
+                <div key={i} {...lineProps}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({token, key})} />
+                  ))}
+                </div>
+              );
+            })}
           </pre>
-        )}
-      </Highlight>
-    </div>
+          <button
+            ref={button}
+            type="button"
+            aria-label="Copy code to clipboard"
+            className={styles.copyButton}
+            onClick={handleCopyCode}>
+            {showCopied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      )}
+    </Highlight>
   );
 };

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -4,6 +4,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+ 
+.codeBlock {
+  border-radius: 0;
+  margin-bottom: 0;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
 
 .codeBlockWrapper {
   position: relative;
@@ -30,19 +38,4 @@
   visibility: hidden;
   transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
     bottom 200ms ease-in-out;
-}
-
-.codeBlock {
-  overflow: auto;
-  display: block;
-  padding: 0;
-  font-size: inherit;
-}
-
-.codeBlockLines {
-  border-radius: 0;
-  margin-bottom: 0;
-  float: left;
-  min-width: 100%;
-  padding: var(--ifm-pre-padding);
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -94,7 +94,7 @@ function DocItem(props) {
       <div className="padding-vert--lg">
         <div className="container">
           <div className="row">
-            <div className="col col--9">
+            <div className="col">
               <div className={styles.docItemContainer}>
                 <article>
                   {version && (

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -81,46 +81,43 @@ export default ({
   };
 
   return (
-    <div className={styles.codeBlockWrapper}>
-      <button
-        ref={button}
-        type="button"
-        aria-label="Copy code to clipboard"
-        className={styles.copyButton}
-        onClick={handleCopyCode}>
-        {showCopied ? 'Copied' : 'Copy'}
-      </button>
+    <Highlight
+      {...defaultProps}
+      theme={prism.theme || defaultTheme}
+      code={children.trim()}
+      language={language}>
+      {({className, style, tokens, getLineProps, getTokenProps}) => (
+        <div className={styles.codeBlockWrapper}>
+          <pre
+            ref={target}
+            className={classnames(className, styles.codeBlock)}
+            style={style}>
+            {tokens.map((line, i) => {
+              const lineProps = getLineProps({line, key: i});
 
-      <Highlight
-        {...defaultProps}
-        theme={prism.theme || defaultTheme}
-        code={children.trim()}
-        language={language}>
-        {({className, style, tokens, getLineProps, getTokenProps}) => (
-          <pre className={classnames(className, styles.codeBlock)}>
-            <code
-              ref={target}
-              className={classnames(className, styles.codeBlockLines)}
-              style={style}>
-              {tokens.map((line, i) => {
-                const lineProps = getLineProps({line, key: i});
+              if (highlightLines.includes(i + 1)) {
+                lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+              }
 
-                if (highlightLines.includes(i + 1)) {
-                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-                }
-
-                return (
-                  <div key={i} {...lineProps}>
-                    {line.map((token, key) => (
-                      <span key={key} {...getTokenProps({token, key})} />
-                    ))}
-                  </div>
-                );
-              })}
-            </code>
+              return (
+                <div key={i} {...lineProps}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({token, key})} />
+                  ))}
+                </div>
+              );
+            })}
           </pre>
-        )}
-      </Highlight>
-    </div>
+          <button
+            ref={button}
+            type="button"
+            aria-label="Copy code to clipboard"
+            className={styles.copyButton}
+            onClick={handleCopyCode}>
+            {showCopied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      )}
+    </Highlight>
   );
 };

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -1,3 +1,12 @@
+.codeBlock {
+  border-radius: 0;
+  font-size: inherit;
+  margin-bottom: 0;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
 .codeBlockWrapper {
   position: relative;
 }
@@ -23,19 +32,4 @@
   visibility: hidden;
   transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
     bottom 200ms ease-in-out;
-}
-
-.codeBlock {
-  overflow: auto;
-  display: block;
-  padding: 0;
-  font-size: inherit;
-}
-
-.codeBlockLines {
-  border-radius: 0;
-  margin-bottom: 0;
-  float: left;
-  min-width: 100%;
-  padding: var(--ifm-pre-padding);
 }


### PR DESCRIPTION
## Motivation

As mentioned in https://github.com/facebook/docusaurus/pull/2056
and https://github.com/facebook/docusaurus/pull/2048#issuecomment-558557240

I think it might be best to revert #2048 first. If we want to attempt on removing the codeblock autowrap, we can do it in new PR. Lot of changes has been added since alpha.36 and I think it'd be best to release soon so we can dogfood versioning & lot of other critical bugfix can land.

Because I'm seeing some unpleasant layout that is kinda zoomed and cut off. Notice the scrollbar
https://v2.docusaurus.io/docs/next/lifecycle-apis/
<img width="960" alt="before- (#2048)" src="https://user-images.githubusercontent.com/17883920/69898328-a867a200-138a-11ea-8ed9-76484dfd9061.PNG">

https://v2.docusaurus.io/docs/next/markdown-features
![image](https://user-images.githubusercontent.com/17883920/69898335-d4832300-138a-11ea-9e91-683ca71276db.png)




### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

No longer zoomed
![image](https://user-images.githubusercontent.com/17883920/69898358-3c396e00-138b-11ea-8b29-2be544a1daf2.png)

![image](https://user-images.githubusercontent.com/17883920/69898362-4a878a00-138b-11ea-9c3e-9a3a75e8c3b9.png)
