### PR TITLE
feat(v2): add @theme-original alias to give access to pre-swizzled components

### DIFF
--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -89,7 +89,7 @@ export async function load(
     plugins.map(plugin => plugin.getThemePath && plugin.getThemePath()),
   );
   const userTheme = path.resolve(siteDir, THEME_PATH);
-  const alias = loadThemeAlias([fallbackTheme, ...pluginThemes, userTheme]);
+  const alias = loadThemeAlias([fallbackTheme, ...pluginThemes], [userTheme]);
 
   // Make a fake plugin to:
   // - Resolve aliased theme components

--- a/packages/docusaurus/src/server/themes/__tests__/alias.test.ts
+++ b/packages/docusaurus/src/server/themes/__tests__/alias.test.ts
@@ -16,6 +16,19 @@ describe('themeAlias', () => {
     const alias = themeAlias(themePath);
     expect(alias).toEqual({
       '@theme/Footer': path.join(themePath, 'Footer/index.js'),
+      '@theme-original/Footer': path.join(themePath, 'Footer/index.js'),
+      '@theme/Layout': path.join(themePath, 'Layout.js'),
+      '@theme-original/Layout': path.join(themePath, 'Layout.js'),
+    });
+    expect(alias).not.toEqual({});
+  });
+
+  test('valid themePath 1 with components without original', () => {
+    const fixtures = path.join(__dirname, '__fixtures__');
+    const themePath = path.join(fixtures, 'theme-1');
+    const alias = themeAlias(themePath, false);
+    expect(alias).toEqual({
+      '@theme/Footer': path.join(themePath, 'Footer/index.js'),
       '@theme/Layout': path.join(themePath, 'Layout.js'),
     });
     expect(alias).not.toEqual({});
@@ -25,6 +38,19 @@ describe('themeAlias', () => {
     const fixtures = path.join(__dirname, '__fixtures__');
     const themePath = path.join(fixtures, 'theme-2');
     const alias = themeAlias(themePath);
+    expect(alias).toEqual({
+      '@theme/Navbar': path.join(themePath, 'Navbar.js'),
+      '@theme-original/Navbar': path.join(themePath, 'Navbar.js'),
+      '@theme/Layout': path.join(themePath, 'Layout/index.js'),
+      '@theme-original/Layout': path.join(themePath, 'Layout/index.js'),
+    });
+    expect(alias).not.toEqual({});
+  });
+
+  test('valid themePath 2 with components without original', () => {
+    const fixtures = path.join(__dirname, '__fixtures__');
+    const themePath = path.join(fixtures, 'theme-2');
+    const alias = themeAlias(themePath, false);
     expect(alias).toEqual({
       '@theme/Navbar': path.join(themePath, 'Navbar.js'),
       '@theme/Layout': path.join(themePath, 'Layout/index.js'),
@@ -37,6 +63,14 @@ describe('themeAlias', () => {
     const themePath = path.join(fixtures, 'empty-theme');
     fs.ensureDirSync(themePath);
     const alias = themeAlias(themePath);
+    expect(alias).toEqual({});
+  });
+
+  test('valid themePath with no components without original', () => {
+    const fixtures = path.join(__dirname, '__fixtures__');
+    const themePath = path.join(fixtures, 'empty-theme');
+    fs.ensureDirSync(themePath);
+    const alias = themeAlias(themePath, false);
     expect(alias).toEqual({});
   });
 

--- a/packages/docusaurus/src/server/themes/__tests__/index.ts
+++ b/packages/docusaurus/src/server/themes/__tests__/index.ts
@@ -17,8 +17,11 @@ describe('loadThemeAlias', () => {
     const alias = loadThemeAlias([theme1Path, theme2Path]);
     expect(alias).toEqual({
       '@theme/Footer': path.join(theme1Path, 'Footer/index.js'),
+      '@theme-original/Footer': path.join(theme1Path, 'Footer/index.js'),
       '@theme/Navbar': path.join(theme2Path, 'Navbar.js'),
+      '@theme-original/Navbar': path.join(theme2Path, 'Navbar.js'),
       '@theme/Layout': path.join(theme2Path, 'Layout/index.js'),
+      '@theme-original/Layout': path.join(theme2Path, 'Layout/index.js'),
     });
     expect(alias).not.toEqual({});
   });

--- a/packages/docusaurus/src/server/themes/alias.ts
+++ b/packages/docusaurus/src/server/themes/alias.ts
@@ -11,7 +11,10 @@ import path from 'path';
 import {fileToPath, posixPath, normalizeUrl} from '@docusaurus/utils';
 import {ThemeAlias} from '@docusaurus/types';
 
-export function themeAlias(themePath: string): ThemeAlias {
+export function themeAlias(
+  themePath: string,
+  addOriginalAlias: boolean = true,
+): ThemeAlias {
   if (!fs.pathExistsSync(themePath)) {
     return {};
   }
@@ -20,15 +23,25 @@ export function themeAlias(themePath: string): ThemeAlias {
     cwd: themePath,
   });
 
-  const alias: ThemeAlias = {};
+  const aliases: ThemeAlias = {};
+
   themeComponentFiles.forEach(relativeSource => {
     const filePath = path.join(themePath, relativeSource);
     const fileName = fileToPath(relativeSource);
+
     const aliasName = posixPath(
       normalizeUrl(['@theme', fileName]).replace(/\/$/, ''),
     );
-    alias[aliasName] = filePath;
+    aliases[aliasName] = filePath;
+
+    if (addOriginalAlias) {
+      // For swizzled components to access the original.
+      const originalAliasName = posixPath(
+        normalizeUrl(['@theme-original', fileName]).replace(/\/$/, ''),
+      );
+      aliases[originalAliasName] = filePath;
+    }
   });
 
-  return alias;
+  return aliases;
 }

--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -8,12 +8,25 @@
 import {ThemeAlias} from '@docusaurus/types';
 import {themeAlias} from './alias';
 
-export function loadThemeAlias(themePaths: string[]): ThemeAlias {
-  return themePaths.reduce(
-    (alias, themePath) => ({
-      ...alias,
-      ...themeAlias(themePath),
-    }),
-    {},
-  );
+export function loadThemeAlias(
+  themePaths: string[],
+  userThemePaths: string[] = [],
+): ThemeAlias {
+  const aliases = {};
+
+  themePaths.forEach(themePath => {
+    const themeAliases = themeAlias(themePath);
+    Object.keys(themeAliases).forEach(aliasKey => {
+      aliases[aliasKey] = themeAliases[aliasKey];
+    });
+  });
+
+  userThemePaths.forEach(themePath => {
+    const userThemeAliases = themeAlias(themePath, false);
+    Object.keys(userThemeAliases).forEach(aliasKey => {
+      aliases[aliasKey] = userThemeAliases[aliasKey];
+    });
+  });
+
+  return aliases;
 }


### PR DESCRIPTION
## Motivation

Provide an alias for theme components so that they can be semi-swizzled. Meaning you swizzle a component but only to wrap things around it, possibly to call new lifecycle logic or have components above/below it.

For example, I can now do this

```jsx
import React from 'react';

import DocItemOriginal from '@theme-original/DocItem';

function DocItem(props) {
  return (
    <div>
      <p>Wrapper</p>
      <DocItemOriginal {...props} />
      <p>Wrapper</p>
    </div>
  );
}

export default DocItem;
```

and get this

<img width="1552" alt="Screen Shot 2020-03-24 at 12 19 30 PM" src="https://user-images.githubusercontent.com/1315101/77388306-b2466280-6dca-11ea-8bad-18e58bda7653.png">

This is partially inspired by [VuePress](https://vuepress.vuejs.org/theme/inheritance.html#override-components) (although Endi and I already had this idea long ago when we were building themes). [Libra docs](https://developer.libra.com) is moving to v2 and wants this level of customization.

This `@theme-original` alias will also allow us to specify slot props (components as props) which serve to inject components somewhere into a component. We could do this for the various doc and blog items.

#### Follow Up

- Add docs
- Add slot props to doc and blog

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Modified unit tests and added example.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
