### PR TITLE
docs(v2): fix getPathsToWatch() example syntax in lifecycle APIs

### DIFF
--- a/website/docs/lifecycle-apis.md
+++ b/website/docs/lifecycle-apis.md
@@ -25,7 +25,7 @@ module.exports = function(context, options) {
     name: 'docusaurus-plugin',
     getPathsToWatch() {
       const contentPath = path.resolve(context.siteDir, options.path);
-      return [`${contentPath}/**/*.{ts,tsx}`);
+      return [`${contentPath}/**/*.{ts,tsx}`];
     },
   };
 };

--- a/website/versioned_docs/version-2.0.0-alpha.39/lifecycle-apis.md
+++ b/website/versioned_docs/version-2.0.0-alpha.39/lifecycle-apis.md
@@ -21,7 +21,7 @@ module.exports = function(context, options) {
     name: 'docusaurus-plugin',
     getPathsToWatch() {
       const contentPath = path.resolve(context.siteDir, options.path);
-      return [`${contentPath}/**/*.{ts,tsx}`);
+      return [`${contentPath}/**/*.{ts,tsx}`];
     },
   };
 };

--- a/website/versioned_docs/version-2.0.0-alpha.40/lifecycle-apis.md
+++ b/website/versioned_docs/version-2.0.0-alpha.40/lifecycle-apis.md
@@ -21,7 +21,7 @@ module.exports = function(context, options) {
     name: 'docusaurus-plugin',
     getPathsToWatch() {
       const contentPath = path.resolve(context.siteDir, options.path);
-      return [`${contentPath}/**/*.{ts,tsx}`);
+      return [`${contentPath}/**/*.{ts,tsx}`];
     },
   };
 };

--- a/website/versioned_docs/version-2.0.0-alpha.43/lifecycle-apis.md
+++ b/website/versioned_docs/version-2.0.0-alpha.43/lifecycle-apis.md
@@ -21,7 +21,7 @@ module.exports = function(context, options) {
     name: 'docusaurus-plugin',
     getPathsToWatch() {
       const contentPath = path.resolve(context.siteDir, options.path);
-      return [`${contentPath}/**/*.{ts,tsx}`);
+      return [`${contentPath}/**/*.{ts,tsx}`];
     },
   };
 };


### PR DESCRIPTION
Fix getPathsToWatch() example syntax issue

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix issue in documentation.
