### PR TITLE
feat(v2): add ESLint to Facebook template

### DIFF
--- a/packages/docusaurus-init/templates/facebook/.eslintrc.js
+++ b/packages/docusaurus-init/templates/facebook/.eslintrc.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const OFF = 0;
+const WARNING = 1;
+const ERROR = 2;
+
+module.exports = {
+  env: {
+    browser: true,
+    commonjs: true,
+    jest: true,
+    node: true,
+  },
+  parser: 'babel-eslint',
+  parserOptions: {
+    allowImportExportEverywhere: true,
+  },
+  extends: ['airbnb', 'prettier', 'prettier/react'],
+  plugins: ['react-hooks', 'header'],
+  rules: {
+    // Ignore certain webpack alias because it can't be resolved
+    'import/no-unresolved': [
+      ERROR,
+      {ignore: ['^@theme', '^@docusaurus', '^@generated']},
+    ],
+    'import/extensions': OFF,
+    'header/header': [
+      ERROR,
+      'block',
+      [
+        '*',
+        {
+          pattern:
+            ' \\* Copyright \\(c\\) Facebook\\, Inc\\. and its affiliates\\.',
+          template: ' * Copyright (c) Facebook, Inc. and its affiliates.',
+        },
+        ' *',
+        ' * This source code is licensed under the MIT license found in the',
+        ' * LICENSE file in the root directory of this source tree.',
+        ' *',
+        // Unfortunately eslint-plugin-header doesn't support optional lines.
+        // If you want to enforce your website JS files to have @flow or @format,
+        // modify these lines accordingly.
+        {
+          pattern: '.* @format',
+        },
+        ' ',
+      ],
+    ],
+    'react/jsx-closing-bracket-location': OFF, // Conflicts with Prettier.
+    'react/jsx-filename-extension': OFF,
+    'react-hooks/rules-of-hooks': ERROR,
+    'react/prop-types': OFF, // PropTypes aren't used much these days.
+  },
+};

--- a/packages/docusaurus-init/templates/facebook/README.md
+++ b/packages/docusaurus-init/templates/facebook/README.md
@@ -31,3 +31,11 @@ $ GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+### Continuous Integration
+
+Some common defaults for linting/formatting have been set for you. If you integrate your project with an open source Continuous Integration system (e.g. Travis CI, CircleCI), you may check for issues using the following command.
+
+```
+$ yarn ci
+```

--- a/packages/docusaurus-init/templates/facebook/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/facebook/docusaurus.config.js
@@ -1,8 +1,10 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
  */
 
 module.exports = {

--- a/packages/docusaurus-init/templates/facebook/package.json
+++ b/packages/docusaurus-init/templates/facebook/package.json
@@ -6,7 +6,9 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy"
+    "deploy": "docusaurus deploy",
+    "ci": "yarn lint",
+    "lint": "eslint --cache \"**/*.js\""
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.40",
@@ -14,6 +16,17 @@
     "classnames": "^2.2.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
+  },
+  "devDependencies": {
+    "babel-eslint": "^10.0.3",
+    "eslint": "^6.7.1",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^6.7.0",
+    "eslint-plugin-header": "^3.0.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-react": "^7.16.0",
+    "eslint-plugin-react-hooks": "^2.3.0"
   },
   "browserslist": {
     "production": [

--- a/packages/docusaurus-init/templates/facebook/sidebars.js
+++ b/packages/docusaurus-init/templates/facebook/sidebars.js
@@ -1,8 +1,10 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
  */
 
 module.exports = {

--- a/packages/docusaurus-init/templates/facebook/src/css/custom.css
+++ b/packages/docusaurus-init/templates/facebook/src/css/custom.css
@@ -1,8 +1,10 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
  */
 
 /**

--- a/packages/docusaurus-init/templates/facebook/src/pages/index.js
+++ b/packages/docusaurus-init/templates/facebook/src/pages/index.js
@@ -1,8 +1,10 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
  */
 
 import React from 'react';
@@ -89,8 +91,13 @@ function Home() {
           <section className={styles.features}>
             <div className="container">
               <div className="row">
-                {features.map((props, idx) => (
-                  <Feature key={idx} {...props} />
+                {features.map(({title, imageUrl, description}) => (
+                  <Feature
+                    key={title}
+                    title={title}
+                    imageUrl={imageUrl}
+                    description={description}
+                  />
                 ))}
               </div>
             </div>

--- a/packages/docusaurus-init/templates/facebook/src/pages/styles.module.css
+++ b/packages/docusaurus-init/templates/facebook/src/pages/styles.module.css
@@ -1,8 +1,10 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
  */
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5854,9 +5854,9 @@ eslint-config-airbnb@^18.0.1:
     object.entries "^1.1.0"
 
 eslint-config-prettier@^6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.7.0.tgz#9a876952e12df2b284adbd3440994bf1f39dfbb9"
-  integrity sha512-FamQVKM3jjUVwhG4hEMnbtsq7xOIDm+SY5iBPfR8gKsJoAB2IQnNF+bk1+8Fy44Nq7PPJaLvkRxILYdJWoguKQ==
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.9.0.tgz#430d24822e82f7deb1e22a435bfa3999fae4ad64"
+  integrity sha512-k4E14HBtcLv0uqThaI6I/n1LEqROp8XaPu6SO9Z32u5NlGRC07Enu1Bh2KEFw4FNHbekH8yzbIU9kUGxbiGmCA==
   dependencies:
     get-stdin "^6.0.0"
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make the Docusaurus website template for Facebook OSS projects use ESLint.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
yarn ci
```

within the `docusaurus/packages/docusaurus-init/templates/facebook` directory.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
