### PR TITLE
fix(v2): remove horizontal scroll on docs page

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -102,7 +102,7 @@ function DocItem(props) {
         {permalink && <meta property="og:url" content={siteUrl + permalink} />}
       </Head>
       <div className="padding-vert--lg">
-        <div className="container">
+        <div className={classnames('container', styles.docItemWrapper)}>
           <div className="row">
             <div className={classnames('col', styles.docItemCol)}>
               <div className={styles.docItemContainer}>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -28,6 +28,14 @@
   }
 }
 
+@media (min-width: 997px) and (max-width: 1320px) {
+  .docItemWrapper {
+    max-width: calc(
+      var(--ifm-container-width) - 300px - var(--ifm-spacing-horizontal) * 2
+    );
+  }
+}
+
 .tableOfContents {
   display: inherit;
   max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2548

This PR solves the horizontal scroll issue not only for tablets in landscape orientation, but in general for all screens.
The bottom line is that we limit the width of the container with docs content on screens from 997px to 1320 px (this is the maximum width when scrolling appears), so this change does not affect large screens.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I tested on different generations of the iPad (6th, 7th) using BrowserStack and also some tablets on Android.  Basically, just go to the docs page with "large" content (https://v2.docusaurus.io/docs/next/markdown-features/) and through devtools manually change the page size - horizontal scrolling should not be.

Initial issue:

Before:

![image](https://user-images.githubusercontent.com/4408379/79044991-401aae00-7c11-11ea-848b-a5c04dab80ff.png)

After:

![image](https://user-images.githubusercontent.com/4408379/79044993-46a92580-7c11-11ea-8cb8-fddc1730c1c7.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
