### PR TITLE
fix(v2): normalize location for route matching

### DIFF
--- a/packages/docusaurus/src/client/PendingNavigation.js
+++ b/packages/docusaurus/src/client/PendingNavigation.js
@@ -96,7 +96,7 @@ class PendingNavigation extends React.Component {
     this.clearProgressBarTimeout();
     this.progressBarTimeout = setTimeout(() => {
       clientLifecyclesDispatcher.onRouteUpdateDelayed({
-        location: this.state.location,
+        location: normalizeLocation(this.props.location),
       });
       nprogress.start();
     }, delay);

--- a/packages/docusaurus/src/client/PendingNavigation.js
+++ b/packages/docusaurus/src/client/PendingNavigation.js
@@ -25,7 +25,6 @@ class PendingNavigation extends React.Component {
     this.previousLocation = null;
     this.progressBarTimeout = null;
     this.state = {
-      location: normalizeLocation(props.location),
       nextRouteHasLoaded: true,
     };
   }
@@ -42,9 +41,8 @@ class PendingNavigation extends React.Component {
       const nextLocation = normalizeLocation(nextProps.location);
       this.startProgressBar(delay);
       // Save the location first.
-      this.previousLocation = this.state.location;
+      this.previousLocation = normalizeLocation(this.props.location);
       this.setState({
-        location: nextLocation,
         nextRouteHasLoaded: false,
       });
 
@@ -110,9 +108,10 @@ class PendingNavigation extends React.Component {
   }
 
   render() {
-    const {children} = this.props;
-    const {location} = this.state;
-    return <Route location={location} render={() => children} />;
+    const {children, location} = this.props;
+    return (
+      <Route location={normalizeLocation(location)} render={() => children} />
+    );
   }
 }
 

--- a/packages/docusaurus/src/client/__tests__/normalizeLocation.test.js
+++ b/packages/docusaurus/src/client/__tests__/normalizeLocation.test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import normalizeLocation from '../normalizeLocation';
+
+describe('normalizeLocation', () => {
+  test('rewrite locations with index.html', () => {
+    expect(
+      normalizeLocation({
+        pathname: '/docs/introduction/index.html',
+        search: '#features',
+        hash: '',
+      }),
+    ).toEqual({
+      pathname: '/docs/introduction',
+      search: '#features',
+      hash: '',
+    });
+
+    expect(
+      normalizeLocation({
+        pathname: '/index.html',
+        search: '#features',
+        hash: '',
+      }),
+    ).toEqual({
+      pathname: '/',
+      search: '#features',
+      hash: '',
+    });
+  });
+
+  test('untouched pathnames', () => {
+    expect(
+      normalizeLocation({
+        pathname: '/docs/introduction',
+        search: '#features',
+        hash: '',
+      }),
+    ).toEqual({
+      pathname: '/docs/introduction',
+      search: '#features',
+      hash: '',
+    });
+
+    expect(
+      normalizeLocation({
+        pathname: '/',
+      }),
+    ).toEqual({
+      pathname: '/',
+    });
+  });
+});

--- a/packages/docusaurus/src/client/__tests__/normalizeLocation.test.js
+++ b/packages/docusaurus/src/client/__tests__/normalizeLocation.test.js
@@ -12,25 +12,25 @@ describe('normalizeLocation', () => {
     expect(
       normalizeLocation({
         pathname: '/docs/introduction/index.html',
-        search: '#features',
-        hash: '',
+        search: '?search=foo',
+        hash: '#features',
       }),
     ).toEqual({
       pathname: '/docs/introduction',
-      search: '#features',
-      hash: '',
+      search: '?search=foo',
+      hash: '#features',
     });
 
     expect(
       normalizeLocation({
         pathname: '/index.html',
-        search: '#features',
-        hash: '',
+        search: '',
+        hash: '#features',
       }),
     ).toEqual({
       pathname: '/',
-      search: '#features',
-      hash: '',
+      search: '',
+      hash: '#features',
     });
   });
 
@@ -38,13 +38,25 @@ describe('normalizeLocation', () => {
     expect(
       normalizeLocation({
         pathname: '/docs/introduction',
-        search: '#features',
-        hash: '',
+        search: '',
+        hash: '#features',
       }),
     ).toEqual({
       pathname: '/docs/introduction',
-      search: '#features',
-      hash: '',
+      search: '',
+      hash: '#features',
+    });
+
+    expect(
+      normalizeLocation({
+        pathname: '/docs/introduction/foo.html',
+        search: '',
+        hash: '#bar',
+      }),
+    ).toEqual({
+      pathname: '/docs/introduction/foo.html',
+      search: '',
+      hash: '#bar',
     });
 
     expect(

--- a/packages/docusaurus/src/client/normalizeLocation.js
+++ b/packages/docusaurus/src/client/normalizeLocation.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+function normalizeLocation(location) {
+  let pathname = location.pathname || '/';
+  pathname = pathname.trim().replace(/\/index\.html$/, '');
+  if (pathname === '') {
+    pathname = '/';
+  }
+  return {
+    ...location,
+    pathname,
+  };
+}
+
+export default normalizeLocation;

--- a/packages/docusaurus/src/client/normalizeLocation.js
+++ b/packages/docusaurus/src/client/normalizeLocation.js
@@ -4,13 +4,21 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const pathnames = {};
 
 function normalizeLocation(location) {
+  if (pathnames[location.pathname]) {
+    return {
+      ...location,
+      pathname: pathnames[location.pathname],
+    };
+  }
   let pathname = location.pathname || '/';
   pathname = pathname.trim().replace(/\/index\.html$/, '');
   if (pathname === '') {
     pathname = '/';
   }
+  pathnames[location.pathname] = pathname;
   return {
     ...location,
     pathname,

--- a/packages/docusaurus/src/client/normalizeLocation.js
+++ b/packages/docusaurus/src/client/normalizeLocation.js
@@ -4,6 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+// Memoize previously normalized pathnames.
 const pathnames = {};
 
 function normalizeLocation(location) {
@@ -13,12 +15,16 @@ function normalizeLocation(location) {
       pathname: pathnames[location.pathname],
     };
   }
+  
   let pathname = location.pathname || '/';
   pathname = pathname.trim().replace(/\/index\.html$/, '');
+  
   if (pathname === '') {
     pathname = '/';
   }
+  
   pathnames[location.pathname] = pathname;
+  
   return {
     ...location,
     pathname,


### PR DESCRIPTION
## Motivation

Fixes #2392

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The `PendingNavigation` component now uses a `normalizeLocation` function. I added a single file for the new function to easily add unit tests and check the proper normalization of the pathname in the location object before it is passed to react-router's `Route` components for matching:

| Original Path       |  Normalized Path  |
| ------------- |-------------|
| /docs/introduction/index.html      | /docs/introduction |
| /docs/introduction    | /docs/introduction      | 
| /docs/introduction/foo.html    | /docs/introduction/foo.html        | 
| /index.html | /  |
| / | /  |


