### PR TITLE
chore(v2): add netlify logo for open source plan

### DIFF
--- a/packages/docusaurus-mdx-loader/README.md
+++ b/packages/docusaurus-mdx-loader/README.md
@@ -42,4 +42,5 @@ Array of rehype plugins to manipulate the MDXHAST
 Array of remark plugins to manipulate the MDXAST
 
 ### `metadataPath`
+
 A function to provide the metadataPath depending on current loaded MDX path that will be exported as the MDX metadata.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -160,7 +160,7 @@ module.exports = {
               href: 'https://twitter.com/docusaurus',
             },
             {
-              html: `<a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-dark.svg"/></a>`,
+              html: `<a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"/></a>`,
             },
           ],
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -160,7 +160,7 @@ module.exports = {
               href: 'https://twitter.com/docusaurus',
             },
             {
-              html: `<a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"/></a>`,
+              html: `<a href="https://www.netlify.com" target="_blank" rel="noreferrer noopener"><img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"/></a>`,
             },
           ],
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -159,6 +159,9 @@ module.exports = {
               label: 'Twitter',
               href: 'https://twitter.com/docusaurus',
             },
+            {
+              html: `<a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-dark.svg"/></a>`,
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Motivation

In order to get 1000 free build minutes for netlify instead of 300 using open source plan, we need to add netlify logo to our site. https://www.netlify.com/pricing/

Let me know if this is a good idea, otherwise we can move away from netlify ...
or we can move it to other places. Feel free to patch the PR
![image](https://user-images.githubusercontent.com/17883920/71435014-a8548b00-2719-11ea-979c-95996f3ce947.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

See preview,. logo on footer