### PR TITLE
docs(v2): fix 1st custom admonition title example

### DIFF
--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -433,7 +433,7 @@ Example:
 The content and title *can* include markdown.
 :::
 
-:::tip
+:::tip You can specify an optional title
 Heads up! Here's a pro-tip.
 :::
 


### PR DESCRIPTION
In order to stay more consistent, the custom title could also be removed in its entirely. The next section is just about customizing admonition titles in general.