### PR TITLE
feat(v2): add CLI option for polling

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -60,6 +60,7 @@ export interface StartCLIOptions {
   host: string;
   hotOnly: boolean;
   open: boolean;
+  poll: boolean;
 }
 
 export interface BuildCLIOptions {

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -87,7 +87,7 @@ cli
   .option('--no-open', 'Do not open page in the browser (default: false)')
   .option(
     '--poll',
-    'Use polling rather than wathcing for reload (default: false)',
+    'Use polling rather than watching for reload (default: false)',
   )
   .action((siteDir = '.', {port, host, hotOnly, open, poll}) => {
     wrapCommand(start)(path.resolve(siteDir), {

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -85,12 +85,17 @@ cli
     'Do not fallback to page refresh if hot reload fails (default: false)',
   )
   .option('--no-open', 'Do not open page in the browser (default: false)')
-  .action((siteDir = '.', {port, host, hotOnly, open}) => {
+  .option(
+    '--poll',
+    'Use polling rather than wathcing for reload (default: false)',
+  )
+  .action((siteDir = '.', {port, host, hotOnly, open, poll}) => {
     wrapCommand(start)(path.resolve(siteDir), {
       port,
       host,
       hotOnly,
       open,
+      poll,
     });
   });
 

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -141,6 +141,7 @@ export async function start(
     publicPath: baseUrl,
     watchOptions: {
       ignored: /node_modules/,
+      poll: cliOptions.poll,
     },
     historyApiFallback: {
       rewrites: [{from: /\/*/, to: baseUrl}],

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -48,7 +48,7 @@ Builds and serves a preview of your site locally with [Webpack Dev Server](https
 | `--host` | `localhost` | Specify a host to use. E.g., if you want your server to be accessible externally, you can use `--host 0.0.0.0` |
 | `--hot-only` | `false` | Enables Hot Module Replacement without page refresh as fallback in case of build failures. More information [here](https://webpack.js.org/configuration/dev-server/#devserverhotonly). |
 | `--no-open` | `false` | Do not open automatically the page in the browser. |
-| `--poll` | `false` | Use polling of files rather than watching for live reload as a fallback in enviroments where watching doesn't work. More information [here](https://webpack.js.org/configuration/watch/#watchoptionspoll). |
+| `--poll` | `false` | Use polling of files rather than watching for live reload as a fallback in environments where watching doesn't work. More information [here](https://webpack.js.org/configuration/watch/#watchoptionspoll). |
 
 :::important
 

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -48,6 +48,7 @@ Builds and serves a preview of your site locally with [Webpack Dev Server](https
 | `--host` | `localhost` | Specify a host to use. E.g., if you want your server to be accessible externally, you can use `--host 0.0.0.0` |
 | `--hot-only` | `false` | Enables Hot Module Replacement without page refresh as fallback in case of build failures. More information [here](https://webpack.js.org/configuration/dev-server/#devserverhotonly). |
 | `--no-open` | `false` | Do not open automatically the page in the browser. |
+| `--poll` | `false` | Use polling of files rather than watching for live reload as a fallback in enviroments where watching doesn't work. More information [here](https://webpack.js.org/configuration/watch/#watchoptionspoll). |
 
 :::important
 


### PR DESCRIPTION
## Motivation

I've been working with a project that likes to have repos contain VS Code devcontainers so that you can simply open the repo in VS code, load up a configured Docker container and away you go. I have this working 99 % with our Docusaurus 2 repos but live reloading does not work use the `fsevents` and `inotify` methods used to watch for file changes in this case.  [Webpack Dev Server provides a polling alternative](https://webpack.js.org/configuration/watch/#watchoptionspoll) option for this and it is noted that this is recommended for such environments. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

-   Run this repository following the standard instruction set [here](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#installation).
-   Build the website with standard `yarn start` to check works with no flag provide. Make some minor edits and check there is an instant reload. It does ✔
-   Build the website with `yarn start --poll` which uses the newly add `--poll` option to set `watchOptions.poll` to `true`. Make some minor edits and see a reload after a small delay from the 1 s polling time. It does ✔
## Related PRs

Docs are (I think) updated correctly. I could not quite ascertain the convention for adding to the changelog so I'm guessing that that is done at release?
