### PR TITLE
fix(v2): properly link top-level github pages sites in deploy command

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -169,13 +169,11 @@ export async function deploy(
           // The commit might return a non-zero value when site is up to date.
           let websiteURL = '';
           if (githubHost === 'github.com') {
-            // github.io hosting
-            if (projectName.includes('.github.io')) {
-              // domain root gh-pages hosted repo
-              websiteURL = `https://${organizationName}.github.io/`;
-            } else {
-              websiteURL = `https://${organizationName}.github.io/${projectName}/`;
-            }
+            websiteURL = projectName.includes('.github.io')
+              ?
+                   `https://${organizationName}.github.io/`;
+              :
+                   `https://${organizationName}.github.io/${projectName}/`;
           } else {
             // GitHub enterprise hosting.
             websiteURL = `https://${githubHost}/pages/${organizationName}/${projectName}/`;

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -170,10 +170,8 @@ export async function deploy(
           let websiteURL = '';
           if (githubHost === 'github.com') {
             websiteURL = projectName.includes('.github.io')
-              ?
-                   `https://${organizationName}.github.io/`;
-              :
-                   `https://${organizationName}.github.io/${projectName}/`;
+              ? `https://${organizationName}.github.io/`
+              : `https://${organizationName}.github.io/${projectName}/`;
           } else {
             // GitHub enterprise hosting.
             websiteURL = `https://${githubHost}/pages/${organizationName}/${projectName}/`;

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -167,12 +167,19 @@ export async function deploy(
           throw new Error('Error: Git push failed');
         } else if (commitResults.code === 0) {
           // The commit might return a non-zero value when site is up to date.
-          const websiteURL =
-            githubHost === 'github.com'
-              ? // gh-pages hosted repo
-                `https://${organizationName}.github.io/${projectName}`
-              : // GitHub enterprise hosting.
-                `https://${githubHost}/pages/${organizationName}/${projectName}`;
+          let websiteURL = '';
+          if (githubHost === 'github.com') {
+            // github.io hosting
+            if (projectName.includes('.github.io')) {
+              // domain root gh-pages hosted repo
+              websiteURL = `https://${organizationName}.github.io/`;
+            } else {
+              websiteURL = `https://${organizationName}.github.io/${projectName}/`;
+            }
+          } else {
+            // GitHub enterprise hosting.
+            websiteURL = `https://${githubHost}/pages/${organizationName}/${projectName}/`;
+          }
           shell.echo(`Website is live at ${websiteURL}`);
           shell.exit(0);
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Found this issue while trying to make a site, so I fixed it

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

I tested it by creating a docusaurus site and I verified that the correct URLs are logged.  

## Related PRs

This was in #2556 but @yangshun reverted it