### PR TITLE
fix(v2): make doc sidebar height equal viewport

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -7,7 +7,7 @@
 
 @media (min-width: 997px) {
   .sidebar {
-    height: calc(100vh - var(--ifm-navbar-height));
+    height: 100vh;
     overflow-y: auto;
     padding: 0.5rem;
     position: sticky;


### PR DESCRIPTION
## Motivation

I thought to make a collapsible sidebar and put a button to hide the sidebar to menu, but this idea did not find approval, so I fix this bug with height after merge #2161

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/71643917-f72d9200-2cd0-11ea-8d23-f265f7d98368.png) | ![image](https://user-images.githubusercontent.com/4408379/71643919-fe54a000-2cd0-11ea-81d3-83fa43e246a6.png) |
