### PR TITLE
fix(v2): render correct syntax theme for current website theme

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -24,7 +24,20 @@ export default ({children, className: languageClassName, metastring}) => {
       themeConfig: {prism = {}},
     },
   } = useDocusaurusContext();
+
   const [showCopied, setShowCopied] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  // The Prism theme on SSR is always the default theme but the site theme
+  // can be in a different mode. React hydration doesn't update DOM styles
+  // that come from SSR. Hence force a re-render after mounting to apply the
+  // current relevant styles. There will be a flash seen of the original
+  // styles seen using this current approach but that's probably ok. Fixing
+  // the flash will require changing the theming approach and is not worth it
+  // at this point.
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const target = useRef(null);
   const button = useRef(null);
   let highlightLines = [];
@@ -70,6 +83,7 @@ export default ({children, className: languageClassName, metastring}) => {
   return (
     <Highlight
       {...defaultProps}
+      key={mounted}
       theme={prismTheme}
       code={children.trim()}
       language={language}>

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -31,7 +31,20 @@ export default ({
       themeConfig: {prism = {}},
     },
   } = useDocusaurusContext();
+
   const [showCopied, setShowCopied] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  // The Prism theme on SSR is always the default theme but the site theme
+  // can be in a different mode. React hydration doesn't update DOM styles
+  // that come from SSR. Hence force a re-render after mounting to apply the
+  // current relevant styles. There will be a flash seen of the original
+  // styles seen using this current approach but that's probably ok. Fixing
+  // the flash will require changing the theming approach and is not worth it
+  // at this point.
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const target = useRef(null);
   const button = useRef(null);
   let highlightLines = [];
@@ -88,6 +101,7 @@ export default ({
   return (
     <Highlight
       {...defaultProps}
+      key={mounted}
       theme={prismTheme}
       code={children.trim()}
       language={language}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #2149

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Go to Netlify preview's /docs/introduction
2. Set to dark mode if it's not already dark mode
3. Refresh page, see code block syntax theme is dark

## Related PRs

https://github.com/facebook/docusaurus/pull/1984
