### PR TITLE
fix(v2): make proper path to pages in TS

### DIFF
--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.tsx
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Head from '@docusaurus/Head';
+
+export default class Home extends React.Component {
+  render() {
+    return (
+      <div>
+        <Head>
+          <title>Hello</title>
+        </Head>
+        <div>TypeScript...</div>
+      </div>
+    );
+  }
+}

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
@@ -34,6 +34,10 @@ describe('docusaurus-plugin-content-pages', () => {
         source: path.join('@site', pluginPath, 'index.js'),
       },
       {
+        permalink: '/typescript',
+        source: path.join('@site', pluginPath, 'typescript.tsx'),
+      },
+      {
         permalink: '/hello/world',
         source: path.join('@site', pluginPath, 'hello', 'world.js'),
       },

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -61,7 +61,7 @@ export function objectWithKeySorted(obj: Object) {
 }
 
 const indexRE = /(^|.*\/)index\.(md|js|jsx|ts|tsx)$/i;
-const extRE = /\.(md|js)$/;
+const extRE = /\.(md|js|tsx)$/;
 
 /**
  * Convert filepath to url path.

--- a/website/docs/creating-pages.md
+++ b/website/docs/creating-pages.md
@@ -41,6 +41,12 @@ Once you save the file, the development server will automatically reload the cha
 
 Each page doesn't come with any styling. You will need to import the `Layout` component from `@theme/Layout` and wrap your contents within that component if you want the navbar and/or footer to appear.
 
+:::tip
+
+You can also create a page in TypeScript, in which case the its file name should use the `.tsx` extension, eg. `hello.tsx`.
+
+:::
+
 ## Routing
 
 If you are familiar with other static site generators like Jekyll and Next, this routing approach will feel familiar to you. Any JavaScript file you create under `/src/pages/` directory will be automatically converted to a website page, following the `/src/pages/` directory hierarchy. For example:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This was not a quick way to add support for pages in TypeScript - [one](https://github.com/facebook/docusaurus/pull/2221), [two](https://github.com/facebook/docusaurus/pull/222), and finally this third (and last) attempt for this! Now officially D2 supports the creation of pages in TS, woohoo!

Corresponding request on Canny - https://docusaurus.canny.io/admin/board/feature-requests/p/typescript-pages

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Create a page in TS (eg `page.tsx`) with any valid contents, for example:

```tsx
import React, {useEffect} from 'react';
import Layout from '@theme/Layout';

function Page() {
  let name: string = 'TypeScript';

  return (
    <Layout>
      <div className="container margin-vert--xl">
        <h1>Hello {name}!</h1>;
      </div>
    </Layout>
  );
}

export default Page;

```
2. Start D2 and check it out new page by navigating on `/page`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
