### PR TITLE
fix(v2): add missing hyphen in color generator

### DIFF
--- a/website/src/components/ColorGenerator/index.js
+++ b/website/src/components/ColorGenerator/index.js
@@ -12,43 +12,43 @@ import Color from 'color';
 import styles from './styles.module.css';
 
 const COLOR_SHADES = {
-  '-ifm-color-primary': {
+  '--ifm-color-primary': {
     adjustment: 0,
     adjustmentInput: 0,
     displayOrder: 3,
     codeOrder: 0,
   },
-  '-ifm-color-primary-dark': {
+  '--ifm-color-primary-dark': {
     adjustment: 0.1,
     adjustmentInput: '10',
     displayOrder: 4,
     codeOrder: 1,
   },
-  '-ifm-color-primary-darker': {
+  '--ifm-color-primary-darker': {
     adjustment: 0.15,
     adjustmentInput: '15',
     displayOrder: 5,
     codeOrder: 2,
   },
-  '-ifm-color-primary-darkest': {
+  '--ifm-color-primary-darkest': {
     adjustment: 0.3,
     adjustmentInput: '30',
     displayOrder: 6,
     codeOrder: 3,
   },
-  '-ifm-color-primary-light': {
+  '--ifm-color-primary-light': {
     adjustment: -0.1,
     adjustmentInput: '-10',
     displayOrder: 2,
     codeOrder: 4,
   },
-  '-ifm-color-primary-lighter': {
+  '--ifm-color-primary-lighter': {
     adjustment: -0.15,
     adjustmentInput: '-15',
     displayOrder: 1,
     codeOrder: 5,
   },
-  '-ifm-color-primary-lightest': {
+  '--ifm-color-primary-lightest': {
     adjustment: -0.3,
     adjustmentInput: '-30',
     displayOrder: 0,
@@ -121,7 +121,7 @@ function ColorGenerator({children, minHeight, url}) {
                       </code>
                     </td>
                     <td>
-                      {variableName === '-ifm-color-primary' ? (
+                      {variableName === '--ifm-color-primary' ? (
                         0
                       ) : (
                         <input


### PR DESCRIPTION
## Motivation

CSS vars starts with two hyphens.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![image](https://user-images.githubusercontent.com/4408379/70444552-20c91400-1aab-11ea-982a-c21e724e368b.png)


