### PR TITLE
chore(v1): Updated users list, removing sites not using docusaurus

### DIFF
--- a/website-1.x/data/users.js
+++ b/website-1.x/data/users.js
@@ -71,13 +71,6 @@ module.exports = [
     pinned: false,
   },
   {
-    caption: 'Atalaya',
-    image: '/img/users/atalaya.png',
-    infoLink: 'https://atalaya.io/',
-    fbOpenSource: false,
-    pinned: false,
-  },
-  {
     caption: 'Ax',
     image: '/img/users/ax.svg',
     infoLink: 'https://ax.dev/',
@@ -417,14 +410,6 @@ module.exports = [
     caption: 'Noderize',
     image: '/img/users/noderize.svg',
     infoLink: 'https://noderize.js.org/',
-    fbOpenSource: false,
-    pinned: false,
-  },
-  {
-    caption: 'nteract',
-    image:
-      'https://media.githubusercontent.com/media/nteract/logos/master/nteract_logo_cube_book/exports/images/png/nteract_logo_mark_purple.png',
-    infoLink: 'https://docs.nteract.io/',
     fbOpenSource: false,
     pinned: false,
   },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I went through the examples in https://docusaurus.io/en/users and found a couple that moved away from docusaurus. 

These were removed:

https://docs.nteract.io/
https://atalaya.io/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Passed `yarn run test`. Nothing to write a test for here.

## Related PRs

N/A
