### PR TITLE
feat(v2): preload first page load script asap

### DIFF
--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -19,6 +19,9 @@ module.exports = `
     <% stylesheets.forEach((stylesheet) => { %>
       <link rel="stylesheet" type="text/css" href="<%= baseUrl %><%= stylesheet %>" />
     <% }); %>
+    <% scripts.forEach((script) => { %>
+      <link rel="preload" href="<%= baseUrl %><%= script %>" as="script">
+    <% }); %>
   </head>
   <body <%- bodyAttributes %>>
     <%- preBodyTags %>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Finishing up a PR made by @endiliey. Improve performance by preloading scripts needed by the page which is only inserted at the bottom of the page. Gatsby does this too.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See the `index.html` of Netlify preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
