### PR TITLE
fix(v2): make sidebar logo positioning relative navbar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -142,7 +142,7 @@ function DocSidebar(props) {
         {title != null && <strong>{title}</strong>}
       </div>
       <div
-        className={classnames('menu', 'menu--responsive', {
+        className={classnames('menu', 'menu--responsive', styles.menu, {
           'menu--show': showResponsiveSidebar,
         })}>
         <button

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -9,7 +9,6 @@
   .sidebar {
     height: 100vh;
     overflow-y: auto;
-    padding: 0.5rem;
     position: sticky;
     top: 0;
     padding-top: var(--ifm-navbar-height);
@@ -37,13 +36,18 @@
     display: flex !important;
     align-items: center;
     position: absolute;
-    top: var(--ifm-navbar-padding-horizontal);
-    padding: 0 0 0 var(--ifm-navbar-padding-vertical);
+    top: 0;
+    margin: 0 var(--ifm-navbar-padding-horizontal);
+    height: var(--ifm-navbar-height);
   }
 
   .sidebarLogo img {
     margin-right: 0.5rem;
     height: 2rem;
+  }
+
+  .menu {
+    padding: 0.5rem;
   }
 }
 


### PR DESCRIPTION


## Motivation

Currently, the sidebar logo is positioned 2px lower than the navbar logo (see test plan).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

With `z-index = -1` to `navbar`.

|   |  |
| -------- | -------- |
| Before | ![screencast-nimbus-capture-2020 01 03-00_14_13](https://user-images.githubusercontent.com/4408379/71693690-2968ed80-2dbe-11ea-9a45-d3c1cb05b0da.gif) |
| After | ![screencast-nimbus-capture-2020 01 03-00_13_29](https://user-images.githubusercontent.com/4408379/71693686-240ba300-2dbe-11ea-8e52-8f4334d7f90b.gif) |