### PR TITLE
docs(v2): mention about disabling Jekyll when using GitHub pages

### DIFF
--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -67,6 +67,10 @@ module.exports = {
 }
 ```
 
+### Configuration
+
+By default, GitHub Pages publishes sites with jekyll enabled. To prevent conflicts between docusarus and jekyll, it is recommended that you disable jekyll by adding an empty file named `.nojekyll` file to your `static` directory.
+
 ### Environment settings
 
 Specify the Git user as an environment variable.

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -67,9 +67,11 @@ module.exports = {
 }
 ```
 
-### Configuration
+:::tip
 
-By default, GitHub Pages publishes sites with jekyll enabled. To prevent conflicts between docusarus and jekyll, it is recommended that you disable jekyll by adding an empty file named `.nojekyll` file to your `static` directory.
+By default, GitHub Pages runs published files through [Jekyll](https://jekyllrb.com/). Since Jekyll will discard any files that begin with `_`, it is recommended that you disable Jekyll by adding an empty file named `.nojekyll` file to your `static` directory.
+
+:::
 
 ### Environment settings
 


### PR DESCRIPTION
## Motivation

Prevent users from experiencing 404's with pages that are named with underscores

Closes #2332 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A