### PR TITLE
refactor(v2): extract scroll position detection into separate hook

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useState, useEffect} from 'react';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+const getScrollPosition = () => ({
+  scrollX: ExecutionEnvironment.canUseDOM ? window.pageXOffset : 0,
+  scrollY: ExecutionEnvironment.canUseDOM ? window.pageYOffset : 0,
+});
+
+const useScrollPosition = (effect, deps = []) => {
+  const [scrollPosition, setScrollPosition] = useState(getScrollPosition());
+
+  const handleScroll = () => {
+    const currentScrollPosition = getScrollPosition();
+
+    setScrollPosition(currentScrollPosition);
+
+    if (effect) {
+      effect(currentScrollPosition);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () =>
+      window.removeEventListener('scroll', handleScroll, {
+        passive: true,
+      });
+  }, deps);
+
+  return scrollPosition;
+};
+
+export default useScrollPosition;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

We definitely need a separate hook for scroll position, because in the future it will be used repeatedly.

FYI I'm trying to solve one bug right now, and seems needs a new scroll event there.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
