### PR TITLE
feat(v2): add option to toggle sidebar category open by default

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-category.js
@@ -9,25 +9,30 @@ module.exports = {
   docs: [
     {
       type: 'category',
+      collapsed: true,
       label: 'level 1',
       items: [
         'a',
         {
           type: 'category',
+          collapsed: true,
           label: 'level 2',
           items: [
             {
               type: 'category',
+              collapsed: true,
               label: 'level 3',
               items: [
                 'c',
                 {
                   type: 'category',
+                  collapsed: true,
                   label: 'level 4',
                   items: [
                     'd',
                     {
                       type: 'category',
+                      collapsed: true,
                       label: 'deeper more more',
                       items: ['e'],
                     },

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed-first-level.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed-first-level.json
@@ -1,0 +1,20 @@
+{
+    "docs": [
+        {
+            "type": "category",
+            "label": "Introduction",
+            "items": [
+                "doc1"
+            ],
+            "collapsed": false
+        },
+        {
+            "type": "category",
+            "label": "Powering MDX",
+            "items": [
+                "doc2"
+            ],
+            "collapsed": false
+        }
+    ]
+}

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed.json
@@ -1,0 +1,21 @@
+{
+    "docs": {
+      "Test": [
+        {
+          "type": "category",
+          "label": "Introduction",
+          "items": ["doc1"],
+          "collapsed": false
+        }
+      ],
+      "Reference": [
+        {
+          "type": "category",
+          "label": "Powering MDX",
+          "items": ["doc2"],
+          "collapsed": false
+        }
+      ]
+    }
+  }
+  

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -4,6 +4,7 @@ exports[`simple website content 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "items": Array [
@@ -36,6 +37,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/hello",
@@ -200,6 +202,7 @@ exports[`versioned website content: all sidebars 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/next/foo/bar",
@@ -211,6 +214,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/next/hello",
@@ -224,6 +228,7 @@ Object {
   ],
   "version-1.0.0/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/1.0.0/foo/bar",
@@ -240,6 +245,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/1.0.0/hello",
@@ -253,6 +259,7 @@ Object {
   ],
   "version-1.0.1/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/foo/bar",
@@ -264,6 +271,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/hello",
@@ -283,6 +291,7 @@ Object {
   "docsSidebars": Object {
     "version-1.0.0/docs": Array [
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/1.0.0/foo/bar",
@@ -299,6 +308,7 @@ Object {
         "type": "category",
       },
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/1.0.0/hello",
@@ -325,6 +335,7 @@ Object {
   "docsSidebars": Object {
     "version-1.0.1/docs": Array [
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/foo/bar",
@@ -336,6 +347,7 @@ Object {
         "type": "category",
       },
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/hello",
@@ -361,6 +373,7 @@ Object {
   "docsSidebars": Object {
     "docs": Array [
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/next/foo/bar",
@@ -372,6 +385,7 @@ Object {
         "type": "category",
       },
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/next/hello",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -4,6 +4,7 @@ exports[`loadSidebars sidebars link 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "https://github.com",
@@ -172,6 +173,7 @@ exports[`loadSidebars sidebars with known sidebar item type 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "foo/bar",
@@ -195,6 +197,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "hello",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -18,6 +18,49 @@ Object {
 }
 `;
 
+exports[`loadSidebars sidebars with category.collapsed property 1`] = `
+Object {
+  "docs": Array [
+    Object {
+      "collapsed": true,
+      "items": Array [
+        Object {
+          "collapsed": false,
+          "items": Array [
+            Object {
+              "id": "doc1",
+              "type": "doc",
+            },
+          ],
+          "label": "Introduction",
+          "type": "category",
+        },
+      ],
+      "label": "Test",
+      "type": "category",
+    },
+    Object {
+      "collapsed": true,
+      "items": Array [
+        Object {
+          "collapsed": false,
+          "items": Array [
+            Object {
+              "id": "doc2",
+              "type": "doc",
+            },
+          ],
+          "label": "Powering MDX",
+          "type": "category",
+        },
+      ],
+      "label": "Reference",
+      "type": "category",
+    },
+  ],
+}
+`;
+
 exports[`loadSidebars sidebars with deep level of category 1`] = `
 Object {
   "docs": Array [

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -95,26 +95,31 @@ exports[`loadSidebars sidebars with deep level of category 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "a",
           "type": "doc",
         },
         Object {
+          "collapsed": true,
           "items": Array [
             Object {
+              "collapsed": true,
               "items": Array [
                 Object {
                   "id": "c",
                   "type": "doc",
                 },
                 Object {
+                  "collapsed": true,
                   "items": Array [
                     Object {
                       "id": "d",
                       "type": "doc",
                     },
                     Object {
+                      "collapsed": true,
                       "items": Array [
                         Object {
                           "id": "e",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -61,6 +61,35 @@ Object {
 }
 `;
 
+exports[`loadSidebars sidebars with category.collapsed property at first level 1`] = `
+Object {
+  "docs": Array [
+    Object {
+      "collapsed": false,
+      "items": Array [
+        Object {
+          "id": "doc1",
+          "type": "doc",
+        },
+      ],
+      "label": "Introduction",
+      "type": "category",
+    },
+    Object {
+      "collapsed": false,
+      "items": Array [
+        Object {
+          "id": "doc2",
+          "type": "doc",
+        },
+      ],
+      "label": "Powering MDX",
+      "type": "category",
+    },
+  ],
+}
+`;
+
 exports[`loadSidebars sidebars with deep level of category 1`] = `
 Object {
   "docs": Array [

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/version.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/version.test.ts.snap
@@ -4,6 +4,7 @@ exports[`docsVersion first time versioning 1`] = `
 Object {
   "version-1.0.0/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "items": Array [
@@ -33,6 +34,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "version-1.0.0/hello",
@@ -50,6 +52,7 @@ exports[`docsVersion not the first time versioning 1`] = `
 Object {
   "version-2.0.0/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "version-2.0.0/foo/bar",
@@ -60,6 +63,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "version-2.0.0/hello",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
@@ -126,4 +126,10 @@ describe('loadSidebars', () => {
     const result = loadSidebars(null);
     expect(result).toEqual({});
   });
+
+  test('sidebars with category.collapsed property', async () => {
+    const sidebarPath = path.join(fixtureDir, 'sidebars-collapsed.json');
+    const result = loadSidebars([sidebarPath]);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
@@ -132,4 +132,13 @@ describe('loadSidebars', () => {
     const result = loadSidebars([sidebarPath]);
     expect(result).toMatchSnapshot();
   });
+
+  test('sidebars with category.collapsed property at first level', async () => {
+    const sidebarPath = path.join(
+      fixtureDir,
+      'sidebars-collapsed-first-level.json',
+    );
+    const result = loadSidebars([sidebarPath]);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -33,6 +33,7 @@ function normalizeCategoryShorthand(
 ): SidebarItemCategoryRaw[] {
   return Object.entries(sidebar).map(([label, items]) => ({
     type: 'category',
+    collapsed: true,
     label,
     items,
   }));
@@ -56,7 +57,7 @@ function assertItem(item: Object, keys: string[]): void {
 }
 
 function assertIsCategory(item: any): asserts item is SidebarItemCategoryRaw {
-  assertItem(item, ['items', 'label']);
+  assertItem(item, ['items', 'label', 'collapsed']);
   if (typeof item.label !== 'string') {
     throw new Error(
       `Error loading ${JSON.stringify(item)}. "label" must be a string.`,
@@ -65,6 +66,12 @@ function assertIsCategory(item: any): asserts item is SidebarItemCategoryRaw {
   if (!Array.isArray(item.items)) {
     throw new Error(
       `Error loading ${JSON.stringify(item)}. "items" must be an array.`,
+    );
+  }
+  // "collapsed" is an optional property
+  if (item.hasOwnProperty('collapsed') && typeof item.collapsed !== 'boolean') {
+    throw new Error(
+      `Error loading ${JSON.stringify(item)}. "collapsed" must be a boolean.`,
     );
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -40,12 +40,14 @@ export interface SidebarItemCategory {
   type: 'category';
   label: string;
   items: SidebarItem[];
+  collapsed?: boolean;
 }
 
 export interface SidebarItemCategoryRaw {
   type: 'category';
   label: string;
   items: SidebarItemRaw[];
+  collapsed?: boolean;
 }
 
 export type SidebarItem =
@@ -81,6 +83,7 @@ export interface DocsSidebarItemCategory {
   type: 'category';
   label: string;
   items: DocsSidebarItem[];
+  collapsed?: boolean;
 }
 
 export type DocsSidebarItem = SidebarItemLink | DocsSidebarItemCategory;

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -101,8 +101,11 @@ function mutateSidebarCollapsingState(item, path) {
         items
           .map((childItem) => mutateSidebarCollapsingState(childItem, path))
           .filter((val) => val).length > 0;
-      // eslint-disable-next-line no-param-reassign
-      item.collapsed = !anyChildItemsActive;
+      // only modify item.collapsed if there are child items active and the category collapsed is set to true
+      if (anyChildItemsActive && item.collapsed) {
+        // eslint-disable-next-line no-param-reassign
+        item.collapsed = !anyChildItemsActive;
+      }
       return anyChildItemsActive;
     }
 

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -207,6 +207,7 @@ type SidebarItemCategory = {
   type: 'category';
   label: string; // Sidebar label text.
   items: SidebarItem[]; // Array of sidebar items.
+  collapsed: boolean; // Set the category to be collapsed or open by default
 };
 ```
 


### PR DESCRIPTION
This PR adds the ability to toggle sidebar categories open by default.

## Changes
- update sidebar category to take collapsed prop 
- add extra sidebars collapsed test
- only mutate `item.collapsed` if necessary
- update docs for SidebarItemCategory

## Motivation

Fixes #2354 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I wrote extensive notes on the issue: https://github.com/facebook/docusaurus/issues/2354

Here's how I tested my changes:
1. Built project: `yarn build`
2. Published to `verdaccio` locally: `yarn lerna publish --registry http://localhost:4873 --no-git-tag-version` 
3. Created a new website: 
```shell
# set the registry to verdaccio
npm set registry http://localhost:4873/
# install @docusaurus/init globally
npm i -g @docusaurus/init
# run the binary from the location directly
/Users/jprevite/.nvm/versions/node/v10.15.1/lib/node_modules/@docusaurus/init/bin/index.js init test-joe
```
4. Modified the `sidebars.js` file:
```js
module.exports = {
  someSidebar: 
     [
      {
        "type": "category",
        "label": "Introduction",
        "items": ["doc1"],
        "collapsed": true
      },
      {
        "type": "category",
        "label": "Powering MDX",
        "items": ["doc2"],
        "collapsed": false
      }
    ]
  }
```
5. Tested if changes worked (and they did 🎉). You can tell because "Powering MDX" is **not collapsed** (because it's set to `false` in the `sidebars.js` file. 
![image](https://user-images.githubusercontent.com/3806031/79397442-f690d280-7f32-11ea-9df7-d5e52dd4da7d.png)

## Screenshots

Here are a few other screenshots of it in action:

### Before

This is what happens before I made any changes. (note: I load the page, "Powering MDX" is collapsed). 

![2020-04-15 13 27 25](https://user-images.githubusercontent.com/3806031/79388145-b07f4300-7f21-11ea-96a2-395410a3725f.gif)

### After

I made the change and now it loads and is expanded (not collapsed) like I want! 

![2020-04-15 14 02 17](https://user-images.githubusercontent.com/3806031/79388175-bd9c3200-7f21-11ea-9e85-24dcb85d8896.gif)

And, if I'm on the "Powering MDX", it should be expanded (because it's the current page), which still works as expected.

![2020-04-15 14 02 53](https://user-images.githubusercontent.com/3806031/79388270-e45a6880-7f21-11ea-972c-58a3ead8c210.gif)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
