### PR TITLE
fix(v2): do not force terminate building when running deploy command

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -47,6 +47,7 @@ function compile(config: Configuration[]): Promise<any> {
 export async function build(
   siteDir: string,
   cliOptions: Partial<BuildCLIOptions> = {},
+  forceTerminate: boolean = true,
 ): Promise<string> {
   process.env.BABEL_ENV = 'production';
   process.env.NODE_ENV = 'production';
@@ -150,6 +151,6 @@ export async function build(
       relativeDir,
     )}.\n`,
   );
-  !cliOptions.bundleAnalyzer && process.exit(0);
+  forceTerminate && !cliOptions.bundleAnalyzer && process.exit(0);
   return outDir;
 }

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -98,7 +98,7 @@ export async function deploy(
   fs.removeSync(tempDir);
 
   // Build static html files, then push to deploymentBranch branch of specified repo.
-  build(siteDir, cliOptions)
+  build(siteDir, cliOptions, false)
     .then(outDir => {
       shell.cd(tempDir);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

From Discord chat:

```
ted: Has anyone been able to successfully deploy with alpha.49?
ted: When I run the deploy command with alpha.49, it only builds
```

In PR #2443, we did not take into account that the building process is running during deploying, where the according command is already forced to terminate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
yarn deploy
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
