### PR TITLE
feat(v2): add site title to meta title

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -81,7 +81,7 @@ function DocItem(props) {
       <Head>
         {title && (
           <title>
-            {title} · {siteTitle}
+            {title} | {siteTitle}
           </title>
         )}
         {description && <meta name="description" content={description} />}

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -53,7 +53,7 @@ function Headings({headings, isChild}) {
 
 function DocItem(props) {
   const {siteConfig = {}} = useDocusaurusContext();
-  const {url: siteUrl} = siteConfig;
+  const {url: siteUrl, title: siteTitle} = siteConfig;
   const {content: DocContent} = props;
   const {metadata} = DocContent;
   const {
@@ -79,7 +79,11 @@ function DocItem(props) {
   return (
     <>
       <Head>
-        {title && <title>{title}</title>}
+        {title && (
+          <title>
+            {title} · {siteTitle}
+          </title>
+        )}
         {description && <meta name="description" content={description} />}
         {description && (
           <meta property="og:description" content={description} />

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -36,8 +36,8 @@ function Layout(props) {
     version,
   } = props;
   const metaTitle = title
-    ? `${title} · ${siteTitle}`
-    : `${siteTitle} · ${tagline}`;
+    ? `${title} | ${siteTitle}`
+    : `${siteTitle} | ${tagline}`;
   const metaImage = image || defaultImage;
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
   const faviconUrl = useBaseUrl(favicon);

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -20,7 +20,6 @@ function Layout(props) {
   const {siteConfig = {}} = useDocusaurusContext();
   const {
     favicon,
-    tagline,
     title: siteTitle,
     themeConfig: {image: defaultImage},
     url: siteUrl,
@@ -35,9 +34,7 @@ function Layout(props) {
     permalink,
     version,
   } = props;
-  const metaTitle = title
-    ? `${title} | ${siteTitle}`
-    : `${siteTitle} | ${tagline}`;
+  const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
   const metaImage = image || defaultImage;
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
   const faviconUrl = useBaseUrl(favicon);

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -21,7 +21,7 @@ function Layout(props) {
   const {
     favicon,
     tagline,
-    title: defaultTitle,
+    title: siteTitle,
     themeConfig: {image: defaultImage},
     url: siteUrl,
   } = siteConfig;
@@ -35,7 +35,9 @@ function Layout(props) {
     permalink,
     version,
   } = props;
-  const metaTitle = title || `${defaultTitle} · ${tagline}`;
+  const metaTitle = title
+    ? `${title} · ${siteTitle}`
+    : `${siteTitle} · ${tagline}`;
   const metaImage = image || defaultImage;
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
   const faviconUrl = useBaseUrl(favicon);

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -61,10 +61,13 @@ const QUOTES = [
 
 function Home() {
   const context = useDocusaurusContext();
-  const {siteConfig: {customFields = {}} = {}} = context;
+  const {siteConfig: {customFields = {}, tagline} = {}} = context;
 
   return (
-    <Layout permalink="/" description={customFields.description}>
+    <Layout
+      permalink="/"
+      title={tagline}
+      description={customFields.description}>
       <div className={styles.hero}>
         <div className={styles.heroInner}>
           <h1 className={styles.heroProjectTagline}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves https://docusaurus.canny.io/admin/board/feature-requests/p/allow-browser-tab-title-to-have-a-prefix

Bcause this is the expected behavior (especially since it was in v1) - the site name is usually contained in the title itself and this is suitable for most websites (+ better for SEO).

The only thing I'm not sure about existing a tagline in the case when the title is not set, in v1 there was even a separate config parameter ([`disableTitleTagline`](https://docusaurus.io/docs/en/site-config#disabletitletagline-boolean)) that removes the tagline from the final meta title, but I do not think it is a good idea to implement it in v2.

https://github.com/facebook/docusaurus/blob/7e60a283f13d92d1edfaf9d5698a5ff721db29da/packages/docusaurus-1.x/lib/core/Site.js#L38-L42

Maybe then do not include the tagline in the meta title, after all, this is typical only for the home page, for other pages without a title it is better to just use site title (IMO).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Make sure site title is included in meta title (docs/blog/pages).

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
