### PR TITLE
feat(v2): add ability set dark mode by default

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -11,8 +11,8 @@ const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin')
 // Need to be inlined to prevent dark mode FOUC
 // Make sure that the 'storageKey' is the same as the one in `/theme/hooks/useTheme.js`
 const storageKey = 'theme';
-const noFlash = (forceDarkMode) => `(function() {
-  var forceDarkMode = ${forceDarkMode};
+const noFlash = (defaultDarkMode) => `(function() {
+  var defaultDarkMode = ${defaultDarkMode};
 
   function setDataThemeAttribute(theme) {
     document.documentElement.setAttribute('data-theme', theme);
@@ -32,7 +32,7 @@ const noFlash = (forceDarkMode) => `(function() {
   var preferredTheme = getPreferredTheme();
   if (preferredTheme !== null) {
     setDataThemeAttribute(preferredTheme);
-  } else if (darkQuery.matches || forceDarkMode) {
+  } else if (darkQuery.matches || defaultDarkMode) {
     setDataThemeAttribute('dark');
   }
 })();`;
@@ -43,7 +43,7 @@ module.exports = function (context, options) {
   } = context;
   const {
     disableDarkMode = false,
-    forceDarkMode = false,
+    defaultDarkMode = false,
     prism: {additionalLanguages = []} = {},
   } = themeConfig || {};
   const {customCss} = options || {};
@@ -90,7 +90,7 @@ module.exports = function (context, options) {
             attributes: {
               type: 'text/javascript',
             },
-            innerHTML: noFlash(forceDarkMode),
+            innerHTML: noFlash(defaultDarkMode),
           },
         ],
       };

--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -11,7 +11,9 @@ const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin')
 // Need to be inlined to prevent dark mode FOUC
 // Make sure that the 'storageKey' is the same as the one in `/theme/hooks/useTheme.js`
 const storageKey = 'theme';
-const noFlash = `(function() {
+const noFlash = (forceDarkMode) => `(function() {
+  var forceDarkMode = ${forceDarkMode};
+
   function setDataThemeAttribute(theme) {
     document.documentElement.setAttribute('data-theme', theme);
   }
@@ -30,7 +32,7 @@ const noFlash = `(function() {
   var preferredTheme = getPreferredTheme();
   if (preferredTheme !== null) {
     setDataThemeAttribute(preferredTheme);
-  } else if (darkQuery.matches) {
+  } else if (darkQuery.matches || forceDarkMode) {
     setDataThemeAttribute('dark');
   }
 })();`;
@@ -39,8 +41,11 @@ module.exports = function (context, options) {
   const {
     siteConfig: {themeConfig},
   } = context;
-  const {disableDarkMode = false, prism: {additionalLanguages = []} = {}} =
-    themeConfig || {};
+  const {
+    disableDarkMode = false,
+    forceDarkMode = false,
+    prism: {additionalLanguages = []} = {},
+  } = themeConfig || {};
   const {customCss} = options || {};
 
   return {
@@ -85,7 +90,7 @@ module.exports = function (context, options) {
             attributes: {
               type: 'text/javascript',
             },
-            innerHTML: noFlash,
+            innerHTML: noFlash(forceDarkMode),
           },
         ],
       };

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -25,6 +25,18 @@ module.exports = {
 };
 ```
 
+With the enabled `forceDarkMode` option you could set dark mode by default. However, in this case, the user's preference will not be taken into account until they manually sets the desired mode via toggle in the navbar.
+
+```js {4} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  themeConfig: {
+    forceDarkMode: true,
+    // ...
+  },
+};
+```
+
 ### Meta image
 
 You can configure a default image that will be used for your meta tag, in particular `og:image` and `twitter:image`.

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -25,13 +25,13 @@ module.exports = {
 };
 ```
 
-With the enabled `forceDarkMode` option you could set dark mode by default. However, in this case, the user's preference will not be taken into account until they manually sets the desired mode via toggle in the navbar.
+With the enabled `defaultDarkMode` option you could set dark mode by default. However, in this case, the user's preference will not be taken into account until they manually sets the desired mode via toggle in the navbar.
 
 ```js {4} title="docusaurus.config.js"
 module.exports = {
   // ...
   themeConfig: {
-    forceDarkMode: true,
+    defaultDarkMode: true,
     // ...
   },
 };


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2565 and corresponding request on Canny (https://docusaurus.canny.io/admin/board/feature-requests/p/default-to-dark-theme) 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Make sure that there is no saved proffered theme in local storage (`theme` key) and add the `themeConfig.forceDarkMode=true` option in the config file.

1. Now when you open the website, dark mode will be turned on (light mode can be selected via navbar toggle)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
