### PR TITLE
chore(v2): add Privacy Policy and Terms of Use links to footer

### DIFF
--- a/packages/docusaurus-init/templates/bootstrap/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/bootstrap/docusaurus.config.js
@@ -35,18 +35,22 @@ module.exports = {
               label: 'Discord',
               href: 'https://discordapp.com/invite/docusaurus',
             },
-          ],
-        },
-        {
-          title: 'Social',
-          items: [
-            {
-              label: 'GitHub',
-              href: 'https://github.com/facebook/docusaurus',
-            },
             {
               label: 'Twitter',
               href: 'https://twitter.com/docusaurus',
+            },
+          ],
+        },
+        {
+          title: 'More',
+          items: [
+            {
+              label: 'Blog',
+              to: 'blog',
+            },
+            {
+              label: 'GitHub',
+              href: 'https://github.com/facebook/docusaurus',
             },
           ],
         },

--- a/packages/docusaurus-init/templates/classic/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/classic/docusaurus.config.js
@@ -55,10 +55,14 @@ module.exports = {
               label: 'Discord',
               href: 'https://discordapp.com/invite/docusaurus',
             },
+            {
+              label: 'Twitter',
+              href: 'https://twitter.com/docusaurus',
+            },
           ],
         },
         {
-          title: 'Social',
+          title: 'More',
           items: [
             {
               label: 'Blog',
@@ -67,10 +71,6 @@ module.exports = {
             {
               label: 'GitHub',
               href: 'https://github.com/facebook/docusaurus',
-            },
-            {
-              label: 'Twitter',
-              href: 'https://twitter.com/docusaurus',
             },
           ],
         },

--- a/packages/docusaurus-init/templates/facebook/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/facebook/docusaurus.config.js
@@ -93,8 +93,8 @@ module.exports = {
       // Please do not remove the privacy and terms, it's a legal requirement.
       copyright:
         `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus. ` +
-        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy Policy</a> and ` +
-        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms of Use</a>.`,
+        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy</a> and ` +
+        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms</a>.`,
     },
   },
   presets: [

--- a/packages/docusaurus-init/templates/facebook/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/facebook/docusaurus.config.js
@@ -42,7 +42,7 @@ module.exports = {
       style: 'dark',
       links: [
         {
-          title: 'Docs',
+          title: 'Learn',
           items: [
             {
               label: 'Style Guide',
@@ -62,13 +62,17 @@ module.exports = {
               href: 'https://stackoverflow.com/questions/tagged/docusaurus',
             },
             {
+              label: 'Twitter',
+              href: 'https://twitter.com/docusaurus',
+            },
+            {
               label: 'Discord',
               href: 'https://discordapp.com/invite/docusaurus',
             },
           ],
         },
         {
-          title: 'Social',
+          title: 'More',
           items: [
             {
               label: 'Blog',
@@ -78,9 +82,23 @@ module.exports = {
               label: 'GitHub',
               href: 'https://github.com/facebook/docusaurus',
             },
+          ],
+        },
+        {
+          title: 'Legal',
+          // Please do not remove the privacy and terms, it's a legal requirement.
+          items: [
             {
-              label: 'Twitter',
-              href: 'https://twitter.com/docusaurus',
+              label: 'Privacy',
+              href: 'https://opensource.facebook.com/legal/privacy/',
+              target: '_blank',
+              rel: 'noreferrer noopener',
+            },
+            {
+              label: 'Terms',
+              href: 'https://opensource.facebook.com/legal/terms/',
+              target: '_blank',
+              rel: 'noreferrer noopener',
             },
           ],
         },
@@ -88,13 +106,10 @@ module.exports = {
       logo: {
         alt: 'Facebook Open Source Logo',
         src: 'img/oss_logo.png',
-        href: 'https://opensource.facebook.com/',
+        href: 'https://opensource.facebook.com',
       },
-      // Please do not remove the privacy and terms, it's a legal requirement.
-      copyright:
-        `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus. ` +
-        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy</a> and ` +
-        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms</a>.`,
+      // Please do not remove the credits, help to publicize Docusaurus :)
+      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
     },
   },
   presets: [

--- a/packages/docusaurus-init/templates/facebook/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/facebook/docusaurus.config.js
@@ -90,8 +90,11 @@ module.exports = {
         src: 'img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      // Please do not remove the credits, help to publicize Docusaurus :)
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
+      // Please do not remove the privacy and terms, it's a legal requirement.
+      copyright:
+        `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus. ` +
+        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy Policy</a> and ` +
+        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms of Use</a>.`,
     },
   },
   presets: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -129,7 +129,7 @@ module.exports = {
       style: 'dark',
       links: [
         {
-          title: 'Docs',
+          title: 'Learn',
           items: [
             {
               label: 'Introduction',
@@ -190,16 +190,32 @@ module.exports = {
             },
           ],
         },
+        {
+          title: 'Legal',
+          // Please do not remove the privacy and terms, it's a legal requirement.
+          items: [
+            {
+              label: 'Privacy',
+              href: 'https://opensource.facebook.com/legal/privacy/',
+              target: '_blank',
+              rel: 'noreferrer noopener',
+            },
+            {
+              label: 'Terms',
+              href: 'https://opensource.facebook.com/legal/terms/',
+              target: '_blank',
+              rel: 'noreferrer noopener',
+            },
+          ],
+        },
       ],
       logo: {
         alt: 'Facebook Open Source Logo',
         src: 'https://docusaurus.io/img/oss_logo.png',
-        href: 'https://opensource.facebook.com/',
+        href: 'https://opensource.facebook.com',
       },
       copyright:
-        `Copyright © ${new Date().getFullYear()} Facebook, Inc. ` +
-        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy</a> and ` +
-        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms</a>.`,
+        'Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.',
     },
   },
 };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -196,7 +196,10 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+      copyright:
+        `Copyright © ${new Date().getFullYear()} Facebook, Inc. ` +
+        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy Policy</a> and ` +
+        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms of Use</a>.`,
     },
   },
 };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -198,8 +198,8 @@ module.exports = {
       },
       copyright:
         `Copyright © ${new Date().getFullYear()} Facebook, Inc. ` +
-        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy Policy</a> and ` +
-        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms of Use</a>.`,
+        `<a href="https://opensource.facebook.com/legal/privacy/" target="_blank">Privacy</a> and ` +
+        `<a href="https://opensource.facebook.com/legal/terms/" target="_blank">Terms</a>.`,
     },
   },
 };


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It's now a legal requirement for Facebook's OSS sites to link to our [Privacy Policy](https://opensource.facebook.com/legal/privacy/) and [Terms of Use](https://opensource.facebook.com/legal/terms/).

Hence adding it to our website footer and our template. Will send follow-up PR to update V1 website.

P.S. Thanks @lex111 for allowing HTML for copyright field, came in really handy here.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

<img width="1552" alt="Screen Shot 2020-04-22 at 3 05 10 AM" src="https://user-images.githubusercontent.com/1315101/79904132-ca031c00-8446-11ea-83c6-bb88d9b085e4.png">
<img width="1408" alt="Screen Shot 2020-04-22 at 3 04 29 AM" src="https://user-images.githubusercontent.com/1315101/79904139-cec7d000-8446-11ea-91b5-7874104916c6.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
