### PR TITLE
fix(v2): don't read theme from localStorage if disableDarkMode is on

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
@@ -7,7 +7,12 @@
 
 import React from 'react';
 
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
 const useTheme = () => {
+  const {
+    siteConfig: {themeConfig: {disableDarkMode}} = {},
+  } = useDocusaurusContext();
   const [theme, setTheme] = React.useState(
     typeof document !== 'undefined'
       ? document.documentElement.getAttribute('data-theme')
@@ -19,6 +24,10 @@ const useTheme = () => {
   }, [theme]);
 
   React.useEffect(() => {
+    if (disableDarkMode) {
+      return;
+    }
+
     try {
       const localStorageTheme = localStorage.getItem('theme');
       if (localStorageTheme !== null) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #2176 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Set `themeConfig.disableDarkTheme: true` in `docusaurus.config.js`
1. Run `localStorage.theme = 'dark'` in JS console. This simulates the scenario where a site previously had dark mode toggle and then it was disabled
1. Start the site locally
1. See that the site is not dark

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
