### PR TITLE
fix(v2): disable tab focus on collapsed doc sidebar items

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -17,7 +17,7 @@ import styles from './styles.module.css';
 
 const MOBILE_TOGGLE_SIZE = 24;
 
-function DocSidebarItem({item, onItemClick, collapsible}) {
+function DocSidebarItem({item, onItemClick, collapsible, ...props}) {
   const {items, href, label, type} = item;
   const [collapsed, setCollapsed] = useState(item.collapsed);
   const [prevCollapsedProp, setPreviousCollapsedProp] = useState(null);
@@ -50,12 +50,14 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
                 'menu__link--active': collapsible && !item.collapsed,
               })}
               href="#!"
-              onClick={collapsible ? handleItemClick : undefined}>
+              onClick={collapsible ? handleItemClick : undefined}
+              {...props}>
               {label}
             </a>
             <ul className="menu__list">
               {items.map((childItem) => (
                 <DocSidebarItem
+                  tabIndex={collapsed ? '-1' : '0'}
                   key={childItem.label}
                   item={childItem}
                   onItemClick={onItemClick}
@@ -84,7 +86,8 @@ function DocSidebarItem({item, onItemClick, collapsible}) {
               : {
                   target: '_blank',
                   rel: 'noreferrer noopener',
-                })}>
+                })}
+            {...props}>
             {label}
           </Link>
         </li>
@@ -153,7 +156,11 @@ function DocSidebar(props) {
   return (
     <div className={styles.sidebar}>
       {hideOnScroll && (
-        <Link className={styles.sidebarLogo} to={logoLink} {...logoLinkProps}>
+        <Link
+          tabIndex="-1"
+          className={styles.sidebarLogo}
+          to={logoLink}
+          {...logoLinkProps}>
           {logoImageUrl != null && (
             <img key={isClient} src={logoImageUrl} alt={logoAlt} />
           )}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently tabbing on hidden (collapsed) doc sidebar items is allowed, which makes it difficult to navigate from the keyboard (see video below).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before:

![screencast-v2 docusaurus io-2020 04 18-16_33_41](https://user-images.githubusercontent.com/4408379/79639286-9ba9e600-8193-11ea-8905-4ca609f74767.gif)

After:

![screencast-localhost_3000-2020 04 18-16_36_26](https://user-images.githubusercontent.com/4408379/79639287-9ea4d680-8193-11ea-936d-368acd5ba78e.gif)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
