### PR TITLE
refactor(v2): avoid to use raw theme values

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -42,10 +42,10 @@ export default ({children, className: languageClassName, metastring}) => {
   const button = useRef(null);
   let highlightLines = [];
 
-  const {theme} = useThemeContext();
+  const {isDarkTheme} = useThemeContext();
   const lightModeTheme = prism.theme || defaultTheme;
   const darkModeTheme = prism.darkTheme || lightModeTheme;
-  const prismTheme = theme === 'dark' ? darkModeTheme : lightModeTheme;
+  const prismTheme = isDarkTheme ? darkModeTheme : lightModeTheme;
 
   if (metastring && highlightLinesRangeRegex.test(metastring)) {
     const highlightLinesRange = metastring.match(highlightLinesRangeRegex)[1];

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -52,7 +52,7 @@ function Navbar() {
   const [sidebarShown, setSidebarShown] = useState(false);
   const [isSearchBarExpanded, setIsSearchBarExpanded] = useState(false);
 
-  const {theme, setTheme} = useThemeContext();
+  const {isDarkTheme, setLightTheme, setDarkTheme} = useThemeContext();
   const {navbarRef, isNavbarVisible} = useHideableNavbar(hideOnScroll);
 
   useLockBodyScroll(sidebarShown);
@@ -65,11 +65,8 @@ function Navbar() {
   }, [setSidebarShown]);
 
   const onToggleChange = useCallback(
-    e => {
-      const newTheme = e.target.checked ? 'dark' : '';
-      setTheme(newTheme);
-    },
-    [setTheme],
+    e => (e.target.checked ? setDarkTheme() : setLightTheme()),
+    [setLightTheme, setDarkTheme],
   );
 
   const logoUrl = useBaseUrl(logo.src);
@@ -134,7 +131,7 @@ function Navbar() {
             <Toggle
               className={styles.displayOnlyInLargeViewport}
               aria-label="Dark mode toggle"
-              checked={theme === 'dark'}
+              checked={isDarkTheme}
               onChange={onToggleChange}
             />
           )}
@@ -160,7 +157,7 @@ function Navbar() {
           {!disableDarkMode && sidebarShown && (
             <Toggle
               aria-label="Dark mode toggle in sidebar"
-              checked={theme === 'dark'}
+              checked={isDarkTheme}
               onChange={onToggleChange}
             />
           )}

--- a/packages/docusaurus-theme-classic/src/theme/ThemeContext.js
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeContext.js
@@ -8,8 +8,9 @@
 import React from 'react';
 
 const ThemeContext = React.createContext({
-  theme: null,
-  setTheme: () => {},
+  isDarkTheme: false,
+  setLightTheme: () => {},
+  setDarkTheme: () => {},
 });
 
 export default ThemeContext;

--- a/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.js
@@ -11,10 +11,10 @@ import useTheme from '@theme/hooks/useTheme';
 import ThemeContext from '@theme/ThemeContext';
 
 function ThemeProvider(props) {
-  const [theme, setTheme] = useTheme();
+  const {isDarkTheme, setLightTheme, setDarkTheme} = useTheme();
 
   return (
-    <ThemeContext.Provider value={{theme, setTheme}}>
+    <ThemeContext.Provider value={{isDarkTheme, setLightTheme, setDarkTheme}}>
       {props.children}
     </ThemeContext.Provider>
   );

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
@@ -5,25 +5,48 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import {useState, useCallback, useEffect} from 'react';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+const themes = {
+  light: '',
+  dark: 'dark',
+};
 
 const useTheme = () => {
   const {
     siteConfig: {themeConfig: {disableDarkMode}} = {},
   } = useDocusaurusContext();
-  const [theme, setTheme] = React.useState(
+  const [theme, setTheme] = useState(
     typeof document !== 'undefined'
       ? document.documentElement.getAttribute('data-theme')
-      : '',
+      : themes.light,
   );
+  const setThemeSyncWithLocalStorage = useCallback(
+    newTheme => {
+      try {
+        localStorage.setItem('theme', newTheme);
+      } catch (err) {
+        console.error(err);
+      }
+    },
+    [setTheme],
+  );
+  const setLightTheme = useCallback(() => {
+    setTheme(themes.light);
+    setThemeSyncWithLocalStorage(themes.light);
+  }, []);
+  const setDarkTheme = useCallback(() => {
+    setTheme(themes.dark);
+    setThemeSyncWithLocalStorage(themes.dark);
+  }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
   }, [theme]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (disableDarkMode) {
       return;
     }
@@ -38,19 +61,11 @@ const useTheme = () => {
     }
   }, [setTheme]);
 
-  const setThemeSyncWithLocalStorage = React.useCallback(
-    nextTheme => {
-      try {
-        localStorage.setItem('theme', nextTheme);
-        setTheme(nextTheme);
-      } catch (err) {
-        console.error(err);
-      }
-    },
-    [setTheme],
-  );
-
-  return [theme, setThemeSyncWithLocalStorage];
+  return {
+    isDarkTheme: theme === themes.dark,
+    setLightTheme,
+    setDarkTheme,
+  };
 };
 
 export default useTheme;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -49,10 +49,10 @@ export default ({
   const button = useRef(null);
   let highlightLines = [];
 
-  const {theme} = useThemeContext();
+  const {isDarkTheme} = useThemeContext();
   const lightModeTheme = prism.theme || defaultTheme;
   const darkModeTheme = prism.darkTheme || lightModeTheme;
-  const prismTheme = theme === 'dark' ? darkModeTheme : lightModeTheme;
+  const prismTheme = isDarkTheme ? darkModeTheme : lightModeTheme;
 
   if (metastring && highlightLinesRangeRegex.test(metastring)) {
     const highlightLinesRange = metastring.match(highlightLinesRangeRegex)[1];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

A simple small refactoring in the `useTheme` hook, in order to avoid using of raw values ('' and 'dark') for the theme in the code base. It seems to me that it has become more understandable and easier.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Make sure theme switching works as before.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
