### PR TITLE
refactor(v2): make better code blocks

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -40,14 +40,10 @@
   padding: 0.4rem 0.5rem;
   position: absolute;
   right: var(--ifm-pre-padding);
-  top: var(--ifm-pre-padding);
+  top: calc(var(--ifm-pre-padding) / 2);
   visibility: hidden;
   transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
     bottom 200ms ease-in-out;
-}
-
-.copyButtonWithTitle {
-  top: calc(var(--ifm-pre-padding));
 }
 
 .codeBlockTitle:hover + .codeBlockContent .copyButton,
@@ -64,10 +60,4 @@
   float: left;
   min-width: 100%;
   padding: var(--ifm-pre-padding);
-}
-
-/* Disable top border radius when title is present. */
-.codeBlockTitle + .codeBlockContent .codeBlockLines {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -39,7 +39,7 @@
   outline: none;
   padding: 0.4rem 0.5rem;
   position: absolute;
-  right: var(--ifm-pre-padding);
+  right: calc(var(--ifm-pre-padding) / 2);
   top: calc(var(--ifm-pre-padding) / 2);
   visibility: hidden;
   transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/styles.module.css
@@ -40,14 +40,10 @@
   padding: 0.4rem 0.5rem;
   position: absolute;
   right: var(--ifm-pre-padding);
-  top: var(--ifm-pre-padding);
+  top: calc(var(--ifm-pre-padding) / 2);
   visibility: hidden;
   transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
     bottom 200ms ease-in-out;
-}
-
-.copyButtonWithTitle {
-  top: calc(var(--ifm-pre-padding));
 }
 
 .codeBlockTitle:hover + .codeBlockContent .copyButton,
@@ -64,10 +60,4 @@
   float: left;
   min-width: 100%;
   padding: var(--ifm-pre-padding);
-}
-
-/* Disable top border radius when title is present. */
-.codeBlockTitle + .codeBlockContent .codeBlockLines {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

If there is only one line in the code block, the copy button is too low positioned. I suggest a little lift it.

In addition, I removed the redundant code left after #2533.

@yangshun open-ended question for discussion: do we really want to leave the background opacity? Actually, with long lines of code, this button becomes not so noticeable.

![image](https://user-images.githubusercontent.com/4408379/78470964-23283b80-7736-11ea-82f8-32902c34741f.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/78470930-da708280-7735-11ea-848e-00dda5fb0ebc.png) | ![image](https://user-images.githubusercontent.com/4408379/78470932-e0666380-7735-11ea-9adc-80b1bae89e1e.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
