### PR TITLE
fix(v2): use lodash instead of array-map-polyfill

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,5 +27,5 @@ module.exports = {
   transform: {
     '^.+\\.[jt]sx?$': 'babel-jest',
   },
-  setupFiles: ['./jest/stylelint-rule-test.js', 'array-flat-polyfill'],
+  setupFiles: ['./jest/stylelint-rule-test.js'],
 };

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import _ from 'lodash';
 import fs from 'fs-extra';
 import importFresh from 'import-fresh';
 import {
@@ -105,12 +106,12 @@ function normalizeItem(item: SidebarItemRaw): SidebarItem[] {
     ];
   }
   if (isCategoryShorthand(item)) {
-    return normalizeCategoryShorthand(item).flatMap(normalizeItem);
+    return _.flatMap(normalizeCategoryShorthand(item), normalizeItem);
   }
   switch (item.type) {
     case 'category':
       assertIsCategory(item);
-      return [{...item, items: item.items.flatMap(normalizeItem)}];
+      return [{...item, items: _.flatMap(item.items, normalizeItem)}];
     case 'link':
       assertIsLink(item);
       return [item];
@@ -133,7 +134,7 @@ function normalizeSidebar(sidebars: SidebarRaw): Sidebar {
         ? sidebar
         : normalizeCategoryShorthand(sidebar);
 
-      acc[sidebarId] = normalizedSidebar.flatMap(normalizeItem);
+      acc[sidebarId] = _.flatMap(normalizedSidebar, normalizeItem);
 
       return acc;
     },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -41,7 +41,6 @@
     "@babel/runtime": "^7.7.4",
     "@docusaurus/utils": "^2.0.0-alpha.49",
     "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
-    "array-flat-polyfill": "^1.0.1",
     "babel-loader": "^8.0.6",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "cache-loader": "^4.1.0",

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'array-flat-polyfill';
-
 export {build} from './commands/build';
 export {start} from './commands/start';
 export {swizzle} from './commands/swizzle';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,11 +3196,6 @@ array-find-index@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
 
-array-flat-polyfill@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz#1e3a4255be619dfbffbfd1d635c1cf357cd034e7"
-  integrity sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==
-
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

We already have Lodash installed, so we can use `flatMap` from this lib.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
