### PR TITLE
docs(v2): collapsible categories in sidebar

### DIFF
--- a/website/docs/sidebar.md
+++ b/website/docs/sidebar.md
@@ -227,3 +227,18 @@ module.exports = {
   },
 };
 ```
+
+### Collapsible categories
+
+For sites with a sizable amount of content, we support the option to expand/collapse the links and subcategories under categories. Categories are collapsible by default, but so that they are always expanded, set `themeConfig.sidebarCollapsible` to `false`:
+
+```js
+// docusaurus.config.js
+module.exports = {
+  ...
+  themeConfig: {
+    sidebarCollapsible: false,
+    ...
+  },
+}
+```

--- a/website/docs/sidebar.md
+++ b/website/docs/sidebar.md
@@ -230,9 +230,9 @@ module.exports = {
 
 ### Collapsible categories
 
-For sites with a sizable amount of content, we support the option to expand/collapse the links and subcategories under categories. Categories are collapsible by default, but so that they are always expanded, set `themeConfig.sidebarCollapsible` to `false`:
+For sites with a sizable amount of content, we support the option to expand/collapse a category to toggle the display of its contents. Categories are collapsible by default. If you want them to be always expanded, set `themeConfig.sidebarCollapsible` to `false`:
 
-```js
+```js {5}
 // docusaurus.config.js
 module.exports = {
   ...


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

From discord:

> Hi there! First of all, thx for this amazing project!
I like the collapsible sidebar but the possibility to choose wish one have to be open by default could be a real plus.
Should I open a feature request? Or does it make sense?

I previously added the ability to expand all categories in the doc sidebar, as it was in D1 by default, but this was only documented in Migration from v1 to v2 guide, so new users (who did not use Docusaurus at all) did not know about this possibility. This PR documents this feature in the Sidebar page so that all users know about it


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See Sidebar page.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
