### PR TITLE
refactor(v2): remove unnecessary X-UA-Compatible meta tag

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -53,7 +53,6 @@ function Layout(props) {
           {/* TODO: Do not assume that it is in english language */}
           <html lang="en" />
 
-          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
           {metaTitle && <title>{metaTitle}</title>}
           {metaTitle && <meta property="og:title" content={metaTitle} />}
           {favicon && <link rel="shortcut icon" href={faviconUrl} />}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The old `<meta http-equiv="X-UA-Compatible" content="ie=edge">` is not necessary anymore nowadays...

See https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do/6771584#6771584

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
