### PR TITLE
feat(v2): auto switch theme depending on the system theme

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -14,19 +14,29 @@ const noFlash = `(function() {
   function setDataThemeAttribute(theme) {
     document.querySelector('html').setAttribute('data-theme', theme);
   }
-  
-  var preferDarkQuery = '(prefers-color-scheme: dark)';
-  var mql = window.matchMedia(preferDarkQuery);
-  var supportsColorSchemeQuery = mql.media === preferDarkQuery;
-  var localStorageTheme = null;
-  try {
-    localStorageTheme = localStorage.getItem('${storageKey}');
-  } catch (err) {}
-  var localStorageExists = localStorageTheme !== null;
 
-  if (localStorageExists) {
-    setDataThemeAttribute(localStorageTheme);
-  } else if (supportsColorSchemeQuery && mql.matches) {
+  function getPreferredTheme() {
+    var theme = null;
+    try {
+      theme = localStorage.getItem('${storageKey}');
+    } catch (err) {}
+
+    return theme;
+  }
+
+  var darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  darkQuery.addListener(function(e) {
+    if (getPreferredTheme() !== null) {
+      return;
+    }
+
+    setDataThemeAttribute(e.matches ? 'dark' : '');
+  });
+
+  var preferredTheme = getPreferredTheme();
+  if (preferredTheme !== null) {
+    setDataThemeAttribute(preferredTheme);
+  } else if (darkQuery.matches) {
     setDataThemeAttribute('dark');
   }
 })();`;


### PR DESCRIPTION
## Motivation

We can change the theme on the website depending on the installed system theme in real time. That is, when a user changes the theme in their OS, it changes on the website (if at that moment a tab with the website is open!)

Important point - if the user has already selected a theme on website, we do not switch theme when system theme has been changed. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Open website (clear local storage just in case) in new tab
1. Change the theme in your OS settings
1. Make sure that on the website (in the previously opened tab) the theme has also changed. For example, if a dark theme was selected on the OS, then exactly this theme should be selected on the website.
