### PR TITLE
fix(v2): allow external links in doc sidebar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Link from '@docusaurus/Link';
-import isInternalUrl from '@docusaurus/utils';
+import isInternalUrl from '@docusaurus/utils'; // eslint-disable-line import/no-extraneous-dependencies
 
 import styles from './styles.module.css';
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Link from '@docusaurus/Link';
+import isInternalUrl from '@docusaurus/utils';
 
 import styles from './styles.module.css';
 
@@ -70,11 +71,18 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
       return (
         <li className="menu__list-item" key={label}>
           <Link
-            activeClassName="menu__link--active"
             className="menu__link"
-            exact
             to={href}
-            onClick={onItemClick}>
+            {...(isInternalUrl(href)
+              ? {
+                  activeClassName: 'menu__link--active',
+                  exact: true,
+                  onClick: onItemClick,
+                }
+              : {
+                  target: '_blank',
+                  rel: 'noreferrer noopener',
+                })}>
             {label}
           </Link>
         </li>

--- a/packages/docusaurus/src/client/exports/Link.js
+++ b/packages/docusaurus/src/client/exports/Link.js
@@ -7,12 +7,12 @@
 
 import React, {useEffect, useRef} from 'react';
 import {NavLink} from 'react-router-dom';
-import isInternalLink from '@docusaurus/utils';
+import isInternalUrl from '@docusaurus/utils';
 
 function Link(props) {
   const {to, href} = props;
   const targetLink = to || href;
-  const isInternal = isInternalLink;
+  const isInternal = isInternalUrl;
   const preloaded = useRef(false);
 
   const IOSupported =

--- a/packages/docusaurus/src/client/exports/Link.js
+++ b/packages/docusaurus/src/client/exports/Link.js
@@ -7,13 +7,12 @@
 
 import React, {useEffect, useRef} from 'react';
 import {NavLink} from 'react-router-dom';
-
-const internalRegex = /^\/(?!\/)/;
+import isInternalLink from '@docusaurus/utils';
 
 function Link(props) {
   const {to, href} = props;
   const targetLink = to || href;
-  const isInternal = internalRegex.test(targetLink);
+  const isInternal = isInternalLink;
   const preloaded = useRef(false);
 
   const IOSupported =

--- a/packages/docusaurus/src/client/exports/utils.js
+++ b/packages/docusaurus/src/client/exports/utils.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export default function isInternalUrl(url) {
+  return /^\/(?!\/)/.test(url);
+}


### PR DESCRIPTION
## Motivation

Close #2185 

Currently, not possible to add an item with an external link in the doc sidebar.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add an item with an external link in sidebars.js file, eg:

```js
          {
            type: 'link',
            label: 'Docusaurus',
            href: 'https://v2.docusaurus.io',
          },
```



