### PR TITLE
docs(v2): move versioning to Advanced Guides section

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -21,14 +21,19 @@ module.exports = {
       {
         type: 'category',
         label: 'Docs',
-        items: ['markdown-features', 'sidebar', 'versioning'],
+        items: ['markdown-features', 'sidebar'],
       },
       'blog',
       'search',
       'deployment',
       'migrating-from-v1-to-v2',
     ],
-    'Advanced Guides': ['using-plugins', 'using-themes', 'presets'],
+    'Advanced Guides': [
+      'using-plugins',
+      'using-themes',
+      'presets',
+      'versioning',
+    ],
     'API Reference': [
       'cli',
       'docusaurus-core',


### PR DESCRIPTION
This moves the `Versioning` page to the `Advanced Guides`  sidebar section (as this clearly is for advanced usage).

![image](https://user-images.githubusercontent.com/230500/76685727-415aba00-6616-11ea-9bc5-8373c7b62148.png)
