### PR TITLE
feat(v2): add ability to use HTML in footer copyright

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.js
@@ -105,7 +105,12 @@ function Footer() {
                 )}
               </div>
             )}
-            {copyright}
+
+            <div
+              dangerouslySetInnerHTML={{
+                __html: copyright,
+              }}
+            />
           </div>
         )}
       </div>

--- a/website/docs/docusaurus.config.js.md
+++ b/website/docs/docusaurus.config.js.md
@@ -188,7 +188,7 @@ module.exports = {
         alt: 'Facebook Open Source Logo',
         src: 'https://docusaurus.io/img/oss_logo.png',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here
     },
   },
 };

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -226,7 +226,7 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here
     },
     image: 'img/docusaurus.png',
     // Equivalent to `docsSideNavCollapsible`


### PR DESCRIPTION
## Motivation

I have repeatedly heard in Discord how users needed to add a link to footer copyright, but to do this except via swizzling the `Footer` component, at the moment this is not possible.

I think we could add such a tiny but useful addition.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add any valid HTML in `footer.copyright` field of config file.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
