### PR TITLE
fix(v2): make code block nicer again

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -10,10 +10,12 @@
 }
 
 .codeBlockTitle {
+  border-top-left-radius: var(--ifm-global-radius);
+  border-top-right-radius: var(--ifm-global-radius);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
   font-family: var(--ifm-font-family-monospace);
   font-weight: bold;
-  padding: var(--ifm-pre-padding);
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  padding: 0.75rem var(--ifm-pre-padding);
   width: 100%;
 }
 
@@ -30,12 +32,11 @@
   background: rgba(0, 0, 0, 0.3);
   border: none;
   border-radius: var(--ifm-global-radius);
-  color: var(--ifm-color-content);
+  color: var(--ifm-color-white);
   cursor: pointer;
-  line-height: 12px;
   opacity: 0;
   outline: none;
-  padding: 4px 8px;
+  padding: 0.4rem 0.5rem;
   position: absolute;
   right: var(--ifm-pre-padding);
   top: var(--ifm-pre-padding);
@@ -55,6 +56,7 @@
 }
 
 .codeBlockLines {
+  border-radius: var(--ifm-global-radius);
   font-family: var(--ifm-font-family-monospace);
   font-size: inherit;
   line-height: var(--ifm-pre-line-height);
@@ -62,4 +64,10 @@
   float: left;
   min-width: 100%;
   padding: var(--ifm-pre-padding);
+}
+
+/* Disable top border radius when title is present. */
+.codeBlockTitle + .codeBlockContent .codeBlockLines {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -10,10 +10,12 @@
 }
 
 .codeBlockTitle {
+  border-top-left-radius: var(--ifm-global-radius);
+  border-top-right-radius: var(--ifm-global-radius);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
   font-family: var(--ifm-font-family-monospace);
   font-weight: bold;
-  padding: var(--ifm-pre-padding);
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  padding: 0.75rem var(--ifm-pre-padding);
   width: 100%;
 }
 
@@ -30,12 +32,11 @@
   background: rgba(0, 0, 0, 0.3);
   border: none;
   border-radius: var(--ifm-global-radius);
-  color: var(--ifm-color-content);
+  color: var(--ifm-color-white);
   cursor: pointer;
-  line-height: 12px;
   opacity: 0;
   outline: none;
-  padding: 4px 8px;
+  padding: 0.4rem 0.5rem;
   position: absolute;
   right: var(--ifm-pre-padding);
   top: var(--ifm-pre-padding);
@@ -55,6 +56,7 @@
 }
 
 .codeBlockLines {
+  border-radius: var(--ifm-global-radius);
   font-family: var(--ifm-font-family-monospace);
   font-size: inherit;
   line-height: var(--ifm-pre-line-height);
@@ -62,4 +64,10 @@
   float: left;
   min-width: 100%;
   padding: var(--ifm-pre-padding);
+}
+
+/* Disable top border radius when title is present. */
+.codeBlockTitle + .codeBlockContent .codeBlockLines {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #2523. #2502 used theme-aware button color for the copy button but not everyone is using theme-aware code blocks.

The fix here is to hardcode the color for the code block regardless of theme.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="812" alt="Screen Shot 2020-04-04 at 12 51 26 PM" src="https://user-images.githubusercontent.com/1315101/78419052-47bbdf00-7674-11ea-9879-6166676ae095.png">
<img width="817" alt="Screen Shot 2020-04-04 at 12 51 21 PM" src="https://user-images.githubusercontent.com/1315101/78419055-4b4f6600-7674-11ea-837f-f71df6f8482d.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
