### PR TITLE
chore(v2): Add @babel/preset-typescript to babel-loader

### DIFF
--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -120,6 +120,7 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
                 },
               ],
           '@babel/react',
+          '@babel/preset-typescript',
         ],
         plugins: [
           // Polyfills the runtime needed for async/await, generators, and friends


### PR DESCRIPTION
## Motivation

With #2221 docusaurus v2 is able to detect `{ts,tsx}` pages and components, but as soon as babel hits TypeScript syntax it fails. While the docusaurus `babel.config.js` includes `@babel/preset-typescript`, `babel-loader` inside the Webpack config does not.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Add `typescript.tsx` to your pages directory
2. Add TypeScript syntax

```
import React from 'react';

export default () => {
  let name: string = 'World';

  return (
    <h1>Hello {name}!</h1>
  );
};
```
3. Run docusaurus
4. Check localhost:3000/typescript

## Related PRs

#2221 
