### PR TITLE
fix(v2): don't include 404 page in sitemaps

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -30,7 +30,22 @@ describe('createSitemap', () => {
     expect(() => {
       createSitemap({} as any, [], {} as any);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Url in docusaurus.config.js cannot be empty/undefined"`,
+      `"url in docusaurus.config.js cannot be empty/undefined"`,
     );
+  });
+
+  test('exclusion of 404 page', () => {
+    const sitemap = createSitemap(
+      {
+        url: 'https://example.com',
+      } as DocusaurusConfig,
+      ['/', '/404', '/mypage'],
+      {
+        cacheTime: 600,
+        changefreq: 'daily',
+        priority: 0.7,
+      },
+    );
+    expect(sitemap.toString()).not.toContain('404');
   });
 });

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -39,7 +39,7 @@ describe('createSitemap', () => {
       {
         url: 'https://example.com',
       } as DocusaurusConfig,
-      ['/', '/404', '/mypage'],
+      ['/', '/404.html', '/mypage'],
       {
         cacheTime: 600,
         changefreq: 'daily',

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -16,10 +16,18 @@ export default function createSitemap(
 ) {
   const {url: hostname} = siteConfig;
   if (!hostname) {
-    throw new Error('Url in docusaurus.config.js cannot be empty/undefined');
+    throw new Error('url in docusaurus.config.js cannot be empty/undefined');
   }
 
-  const urls = routesPaths.map(
+  let finalizedRoutesPaths: string[] = [];
+  // filter through routes to exclude the 404 page
+  routesPaths.forEach((route: string) => {
+    if (route.indexOf('404') === -1) {
+      finalizedRoutesPaths.push(route);
+    }
+  });
+
+  const urls = finalizedRoutesPaths.map(
     (routesPath) =>
       ({
         url: routesPath,

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -19,22 +19,16 @@ export default function createSitemap(
     throw new Error('url in docusaurus.config.js cannot be empty/undefined');
   }
 
-  let finalizedRoutesPaths: string[] = [];
-  // filter through routes to exclude the 404 page
-  routesPaths.forEach((route: string) => {
-    if (route.indexOf('404') === -1) {
-      finalizedRoutesPaths.push(route);
-    }
-  });
-
-  const urls = finalizedRoutesPaths.map(
-    (routesPath) =>
-      ({
-        url: routesPath,
-        changefreq: options.changefreq,
-        priority: options.priority,
-      } as SitemapItemOptions),
-  );
+  const urls = routesPaths
+    .filter((route: string) => route !== '/404.html')
+    .map(
+      (routesPath) =>
+        ({
+          url: routesPath,
+          changefreq: options.changefreq,
+          priority: options.priority,
+        } as SitemapItemOptions),
+    );
 
   return sitemap.createSitemap({
     hostname,

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -20,7 +20,7 @@ export default function createSitemap(
   }
 
   const urls = routesPaths
-    .filter((route: string) => route !== '/404.html')
+    .filter((route: string) => !route.endsWith('404.html'))
     .map(
       (routesPath) =>
         ({


### PR DESCRIPTION
Signed-off-by: Reece Dunham <me@rdil.rocks>

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #2605

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I added a test to Jest to make sure this works.

In addition, you can also look at the sitemap on v2.docusaurus.io vs the deploy preview.  