### PR TITLE
fix(v2): remove focus on search input when hovering over it

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -78,16 +78,13 @@ const Search = props => {
 
   const handleSearchInputBlur = useCallback(() => {
     props.handleSearchBarToggle(!props.isSearchBarExpanded);
-  }, [algoliaLoaded]);
+  }, [props.isSearchBarExpanded]);
 
-  const handleSearchInput = useCallback(
-    e => {
-      const needFocus = e.type !== 'mouseover';
+  const handleSearchInput = useCallback(e => {
+    const needFocus = e.type !== 'mouseover';
 
-      loadAlgolia(needFocus);
-    },
-    [algoliaLoaded],
-  );
+    loadAlgolia(needFocus);
+  });
 
   return (
     <div className="navbar__search" key="search-box">

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -22,7 +22,7 @@ const Search = props => {
   } = siteConfig;
   const history = useHistory();
 
-  function initAlgolia() {
+  function initAlgolia(focus) {
     window.docsearch({
       appId: algolia.appId,
       apiKey: algolia.apiKey,
@@ -47,11 +47,12 @@ const Search = props => {
       },
     });
 
-    // Needed because the search input loses focus after calling window.docsearch()
-    searchBarRef.current.focus();
+    if (focus) {
+      searchBarRef.current.focus();
+    }
   }
 
-  const loadAlgolia = () => {
+  const loadAlgolia = (focus = true) => {
     if (algoliaLoaded) {
       return;
     }
@@ -60,7 +61,7 @@ const Search = props => {
       ([{default: docsearch}]) => {
         setAlgoliaLoaded(true);
         window.docsearch = docsearch;
-        initAlgolia();
+        initAlgolia(focus);
       },
     );
   };
@@ -78,6 +79,15 @@ const Search = props => {
   const handleSearchInputBlur = useCallback(() => {
     props.handleSearchBarToggle(!props.isSearchBarExpanded);
   }, [algoliaLoaded]);
+
+  const handleSearchInput = useCallback(
+    e => {
+      const needFocus = e.type !== 'mouseover';
+
+      loadAlgolia(needFocus);
+    },
+    [algoliaLoaded],
+  );
 
   return (
     <div className="navbar__search" key="search-box">
@@ -101,8 +111,8 @@ const Search = props => {
           {'search-bar-expanded': props.isSearchBarExpanded},
           {'search-bar': !props.isSearchBarExpanded},
         )}
-        onMouseOver={loadAlgolia}
-        onFocus={loadAlgolia}
+        onMouseOver={handleSearchInput}
+        onFocus={handleSearchInput}
         onBlur={handleSearchInputBlur}
         ref={searchBarRef}
       />

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -66,7 +66,7 @@ const Search = props => {
     );
   };
 
-  const toggleSearchIconClick = useCallback(() => {
+  const handleSearchIcon = useCallback(() => {
     loadAlgolia();
 
     if (algoliaLoaded) {
@@ -94,8 +94,8 @@ const Search = props => {
         className={classnames('search-icon', {
           'search-icon-hidden': props.isSearchBarExpanded,
         })}
-        onClick={toggleSearchIconClick}
-        onKeyDown={toggleSearchIconClick}
+        onClick={handleSearchIcon}
+        onKeyDown={handleSearchIcon}
         tabIndex={0}
       />
       <input


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

PR #2188 brought an unpleasant side effect - when you hover over the search field, auto focus occurred on this field. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Check the search input work - when hovering, when focus, also consider mobiles.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
