### PR TITLE
refactor(v2): replace Lodash with single methods packages in utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/inquirer": "^6.5.0",
     "@types/jest": "^24.0.23",
     "@types/loader-utils": "^1.1.3",
-    "@types/lodash": "^4.14.149",
+    "@types/lodash.camelcase": "^4.3.6",
     "@types/lodash.flatmap": "^4.5.6",
     "@types/lodash.groupby": "^4.6.6",
     "@types/lodash.kebabcase": "^4.1.6",

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -15,7 +15,8 @@
     "escape-string-regexp": "^2.0.0",
     "fs-extra": "^8.1.0",
     "gray-matter": "^4.0.2",
-    "lodash": "^4.17.15"
+    "lodash.camelcase": "^4.3.0",
+    "lodash.kebabcase": "^4.1.1"
   },
   "engines": {
     "node": ">=10.9.0"


### PR DESCRIPTION
## Motivation

This is probably the last PR in Lodash series from me. This PR replaces `lodash` package in `docusaurus-utils` which also allows to remove `@types/lodash` from the workspace `package.json`.

There may by one more PR which cleans things up, but I need to fix my `yarn build` first.

`lodash` package cannot be remove from workspace `package.json` because V1 is still using it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Same test results before and after code refactor.

## Related PRs

#2460
#2519
#2520
#2529
#2535