### PR TITLE
fix(v2): add a11y support for dropdown

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -25,7 +25,6 @@ function NavLink({
   to,
   href,
   label,
-  position,
   activeClassName = 'navbar__link--active',
   ...props
 }) {
@@ -58,11 +57,14 @@ function NavLink({
 }
 
 function NavItem({items, position, className, ...props}) {
-  const navLinkClassNames = (extraClassName, isDropdownItem) =>
-    classnames(extraClassName, {
-      'navbar__item navbar__link': !isDropdownItem,
-      dropdown__link: isDropdownItem,
-    });
+  const navLinkClassNames = (extraClassName, isDropdownItem = false) =>
+    classnames(
+      {
+        'navbar__item navbar__link': !isDropdownItem,
+        dropdown__link: isDropdownItem,
+      },
+      extraClassName,
+    );
 
   if (!items) {
     return <NavLink className={navLinkClassNames(className)} {...props} />;
@@ -74,21 +76,27 @@ function NavItem({items, position, className, ...props}) {
         'dropdown--left': position === 'left',
         'dropdown--right': position === 'right',
       })}>
-      <NavLink className={navLinkClassNames(className)} {...props}>
+      <NavLink
+        className={navLinkClassNames(className)}
+        {...props}
+        onClick={(e) => e.preventDefault()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.target.parentNode.classList.toggle('dropdown--show');
+          }
+        }}>
         {props.label}
       </NavLink>
       <ul className="dropdown__menu">
-        {items.map(
-          ({className: childItemClassName, ...linkItemInnerProps}, i) => (
-            <li key={i}>
-              <NavLink
-                activeClassName="dropdown__link--active"
-                className={navLinkClassNames(childItemClassName, true)}
-                {...linkItemInnerProps}
-              />
-            </li>
-          ),
-        )}
+        {items.map(({className: childItemClassName, ...childItemProps}, i) => (
+          <li key={i}>
+            <NavLink
+              activeClassName="dropdown__link--active"
+              className={navLinkClassNames(childItemClassName, true)}
+              {...childItemProps}
+            />
+          </li>
+        ))}
       </ul>
     </div>
   );
@@ -96,9 +104,13 @@ function NavItem({items, position, className, ...props}) {
 
 function MobileNavItem({items, className, ...props}) {
   const navLinkClassNames = (extraClassName, isSubList = false) =>
-    classnames('menu__link', extraClassName, {
-      'menu__link--sublist': isSubList,
-    });
+    classnames(
+      'menu__link',
+      {
+        'menu__link--sublist': isSubList,
+      },
+      extraClassName,
+    );
 
   if (!items) {
     return (
@@ -114,18 +126,16 @@ function MobileNavItem({items, className, ...props}) {
         {props.label}
       </NavLink>
       <ul className="menu__list">
-        {items.map(
-          ({className: childItemClassName, ...linkItemInnerProps}, i) => (
-            <li className="menu__list-item" key={i}>
-              <NavLink
-                activeClassName="menu__link--active"
-                className={navLinkClassNames(childItemClassName)}
-                {...linkItemInnerProps}
-                onClick={props.onClick}
-              />
-            </li>
-          ),
-        )}
+        {items.map(({className: childItemClassName, ...childItemProps}, i) => (
+          <li className="menu__list-item" key={i}>
+            <NavLink
+              activeClassName="menu__link--active"
+              className={navLinkClassNames(childItemClassName)}
+              {...childItemProps}
+              onClick={props.onClick}
+            />
+          </li>
+        ))}
       </ul>
     </li>
   );

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -122,6 +122,7 @@ module.exports = {
           href: 'https://github.com/facebook/docusaurus',
           position: 'right',
           className: 'header-github-link',
+          'aria-label': 'GitHub repository',
         },
       ],
     },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After that, you can open dropdown (and navigate it) using the keyboard, this is good for accessibility.

In addition to that, in current PR, for consistency and easier code understanding, I changed the naming of some args and moved the custom CSS class to the end of the class list. This is a simple refactoring.

![screencast-localhost_3000-2020 04 27-11_02_32](https://user-images.githubusercontent.com/4408379/80349493-00da9700-8878-11ea-84cd-c975eb6b919f.gif)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
