### PR TITLE
fix(v2): metadata error if markdown does not have ending line

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -37,6 +37,7 @@ export = function(fileString: string) {
     if (err) return callback && callback(err);
 
     const metadataStr = `export const metadata = ${metadata};`;
-    callback && callback(null, finalContent + '\n' + metadataStr);
+    // We need to add two lines break so that mdx won't mistake it as part of previous paragraph
+    callback && callback(null, finalContent + '\n\n' + metadataStr);
   });
 } as loader.Loader;

--- a/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
@@ -44,6 +44,7 @@ export = function(fileString: string) {
     if (err) return callback && callback(err);
 
     const metadataStr = `export const metadata = ${metadata}`;
-    callback && callback(null, linkifiedStr + '\n' + metadataStr);
+    // We need to add two lines break so that mdx won't mistake it as part of previous paragraph
+    callback && callback(null, linkifiedStr + '\n\n' + metadataStr);
   });
 } as loader.Loader;


### PR DESCRIPTION
## Motivation

If markdown file does not have an ending line, the metadata embed in content will error out due to MDX mistaking `export const metadata` as part of paragraph

Example:
This won't error
![image](https://user-images.githubusercontent.com/17883920/70306949-aabe7600-183a-11ea-8ff7-d6637d86240c.png)

Error
![image](https://user-images.githubusercontent.com/17883920/70306966-b6aa3800-183a-11ea-8a23-86aa0af87139.png)

So whats happening under the hood ?
<img width="960" alt="1  error if got no linebreak" src="https://user-images.githubusercontent.com/17883920/70306996-c295fa00-183a-11ea-9ffe-8b8b166c067d.PNG">

The metadata is mistaken as part of paragraph
<img width="959" alt="2  whats happening is that metadata is thought as paragraph" src="https://user-images.githubusercontent.com/17883920/70306997-c295fa00-183a-11ea-9aca-c56c13f2446e.PNG">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

No more error
<img width="960" alt="3  correct export" src="https://user-images.githubusercontent.com/17883920/70307006-c9247180-183a-11ea-8a4c-f8d8c582cf7e.PNG">


## Related PRs

#2088 