### PR TITLE
doc(v2): remove legacy blog metadata

### DIFF
--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -37,7 +37,6 @@ author: Joel Marcey
 author_title: Co-creator of Docusaurus 1
 author_url: https://github.com/JoelMarcey
 author_image_url: https://graph.facebook.com/611217057/picture/?height=200&width=200
-authorURL: https://github.com/JoelMarcey
 tags: [hello, docusaurus-v2]
 ---
 Welcome to this blog. This blog is created with [**Docusaurus 2 alpha**](https://v2.docusaurus.io/).


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I copied and pasted that block for my project, and noticed that it was unused now because it has `author_url` (as can be seen earlier in the example) present.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have verified that `authorURL` is no longer valid metadata

## Related PRs

None.
