### PR TITLE
fix(v2): adjust sidebar menu close icon to center

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -56,7 +56,9 @@
 }
 
 .sidebarMenuCloseIcon {
-  display: inline-block;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
   height: 24px;
   font-size: 1.5rem;
   font-weight: var(--ifm-font-weight-bold);


### PR DESCRIPTION
##  Motivation

Make correct vertically centering of sidebar menu close icon on mobiles. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/71666549-60b1ad00-2d72-11ea-8dc6-fd2eac532e2b.png) | ![image](https://user-images.githubusercontent.com/4408379/71666568-7a52f480-2d72-11ea-9e08-98b7cd108a72.png) |