### PR TITLE
docs(v2): update custom webpack configuration snippet

### DIFF
--- a/website/docs/lifecycle-apis.md
+++ b/website/docs/lifecycle-apis.md
@@ -155,7 +155,7 @@ For example, this plugin below modify the webpack config to transpile `.foo` fil
 module.exports = function(context, options) {
   return {
     name: 'custom-docusaurus-plugin',
-    configureWebpack(_config, isServer, utils) {
+    configureWebpack(config, isServer, utils) {
       const {getCacheLoader} = utils;
       return {
         module: {

--- a/website/docs/lifecycle-apis.md
+++ b/website/docs/lifecycle-apis.md
@@ -154,17 +154,22 @@ For example, this plugin below modify the webpack config to transpile `.foo` fil
 // docusaurus-plugin/src/index.js
 module.exports = function(context, options) {
   return {
-    name: 'docusaurus-plugin',
-    configureWebpack(config, isServer, utils) {
+    name: 'custom-docusaurus-plugin',
+    configureWebpack(_config, isServer, utils) {
       const {getCacheLoader} = utils;
-      config.modules.rules.push({
-        test: /\.foo$/,
-        use: [getCacheLoader(isServer), 'my-custom-webpack-loader'],
-      });
-      return config;
+      return {
+        module: {
+          rules: [
+            {
+              test: /\.foo$/,
+              use: [getCacheLoader(isServer), 'my-custom-webpack-loader']
+            }
+          ],
+        },
+      };
     },
   };
-};
+}
 ```
 
 ## postBuild(props)


### PR DESCRIPTION
## Motivation

The code snippet used [here](https://v2.docusaurus.io/docs/lifecycle-apis#configurewebpackconfig-isserver-utils) is not working, using this format it returns a double `React` declaration. According to #2097 i've updated it with one of the two working formats.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes