### PR TITLE
fix(v2): adjust correct behavior of navbar when active anchor

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.js
@@ -7,9 +7,11 @@
 
 import {useState, useCallback, useEffect} from 'react';
 import {useLocation} from '@docusaurus/router';
+import useLocationHash from '@theme/hooks/useLocationHash';
 
 const useHideableNavbar = hideOnScroll => {
   const [isNavbarVisible, setIsNavbarVisible] = useState(true);
+  const [isFocusedAnchor, setIsFocusedAnchor] = useState(false);
   const [lastScrollTop, setLastScrollTop] = useState(0);
   const [navbarHeight, setNavbarHeight] = useState(0);
   const navbarRef = useCallback(node => {
@@ -18,6 +20,7 @@ const useHideableNavbar = hideOnScroll => {
     }
   }, []);
   const location = useLocation();
+  const [hash, setHash] = useLocationHash(location.hash);
 
   const handleScroll = () => {
     const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
@@ -26,11 +29,10 @@ const useHideableNavbar = hideOnScroll => {
       return;
     }
 
-    const focusedElement = document.activeElement;
-
-    if (focusedElement && /^#/.test(window.location.hash)) {
+    if (isFocusedAnchor) {
+      setIsFocusedAnchor(false);
       setIsNavbarVisible(false);
-      focusedElement.blur();
+      setLastScrollTop(scrollTop);
       return;
     }
 
@@ -59,8 +61,25 @@ const useHideableNavbar = hideOnScroll => {
   }, [lastScrollTop, navbarHeight]);
 
   useEffect(() => {
+    if (!hideOnScroll) {
+      return;
+    }
+
     setIsNavbarVisible(true);
+    setHash(location.hash);
   }, [location]);
+
+  useEffect(() => {
+    if (!hideOnScroll) {
+      return;
+    }
+
+    if (!hash) {
+      return;
+    }
+
+    setIsFocusedAnchor(true);
+  }, [hash]);
 
   return {
     navbarRef,

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useState, useEffect} from 'react';
+
+function useLocationHash(initialHash) {
+  const [hash, setHash] = useState(initialHash);
+
+  useEffect(() => {
+    const handleHashChange = () => setHash(window.location.hash);
+
+    window.addEventListener('hashchange', handleHashChange);
+
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  return [hash, setHash];
+}
+
+export default useLocationHash;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In PR #2162 I missed up one use case: when a user opens a web page with an anchor (hash). At the moment, in this case the navbar is **always hidden**, even if the page scrolls to the top.

To demonstrate this bug see GIF (target path - docs/introduction/#️-disclaimer):

![screencast-v2 docusaurus io-2020 01 28-05_40_37](https://user-images.githubusercontent.com/4408379/73231279-05b47f80-4191-11ea-8c0c-860af03f919c.gif)

The previous implementation with `document.activeElement` was wrong, because in fact we have no way via JS to determine the active (focused) anchor. (In CSS, this is possible through the pseudo-class `:target`). Therefore, in order to achieve the desired result, it was required to track the change in the hash location and then synchronize the changes in the hash URL (when switching (updating) the route).

As a result, there was more code, but the behavior of hideable navbar is what it should be.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Navigate to URL with anchor (eg /docs/introduction#%EF%B8%8F-disclaimer) and try to scroll down and then up - navbar should appear again (now it is not).
2. Also check the "regular" use - when the user clicks on the anchor (on `#` sign in heading) or clicks on the link in TOC.