### PR TITLE
fix(v2): make border right of doc sidebar equals doc page

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -14,7 +14,7 @@
   box-sizing: border-box;
   width: 300px;
   position: relative;
-  top: calc(-1 * var(--ifm-navbar-height));
+  margin-top: calc(-1 * var(--ifm-navbar-height));
 }
 
 .docMainContainer {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently the border right of doc sidebar is not stretch to the full height of the column, this PR fixes this.

![image](https://user-images.githubusercontent.com/4408379/79641068-e0d31580-819d-11ea-9b94-86b962682fc1.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

![image](https://user-images.githubusercontent.com/4408379/79641130-34456380-819e-11ea-960f-9fca298a5bdc.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
