### PR TITLE
fix(v2): properly dedupe forward slashes in the entire URL path

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -251,6 +251,10 @@ describe('load utils', () => {
         output: '/test/docs/ro/doc1',
       },
       {
+        input: ['/test/', '/', 'ro', 'doc1'],
+        output: '/test/ro/doc1',
+      },
+      {
         input: ['', '/', 'ko', 'hello'],
         output: '/ko/hello',
       },

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -253,8 +253,8 @@ export function normalizeUrl(rawUrls: string[]): string {
   const parts = str.split('?');
   str = parts.shift() + (parts.length > 0 ? '?' : '') + parts.join('&');
 
-  // Dedupe forward slashes.
-  str = str.replace(/^\/+/, '/');
+  // Dedupe forward slashes in the entire path, avoiding protocol slashes.
+  str = str.replace(/([^:]\/)\/+/g, '$1');
 
   return str;
 }


### PR DESCRIPTION
## Motivation

Fixes #2404.

Currently `@docusaurus-utils.normalizeUrl` method misbehaves when the input contains a single forward slashes `/`, returning duplicated slashes `//`. This occurs when the `routeBasePath` is set to '/' in the docs plugin configuration for example.

Input: `[ '/metro/', '/', '2.0.0-alpha.43' ] `
Output: `/metro//2.0.0-alpha.43`

Expected output: `/metro/2.0.0-alpha.43`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

| Input       |  Normalized URL Path  |
| ------------- |-------------|
| [ '/metro/', '/', '2.0.0-alpha.43' ]    | /metro/2.0.0-alpha.43 |
