### PR TITLE
fix(v2): add HTML lang attribute

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -40,6 +40,9 @@ function Layout(props) {
   return (
     <>
       <Head>
+        {/* TODO: Do not assume that it is in english language */}
+        <html lang="en" />
+
         <meta httpEquiv="x-ua-compatible" content="ie=edge" />
         {metaTitle && <title>{metaTitle}</title>}
         {metaTitle && <meta property="og:title" content={metaTitle} />}


### PR DESCRIPTION
## Motivation

For better accessibility, you must specify the lang attribute in the <html> element.

I don’t know if the functionality for translations will be available soon, therefore I just bring back the previous behavior - by default I set English.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See HTML markup.
