### PR TITLE
fix(v2): use proper tag for custom HTML in footer

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -69,7 +69,7 @@ function Footer() {
                   <ul className="footer__items">
                     {linkItem.items.map((item, key) =>
                       item.html ? (
-                        <div
+                        <li
                           key={key}
                           dangerouslySetInnerHTML={{
                             __html: item.html,


### PR DESCRIPTION
## Motivation

Fix last a11y issue:

- Lists do not contain only \<li\> elements and script supporting elements (\<script\> and \<template\>)

My bad actually :man_facepalming: 

No UI changes, since list-item is a block-level HTML element like a div

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run Audit Lighthouse on preview.