### PR TITLE
fix(v2): do not force terminate building when bundle analyzer is on

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -147,6 +147,6 @@ export async function build(
       relativeDir,
     )}.\n`,
   );
-  process.exit(0);
+  !cliOptions.bundleAnalyzer && process.exit(0);
   return outDir;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Side-effect from https://github.com/facebook/docusaurus/pull/2443

We do not need to force terminate building if the `--bundle-analyzer` flag is passed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`yarn build --bundle-analyzer`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
