### PR TITLE
fix(v2): use site title if enabled blog-only mode

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
@@ -7,15 +7,21 @@
 
 import React from 'react';
 
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import BlogPostItem from '@theme/BlogPostItem';
 import BlogListPaginator from '@theme/BlogListPaginator';
 
 function BlogListPage(props) {
   const {metadata, items} = props;
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const isBlogOnlyMode = metadata.permalink === '/';
+  const title = isBlogOnlyMode ? siteTitle : 'Blog';
 
   return (
-    <Layout title="Blog" description="Blog">
+    <Layout title={title} description="Blog">
       <div className="container margin-vert--xl">
         <div className="row">
           <div className="col col--8 col--offset-2">

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
@@ -48,7 +48,7 @@ function BlogTagsListPage(props) {
     .filter(item => item != null);
 
   return (
-    <Layout title="Blog Tags" description="Blog Tags">
+    <Layout title="Tags" description="Blog Tags">
       <div className="container margin-vert--xl">
         <div className="row">
           <div className="col col--8 col--offset-2">

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
@@ -17,7 +17,7 @@ function BlogTagsPostPage(props) {
 
   return (
     <Layout
-      title={`Blog | Tagged "${tagName}"`}
+      title={`Posts tagged "${tagName}"`}
       description={`Blog | Tagged "${tagName}"`}>
       <div className="container margin-vert--xl">
         <div className="row">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolving of https://docusaurus.canny.io/admin/board/feature-requests/p/how-to-change-title-on-blog-only-mode (see also this [comment](https://docusaurus.canny.io/admin/board/feature-requests/p/how-to-change-title-on-blog-only-mode))

When using Docusaurus as a [blog-only mode](https://v2.docusaurus.io/docs/blog/#blog-only-mode), the title of the main page is just "Blog", although in this case it is expected to see the site title (specified in the config file).

In addition, as part of this PR, the title of other blog-related pages (tags lists and post tag pages) has been adjusted to make them more suitable for blog-only mode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Enable blog-only mode and check meta titles.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
