### PR TITLE
[v2] docs: remove app id from algolia config example

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.50/search.md
+++ b/website/versioned_docs/version-2.0.0-alpha.50/search.md
@@ -22,7 +22,6 @@ To connect your docs with Algolia, add an `algolia` field in your `themeConfig`.
 themeConfig: {
     // ...
     algolia: {
-      appId: 'app-id',
       apiKey: 'api-key',
       indexName: 'index-name',
       algoliaOptions: {}, // Optional, if provided by Algolia


### PR DESCRIPTION
## Motivation

I was approved for DocSearch by Algolia and they provided my api key and index name, but not app id.

I mentioned to the engineer there, who responded that 

> You should not precise the appID as it is BH4.... by default

So I figured it made sense to remove the value from the docs so folks dont go searching for the value like i did

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes, and my commit message is not up to snuff 😞 

## Test Plan

Docs change, I verified that removing the app id from algolia config still works

TBH I didn't really look into the config stuff itself, seems like it still needs to be a valid field in case you're using your own algolia app / index / etc?
