### PR TITLE
refactor(v2): use nav link component only where needed

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -76,6 +76,7 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
             to={href}
             {...(isInternalUrl(href)
               ? {
+                  isNavLink: true,
                   activeClassName: 'menu__link--active',
                   exact: true,
                   onClick: onItemClick,

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -33,6 +33,7 @@ function NavLink({activeBasePath, to, href, label, position, ...props}) {
             href,
           }
         : {
+            isNavLink: true,
             activeClassName: 'navbar__link--active',
             to: toUrl,
             ...(activeBasePath

--- a/packages/docusaurus/src/client/exports/Link.js
+++ b/packages/docusaurus/src/client/exports/Link.js
@@ -6,15 +6,16 @@
  */
 
 import React, {useEffect, useRef} from 'react';
-import {NavLink} from 'react-router-dom';
+import {NavLink, Link as RRLink} from 'react-router-dom';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
-function Link(props) {
+function Link({isNavLink, ...props}) {
   const {to, href} = props;
   const targetLink = to || href;
   const isInternal = isInternalUrl(targetLink);
   const preloaded = useRef(false);
+  const LinkComponent = isNavLink ? NavLink : RRLink;
 
   const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
 
@@ -72,7 +73,7 @@ function Link(props) {
     // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a {...props} href={targetLink} />
   ) : (
-    <NavLink
+    <LinkComponent
       {...props}
       onMouseEnter={onMouseEnter}
       innerRef={handleRef}

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -61,7 +61,7 @@ Outputs
 
 This component enables linking to internal pages as well as a powerful performance feature called preloading. Preloading is used to prefetch resources so that the resources are fetched by the time the user navigates with this component. We use an `IntersectionObserver` to fetch a low-priority request when the `<Link>` is in the viewport and then use an `onMouseOver` event to trigger a high-priority request when it is likely that a user will navigate to the requested resource.
 
-The component is a wrapper around react-router’s `<NavLink>` component that adds useful enhancements specific to Docusaurus. All props are passed through to react-router’s `<NavLink>` component.
+The component is a wrapper around react-router’s `<Link>` component that adds useful enhancements specific to Docusaurus. All props are passed through to react-router’s `<Link>` component.
 
 ```jsx {2,7}
 import React from 'react';
@@ -86,16 +86,6 @@ The target location to navigate to. Example: `/docs/introduction`.
 
 ```jsx
 <Link to="/courses" />
-```
-
-#### `activeClassName`: string
-
-The class to give the `<Link>` when it is active. The default given class is `active`. This will be joined with the `className` prop.
-
-```jsx {1}
-<Link to="/faq" activeClassName="selected">
-  FAQs
-</Link>
 ```
 
 ### `<Redirect/>`


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

As mentioned in https://github.com/facebook/docusaurus/pull/2580#issuecomment-612387653, this will allow clean things up with nav links, in other words, it’s now clearer where we need to use the functionality of nav links, in their _original purpose_*.

> _\*_ A special version of the that will add styling attributes to the rendered element when it matches the current URL.

This basically removes unnecessary DOM attrs related with highlighting (via CSS) the current link (for our needs, this is only necessary for navbar and doc sidebar).

This is potentially BC change, although it seems unlikely that anyone used this functionality, especially since it would not work by default except in the navbar and doc sidebar (because the according CSS styles for the active menu item are defined only for these specified components).
And in general, it is not clear where this can be useful to the end user, so this is absolutely unnecessary functionality for them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
