### PR TITLE
docs(v2): suggest Surge for quick deployment

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -306,3 +306,43 @@ GitHub enterprise installations should work in the same manner as github.com; yo
 | `GITHUB_HOST` | The hostname for the GitHub enterprise server. |
 
 Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname. Alternatively, set an environment variable `GITHUB_HOST` when executing the publish command.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.10.x-publishing
+id: version-1.14.4-publishing
 title: Publishing your site
 original_id: publishing
 ---
@@ -29,6 +29,8 @@ At this point, you can grab all of the files inside the `website/build` director
 - [ZEIT Now](#using-zeit-now)
 - [GitHub Pages](#using-github-pages)
 - [Netlify](#hosting-on-netlify)
+- [Render](#hosting-on-render)
+- [Surge](#using-surge)
 
 ### Using ZEIT Now
 
@@ -49,6 +51,8 @@ now
 ```
 
 **That's all.** Your docs will automatically be deployed.
+
+> Note that the directory structure Now supports is slightly different from the default directory structure of a Docusaurus project - The `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the the [now-examples repository for a Docusaurus project](https://github.com/zeit/now-examples/tree/master/docusaurus).
 
 ### Using GitHub Pages
 
@@ -96,11 +100,19 @@ In case you want to deploy as a user or organization site, specify the project n
 
 To run the script directly from the command-line, you can use the following, filling in the parameter values as appropriate.
 
+**Bash**
+
 ```bash
 GIT_USER=<GIT_USER> \
   CURRENT_BRANCH=master \
   USE_SSH=true \
   yarn run publish-gh-pages # or `npm run publish-gh-pages`
+```
+
+**Windows**
+
+```batch
+cmd /C "set GIT_USER=<GIT_USER> && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
 ```
 
 There are also two optional parameters that are set as environment variables:
@@ -173,7 +185,7 @@ workflows:
 
 Make sure to replace all `<....>` in the `command:` sequence with appropriate values. For `<GIT_USER>`, it should be a GitHub account that has access to push documentation to your GitHub repository. Many times `<GIT_USER>` and `<GITHUB_USERNAME>` will be the same.
 
-**DO NOT** place the actual value of `$GITHUB_TOKEN` in `circle.yml`. We already configured that as an environment variable back in Step 3.
+**DO NOT** place the actual value of `$GITHUB_TOKEN` in `circle.yml`. We already configured that as an environment variable back in Step 5.
 
 > If you want to use SSH for your GitHub repository connection, you can set `USE_SSH=true`. So the above command would look something like: `cd website && npm install && GIT_USER=<GIT_USER> USE_SSH=true npm run publish-gh-pages`.
 
@@ -260,6 +272,33 @@ Steps to configure your Docusaurus-powered site on Netlify.
 
 You can also configure Netlify to rebuild on every commit to your repository, or only `master` branch commits.
 
+### Hosting on Render
+
+Render offers free [static site](https://render.com/docs/static-sites) hosting with fully managed SSL, custom domains, a global CDN and continuous auto deploys from your Git repo. Deploy your app in just a few minutes by following these steps.
+
+1. Create a new **Web Service** on Render, and give Render's GitHub app permission to access your Docusaurus repo.
+
+2. Select the branch to deploy. The default is `master`.
+
+3. Enter the following values during creation.
+
+   | Field                 | Value                                  |
+   | --------------------- | -------------------------------------- |
+   | **Environment**       | `Static Site`                          |
+   | **Build Command**     | `cd website; yarn install; yarn build` |
+   | **Publish Directory** | `website/build/<projectName>`          |
+
+   `projectName` is the value you defined in your `siteConfig.js`.
+
+   ```javascript{7}
+   const siteConfig = {
+     // ...
+     projectName: 'your-project-name',
+     // ...
+   ```
+
+That's it! Your app will be live on your Render URL as soon as the build finishes.
+
 ### Publishing to GitHub Enterprise
 
 GitHub enterprise installations should work in the same manner as github.com; you only need to identify the organization's GitHub Enterprise host.
@@ -272,27 +311,35 @@ Alter your `siteConfig.js` to add a property `'githubHost'` which represents the
 
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -302,7 +349,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
@@ -269,3 +269,43 @@ GitHub enterprise installations should work in the same manner as github.com; yo
 | `GITHUB_HOST` | The hostname for the GitHub enterprise server. |
 
 Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname. Alternatively, set an environment variable `GITHUB_HOST` when executing the publish command.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.10.x/getting-started-publishing.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.14.4-publishing
+id: version-1.10.x-publishing
 title: Publishing your site
 original_id: publishing
 ---

--- a/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.12.0-publishing
+id: version-1.14.4-publishing
 title: Publishing your site
 original_id: publishing
 ---
@@ -30,6 +30,7 @@ At this point, you can grab all of the files inside the `website/build` director
 - [GitHub Pages](#using-github-pages)
 - [Netlify](#hosting-on-netlify)
 - [Render](#hosting-on-render)
+- [Surge](#using-surge)
 
 ### Using ZEIT Now
 
@@ -50,6 +51,8 @@ now
 ```
 
 **That's all.** Your docs will automatically be deployed.
+
+> Note that the directory structure Now supports is slightly different from the default directory structure of a Docusaurus project - The `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the the [now-examples repository for a Docusaurus project](https://github.com/zeit/now-examples/tree/master/docusaurus).
 
 ### Using GitHub Pages
 
@@ -97,11 +100,19 @@ In case you want to deploy as a user or organization site, specify the project n
 
 To run the script directly from the command-line, you can use the following, filling in the parameter values as appropriate.
 
+**Bash**
+
 ```bash
 GIT_USER=<GIT_USER> \
   CURRENT_BRANCH=master \
   USE_SSH=true \
   yarn run publish-gh-pages # or `npm run publish-gh-pages`
+```
+
+**Windows**
+
+```batch
+cmd /C "set GIT_USER=<GIT_USER> && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
 ```
 
 There are also two optional parameters that are set as environment variables:
@@ -300,27 +311,35 @@ Alter your `siteConfig.js` to add a property `'githubHost'` which represents the
 
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -330,7 +349,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
@@ -297,3 +297,43 @@ GitHub enterprise installations should work in the same manner as github.com; yo
 | `GITHUB_HOST` | The hostname for the GitHub enterprise server. |
 
 Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname. Alternatively, set an environment variable `GITHUB_HOST` when executing the publish command.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.12.0/getting-started-publishing.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.14.4-publishing
+id: version-1.12.0-publishing
 title: Publishing your site
 original_id: publishing
 ---

--- a/website-1.x/versioned_docs/version-1.14.4/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.14.4/getting-started-publishing.md
@@ -307,3 +307,43 @@ GitHub enterprise installations should work in the same manner as github.com; yo
 | `GITHUB_HOST` | The hostname for the GitHub enterprise server. |
 
 Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname. Alternatively, set an environment variable `GITHUB_HOST` when executing the publish command.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website-1.x/versioned_docs/version-1.14.4/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.14.4/getting-started-publishing.md
@@ -30,6 +30,7 @@ At this point, you can grab all of the files inside the `website/build` director
 - [GitHub Pages](#using-github-pages)
 - [Netlify](#hosting-on-netlify)
 - [Render](#hosting-on-render)
+- [Surge](#using-surge)
 
 ### Using ZEIT Now
 
@@ -310,27 +311,35 @@ Alter your `siteConfig.js` to add a property `'githubHost'` which represents the
 
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -340,7 +349,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
@@ -269,3 +269,43 @@ GitHub enterprise installations should work in the same manner as github.com; yo
 | `GITHUB_HOST` | The hostname for the GitHub enterprise server. |
 
 Alter your `siteConfig.js` to add a property `'githubHost'` which represents the GitHub Enterprise hostname. Alternatively, set an environment variable `GITHUB_HOST` when executing the publish command.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.14.4-publishing
+id: version-1.9.x-publishing
 title: Publishing your site
 original_id: publishing
 ---

--- a/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
+++ b/website-1.x/versioned_docs/version-1.9.x/getting-started-publishing.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.9.x-publishing
+id: version-1.14.4-publishing
 title: Publishing your site
 original_id: publishing
 ---
@@ -20,15 +20,17 @@ This will generate a `build` directory inside the `website` directory containing
 
 At this point, you can grab all of the files inside the `website/build` directory and copy them over to your favorite web server's `html` directory.
 
-> For example, both Apache and nginx serve content from `/var/www/html` by default. That said, choosing a web server or provider is outside the scope of Docusaurus.
+> For example, both Apache and Nginx serve content from `/var/www/html` by default. That said, choosing a web server or provider is outside the scope of Docusaurus.
 
-> When serving the site from your own web server, ensure the web server is serving the asset files with the proper HTTP headers. CSS files should be served with the `content-type` header of `text/css`. In the case of nginx, this would mean setting `include /etc/nginx/mime.types;` in your `nginx.conf` file. See [this issue](https://github.com/facebook/docusaurus/issues/602) for more info.
+> When serving the site from your own web server, ensure the web server is serving the asset files with the proper HTTP headers. CSS files should be served with the `content-type` header of `text/css`. In the case of Nginx, this would mean setting `include /etc/nginx/mime.types;` in your `nginx.conf` file. See [this issue](https://github.com/facebook/docusaurus/issues/602) for more info.
 
 ### Hosting on a Service:
 
 - [ZEIT Now](#using-zeit-now)
 - [GitHub Pages](#using-github-pages)
 - [Netlify](#hosting-on-netlify)
+- [Render](#hosting-on-render)
+- [Surge](#using-surge)
 
 ### Using ZEIT Now
 
@@ -49,6 +51,8 @@ now
 ```
 
 **That's all.** Your docs will automatically be deployed.
+
+> Note that the directory structure Now supports is slightly different from the default directory structure of a Docusaurus project - The `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the the [now-examples repository for a Docusaurus project](https://github.com/zeit/now-examples/tree/master/docusaurus).
 
 ### Using GitHub Pages
 
@@ -96,11 +100,19 @@ In case you want to deploy as a user or organization site, specify the project n
 
 To run the script directly from the command-line, you can use the following, filling in the parameter values as appropriate.
 
+**Bash**
+
 ```bash
 GIT_USER=<GIT_USER> \
   CURRENT_BRANCH=master \
   USE_SSH=true \
   yarn run publish-gh-pages # or `npm run publish-gh-pages`
+```
+
+**Windows**
+
+```batch
+cmd /C "set GIT_USER=<GIT_USER> && set CURRENT_BRANCH=master && set USE_SSH=true && yarn run publish-gh-pages"
 ```
 
 There are also two optional parameters that are set as environment variables:
@@ -122,7 +134,7 @@ However, you can automate the publishing process with continuous integration (CI
 
 ## Automating Deployments Using Continuous Integration
 
-Continuous integration (CI) services are typically used to perform routine tasks whenever new commits are checked in to source control. These tasks can be any combination of running unit tests and integration tests, automating builds, publishing packages to NPM, and yes, deploying changes to your website. All you need to do to automate deployment of your website is to invoke the `publish-gh-pages` script whenever your docs get updated. In the following section we'll be covering how to do just that using [CircleCI](https://circleci.com/), a popular continuous integration service provider.
+Continuous integration (CI) services are typically used to perform routine tasks whenever new commits are checked in to source control. These tasks can be any combination of running unit tests and integration tests, automating builds, publishing packages to NPM, and yes, deploying changes to your website. All you need to do to automate deployment of your website is to invoke the `publish-gh-pages` script whenever your docs get updated. In the following section, we'll be covering how to do just that using [CircleCI](https://circleci.com/), a popular continuous integration service provider.
 
 ### Using CircleCI 2.0
 
@@ -173,11 +185,11 @@ workflows:
 
 Make sure to replace all `<....>` in the `command:` sequence with appropriate values. For `<GIT_USER>`, it should be a GitHub account that has access to push documentation to your GitHub repository. Many times `<GIT_USER>` and `<GITHUB_USERNAME>` will be the same.
 
-**DO NOT** place the actual value of `$GITHUB_TOKEN` in `circle.yml`. We already configured that as an environment variable back in Step 3.
+**DO NOT** place the actual value of `$GITHUB_TOKEN` in `circle.yml`. We already configured that as an environment variable back in Step 5.
 
 > If you want to use SSH for your GitHub repository connection, you can set `USE_SSH=true`. So the above command would look something like: `cd website && npm install && GIT_USER=<GIT_USER> USE_SSH=true npm run publish-gh-pages`.
 
-> Unlike when you run the `publish-gh-pages` script manually, when the script runs within the Circle environment, the value of `CURRENT_BRANCH` is already defined as an [environment variable within CircleCI](https://circleci.com/docs/1.0/environment-variables/) and will be picked up by the script automatically.
+> Unlike when you run the `publish-gh-pages` script manually when the script runs within the Circle environment, the value of `CURRENT_BRANCH` is already defined as an [environment variable within CircleCI](https://circleci.com/docs/1.0/environment-variables/) and will be picked up by the script automatically.
 
 Now, whenever a new commit lands in `master`, CircleCI will run your suite of tests and, if everything passes, your website will be deployed via the `publish-gh-pages` script.
 
@@ -196,7 +208,7 @@ CUSTOM_COMMIT_MESSAGE="[skip ci]" \
   yarn run publish-gh-pages # or `npm run publish-gh-pages`
 ```
 
-- Alternatively you can work around this by creating a basic CircleCI config with the following contents:
+- Alternatively, you can work around this by creating a basic CircleCI config with the following contents:
 
 ```yaml
 # CircleCI 2.0 Config File
@@ -260,6 +272,33 @@ Steps to configure your Docusaurus-powered site on Netlify.
 
 You can also configure Netlify to rebuild on every commit to your repository, or only `master` branch commits.
 
+### Hosting on Render
+
+Render offers free [static site](https://render.com/docs/static-sites) hosting with fully managed SSL, custom domains, a global CDN and continuous auto deploys from your Git repo. Deploy your app in just a few minutes by following these steps.
+
+1. Create a new **Web Service** on Render, and give Render's GitHub app permission to access your Docusaurus repo.
+
+2. Select the branch to deploy. The default is `master`.
+
+3. Enter the following values during creation.
+
+   | Field                 | Value                                  |
+   | --------------------- | -------------------------------------- |
+   | **Environment**       | `Static Site`                          |
+   | **Build Command**     | `cd website; yarn install; yarn build` |
+   | **Publish Directory** | `website/build/<projectName>`          |
+
+   `projectName` is the value you defined in your `siteConfig.js`.
+
+   ```javascript{7}
+   const siteConfig = {
+     // ...
+     projectName: 'your-project-name',
+     // ...
+   ```
+
+That's it! Your app will be live on your Render URL as soon as the build finishes.
+
 ### Publishing to GitHub Enterprise
 
 GitHub enterprise installations should work in the same manner as github.com; you only need to identify the organization's GitHub Enterprise host.
@@ -272,27 +311,35 @@ Alter your `siteConfig.js` to add a property `'githubHost'` which represents the
 
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -302,7 +349,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -11,7 +11,7 @@ npm run build
 
 Once it finishes, you should see the production build under the `build/` directory.
 
-You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are statically rendered so they work without JavaScript too!
+You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Surge](https://surge.sh/help/getting-started-with-surge). Docusaurus sites are statically rendered so they work without JavaScript too!
 
 ## Deploying to ZEIT Now
 
@@ -184,27 +184,35 @@ Now, whenever a new commit lands in `master`, Travis CI will run your suite of t
 
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -214,7 +222,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -181,3 +181,43 @@ script:
 ```
 
 Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and if everything passes, your website will be deployed via the `yarn deploy` script.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -106,7 +106,7 @@ There are many ways to update your Docusaurus version. One guaranteed way is to 
     "@docusaurus/core": "^2.0.0-alpha.43",
     "@docusaurus/preset-classic": "^2.0.0-alpha.43",
     ...
-  } 
+  }
 ```
 
 Then, in the directory containing `package.json`, run your package manager's install command:

--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -172,7 +172,9 @@ module.exports = {
         /**
          * Remark and Rehype plugins passed to MDX
          */
-        remarkPlugins: [/* require('remark-math') */],
+        remarkPlugins: [
+          /* require('remark-math') */
+        ],
         rehypePlugins: [],
         /**
          * Truncate marker, can be a regex or string.
@@ -246,7 +248,9 @@ module.exports = {
         /**
          * Remark and Rehype plugins passed to MDX
          */
-        remarkPlugins: [/* require('remark-math') */],
+        remarkPlugins: [
+          /* require('remark-math') */
+        ],
         rehypePlugins: [],
         /**
          * Whether to display the author who last updated the doc.

--- a/website/versioned_docs/version-2.0.0-alpha.40/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.40/deployment.md
@@ -11,7 +11,7 @@ npm run build
 
 Once it finishes, you should see the production build under the `build/` directory.
 
-You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are statically rendered so they work without JavaScript too!
+You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Surge](https://surge.sh/help/getting-started-with-surge). Docusaurus sites are statically rendered so they work without JavaScript too!
 
 ## Deploying to ZEIT Now
 
@@ -66,6 +66,12 @@ module.exports = {
   ...
 }
 ```
+
+:::tip
+
+By default, GitHub Pages runs published files through [Jekyll](https://jekyllrb.com/). Since Jekyll will discard any files that begin with `_`, it is recommended that you disable Jekyll by adding an empty file named `.nojekyll` file to your `static` directory.
+
+:::
 
 ### Environment settings
 
@@ -147,29 +153,66 @@ Render offers [free static site hosting](https://render.com/docs/static-sites) w
 
 That's it! Your app will be live on your Render URL as soon as the build finishes.
 
+### Deplying to Travis CI
+
+Continuous integration (CI) services are typically used to perform routine tasks whenever new commits are checked in to source control. These tasks can be any combination of running unit tests and integration tests, automating builds, publishing packages to NPM, and deploying changes to your website. All you need to do to automate deployment of your website is to invoke the `yarn deploy` script whenever your website is updated. The following section covers how to do just that using [Travis CI](https://travis-ci.com/), a popular continuous integration service provider.
+
+1. Go to https://github.com/settings/tokens and generate a new [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
+1. Using your GitHub account, [add the Travis CI app](https://github.com/marketplace/travis-ci) to the repository you want to activate.
+1. Open your Travis CI dashboard. The URL looks like https://travis-ci.com/USERNAME/REPO, and navigate to the `More options` > `Setting` > `Environment Variables` section of your repository.
+1. Create a new environment variable named `GH_TOKEN` with your newly generated token as its value, then `GH_EMAIL` (your email address) and `GH_NAME` (your GitHub username).
+1. Create a `.travis.yml` on the root of your repository with the following:
+
+```yaml
+# .travis.yml
+language: node_js
+node_js:
+  - '10'
+branches:
+  only:
+    - master
+cache:
+  yarn: true
+script:
+  - git config --global user.name "${GH_NAME}"
+  - git config --global user.email "${GH_EMAIL}"
+  - echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
+  - yarn && GIT_USER="${GH_NAME}" yarn deploy
+```
+
+Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and if everything passes, your website will be deployed via the `yarn deploy` script.
+
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -179,7 +222,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website/versioned_docs/version-2.0.0-alpha.40/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.40/deployment.md
@@ -146,3 +146,43 @@ Render offers [free static site hosting](https://render.com/docs/static-sites) w
    | **Publish Directory** | `build`       |
 
 That's it! Your app will be live on your Render URL as soon as the build finishes.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website/versioned_docs/version-2.0.0-alpha.43/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.43/deployment.md
@@ -11,7 +11,7 @@ npm run build
 
 Once it finishes, you should see the production build under the `build/` directory.
 
-You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are statically rendered so they work without JavaScript too!
+You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Surge](https://surge.sh/help/getting-started-with-surge). Docusaurus sites are statically rendered so they work without JavaScript too!
 
 ## Deploying to ZEIT Now
 
@@ -66,6 +66,12 @@ module.exports = {
   ...
 }
 ```
+
+:::tip
+
+By default, GitHub Pages runs published files through [Jekyll](https://jekyllrb.com/). Since Jekyll will discard any files that begin with `_`, it is recommended that you disable Jekyll by adding an empty file named `.nojekyll` file to your `static` directory.
+
+:::
 
 ### Environment settings
 
@@ -147,29 +153,66 @@ Render offers [free static site hosting](https://render.com/docs/static-sites) w
 
 That's it! Your app will be live on your Render URL as soon as the build finishes.
 
+### Deplying to Travis CI
+
+Continuous integration (CI) services are typically used to perform routine tasks whenever new commits are checked in to source control. These tasks can be any combination of running unit tests and integration tests, automating builds, publishing packages to NPM, and deploying changes to your website. All you need to do to automate deployment of your website is to invoke the `yarn deploy` script whenever your website is updated. The following section covers how to do just that using [Travis CI](https://travis-ci.com/), a popular continuous integration service provider.
+
+1. Go to https://github.com/settings/tokens and generate a new [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
+1. Using your GitHub account, [add the Travis CI app](https://github.com/marketplace/travis-ci) to the repository you want to activate.
+1. Open your Travis CI dashboard. The URL looks like https://travis-ci.com/USERNAME/REPO, and navigate to the `More options` > `Setting` > `Environment Variables` section of your repository.
+1. Create a new environment variable named `GH_TOKEN` with your newly generated token as its value, then `GH_EMAIL` (your email address) and `GH_NAME` (your GitHub username).
+1. Create a `.travis.yml` on the root of your repository with the following:
+
+```yaml
+# .travis.yml
+language: node_js
+node_js:
+  - '10'
+branches:
+  only:
+    - master
+cache:
+  yarn: true
+script:
+  - git config --global user.name "${GH_NAME}"
+  - git config --global user.email "${GH_EMAIL}"
+  - echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
+  - yarn && GIT_USER="${GH_NAME}" yarn deploy
+```
+
+Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and if everything passes, your website will be deployed via the `yarn deploy` script.
+
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -179,7 +222,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website/versioned_docs/version-2.0.0-alpha.43/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.43/deployment.md
@@ -146,3 +146,43 @@ Render offers [free static site hosting](https://render.com/docs/static-sites) w
    | **Publish Directory** | `build`       |
 
 That's it! Your app will be live on your Render URL as soon as the build finishes.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`

--- a/website/versioned_docs/version-2.0.0-alpha.48/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.48/deployment.md
@@ -11,7 +11,7 @@ npm run build
 
 Once it finishes, you should see the production build under the `build/` directory.
 
-You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Render](https://render.com/static-sites). Docusaurus sites are statically rendered so they work without JavaScript too!
+You can deploy your site to static site hosting services such as [ZEIT Now](https://zeit.co/now), [GitHub Pages](https://pages.github.com/), [Netlify](https://www.netlify.com/), and [Surge](https://surge.sh/help/getting-started-with-surge). Docusaurus sites are statically rendered so they work without JavaScript too!
 
 ## Deploying to ZEIT Now
 
@@ -184,27 +184,35 @@ Now, whenever a new commit lands in `master`, Travis CI will run your suite of t
 
 ## Deploying with Surge
 
-Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge), it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
 
 Deploy your app in a matter of seconds using surge with the following steps:
 
-1. First, install surge using npm by running the following command
+1. First, install surge using npm by running the following command:
 
 ```bash
-npm install --global surge
+npm install --g surge
 ```
 
-2. Run a single command inside the root directory of your project
+2. To build the static files of your site for production in the root directory of your project, run:
+
+```bash
+npm run build
+```
+
+2. Then, run a single command inside the root directory of your project:
 
 ```bash
 surge build/
 ```
 
-This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+First time users of Surge would be prompted to create an account from the command line(happens only once).
+
+Confirm that the site you want to publish is in the `build` directory, a randomly generate subdomain `*.surge.sh subdomain` is always given(which can be edited).
 
 ### Using your domain
 
-if you have a domain name you can deploy your site using surge to your domain using the command
+If you have a domain name you can deploy your site using surge to your domain using the command:
 
 ```bash
 surge build/ yourdomain.com
@@ -214,7 +222,7 @@ You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` de
 
 ### Setting up CNAME file
 
-Store your domain in a CNAME file for future deployments with the following commands
+Store your domain in a CNAME file for future deployments with the following command:
 
 ```bash
 echo subdomain.surge.sh > CNAME

--- a/website/versioned_docs/version-2.0.0-alpha.48/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.48/deployment.md
@@ -181,3 +181,43 @@ script:
 ```
 
 Now, whenever a new commit lands in `master`, Travis CI will run your suite of tests and if everything passes, your website will be deployed via the `yarn deploy` script.
+
+## Deploying with Surge
+
+Surge is a [static web hosting platform](https://surge.sh/help/getting-started-with-surge) , it is used to deploy your Docusaurus project from command line in a minute. Deploying your project to surge is easy and it’s also free (including a custom domain and SSL).
+
+Deploy your app in a matter of seconds using surge with the following steps:
+
+1. First, install surge using npm by running the following command
+
+```bash
+npm install --global surge
+```
+
+2. Run a single command inside the root directory of your project
+
+```bash
+surge build/
+```
+
+This generate the version of the site you want to publish in the `build` directory. A site `url` would be given at the end of the upload which can be edited if you want. Done! You will be given a `*.surge.sh subdomain`.
+
+### Using your domain
+
+if you have a domain name you can deploy your site using surge to your domain using the command
+
+```bash
+surge build/ yourdomain.com
+```
+
+You site is now deployed for free at `subdomain.surge.sh` or `yourdomain.com` depending on the method you chose.
+
+### Setting up CNAME file
+
+Store your domain in a CNAME file for future deployments with the following commands
+
+```bash
+echo subdomain.surge.sh > CNAME
+```
+
+You can deploy any other changes in the future with the command `surge`


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
My motivation was to include how Surge can also be used to deploy docusaurus project in a matter of minutes.
 I thought it would be a good idea to have Docusaurus users take advantage of this, so I added it to the docs.
**Steps:**
`npx @docusaurus/init@next init my-website classic`
`surge build/`
**if you have a domain name**
`surge build/ yourdomain.com`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
usage described in the section above. pretty easy. Also, an example of a docusaurus app deployed using surge 
(http://panicky-observation.surge.sh/)

