### PR TITLE
fix(v2): render correct theme for live code blocks on SSR

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -78,6 +78,7 @@ export default ({
   if (live) {
     return (
       <Playground
+        key={mounted}
         scope={{...React}}
         code={children.trim()}
         theme={prismTheme}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, the correct syntax theme is not applied to live code blocks, if you go **not** through client navigation (for example, open a link directly). This PR fixes this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Compare current version (https://v2.docusaurus.io/docs/markdown-features/) with preview one.
