### PR TITLE
docs(v1): fix Windows instructions for GitHub Pages publishing

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -110,7 +110,7 @@ GIT_USER=<GIT_USER> \
 **Windows**
 
 ```batch
-cmd /C "set "GIT_USER=<GIT_USER>" && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
+cmd /C "set "GIT_USER=<GIT_USER>"&& set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
 ```
 
 There are also two optional parameters that are set as environment variables:


### PR DESCRIPTION
additional space after GIT_USER=<GIT_USER> && was throwing errors on windows

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I had an issue publishing to gh pages from windows. Created an issue and got a solution which I'm now passing on as a pr!
https://github.com/facebook/docusaurus/issues/2258

Fixes #2258 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I tried pushing a change to my gh-pages docs with the space "<GIT_USER> &&" it failed, when I tried without a space <GIT_USER>&&  it worked.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
