### PR TITLE
docs(v2): include appId key for Algolia

### DIFF
--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -18,11 +18,12 @@ Algolia DocSearch works by crawling the content of your website every 24 hours a
 
 To connect your docs with Algolia, add an `algolia` field in your `themeConfig`. Note that you will need algolia API key and algolia index. You can [apply for DocSearch here](https://community.algolia.com/docsearch/).
 
-```jsx {4-8}
+```jsx {4-9}
 // docusaurus.config.js
 themeConfig: {
     // ....
     algolia: {
+      appId: 'app-id',
       apiKey: 'api-key',
       indexName: 'index-name',
       algoliaOptions: {}, // Optional, if provided by Algolia

--- a/website/versioned_docs/version-2.0.0-alpha.40/search.md
+++ b/website/versioned_docs/version-2.0.0-alpha.40/search.md
@@ -18,11 +18,12 @@ Algolia DocSearch works by crawling the content of your website every 24 hours a
 
 To connect your docs with Algolia, add an `algolia` field in your `themeConfig`. Note that you will need algolia API key and algolia index. You can [apply for DocSearch here](https://community.algolia.com/docsearch/).
 
-```jsx {4-8}
+```jsx {4-9}
 // docusaurus.config.js
 themeConfig: {
     // ....
     algolia: {
+      appId: 'app-id',
       apiKey: 'api-key',
       indexName: 'index-name',
       algoliaOptions: {}, // Optional, if provided by Algolia

--- a/website/versioned_docs/version-2.0.0-alpha.43/search.md
+++ b/website/versioned_docs/version-2.0.0-alpha.43/search.md
@@ -18,11 +18,12 @@ Algolia DocSearch works by crawling the content of your website every 24 hours a
 
 To connect your docs with Algolia, add an `algolia` field in your `themeConfig`. Note that you will need algolia API key and algolia index. You can [apply for DocSearch here](https://community.algolia.com/docsearch/).
 
-```jsx {4-8}
+```jsx {4-9}
 // docusaurus.config.js
 themeConfig: {
     // ....
     algolia: {
+      appId: 'app-id',
       apiKey: 'api-key',
       indexName: 'index-name',
       algoliaOptions: {}, // Optional, if provided by Algolia

--- a/website/versioned_docs/version-2.0.0-alpha.48/search.md
+++ b/website/versioned_docs/version-2.0.0-alpha.48/search.md
@@ -18,11 +18,12 @@ Algolia DocSearch works by crawling the content of your website every 24 hours a
 
 To connect your docs with Algolia, add an `algolia` field in your `themeConfig`. Note that you will need algolia API key and algolia index. You can [apply for DocSearch here](https://community.algolia.com/docsearch/).
 
-```jsx {4-8}
+```jsx {4-9}
 // docusaurus.config.js
 themeConfig: {
     // ....
     algolia: {
+      appId: 'app-id',
       apiKey: 'api-key',
       indexName: 'index-name',
       algoliaOptions: {}, // Optional, if provided by Algolia


### PR DESCRIPTION
appId is needed for self-hosted Docsearch

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Update Algolia information. The information is similar for v1: https://docusaurus.io/docs/en/site-config.html#algolia-object

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Not yet

## Test Plan

I used it on my personal site

## Related PRs

None
