### PR TITLE
docs(v2): fix syntax error for plugin config

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -389,12 +389,14 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 ```js title="docusaurus.config.js"
 module.exports = {
   plugins: [
-    '@docusaurus/plugin-sitemap',
-    {
-      cacheTime: 600 * 1000, // 600 sec - cache purge period
-      changefreq: 'weekly',
-      priority: 0.5,
-    },
+    [
+      '@docusaurus/plugin-sitemap',
+      {
+        cacheTime: 600 * 1000, // 600 sec - cache purge period
+        changefreq: 'weekly',
+        priority: 0.5,
+      },
+    ],
   ],
 };
 ```

--- a/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
@@ -380,12 +380,14 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 ```js title="docusaurus.config.js"
 module.exports = {
   plugins: [
-    '@docusaurus/plugin-sitemap',
-    {
-      cacheTime: 600 * 1000, // 600 sec - cache purge period
-      changefreq: 'weekly',
-      priority: 0.5,
-    },
+    [
+      '@docusaurus/plugin-sitemap',
+      {
+        cacheTime: 600 * 1000, // 600 sec - cache purge period
+        changefreq: 'weekly',
+        priority: 0.5,
+      },
+    ]
   ],
 };
 ```


### PR DESCRIPTION
## Motivation

The plugin config had a syntax error

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

View the  https://v2.docusaurus.io/docs/using-plugins/#docusaurusplugin-sitemap page
