### PR TITLE
fix(v1): check repoUrl before using on users.js

### DIFF
--- a/packages/docusaurus-1.x/examples/basics/pages/en/users.js
+++ b/packages/docusaurus-1.x/examples/basics/pages/en/users.js
@@ -36,7 +36,9 @@ class Users extends React.Component {
             {siteConfig.repoUrl && (
               <>
                 <p>Are you using this project?</p>
-                <a href={`${siteConfig.repoUrl}/edit/master/website/siteConfig.js`} className="button">
+                <a
+                  href={`${siteConfig.repoUrl}/edit/master/website/siteConfig.js`}
+                  className="button">
                   Add your company
                 </a>
               </>

--- a/packages/docusaurus-1.x/examples/basics/pages/en/users.js
+++ b/packages/docusaurus-1.x/examples/basics/pages/en/users.js
@@ -18,7 +18,6 @@ class Users extends React.Component {
       return null;
     }
 
-    const editUrl = `${siteConfig.repoUrl}/edit/master/website/siteConfig.js`;
     const showcase = siteConfig.users.map(user => (
       <a href={user.infoLink} key={user.infoLink}>
         <img src={user.image} alt={user.caption} title={user.caption} />
@@ -34,10 +33,14 @@ class Users extends React.Component {
               <p>This project is used by many folks</p>
             </div>
             <div className="logos">{showcase}</div>
-            <p>Are you using this project?</p>
-            <a href={editUrl} className="button">
-              Add your company
-            </a>
+            {siteConfig.repoUrl && (
+              <>
+                <p>Are you using this project?</p>
+                <a href={`${siteConfig.repoUrl}/edit/master/website/siteConfig.js`} className="button">
+                  Add your company
+                </a>
+              </>
+            )}
           </div>
         </Container>
       </div>

--- a/packages/docusaurus-1.x/examples/basics/siteConfig.js
+++ b/packages/docusaurus-1.x/examples/basics/siteConfig.js
@@ -104,7 +104,7 @@ const siteConfig = {
 
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
-  //   repoUrl: 'https://github.com/facebook/test-site',
+  // repoUrl: 'https://github.com/facebook/test-site',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Fixes #2275 
- Minor fix in `siteConfig` to remove extra whitespace in code comment 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I first reproduced the issue locally following the instructions in the issue. After that, I implemented the change they suggested in that local docusaurus project and it fixed the issue.

<img width="1792" alt="Screen Shot 2020-02-26 at 10 51 36 AM" src="https://user-images.githubusercontent.com/3806031/75378062-daa07700-5887-11ea-89f0-beabca7f8e8f.png">


## Related PRs

N/A