### PR TITLE
fix(v2): hide read more button on non-truncated posts

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -57,6 +57,7 @@ describe('loadBlog', () => {
         permalink: noDatePermalink,
         title: 'no date',
       },
+      truncated: false,
     });
     expect(
       blogPosts.find(v => v.metadata.title === 'Happy 1st Birthday Slash!')
@@ -76,6 +77,7 @@ describe('loadBlog', () => {
         permalink: '/blog/2019/01/01/date-matter',
         title: 'date-matter',
       },
+      truncated: false,
     });
 
     expect(
@@ -91,6 +93,7 @@ describe('loadBlog', () => {
         permalink: '/blog/2019/01/01/date-matter',
         title: 'date-matter',
       },
+      truncated: false,
     });
   });
 });

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -13,7 +13,7 @@ import {PluginOptions, BlogPost, DateLink} from './types';
 import {parse, normalizeUrl, aliasedSitePath} from '@docusaurus/utils';
 import {LoadContext} from '@docusaurus/types';
 
-export function truncate(fileString: string, truncateMarker: RegExp | string) {
+export function truncate(fileString: string, truncateMarker: RegExp) {
   return fileString.split(truncateMarker, 1).shift()!;
 }
 
@@ -85,7 +85,7 @@ export async function generateBlogPosts(
   {siteConfig, siteDir}: LoadContext,
   options: PluginOptions,
 ) {
-  const {include, routeBasePath} = options;
+  const {include, routeBasePath, truncateMarker} = options;
 
   if (!fs.existsSync(blogDir)) {
     return null;
@@ -105,7 +105,7 @@ export async function generateBlogPosts(
       const blogFileName = path.basename(relativeSource);
 
       const fileString = await fs.readFile(source, 'utf-8');
-      const {frontMatter, excerpt} = parse(fileString);
+      const {frontMatter, content, excerpt} = parse(fileString);
 
       let date;
       // Extract date and title from filename.
@@ -137,6 +137,7 @@ export async function generateBlogPosts(
           date,
           tags: frontMatter.tags,
           title: frontMatter.title,
+          truncated: truncateMarker.test(content),
         },
       });
     }),

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -137,7 +137,7 @@ export async function generateBlogPosts(
           date,
           tags: frontMatter.tags,
           title: frontMatter.title,
-          truncated: truncateMarker.test(content),
+          truncated: truncateMarker?.test(content) || false,
         },
       });
     }),

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -41,7 +41,7 @@ const DEFAULT_OPTIONS: PluginOptions = {
   blogTagsPostsComponent: '@theme/BlogTagsPostsPage',
   remarkPlugins: [],
   rehypePlugins: [],
-  truncateMarker: /<!--\s*(truncate)\s*-->/, // string or regex
+  truncateMarker: /<!--\s*(truncate)\s*-->/, // Regex
 };
 
 function assertFeedTypes(val: any): asserts val is FeedType {

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -12,7 +12,7 @@ import {truncate} from './blogUtils';
 export = function(fileString: string) {
   const callback = this.async();
 
-  const {truncateMarker}: {truncateMarker: RegExp | string} = getOptions(this);
+  const {truncateMarker}: {truncateMarker: RegExp} = getOptions(this);
 
   let finalContent = fileString;
 

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -30,7 +30,7 @@ export interface PluginOptions {
   blogTagsPostsComponent: string;
   remarkPlugins: string[];
   rehypePlugins: string[];
-  truncateMarker: RegExp | string;
+  truncateMarker: RegExp;
   feedOptions?: {
     type: FeedType;
     title?: string;
@@ -79,6 +79,7 @@ export interface MetaData {
   title: string;
   prevItem?: Paginator;
   nextItem?: Paginator;
+  truncated: boolean;
 }
 
 export interface Paginator {

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
@@ -24,7 +24,7 @@ function BlogListPage(props) {
                 key={BlogPostContent.metadata.permalink}
                 frontMatter={BlogPostContent.frontMatter}
                 metadata={BlogPostContent.metadata}
-                truncated>
+                truncated={BlogPostContent.metadata.truncated}>
                 <BlogPostContent />
               </BlogPostItem>
             ))}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix the bug reported on Canny - https://docusaurus.canny.io/admin/board/feature-requests/p/allow-no-truncate-on-blog-post

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Check that the blog post without the `<!--truncate-->` marker does not display the Read more button on the blog lists page.

