### PR TITLE
docs: update test plan in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,8 @@ A good test plan has the exact commands you ran and their output, provides scree
 
 - If you've changed APIs, update the documentation.
 
+If you need help testing your changes locally, you can check out the doc on doing [local third party testing](./admin/local-third-party-project-testing.md).
+
 #### Breaking Changes
 
 When adding a new breaking change, follow this template in your pull request:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When testing my changes locally, I wasn't aware of the document Local Third Party Project Testing. I think we should tell people about it in the `CONTRIBUTING` document. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

N/A - it's a markdown file. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
N/A