### PR TITLE
docs(v2): add setup of mdx plugins

### DIFF
--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -332,19 +332,19 @@ function HelloCodeTitle(props) {
 
 ### Configuring plugins
 
-You can expand the mdx functionalities, using plugins. An MDX plugin is usually a npm package, 
+You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, 
 so you install them like other npm packages using npm. Docusaurus supports both [remark](https://github.com/remarkjs/remark)
 and [rehype-style](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install [remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins
+First, install [remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
 For example:
 
 ```bash npm2yarn
 npm install --save remark-images
 npm install --save rehype-truncate
-
 ```
-Next, import the plugins
+
+Next, import the plugins:
 
 ```jsx
 const remarkImages = require('remark-images')
@@ -352,7 +352,7 @@ const rehypeTruncate = require('rehype-truncate')
 ```
 Finally, add in your `docusaurus.config.js` in `presets` option:
 
-```jsx {11,12}
+```js {11,12}
 // docusaurus.config.js
 module.exports = {
   // ...
@@ -375,7 +375,7 @@ presets: [
 
 ### Configuring plugin options
 
-Some plugins can be configured and accept their own options. In that case, use the [plugin, pluginOptions] syntax, like so:
+Some plugins can be configured and accept their own options. In that case, use the `[plugin, pluginOptions]` syntax, like so:
 
 ```jsx {11}
 // docusaurus.config.js
@@ -397,7 +397,7 @@ presets: [
 };
 ```
 
-See more information in the [MDXjs documentation](https://mdxjs.com/advanced/plugins).
+See more information in the [MDX documentation](https://mdxjs.com/advanced/plugins).
 
 
 ### Interactive code editor

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -332,11 +332,10 @@ function HelloCodeTitle(props) {
 
 ### Configuring plugins
 
-You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, 
-so you install them like other npm packages using npm. Docusaurus supports both [remark](https://github.com/remarkjs/remark)
-and [rehype-style](https://github.com/rehypejs/rehype) plugins that work with MDX.
+You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, so you install them like other npm packages using npm. Docusaurus supports both [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install [remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+First, install your [remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+
 For example:
 
 ```bash npm2yarn
@@ -347,16 +346,17 @@ npm install --save rehype-truncate
 Next, import the plugins:
 
 ```js
-const remarkImages = require('remark-images')
-const rehypeTruncate = require('rehype-truncate')
+const remarkImages = require('remark-images');
+const rehypeTruncate = require('rehype-truncate');
 ```
-Finally, add in your `docusaurus.config.js` in `presets` option:
+
+Finally, add them to the `@docusaurus/preset-classic` options in `docusaurus.config.js`:
 
 ```js {11,12}
 // docusaurus.config.js
 module.exports = {
   // ...
-presets: [
+  presets: [
     [
       '@docusaurus/preset-classic',
       {
@@ -365,7 +365,6 @@ presets: [
           // ...
           remarkPlugins: [remarkImages], 
           rehypePlugins: [rehypeTruncate],
-        },
         },
       },
     ],
@@ -377,19 +376,21 @@ presets: [
 
 Some plugins can be configured and accept their own options. In that case, use the `[plugin, pluginOptions]` syntax, like so:
 
-```jsx {11}
+```jsx {11-14}
 // docusaurus.config.js
 module.exports = {
   // ...
-presets: [
+  presets: [
     [
       '@docusaurus/preset-classic',
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // ...
-          remarkPlugins: [plugin1, [plugin2, {option1: setting1} ]], 
-        },
+          remarkPlugins: [
+            plugin1, 
+            [plugin2, {option1: {...}}],
+          ], 
         },
       },
     ],
@@ -398,7 +399,6 @@ presets: [
 ```
 
 See more information in the [MDX documentation](https://mdxjs.com/advanced/plugins).
-
 
 ### Interactive code editor
 

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -330,6 +330,75 @@ function HelloCodeTitle(props) {
 }
 ```
 
+### Configuring plugins
+
+You can expand the mdx functionalities, using plugins. An MDX plugin is usually a npm package, 
+so you install them like other npm packages using npm. Docusaurus supports both [remark](https://github.com/remarkjs/remark)
+and [rehype-style](https://github.com/rehypejs/rehype) plugins that work with MDX.
+
+First, install [remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins
+For example:
+
+```bash npm2yarn
+npm install --save remark-images
+npm install --save rehype-truncate
+
+```
+Next, import the plugins
+
+```jsx
+const remarkImages = require('remark-images')
+const rehypeTruncate = require('rehype-truncate')
+```
+Finally, add in your `docusaurus.config.js` in `presets` option:
+
+```jsx {11,12}
+// docusaurus.config.js
+module.exports = {
+  // ...
+presets: [
+    [
+      '@docusaurus/preset-classic',
+      {
+        docs: {
+          sidebarPath: require.resolve('./sidebars.js'),
+          // ...
+          remarkPlugins: [remarkImages], 
+          rehypePlugins: [rehypeTruncate],
+        },
+        },
+      },
+    ],
+  ],
+};
+```
+
+### Configuring plugin options
+
+Some plugins can be configured and accept their own options. In that case, use the [plugin, pluginOptions] syntax, like so:
+
+```jsx {11}
+// docusaurus.config.js
+module.exports = {
+  // ...
+presets: [
+    [
+      '@docusaurus/preset-classic',
+      {
+        docs: {
+          sidebarPath: require.resolve('./sidebars.js'),
+          // ...
+          remarkPlugins: [plugin1, [plugin2, {option1: setting1} ]], 
+        },
+        },
+      },
+    ],
+  ],
+};
+```
+
+See more information in the [MDXjs documentation](https://mdxjs.com/advanced/plugins).
+
 
 ### Interactive code editor
 

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -346,7 +346,7 @@ npm install --save rehype-truncate
 
 Next, import the plugins:
 
-```jsx
+```js
 const remarkImages = require('remark-images')
 const rehypeTruncate = require('rehype-truncate')
 ```


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

As discussed in #2249, we need to add the mdx plugin docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
yes

## Test Plan

1. `yarn start`
2. go to `docs/next/markdown-features#configuring-plugins`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
#2249 

cc @yangshun 