### PR TITLE
fix(v2): do not render sidebar logo if used sticky navbar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -115,7 +115,9 @@ function mutateSidebarCollapsingState(item, path) {
 function DocSidebar(props) {
   const [showResponsiveSidebar, setShowResponsiveSidebar] = useState(false);
   const {
-    siteConfig: {themeConfig: {navbar: {title} = {}}} = {},
+    siteConfig: {
+      themeConfig: {navbar: {title, hideOnScroll = false} = {}},
+    } = {},
     isClient,
   } = useDocusaurusContext();
   const {logoLink, logoLinkProps, logoImageUrl, logoAlt} = useLogo();
@@ -149,12 +151,14 @@ function DocSidebar(props) {
 
   return (
     <div className={styles.sidebar}>
-      <Link className={styles.sidebarLogo} to={logoLink} {...logoLinkProps}>
-        {logoImageUrl != null && (
-          <img key={isClient} src={logoImageUrl} alt={logoAlt} />
-        )}
-        {title != null && <strong>{title}</strong>}
-      </Link>
+      {hideOnScroll && (
+        <Link className={styles.sidebarLogo} to={logoLink} {...logoLinkProps}>
+          {logoImageUrl != null && (
+            <img key={isClient} src={logoImageUrl} alt={logoAlt} />
+          )}
+          {title != null && <strong>{title}</strong>}
+        </Link>
+      )}
       <div
         className={classnames('menu', 'menu--responsive', styles.menu, {
           'menu--show': showResponsiveSidebar,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When sticky navbar is on, we don’t need to display the sidebar logo, which is shown when navbar hides when scrolling.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
