### PR TITLE
feat(v2): add logo and title in doc sidebar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -13,6 +13,8 @@
   border-right: 1px solid var(--ifm-contents-border-color);
   box-sizing: border-box;
   width: 300px;
+  position: relative;
+  top: calc(-1 * var(--ifm-navbar-height));
 }
 
 .docMainContainer {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -7,7 +7,8 @@
 
 import React, {useState, useCallback} from 'react';
 import classnames from 'classnames';
-
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Link from '@docusaurus/Link';
 
 import styles from './styles.module.css';
@@ -104,6 +105,10 @@ function mutateSidebarCollapsingState(item, location) {
 
 function DocSidebar(props) {
   const [showResponsiveSidebar, setShowResponsiveSidebar] = useState(false);
+  const {
+    siteConfig: {themeConfig: {navbar: {title, logo = {}} = {}}} = {},
+  } = useDocusaurusContext();
+  const logoUrl = useBaseUrl(logo.src);
 
   const {
     docsSidebars,
@@ -132,6 +137,10 @@ function DocSidebar(props) {
 
   return (
     <div className={styles.sidebar}>
+      <div className={styles.sidebarLogo}>
+        {logo != null && <img src={logoUrl} alt={logo.alt} />}
+        {title != null && <strong>{title}</strong>}
+      </div>
       <div
         className={classnames('menu', 'menu--responsive', {
           'menu--show': showResponsiveSidebar,

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -11,7 +11,8 @@
     overflow-y: auto;
     padding: 0.5rem;
     position: sticky;
-    top: var(--ifm-navbar-height);
+    top: 0;
+    padding-top: var(--ifm-navbar-height);
   }
 
   .sidebar::-webkit-scrollbar {
@@ -30,6 +31,19 @@
 
   .sidebar::-webkit-scrollbar-thumb:hover {
     background: #555;
+  }
+
+  .sidebarLogo {
+    display: flex;
+    align-items: center;
+    position: absolute;
+    top: var(--ifm-navbar-padding-horizontal);
+    padding: 0 0 0 var(--ifm-navbar-padding-vertical);
+  }
+
+  .sidebarLogo img {
+    margin-right: 0.5rem;
+    height: 2rem;
   }
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -34,7 +34,7 @@
   }
 
   .sidebarLogo {
-    display: flex;
+    display: flex !important;
     align-items: center;
     position: absolute;
     top: var(--ifm-navbar-padding-horizontal);
@@ -45,6 +45,10 @@
     margin-right: 0.5rem;
     height: 2rem;
   }
+}
+
+.sidebarLogo {
+  display: none;
 }
 
 .sidebarMenuIcon {


### PR DESCRIPTION
## Motivation

Currently, when scrolling down, the sticky header is hiding and there is an empty space in the doc sidebar, so I figured out how to fill it in - put the logo and title there, as in navbar (see test plan or check out preview)!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![screencast-nimbus-capture-2019 12 30-02_12_27](https://user-images.githubusercontent.com/4408379/71564020-7bea9700-2aaa-11ea-88ef-80d60ca32b64.gif) | ![screencast-nimbus-capture-2019 12 30-02_13_31](https://user-images.githubusercontent.com/4408379/71564018-78571000-2aaa-11ea-9027-21441ddf4d27.gif) |


