### PR TITLE
fix(v2): set stored theme only if it exists

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
@@ -14,7 +14,10 @@ const useTheme = () => {
   );
   React.useEffect(() => {
     try {
-      setTheme(localStorage.getItem('theme'));
+      const localStorageTheme = localStorage.getItem('theme');
+      if (localStorageTheme !== null) {
+        setTheme(localStorageTheme);
+      }
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Motivation

Currently, automatic switching to a dark theme does not work if a dark theme is selected in the system (because even when there is no saved theme in local storage, we set (override init value with correct theme) the theme to `null` value which is cast to an empty string (i.e. light theme)). This PR solves this bug.

https://github.com/facebook/docusaurus/blob/ba7c38cf0fc3e384373e6da4147fb154a939279b/packages/docusaurus-theme-classic/src/index.js#L29-L30

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Select a dark theme in your OS
1. Go to the docs site (after clearing localstorage), a dark theme should be enabled.
