### PR TITLE
refactor(v2): make margin top on blog pages as on other pages

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
@@ -22,7 +22,7 @@ function BlogListPage(props) {
 
   return (
     <Layout title={title} description="Blog">
-      <div className="container margin-vert--xl">
+      <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--8 col--offset-2">
             {items.map(({content: BlogPostContent}) => (

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.js
@@ -19,7 +19,7 @@ function BlogPostPage(props) {
   return (
     <Layout title={title} description={description}>
       {BlogPostContents && (
-        <div className="container margin-vert--xl">
+        <div className="container margin-vert--lg">
           <div className="row">
             <div className="col col--8 col--offset-2">
               <BlogPostItem

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
@@ -49,7 +49,7 @@ function BlogTagsListPage(props) {
 
   return (
     <Layout title="Tags" description="Blog Tags">
-      <div className="container margin-vert--xl">
+      <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--8 col--offset-2">
             <h1>Tags</h1>

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
@@ -23,7 +23,7 @@ function BlogTagsPostPage(props) {
     <Layout
       title={`Posts tagged "${tagName}"`}
       description={`Blog | Tagged "${tagName}"`}>
-      <div className="container margin-vert--xl">
+      <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--8 col--offset-2">
             <h1>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I think it's better to unify margin top on the blog pages, that it was the same as on other pages (docs, pages)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
