### PR TITLE
fix(v2): unbreak blog-only mode routing by deplicating starting forward slashes

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -255,6 +255,10 @@ describe('load utils', () => {
         output: '/test/ro/doc1',
       },
       {
+        input: ['/', '/', '2020/02/29/leap-day'],
+        output: '/2020/02/29/leap-day',
+      },
+      {
         input: ['', '/', 'ko', 'hello'],
         output: '/ko/hello',
       },

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -256,6 +256,9 @@ export function normalizeUrl(rawUrls: string[]): string {
   // Dedupe forward slashes in the entire path, avoiding protocol slashes.
   str = str.replace(/([^:]\/)\/+/g, '$1');
 
+  // Dedupe forward slashes at the beginning of the path.
+  str = str.replace(/^\/+/g, '/');
+
   return str;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #2493

In blog-only mode, we will have URL components like this:

```js
[/* site baseUrl */ '/', /* blog routeRootUrl */ '/',  '/2020/01/01/foo-bar']
```

, which will be normalized to `//2020/01/01/foo-bar` by the old algorithm.

My fix adds a final pass that collapses all forward slashes at the beginning of the final string into 1 slash, so `//2020/01/01/foo-bar` will become `/2020/01/01/foo-bar`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

- A test case has been added to test the new normalizing behavior for a URL of blog post in blog-only mode
- Repeat the repro plan in #2493 with this change, the problem no longer exists.

Now blog-only mode has correct path:

<img width="1323" alt="Screen Shot 2020-04-01 at 22 49 53" src="https://user-images.githubusercontent.com/4290500/78205830-30f66c00-746b-11ea-9af8-fc39b3c380ec.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
