### PR TITLE
fix(v2): remove line break from end of code blocks

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -87,7 +87,7 @@ export default ({children, className: languageClassName, metastring}) => {
       {...defaultProps}
       key={mounted}
       theme={prismTheme}
-      code={children.trim()}
+      code={children.replace(/\n$/, '')}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <pre className={classnames(className, styles.codeBlock)}>

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -80,7 +80,7 @@ export default ({
       <Playground
         key={mounted}
         scope={{...React}}
-        code={children.trim()}
+        code={children.replace(/\n$/, '')}
         theme={prismTheme}
         {...props}
       />
@@ -106,7 +106,7 @@ export default ({
       {...defaultProps}
       key={mounted}
       theme={prismTheme}
-      code={children.trim()}
+      code={children.replace(/\n$/, '')}
       language={language}>
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <pre className={classnames(className, styles.codeBlock)}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2352

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Suppose we have an indented code block:

````
```
      --chart string                                   A helm chart to deploy (e.g. ./chart or stable/mysql)

      --chart-repo string                              The helm chart repository url to use
      --chart-version string                           The helm chart version to use
      --component devspace list available-components   A predefined component to use (run devspace list available-components to see all available components)
      --context string
      --dockerfile string                              A dockerfile
  -h, --help                                           help for deployment
      --image string                                   A docker image to deploy (e.g. dscr.io/myuser/myrepo or dockeruser/repo:0.1 or mysql:latest)
      --manifests string                               The kubernetes manifests to deploy (glob pattern are allowed, comma separated, e.g. manifests/** or kube/pod.yaml)
```
````

Before this fix (the first line has no indent):

```
--chart string                                   A helm chart to deploy (e.g. ./chart or stable/mysql)
      --chart-repo string                              The helm chart repository url to use
      --chart-version string                           The helm chart version to use
      --component devspace list available-components   A predefined component to use (run devspace list available-components to see all available components)
      --context string
      --dockerfile string                              A dockerfile
  -h, --help                                           help for deployment
      --image string                                   A docker image to deploy (e.g. dscr.io/myuser/myrepo or dockeruser/repo:0.1 or mysql:latest)
      --manifests string                               The kubernetes manifests to deploy (glob pattern are allowed, comma separated, e.g. manifests/** or kube/pod.yaml)
```

After this fix (all indents is in place, as expected):

```
      --chart string                                   A helm chart to deploy (e.g. ./chart or stable/mysql)

      --chart-repo string                              The helm chart repository url to use
      --chart-version string                           The helm chart version to use
      --component devspace list available-components   A predefined component to use (run devspace list available-components to see all available components)
      --context string
      --dockerfile string                              A dockerfile
  -h, --help                                           help for deployment
      --image string                                   A docker image to deploy (e.g. dscr.io/myuser/myrepo or dockeruser/repo:0.1 or mysql:latest)
      --manifests string                               The kubernetes manifests to deploy (glob pattern are allowed, comma separated, e.g. manifests/** or kube/pod.yaml)
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
