### PR TITLE
fix(v2): hide sidebar after click on child item

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -91,7 +91,11 @@ function MobileNavItem({items, ...props}) {
       <ul className="menu__list">
         {items.map((linkItemInner, i) => (
           <li className="menu__list-item" key={i}>
-            <NavLink className="menu__link" {...linkItemInner} />
+            <NavLink
+              className="menu__link"
+              {...linkItemInner}
+              onClick={props.onClick}
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2647

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

_Test on v2 website_

1. In config file add a new new child item of nav that belongs to the same sidebar, for example:

```js
    navbar: {
    // ...
      links: [
        {
          label: 'Docs',
          items: [
            {
              label: 'First item',
              to: 'docs/design-principles',
            },
            {
              label: 'Second item',
              to: 'docs/introduction',
            },
```

1. Run dev server

1. Click alternately on the first and second items - the sidebar should close.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
