### PR TITLE
fix(v2): inherit color for announcement bar close icon

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -22,6 +22,7 @@
   border: none;
   cursor: pointer;
   background: none;
+  color: inherit;
   height: 100%;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

On a recently added project in Showcase I noticed that the announcement bar close icon is hard to see when using a dark color, see an example below

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

https://graphql-inspector.com/docs/index

Before:

![image](https://user-images.githubusercontent.com/4408379/79221525-a6484080-7e5e-11ea-9fac-7a09fdaa0044.png)

After:

![image](https://user-images.githubusercontent.com/4408379/79221494-93ce0700-7e5e-11ea-9a97-a8d37e21c692.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
