### PR TITLE
fix(v2): remove logo background

### DIFF
--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -89,7 +89,6 @@
   float: right;
   margin-top: 20px;
   padding: 20px;
-  background-color: #2b3137;
 }
 
 .indexCtas {


### PR DESCRIPTION
## Motivation

Currently, on mobiles, when the logo (which is transparent always) is animated, then its background is overlays on upper part tagline.

![image](https://user-images.githubusercontent.com/4408379/72219216-a29dd880-3554-11ea-9165-34fd535e1bdc.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Open preview on mobile and make sure there is no background during animation.
