### PR TITLE
feat(v2): add version to meta generator

### DIFF
--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -17,6 +17,7 @@ import {minify} from 'html-minifier-terser';
 import path from 'path';
 import fs from 'fs-extra';
 import routes from '@generated/routes';
+import packageJson from '../../package.json';
 import preload from './preload';
 import App from './App';
 import ssrTemplate from './templates/ssr.html.template';
@@ -71,6 +72,7 @@ export default async function render(locals) {
       metaAttributes,
       scripts,
       stylesheets,
+      version: packageJson.version,
     },
     {
       rmWhitespace: true,

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -11,7 +11,7 @@ module.exports = `
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <meta name="generator" content="Docusaurus">
+    <meta name="generator" content="Docusaurus v<%= version %>">
     <%- headTags %>
     <% metaAttributes.forEach((metaAttribute) => { %>
       <%- metaAttribute %>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Often, the version is also indicated in the meta generator tag, for example, Wappalyzer can display it and it just helps us in future with feedback to users.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```diff
- <meta name="generator" content="Docusaurus">
+ <meta name="generator" content="Docusaurus v2.0.0-alpha.48">
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
