### PR TITLE
feat(v2): expanded sidebar categories by default

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-category.js
@@ -9,25 +9,30 @@ module.exports = {
   docs: [
     {
       type: 'category',
+      collapsed: true,
       label: 'level 1',
       items: [
         'a',
         {
           type: 'category',
+          collapsed: true,
           label: 'level 2',
           items: [
             {
               type: 'category',
+              collapsed: true,
               label: 'level 3',
               items: [
                 'c',
                 {
                   type: 'category',
+                  collapsed: true,
                   label: 'level 4',
                   items: [
                     'd',
                     {
                       type: 'category',
+                      collapsed: true,
                       label: 'deeper more more',
                       items: ['e'],
                     },

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed-first-level.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed-first-level.json
@@ -1,0 +1,20 @@
+{
+    "docs": [
+        {
+            "type": "category",
+            "label": "Introduction",
+            "items": [
+                "doc1"
+            ],
+            "collapsed": false
+        },
+        {
+            "type": "category",
+            "label": "Powering MDX",
+            "items": [
+                "doc2"
+            ],
+            "collapsed": false
+        }
+    ]
+}

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-collapsed.json
@@ -1,0 +1,21 @@
+{
+    "docs": {
+      "Test": [
+        {
+          "type": "category",
+          "label": "Introduction",
+          "items": ["doc1"],
+          "collapsed": false
+        }
+      ],
+      "Reference": [
+        {
+          "type": "category",
+          "label": "Powering MDX",
+          "items": ["doc2"],
+          "collapsed": false
+        }
+      ]
+    }
+  }
+  

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -4,6 +4,7 @@ exports[`simple website content 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "items": Array [
@@ -36,6 +37,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/hello",
@@ -236,6 +238,7 @@ exports[`versioned website content: all sidebars 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/next/foo/bar",
@@ -247,6 +250,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/next/hello",
@@ -260,6 +264,7 @@ Object {
   ],
   "version-1.0.0/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/1.0.0/foo/bar",
@@ -276,6 +281,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/1.0.0/hello",
@@ -289,6 +295,7 @@ Object {
   ],
   "version-1.0.1/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/foo/bar",
@@ -300,6 +307,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "/docs/hello",
@@ -319,6 +327,7 @@ Object {
   "docsSidebars": Object {
     "version-1.0.0/docs": Array [
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/1.0.0/foo/bar",
@@ -335,6 +344,7 @@ Object {
         "type": "category",
       },
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/1.0.0/hello",
@@ -361,6 +371,7 @@ Object {
   "docsSidebars": Object {
     "version-1.0.1/docs": Array [
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/foo/bar",
@@ -372,6 +383,7 @@ Object {
         "type": "category",
       },
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/hello",
@@ -397,6 +409,7 @@ Object {
   "docsSidebars": Object {
     "docs": Array [
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/next/foo/bar",
@@ -408,6 +421,7 @@ Object {
         "type": "category",
       },
       Object {
+        "collapsed": true,
         "items": Array [
           Object {
             "href": "/docs/next/hello",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -4,6 +4,7 @@ exports[`loadSidebars sidebars link 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "href": "https://github.com",
@@ -172,6 +173,7 @@ exports[`loadSidebars sidebars with known sidebar item type 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "foo/bar",
@@ -195,6 +197,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "hello",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -18,6 +18,49 @@ Object {
 }
 `;
 
+exports[`loadSidebars sidebars with category.collapsed property 1`] = `
+Object {
+  "docs": Array [
+    Object {
+      "collapsed": true,
+      "items": Array [
+        Object {
+          "collapsed": false,
+          "items": Array [
+            Object {
+              "id": "doc1",
+              "type": "doc",
+            },
+          ],
+          "label": "Introduction",
+          "type": "category",
+        },
+      ],
+      "label": "Test",
+      "type": "category",
+    },
+    Object {
+      "collapsed": true,
+      "items": Array [
+        Object {
+          "collapsed": false,
+          "items": Array [
+            Object {
+              "id": "doc2",
+              "type": "doc",
+            },
+          ],
+          "label": "Powering MDX",
+          "type": "category",
+        },
+      ],
+      "label": "Reference",
+      "type": "category",
+    },
+  ],
+}
+`;
+
 exports[`loadSidebars sidebars with deep level of category 1`] = `
 Object {
   "docs": Array [

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -95,26 +95,31 @@ exports[`loadSidebars sidebars with deep level of category 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "a",
           "type": "doc",
         },
         Object {
+          "collapsed": true,
           "items": Array [
             Object {
+              "collapsed": true,
               "items": Array [
                 Object {
                   "id": "c",
                   "type": "doc",
                 },
                 Object {
+                  "collapsed": true,
                   "items": Array [
                     Object {
                       "id": "d",
                       "type": "doc",
                     },
                     Object {
+                      "collapsed": true,
                       "items": Array [
                         Object {
                           "id": "e",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -61,6 +61,35 @@ Object {
 }
 `;
 
+exports[`loadSidebars sidebars with category.collapsed property at first level 1`] = `
+Object {
+  "docs": Array [
+    Object {
+      "collapsed": false,
+      "items": Array [
+        Object {
+          "id": "doc1",
+          "type": "doc",
+        },
+      ],
+      "label": "Introduction",
+      "type": "category",
+    },
+    Object {
+      "collapsed": false,
+      "items": Array [
+        Object {
+          "id": "doc2",
+          "type": "doc",
+        },
+      ],
+      "label": "Powering MDX",
+      "type": "category",
+    },
+  ],
+}
+`;
+
 exports[`loadSidebars sidebars with deep level of category 1`] = `
 Object {
   "docs": Array [

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/version.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/version.test.ts.snap
@@ -4,6 +4,7 @@ exports[`docsVersion first time versioning 1`] = `
 Object {
   "version-1.0.0/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "items": Array [
@@ -33,6 +34,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "version-1.0.0/hello",
@@ -50,6 +52,7 @@ exports[`docsVersion not the first time versioning 1`] = `
 Object {
   "version-2.0.0/docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "version-2.0.0/foo/bar",
@@ -60,6 +63,7 @@ Object {
       "type": "category",
     },
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "version-2.0.0/hello",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
@@ -126,4 +126,10 @@ describe('loadSidebars', () => {
     const result = loadSidebars(null);
     expect(result).toEqual({});
   });
+
+  test('sidebars with category.collapsed property', async () => {
+    const sidebarPath = path.join(fixtureDir, 'sidebars-collapsed.json');
+    const result = loadSidebars([sidebarPath]);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
@@ -132,4 +132,13 @@ describe('loadSidebars', () => {
     const result = loadSidebars([sidebarPath]);
     expect(result).toMatchSnapshot();
   });
+
+  test('sidebars with category.collapsed property at first level', async () => {
+    const sidebarPath = path.join(
+      fixtureDir,
+      'sidebars-collapsed-first-level.json',
+    );
+    const result = loadSidebars([sidebarPath]);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -33,6 +33,7 @@ function normalizeCategoryShorthand(
 ): SidebarItemCategoryRaw[] {
   return Object.entries(sidebar).map(([label, items]) => ({
     type: 'category',
+    collapsed: true,
     label,
     items,
   }));
@@ -56,7 +57,7 @@ function assertItem(item: Object, keys: string[]): void {
 }
 
 function assertIsCategory(item: any): asserts item is SidebarItemCategoryRaw {
-  assertItem(item, ['items', 'label']);
+  assertItem(item, ['items', 'label', 'collapsed']);
   if (typeof item.label !== 'string') {
     throw new Error(
       `Error loading ${JSON.stringify(item)}. "label" must be a string.`,
@@ -65,6 +66,12 @@ function assertIsCategory(item: any): asserts item is SidebarItemCategoryRaw {
   if (!Array.isArray(item.items)) {
     throw new Error(
       `Error loading ${JSON.stringify(item)}. "items" must be an array.`,
+    );
+  }
+  // "collapsed" is an optional property
+  if (item.hasOwnProperty('collapsed') && typeof item.collapsed !== 'boolean') {
+    throw new Error(
+      `Error loading ${JSON.stringify(item)}. "collapsed" must be a boolean.`,
     );
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -42,12 +42,14 @@ export interface SidebarItemCategory {
   type: 'category';
   label: string;
   items: SidebarItem[];
+  collapsed?: boolean;
 }
 
 export interface SidebarItemCategoryRaw {
   type: 'category';
   label: string;
   items: SidebarItemRaw[];
+  collapsed?: boolean;
 }
 
 export type SidebarItem =
@@ -83,6 +85,7 @@ export interface DocsSidebarItemCategory {
   type: 'category';
   label: string;
   items: DocsSidebarItem[];
+  collapsed?: boolean;
 }
 
 export type DocsSidebarItem = SidebarItemLink | DocsSidebarItemCategory;

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -44,6 +44,26 @@ function DocSidebarItem({
     setCollapsed((state) => !state);
   });
 
+  const activePageRelativeUrl =
+    window.location.pathname + window.location.search;
+
+  // We need to know if the category item
+  // is the parent of the active page
+  // If it is, this returns true and make sure to highlight this category
+  const isCategoryOfActivePage = () => {
+    // Make sure we have items
+    if (typeof items !== 'undefined') {
+      return items.some((categoryItem) => {
+        // Grab the category item's href
+        const childHref = categoryItem.href;
+        // Compare it to the current active page
+        return activePageRelativeUrl === childHref;
+      });
+    }
+
+    return false;
+  };
+
   switch (type) {
     case 'category':
       return (
@@ -56,7 +76,8 @@ function DocSidebarItem({
             <a
               className={classnames('menu__link', {
                 'menu__link--sublist': collapsible,
-                'menu__link--active': collapsible && !item.collapsed,
+                'menu__link--active':
+                  collapsible && !item.collapsed && isCategoryOfActivePage(),
               })}
               href="#!"
               onClick={collapsible ? handleItemClick : undefined}

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -116,11 +116,18 @@ function mutateSidebarCollapsingState(item, path) {
         items
           .map((childItem) => mutateSidebarCollapsingState(childItem, path))
           .filter((val) => val).length > 0;
-      // only modify item.collapsed if there are child items active and the category collapsed is set to true
-      if (anyChildItemsActive && item.collapsed) {
+
+      // Check if the user wants the category to be expanded by default
+      const shouldExpand = item.collapsed === false;
+
+      // eslint-disable-next-line no-param-reassign
+      item.collapsed = !anyChildItemsActive;
+
+      if (shouldExpand) {
         // eslint-disable-next-line no-param-reassign
-        item.collapsed = !anyChildItemsActive;
+        item.collapsed = false;
       }
+
       return anyChildItemsActive;
     }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -53,14 +53,14 @@ function DocSidebarItem({
   // We need to know if the category item
   // is the parent of the active page
   // If it is, this returns true and make sure to highlight this category
-  const isCategoryOfActivePage = () => {
+  const isCategoryOfActivePage = (_items, _activePageRelativeUrl) => {
     // Make sure we have items
-    if (typeof items !== 'undefined') {
-      return items.some((categoryItem) => {
+    if (typeof _items !== 'undefined') {
+      return _items.some((categoryItem) => {
         // Grab the category item's href
         const childHref = categoryItem.href;
         // Compare it to the current active page
-        return activePageRelativeUrl === childHref;
+        return _activePageRelativeUrl === childHref;
       });
     }
 
@@ -80,7 +80,9 @@ function DocSidebarItem({
               className={classnames('menu__link', {
                 'menu__link--sublist': collapsible,
                 'menu__link--active':
-                  collapsible && !item.collapsed && isCategoryOfActivePage(),
+                  collapsible &&
+                  !item.collapsed &&
+                  isCategoryOfActivePage(items, activePageRelativeUrl),
               })}
               href="#!"
               onClick={collapsible ? handleItemClick : undefined}

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -116,8 +116,11 @@ function mutateSidebarCollapsingState(item, path) {
         items
           .map((childItem) => mutateSidebarCollapsingState(childItem, path))
           .filter((val) => val).length > 0;
-      // eslint-disable-next-line no-param-reassign
-      item.collapsed = !anyChildItemsActive;
+      // only modify item.collapsed if there are child items active and the category collapsed is set to true
+      if (anyChildItemsActive && item.collapsed) {
+        // eslint-disable-next-line no-param-reassign
+        item.collapsed = !anyChildItemsActive;
+      }
       return anyChildItemsActive;
     }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -6,6 +6,7 @@
  */
 
 import React, {useState, useCallback} from 'react';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import classnames from 'classnames';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useAnnouncementBarContext from '@theme/hooks/useAnnouncementBarContext';
@@ -44,13 +45,10 @@ function DocSidebarItem({
     setCollapsed((state) => !state);
   });
 
-  let activePageRelativeUrl = '';
-
-  // Because this is built on the server
-  // we need to check if window is available
-  if (typeof window !== 'undefined') {
-    activePageRelativeUrl = window.location.pathname + window.location.search;
-  }
+  // Make sure we have access to the window
+  const activePageRelativeUrl = ExecutionEnvironment.canUseDOM
+    ? window.location.pathname + window.location.search
+    : null;
 
   // We need to know if the category item
   // is the parent of the active page

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -44,8 +44,13 @@ function DocSidebarItem({
     setCollapsed((state) => !state);
   });
 
-  const activePageRelativeUrl =
-    window.location.pathname + window.location.search;
+  let activePageRelativeUrl = '';
+
+  // Because this is built on the server
+  // we need to check if window is available
+  if (typeof window !== 'undefined') {
+    activePageRelativeUrl = window.location.pathname + window.location.search;
+  }
 
   // We need to know if the category item
   // is the parent of the active page

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -293,9 +293,9 @@ module.exports = {
 };
 ```
 
-#### Toggling category open by default
+#### Expanded categories by default
 
-For sites that have collapsible categories, you may want more fine grain control over certain categories. If you want specific categories to be alwasy expanded, you can set `collapsed` to `false`:
+For docs that have collapsible categories, you may want more fine-grain control over certain categories. If you want specific categories to be always expanded, you can set `collapsed` to `false`:
 
 ```js title="sidebars.js"
 module.exports = {

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -243,6 +243,7 @@ type SidebarItemCategory = {
   type: 'category';
   label: string; // Sidebar label text.
   items: SidebarItem[]; // Array of sidebar items.
+  collapsed: boolean; // Set the category to be collapsed or open by default
 };
 ```
 

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -293,6 +293,26 @@ module.exports = {
 };
 ```
 
+#### Toggling category open by default
+
+For sites that have collapsible categories, you may want more fine grain control over certain categories. If you want specific categories to be alwasy expanded, you can set `collapsed` to `false`:
+
+```js title="sidebars.js"
+module.exports = {
+  docs: {
+    Guides: [
+      'creating-pages',
+      {
+        type: 'category',
+        label: 'Docs',
+        collapsed: false,
+        items: ['markdown-features', 'sidebar', 'versioning'],
+      },
+    ],
+  },
+};
+```
+
 ## Docs-only mode
 
 If you just want the documentation feature, you can enable "docs-only mode".

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -6,30 +6,55 @@
  */
 
 module.exports = {
-  docs: {
-    Docusaurus: ['introduction', 'design-principles', 'contributing'],
-    'Getting Started': ['installation', 'configuration'],
-    Guides: [
-      'creating-pages',
-      'styling-layout',
-      'static-assets',
-      {
-        Docs: ['docs-introduction', 'markdown-features', 'versioning'],
-      },
-      'blog',
-      'search',
-      'deployment',
-      'migrating-from-v1-to-v2',
-    ],
-    'Advanced Guides': ['using-plugins', 'using-themes', 'presets'],
-    'API Reference': [
-      'cli',
-      'docusaurus-core',
-      'docusaurus.config.js',
-      'lifecycle-apis',
-      'theme-classic',
-    ],
-  },
+  docs: [
+    {
+      type: 'category',
+      label: 'Docusaurus',
+      collapsed: false,
+      items: ['introduction', 'design-principles', 'contributing'],
+    },
+    {
+      type: 'category',
+      label: 'Getting Started',
+      collapsed: true,
+      items: ['installation', 'configuration'],
+    },
+    {
+      type: 'category',
+      label: 'Guides',
+      collapsed: true,
+      items: [
+        'creating-pages',
+        'styling-layout',
+        'static-assets',
+        {
+          Docs: ['docs', 'markdown-features', 'versioning'],
+        },
+        'blog',
+        'search',
+        'deployment',
+        'migrating-from-v1-to-v2',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Advanced Guides',
+      collapsed: true,
+      items: ['using-plugins', 'using-themes', 'presets'],
+    },
+    {
+      type: 'category',
+      label: 'API Reference',
+      collapsed: true,
+      items: [
+        'cli',
+        'docusaurus-core',
+        'docusaurus.config.js',
+        'lifecycle-apis',
+        'theme-classic',
+      ],
+    },
+  ],
   community: [
     'support',
     'team',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -28,7 +28,7 @@ module.exports = {
         'styling-layout',
         'static-assets',
         {
-          Docs: ['docs', 'markdown-features', 'versioning'],
+          Docs: ['docs-introduction', 'markdown-features', 'versioning'],
         },
         'blog',
         'search',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -10,19 +10,17 @@ module.exports = {
     {
       type: 'category',
       label: 'Docusaurus',
-      collapsed: false,
       items: ['introduction', 'design-principles', 'contributing'],
     },
     {
       type: 'category',
       label: 'Getting Started',
-      collapsed: true,
+      collapsed: false,
       items: ['installation', 'configuration'],
     },
     {
       type: 'category',
       label: 'Guides',
-      collapsed: true,
       items: [
         'creating-pages',
         'styling-layout',
@@ -39,13 +37,11 @@ module.exports = {
     {
       type: 'category',
       label: 'Advanced Guides',
-      collapsed: true,
       items: ['using-plugins', 'using-themes', 'presets'],
     },
     {
       type: 'category',
       label: 'API Reference',
-      collapsed: true,
       items: [
         'cli',
         'docusaurus-core',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: `https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md`

Happy contributing!

-->

## Motivation

This allows a user to toggle a category open by default.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Thanks to the tip from @lex111 I tested this locally on the Docusaurus website by modifying website/versioned_sidebars/version-2.0.0-alpha.40-sidebars.json and the changes worked as expected.

### Screenrecording

![2020-04-27 10 53 04](https://user-images.githubusercontent.com/3806031/80404325-e2739c00-8875-11ea-8d94-7d290d33e5cb.gif)

**Updated**: only highlight the category if the category belongs to the current page being viewed
![2020-04-29 16 11 34](https://user-images.githubusercontent.com/3806031/80655710-35934d80-8a34-11ea-9c8d-24d4c615f307.gif)

## Related PRs

- Fixes #2354 
- Original PR: #2613 
- PR that reverted work (due to breaking change): #2644 

## Remaining todos

- [x] update docs with example
- [x] link related PRs