### PR TITLE
feat(v2): allow to specify different logo for dark mode

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -77,7 +77,7 @@ function Navbar() {
         target: '_blank',
       }
     : null;
-  const logoSrc = logo.darkSrc && isDarkTheme ? logo.darkSrc : logo.src;
+  const logoSrc = logo.srcDark && isDarkTheme ? logo.srcDark : logo.src;
   const logoImageUrl = useBaseUrl(logoSrc);
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -77,7 +77,8 @@ function Navbar() {
         target: '_blank',
       }
     : null;
-  const logoImageUrl = useBaseUrl(logo.src);
+  const logoSrc = logo.darkSrc && isDarkTheme ? logo.darkSrc : logo.src;
+  const logoImageUrl = useBaseUrl(logoSrc);
 
   return (
     <nav

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -57,7 +57,7 @@ module.exports = {
       logo: {
         alt: 'Site Logo',
         src: 'img/logo.svg',
-        darkSrc: 'img/logo_dark.svg', // default to logo.src
+        srcDark: 'img/logo_dark.svg', // default to logo.src
         href: 'https://v2.docusaurus.io/', // default to siteConfig.baseUrl
       },
     },

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -45,7 +45,7 @@ module.exports = {
 
 ### Navbar Title & Logo
 
-You can add a logo and title to the navbar via `themeConfig.navbar`. Logo can be placed in [static folder](static-assets.md). Logo URL is set to base URL of your site by default. Although you can specify your own URL for the logo, if it is an external link, it will open in a new tab.
+You can add a logo and title to the navbar via `themeConfig.navbar`. Logo can be placed in [static folder](static-assets.md). Logo URL is set to base URL of your site by default. Although you can specify your own URL for the logo, if it is an external link, it will open in a new tab. You can also set a different logo for dark mode.
 
 ```js
 // docusaurus.config.js
@@ -57,6 +57,7 @@ module.exports = {
       logo: {
         alt: 'Site Logo',
         src: 'img/logo.svg',
+        darkSrc: 'img/logo_dark.svg', // default to logo.src
         href: 'https://v2.docusaurus.io/', // default to siteConfig.baseUrl
       },
     },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolving of https://docusaurus.canny.io/admin/board/feature-requests/p/specify-different-dark-mode-logo

Since we have dark mode enabled by default, it makes sense to give our users the ability to set a different logo for dark mode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Specify `logo.darkSrc` filed and switch to dark mode to make sure the logo has changed.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)