### PR TITLE
docs(v2): add examples to plugin usage doc

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -172,7 +172,7 @@ module.exports = {
         /**
          * Remark and Rehype plugins passed to MDX
          */
-        remarkPlugins: [],
+        remarkPlugins: [/* require('remark-math') */],
         rehypePlugins: [],
         /**
          * Truncate marker, can be a regex or string.
@@ -246,7 +246,7 @@ module.exports = {
         /**
          * Remark and Rehype plugins passed to MDX
          */
-        remarkPlugins: [],
+        remarkPlugins: [/* require('remark-math') */],
         rehypePlugins: [],
         /**
          * Whether to display the author who last updated the doc.


### PR DESCRIPTION
docs: add an example value for the remarkPlugins config option for plugin-content-blog and plugin-content docs.

## Motivation

Initially I tried to use a string value with this config and got an esoteric error. Having an example of it's usage would help.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

View the `using-plugins.md` file, and ensure an example value for the `remarkPlugins` config exists for both the `@docusaurus/plugin-content-docs` and `@docusaurus/plugin-content-blog` config docs. 
