### PR TITLE
refactor(v2): remove redundant container on docs page

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -101,104 +101,106 @@ function DocItem(props) {
         )}
         {permalink && <meta property="og:url" content={siteUrl + permalink} />}
       </Head>
-      <div className="padding-vert--lg">
-        <div className={classnames('container', styles.docItemWrapper)}>
-          <div className="row">
-            <div className={classnames('col', styles.docItemCol)}>
-              <div className={styles.docItemContainer}>
-                <article>
-                  {version && (
-                    <div>
-                      <span className="badge badge--secondary">
-                        Version: {version}
-                      </span>
-                    </div>
-                  )}
-                  {!hideTitle && (
-                    <header>
-                      <h1 className={styles.docTitle}>{title}</h1>
-                    </header>
-                  )}
-                  <div className="markdown">
-                    <DocContent />
-                  </div>
-                </article>
-                {(editUrl || lastUpdatedAt || lastUpdatedBy) && (
-                  <div className="margin-vert--xl">
-                    <div className="row">
-                      <div className="col">
-                        {editUrl && (
-                          <a
-                            href={editUrl}
-                            target="_blank"
-                            rel="noreferrer noopener">
-                            <svg
-                              fill="currentColor"
-                              height="1.2em"
-                              width="1.2em"
-                              preserveAspectRatio="xMidYMid meet"
-                              viewBox="0 0 40 40"
-                              style={{
-                                marginRight: '0.3em',
-                                verticalAlign: 'sub',
-                              }}>
-                              <g>
-                                <path d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z" />
-                              </g>
-                            </svg>
-                            Edit this page
-                          </a>
-                        )}
-                      </div>
-                      {(lastUpdatedAt || lastUpdatedBy) && (
-                        <div className="col text--right">
-                          <em>
-                            <small>
-                              Last updated{' '}
-                              {lastUpdatedAt && (
-                                <>
-                                  on{' '}
-                                  <time
-                                    dateTime={new Date(
-                                      lastUpdatedAt * 1000,
-                                    ).toISOString()}
-                                    className={styles.docLastUpdatedAt}>
-                                    {new Date(
-                                      lastUpdatedAt * 1000,
-                                    ).toLocaleDateString()}
-                                  </time>
-                                  {lastUpdatedBy && ' '}
-                                </>
-                              )}
-                              {lastUpdatedBy && (
-                                <>
-                                  by <strong>{lastUpdatedBy}</strong>
-                                </>
-                              )}
-                              {process.env.NODE_ENV === 'development' && (
-                                <div>
-                                  <small>
-                                    {' '}
-                                    (Simulated during dev for better perf)
-                                  </small>
-                                </div>
-                              )}
-                            </small>
-                          </em>
-                        </div>
-                      )}
-                    </div>
+      <div
+        className={classnames(
+          'container padding-vert--lg',
+          styles.docItemWrapper,
+        )}>
+        <div className="row">
+          <div className={classnames('col', styles.docItemCol)}>
+            <div className={styles.docItemContainer}>
+              <article>
+                {version && (
+                  <div>
+                    <span className="badge badge--secondary">
+                      Version: {version}
+                    </span>
                   </div>
                 )}
-                <div className="margin-vert--lg">
-                  <DocPaginator metadata={metadata} />
+                {!hideTitle && (
+                  <header>
+                    <h1 className={styles.docTitle}>{title}</h1>
+                  </header>
+                )}
+                <div className="markdown">
+                  <DocContent />
                 </div>
+              </article>
+              {(editUrl || lastUpdatedAt || lastUpdatedBy) && (
+                <div className="margin-vert--xl">
+                  <div className="row">
+                    <div className="col">
+                      {editUrl && (
+                        <a
+                          href={editUrl}
+                          target="_blank"
+                          rel="noreferrer noopener">
+                          <svg
+                            fill="currentColor"
+                            height="1.2em"
+                            width="1.2em"
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 40 40"
+                            style={{
+                              marginRight: '0.3em',
+                              verticalAlign: 'sub',
+                            }}>
+                            <g>
+                              <path d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z" />
+                            </g>
+                          </svg>
+                          Edit this page
+                        </a>
+                      )}
+                    </div>
+                    {(lastUpdatedAt || lastUpdatedBy) && (
+                      <div className="col text--right">
+                        <em>
+                          <small>
+                            Last updated{' '}
+                            {lastUpdatedAt && (
+                              <>
+                                on{' '}
+                                <time
+                                  dateTime={new Date(
+                                    lastUpdatedAt * 1000,
+                                  ).toISOString()}
+                                  className={styles.docLastUpdatedAt}>
+                                  {new Date(
+                                    lastUpdatedAt * 1000,
+                                  ).toLocaleDateString()}
+                                </time>
+                                {lastUpdatedBy && ' '}
+                              </>
+                            )}
+                            {lastUpdatedBy && (
+                              <>
+                                by <strong>{lastUpdatedBy}</strong>
+                              </>
+                            )}
+                            {process.env.NODE_ENV === 'development' && (
+                              <div>
+                                <small>
+                                  {' '}
+                                  (Simulated during dev for better perf)
+                                </small>
+                              </div>
+                            )}
+                          </small>
+                        </em>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+              <div className="margin-vert--lg">
+                <DocPaginator metadata={metadata} />
               </div>
             </div>
-            {!hideTableOfContents && DocContent.rightToc && (
-              <DocTOC headings={DocContent.rightToc} />
-            )}
           </div>
+          {!hideTableOfContents && DocContent.rightToc && (
+            <DocTOC headings={DocContent.rightToc} />
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In accordance with recommendations for improving website performance, we should avoid a large number of nested elements. This tiny change removes the extra wrapper (util  `padding-vert--lg` class is now added to another container).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
