### PR TITLE
fix(v2): remove style-loader, use minicssextract in both dev & prod

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -77,7 +77,6 @@
     "semver": "^6.3.0",
     "shelljs": "^0.8.3",
     "std-env": "^2.2.1",
-    "style-loader": "1.0.2",
     "terser-webpack-plugin": "^2.2.1",
     "wait-file": "^1.0.5",
     "webpack": "^4.41.2",

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -33,10 +33,12 @@ export function getStyleLoaders(
 
   const isProd = process.env.NODE_ENV === 'production';
   const loaders = [
-    isProd && {
+    {
       loader: MiniCssExtractPlugin.loader,
+      options: {
+        hmr: !isProd,
+      },
     },
-    !isProd && require.resolve('style-loader'),
     {
       loader: require.resolve('css-loader'),
       options: cssOptions,
@@ -60,7 +62,7 @@ export function getStyleLoaders(
         ],
       },
     },
-  ].filter(Boolean) as Loader[];
+  ];
   return loaders;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13438,7 +13438,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0, schema-utils@^2.0.1, schema-utils@^2.6.0, schema-utils@^2.6.1:
+schema-utils@^2.0.0, schema-utils@^2.6.0, schema-utils@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.1.tgz#eb78f0b945c7bcfa2082b3565e8db3548011dc4f"
   integrity sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==
@@ -14301,14 +14301,6 @@ strong-log-transformer@^2.0.0:
     duplexer "^0.1.1"
     minimist "^1.2.0"
     through "^2.3.4"
-
-style-loader@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.0.2.tgz#433d72eab8d1dd7d64c648b8ad7d9cbff3184111"
-  integrity sha512-xehHGWeCPrr+R/bU82To0j7L7ENzH30RHYmMhmAumbuIpQ/bHmv3SAj1aTRfBSszkXoqNtpKnJyWXEDydS+KeA==
-  dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^2.0.1"
 
 style-to-object@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
## Motivation

Close #2143 
Close #2141 

Remove `style-loader` and its annoying bug and use `MiniCssExtractPlugin` for both development and production environment.

The main reasons to use style-loader in development mode previously is to support hot module reloading but MiniCssExtractPlugin which is used for production build does support HMR feature since v0.6.0 (2019-04-10).

This ensures consistency
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Local hmr still working
![hmr dev](https://user-images.githubusercontent.com/17883920/71431852-89e59400-2707-11ea-8f2b-409337513dec.gif)

Production build styles should work OK (Netlify)