### PR TITLE
docs(v2): clarify instructions on docs-only mode

### DIFF
--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -150,27 +150,51 @@ If you just want to use those fields on the client side, you could create your o
 
 ## Docs-only mode
 
-You can run your Docusaurus 2 site without a landing page and instead have a page from your documentation as the index page.
+While Docusaurus 2 is a performant static site generator with support for blogs, product landing and marketing pages, some sites just want the documentation component.
 
-Set the `routeBasePath` to indicate that it’s the root path.
+There are some steps you need to follow for a ”docs-only mode“:
 
-**Note**: Make sure there’s no `index.js` page in `src/pages` or there will be two files mapped to the same route!
+1. Set the `routeBasePath` property of the `docs` object in `@docusaurus/preset-classic` in `docusaurus.config.js` to the root of your site:
 
-```js {9}
+```js {11}
 // docusaurus.config.js
 module.exports = {
+
   // ...
+
   presets: [
     [
       '@docusaurus/preset-classic',
       {
         docs: {
-          routeBasePath: '/' // Set this value to '/'.
-        },
-      },
-    ],
-  ],
+          routeBasePath: '/'
+        }
+      }
+    ]
+  ]
+
+  // ...
 };
 ```
 
-You can apply the same principle for blogs with the [Blog-only mode](blog.md#blog-only-mode).
+2. Set up a redirect to the initial document on the home page in `src/pages/index.js`, e.g. for the document `getting-started`:
+
+```jsx
+import React from "react";
+
+import { Redirect } from "@docusaurus/router";
+
+function Home() {
+  return <Redirect to="/getting-started" />;
+}
+
+export default Home;
+```
+
+Now, when visiting your site, it will show your initial document instead of a landing page.
+
+:::tip
+
+There’s also a ”blog-only mode“, for those who only want to use the blog component of Docusaurus 2. You can use the same method detailed above, except that you need to delete the `src/pages/index.js` file. Follow the setup instructions on [Blog-only mode](blog.md#blog-only-mode).
+
+:::

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -150,42 +150,41 @@ If you just want to use those fields on the client side, you could create your o
 
 ## Docs-only mode
 
-While Docusaurus 2 is a performant static site generator with support for blogs, product landing and marketing pages, some sites just want the documentation component.
+While Docusaurus is a performant static site generator with support for blogs, product landing and marketing pages, some sites just want the documentation component.
 
-There are some steps you need to follow for a ”docs-only mode“:
+Here are some steps you need to follow for a "docs-only mode":
 
 1. Set the `routeBasePath` property of the `docs` object in `@docusaurus/preset-classic` in `docusaurus.config.js` to the root of your site:
 
-```js {11}
+```js {9}
 // docusaurus.config.js
 module.exports = {
-
   // ...
-
   presets: [
     [
       '@docusaurus/preset-classic',
       {
         docs: {
-          routeBasePath: '/'
-        }
-      }
-    ]
-  ]
-
+          routeBasePath: '', // Set to empty string.
+          ...
+        },
+      },
+    ],
+  ],
   // ...
 };
 ```
 
-2. Set up a redirect to the initial document on the home page in `src/pages/index.js`, e.g. for the document `getting-started`:
+2. Set up a redirect to the initial document on the home page in `src/pages/index.js`, e.g. for the document `getting-started`. This is needed because by default there's no page created for the root of the docs.
 
 ```jsx
-import React from "react";
+import React from 'react';
 
-import { Redirect } from "@docusaurus/router";
+import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 function Home() {
-  return <Redirect to="/getting-started" />;
+  return <Redirect to={useBaseUrl('/getting-started')} />;
 }
 
 export default Home;
@@ -195,6 +194,6 @@ Now, when visiting your site, it will show your initial document instead of a la
 
 :::tip
 
-There’s also a ”blog-only mode“, for those who only want to use the blog component of Docusaurus 2. You can use the same method detailed above, except that you need to delete the `src/pages/index.js` file. Follow the setup instructions on [Blog-only mode](blog.md#blog-only-mode).
+There's also a "blog-only mode", for those who only want to use the blog component of Docusaurus 2. You can use the same method detailed above, except that you need to delete the `src/pages/index.js` file. Follow the setup instructions on [Blog-only mode](blog.md#blog-only-mode).
 
 :::


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The docs-only mode instructions didn't work, this change clarifies the instructions and adds an additional step for the index page.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

https://github.com/facebook/docusaurus/pull/2378
