### PR TITLE
feat(v2): explicit babel/runtime version

### DIFF
--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -127,6 +127,10 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
             {
               corejs: false,
               helpers: true,
+              // By default, it assumes @babel/runtime@7.0.0. Since we use >7.0.0, better to
+              // explicitly specify the version so that it can reuse the helper better
+              // See https://github.com/babel/babel/issues/10261
+              version: require('@babel/runtime/package.json').version,
               regenerator: true,
               useESModules: true,
               // Undocumented option that lets us encapsulate our runtime, ensuring


### PR DESCRIPTION
## Motivation

See https://github.com/babel/babel/issues/10261 and https://github.com/babel/babel/issues/10261#issuecomment-520990162

By default transform-runtime assumes that @babel/runtime@7.0.0 is installed. If you have later versions of @babel/runtime but did not specify version, transform-runtime will only use the helper from 7.0.0 resulting in larger bundle size.

>In this case, it will assume you are using babel/helpers 7.0.0-beta.0, which means every helper introduced later than 7.0.0-beta.0 will be inlined instead of require. 

Better to be explicit

Inspired from https://github.com/facebook/create-react-app/pull/7726

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

- Netlify should all pass
- CI