### PR TITLE
docs(v2): fix plugin-content-docs config comment typo

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.40/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.40/using-plugins.md
@@ -220,7 +220,7 @@ module.exports = {
          */
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
         /**
-         * URL route for the blog section of your site
+         * URL route for the docs section of your site
          * do not include trailing slash
          */
         routeBasePath: 'docs',


### PR DESCRIPTION
copy/pasted comment referred to "blogs" not "docs".

## Motivation

I was reading the docs and got confused :) 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

N/A
