### PR TITLE
docs(v2): add docusaurus-plugin-sass to community plugins

### DIFF
--- a/website/docs/resources.md
+++ b/website/docs/resources.md
@@ -29,6 +29,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-lunr-search](https://github.com/lelouch77/docusurus-lunr-search) - Offline Search for Docusaurus v2
 - [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) - Offline/local search for Docusaurus v2
 - [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format
+- [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
 
 ## Enterprise usage
 


### PR DESCRIPTION
## Motivation

Add `docusaurus-plugin-sass` to the list of community plugins for those looking for Sass support.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
