### PR TITLE
fix(v2): fix external URL for og:image tag

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -75,7 +75,11 @@ function DocItem(props) {
     },
   } = DocContent;
 
-  const metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  const _metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  const externalRegex = /^(https?:|\/\/)/;
+  const metaImageUrl = externalRegex.test(metaImage)
+    ? metaImage
+    : _metaImageUrl;
 
   return (
     <>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import Head from '@docusaurus/Head';
+import isInternalUrl from '@docusaurus/isInternalUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import DocPaginator from '@theme/DocPaginator';
@@ -75,11 +76,10 @@ function DocItem(props) {
     },
   } = DocContent;
 
-  const _metaImageUrl = siteUrl + useBaseUrl(metaImage);
-  const externalRegex = /^(https?:|\/\/)/;
-  const metaImageUrl = externalRegex.test(metaImage)
-    ? metaImage
-    : _metaImageUrl;
+  let metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  if (!isInternalUrl(metaImage)) {
+    metaImageUrl = metaImage;
+  }
 
   return (
     <>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -76,10 +76,9 @@ function DocItem(props) {
     },
   } = DocContent;
 
-  let metaImageUrl = siteUrl + useBaseUrl(metaImage);
-  if (!isInternalUrl(metaImage)) {
-    metaImageUrl = metaImage;
-  }
+  const metaImageUrl = isInternalUrl(metaImage)
+    ? metaImage
+    : siteUrl + useBaseUrl(metaImage);
 
   return (
     <>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -76,9 +76,10 @@ function DocItem(props) {
     },
   } = DocContent;
 
-  const metaImageUrl = isInternalUrl(metaImage)
-    ? metaImage
-    : siteUrl + useBaseUrl(metaImage);
+  let metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  if (!isInternalUrl(metaImage)) {
+    metaImageUrl = metaImage;
+  }
 
   return (
     <>

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import Head from '@docusaurus/Head';
+import isInternalUrl from '@docusaurus/isInternalUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
@@ -37,11 +38,10 @@ function Layout(props) {
   } = props;
   const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
   const metaImage = image || defaultImage;
-  const _metaImageUrl = siteUrl + useBaseUrl(metaImage);
-  const externalRegex = /^(https?:|\/\/)/;
-  const metaImageUrl = externalRegex.test(metaImage)
-    ? metaImage
-    : _metaImageUrl;
+  let metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  if (!isInternalUrl(metaImage)) {
+    metaImageUrl = metaImage;
+  }
   const faviconUrl = useBaseUrl(favicon);
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -37,11 +37,12 @@ function Layout(props) {
     version,
   } = props;
   const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
+
   const metaImage = image || defaultImage;
-  let metaImageUrl = siteUrl + useBaseUrl(metaImage);
-  if (!isInternalUrl(metaImage)) {
-    metaImageUrl = metaImage;
-  }
+  const metaImageUrl = isInternalUrl(metaImage)
+    ? metaImage
+    : siteUrl + useBaseUrl(metaImage);
+  
   const faviconUrl = useBaseUrl(favicon);
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -42,7 +42,7 @@ function Layout(props) {
   const metaImageUrl = isInternalUrl(metaImage)
     ? metaImage
     : siteUrl + useBaseUrl(metaImage);
-  
+
   const faviconUrl = useBaseUrl(favicon);
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -37,7 +37,11 @@ function Layout(props) {
   } = props;
   const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
   const metaImage = image || defaultImage;
-  const metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  const _metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  const externalRegex = /^(https?:|\/\/)/;
+  const metaImageUrl = externalRegex.test(metaImage)
+    ? metaImage
+    : _metaImageUrl;
   const faviconUrl = useBaseUrl(favicon);
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -38,10 +38,10 @@ function Layout(props) {
   } = props;
   const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
 
-  const metaImage = image || defaultImage;
-  const metaImageUrl = isInternalUrl(metaImage)
-    ? metaImage
-    : siteUrl + useBaseUrl(metaImage);
+  let metaImageUrl = siteUrl + useBaseUrl(metaImage);
+  if (!isInternalUrl(metaImage)) {
+    metaImageUrl = metaImage;
+  }
 
   const faviconUrl = useBaseUrl(favicon);
 


### PR DESCRIPTION
## Motivation


```js 
// docusaurus.config.js
module.exports = {
  ...
  themeConfig: {
    // Relative to your site's "static" directory.
    // Cannot be SVGs. Can be external URLs too.
    image: 'img/docusaurus.png',
    ...
  },
}
```

https://github.com/facebook/docusaurus/blob/2b6e4409704fb20a39a9273b1b051065f0eb8079/website/docs/theme-classic.md#meta-image

Currently, when url is setted to `themeConfig.image`, this does not work as below.

`https://example.comhttps://example.com/img/foo.png`

This fixes it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
