### PR TITLE
fix(v2): move metadata export after compiling MDX to avoid weird MDX parsing error. 

### DIFF
--- a/packages/docusaurus-mdx-loader/README.md
+++ b/packages/docusaurus-mdx-loader/README.md
@@ -39,11 +39,3 @@ Array of rehype plugins to manipulate the MDXHAST
 ### `remarkPlugins`
 Array of remark plugins to manipulate the MDXAST
 
-### `metadataPath`
-A function to provide the metadataPath depending on current loaded MDX path that will be embedded as the MDX metadata.
-Example
-```js
-const metadataPath = (mdxPath) => {
-  return path.join('/some/metadata/path', `${path.basename(mdxPath)}-metadata.json`);
-}
-```

--- a/packages/docusaurus-mdx-loader/README.md
+++ b/packages/docusaurus-mdx-loader/README.md
@@ -38,3 +38,12 @@ Array of rehype plugins to manipulate the MDXHAST
 
 ### `remarkPlugins`
 Array of remark plugins to manipulate the MDXAST
+
+### `metadataPath`
+A function to provide the metadataPath depending on current loaded MDX path that will be embedded as the MDX metadata.
+Example
+```js
+const metadataPath = (mdxPath) => {
+  return path.join('/some/metadata/path', `${path.basename(mdxPath)}-metadata.json`);
+}
+```

--- a/packages/docusaurus-mdx-loader/README.md
+++ b/packages/docusaurus-mdx-loader/README.md
@@ -41,4 +41,3 @@ Array of remark plugins to manipulate the MDXAST
 
 ### `metadataPath`
 A function to provide the metadataPath depending on current loaded MDX path that will be exported as the MDX metadata.
-```

--- a/packages/docusaurus-mdx-loader/README.md
+++ b/packages/docusaurus-mdx-loader/README.md
@@ -39,3 +39,6 @@ Array of rehype plugins to manipulate the MDXHAST
 ### `remarkPlugins`
 Array of remark plugins to manipulate the MDXAST
 
+### `metadataPath`
+A function to provide the metadataPath depending on current loaded MDX path that will be exported as the MDX metadata.
+```

--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -13,6 +13,7 @@
     "@mdx-js/mdx": "^1.5.1",
     "@mdx-js/react": "^1.5.1",
     "escape-html": "^1.0.3",
+    "fs-extra": "^8.1.0",
     "github-slugger": "^1.2.1",
     "gray-matter": "^4.0.2",
     "loader-utils": "^1.2.3",

--- a/packages/docusaurus-mdx-loader/src/index.js
+++ b/packages/docusaurus-mdx-loader/src/index.js
@@ -44,6 +44,8 @@ module.exports = async function(fileString) {
     return callback(err);
   }
 
+  let exportStr = `export const frontMatter = ${stringifyObject(data)};`;
+
   // If metadataPath is provided, we read metadata & then embed it to this MDX content
   if (options.metadataPath && typeof options.metadataPath === 'function') {
     const metadataPath = options.metadataPath(this.resourcePath);
@@ -52,7 +54,7 @@ module.exports = async function(fileString) {
       // Add as dependency of this loader result so that we can recompile if metadata is changed
       this.addDependency(metadataPath);
       const metadata = await readFile(metadataPath, 'utf8');
-      result = `export const metadata = ${metadata};\n${result}`;
+      exportStr += `\nexport const metadata = ${metadata};`;
     }
   }
 
