### PR TITLE
fix(v2): treat mailto and tel links properly

### DIFF
--- a/packages/docusaurus/src/client/exports/__tests__/isInternalUrl.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/isInternalUrl.ts
@@ -27,4 +27,12 @@ describe('isInternalUrl', () => {
   test('should be false for whatever protocol links', () => {
     expect(isInternalUrl('//foo.com')).toBeFalsy();
   });
+
+  test('should be false for telephone links', () => {
+    expect(isInternalUrl('tel:+1234567890')).toBeFalsy();
+  });
+
+  test('should be false for mailto links', () => {
+    expect(isInternalUrl('mailto:someone@example.com')).toBeFalsy();
+  });
 });

--- a/packages/docusaurus/src/client/exports/isInternalUrl.js
+++ b/packages/docusaurus/src/client/exports/isInternalUrl.js
@@ -6,5 +6,5 @@
  */
 
 export default function isInternalUrl(url) {
-  return /^(https?:|\/\/)/.test(url) === false;
+  return /^(https?:|\/\/|mailto:|tel:)/.test(url) === false;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2568

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Use the similar elements as the item link in navbar and footer.

```js
        {
          label: 'Mailto link',
          href: 'mailto:foo@bar.com',
          position: 'right',
        },
```

```js
            {
              label: 'Telephone link',
              href: 'tel:+1234567890',
              position: 'right',
            },
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
