### PR TITLE
fix(v1): prevent occasional generation of redirect for paths containing 'en' (#2306)

### DIFF
--- a/packages/docusaurus-1.x/lib/server/docs.js
+++ b/packages/docusaurus-1.x/lib/server/docs.js
@@ -127,13 +127,26 @@ function getMarkup(rawContent, mdToHtml, metadata, siteConfig) {
 }
 
 function getRedirectMarkup(metadata, siteConfig) {
-  const docsPart = `${siteConfig.docsUrl ? `${siteConfig.docsUrl}/` : ''}`;
-  if (
-    !env.translation.enabled ||
-    !metadata.permalink.includes(`${docsPart}en`)
-  ) {
+  if (!env.translation.enabled) {
     return null;
   }
+
+  const permalinkParts = metadata.permalink.split('/');
+  const defaultLocalePrefix = 'en';
+  let isUnderDefaultLocalePath;
+  if (siteConfig.docsUrl) {
+    isUnderDefaultLocalePath =
+      permalinkParts.indexOf(siteConfig.docsUrl) === 0 &&
+      permalinkParts.indexOf(defaultLocalePrefix) === 1;
+  } else {
+    isUnderDefaultLocalePath =
+      permalinkParts.indexOf(defaultLocalePrefix) === 0;
+  }
+
+  if (!isUnderDefaultLocalePath) {
+    return null;
+  }
+
   const Redirect = require('../core/Redirect.js');
   const redirectlink = getPath(metadata.permalink, siteConfig.cleanUrl);
   return renderToStaticMarkupWithDoctype(


### PR DESCRIPTION
## Motivation

this problem blocks me :)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Having files in documentation folder named "components" (contains "en"), I built documentation for 2 versions of siteConfig.js : with `docsUrl: ''` and `doscUrl: 'docs` before and after fix.
Before - worked only for non-empty `docsUrl` 
After - works for both

## Related PRs

NA
