### PR TITLE
docs(v2): add link to master docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -100,12 +100,15 @@ module.exports = {
               label: versions[0],
               to: 'docs/introduction',
             },
-          ].concat(
-            versions.slice(1).map(version => ({
+            ...versions.slice(1).map(version => ({
               label: version,
               to: `docs/${version}/introduction`,
             })),
-          ),
+            {
+              label: 'Master/Unreleased',
+              to: 'docs/next/introduction',
+            },
+          ],
         },
         {to: 'blog', label: 'Blog', position: 'left'},
         {to: 'showcase', label: 'Showcase', position: 'left'},


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make it easier to discover the `master` version of docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![Screen Shot 2020-04-02 at 2 43 02 PM](https://user-images.githubusercontent.com/1315101/78218389-495c9a00-74f0-11ea-8650-e7f6cedbf708.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
