### PR TITLE
chore(v2): ignore jetbrains editors .iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .vscode
 .idea
+*.iml
 *.code-workspace
 .changelog
 


### PR DESCRIPTION

## Motivation

Jetbrains IDE generally generate a docusaurus.iml at the root of the project, which should rather not be commited by contributors.

As there's already ".idea" and ".vscode," I thought this one is just missing, and adding it will be welcome for contributors using Jetbrains

I'm using Intellij, and currently discussing with @JoelMarcey about contributing to this project. I thought this would be a nice small PR to get started :D

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

N/A

