### PR TITLE
fix(v2): remove trailing slash from router links

### DIFF
--- a/packages/docusaurus/src/client/exports/Link.js
+++ b/packages/docusaurus/src/client/exports/Link.js
@@ -9,12 +9,16 @@ import React, {useEffect, useRef} from 'react';
 import {NavLink} from 'react-router-dom';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import {useLocation} from '@docusaurus/router';
 
 function Link(props) {
   const {to, href} = props;
   const targetLink = to || href;
   const isInternal = isInternalUrl(targetLink);
   const preloaded = useRef(false);
+  const location = useLocation();
+  // Change the current state of location by removing trailing slash from its pathname.
+  location.pathname = location.pathname.replace(/\/$/, '');
 
   const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves #2394

Some hosting providers automatically add a trailing slash to the website links, which leads to the fact that some functionality stops working correctly. For example, in such cases, relative links to other Markdown files do not work. Therefore, to avoid this, we can remove the trailing slash from the internal (_which are processed by the router_) links before they get to the router. This is safe operation, because we usually get links without a trailing slash, and we can safely delete it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.


## Test Plan

1. Create a Markdown file in a new subdirectory so that it refers to the file in the parent directory OR follow instructions in To Reproduce section in the issue #2394

docs/main.md:

```
---
id: main
title: Main page
---

Some page...
```


docs/sub/index.md:


```
---
id: sub
title: Subcategory page
---

See [main page](../main).
```

sidebars.js

```js
module.exports = {
  docs: {
    Root: ['main', 'sub/sub']
  }
}
```

Now, when navigating to the `docs/sub/sub` path without a trailing slash and with it (`docs/sub/sub/`), the result should be the same:

```html
<p><a href="/docs/main">See main page</a>.</p>
```

Earlier, when navigating a path with a trailing slash, the result was as follows:

```html
<p><a href="/docs/sub/main">See main page</a>.</p>
```


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
