### PR TITLE
perf(v2): improve dev build time by not overwriting file if possible

### DIFF
--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -27,7 +27,18 @@ export async function generate(
     return;
   }
 
-  const lastHash = fileHash.get(filepath);
+  let lastHash = fileHash.get(filepath);
+
+  // If file already exist but its not in runtime cache hash yet,
+  // we try to calculate the content hash and then compare
+  // This is to avoid unnecessary overwrite and we can reuse old file
+  if (!lastHash && fs.existsSync(filepath)) {
+    const lastContent = await fs.readFile(filepath, 'utf8');
+    lastHash = createHash('md5')
+      .update(lastContent)
+      .digest('hex');
+  }
+
   const currentHash = createHash('md5')
     .update(content)
     .digest('hex');

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -37,6 +37,7 @@ export async function generate(
     lastHash = createHash('md5')
       .update(lastContent)
       .digest('hex');
+    fileHash.set(filepath, lastHash);
   }
 
   const currentHash = createHash('md5')

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -183,6 +183,7 @@ For example, if you are in `doc2.md` and you want to reference `doc1.md` and `fo
 
 ```md
 I am referencing a [document](doc1.md). Reference to another [document in a folder](folder/doc3.md)
+[Relative document](../doc2.md) referencing works as well.
 ```
 
 One benefit of this approach is that the links to external files will still work if you are viewing the file on GitHub.


### PR DESCRIPTION
## Motivation

Cache-loader compares with [mtime](https://github.com/webpack-contrib/cache-loader/blob/3371562bc05c645dcd20e851ec6c0cc82387fd7f/src/index.js#L311-L313)

And currently, whenever we run new "docusaurus start", we always overwrite a lot of the generated files for the first time, invalidating cache. The next reload is fine, because we have runtime content hash cache.

We can do better by checking If file already exist but its not in runtime cache hash yet, then we try to calculate the content hash and then compare. This is to avoid unnecessary overwrite and we can reuse old file. Thus, cache-loader wont invalidate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan
Before ~7s
![image](https://user-images.githubusercontent.com/17883920/70258310-9046b700-17be-11ea-924c-6cb25b4c3ed7.png)

My next dev server (second run) went down to ~5s
![image](https://user-images.githubusercontent.com/17883920/70257979-f5e67380-17bd-11ea-8c5d-04479a1db36c.png)

This is minor improvement, but as more metadata is written, this is gonna improve a lot

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
