### PR TITLE
fix(v2): update twitter:card to summary_large_image

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -75,7 +75,7 @@ function Layout(props) {
           {permalink && (
             <meta property="og:url" content={siteUrl + permalink} />
           )}
-          <meta name="twitter:card" content="summary" />
+          <meta name="twitter:card" content="summary_large_image" />
         </Head>
         <Navbar />
         <div className="main-wrapper">{children}</div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

According to https://socialsharepreview.com/ and SEO recommendations need to use summary_large_image for Twitter card.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Check it out at https://socialsharepreview.com/

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
