### PR TITLE
docs(v1): add space between "out" and "Docusaurus"

### DIFF
--- a/website-1.x/pages/en/index.js
+++ b/website-1.x/pages/en/index.js
@@ -63,7 +63,7 @@ class Index extends React.Component {
         <div className="announcement">
           <div className="announcement-inner">
             If you don't need advanced features such as versioning or
-            translations, try out
+            translations, try out 
             <a href="https://v2.docusaurus.io">Docusaurus 2</a> instead!
             Contribute to its roadmap by suggesting features or{' '}
             <a href="https://v2.docusaurus.io/feedback/">

--- a/website-1.x/pages/en/index.js
+++ b/website-1.x/pages/en/index.js
@@ -63,7 +63,7 @@ class Index extends React.Component {
         <div className="announcement">
           <div className="announcement-inner">
             If you don't need advanced features such as versioning or
-            translations, try out 
+            translations, try out{' '}
             <a href="https://v2.docusaurus.io">Docusaurus 2</a> instead!
             Contribute to its roadmap by suggesting features or{' '}
             <a href="https://v2.docusaurus.io/feedback/">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Went to the Docusaurus homepage and noticed there was a missing space. Felt it would be a good place to open a PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

It's a simple space, so I don't think it requires special planning.
