### PR TITLE
misc(v2): remove deprecated/useless lerna field

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "lerna": "3.14.1",
   "version": "2.0.0-alpha.50",
   "npmClient": "yarn",
   "useWorkspaces": true,


### PR DESCRIPTION
Not very important, but noticed this deprecated attribute in lerna config that can be removed

https://github.com/lerna/lerna#legacy-fields

![image](https://user-images.githubusercontent.com/749374/78564289-7eccf480-781c-11ea-804e-f4c8f8b73c0f.png)
