### PR TITLE
feat(v2): allow customized route for mdx

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -105,7 +105,11 @@ export default async function processMetadata({
   }
 
   // Append subdirectory as part of id.
-  const id = frontMatter.route || (dirName !== '.' ? `${dirName}/${baseID}` : baseID);
+  let id = dirName !== '.' ? `${dirName}/${baseID}` : baseID;
+
+  if (frontMatter.route) {
+    id = frontMatter.route;
+  }
 
   // Default title is the id.
   const title: string = frontMatter.title || baseID;

--- a/packages/docusaurus-plugin-content-docs/src/metadata.ts
+++ b/packages/docusaurus-plugin-content-docs/src/metadata.ts
@@ -105,7 +105,7 @@ export default async function processMetadata({
   }
 
   // Append subdirectory as part of id.
-  const id = dirName !== '.' ? `${dirName}/${baseID}` : baseID;
+  const id = frontMatter.route || (dirName !== '.' ? `${dirName}/${baseID}` : baseID);
 
   // Default title is the id.
   const title: string = frontMatter.title || baseID;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I move doc files from `docz`.
I place each doc file in the same folder as a component folder it belongs to.

```
-- src
---- Button
------ Button.mdx
------ Button.tsx
---- Checkbox
------ Checkbox.mdx
------ Checkbox.tsx
```

The url by default will be `docs/Button/Button` for Button.mdx is inside a subfolder
So I'd like to customize route for each mdx file.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

`YES`

## Test Plan

- The `id` used in `sidebars.js` should be equal to its `route` if route is configed
- The `permalink` should be equal to `/docs/:route` if route is configed

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

## Another way
```js
if (baseID.includes('/')) {
   throw new Error('Document id cannot include "/".');
}

const id = dirName !== '.' ? `${dirName}/${baseID}` : baseID;
```
Another way is slash in id can be allowed, and dirName should not add as a prefix if slash inside id
