### PR TITLE
refactor(v2): Expose docusaurus module type aliases to end-users

### DIFF
--- a/packages/docusaurus-module-type-aliases/package.json
+++ b/packages/docusaurus-module-type-aliases/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@docusaurus/module-type-aliases",
+  "version": "2.0.0-alpha.50",
+  "description": "Docusaurus module type aliases",
+  "types": "./src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
+}

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module '@generated/client-modules' {
+  const clientModules: readonly any[];
+  export default clientModules;
+}
+
+declare module '@generated/docusaurus.config' {
+  const config: any;
+  export default config;
+}
+
+declare module '@generated/registry' {
+  const registry: {
+    readonly [key: string]: [() => Promise<any>, string, string];
+  };
+  export default registry;
+}
+
+declare module '@generated/routes' {
+  type Route = {
+    readonly path: string;
+    readonly component: any;
+    readonly exact?: boolean;
+  };
+  const routes: Route[];
+  export default routes;
+}
+
+declare module '@generated/routesChunkNames' {
+  const routesChunkNames: any;
+  export default routesChunkNames;
+}
+
+declare module '@theme/*' {
+  const component: any;
+  export default component;
+}

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/facebook/docusaurus/issues"
   },
   "devDependencies": {
+    "@docusaurus/module-type-aliases": "^2.0.0-alpha.50",
     "@docusaurus/types": "^2.0.0-alpha.50"
   },
   "dependencies": {

--- a/packages/docusaurus/src/client/types.d.ts
+++ b/packages/docusaurus/src/client/types.d.ts
@@ -5,39 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-declare module '@generated/client-modules' {
-  const clientModules: readonly any[];
-  export default clientModules;
-}
-
-declare module '@generated/docusaurus.config' {
-  const config: any;
-  export default config;
-}
-
-declare module '@generated/registry' {
-  const registry: {
-    readonly [key: string]: [() => Promise<any>, string, string];
-  };
-  export default registry;
-}
-
-declare module '@generated/routes' {
-  type Route = {
-    readonly path: string;
-    readonly component: any;
-    readonly exact?: boolean;
-  };
-  const routes: Route[];
-  export default routes;
-}
-
-declare module '@generated/routesChunkNames' {
-  const routesChunkNames: any;
-  export default routesChunkNames;
-}
-
-declare module '@theme/*' {
-  const component: any;
-  export default component;
-}
+/// <reference types="@docusaurus/module-type-aliases" />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In #2578, I migrated all `@docusaurus/core` to TypeScript. During the migration, I have to declare modules to make TypeScript understand docusaurus-specific webpack aliases like `@generated` `@theme`. I put those declarations in a `types.d.ts` file inside `@docusaurus/core`.

In order to provide better TypeScript support for end-users, these aliases information also has to be available externally. TypeScript won't scan all `node_modules` to find this `types.d.ts`. Therefore, we need a way to tell to TypeScript to find the module declaration file.

My solution is to use the [`<reference types=... />` triple-slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-). I moved the module declaration to a new package `@docusaurus/module-type-aliases`, and put

```typescript
/// <reference types="@docusaurus/module-type-aliases" />
```

in place of the original `types.d.ts`.

Then once we published `@docusaurus/module-type-aliases`, An end-user can install it and add a file `docusaurus.d.ts` to their root with content `/// <reference types="@docusaurus/module-type-aliases" />`, then all the red-squiggly line under `@theme`, `@generated` will be gone! User doesn't need to go through the hack mentioned in https://github.com/facebook/docusaurus/pull/2578#issuecomment-613501680.

(This is the same approach taken by `create-teact-app`. It declares the css modules [here](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/lib/react-app.d.ts), and link it in package.json [here](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/package.json), and it will generate a `react-app-env.d.ts` with `/// <reference types="react-scripts" />` in user's project folder).

### Note

You might wonder why I didn't put the declarations in `@docusaurus/types`. In fact, this is the first thing I tried. However, it doesn't work well to mix module declaration and type definition together in one file, so I have to separate these two packages.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Everything still compiles and the preview site still works, which shows that this diff doesn't break anything.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
