### PR TITLE
fix(v2): add rounded corners in code blocks properly

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -21,6 +21,7 @@
 
 .codeBlock {
   overflow: auto;
+  border-radius: var(--ifm-global-radius);
 }
 
 .codeBlockWithTitle {
@@ -56,7 +57,6 @@
 }
 
 .codeBlockLines {
-  border-radius: var(--ifm-global-radius);
   font-family: var(--ifm-font-family-monospace);
   font-size: inherit;
   line-height: var(--ifm-pre-line-height);

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.module.css
@@ -7,7 +7,6 @@
 
 .mdxCodeBlock {
   position: relative;
-  border-radius: var(--ifm-global-radius);
   margin-bottom: var(--ifm-leading);
   font-size: var(--ifm-code-font-size);
 }

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -21,6 +21,7 @@
 
 .codeBlock {
   overflow: auto;
+  border-radius: var(--ifm-global-radius);
 }
 
 .codeBlockWithTitle {
@@ -56,7 +57,6 @@
 }
 
 .codeBlockLines {
-  border-radius: var(--ifm-global-radius);
   font-family: var(--ifm-font-family-monospace);
   font-size: inherit;
   line-height: var(--ifm-pre-line-height);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The rounded corners in the code blocks must be set to non-scrollable containers of code blocks, otherwise they will not be visible when scrolling.

![image](https://user-images.githubusercontent.com/4408379/78469112-b0fc2a80-7726-11ea-9c1c-266a435eca41.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
