### PR TITLE
fix(v2): windows compatibility regression

### DIFF
--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -152,6 +152,7 @@ ${Object.keys(registry)
   .sort()
   .map(
     key =>
+      // We need to JSON.stringify so that if its on windows, backslash are escaped.
       `  '${key}': [${registry[key].loader}, ${JSON.stringify(
         registry[key].modulePath,
       )}, require.resolveWeak(${JSON.stringify(registry[key].modulePath)})],`,

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -129,7 +129,7 @@ export async function load(siteDir: string): Promise<Props> {
     `export default [\n${clientModules
       // import() is async so we use require() because client modules can have
       // CSS and the order matters for loading CSS.
-      .map(module => `  require("${module}"),`)
+      .map(module => `  require(${JSON.stringify(module)}),`)
       .join('\n')}\n];\n`,
   );
 
@@ -152,7 +152,9 @@ ${Object.keys(registry)
   .sort()
   .map(
     key =>
-      `  '${key}': [${registry[key].loader}, "${registry[key].modulePath}", require.resolveWeak("${registry[key].modulePath}")],`,
+      `  '${key}': [${registry[key].loader}, ${JSON.stringify(
+        registry[key].modulePath,
+      )}, require.resolveWeak(${JSON.stringify(registry[key].modulePath)})],`,
   )
   .join('\n')}};\n`,
   );

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -129,6 +129,7 @@ export async function load(siteDir: string): Promise<Props> {
     `export default [\n${clientModules
       // import() is async so we use require() because client modules can have
       // CSS and the order matters for loading CSS.
+      // We need to JSON.stringify so that if its on windows, backslash are escaped.
       .map(module => `  require(${JSON.stringify(module)}),`)
       .join('\n')}\n];\n`,
   );


### PR DESCRIPTION
## Motivation

This reverts #2039 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Previously registry.js will be like this on Windows. 

[Error in babel](
https://babeljs.io/repl#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=KYDwDg9gTgLgBAE2AMwIYFcA28DeAoOOAcgGMIA7GYSgWjoCNMIBzGgJgHYBmGj5LogC44AbQAUASjgBeAHxwAlgFtIsMQHoAVHADuwemFQkA1gGEAFunLGAcqiXBhpClVoMmrTjz4C4m9XAARAACAM4KVOqMLAA6bAAMAIwAnDTxAKzsABw05hCYqAB0SggA_DBQViSoVAjSFejAgRIANEFhEcBRHnFJqRnZuflFJeWV5NW19ZVNbVDAAI7oCvOF86H5AG7AAOrAqMZiIeGR0cy9KWmZbDl5BcVlDRM1wHUNTRIAui14AL5AA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=7.7.4&externalPlugins=)
![image](https://user-images.githubusercontent.com/17883920/70206214-60b19380-1759-11ea-9f14-45b2e8607dcd.png)

[After](
https://babeljs.io/repl#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=KYDwDg9gTgLgBAE2AMwIYFcA28DeAoOOAcgGMIA7GYSgWjoCNMIBzGgJgHYBmGj5LogC44AbQAUASjgBeAHxwAlgFtIsMQHoAVHADuwemFQkA1gGEAFunLGAcqiXBhpClVoMmrTjz4C4m9XAARAACAM4KVOqMLAA6MWwADACMAJw0CQCs7AAcNOYQmKgAdEoIAPwwUFYkqFQI0pXowIESADRBYRHAUR5xianpWWy5-YUl5Y3kNXUNVc3tUMAAjugKi0WLoQUAbsAA6sCoxmIh4ZHRzH3JaZk5eQXFpRVVU7XA9Y3NEgC6rXgAvkA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=7.7.4&externalPlugins=)

![image](https://user-images.githubusercontent.com/17883920/70206260-7921ae00-1759-11ea-88c1-c0d6622a6328.png)

I've tested it on windows, 
![image](https://user-images.githubusercontent.com/17883920/70206334-bc7c1c80-1759-11ea-80f2-9c5bc2b7b0c6.png)

