### PR TITLE
fix(v2): fix reading front matter keywords and image fields

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -58,15 +58,15 @@ function DocItem(props) {
     description,
     title,
     permalink,
-    image: metaImage,
     editUrl,
     lastUpdatedAt,
     lastUpdatedBy,
-    keywords,
     version,
   } = metadata;
   const {
     frontMatter: {
+      image: metaImage,
+      keywords,
       hide_title: hideTitle,
       hide_table_of_contents: hideTableOfContents,
     },

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -2,7 +2,7 @@
 id: search
 title: Search
 keywords:
-  - docusaurus
+  - algolia
   - search
 ---
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The `keywords` and `image` field in the front matter files were broken because we were still reading them from the `metadata` when they should be read from `frontMatter` instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Modifed `website/docs/search.md`'s front matter to add an `image` key.

<img width="730" alt="Screen Shot 2019-12-31 at 9 18 49 PM" src="https://user-images.githubusercontent.com/1315101/71622867-a7d55c00-2c13-11ea-8cb7-3595872de083.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
