### PR TITLE
fix: MDX transclusion from outside `docs/`

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -444,7 +444,11 @@ export default function pluginContentDocs(
             // Allow imports from outside `docs/`, e.g. `../CODE_OF_CONDUCT.md`
             {
               test: /(\.mdx?)$/,
-              exclude: [docsDir, versionedDir].filter(Boolean),
+              exclude: [
+                docsDir,
+                versionedDir,
+                /\.\.\/.+\//, // Any directory (but not file) inside parent dirs
+              ].filter(Boolean),
               use: [
                 getCacheLoader(isServer),
                 getBabelLoader(isServer),

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -440,6 +440,23 @@ export default function pluginContentDocs(
                 },
               ].filter(Boolean),
             },
+
+            // Allow imports from outside `docs/`, e.g. `../CODE_OF_CONDUCT.md`
+            {
+              test: /(\.mdx?)$/,
+              exclude: [docsDir, versionedDir].filter(Boolean),
+              use: [
+                getCacheLoader(isServer),
+                getBabelLoader(isServer),
+                {
+                  loader: '@docusaurus/mdx-loader',
+                  options: {
+                    remarkPlugins,
+                    rehypePlugins,
+                  },
+                },
+              ].filter(Boolean),
+            },
           ],
         },
       } as Configuration;

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -443,12 +443,8 @@ export default function pluginContentDocs(
 
             // Allow imports from outside `docs/`, e.g. `../CODE_OF_CONDUCT.md`
             {
-              test: /(\.mdx?)$/,
-              exclude: [
-                docsDir,
-                versionedDir,
-                /\.\.\/.+\//, // Any directory (but not file) inside parent dirs
-              ].filter(Boolean),
+              test: /^(..\/)+[^/]+(\.mdx?)$/, // Files inside immediate parents
+              exclude: [docsDir, versionedDir].filter(Boolean),
               use: [
                 getCacheLoader(isServer),
                 getBabelLoader(isServer),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make it possible to import `.md(x)` files from outside `website/docs/`. This can be used for referencing files like `../CONTRIBUTING.md` and `../CODE_OF_CONDUCT.md`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Related issue

Partial fix for #2618.
