### PR TITLE
feat(v2): can target deployment branch with environment variable

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -62,7 +62,9 @@ export async function deploy(siteDir: string): Promise<void> {
 
   // github.io indicates organization repos that deploy via master. All others use gh-pages.
   const deploymentBranch =
-    projectName.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages';
+    process.env.DEPLOYMENT_BRANCH || projectName.indexOf('.github.io') !== -1
+      ? 'master'
+      : 'gh-pages';
   const githubHost =
     process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
 

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -86,6 +86,7 @@ There are two more optional parameters that are set as environment variables:
 | Name | Description |
 | --- | --- |
 | `USE_SSH` | Set to `true` to use SSH instead of the default HTTPS for the connection to the GitHub repo. |
+| `DEPLOYMENT_BRANCH` | The branch that the website will be deployed to, defaults to `gh-pages` for normal repos and `master` for repository names ending in `github.io`. |
 | `CURRENT_BRANCH` | The branch that contains the latest docs changes that will be deployed. Usually, the branch will be `master`, but it could be any branch (default or otherwise) except for `gh-pages`. If nothing is set for this variable, then the current branch will be used. |
 
 ### Deploy


### PR DESCRIPTION


## Motivation
At the moment there can be some issues with using github pages from a non `.github.io` ending url. For example when using `.github.company.co`. We can resolve this by introducing an environment variable for selecting the deployment branch.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. run `GIT_USER=user DEPLOYMENT_BRANCH=master yarn deploy`
2. Succesfully deploys to the master branch

## Related PRs

related bug report https://github.com/facebook/docusaurus/issues/2362
