### PR TITLE
docs(v2): mention that `plugin-ideal-image` only perform compression on a production build

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -401,7 +401,7 @@ module.exports = {
 
 ### `@docusaurus/plugin-ideal-image`
 
-Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, and low quality placeholder)
+Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, and low quality placeholder) **in the production builds**.
 
 ```bash npm2yarn
 npm install --save @docusaurus/plugin-ideal-image
@@ -409,18 +409,17 @@ npm install --save @docusaurus/plugin-ideal-image
 
 Modify your `docusaurus.config.js`
 
-```js title="docusaurus.config.js"
+```diff
 module.exports = {
-  // ...
-  // highlight-next-line
-  plugins: ['@docusaurus/plugin-ideal-image'],
-  // ...
-};
+  ...
++ plugins: ['@docusaurus/plugin-ideal-image'],
+  ...
+}
 ```
 
 #### Usage
 
-This plugin supports png, gif and jpg only
+This plugin supports the PNG, GIF and JPG formats only.
 
 ```jsx
 import Image from '@theme/IdealImage';

--- a/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
@@ -392,7 +392,7 @@ module.exports = {
 
 ### `@docusaurus/plugin-ideal-image`
 
-Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, and low quality placeholder)
+Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, and low quality placeholder) *in the production builds*.
 
 ```bash npm2yarn
 npm install --save @docusaurus/plugin-ideal-image
@@ -410,7 +410,7 @@ module.exports = {
 
 #### Usage
 
-This plugin supports png, gif and jpg only
+This plugin supports the PNG, GIF and JPG formats only.
 
 ```jsx
 import Image from '@theme/IdealImage';
@@ -424,10 +424,6 @@ import thumbnail from './path/to/img.png';
 ```
 
 #### Options
-
-:::note
-Image compression/transformation will only happen in a production build. When developing with the local server, full, original size images will always be returned.
-:::
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
@@ -425,6 +425,10 @@ import thumbnail from './path/to/img.png';
 
 #### Options
 
+:::note
+Image compression/transformation will only happen in a production build. When developing with the local server, full, original size images will always be returned.
+:::
+
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | `string` | `ideal-img/[name].[hash:hex:7].[width].[ext]` | Filename template for output files. |

--- a/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
@@ -392,7 +392,7 @@ module.exports = {
 
 ### `@docusaurus/plugin-ideal-image`
 
-Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, and low quality placeholder) *in the production builds*.
+Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, and low quality placeholder) **in the production builds**.
 
 ```bash npm2yarn
 npm install --save @docusaurus/plugin-ideal-image


### PR DESCRIPTION
In reference to https://github.com/facebook/docusaurus/issues/2571

## Motivation

I attempted to use the `@docusaurus/plugin-ideal-image` plugin, and found it wasn't compressing images in a development enviroment. I needed to do a production build for it to compress images, so I wanted to add a note to the docs so other developers don't get confused like me.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Check for spelling and grammar.