### PR TITLE
feat: configurable title template

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -24,12 +24,16 @@ function Layout(props) {
   const {
     favicon,
     title: siteTitle,
-    themeConfig: {image: defaultImage},
+    themeConfig: {
+      image: defaultImage,
+      titleTemplate: defaultTitleTemplate = '%pageTitle | %siteTitle',
+    },
     url: siteUrl,
   } = siteConfig;
   const {
     children,
     title,
+    titleTemplate,
     noFooter,
     description,
     image,
@@ -37,7 +41,11 @@ function Layout(props) {
     permalink,
     version,
   } = props;
-  const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
+  const metaTitle = title
+    ? (titleTemplate || defaultTitleTemplate)
+        .replace(/%pageTitle/g, title)
+        .replace(/%siteTitle/g, siteTitle)
+    : siteTitle;
 
   const metaImage = image || defaultImage;
   let metaImageUrl = siteUrl + useBaseUrl(metaImage);

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -61,6 +61,37 @@ module.exports = {
 };
 ```
 
+### Custom title template
+
+The default title template (`'%pageTitle | %siteTitle'`) can be customized in the theme for the entire website:
+
+```js {4} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  themeConfig: {
+    // Defaults to `%pageTitle | %siteTitle`
+    titleTemplate: '%pageTitle • %siteTitle',
+    // ...
+  },
+};
+```
+
+It can also be overridden on a per-page basis. For instance, the site's title may be shown first on the home page:
+
+```jsx {7} title="src/pages/index.jsx"
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export default function HomePage() {
+  const {siteConfig} = useDocusaurusContext();
+
+  return (
+    <Layout titleTemplate="%siteTitle - %pageTitle" title={siteConfig.tagline}>
+      {/* ... */}
+    </Layout>
+  );
+}
+```
+
 ## Hooks
 
 ### `useThemeContext`


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Projects like [React](https://reactjs.org/) put emphasis on the site's title rather than the page title (e.g. tagline) on their home page:

![Comparing the title of the React docs' home page and 'Getting Started' page](https://user-images.githubusercontent.com/14854048/79597666-fcc5b100-80e2-11ea-9c1b-4a8a1917d517.gif)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I verified the changes manually by following the instructions as written in this PR's documentation update.
