### PR TITLE
feat(v2): add draft feature to blog posts

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/__fixtures__/website/blog/draft.md
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/__fixtures__/website/blog/draft.md
@@ -1,0 +1,6 @@
+---
+date: 2020-02-27
+draft: true
+---
+
+this post should not be published yet

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/generateBlogFeed.test.ts.snap
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/generateBlogFeed.test.ts.snap
@@ -7,12 +7,19 @@ exports[`blogFeed atom shows feed item for each post 1`] = `
 <feed xmlns=\\"http://www.w3.org/2005/Atom\\">
     <id>https://docusaurus.io/blog</id>
     <title>Hello Blog</title>
-    <updated>2019-01-01T00:00:00.000Z</updated>
+    <updated>2020-02-27T00:00:00.000Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <link rel=\\"alternate\\" href=\\"https://docusaurus.io/blog\\"/>
     <subtitle>Hello Blog</subtitle>
     <icon>https://docusaurus.io/image/favicon.ico</icon>
     <rights>Copyright</rights>
+    <entry>
+        <title type=\\"html\\"><![CDATA[draft]]></title>
+        <id>draft</id>
+        <link href=\\"https://docusaurus.io/blog/2020/02/27/draft\\"/>
+        <updated>2020-02-27T00:00:00.000Z</updated>
+        <summary type=\\"html\\"><![CDATA[this post should not be published yet]]></summary>
+    </entry>
     <entry>
         <title type=\\"html\\"><![CDATA[date-matter]]></title>
         <id>date-matter</id>
@@ -39,10 +46,17 @@ exports[`blogFeed rss shows feed item for each post 1`] = `
         <title>Hello Blog</title>
         <link>https://docusaurus.io/blog</link>
         <description>Hello Blog</description>
-        <lastBuildDate>Tue, 01 Jan 2019 00:00:00 GMT</lastBuildDate>
+        <lastBuildDate>Thu, 27 Feb 2020 00:00:00 GMT</lastBuildDate>
         <docs>http://blogs.law.harvard.edu/tech/rss</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <copyright>Copyright</copyright>
+        <item>
+            <title><![CDATA[draft]]></title>
+            <link>https://docusaurus.io/blog/2020/02/27/draft</link>
+            <guid>https://docusaurus.io/blog/2020/02/27/draft</guid>
+            <pubDate>Thu, 27 Feb 2020 00:00:00 GMT</pubDate>
+            <description><![CDATA[this post should not be published yet]]></description>
+        </item>
         <item>
             <title><![CDATA[date-matter]]></title>
             <link>https://docusaurus.io/blog/2019/01/01/date-matter</link>

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -107,6 +107,10 @@ export async function generateBlogPosts(
       const fileString = await fs.readFile(source, 'utf-8');
       const {frontMatter, content, excerpt} = parse(fileString);
 
+      if (frontMatter.draft && process.env.NODE_ENV === 'production') {
+        return;
+      }
+
       let date;
       // Extract date and title from filename.
       const match = blogFileName.match(FILENAME_PATTERN);

--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -52,6 +52,7 @@ The only required field is `title`; however, we provide options to add author in
 - `author_title` - A description of the author.
 - `title` - The blog post title.
 - `tags` - A list of strings to tag to your post.
+- `draft` - A boolean flag to indicate that the blog post is work in process and therefore should not be published yet. However, draft blog posts will be displayed during development.
 
 ## Summary truncation
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve https://github.com/facebook/docusaurus/issues/2314

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Create a new blog post with approximately the same contents:

```md
---
title: Draft post
draft: true
---

This post is in WIP state and should not be published!
```

2. Run local development server and make sure the new blog post is displayed.

3. Build website and make sure the new blog post is **not** in the posts list.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
