### PR TITLE
fix(v2): add support dark theme for version badge

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import classnames from 'classnames';
 
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -101,7 +102,10 @@ function DocItem(props) {
                   {version && (
                     <span
                       style={{verticalAlign: 'top'}}
-                      className="badge badge--info">
+                      className={classnames(
+                        'badge badge--info',
+                        styles.versionBadge,
+                      )}>
                       Version: {version}
                     </span>
                   )}

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -61,3 +61,7 @@
 .docLastUpdatedAt {
   font-weight: bold;
 }
+
+[data-theme='dark'] .versionBadge {
+  --ifm-badge-background-color: var(--ifm-color-info-darkest);
+}


### PR DESCRIPTION
## Motivation

Currently in dark mode, the version badge looks very light.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/71069673-3cf34200-218a-11ea-8447-af2ae45e0a05.png) | ![image](https://user-images.githubusercontent.com/4408379/71069595-1f25dd00-218a-11ea-9f6a-38d5d1775e6b.png) |
