### PR TITLE
docs(v2): fix typo in remark-admonitions example

### DIFF
--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -479,7 +479,7 @@ Example:
 
   ```markdown
   :::tip Title
-  The and title *can* include markdown.
+  The content and title *can* include markdown.
   :::
   ```
 

--- a/website/versioned_docs/version-2.0.0-alpha.43/markdown-features.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.43/markdown-features.mdx
@@ -479,7 +479,7 @@ Example:
 
   ```markdown
   :::tip Title
-  The and title *can* include markdown.
+  The content and title *can* include markdown.
   :::
   ```
 


### PR DESCRIPTION
## Motivation

Removing typo errors, making documentation more useful.

## Related PRs

Not required.