### PR TITLE
feat(v2): pluralize posts on tag's page

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -23,6 +23,9 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },
+  "bundledDependencies": [
+    "@docusaurus/utils"
+  ],
   "engines": {
     "node": ">=10.9.0"
   }

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
@@ -10,7 +10,7 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import BlogPostItem from '@theme/BlogPostItem';
 import Link from '@docusaurus/Link';
-import {pluralize} from '@docusaurus/utils'; // eslint-disable-line import/no-extraneous-dependencies
+import {pluralize} from '@docusaurus/utils';
 
 function BlogTagsPostPage(props) {
   const {metadata, items} = props;

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
@@ -10,6 +10,7 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import BlogPostItem from '@theme/BlogPostItem';
 import Link from '@docusaurus/Link';
+import {pluralize} from '@docusaurus/utils'; // eslint-disable-line import/no-extraneous-dependencies
 
 function BlogTagsPostPage(props) {
   const {metadata, items} = props;
@@ -23,7 +24,8 @@ function BlogTagsPostPage(props) {
         <div className="row">
           <div className="col col--8 col--offset-2">
             <h1>
-              {count} post(s) tagged with &quot;{tagName}&quot;
+              {count} {pluralize(count, 'post')} tagged with &quot;{tagName}
+              &quot;
             </h1>
             <Link href={allTagsPath}>View All Tags</Link>
             <div className="margin-vert--xl">

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
@@ -10,7 +10,10 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import BlogPostItem from '@theme/BlogPostItem';
 import Link from '@docusaurus/Link';
-import {pluralize} from '@docusaurus/utils';
+
+function pluralize(count, word) {
+  return count > 1 ? `${word}s` : word;
+}
 
 function BlogTagsPostPage(props) {
   const {metadata, items} = props;

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -11,7 +11,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
 import Link from '@docusaurus/Link';
-import isInternalUrl from '@docusaurus/utils'; // eslint-disable-line import/no-extraneous-dependencies
+import {isInternalUrl} from '@docusaurus/utils'; // eslint-disable-line import/no-extraneous-dependencies
 
 import styles from './styles.module.css';
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -11,7 +11,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
 import Link from '@docusaurus/Link';
-import {isInternalUrl} from '@docusaurus/utils'; // eslint-disable-line import/no-extraneous-dependencies
+import {isInternalUrl} from '@docusaurus/utils';
 
 import styles from './styles.module.css';
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -11,7 +11,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
 import Link from '@docusaurus/Link';
-import {isInternalUrl} from '@docusaurus/utils';
+import isInternalUrl from '@docusaurus/utils';
 
 import styles from './styles.module.css';
 

--- a/packages/docusaurus/src/client/exports/Link.js
+++ b/packages/docusaurus/src/client/exports/Link.js
@@ -7,7 +7,7 @@
 
 import React, {useEffect, useRef} from 'react';
 import {NavLink} from 'react-router-dom';
-import {isInternalUrl} from '@docusaurus/utils';
+import isInternalUrl from '@docusaurus/utils';
 
 function Link(props) {
   const {to, href} = props;

--- a/packages/docusaurus/src/client/exports/Link.js
+++ b/packages/docusaurus/src/client/exports/Link.js
@@ -7,7 +7,7 @@
 
 import React, {useEffect, useRef} from 'react';
 import {NavLink} from 'react-router-dom';
-import isInternalUrl from '@docusaurus/utils';
+import {isInternalUrl} from '@docusaurus/utils';
 
 function Link(props) {
   const {to, href} = props;

--- a/packages/docusaurus/src/client/exports/utils.js
+++ b/packages/docusaurus/src/client/exports/utils.js
@@ -4,6 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export default function isInternalUrl(url) {
+
+export function isInternalUrl(url) {
   return /^\/(?!\/)/.test(url);
+}
+
+export function pluralize(count, word) {
+  return count > 1 ? `${word}s` : word;
 }

--- a/packages/docusaurus/src/client/exports/utils.js
+++ b/packages/docusaurus/src/client/exports/utils.js
@@ -5,10 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export function isInternalUrl(url) {
+export default function isInternalUrl(url) {
   return /^\/(?!\/)/.test(url);
-}
-
-export function pluralize(count, word) {
-  return count > 1 ? `${word}s` : word;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Adding basic feature to form plural word forms. This is of course a very simple util function, and when localization functionality appears, it needs to be improved, but at the moment it is doing its job perfectly

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/73599705-4e848380-4557-11ea-99d8-13a5ebe36ae1.png) | ![image](https://user-images.githubusercontent.com/4408379/73599706-5a704580-4557-11ea-92e4-bf75b03adc38.png) |


