### PR TITLE
fix(v2): pass options to remark-admonitions

### DIFF
--- a/packages/docusaurus-preset-classic/src/index.js
+++ b/packages/docusaurus-preset-classic/src/index.js
@@ -19,8 +19,7 @@ const addAdmonitions = pluginOptions => {
 
   const admonitionsOptions = {
     remarkPlugins: (pluginOptions.remarkPlugins || []).concat([
-      admonitions,
-      pluginOptions.admonitions || {},
+      [admonitions, pluginOptions.admonitions || {}],
     ]),
   };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves #2447
Currently it is impossible to pass options to the `remark-admonitions` plugin due to misconfiguration.

![localhost_3000_docs_doc1 (2)](https://user-images.githubusercontent.com/10013769/77357953-009a2980-6d17-11ea-8675-2d34fe2d0c76.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Create a new Docusaurus v2 site with `@docusaurus/init`
1. Add config from #2447
1. npm start

```js
 presets: [
    [
      '@docusaurus/preset-classic',
      {
        docs: {
          sidebarPath: require.resolve('./sidebars.js'),
          editUrl:
            'https://github.com/facebook/docusaurus/edit/master/website/',
          admonitions: {
            customTypes: {
              kk: {
                keyword: 'kk',
                svg:
                  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>'
              },
            }
          },
        },
        theme: {
          customCss: require.resolve('./src/css/custom.css'),
        },
      },
    ],
  ],
```

## Related PRs

N/A
