### PR TITLE
fix(v2): make correct Open Graph title for doc page

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -76,6 +76,7 @@ function DocItem(props) {
     },
   } = DocContent;
 
+  const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
   let metaImageUrl = siteUrl + useBaseUrl(metaImage);
   if (!isInternalUrl(metaImage)) {
     metaImageUrl = metaImage;
@@ -84,11 +85,8 @@ function DocItem(props) {
   return (
     <>
       <Head>
-        {title && (
-          <title>
-            {title} | {siteTitle}
-          </title>
-        )}
+        <title>{metaTitle}</title>
+        <meta property="og:title" content={metaTitle} />
         {description && <meta name="description" content={description} />}
         {description && (
           <meta property="og:description" content={description} />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I noticed that OG title it is wrong for the doc page:

![image](https://user-images.githubusercontent.com/4408379/77836010-6b0df800-7163-11ea-86bc-f3fbb403f2fb.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview - https://deploy-preview-2475--docusaurus-2.netlify.com/docs/theme-classic/

![image](https://user-images.githubusercontent.com/4408379/77838594-0e6c0680-717e-11ea-85c6-8cff9eaf65d4.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
