### PR TITLE
fix(v1): updated routing RegExp to support md files ending with html 

### DIFF
--- a/packages/docusaurus-1.x/lib/server/__tests__/routing.test.js
+++ b/packages/docusaurus-1.x/lib/server/__tests__/routing.test.js
@@ -142,6 +142,7 @@ describe('Page routing', () => {
 
   test('valid page url', () => {
     expect('/index.html').toMatch(pageRegex);
+    expect('/en/example-html/index.html').toMatch(pageRegex);
     expect('/en/help.html').toMatch(pageRegex);
     expect('/reason/index.html').toMatch(pageRegex2);
     expect('/reason/ro/users.html').toMatch(pageRegex2);

--- a/packages/docusaurus-1.x/lib/server/routing.js
+++ b/packages/docusaurus-1.x/lib/server/routing.js
@@ -36,7 +36,7 @@ function page(siteConfig) {
   return new RegExp(
     `(?!${gr(blog(siteConfig))}|${gr(docs(siteConfig))})^${
       siteConfig.baseUrl
-    }.*.html$`,
+    }.*\\.html$`,
   );
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR fixes #2133 issue about unsupported md files ending with html. 
Example: `file-html.md`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've updated the `routing.page` RegExp. Next, I introduced a new test case with an html ending endpoint then I ran `yarn prettier && yarn lint` and `yarn test`. 