### PR TITLE
feat(v2): add filename in CodeBlock

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -41,24 +41,24 @@ export default ({children, className: languageClassName, metastring}) => {
 
   const target = useRef(null);
   const button = useRef(null);
-  let codeBlockTitle = '';
   let highlightLines = [];
+  let codeBlockTitle = '';
 
   const {isDarkTheme} = useThemeContext();
   const lightModeTheme = prism.theme || defaultTheme;
   const darkModeTheme = prism.darkTheme || lightModeTheme;
   const prismTheme = isDarkTheme ? darkModeTheme : lightModeTheme;
 
+  if (metastring && highlightLinesRangeRegex.test(metastring)) {
+    const highlightLinesRange = metastring.match(highlightLinesRangeRegex)[1];
+    highlightLines = rangeParser.parse(highlightLinesRange).filter(n => n > 0);
+  }
+
   if (metastring && codeBlockTitleRegex.test(metastring)) {
     codeBlockTitle = metastring
       .match(codeBlockTitleRegex)[0]
       .split('title=')[1]
       .replace(/"+/g, '');
-  }
-
-  if (metastring && highlightLinesRangeRegex.test(metastring)) {
-    const highlightLinesRange = metastring.match(highlightLinesRangeRegex)[1];
-    highlightLines = rangeParser.parse(highlightLinesRange).filter(n => n > 0);
   }
 
   useEffect(() => {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -17,6 +17,7 @@ import useThemeContext from '@theme/hooks/useThemeContext';
 import styles from './styles.module.css';
 
 const highlightLinesRangeRegex = /{([\d,-]+)}/;
+const codeBlockTitleRegex = /title=".*"/;
 
 export default ({children, className: languageClassName, metastring}) => {
   const {
@@ -40,13 +41,20 @@ export default ({children, className: languageClassName, metastring}) => {
 
   const target = useRef(null);
   const button = useRef(null);
-  const fileName = languageClassName.split(':')[1];
+  let codeBlockTitle = '';
   let highlightLines = [];
 
   const {isDarkTheme} = useThemeContext();
   const lightModeTheme = prism.theme || defaultTheme;
   const darkModeTheme = prism.darkTheme || lightModeTheme;
   const prismTheme = isDarkTheme ? darkModeTheme : lightModeTheme;
+
+  if (metastring && codeBlockTitleRegex.test(metastring)) {
+    codeBlockTitle = metastring
+      .match(codeBlockTitleRegex)[0]
+      .split('title=')[1]
+      .replace(/"+/g, '');
+  }
 
   if (metastring && highlightLinesRangeRegex.test(metastring)) {
     const highlightLinesRange = metastring.match(highlightLinesRangeRegex)[1];
@@ -70,8 +78,7 @@ export default ({children, className: languageClassName, metastring}) => {
   }, [button.current, target.current]);
 
   let language =
-    languageClassName &&
-    languageClassName.split(':')[0].replace(/language-/, '');
+    languageClassName && languageClassName.replace(/language-/, '');
 
   if (!language && prism.defaultLanguage) {
     language = prism.defaultLanguage;
@@ -92,39 +99,49 @@ export default ({children, className: languageClassName, metastring}) => {
       code={children.replace(/\n$/, '')}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <pre className={classnames(className, styles.codeBlock)} style={style}>
-          {fileName && <div className={styles.fileName}>{fileName}</div>}
+        <div className={styles.codeBlockWrapper}>
+          {codeBlockTitle && (
+            <div style={style} className={styles.codeBlockTitle}>
+              {codeBlockTitle}
+            </div>
+          )}
           <button
             ref={button}
             type="button"
             aria-label="Copy code to clipboard"
-            className={styles.copyButton}
+            className={classnames(styles.copyButton, {
+              [`${styles.copyButtonWithTitle}`]: codeBlockTitle,
+            })}
             onClick={handleCopyCode}>
             {showCopied ? 'Copied' : 'Copy'}
           </button>
+          <pre
+            className={classnames(className, styles.codeBlock, {
+              [`${styles.codeBlockWithTitle}`]: codeBlockTitle,
+            })}>
+            <div ref={target} className={styles.codeBlockLines} style={style}>
+              {tokens.map((line, i) => {
+                if (line.length === 1 && line[0].content === '') {
+                  line[0].content = '\n'; // eslint-disable-line no-param-reassign
+                }
 
-          <div ref={target} className={styles.codeBlockLines} style={style}>
-            {tokens.map((line, i) => {
-              if (line.length === 1 && line[0].content === '') {
-                line[0].content = '\n'; // eslint-disable-line no-param-reassign
-              }
+                const lineProps = getLineProps({line, key: i});
 
-              const lineProps = getLineProps({line, key: i});
+                if (highlightLines.includes(i + 1)) {
+                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+                }
 
-              if (highlightLines.includes(i + 1)) {
-                lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-              }
-
-              return (
-                <div key={i} {...lineProps}>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({token, key})} />
-                  ))}
-                </div>
-              );
-            })}
-          </div>
-        </pre>
+                return (
+                  <div key={i} {...lineProps}>
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({token, key})} />
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </pre>
+        </div>
       )}
     </Highlight>
   );

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -40,6 +40,7 @@ export default ({children, className: languageClassName, metastring}) => {
 
   const target = useRef(null);
   const button = useRef(null);
+  const fileName = languageClassName.split(':')[1];
   let highlightLines = [];
 
   const {isDarkTheme} = useThemeContext();
@@ -69,7 +70,8 @@ export default ({children, className: languageClassName, metastring}) => {
   }, [button.current, target.current]);
 
   let language =
-    languageClassName && languageClassName.replace(/language-/, '');
+    languageClassName &&
+    languageClassName.split(':')[0].replace(/language-/, '');
 
   if (!language && prism.defaultLanguage) {
     language = prism.defaultLanguage;
@@ -90,7 +92,8 @@ export default ({children, className: languageClassName, metastring}) => {
       code={children.replace(/\n$/, '')}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <pre className={classnames(className, styles.codeBlock)}>
+        <pre className={classnames(className, styles.codeBlock)} style={style}>
+          {fileName && <div className={styles.fileName}>{fileName}</div>}
           <button
             ref={button}
             type="button"

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -105,7 +105,7 @@ export default ({children, className: languageClassName, metastring}) => {
               {codeBlockTitle}
             </div>
           )}
-          <div className={styles.codeBlockWrapper}>
+          <div className={styles.codeBlockContent}>
             <button
               ref={button}
               type="button"

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -99,49 +99,51 @@ export default ({children, className: languageClassName, metastring}) => {
       code={children.replace(/\n$/, '')}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <div className={styles.codeBlockWrapper}>
+        <>
           {codeBlockTitle && (
             <div style={style} className={styles.codeBlockTitle}>
               {codeBlockTitle}
             </div>
           )}
-          <button
-            ref={button}
-            type="button"
-            aria-label="Copy code to clipboard"
-            className={classnames(styles.copyButton, {
-              [styles.copyButtonWithTitle]: codeBlockTitle,
-            })}
-            onClick={handleCopyCode}>
-            {showCopied ? 'Copied' : 'Copy'}
-          </button>
-          <pre
-            className={classnames(className, styles.codeBlock, {
-              [styles.codeBlockWithTitle]: codeBlockTitle,
-            })}>
-            <div ref={target} className={styles.codeBlockLines} style={style}>
-              {tokens.map((line, i) => {
-                if (line.length === 1 && line[0].content === '') {
-                  line[0].content = '\n'; // eslint-disable-line no-param-reassign
-                }
-
-                const lineProps = getLineProps({line, key: i});
-
-                if (highlightLines.includes(i + 1)) {
-                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-                }
-
-                return (
-                  <div key={i} {...lineProps}>
-                    {line.map((token, key) => (
-                      <span key={key} {...getTokenProps({token, key})} />
-                    ))}
-                  </div>
-                );
+          <div className={styles.codeBlockWrapper}>
+            <button
+              ref={button}
+              type="button"
+              aria-label="Copy code to clipboard"
+              className={classnames(styles.copyButton, {
+                [styles.copyButtonWithTitle]: codeBlockTitle,
               })}
-            </div>
-          </pre>
-        </div>
+              onClick={handleCopyCode}>
+              {showCopied ? 'Copied' : 'Copy'}
+            </button>
+            <pre
+              className={classnames(className, styles.codeBlock, {
+                [styles.codeBlockWithTitle]: codeBlockTitle,
+              })}>
+              <div ref={target} className={styles.codeBlockLines} style={style}>
+                {tokens.map((line, i) => {
+                  if (line.length === 1 && line[0].content === '') {
+                    line[0].content = '\n'; // eslint-disable-line no-param-reassign
+                  }
+
+                  const lineProps = getLineProps({line, key: i});
+
+                  if (highlightLines.includes(i + 1)) {
+                    lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+                  }
+
+                  return (
+                    <div key={i} {...lineProps}>
+                      {line.map((token, key) => (
+                        <span key={key} {...getTokenProps({token, key})} />
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            </pre>
+          </div>
+        </>
       )}
     </Highlight>
   );

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -110,14 +110,14 @@ export default ({children, className: languageClassName, metastring}) => {
             type="button"
             aria-label="Copy code to clipboard"
             className={classnames(styles.copyButton, {
-              [`${styles.copyButtonWithTitle}`]: codeBlockTitle,
+              [styles.copyButtonWithTitle]: codeBlockTitle,
             })}
             onClick={handleCopyCode}>
             {showCopied ? 'Copied' : 'Copy'}
           </button>
           <pre
             className={classnames(className, styles.codeBlock, {
-              [`${styles.codeBlockWithTitle}`]: codeBlockTitle,
+              [styles.codeBlockWithTitle]: codeBlockTitle,
             })}>
             <div ref={target} className={styles.codeBlockLines} style={style}>
               {tokens.map((line, i) => {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -5,6 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+.codeBlockWrapper {
+  position: relative;
+}
+
+.codeBlockTitle {
+  border-top-left-radius: var(--ifm-pre-border-radius);
+  border-top-right-radius: var(--ifm-pre-border-radius);
+  font-weight: bold;
+  height: 32px;
+  padding: 4px 12px;
+  border-bottom: 1px solid;
+  width: 100%;
+}
+
 .codeBlock {
   overflow: auto;
   display: block;
@@ -12,10 +26,9 @@
   margin: 0;
 }
 
-.fileName {
-  padding: 4px 12px;
-  font-weight: bold;
-  text-decoration: underline;
+.codeBlockWithTitle {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .copyButton {
@@ -36,7 +49,11 @@
     bottom 200ms ease-in-out;
 }
 
-.codeBlock:hover > .copyButton {
+.copyButtonWithTitle {
+  top: calc(32px + var(--ifm-pre-padding))!important;
+}
+
+.codeBlockWrapper:hover > .copyButton {
   visibility: visible;
   opacity: 1;
 }

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -13,7 +13,6 @@
   border-top-left-radius: var(--ifm-pre-border-radius);
   border-top-right-radius: var(--ifm-pre-border-radius);
   font-weight: bold;
-  height: 32px;
   padding: 4px 12px;
   border-bottom: 1px solid;
   width: 100%;
@@ -50,7 +49,7 @@
 }
 
 .copyButtonWithTitle {
-  top: calc(32px + var(--ifm-pre-padding));
+  top: calc(var(--ifm-pre-padding));
 }
 
 .codeBlockWrapper:hover > .copyButton {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -12,6 +12,12 @@
   margin: 0;
 }
 
+.fileName {
+  padding: 4px 12px;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
 .copyButton {
   background: rgb(1, 22, 39);
   border: 1px solid rgb(214, 222, 235);

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -50,7 +50,7 @@
 }
 
 .copyButtonWithTitle {
-  top: calc(32px + var(--ifm-pre-padding))!important;
+  top: calc(32px + var(--ifm-pre-padding));
 }
 
 .codeBlockWrapper:hover > .copyButton {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.codeBlockWrapper {
+.codeBlockContent {
   position: relative;
 }
 
@@ -52,7 +52,7 @@
   top: calc(var(--ifm-pre-padding));
 }
 
-.codeBlockWrapper:hover > .copyButton {
+.codeBlockContent:hover > .copyButton {
   visibility: visible;
   opacity: 1;
 }

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -52,6 +52,7 @@
   top: calc(var(--ifm-pre-padding));
 }
 
+.codeBlockTitle:hover + .codeBlockContent .copyButton,
 .codeBlockContent:hover > .copyButton {
   visibility: visible;
   opacity: 1;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -118,51 +118,51 @@ export default ({
       code={children.replace(/\n$/, '')}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <div className={styles.codeBlockWrapper}>
+        <>
           {codeBlockTitle && (
             <div style={style} className={styles.codeBlockTitle}>
               {codeBlockTitle}
             </div>
           )}
-
-          <button
-            ref={button}
-            type="button"
-            aria-label="Copy code to clipboard"
-            className={classnames(styles.copyButton, {
-              [styles.copyButtonWithTitle]: codeBlockTitle,
-            })}
-            onClick={handleCopyCode}>
-            {showCopied ? 'Copied' : 'Copy'}
-          </button>
-
-          <pre
-            className={classnames(className, styles.codeBlock, {
-              [styles.codeBlockWithTitle]: codeBlockTitle,
-            })}>
-            <div ref={target} className={styles.codeBlockLines} style={style}>
-              {tokens.map((line, i) => {
-                if (line.length === 1 && line[0].content === '') {
-                  line[0].content = '\n'; // eslint-disable-line no-param-reassign
-                }
-
-                const lineProps = getLineProps({line, key: i});
-
-                if (highlightLines.includes(i + 1)) {
-                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-                }
-
-                return (
-                  <div key={i} {...lineProps}>
-                    {line.map((token, key) => (
-                      <span key={key} {...getTokenProps({token, key})} />
-                    ))}
-                  </div>
-                );
+          <div className={styles.codeBlockWrapper}>
+            <button
+              ref={button}
+              type="button"
+              aria-label="Copy code to clipboard"
+              className={classnames(styles.copyButton, {
+                [styles.copyButtonWithTitle]: codeBlockTitle,
               })}
-            </div>
-          </pre>
-        </div>
+              onClick={handleCopyCode}>
+              {showCopied ? 'Copied' : 'Copy'}
+            </button>
+            <pre
+              className={classnames(className, styles.codeBlock, {
+                [styles.codeBlockWithTitle]: codeBlockTitle,
+              })}>
+              <div ref={target} className={styles.codeBlockLines} style={style}>
+                {tokens.map((line, i) => {
+                  if (line.length === 1 && line[0].content === '') {
+                    line[0].content = '\n'; // eslint-disable-line no-param-reassign
+                  }
+
+                  const lineProps = getLineProps({line, key: i});
+
+                  if (highlightLines.includes(i + 1)) {
+                    lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+                  }
+
+                  return (
+                    <div key={i} {...lineProps}>
+                      {line.map((token, key) => (
+                        <span key={key} {...getTokenProps({token, key})} />
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            </pre>
+          </div>
+        </>
       )}
     </Highlight>
   );

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -124,7 +124,7 @@ export default ({
               {codeBlockTitle}
             </div>
           )}
-          <div className={styles.codeBlockWrapper}>
+          <div className={styles.codeBlockContent}>
             <button
               ref={button}
               type="button"

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -18,6 +18,7 @@ import Playground from '@theme/Playground';
 import styles from './styles.module.css';
 
 const highlightLinesRangeRegex = /{([\d,-]+)}/;
+const codeBlockTitleRegex = /title=".*"/;
 
 export default ({
   children,
@@ -48,6 +49,7 @@ export default ({
   const target = useRef(null);
   const button = useRef(null);
   let highlightLines = [];
+  let codeBlockTitle = '';
 
   const {isDarkTheme} = useThemeContext();
   const lightModeTheme = prism.theme || defaultTheme;
@@ -57,6 +59,13 @@ export default ({
   if (metastring && highlightLinesRangeRegex.test(metastring)) {
     const highlightLinesRange = metastring.match(highlightLinesRangeRegex)[1];
     highlightLines = rangeParser.parse(highlightLinesRange).filter(n => n > 0);
+  }
+
+  if (metastring && codeBlockTitleRegex.test(metastring)) {
+    codeBlockTitle = metastring
+      .match(codeBlockTitleRegex)[0]
+      .split('title=')[1]
+      .replace(/"+/g, '');
   }
 
   useEffect(() => {
@@ -109,38 +118,51 @@ export default ({
       code={children.replace(/\n$/, '')}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <pre className={classnames(className, styles.codeBlock)}>
+        <div className={styles.codeBlockWrapper}>
+          {codeBlockTitle && (
+            <div style={style} className={styles.codeBlockTitle}>
+              {codeBlockTitle}
+            </div>
+          )}
+
           <button
             ref={button}
             type="button"
             aria-label="Copy code to clipboard"
-            className={styles.copyButton}
+            className={classnames(styles.copyButton, {
+              [styles.copyButtonWithTitle]: codeBlockTitle,
+            })}
             onClick={handleCopyCode}>
             {showCopied ? 'Copied' : 'Copy'}
           </button>
 
-          <div ref={target} className={styles.codeBlockLines} style={style}>
-            {tokens.map((line, i) => {
-              if (line.length === 1 && line[0].content === '') {
-                line[0].content = '\n'; // eslint-disable-line no-param-reassign
-              }
+          <pre
+            className={classnames(className, styles.codeBlock, {
+              [styles.codeBlockWithTitle]: codeBlockTitle,
+            })}>
+            <div ref={target} className={styles.codeBlockLines} style={style}>
+              {tokens.map((line, i) => {
+                if (line.length === 1 && line[0].content === '') {
+                  line[0].content = '\n'; // eslint-disable-line no-param-reassign
+                }
 
-              const lineProps = getLineProps({line, key: i});
+                const lineProps = getLineProps({line, key: i});
 
-              if (highlightLines.includes(i + 1)) {
-                lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
-              }
+                if (highlightLines.includes(i + 1)) {
+                  lineProps.className = `${lineProps.className} docusaurus-highlight-code-line`;
+                }
 
-              return (
-                <div key={i} {...lineProps}>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({token, key})} />
-                  ))}
-                </div>
-              );
-            })}
-          </div>
-        </pre>
+                return (
+                  <div key={i} {...lineProps}>
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({token, key})} />
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </pre>
+        </div>
       )}
     </Highlight>
   );

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -13,7 +13,6 @@
   border-top-left-radius: var(--ifm-pre-border-radius);
   border-top-right-radius: var(--ifm-pre-border-radius);
   font-weight: bold;
-  height: 32px;
   padding: 4px 12px;
   border-bottom: 1px solid;
   width: 100%;
@@ -50,7 +49,7 @@
 }
 
 .copyButtonWithTitle {
-  top: calc(32px + var(--ifm-pre-padding));
+  top: calc(var(--ifm-pre-padding));
 }
 
 .codeBlockWrapper:hover > .copyButton {

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.codeBlockWrapper {
+.codeBlockContent {
   position: relative;
 }
 
@@ -52,7 +52,7 @@
   top: calc(var(--ifm-pre-padding));
 }
 
-.codeBlockWrapper:hover > .copyButton {
+.codeBlockContent:hover > .copyButton {
   visibility: visible;
   opacity: 1;
 }

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -52,6 +52,7 @@
   top: calc(var(--ifm-pre-padding));
 }
 
+.codeBlockTitle:hover + .codeBlockContent .copyButton,
 .codeBlockContent:hover > .copyButton {
   visibility: visible;
   opacity: 1;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -5,11 +5,30 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+.codeBlockWrapper {
+  position: relative;
+}
+
+.codeBlockTitle {
+  border-top-left-radius: var(--ifm-pre-border-radius);
+  border-top-right-radius: var(--ifm-pre-border-radius);
+  font-weight: bold;
+  height: 32px;
+  padding: 4px 12px;
+  border-bottom: 1px solid;
+  width: 100%;
+}
+
 .codeBlock {
   overflow: auto;
   display: block;
   padding: 0;
   margin: 0;
+}
+
+.codeBlockWithTitle {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .copyButton {
@@ -30,7 +49,11 @@
     bottom 200ms ease-in-out;
 }
 
-.codeBlock:hover > .copyButton {
+.copyButtonWithTitle {
+  top: calc(32px + var(--ifm-pre-padding));
+}
+
+.codeBlockWrapper:hover > .copyButton {
   visibility: visible;
   opacity: 1;
 }

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -314,8 +314,9 @@ function MyComponent(props) {
 export default MyComponent;
 ```
 
-### Code Title
-You can add title to code block by addding `title` key after the language meta string (leave a space after the language).
+### Code title
+
+You can add title to code block by adding `title` key after the language (leave a space between them).
 
     ```jsx title="src/components/HelloCodeTitle.js"
     function HelloCodeTitle(props) {

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -314,6 +314,22 @@ function MyComponent(props) {
 export default MyComponent;
 ```
 
+### Code Title
+You can add title to code block by addding `title` key after the language meta string (leave a space after the language).
+
+    ```jsx title="src/components/HelloCodeTitle.js"
+    function HelloCodeTitle(props) {
+      return <h1>Hello, {props.name}</h1>;
+    }
+    ```
+
+```jsx title="src/components/HelloCodeTitle.js"
+function HelloCodeTitle(props) {
+  return <h1>Hello, {props.name}</h1>;
+}
+```
+
+
 ### Interactive code editor
 
 (Powered by [React Live](https://github.com/FormidableLabs/react-live))

--- a/website/docs/migrating-from-v1-to-v2.md
+++ b/website/docs/migrating-from-v1-to-v2.md
@@ -36,8 +36,7 @@ This provides a clear distinction between Docusaurus' official packages and comm
 
 Meanwhile, the default doc site functionalities provided by Docusaurus 1 are now provided by `@docusaurus/preset-classic`. Therefore, we need to add this dependency as well:
 
-```json
-// package.json
+```json title="package.json"
 {
   dependencies: {
 -   "docusaurus": "^1.x.x",


### PR DESCRIPTION
## Motivation

Add filename in CodeBlock which is mentioned in #2271 

If you write below markdown like below, it will create filename in CodeBlock.

> 
> \`\`\`js:src/pages/hello.js {2}
> console.log('hogehoge');
> \`\`\`
> 

## Screenshot of output
**[dark mode]**
![ss-of-code-filename-docusaurus-dark](https://user-images.githubusercontent.com/29557494/75619204-78a78080-5bab-11ea-95ff-c68a46a61152.png)

**[white mode]**
![ss-of-code-filename-docusaurus](https://user-images.githubusercontent.com/29557494/75619205-7a714400-5bab-11ea-983e-2b19d5aec4f8.png)

I like this markdown syntax to create "filename", but it depends on docusaurus team.
> 
> \`\`\`js:src/pages/hello.js {2}
> console.log('hogehoge');
> \`\`\`
> 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

Add CodeBlock with this syntax in your doc.
> \`\`\`js:src/pages/hello.js {2}
> console.log('hogehoge');
> \`\`\`
> 
