### PR TITLE
perf(v2): load algolia JS only when user interacts with search

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState, useRef, useCallback} from 'react';
+import React, {useRef, useCallback} from 'react';
 import classnames from 'classnames';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -16,7 +16,7 @@ const loadJS = () => import('docsearch.js');
 let loadedJs = false;
 
 const Search = props => {
-  const [initialized, setInitialized] = useState(false);
+  const initialized = useRef(false);
   const searchBarRef = useRef(null);
   const {siteConfig = {}} = useDocusaurusContext();
   const {
@@ -24,7 +24,7 @@ const Search = props => {
   } = siteConfig;
 
   const initAlgolia = () => {
-    if (!initialized) {
+    if (!initialized.current) {
       window.docsearch({
         appId: algolia.appId,
         apiKey: algolia.apiKey,
@@ -32,7 +32,7 @@ const Search = props => {
         inputSelector: '#search_input_react',
         algoliaOptions: algolia.algoliaOptions,
       });
-      setInitialized(true);
+      initialized.current = true;
     }
   };
 

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -5,47 +5,48 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {
-  useState,
-  useEffect,
-  useContext,
-  useRef,
-  useCallback,
-} from 'react';
+import React, {useState, useRef, useCallback} from 'react';
 import classnames from 'classnames';
 
-import DocusaurusContext from '@docusaurus/context';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import './styles.css';
 
+const loadJS = () => import('docsearch.js');
+let loadedJs = false;
+
 const Search = props => {
-  const [isEnabled, setIsEnabled] = useState(true);
+  const [initialized, setInitialized] = useState(false);
   const searchBarRef = useRef(null);
-  const context = useContext(DocusaurusContext);
+  const {siteConfig = {}} = useDocusaurusContext();
+  const {
+    themeConfig: {algolia},
+  } = siteConfig;
 
-  useEffect(() => {
-    const {siteConfig = {}} = context;
-    const {
-      themeConfig: {algolia},
-    } = siteConfig;
+  const initAlgolia = () => {
+    if (!initialized) {
+      window.docsearch({
+        appId: algolia.appId,
+        apiKey: algolia.apiKey,
+        indexName: algolia.indexName,
+        inputSelector: '#search_input_react',
+        algoliaOptions: algolia.algoliaOptions,
+      });
+      setInitialized(true);
+    }
+  };
 
-    // https://github.com/algolia/docsearch/issues/352
-    const isClient = typeof window !== 'undefined';
-    if (isClient) {
-      import('docsearch.js').then(({default: docsearch}) => {
-        docsearch({
-          appId: algolia.appId,
-          apiKey: algolia.apiKey,
-          indexName: algolia.indexName,
-          inputSelector: '#search_input_react',
-          algoliaOptions: algolia.algoliaOptions,
-        });
+  const loadAlgoliaJS = () => {
+    if (!loadedJs) {
+      loadJS().then(a => {
+        loadedJs = true;
+        window.docsearch = a.default;
+        initAlgolia();
       });
     } else {
-      console.warn('Search has failed to load and now is being disabled');
-      setIsEnabled(false);
+      initAlgolia();
     }
-  }, []);
+  };
 
   const toggleSearchIconClick = useCallback(
     e => {
@@ -58,7 +59,7 @@ const Search = props => {
     [props.isSearchBarExpanded],
   );
 
-  return isEnabled ? (
+  return (
     <div className="navbar__search" key="search-box">
       <span
         aria-label="expand searchbar"
@@ -80,12 +81,14 @@ const Search = props => {
           {'search-bar-expanded': props.isSearchBarExpanded},
           {'search-bar': !props.isSearchBarExpanded},
         )}
+        onClick={loadAlgoliaJS}
+        onMouseOver={loadAlgoliaJS}
         onFocus={toggleSearchIconClick}
         onBlur={toggleSearchIconClick}
         ref={searchBarRef}
       />
     </div>
-  ) : null;
+  );
 };
 
 export default Search;


### PR DESCRIPTION
## Motivation

Docsearch bundle size is a whooping 35kbs gzipped. That's huge ...

<img width="959" alt="js files in v2docusaurus" src="https://user-images.githubusercontent.com/17883920/69943864-7edc8100-1518-11ea-851d-ac446e7fb1d0.PNG">

Trying to improve our TTI performance by only loading algolia when user interact with the search

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Still working ✌️ 
![lazyload algolia normal](https://user-images.githubusercontent.com/17883920/69943988-c105c280-1518-11ea-991b-4cfdbb827068.gif)

Notice how the bundle is only loaded when user interact with it
![lazyload algolia](https://user-images.githubusercontent.com/17883920/69943974-b9461e00-1518-11ea-8675-0c1f6c606800.gif)

Benefit.
- Less bundle size shipped to user. 35kbs gzipped is huge. At first page load, our main thread is already busy parsing other javascript.

This increase our lighthouse TTI by 1s
After is 2.8s+
<img width="951" alt="lighthouse 99" src="https://user-images.githubusercontent.com/17883920/69944081-01fdd700-1519-11ea-9fc0-3f0c1025a774.PNG">

Before was 3.9s +
<img width="954" alt="lighthouse 96" src="https://user-images.githubusercontent.com/17883920/69944098-0d510280-1519-11ea-9d57-cb459bdf1ed6.PNG">

Slight caveat:
- There might be some kind of delay when user "search" with algolia for the first time since the JS is lazily loaded. Almost unnoticeable though, depends on internet speed. But since main thread is no longer busy, it will definitely be faster. see gif preview or try it on netlify