### PR TITLE
feat(v2): allow for Typescript pages and components

### DIFF
--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -16,7 +16,7 @@ import {PluginOptions, LoadedContent} from './types';
 const DEFAULT_OPTIONS: PluginOptions = {
   path: 'src/pages', // Path to data on filesystem, relative to site dir.
   routeBasePath: '', // URL Route.
-  include: ['**/*.{js,jsx}'], // Extensions to include.
+  include: ['**/*.{js,jsx,ts,tsx}'], // Extensions to include.
 };
 
 export default function pluginContentPages(

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -60,7 +60,7 @@ export function objectWithKeySorted(obj: Object) {
     .value();
 }
 
-const indexRE = /(^|.*\/)index\.(md|js)$/i;
+const indexRE = /(^|.*\/)index\.(md|js|jsx|ts|tsx)$/i;
 const extRE = /\.(md|js)$/;
 
 /**

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -56,6 +56,7 @@ export function createBaseConfig(
     },
     devtool: isProd ? false : 'cheap-module-eval-source-map',
     resolve: {
+      extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
       symlinks: true,
       alias: {
         // https://stackoverflow.com/a/55433680/6072730
@@ -146,7 +147,7 @@ export function createBaseConfig(
     module: {
       rules: [
         {
-          test: /\.jsx?$/,
+          test: /\.(j|t)sx?$/,
           exclude: excludeJS,
           use: [getCacheLoader(isServer), getBabelLoader(isServer)].filter(
             Boolean,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Most of our codebase is in Typescript. We want some dynamic documentation to where we can reference variables in Typescript files. It would be awesome to further support inline Typescript files as well.

This is a very simple change that enables a lot of possibilities.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Pretty straight forward!
- Try putting a `.ts` file in the pages folder (and a `.js` file for backwards compatibility) and test it compiles
- Try putting a `.ts` or a `.tsx` file somewhere in the project, then reference it in any `.md` or `.mdx` file and be amazed as it works

## Related PRs

Let me know how we want this documented (a page or a footnote) and I'll add it to the PR.

Fixes #2120 