### PR TITLE
feat(v2): add fallback to BrowserOnly component

### DIFF
--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -8,10 +8,12 @@
 import React from 'react';
 import ExecutionEnvironment from './ExecutionEnvironment';
 
-function BrowserOnly({children}) {
-  return (
-    ExecutionEnvironment.canUseDOM && children != null && <>{children()}</>
-  );
+function BrowserOnly({children, fallback}) {
+  if (ExecutionEnvironment.canUseDOM && children != null) {
+    return <>{children()}</>;
+  }
+
+  return fallback || null;
 }
 
 export default BrowserOnly;

--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -9,11 +9,11 @@ import React from 'react';
 import ExecutionEnvironment from './ExecutionEnvironment';
 
 function BrowserOnly({children, fallback}) {
-  if (ExecutionEnvironment.canUseDOM && children != null) {
-    return <>{children()}</>;
+  if (!ExecutionEnvironment.canUseDOM || children == null) {  
+    return fallback || null;
   }
-
-  return fallback || null;
+  
+  return <>{children()}</>;
 }
 
 export default BrowserOnly;

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -105,14 +105,15 @@ function Home() {
 
 ### `<BrowserOnly/>`
 
-The `<BrowserOnly>` component accepts a `children` prop, a render function which will not be executed during the pre-rendering phase of the build process. This is useful for hiding code that is only meant to run in the browsers (e.g. where the `window`/`document` objects are being accessed). To improve SEO, with `fallback` prop you can also provide fallback content which will be displayed until the component is rendered on client-side.
+The `<BrowserOnly>` component accepts a `children` prop, a render function which will not be executed during the pre-rendering phase of the build process. This is useful for hiding code that is only meant to run in the browsers (e.g. where the `window`/`document` objects are being accessed). To improve SEO, you can also provide fallback content using the `fallback` prop, which will be prerendered until in the build process and replaced with the client-side only contents when viewed in the browser.
 
 ```jsx
 import BrowserOnly from '@docusaurus/BrowserOnly';
 
 function MyComponent() {
   return (
-    <BrowserOnly fallback="The fallback content to display on prerendering">
+    <BrowserOnly
+      fallback={<div>The fallback content to display on prerendering</div>}>
       {() => {
         // Something that should be excluded during build process prerendering.
       }}

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -105,14 +105,14 @@ function Home() {
 
 ### `<BrowserOnly/>`
 
-The `<BrowserOnly>` component accepts a `children` prop, a render function which will not be executed during the pre-rendering phase of the build process. This is useful for hiding code that is only meant to run in the browsers (e.g. where the `window`/`document` objects are being accessed).
+The `<BrowserOnly>` component accepts a `children` prop, a render function which will not be executed during the pre-rendering phase of the build process. This is useful for hiding code that is only meant to run in the browsers (e.g. where the `window`/`document` objects are being accessed). To improve SEO, with `fallback` prop you can also provide fallback content which will be displayed until the component is rendered on client-side.
 
 ```jsx
 import BrowserOnly from '@docusaurus/BrowserOnly';
 
 function MyComponent() {
   return (
-    <BrowserOnly>
+    <BrowserOnly fallback="The fallback content to display on prerendering">
       {() => {
         // Something that should be excluded during build process prerendering.
       }}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2573

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Put any target content in `BrowserOnly` component (eg. on `index` page at `src/pages/index.js`):

```
<BrowserOnly fallback="Fallback content">
    {() => (
        <p>Target content</p>
    )}
</BrowserOnly>
```

1. Build the website running `yarn build` command. Then find substring of "Fallback content" in generated file in which the `BrowserOnly` component was used (eg. `build/index.html`)

1. Serve website built via the npm [serve](https://www.npmjs.com/package/serve) package (`serve build`) to make sure that target content is displayed in the web browser.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
