### PR TITLE
chore(v2): replace few Lodash methods with native counterparts

### DIFF
--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -10,7 +10,6 @@ import chalk = require('chalk');
 import chokidar from 'chokidar';
 import express from 'express';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import _ from 'lodash';
 import path from 'path';
 import portfinder from 'portfinder';
 import openBrowser from 'react-dev-utils/openBrowser';
@@ -64,11 +63,11 @@ export async function start(
     return posixPath(filepath);
   };
 
-  const pluginPaths: string[] = _.compact(
-    _.flatten<string | undefined>(
-      plugins.map(plugin => plugin.getPathsToWatch && plugin.getPathsToWatch()),
-    ),
-  ).map(normalizeToSiteDir);
+  const pluginPaths: string[] = plugins
+    .map(plugin => plugin.getPathsToWatch && plugin.getPathsToWatch())
+    .reduce((a, b) => a.concat(b), [])
+    .filter(Boolean)
+    .map(normalizeToSiteDir);
   const fsWatcher = chokidar.watch([...pluginPaths, CONFIG_FILE_NAME], {
     cwd: siteDir,
     ignoreInitial: true,

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -63,11 +63,12 @@ export async function start(
     return posixPath(filepath);
   };
 
-  const pluginPaths: string[] = plugins
-    .map(plugin => plugin.getPathsToWatch && plugin.getPathsToWatch())
-    .reduce((a, b) => a.concat(b), [])
-    .filter(Boolean)
-    .map(normalizeToSiteDir);
+  const pluginPaths: string[] = ([] as string[]).concat(
+    ...plugins
+      .map<any>(plugin => plugin.getPathsToWatch && plugin.getPathsToWatch())
+      .filter(Boolean)
+      .map(normalizeToSiteDir),
+  );
   const fsWatcher = chokidar.watch([...pluginPaths, CONFIG_FILE_NAME], {
     cwd: siteDir,
     ignoreInitial: true,

--- a/packages/docusaurus/src/server/client-modules/index.ts
+++ b/packages/docusaurus/src/server/client-modules/index.ts
@@ -5,19 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import _ from 'lodash';
 import {Plugin} from '@docusaurus/types';
 
 export function loadClientModules(plugins: Plugin<any>[]): string[] {
-  return _.compact(
-    _.flatten<string | null>(
-      plugins.map(plugin => {
-        if (!plugin.getClientModules) {
-          return null;
-        }
-
-        return plugin.getClientModules();
-      }),
-    ),
-  );
+  return plugins
+    .map(plugin =>
+      !plugin.getClientModules ? null : plugin.getClientModules(),
+    )
+    .reduce((a, b) => a.concat(b), [])
+    .filter(Boolean);
 }

--- a/packages/docusaurus/src/server/client-modules/index.ts
+++ b/packages/docusaurus/src/server/client-modules/index.ts
@@ -8,10 +8,9 @@
 import {Plugin} from '@docusaurus/types';
 
 export function loadClientModules(plugins: Plugin<any>[]): string[] {
-  return plugins
-    .map(plugin =>
-      !plugin.getClientModules ? null : plugin.getClientModules(),
-    )
-    .reduce((a, b) => a.concat(b), [])
-    .filter(Boolean);
+  return ([] as string[]).concat(
+    ...plugins
+      .map<any>(plugin => plugin.getClientModules && plugin.getClientModules())
+      .filter(Boolean),
+  );
 }

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -6,7 +6,6 @@
  */
 
 import {generate} from '@docusaurus/utils';
-import _ from 'lodash';
 import path from 'path';
 import {
   BUILD_DIR_NAME,

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -84,8 +84,12 @@ export async function load(
 
   // Themes.
   const fallbackTheme = path.resolve(__dirname, '../client/theme-fallback');
-  const pluginThemes = plugins
-    .map(plugin => plugin.getThemePath && plugin.getThemePath())
+  const pluginThemes = ([] as string[])
+    .concat(
+      ...plugins.map<any>(
+        plugin => plugin.getThemePath && plugin.getThemePath(),
+      ),
+    )
     .filter(Boolean);
   const userTheme = path.resolve(siteDir, THEME_PATH);
   const alias = loadThemeAlias([fallbackTheme, ...pluginThemes], [userTheme]);

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -85,9 +85,9 @@ export async function load(
 
   // Themes.
   const fallbackTheme = path.resolve(__dirname, '../client/theme-fallback');
-  const pluginThemes = _.compact(
-    plugins.map(plugin => plugin.getThemePath && plugin.getThemePath()),
-  );
+  const pluginThemes = plugins
+    .map(plugin => plugin.getThemePath && plugin.getThemePath())
+    .filter(Boolean);
   const userTheme = path.resolve(siteDir, THEME_PATH);
   const alias = loadThemeAlias([fallbackTheme, ...pluginThemes], [userTheme]);
 

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import _ from 'lodash';
 import importFresh from 'import-fresh';
 import {LoadContext, Plugin, PluginConfig} from '@docusaurus/types';
 
@@ -16,8 +15,8 @@ export function initPlugins({
   pluginConfigs: PluginConfig[];
   context: LoadContext;
 }): Plugin<any>[] {
-  const plugins: Plugin<any>[] = _.compact(
-    pluginConfigs.map(pluginItem => {
+  const plugins: Plugin<any>[] = pluginConfigs
+    .map(pluginItem => {
       let pluginModuleImport;
       let pluginOptions = {};
 
@@ -40,8 +39,8 @@ export function initPlugins({
       // module identifier - npm package or locally-resolved path.
       const pluginModule: any = importFresh(pluginModuleImport);
       return (pluginModule.default || pluginModule)(context, pluginOptions);
-    }),
-  );
+    })
+    .filter(Boolean);
 
   return plugins;
 }

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -6,7 +6,6 @@
  */
 
 import importFresh from 'import-fresh';
-import _ from 'lodash';
 import {
   LoadContext,
   PluginConfig,
@@ -47,7 +46,7 @@ export function loadPresets(
   });
 
   return {
-    plugins: _.compact(_.flatten<PluginConfig>(unflatPlugins)),
-    themes: _.compact(_.flatten<PluginConfig>(unflatThemes)),
+    plugins: unflatPlugins.reduce((a, b) => a.concat(b), []).filter(Boolean),
+    themes: unflatThemes.reduce((a, b) => a.concat(b), []).filter(Boolean),
   };
 }


### PR DESCRIPTION
## Motivation

Same motivation like in previous PRs.

This is the initial step in getting rid of main `lodash` package in core v2 Docusaurus package. In this PR `_.compact` and `_.flatten` methods has been replaced with their native counterparts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Same test results before and after code refactor.

## Related PRs

* #2460
* #2519 
