### PR TITLE
feat(v2): allow per-doc hiding of edit url

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docs/ipsum.md
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docs/ipsum.md
@@ -1,0 +1,5 @@
+---
+custom_edit_url: null
+---
+
+Lorem ipsum.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -88,6 +88,14 @@ Array [
         "component": "@theme/DocItem",
         "exact": true,
         "modules": Object {
+          "content": "@site/docs/ipsum.md",
+        },
+        "path": "/docs/ipsum",
+      },
+      Object {
+        "component": "@theme/DocItem",
+        "exact": true,
+        "modules": Object {
           "content": "@site/docs/lorem.md",
         },
         "path": "/docs/lorem",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -143,6 +143,34 @@ describe('simple site', () => {
     });
   });
 
+  test('docs with null custom_edit_url', async () => {
+    const source = 'ipsum.md';
+    const options = {
+      routeBasePath,
+      showLastUpdateAuthor: true,
+      showLastUpdateTime: true,
+    };
+
+    const data = await processMetadata({
+      source,
+      refDir: docsDir,
+      context,
+      options,
+      env,
+    });
+
+    expect(data).toEqual({
+      id: 'ipsum',
+      permalink: '/docs/ipsum',
+      source: path.join('@site', routeBasePath, source),
+      title: 'ipsum',
+      editUrl: null,
+      description: 'Lorem ipsum.',
+      lastUpdatedAt: 1539502055,
+      lastUpdatedBy: 'Author',
+    });
+  });
+
   test('docs with invalid id', async () => {
     const badSiteDir = path.join(fixtureDir, 'bad-site');
     const options = {

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -134,7 +134,7 @@ export default async function processMetadata({
     description,
     source: aliasedSitePath(filePath, siteDir),
     permalink,
-    editUrl: custom_edit_url || docsEditUrl,
+    editUrl: custom_edit_url !== undefined ? custom_edit_url : docsEditUrl,
     version,
     lastUpdatedBy,
     lastUpdatedAt,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Allow per-doc hiding of edit url by setting it to `null`.

Fixes #2159 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests. Also tried setting to `null` manually in a doc and see that the edit link doesn't appear.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
