### PR TITLE
chore: docusaurus build on Windows with GitHub actions

### DIFF
--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -1,4 +1,4 @@
-name: Node CI Build on Windows
+name: Docusaurus on Windows
 
 on:
   # Trigger the workflow on push or pull request,
@@ -22,9 +22,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: yarn and yarn build
-      run: |
-        yarn
-        yarn build
+    - name: Installation
+      run: yarn
+    - name: Docusaurus 1 Build
+      run: yarn build:v1
+    - name: Docusaurus 2 Build
+      run: yarn build:v2
       env:
         CI: true

--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -1,0 +1,30 @@
+name: Node CI Build on Windows
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: yarn and yarn build
+      run: |
+        yarn
+        yarn build
+      env:
+        CI: true


### PR DESCRIPTION
## Motivation

Testing GitHub actions to build Windows for both v1 and v2 to prevent regression

all code is kinda self-made from reading https://help.github.com/en/actions/automating-your-workflow-with-github-actions

Seems to work well

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

TBD. CI should appear ??
![image](https://user-images.githubusercontent.com/17883920/70368427-aea2d480-18dc-11ea-8e7d-662fc0658af9.png)

![image](https://user-images.githubusercontent.com/17883920/70368466-6d5ef480-18dd-11ea-8e20-4ca6dffefdbd.png)

![image](https://user-images.githubusercontent.com/17883920/70368479-93849480-18dd-11ea-84ea-643a7824473d.png)

## Gonna release 2.0.0-alpha.39 soon for hotfix