### PR TITLE
refactor(v2): move scripts/stylesheets injection to server side

### DIFF
--- a/packages/docusaurus/src/client/App.js
+++ b/packages/docusaurus/src/client/App.js
@@ -7,7 +7,6 @@
 
 import React, {useEffect, useState} from 'react';
 
-import Head from '@docusaurus/Head';
 import routes from '@generated/routes';
 import siteConfig from '@generated/docusaurus.config';
 import renderRoutes from '@docusaurus/renderRoutes';
@@ -17,7 +16,6 @@ import PendingNavigation from './PendingNavigation';
 import './client-lifecycles-dispatcher';
 
 function App() {
-  const {stylesheets, scripts} = siteConfig;
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
@@ -26,26 +24,6 @@ function App() {
 
   return (
     <DocusaurusContext.Provider value={{siteConfig, isClient}}>
-      {(stylesheets || scripts) && (
-        <Head>
-          {stylesheets &&
-            stylesheets.map(source =>
-              typeof source === 'string' ? (
-                <link rel="stylesheet" key={source} href={source} />
-              ) : (
-                <link rel="stylesheet" key={source.href} {...source} />
-              ),
-            )}
-          {scripts &&
-            scripts.map(source =>
-              typeof source === 'string' ? (
-                <script type="text/javascript" src={source} key={source} />
-              ) : (
-                <script type="text/javascript" key={source.src} {...source} />
-              ),
-            )}
-        </Head>
-      )}
       <PendingNavigation routes={routes}>
         {renderRoutes(routes)}
       </PendingNavigation>

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -82,7 +82,9 @@ export async function load(siteDir: string): Promise<Props> {
   );
   const userTheme = path.resolve(siteDir, THEME_PATH);
   const alias = loadThemeAlias([fallbackTheme, ...pluginThemes, userTheme]);
-  // Make a fake plugin to resolve aliased theme components.
+
+  // Make a fake plugin to resolve aliased theme components && inject scripts/stylesheets
+  const {stylesheets = [], scripts = []} = siteConfig;
   plugins.push({
     name: 'docusaurus-bootstrap-plugin',
     configureWebpack: () => ({
@@ -90,6 +92,33 @@ export async function load(siteDir: string): Promise<Props> {
         alias,
       },
     }),
+    injectHtmlTags: () => {
+      const stylesheetsTags = stylesheets.map(source =>
+        typeof source === 'string'
+          ? `<link rel="stylesheet" href="${source}">`
+          : {
+              tagName: 'link',
+              attributes: {
+                rel: 'stylesheet',
+                ...source,
+              },
+            },
+      );
+      const scriptsTags = scripts.map(source =>
+        typeof source === 'string'
+          ? `<script type="text/javascript" src="${source}"></script>`
+          : {
+              tagName: 'script',
+              attributes: {
+                type: 'text/javascript',
+                ...source,
+              },
+            },
+      );
+      return {
+        headTags: [...stylesheetsTags, ...scriptsTags],
+      };
+    },
   });
 
   // Load client modules.


### PR DESCRIPTION
## Motivation

Move scripts/stylesheets siteConfig client side injection to server side using injectHtmlTag API

The benefit of this approach is that there won't be weird `data-helmet` attribute on the injected head tags and theoretically server side should be faster than react helmet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan
Nothing broke
<img width="959" alt="nothing broke" src="https://user-images.githubusercontent.com/17883920/70052612-431fe500-1606-11ea-8c30-6990af40811d.PNG">

Add random scripts and stylesheets into config
<img width="766" alt="still working" src="https://user-images.githubusercontent.com/17883920/70052631-4dda7a00-1606-11ea-88f3-e2b2a2a0f393.png">


## To consider
Deprecate scripts and stylesheets option ? But that would require v1 user migrating having to create a local plugin which can be slightly annoying