### PR TITLE
fix(v2): do not process anchor links by router

### DIFF
--- a/packages/docusaurus/src/client/exports/Link.js
+++ b/packages/docusaurus/src/client/exports/Link.js
@@ -68,7 +68,7 @@ function Link(props) {
     };
   }, [targetLink, IOSupported, isInternal]);
 
-  return !targetLink || !isInternal ? (
+  return !targetLink || !isInternal || targetLink.startsWith('#') ? (
     // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a {...props} href={targetLink} />
   ) : (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2552

Anchor links that refer to sections in the current file should not be processed by the router, because otherwise the current URL is added to them (_"/docs/docs/#doc" instead of just "#doc"_), and this breaks them (in case of non-ASCII characters).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

In any MD document, define new heading using non-ASCII characters. And then try to refer to
this section through a new link.

> The example below uses Russian characters, for example, but you can use Persian, as indicated in  #2552


```md

...

# Тест

...

[Тест](#тест)


```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
