### PR TITLE
fix(v2): dont collapse whitespace in minified html

### DIFF
--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -78,7 +78,6 @@ export default async function render(locals) {
 
   // minify html with https://github.com/DanielRuf/html-minifier-terser
   return minify(renderedHtml, {
-    collapseWhitespace: true,
     removeComments: true,
     removeRedundantAttributes: true,
     removeEmptyAttributes: true,


### PR DESCRIPTION
## Motivation
Continuation #2116 
Tweak minify html to be safer.

1. Dont collapse whitespace
Why ?
```js
 var input = '<div> <p>    foo </p>    </div>';
  var output = minify(input, { collapseWhitespace: true });

  output; // '<div><p>foo</p></div>'
```

This causes our SSR to be weird. Notice "optimizedwebsites" instead of "optimized websites" when javascript is disabled.
<img width="958" alt="minifed html too aggressive" src="https://user-images.githubusercontent.com/17883920/70789648-fbe3e200-1dc5-11ea-86f5-c708229c045f.PNG">

See http://perfectionkills.com/experimenting-with-html-minifier/#collapse_whitespace

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Rendered HTML should be fine now
- Netlify with JS disabled