@@ -60,7 +62,7 @@ module.exports = async function(fileString) {
   import React from 'react';
   import { mdx } from '@mdx-js/react';
 
-  export const frontMatter = ${stringifyObject(data)};
+  ${exportStr}
   ${result}
   `;
 

--- a/packages/docusaurus-mdx-loader/src/index.js
+++ b/packages/docusaurus-mdx-loader/src/index.js
@@ -46,7 +46,7 @@ module.exports = async function(fileString) {
 
   let exportStr = `export const frontMatter = ${stringifyObject(data)};`;
 
-  // If metadataPath is provided, we read metadata & then embed it to this MDX content
+  // Read metadata for this MDX and export it
   if (options.metadataPath && typeof options.metadataPath === 'function') {
     const metadataPath = options.metadataPath(this.resourcePath);
 

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -8,14 +8,11 @@
 const {parseQuery, getOptions} = require('loader-utils');
 import {loader} from 'webpack';
 import {truncate} from './blogUtils';
-import path from 'path';
-import {readFile} from 'fs-extra';
-import {aliasedSitePath, docuHash} from '@docusaurus/utils';
 
 export = function(fileString: string) {
   const callback = this.async();
 
-  const {truncateMarker, siteDir, dataDir} = getOptions(this);
+  const {truncateMarker}: {truncateMarker: RegExp | string} = getOptions(this);
 
   let finalContent = fileString;
 
@@ -24,20 +21,5 @@ export = function(fileString: string) {
   if (truncated) {
     finalContent = truncate(fileString, truncateMarker);
   }
-
-  // Read metadata & then embed it to this markdown content
-  // Note that metadataPath must be the same/ in-sync as the path from createData
-  const aliasedSource = aliasedSitePath(this.resourcePath, siteDir);
-  const metadataPath = path.join(dataDir, `${docuHash(aliasedSource)}.json`);
-
-  // Add metadataPath as dependency of this loader result so that we can recompile if metadata is changed
-  this.addDependency(metadataPath);
-
-  readFile(metadataPath, 'utf8', function(err, metadata) {
-    if (err) return callback && callback(err);
-
-    const metadataStr = `export const metadata = ${metadata};`;
-    // We need to add two lines break so that mdx won't mistake it as part of previous paragraph
-    callback && callback(null, finalContent + '\n\n' + metadataStr);
-  });
+  return callback && callback(null, finalContent);
 } as loader.Loader;

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -9,7 +9,12 @@ import _ from 'lodash';
 import globby from 'globby';
 import fs from 'fs-extra';
 import path from 'path';
-import {normalizeUrl, docuHash, objectWithKeySorted} from '@docusaurus/utils';
+import {
+  normalizeUrl,
+  docuHash,
+  objectWithKeySorted,
+  aliasedSitePath,
+} from '@docusaurus/utils';
 import {LoadContext, Plugin, RouteConfig} from '@docusaurus/types';
 
 import createOrder from './order';
@@ -285,7 +290,7 @@ export default function pluginContentDocs(
         const routes = await Promise.all(
           metadataItems.map(async metadataItem => {
             await createData(
-              // Note that this created data path must be in sync with markdown/index.ts metadataPath
+              // Note that this created data path must be in sync with metadataPath provided to mdx-loader
               `${docuHash(metadataItem.source)}.json`,
               JSON.stringify(metadataItem, null, 2),
             );
@@ -404,13 +409,20 @@ export default function pluginContentDocs(
                   options: {
                     remarkPlugins,
                     rehypePlugins,
+                    metadataPath: (mdxPath: string) => {
+                      // Note that metadataPath must be the same/ in-sync as the path from createData for each MDX
+                      const aliasedSource = aliasedSitePath(mdxPath, siteDir);
+                      return path.join(
+                        dataDir,
+                        `${docuHash(aliasedSource)}.json`,
+                      );
+                    },
                   },
                 },
                 {
                   loader: path.resolve(__dirname, './markdown/index.js'),
                   options: {
                     siteDir,
-                    dataDir,
                     docsDir,
                     sourceToPermalink: sourceToPermalink,
                     versionedDir,

--- a/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
@@ -5,46 +5,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import {readFile} from 'fs-extra';
 import {getOptions} from 'loader-utils';
 import {loader} from 'webpack';
 import linkify from './linkify';
-import {docuHash, aliasedSitePath} from '@docusaurus/utils';
 
 export = function(fileString: string) {
   const callback = this.async();
-  const {
-    dataDir,
-    docsDir,
-    siteDir,
-    versionedDir,
-    sourceToPermalink,
-  } = getOptions(this);
-
-  // Replace all markdown linking to correct url
-  const linkifiedStr = linkify(
-    fileString,
-    this.resourcePath,
-    docsDir,
-    siteDir,
-    sourceToPermalink,
-    versionedDir,
+  const {docsDir, siteDir, versionedDir, sourceToPermalink} = getOptions(this);
+  return (
+    callback &&
+    callback(
+      null,
+      linkify(
+        fileString,
+        this.resourcePath,
+        docsDir,
+        siteDir,
+        sourceToPermalink,
+        versionedDir,
+      ),
+    )
   );
-
-  // Read metadata & then embed it to this markdown content
-  // Note that metadataPath must be the same/ in-sync as the path from createData
-  const aliasedSource = aliasedSitePath(this.resourcePath, siteDir);
-  const metadataPath = path.join(dataDir, `${docuHash(aliasedSource)}.json`);
-
-  // Add metadataPath as dependency of this loader result so that we can recompile if metadata is changed
-  this.addDependency(metadataPath);
-
-  readFile(metadataPath, 'utf8', function(err, metadata) {
-    if (err) return callback && callback(err);
-
-    const metadataStr = `export const metadata = ${metadata}`;
-    // We need to add two lines break so that mdx won't mistake it as part of previous paragraph
-    callback && callback(null, linkifiedStr + '\n\n' + metadataStr);
-  });
 } as loader.Loader;

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -122,7 +122,7 @@ export async function start(
   // https://webpack.js.org/configuration/dev-server
   const devServerConfig: WebpackDevServer.Configuration = {
     compress: true,
-    clientLogLevel: 'info',
+    clientLogLevel: 'error',
     hot: true,
     hotOnly: cliOptions.hotOnly,
     quiet: true,

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -122,7 +122,7 @@ export async function start(
   // https://webpack.js.org/configuration/dev-server
   const devServerConfig: WebpackDevServer.Configuration = {
     compress: true,
-    clientLogLevel: 'error',
+    clientLogLevel: 'info',
     hot: true,
     hotOnly: cliOptions.hotOnly,
     quiet: true,


### PR DESCRIPTION
## Motivation

Move metadata export after compiling the MDX to avoid weird MDX parsing error. 
Although we've fixed #2095 (MDX thinking that metadata was part of paragraph), there might be some other unexpected case.

For example:

This  will error out, because it is unclosed (funnily it thinks its unclosed because style must always have `</style>` counterpart. And MDX think metadata is part of the JSX
```mdx
## Hello World
<style dangerouslySetInnerHTML={{__html: `
  .comparisonTable td {
    width: 25%;
  }
  .comparisonTable .middle {
    text-align: center;
    vertical-align: middle;
  }
  .comparisonTable ul {
    padding-left: 1em;
  }
`}}/>

export const metadata = {
  id: 'test'
}
```

https://mdxjs.com/playground
![image](https://user-images.githubusercontent.com/17883920/70435116-91c2f880-1ab8-11ea-86d1-419d1ba03639.png)

If its closed properly, it doesnt error. Now I'm pretty confused how they determine HTML or JSX
```mdx
## Hello World
<style dangerouslySetInnerHTML={{__html: `
  .comparisonTable td {
    width: 25%;
  }
  .comparisonTable .middle {
    text-align: center;
    vertical-align: middle;
  }
  .comparisonTable ul {
    padding-left: 1em;
  }
`}}></style>

export const metadata = {
  id: 'test'
}
```
![image](https://user-images.githubusercontent.com/17883920/70435802-63deb380-1aba-11ea-9d96-ee619d124a49.png)



A real scenario is https://github.com/CanopyTax/single-spa.js.org/blob/master/docs/separating-applications.md
![image](https://user-images.githubusercontent.com/17883920/70434802-c84c4380-1ab7-11ea-8e76-3e5bd98fa06b.png)

Now, we will just do the export on top level on mdx-loader part. See code in this PR `packages/docusaurus-mdx-loader/src/index.js`


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Test with this markdown. No more error.
![image](https://user-images.githubusercontent.com/17883920/70435299-16157b80-1ab9-11ea-89d6-828d370767d0.png)

![image](https://user-images.githubusercontent.com/17883920/70435323-275e8800-1ab9-11ea-8fd0-770e57657567.png)


Hot reload still working and everything

![hot reload still fine for metadata](https://user-images.githubusercontent.com/17883920/70434818-d4d09c00-1ab7-11ea-9f3c-ab6111742bd7.gif)
