### PR TITLE
fix(v2): Use `writeFileSync` to write generated sitemap.xml to avoid early termination

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/index.ts
+++ b/packages/docusaurus-plugin-sitemap/src/index.ts
@@ -36,11 +36,11 @@ export default function pluginSitemap(
 
       // Write sitemap file.
       const sitemapPath = path.join(outDir, 'sitemap.xml');
-      fs.writeFile(sitemapPath, generatedSitemap, err => {
-        if (err) {
-          throw new Error(`Sitemap error: ${err}`);
-        }
-      });
+      try {
+        fs.writeFileSync(sitemapPath, generatedSitemap);
+      } catch (err) {
+        throw new Error(`Sitemap error: ${err}`);
+      }
     },
   };
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

Fix #2516.

Without a synchronous write, the callback may never be invoked because it's killed by `process.exit` introduced in #2443.

## Motivation

Unbreak sitemap generation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

Since I wasn't able to produce a repro for the docusaurus repo but I was able to repro it on my repo (see #2516), so I made the test against my repo.

1. Run `yarn` to compile all files.
1. Copy generated `packages/docusaurus-plugin-sitemap/lib/index.js` into correct place in https://github.com/SamChou19815/website 's `node_modules`
1. Run `yarn workspace blog build` in https://github.com/SamChou19815/website, now the sitemap is correctly generated.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
