### PR TITLE
refactor(v2): move no-flash script to head tag

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -63,12 +63,9 @@ module.exports = function(context, options) {
         return {};
       }
       return {
-        preBodyTags: [
+        headTags: [
           {
             tagName: 'script',
-            attributes: {
-              type: 'text/javascript',
-            },
             innerHTML: noFlash,
           },
         ],


### PR DESCRIPTION
## Motivation

> If your <script>…</script> blocks have no dependency on CSS, place them above your stylesheets.

According this [article](https://csswizardry.com/2018/11/css-and-network-performance/#dont-place-link-relstylesheet--before-async-snippets).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See Netlify.

