### PR TITLE
fix(v2): show doc sidebar on pages with case-sensitive paths

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
@@ -18,29 +18,33 @@ import {matchPath} from '@docusaurus/router';
 
 import styles from './styles.module.css';
 
-function matchingRouteExist(routes, pathname) {
-  return routes.some(route => matchPath(pathname, route));
-}
-
 function DocPage(props) {
-  const {route, docsMetadata, location} = props;
+  const {route: baseRoute, docsMetadata, location} = props;
+  // case-sensitive route such as it is defined in the sidebar
+  const currentRoute = baseRoute.routes.find(route =>
+    matchPath(location.pathname, route),
+  );
+
   const {permalinkToSidebar, docsSidebars, version} = docsMetadata;
-  const sidebar = permalinkToSidebar[location.pathname.replace(/\/$/, '')];
-  const {siteConfig: {themeConfig = {}} = {}} = useDocusaurusContext();
+  const sidebar = permalinkToSidebar[currentRoute.path];
+  const {
+    siteConfig: {themeConfig = {}} = {},
+    isClient,
+  } = useDocusaurusContext();
   const {sidebarCollapsible = true} = themeConfig;
 
-  if (!matchingRouteExist(route.routes, location.pathname)) {
+  if (!currentRoute) {
     return <NotFound {...props} />;
   }
 
   return (
-    <Layout version={version}>
+    <Layout version={version} key={isClient}>
       <div className={styles.docPage}>
         {sidebar && (
           <div className={styles.docSidebarContainer}>
             <DocSidebar
               docsSidebars={docsSidebars}
-              location={location}
+              path={currentRoute.path}
               sidebar={sidebar}
               sidebarCollapsible={sidebarCollapsible}
             />
@@ -48,7 +52,7 @@ function DocPage(props) {
         )}
         <main className={styles.docMainContainer}>
           <MDXProvider components={MDXComponents}>
-            {renderRoutes(route.routes)}
+            {renderRoutes(baseRoute.routes)}
           </MDXProvider>
         </main>
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -93,13 +93,13 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
 
 // Calculate the category collapsing state when a page navigation occurs.
 // We want to automatically expand the categories which contains the current page.
-function mutateSidebarCollapsingState(item, location) {
+function mutateSidebarCollapsingState(item, path) {
   const {items, href, type} = item;
   switch (type) {
     case 'category': {
       const anyChildItemsActive =
         items
-          .map(childItem => mutateSidebarCollapsingState(childItem, location))
+          .map(childItem => mutateSidebarCollapsingState(childItem, path))
           .filter(val => val).length > 0;
       // eslint-disable-next-line no-param-reassign
       item.collapsed = !anyChildItemsActive;
@@ -108,7 +108,7 @@ function mutateSidebarCollapsingState(item, location) {
 
     case 'link':
     default:
-      return href === location.pathname.replace(/\/$/, '');
+      return href === path;
   }
 }
 
@@ -121,7 +121,7 @@ function DocSidebar(props) {
 
   const {
     docsSidebars,
-    location,
+    path,
     sidebar: currentSidebar,
     sidebarCollapsible,
   } = props;
@@ -142,7 +142,7 @@ function DocSidebar(props) {
 
   if (sidebarCollapsible) {
     sidebarData.forEach(sidebarItem =>
-      mutateSidebarCollapsingState(sidebarItem, location),
+      mutateSidebarCollapsingState(sidebarItem, path),
     );
   }
 


### PR DESCRIPTION
## Motivation

Since the router configures with case-insensitive paths (by default), we will display the page correctly if the path is written in a different case (`creating-Pages` -> `creating-pages` (proper path), and vice versa). _Although my personal opinion is that in this case you need to display a 404 error, because this is technically the wrong address, it means that we need to work it out correctly._

However, changing current behavior will result in breaking changes, which is best avoided, so let's leave it as it is. But as noted in issue #2190, in such cases the doc sidebar is not shown. This PR fixes this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Change or create the id of front matter and filename of any doc page to case-sensitive, eg:

```diff
- id: docusaurus-core
+ id: Docusaurus-Core
```

Make the appropriate changes also in sidebar.js file.

2. Navigate to `docs/docusaurus-core` (page with wrong path that we will handle) and `docs/Docusaurus-Core` (new correct path) - the result should be the same.
Note that, only when going to the wrong page (`docs/docusaurus-core`) for a second or so will content of 404 page be displayed (which should be)