### PR TITLE
refactor(v2): change title of last footer column

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -149,7 +149,7 @@ module.exports = {
           ],
         },
         {
-          title: 'Social',
+          title: 'More',
           items: [
             {
               label: 'Blog',


### PR DESCRIPTION

## Motivation

Since we have a link to Blog and Netlify, it seems to me to rename the title of last item in the footer to something more general like "More".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See Netlify preview.
