### PR TITLE
docs: add deployment workflow manual for GitHub Actions

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.50/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.50/deployment.md
@@ -82,6 +82,80 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 ```batch
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
+### Triggering deployment with GitHub Actions
+[GitHub Actions](https://help.github.com/en/actions ) allow you to automate, customize, and execute your software
+development workflows right in your repository.
+This workflow assumes your documentation resided in `documentation` branch of your repository and your [publishing source](https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
+is configured for `gh-pages` branch.
+
+1. Generate a new [SSH
+   key](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+2. By default, your public key should have been created in `~/.ssh/id_rsa.pub` or use the name you've provided in the
+   previous step to add your key to [GitHub Deploy keys](https://developer.github.com/v3/guides/managing-deploy-keys/)
+3. Copy key to clipboard with `xclip -sel clip < ~/.ssh/id_rsa.pub` and paste it as a [deploy
+   key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys ) in your repository. Copy file content if the command line doesn't work for you. Check the box for `Allow write access` before saving your deployment key.
+4. You'll need your private key as a [GitHub
+   secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) to allow Docusaurus to run the deployment for you.
+5. Copy your private key with `xclip -sel clip < ~/.ssh/id_rsa` and paste a GitHub secret with name
+   `GH_PAGES_DEPLOY`. Copy file content if the command line doesn't work for you. Save your secret.
+6. Create you [documentation workflow
+   file](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#creating-a-workflow-file)
+   in `.github/workflows/`. In this example it's `documentation.yml`.
+```yaml title="documentation.yml"
+name: documentation
+
+on:
+  pull_request:
+    branches: [documentation]
+  push:
+    branches: [documentation]
+
+jobs:
+ checks:
+   if: github.event_name != 'push'
+   runs-on: ubuntu-latest
+   steps:
+     - uses: actions/checkout@v1
+     - uses: actions/setup-node@v1
+       with:
+         node-version: '12.x'
+         run: |
+          npm ci
+          npm run build
+ gh-release:
+   if: github.event_name != 'pull_request'
+   runs-on: ubuntu-latest
+   steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: Add key to allow access to repository
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+        mkdir -p ~/.ssh
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        echo "${{ secrets.GH_PAGES_DEPLOY }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        cat <<EOT >> ~/.ssh/config
+        Host github.com
+        HostName github.com
+        IdentityFile ~/.ssh/id_rsa
+        EOT
+    - name: Release to GitHub Pages
+      env:
+        USE_SSH: true
+        GIT_USER: git
+      run: |
+        git config --global user.email "actions@gihub.com"
+        git config --global user.name "gh-actions"
+        npm ci
+        npx docusaurus deploy
+```
+8. Now when a new `pull-request` arrives towards your repository in branch `documentation` it will automatically ensure that Docusaurus build is successful.
+9. When `pull-request` is merged to `documentation` branch or someone pushes to `documentation` branch directly it will be built and deployed to `gh-pages` branch.
+10. After this step, your updated documentation will be available on the GitHub pages.
 
 ### Triggering deployment with Travis CI
 


### PR DESCRIPTION
I built a workflow to deploy docs for our project with GitHub Actions. After testing it on our repository I'm happy to share it with other Docusaurus users.

## Motivation
I haven't found nice docs on deploying Docusaurus with GitHub Actions. I spent quite some time to test out such a deployment for our project. I think it's a popular deployment option and other Docusaurus users will benefit from it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes, I did.

## Test Plan

These PR contributes only to documentations. I verified everything step by step in my project's repository which lead to successful deployment of documentation to GH Pages.
Here's green pipeline screenshot:
![image](https://user-images.githubusercontent.com/10460752/80315452-ecef5080-87f7-11ea-81a9-091826d23e4e.png)
Here's a result hosted on GH pages:
![image](https://user-images.githubusercontent.com/10460752/80315558-97677380-87f8-11ea-9505-b81474fcdf7b.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
