### PR TITLE
refactor(v2): use single method package instead of whole Lodash package in blog plugin

### DIFF
--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -20,7 +20,7 @@
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
     "loader-utils": "^1.2.3",
-    "lodash": "^4.17.15"
+    "lodash.kebabcase": "^4.1.1"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import fs from 'fs-extra';
-import _ from 'lodash';
+import kebabCase from 'lodash.kebabcase';
 import path from 'path';
 import {normalizeUrl, docuHash, aliasedSitePath} from '@docusaurus/utils';
 
@@ -167,7 +167,7 @@ export default function pluginContentBlog(
         // eslint-disable-next-line no-param-reassign
         blogPost.metadata.tags = tags.map(tag => {
           if (typeof tag === 'string') {
-            const normalizedTag = _.kebabCase(tag);
+            const normalizedTag = kebabCase(tag);
             const permalink = normalizeUrl([tagsPath, normalizedTag]);
             if (!blogTags[normalizedTag]) {
               blogTags[normalizedTag] = {


### PR DESCRIPTION
## Motivation

Currently Lodash in this repository is quite freely used without much care of it's footprint on the bundles/packages sizes. This is the first PR in a series which aims to improve this aspect.

This PR replace `@docusaurus/plugin-content-blog` Lodash import with single method package `lodash.kebabcase` because only this method was used from the whole package across all files.

I would like to improve other packages but before I can do that I need an answer in which way you would like me to handle packages that are using multiple Lodash methods. There are two ways:

- instead of `lodash` include few, single method packages (like in example above)
- maintain `lodash` in the package but use cherry picking for the packages
  > e.g.: `import flatten from 'lodash/flatten';`

Personally I would also consider opting-out Lodash completely in favor of native code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yup.

## Test Plan

Same test result before and after package swaps.

## Related PRs

None at this time.