### PR TITLE
docs(v2): drop support for node <10.9

### DIFF
--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -14,7 +14,7 @@ We have created a helpful script that will get all of the infrastructure set up 
 
 1.  Ensure you have the latest version of [Node](https://nodejs.org/en/download/) installed. We also recommend you install [Yarn](https://yarnpkg.com/en/docs/install) as well.
 
-    > You have to be on Node >= 8.x and Yarn >= 1.5.
+    > You have to be on Node >= 10.9.0 and Yarn >= 1.5.
 
 1.  Create a project, if none exists, and change your directory to this project's root.
 


### PR DESCRIPTION
## Motivation

My node version is 8.9.4, npm version is 5.6.0.
When I run command docusaurus-init in my environment, there is no doc folder, and only package.json file in the website folder.

Close #2198

So, I update `getting stated` documentation compatible with current LTS version `(Node.js >= 10)`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

👌 

## Test Plan


## Related PRs

- https://github.com/facebook/docusaurus/pull/2207