### PR TITLE
fix(v2): add syntax highlight to generated colors

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -4,9 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
- 
+
 .codeBlock {
-  border-radius: 0;
   margin-bottom: 0;
   overflow: hidden;
   overflow-wrap: break-word;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -1,5 +1,4 @@
 .codeBlock {
-  border-radius: 0;
   font-size: inherit;
   margin-bottom: 0;
   overflow: hidden;

--- a/website/src/components/ColorGenerator/index.js
+++ b/website/src/components/ColorGenerator/index.js
@@ -9,6 +9,8 @@ import React, {useState} from 'react';
 
 import Color from 'color';
 
+import CodeBlock from '@theme/CodeBlock';
+
 import styles from './styles.module.css';
 
 const COLOR_SHADES = {
@@ -154,12 +156,12 @@ function ColorGenerator({children, minHeight, url}) {
         Replace the variables in <code>src/css/custom.css</code> with these new
         variables.
       </p>
-      <pre>
+      <CodeBlock className="css">
         {adjustedColors
           .sort((a, b) => a.codeOrder - b.codeOrder)
           .map(value => `${value.variableName}: ${value.hex.toLowerCase()};`)
           .join('\n')}
-      </pre>
+      </CodeBlock>
     </div>
   );
 }


### PR DESCRIPTION
## Motivation

In addition to the syntax highlighting itself, which is important given the dark/light Prism theme (coming soon https://github.com/facebook/docusaurus/pull/1984), it is possible to copy CSS vars simply click button.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![image](https://user-images.githubusercontent.com/4408379/70538272-db701980-1b72-11ea-933e-f346fbf5e900.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
