### PR TITLE
fix(v2): fix codeblock copy button not including blank lines

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -102,6 +102,10 @@ export default ({children, className: languageClassName, metastring}) => {
 
           <code ref={target} className={styles.codeBlockLines} style={style}>
             {tokens.map((line, i) => {
+              if (line.length === 1 && line[0].content === '') {
+                line[0].content = '\n'; // eslint-disable-line no-param-reassign
+              }
+
               const lineProps = getLineProps({line, key: i});
 
               if (highlightLines.includes(i + 1)) {

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -121,6 +121,10 @@ export default ({
 
           <code ref={target} className={styles.codeBlockLines} style={style}>
             {tokens.map((line, i) => {
+              if (line.length === 1 && line[0].content === '') {
+                line[0].content = '\n'; // eslint-disable-line no-param-reassign
+              }
+
               const lineProps = getLineProps({line, key: i});
 
               if (highlightLines.includes(i + 1)) {


### PR DESCRIPTION
## Motivation

Fixes #2284 (copy button in CodeBlock ignores blank line in code block)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes!

## Test Plan
- Click "Copy" button in CodeBlock with blank lines(ex: https://v2.docusaurus.io/docs/creating-pages#adding-a-new-page)
- Paste to editor

## Related PRs
This is a PR to add "Copy" button https://github.com/facebook/docusaurus/pull/1643
