### PR TITLE
fix(v1): add key to versions.map in versions.js

### DIFF
--- a/packages/docusaurus-1.x/examples/versions/pages/en/versions.js
+++ b/packages/docusaurus-1.x/examples/versions/pages/en/versions.js
@@ -81,7 +81,7 @@ function Versions(props) {
               {versions.map(
                 version =>
                   version !== latestVersion && (
-                    <tr>
+                    <tr key={version}>
                       <th>{version}</th>
                       <td>
                         {/* You are supposed to change this href where appropriate


### PR DESCRIPTION
I noticed the v1 examples `versions.js` when calling `map` function does not provide a `key`.

So i added the `key` prop to ` packages/docusaurus-1.x/examples/versions/pages/en/versions.js`
