### PR TITLE
fix(v2): improve accessibility for Netlify badge

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -164,7 +164,11 @@ module.exports = {
               href: 'https://twitter.com/docusaurus',
             },
             {
-              html: `<a href="https://www.netlify.com" target="_blank" rel="noreferrer noopener"><img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"/></a>`,
+              html: `
+                <a href="https://www.netlify.com" target="_blank" rel="noreferrer noopener" aria-label="Deploys by Netlify">
+                  <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
+                </a>
+              `,
             },
           ],
         },


### PR DESCRIPTION
## Motivation

Fixes Lighthouse audit issues about Netlify badge in footer:

- Image elements do not have [alt] attributes
- Links do not have a discernible name

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run Lighthouse on preview.

