### PR TITLE
feat(v2): add TypeScript support for theme components

### DIFF
--- a/packages/docusaurus/src/server/themes/alias.ts
+++ b/packages/docusaurus/src/server/themes/alias.ts
@@ -19,7 +19,7 @@ export function themeAlias(
     return {};
   }
 
-  const themeComponentFiles = globby.sync(['**/*.{js,jsx}'], {
+  const themeComponentFiles = globby.sync(['**/*.{js,jsx,ts,tsx}'], {
     cwd: themePath,
   });
 


### PR DESCRIPTION
## Motivation

I want to write swizzled theme components in TypeScript. (I'm not sure whether the maintainers of docusaurus want to eventually convert `@docusaurus/theme-classic` components into typescript.)

The infrastructure for typescript is already mostly setup in #2221 and #2310. This diff just adds support for recognizing typescript files for theme component.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Without this diff, change `packages/docusaurus-theme-classic/src/theme/Footer/index.js`'s extension to tsx. Try `yarn start`. It will fail by saying `@theme/Footer` cannot be resolved.
2. After I made these changes. Stop dev server and run `yarn start` again. Now `@theme/Footer` is correctly resolved and the page will load successfully.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
