### PR TITLE
fix(v2): fix HTML issues nav dropdown and highlight docs item

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -64,11 +64,9 @@ function NavItem({items, position, ...props}) {
       </NavLink>
       <ul className="dropdown__menu">
         {items.map((linkItemInner, i) => (
-          <NavLink
-            className="navbar__item navbar__link"
-            {...linkItemInner}
-            key={i}
-          />
+          <li key={i}>
+            <NavLink className="navbar__item navbar__link" {...linkItemInner} />
+          </li>
         ))}
       </ul>
     </div>
@@ -91,8 +89,8 @@ function MobileNavItem({items, ...props}) {
       </NavLink>
       <ul className="menu__list">
         {items.map((linkItemInner, i) => (
-          <li className="menu__list-item">
-            <NavLink className="menu__link" {...linkItemInner} key={i} />
+          <li className="menu__list-item" key={i}>
+            <NavLink className="menu__link" {...linkItemInner} />
           </li>
         ))}
       </ul>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -92,12 +92,13 @@ module.exports = {
       links: [
         {
           label: 'Docs',
+          to: 'docs/introduction', // "fake" link
           position: 'left',
           activeBasePath: 'docs',
           items: [
             {
               label: versions[0],
-              to: `docs/introduction`,
+              to: 'docs/introduction',
             },
           ].concat(
             versions.slice(1).map(version => ({

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -30,3 +30,8 @@ html[data-theme='dark'] {
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgb(0, 0, 0, 0.3);
 }
+
+/* This will be removed after new release of Infima */
+.navbar__item.dropdown > .navbar__link {
+  pointer-events: none;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Fix warnings about props
- Add missed `li` element in dropdown
- Make non-clickable parent nav link of dropdown menu
- Fix highlight "Docs" menu item

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
