### PR TITLE
feat(v2): make clickable sidebar logo

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -8,9 +8,8 @@
 import React, {useState, useCallback} from 'react';
 import classnames from 'classnames';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import useThemeContext from '@theme/hooks/useThemeContext';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
+import useLogo from '@theme/hooks/useLogo';
 import Link from '@docusaurus/Link';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 
@@ -116,12 +115,10 @@ function mutateSidebarCollapsingState(item, path) {
 function DocSidebar(props) {
   const [showResponsiveSidebar, setShowResponsiveSidebar] = useState(false);
   const {
-    siteConfig: {themeConfig: {navbar: {title, logo = {}} = {}}} = {},
+    siteConfig: {themeConfig: {navbar: {title} = {}}} = {},
     isClient,
   } = useDocusaurusContext();
-  const {isDarkTheme} = useThemeContext();
-  const logoSrc = logo.srcDark && isDarkTheme ? logo.srcDark : logo.src;
-  const logoUrl = useBaseUrl(logoSrc);
+  const {logoLink, logoLinkProps, logoImageUrl, logoAlt} = useLogo();
 
   const {
     docsSidebars,
@@ -152,10 +149,12 @@ function DocSidebar(props) {
 
   return (
     <div className={styles.sidebar}>
-      <div className={styles.sidebarLogo}>
-        {logo != null && <img key={isClient} src={logoUrl} alt={logo.alt} />}
+      <Link className={styles.sidebarLogo} to={logoLink} {...logoLinkProps}>
+        {logoImageUrl != null && (
+          <img key={isClient} src={logoImageUrl} alt={logoAlt} />
+        )}
         {title != null && <strong>{title}</strong>}
-      </div>
+      </Link>
       <div
         className={classnames('menu', 'menu--responsive', styles.menu, {
           'menu--show': showResponsiveSidebar,

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -39,6 +39,8 @@
     top: 0;
     margin: 0 var(--ifm-navbar-padding-horizontal);
     height: var(--ifm-navbar-height);
+    color: inherit !important;
+    text-decoration: none !important;
   }
 
   .sidebarLogo img {

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -9,7 +9,6 @@ import React, {useCallback, useState} from 'react';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import isInternalUrl from '@docusaurus/isInternalUrl';
 
 import SearchBar from '@theme/SearchBar';
 import Toggle from '@theme/Toggle';
@@ -19,6 +18,7 @@ import classnames from 'classnames';
 import useThemeContext from '@theme/hooks/useThemeContext';
 import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
+import useLogo from '@theme/hooks/useLogo';
 
 import styles from './styles.module.css';
 
@@ -52,16 +52,21 @@ function NavLink({activeBasePath, to, href, label, position, ...props}) {
 }
 
 function Navbar() {
-  const {siteConfig = {}, isClient} = useDocusaurusContext();
-  const {baseUrl, themeConfig = {}} = siteConfig;
-  const {navbar = {}, disableDarkMode = false} = themeConfig;
-  const {title, logo = {}, links = [], hideOnScroll = false} = navbar;
-
+  const {
+    siteConfig: {
+      themeConfig: {
+        navbar: {title, links = [], hideOnScroll = false} = {},
+        disableDarkMode = false,
+      },
+    },
+    isClient,
+  } = useDocusaurusContext();
   const [sidebarShown, setSidebarShown] = useState(false);
   const [isSearchBarExpanded, setIsSearchBarExpanded] = useState(false);
 
   const {isDarkTheme, setLightTheme, setDarkTheme} = useThemeContext();
   const {navbarRef, isNavbarVisible} = useHideableNavbar(hideOnScroll);
+  const {logoLink, logoLinkProps, logoImageUrl, logoAlt} = useLogo();
 
   useLockBodyScroll(sidebarShown);
 
@@ -76,21 +81,6 @@ function Navbar() {
     e => (e.target.checked ? setDarkTheme() : setLightTheme()),
     [setLightTheme, setDarkTheme],
   );
-
-  const logoLink = logo.href || baseUrl;
-  let logoLinkProps = {};
-
-  if (logo.target) {
-    logoLinkProps = {target: logo.target};
-  } else if (!isInternalUrl(logoLink)) {
-    logoLinkProps = {
-      rel: 'noopener noreferrer',
-      target: '_blank',
-    };
-  }
-
-  const logoSrc = logo.srcDark && isDarkTheme ? logo.srcDark : logo.src;
-  const logoImageUrl = useBaseUrl(logoSrc);
 
   return (
     <nav
@@ -127,12 +117,12 @@ function Navbar() {
             </svg>
           </div>
           <Link className="navbar__brand" to={logoLink} {...logoLinkProps}>
-            {logo != null && (
+            {logoImageUrl != null && (
               <img
                 key={isClient}
                 className="navbar__logo"
                 src={logoImageUrl}
-                alt={logo.alt}
+                alt={logoAlt}
               />
             )}
             {title != null && (
@@ -182,12 +172,12 @@ function Navbar() {
             onClick={hideSidebar}
             to={logoLink}
             {...logoLinkProps}>
-            {logo != null && (
+            {logoImageUrl != null && (
               <img
                 key={isClient}
                 className="navbar__logo"
                 src={logoImageUrl}
-                alt={logo.alt}
+                alt={logoAlt}
               />
             )}
             {title != null && (

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useThemeContext from '@theme/hooks/useThemeContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+
+const useLogo = () => {
+  const {
+    siteConfig: {baseUrl, themeConfig: {navbar: {logo = {}} = {}}} = {},
+  } = useDocusaurusContext();
+  const {isDarkTheme} = useThemeContext();
+  const logoLink = logo.href || baseUrl;
+  let logoLinkProps = {};
+
+  if (logo.target) {
+    logoLinkProps = {target: logo.target};
+  } else if (!isInternalUrl(logoLink)) {
+    logoLinkProps = {
+      rel: 'noopener noreferrer',
+      target: '_blank',
+    };
+  }
+
+  const logoSrc = logo.srcDark && isDarkTheme ? logo.srcDark : logo.src;
+  const logoImageUrl = useBaseUrl(logoSrc);
+
+  return {
+    logoLink,
+    logoLinkProps,
+    logoImageUrl,
+    logoAlt: logo.alt,
+  };
+};
+
+export default useLogo;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When the sticky navbar is turned off, the duplicating logo in the sidebar should be clickable, this is the expected behavior in this case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try clicking on the logo in doc sidebar.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
