### PR TITLE
polish(v2): use npm-to-yarn for the npm2yarn remark plugin

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "@docusaurus/preset-classic": "^2.0.0-alpha.48",
     "classnames": "^2.2.6",
     "color": "^3.1.2",
+    "npm-to-yarn": "^1.0.0-0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@docusaurus/preset-classic": "^2.0.0-alpha.48",
     "classnames": "^2.2.6",
     "color": "^3.1.2",
-    "npm-to-yarn": "^1.0.0-0",
+    "npm-to-yarn": "^1.0.0-1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@docusaurus/preset-classic": "^2.0.0-alpha.48",
     "classnames": "^2.2.6",
     "color": "^3.1.2",
-    "npm-to-yarn": "^1.0.0-1",
+    "npm-to-yarn": "^1.0.0-2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/website/src/plugins/remark-npm2yarn.js
+++ b/website/src/plugins/remark-npm2yarn.js
@@ -5,16 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// This is a very naive implementation of converting npm commands to yarn commands
-// Works well for our use case since we only use either 'npm install', or 'npm run <something>'
-// Its impossible to convert it right since some commands at npm are not available in yarn and vice/versa
+const npmToYarn = require('npm-to-yarn');
 
-var n2y = require('npm-to-yarn');
-
-const convertNpmToYarn = npmCode => {
-  // global install: 'npm i' -> 'yarn'
-  return n2y(npmCode, 'yarn');
-};
+// E.g. global install: 'npm i' -> 'yarn'
+const convertNpmToYarn = npmCode => npmToYarn(npmCode, 'yarn');
 
 const transformNode = node => {
   const npmCode = node.value;

--- a/website/src/plugins/remark-npm2yarn.js
+++ b/website/src/plugins/remark-npm2yarn.js
@@ -8,16 +8,12 @@
 // This is a very naive implementation of converting npm commands to yarn commands
 // Works well for our use case since we only use either 'npm install', or 'npm run <something>'
 // Its impossible to convert it right since some commands at npm are not available in yarn and vice/versa
+
+var n2y = require('npm-to-yarn');
+
 const convertNpmToYarn = npmCode => {
   // global install: 'npm i' -> 'yarn'
-  return (
-    npmCode
-      .replace(/^npm i$/gm, 'yarn')
-      // install: 'npm install --save foo' -> 'yarn add foo'
-      .replace(/npm install --save/gm, 'yarn add')
-      // run command: 'npm run start' -> 'yarn run start'
-      .replace(/npm run/gm, 'yarn run')
-  );
+  return n2y(npmCode, 'yarn');
 };
 
 const transformNode = node => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Docusaurus' previous NPM-Yarn code tab generation was very basic and missed many conversions. I extracted some of the logic into a new npm package (`npm-to-yarn`) and made the code more robust.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep

## Test Plan

_(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)_

~~When serving on localhost, NPM to Yarn code tab generation works in almost all cases (though for some reason, it seems to fail, as did the last implementation, on one-line codeblocks? I think it's a problem with the Remark plugin)~~

Actually, the problems I observed previously aren't there any more. Conversions seem to be working perfectly

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

*None yet*