### PR TITLE
Update sitemap links to not redirect

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -22,7 +22,7 @@ export default function createSitemap(
   const urls = routesPaths.map(
     routesPath =>
       ({
-        url: routesPath,
+        url: (routesPath + '/'),
         changefreq: options.changefreq,
         priority: options.priority,
       } as SitemapItemOptions),


### PR DESCRIPTION
#2130  Motivation

The `/sitemap.xml` file contains mostly links that result in 302s, this is not the best SEO practice.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

Closes #2134 