### PR TITLE
docs(v2): remove duplicated package.json in installation directory structure

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -47,7 +47,6 @@ my-website
 │   ├── doc2.md
 │   ├── doc3.md
 │   └── mdx.md
-├── package.json
 ├── src
 │   ├── css
 │   │   └── custom.css


### PR DESCRIPTION
`package.json` was duplicated within the example file structure (line 50 & 60). I've removed the one on 50 so all directories are together and left the second.