### PR TITLE
fix(v2): filter out invalid prefetch script without contenthash

### DIFF
--- a/packages/docusaurus/src/client/docusaurus.js
+++ b/packages/docusaurus/src/client/docusaurus.js
@@ -58,7 +58,10 @@ const docusaurus = {
       // Pass it the chunkName or chunkId you want to load and it will return the URL for that chunk
       // eslint-disable-next-line no-undef
       const chunkAsset = __webpack_require__.gca(chunkName);
-      if (chunkAsset) {
+
+      // In some cases, webpack might decide to optimize further & hence the chunk asssets are merged to another chunk/previous chunk
+      // Hence, we can safely filter it out/ dont need to load it
+      if (chunkAsset && !/undefined/.test(chunkAsset)) {
         prefetchHelper(chunkAsset);
       }
     });


### PR DESCRIPTION
## Motivation

Fix #2164 

In some cases, although we have annotaed webpack chunk name with certain chunkname comment,
webpack can be more aggressive and decide to build its more efficient webpack chunk. Eg: too small

For example
```js
// registry,js
export default {
  '06a89c33': [() => import(/* webpackChunkName: '06a89c33' */ "@site/docs/getting-started/configuring.md"), "@site/docs/getting-started/configuring.md", require.resolveWeak("@site/docs/getting-started/configuring.md")],
  '12a37b48': [() => import(/* webpackChunkName: '12a37b48' */ "@site/docs/contributing/prerequisites.md"), "@site/docs/contributing/prerequisites.md", require.resolveWeak("@site/docs/contributing/prerequisites.md")],
  '17896441': [() => import(/* webpackChunkName: '17896441' */ "@theme/DocItem"), "@theme/DocItem", require.resolveWeak("@theme/DocItem")],
  '1be78505': [() => import(/* webpackChunkName: '1be78505' */ "@theme/DocPage"), "@theme/DocPage", require.resolveWeak("@theme/DocPage")],
  '2470487e': [() => import(/* webpackChunkName: '2470487e' */ "@site/docs/features/profiles.md"), "@site/docs/features/profiles.md", require.resolveWeak("@site/docs/features/profiles.md")],
  '316ca40e': [() => import(/* webpackChunkName: '316ca40e' */ "@site/docs/features/custom-files.md"), "@site/docs/features/custom-files.md", require.resolveWeak("@site/docs/features/custom-files.md")],
  '42c43fc2': [() => import(/* webpackChunkName: '42c43fc2' */ "~docs/vscode-syncify-docs-route-a74.json"), "~docs/vscode-syncify-docs-route-a74.json", require.resolveWeak("~docs/vscode-syncify-docs-route-a74.json")],
  '530ea7a0': [() => import(/* webpackChunkName: '530ea7a0' */ "@site/docs/getting-started/setup.md"), "@site/docs/getting-started/setup.md", require.resolveWeak("@site/docs/getting-started/setup.md")],
  '54f44165': [() => import(/* webpackChunkName: '54f44165' */ "@site/docs/getting-started/installation.md"), "@site/docs/getting-started/installation.md", require.resolveWeak("@site/docs/getting-started/installation.md")],
  '73754917': [() => import(/* webpackChunkName: '73754917' */ "@site/docs/getting-started/prerequisites.md"), "@site/docs/getting-started/prerequisites.md", require.resolveWeak("@site/docs/getting-started/prerequisites.md")],
  '9d206a50': [() => import(/* webpackChunkName: '9d206a50' */ "@site/docs/contributing/language-support.md"), "@site/docs/contributing/language-support.md", require.resolveWeak("@site/docs/contributing/language-support.md")],
  'b46cadd8': [() => import(/* webpackChunkName: 'b46cadd8' */ "@site/docs/features/custom-extensions.md"), "@site/docs/features/custom-extensions.md", require.resolveWeak("@site/docs/features/custom-extensions.md")],
  'c4f5d8e4': [() => import(/* webpackChunkName: 'c4f5d8e4' */ "@site/src/pages/index.js"), "@site/src/pages/index.js", require.resolveWeak("@site/src/pages/index.js")],
  'd15ea271': [() => import(/* webpackChunkName: 'd15ea271' */ "@site/docs/features/sync-pragmas.md"), "@site/docs/features/sync-pragmas.md", require.resolveWeak("@site/docs/features/sync-pragmas.md")],};

```

The DocPage is grouped in another chunk  `17.51.xxxx.js` instead of  `1be78505`

<img width="957" alt="webpack chunk name not used" src="https://user-images.githubusercontent.com/17883920/71639293-83768f80-2ca6-11ea-9d9f-2225c1d7031a.PNG">

See docs-getting-started,its chunked correctly as `06a89c33.3aa64d55.js`
![image](https://user-images.githubusercontent.com/17883920/71639345-86be4b00-2ca7-11ea-9d1c-1c28c018ddef.png)


Anyway the fix is very simple, just filter out non existing chunk because `contentHash` for non existing will always be undefined

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan



before
<img width="771" alt="before" src="https://user-images.githubusercontent.com/17883920/71639317-f1bb5200-2ca6-11ea-904a-9711ec1870e9.PNG">

after
We can just safely filter it out
<img width="820" alt="after" src="https://user-images.githubusercontent.com/17883920/71639316-f1bb5200-2ca6-11ea-905e-e0870a0fdfe7.PNG">