### PR TITLE
fix(v2): make search bar not lose focus after clicking on it after initial load

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -24,7 +24,7 @@ const Search = props => {
   } = siteConfig;
   const history = useHistory();
 
-  const initAlgolia = () => {
+  function initAlgolia(focusOnInit) {
     if (!initialized.current) {
       window.docsearch({
         appId: algolia.appId,
@@ -50,26 +50,30 @@ const Search = props => {
         },
       });
       initialized.current = true;
+      // Needed because the search input loses focus after calling window.docsearch()
+      if (focusOnInit) {
+        searchBarRef.current.focus();
+      }
     }
-  };
+  }
 
-  const loadAlgolia = () => {
+  function loadAlgolia(focusAfterLoading) {
     if (!loaded) {
       Promise.all([import('docsearch.js'), import('./algolia.css')]).then(
         ([{default: docsearch}]) => {
           loaded = true;
           window.docsearch = docsearch;
-          initAlgolia();
+          initAlgolia(focusAfterLoading);
         },
       );
     } else {
-      initAlgolia();
+      initAlgolia(focusAfterLoading);
     }
-  };
+  }
 
   const toggleSearchIconClick = useCallback(
-    e => {
-      if (!searchBarRef.current.contains(e.target)) {
+    event => {
+      if (!searchBarRef.current.contains(event.target)) {
         searchBarRef.current.focus();
       }
 
@@ -100,8 +104,8 @@ const Search = props => {
           {'search-bar-expanded': props.isSearchBarExpanded},
           {'search-bar': !props.isSearchBarExpanded},
         )}
-        onClick={loadAlgolia}
-        onMouseOver={loadAlgolia}
+        onClick={loadAlgolia.bind(this, true)}
+        onMouseOver={loadAlgolia.bind(this, false)}
         onFocus={toggleSearchIconClick}
         onBlur={toggleSearchIconClick}
         ref={searchBarRef}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #2175 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Load Netlify preview (try on mobile too)
1. Click on the search bar
1. See that it doesn't lose focus

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
