### PR TITLE
fix(v1): fix JSX highlighting by passing language to Prism

### DIFF
--- a/packages/docusaurus-1.x/lib/core/renderMarkdown.js
+++ b/packages/docusaurus-1.x/lib/core/renderMarkdown.js
@@ -54,7 +54,11 @@ class MarkdownRenderer {
                 // Currently people using prismjs on Node have to individually require()
                 // every single language (https://github.com/PrismJS/prism/issues/593)
                 loadLanguages([language]);
-                return prismjs.highlight(str, prismjs.languages[language], language);
+                return prismjs.highlight(
+                  str,
+                  prismjs.languages[language],
+                  language
+                );
               } catch (err) {
                 if (err.code === 'MODULE_NOT_FOUND') {
                   const unsupportedLanguageError = chalk.yellow(

--- a/packages/docusaurus-1.x/lib/core/renderMarkdown.js
+++ b/packages/docusaurus-1.x/lib/core/renderMarkdown.js
@@ -54,7 +54,7 @@ class MarkdownRenderer {
                 // Currently people using prismjs on Node have to individually require()
                 // every single language (https://github.com/PrismJS/prism/issues/593)
                 loadLanguages([language]);
-                return prismjs.highlight(str, prismjs.languages[language]);
+                return prismjs.highlight(str, prismjs.languages[language], language);
               } catch (err) {
                 if (err.code === 'MODULE_NOT_FOUND') {
                   const unsupportedLanguageError = chalk.yellow(

--- a/packages/docusaurus-1.x/lib/core/renderMarkdown.js
+++ b/packages/docusaurus-1.x/lib/core/renderMarkdown.js
@@ -57,7 +57,7 @@ class MarkdownRenderer {
                 return prismjs.highlight(
                   str,
                   prismjs.languages[language],
-                  language
+                  language,
                 );
               } catch (err) {
                 if (err.code === 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
The JSX highlighting is subtly broken:

![Screen Shot 2020-01-07 at 4 19 30 PM](https://user-images.githubusercontent.com/810438/71910616-22e5c780-316a-11ea-9ebd-a63c42e0a254.png)

Notice how plain text in JSX gets incorrectly highlighted.

This was fixed in https://github.com/PrismJS/prism/pull/1357 but I couldn't get the fix to work at all. Then I noticed we're not passing the [documented third argument](https://prismjs.com/extending.html) to Prism, so it doesn't actually use the JSX language for tokenization.

This PR fixes it.