### PR TITLE
fix(v2): force terminate building if client bundle failed

### DIFF
--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import chalk = require('chalk');
+import chalk from 'chalk';
 import path from 'path';
 import {Configuration} from 'webpack';
 import merge from 'webpack-merge';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2311.

Server build uses the `WaitPlugin` plugin, which waits until a client bundle is created. This wait is infinite, so if the building of client bundle fails, the build process enters idle mode.

https://github.com/facebook/docusaurus/blob/32c1a92b17bdc347add828be97a49991c0611146/packages/docusaurus/src/webpack/server.ts#L49-L52

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- In a MDX file try to import unresolvable dependency e.g.:

```md
---
id: mdx
title: MDX page
---

import Blah from 'Blah';

Heading...
```

Prior to this fix, the build process became idle and needed to be killed (for example, by pressing CTRL + C)

Now the build process in case of an error in the client bundle terminated immediately.

Results:

| Before (idle)  | After (forced terminated)    |
| -------- | -------- |
| ![снимок_2](https://user-images.githubusercontent.com/4408379/75616022-79fd8c80-5b5c-11ea-976d-1b606f53981c.png) | ![снимок](https://user-images.githubusercontent.com/4408379/75616023-7c5fe680-5b5c-11ea-9ffb-1ca6f853f401.png) |




## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
