### PR TITLE
doc(v2): Add team photos

### DIFF
--- a/website/docs/team.md
+++ b/website/docs/team.md
@@ -16,9 +16,8 @@ title: Team
 ### Fanny Vieira
 
 <br/>
-<img src="https://i.imgur.com/QMznITd.jpg4" width="58%"/>  
-&nbsp;  
 
+![](https://github.com/fanny.png)   
 [@fanny on Github](https://github.com/fanny) · [@fannyvieiira on Twitter](https://twitter.com/fannyvieiira)
 
 ### Joel Marcey  

--- a/website/docs/team.md
+++ b/website/docs/team.md
@@ -5,26 +5,62 @@ title: Team
 
 ## Meet the Docusaurus Team
 
-- Alexey Pyltsyn
-- Fanny Batista Vieira
-- Joel Marcey
-- Yangshun Tay
+### Alexey Pyltsyn
+
+<br/>
+
+![](https://github.com/lex111.png)  
+
+[@lex111 on Github](https://github.com/lex111)
+
+### Fanny Vieira
+
+<br/>
+<img src="https://i.imgur.com/QMznITd.jpg4" width="58%"/>  
+&nbsp;  
+
+[@fanny on Github](https://github.com/fanny) · [@fannyvieiira on Twitter](https://twitter.com/fannyvieiira)
+
+### Joel Marcey  
+
+<br/>
+
+![](https://github.com/joelmarcey.png)  
+[@joelmarcey on Github](https://github.com/joelmarcey) · [@joelmarcey on Twitter](https://twitter.com/joelmarcey)
+
+### Yangshun Tay
+
+<br/>
+
+![](https://github.com/yangshun.png)  
+[@yangshun on Github](https://github.com/yangshun) · [@yangshunz on Twitter](https://twitter.com/yangshunz)
 
 ## Honorary Alumni
 
-- Endilie Yacop Sucipto
-- Wei Gao
+### Endilie Yacop Sucipto
+
+<br/>
+
+![](https://github.com/endiliey.png?width=75&height=75)  
+[@endiliey on Github](https://github.com/endiliey) · [@endiliey on Twitter ](https://twitter.com/endiliey)
+
+### Wei Gao
+
+<br/>
+
+![](https://avatars3.githubusercontent.com/u/2055384?s=460&u=09248b65169cb9909246dfa39b796deffc7bd251&v=4)  
+[@wgao19 on Github](https://github.com/wgao19) · [@wgao19 on Twitter](https://twitter.com/wgao19)
 
 ## Acknowledgements
 
 Docusaurus was originally created by Joel Marcey. Today, Docusaurus has a few hundred open source contributors. We’d like to recognize a few people who have made significant contributions to Docusaurus and its documentation in the past and have helped maintain them over the years:
 
-- Amy Lam
-- Cheng Lou
-- Christine Abernathy
-- Christopher Chedeau
+- [Amy Lam](https://github.com/amyrlam)
+- [Cheng Lou](https://github.com/chenglou)
+- [Christine Abernathy](https://github.com/caabernathy)
+- [Christopher Chedeau](https://github.com/vjeux)
 - Elvis Wolcott
-- Eric Nakagawa
+- [Eric Nakagawa](https://github.com/ericnakagawa)
 - Fienny Angelina
 - Frank Li
 - [Héctor Ramos](https://github.com/hramos)


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

As discussed in #2546, would it be nice have the team profiles, so this pr adds the images of the members.

I was thinking if isn't better create a component to render this, the visual that is applied for each member is equal, we can have a `.json` with the members info, like, the github, twitter, and a brief description about the person.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

`yarn start` go to `/docs/next/team`

![169FCA61-A713-4FD7-BA85-CB77A009DD16_1_105_c](https://user-images.githubusercontent.com/14113480/78668743-930f0100-78b1-11ea-9de1-338f13ad57c2.jpeg)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
