### PR TITLE
fix(v2): (docusaurus-init) remove deprecated Python statement

### DIFF
--- a/packages/docusaurus-init/templates/classic/docs/doc1.md
+++ b/packages/docusaurus-init/templates/classic/docs/doc1.md
@@ -102,7 +102,7 @@ alert(s);
 
 ```python
 s = "Python syntax highlighting"
-print s
+print(s)
 ```
 
 ```


### PR DESCRIPTION
This is Python2 print syntax, and Python2 just reached end-of-life, so swapping it over to Python3 print syntax.

Minor change - no testing plan needed.  