### PR TITLE
fix(v2): unify anchor behavior

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.js
@@ -8,27 +8,45 @@
 /* eslint-disable jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid */
 
 import React from 'react';
+import classnames from 'classnames';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import './styles.css';
+import styles from './styles.module.css';
 
-const Heading = Tag => ({id, ...props}) => {
-  if (!id) {
-    return <Tag {...props} />;
-  }
-  return (
-    <Tag {...props}>
-      <a aria-hidden="true" tabIndex="-1" className="anchor" id={id} />
-      <a
-        aria-hidden="true"
-        tabIndex="-1"
-        className="hash-link"
-        href={`#${id}`}
-        title="Direct link to heading">
-        #
-      </a>
-      {props.children}
-    </Tag>
-  );
-};
+const Heading = Tag =>
+  function TargetComponent({id, ...props}) {
+    const {
+      siteConfig: {
+        themeConfig: {navbar: {hideOnScroll = false} = {}} = {},
+      } = {},
+    } = useDocusaurusContext();
+
+    if (!id) {
+      return <Tag {...props} />;
+    }
+
+    return (
+      <Tag {...props}>
+        <a
+          aria-hidden="true"
+          tabIndex="-1"
+          className={classnames('anchor', {
+            [styles.enhancedAnchor]: !hideOnScroll,
+          })}
+          id={id}
+        />
+        <a
+          aria-hidden="true"
+          tabIndex="-1"
+          className="hash-link"
+          href={`#${id}`}
+          title="Direct link to heading">
+          #
+        </a>
+        {props.children}
+      </Tag>
+    );
+  };
 
 export default Heading;

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -8,13 +8,7 @@
 .anchor {
   display: block;
   position: relative;
-  top: -5rem;
-}
-
-@media only screen and (max-width: 735px) {
-  .anchor {
-    top: -10rem;
-  }
+  top: -0.5rem;
 }
 
 .hash-link {

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -9,6 +9,7 @@
   display: block;
   position: relative;
   top: -0.5rem;
+  outline: none;
 }
 
 .hash-link {

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
@@ -1,0 +1,7 @@
+.enhancedAnchor:target:before {
+  content: '';
+  display: block;
+  height: var(--ifm-navbar-height);
+  margin: calc(var(--ifm-navbar-height) * -1) 0 0;
+  visibility: hidden;
+}

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.js
@@ -19,12 +19,21 @@ const useHideableNavbar = hideOnScroll => {
 
   const handleScroll = () => {
     const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-    const documentHeight = document.documentElement.scrollHeight - navbarHeight;
-    const windowHeight = window.innerHeight;
 
     if (scrollTop < navbarHeight) {
       return;
     }
+
+    const focusedElement = document.querySelector(':focus');
+
+    if (focusedElement && /^#/.test(window.location.hash)) {
+      setIsNavbarVisible(false);
+      focusedElement.blur();
+      return;
+    }
+
+    const documentHeight = document.documentElement.scrollHeight - navbarHeight;
+    const windowHeight = window.innerHeight;
 
     if (lastScrollTop && scrollTop > lastScrollTop) {
       setIsNavbarVisible(false);

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.js
@@ -24,7 +24,7 @@ const useHideableNavbar = hideOnScroll => {
       return;
     }
 
-    const focusedElement = document.querySelector(':focus');
+    const focusedElement = document.activeElement;
 
     if (focusedElement && /^#/.test(window.location.hash)) {
       setIsNavbarVisible(false);


### PR DESCRIPTION
## Motivation

First of all, remove large margin on all screens (see test plan) when following a link from anchor. Further, when you open the referenced link in the browser, the header is automatically hidden, similarly when switching to another anchor on this page.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Prerequisite: open link with anchor, eg https://v2.docusaurus.io/docs/installation#project-structure

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/71564768-223c9980-2ab7-11ea-93d9-4642c1280a70.png) |  ![image](https://user-images.githubusercontent.com/4408379/71564766-1ea91280-2ab7-11ea-8fec-16057e364410.png) |
