### PR TITLE
feat(v2): allow title and label for docs in sidebar

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -237,7 +237,7 @@ export default function pluginContentDocs(
 
         return {
           type: 'link',
-          label: linkMetadata.sidebar_label || linkMetadata.title,
+          label: linkMetadata.sidebar_label || item.label || linkMetadata.title,
           href: linkMetadata.permalink,
         };
       };

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -49,10 +49,15 @@ function assertIsCategory(item: any): asserts item is SidebarItemCategoryRaw {
 }
 
 function assertIsDoc(item: any): asserts item is SidebarItemDoc {
-  assertItem(item, ['id']);
+  assertItem(item, ['id', 'label']);
   if (typeof item.id !== 'string') {
     throw new Error(
       `Error loading ${JSON.stringify(item)}. "id" must be a string.`,
+    );
+  }
+  if (item.label && typeof item.label !== 'string') {
+    throw new Error(
+      `Error loading ${JSON.stringify(item)}. "label" must be a string.`,
     );
   }
 }
@@ -95,7 +100,7 @@ function normalizeItem(item: SidebarItemRaw): SidebarItem {
     case 'ref':
     case 'doc':
       assertIsDoc(item);
-      return item;
+      return {...item};
     default:
       throw new Error(`Unknown sidebar item type: ${item.type}`);
   }

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -28,6 +28,7 @@ export interface PluginOptions extends MetadataOptions, PathOptions {
 export type SidebarItemDoc = {
   type: 'doc' | 'ref';
   id: string;
+  label?: string;
 };
 
 export interface SidebarItemLink {

--- a/packages/docusaurus-plugin-content-docs/src/version.ts
+++ b/packages/docusaurus-plugin-content-docs/src/version.ts
@@ -90,7 +90,7 @@ export function docsVersion(
         case 'ref':
         case 'doc':
           return {
-            type: item.type,
+            ...item,
             id: `version-${version}/${item.id}`,
           };
         default:

--- a/website/docs/sidebar.md
+++ b/website/docs/sidebar.md
@@ -139,6 +139,18 @@ Sidebar item type that links to a doc page. Example:
 }
 ```
 
+If you do not specify sidebar_label in your md files, you can add an optional 'label' option. Example:
+
+```js
+{
+  type: 'doc',
+  id: 'doc1', // string - document id,
+  label: 'First Document', // string - document label (will be shown in sidebar)
+}
+```
+
+However, note that this label option does not override 'sidebar_label' if it is specified in the md files front matter.
+
 Using just the [Document ID](#document-id) is perfectly valid as well, the following is equivalent to the above:
 
 ```js


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Resolve #2337
Add label option in type : 'doc' to reduce the need to inject sidebar_label in frontmatter of md files manually. However, this option do not override sidebar_label in md files if specified.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

before: 
![image](https://user-images.githubusercontent.com/49342399/76143647-23d89e00-60b4-11ea-8d6d-7ed432d0cef4.png)


after adding this code, 
```js
// docusaurus/website/versioned_sidebars/version-2.0.0-alpha.43-sidebars.json
   . . .
        {
          "type": "doc",
          "id": "version-2.0.0-alpha.43/blog"
        },
        {
          "type": "doc",
          "label": "test-doc-label",
          "id": "version-2.0.0-alpha.43/blog"
        },
    . . .
```
I get: 
![image](https://user-images.githubusercontent.com/49342399/76143577-8aa98780-60b3-11ea-8e67-d123e6cc390d.png)

If on top of previous code, i add sidebar_label to blog.md, 
```md
---
id: blog
title: Blog
sidebar_label: 'Blog sidebar label'
---
```
I get: 
![image](https://user-images.githubusercontent.com/49342399/76143595-b3ca1800-60b3-11ea-9d1c-b5e4d980cf96.png)

## Related PRs

https://github.com/facebook/docusaurus/pull/2375
