### PR TITLE
refactor(v2): toggle css should not be css modules since we use globals

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.js
@@ -10,11 +10,10 @@ import Toggle from 'react-toggle';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-import classnames from 'classnames';
-import styles from './styles.module.css';
+import './styles.css';
 
-const Moon = () => <span className={classnames(styles.toggle, styles.moon)} />;
-const Sun = () => <span className={classnames(styles.toggle, styles.sun)} />;
+const Moon = () => <span className="toggle moon" />;
+const Sun = () => <span className="toggle sun" />;
 
 export default function(props) {
   const {isClient} = useDocusaurusContext();

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/styles.css
@@ -29,7 +29,7 @@
  * and also to make sure its compatible with our dark mode
  * https://github.com/aaronshaf/react-toggle/blob/master/style.css
  */
-:global(.react-toggle) {
+.react-toggle {
   touch-action: pan-x;
 
   display: inline-block;
@@ -50,7 +50,7 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-:global(.react-toggle-screenreader-only) {
+.react-toggle-screenreader-only {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -61,11 +61,11 @@
   width: 1px;
 }
 
-:global(.react-toggle--disabled) {
+.react-toggle--disabled {
   cursor: not-allowed;
 }
 
-:global(.react-toggle-track) {
+.react-toggle-track {
   width: 50px;
   height: 24px;
   padding: 0;
@@ -76,7 +76,7 @@
   transition: all 0.2s ease;
 }
 
-:global(.react-toggle-track-check) {
+.react-toggle-track-check {
   position: absolute;
   width: 14px;
   height: 10px;
@@ -92,15 +92,15 @@
   transition: opacity 0.25s ease;
 }
 
-:global([data-theme="dark"] .react-toggle .react-toggle-track-check),
-:global(.react-toggle--checked .react-toggle-track-check) {
+[data-theme="dark"] .react-toggle .react-toggle-track-check,
+.react-toggle--checked .react-toggle-track-check {
   opacity: 1;
   -webkit-transition: opacity 0.25s ease;
   -moz-transition: opacity 0.25s ease;
   transition: opacity 0.25s ease;
 }
 
-:global(.react-toggle-track-x) {
+.react-toggle-track-x {
   position: absolute;
   width: 10px;
   height: 10px;
@@ -116,12 +116,12 @@
   transition: opacity 0.25s ease;
 }
 
-:global([data-theme="dark"] .react-toggle .react-toggle-track-x),
-:global(.react-toggle--checked .react-toggle-track-x) {
+[data-theme="dark"] .react-toggle .react-toggle-track-x,
+.react-toggle--checked .react-toggle-track-x {
   opacity: 0;
 }
 
-:global(.react-toggle-thumb) {
+.react-toggle-thumb {
   transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
   position: absolute;
   top: 1px;
@@ -141,19 +141,19 @@
   transition: all 0.25s ease;
 }
 
-:global([data-theme="dark"] .react-toggle .react-toggle-thumb),
-:global(.react-toggle--checked .react-toggle-thumb) {
+[data-theme="dark"] .react-toggle .react-toggle-thumb,
+.react-toggle--checked .react-toggle-thumb {
   left: 27px;
   border-color: #19ab27;
 }
 
-:global(.react-toggle--focus .react-toggle-thumb) {
+.react-toggle--focus .react-toggle-thumb {
   -webkit-box-shadow: 0px 0px 3px 2px #0099e0;
   -moz-box-shadow: 0px 0px 3px 2px #0099e0;
   box-shadow: 0px 0px 2px 3px #0099e0;
 }
 
-:global(.react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb) {
+.react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb {
   -webkit-box-shadow: 0px 0px 5px 5px #0099e0;
   -moz-box-shadow: 0px 0px 5px 5px #0099e0;
   box-shadow: 0px 0px 5px 5px #0099e0;


### PR DESCRIPTION
## Motivation

Since we use a lot of globals selector in toggle.css, maybe putting it as css modules is not useful at all. Might as well just make it plain css and save us some computing time.

CSS modules is more expensive than plain css.

It's also nicer to be able to override "toggle" classname without swizzling, eg: if i want to use fire icon.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

No css change. 
<img width="957" alt="working" src="https://user-images.githubusercontent.com/17883920/69948508-5b1e3880-1522-11ea-88f1-684e6a794d59.PNG">

## Extra

Maybe this file should've been moved to infima instead :|

https://github.com/facebook/docusaurus/blob/cc2201e997c660f8a334e5d5ada27994d04697f0/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css#L8-L10
https://github.com/facebook/docusaurus/blob/master/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css