### PR TITLE
docs: update windows deploy command

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -110,7 +110,7 @@ GIT_USER=<GIT_USER> \
 **Windows**
 
 ```batch
-cmd /C "set GIT_USER=<GIT_USER> && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
+cmd /C "set "GIT_USER=<GIT_USER>" && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
 ```
 
 There are also two optional parameters that are set as environment variables:

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -95,7 +95,7 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 **Windows**
 
 ```batch
-cmd /C "set GIT_USER=<GITHUB_USERNAME> && yarn deploy"
+cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
 <!--

--- a/website/versioned_docs/version-2.0.0-alpha.38/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.38/deployment.md
@@ -95,7 +95,7 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 **Windows**
 
 ```batch
-cmd /C "set GIT_USER=<GITHUB_USERNAME> && yarn deploy"
+cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
 <!--

--- a/website/versioned_docs/version-2.0.0-alpha.39/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.39/deployment.md
@@ -95,7 +95,7 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 **Windows**
 
 ```batch
-cmd /C "set GIT_USER=<GITHUB_USERNAME> && yarn deploy"
+cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
 <!--

--- a/website/versioned_docs/version-2.0.0-alpha.40/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.40/deployment.md
@@ -95,7 +95,7 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 **Windows**
 
 ```batch
-cmd /C "set GIT_USER=<GITHUB_USERNAME> && yarn deploy"
+cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
 <!--


### PR DESCRIPTION
## Motivation

In #2258, it is described that the publish script fails on Windows. The problem is caused by a whiteline that is appended to the GIT_USER env variable on windows  when you run `cmd /C "set GIT_USER=<GIT_USER> && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"`. The same issue is also in v2, where the command is `cmd /C "set GIT_USER=<GITHUB_USERNAME> && yarn deploy"`.

We can fix the problem by using delayed expansion (surrounding `GIT_USER=<GIT_USER>` with quotation marks).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally on Windows by running the deploy command on both v1 and v2.