### PR TITLE
chore(v2): handle pages which contain special chars

### DIFF
--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -26,7 +26,7 @@ module.exports = `
   <body <%- bodyAttributes %>>
     <%- preBodyTags %>
     <div id="__docusaurus">
-      <%- appHtml %>
+      <%= appHtml %>
     </div>
     <% scripts.forEach((script) => { %>
       <script type="text/javascript" src="<%= baseUrl %><%= script %>"></script>


### PR DESCRIPTION
## Motivation

This PR should fix the issue #2157 : yarn build is failing when there are special characters in markdown files.

## Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes 😄 

## Test Plan

- I've reproduced the issue by adding "< 8" in `website/versionned_docs/blog.md` title

- After investigation, I have changed the `ssr.html.template.js` file to escape the input HTML (cf EJS feature)[https://github.com/tj/ejs#features]

- I've launched again `yarn build` which has succeeded

- Finally, i've launched the build on a local server to check that the result was fine

![image](https://user-images.githubusercontent.com/20051874/72279088-a9504c80-3635-11ea-9dea-29f31d0ea097.png)
