### PR TITLE
fix(v2): hide doc sidebar on mobiles

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -25,4 +25,8 @@
   .docPage {
     display: inherit;
   }
+
+  .docSidebarContainer {
+    display: none;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It really came as a result of tiny refactoring #2595. 

Although I would still notice this bug before the new release, so no reason for concern :ok_hand:.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/79703823-c80a5300-82b6-11ea-9037-8f3d454ce62a.png) | ![image](https://user-images.githubusercontent.com/4408379/79703830-d5bfd880-82b6-11ea-9d5c-d5ee123425d5.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
