### PR TITLE
fix(v2): disable scroll while mobile menu open

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -54,9 +54,11 @@ function Navbar() {
   const {navbarRef, isNavbarVisible} = useHideableNavbar(hideOnScroll);
 
   const showSidebar = useCallback(() => {
+    document.body.style.overflow = 'hidden';
     setSidebarShown(true);
   }, [setSidebarShown]);
   const hideSidebar = useCallback(() => {
+    document.body.style.overflow = 'visible';
     setSidebarShown(false);
   }, [setSidebarShown]);
 
@@ -140,9 +142,7 @@ function Navbar() {
       <div
         role="presentation"
         className="navbar-sidebar__backdrop"
-        onClick={() => {
-          setSidebarShown(false);
-        }}
+        onClick={hideSidebar}
       />
       <div className="navbar-sidebar">
         <div className="navbar-sidebar__brand">


### PR DESCRIPTION
## Motivation

As a rule, it is customary to disable scrolling of body on the webpage when the mobile menu is open, since it itself may have scrolling.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1. Open preview website on mobile
1. Click to sidebar button
1. Try scrolling the webpage
