### PR TITLE
feat(v2): add async loading of script tags

### DIFF
--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -26,7 +26,7 @@ module.exports = `
       <%- appHtml %>
     </div>
     <% scripts.forEach((script) => { %>
-      <script type="text/javascript" src="<%= baseUrl %><%= script %>"></script>
+      <script type="text/javascript" src="<%= baseUrl %><%= script %>" async></script>
     <% }); %>
     <%- postBodyTags %>
   </body>


### PR DESCRIPTION

## Motivation

I think we need to consider adding asynchronous script loading. I have seen other static generator websites use this approach. Perhaps this is wrong or not?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See Netlify

