### PR TITLE
feat(v2): Allow activeBasePath to be a RegExp

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -29,7 +29,8 @@ function NavLink({
   ...props
 }) {
   const toUrl = useBaseUrl(to);
-  const activeBaseUrl = useBaseUrl(activeBasePath);
+  const activeBaseUrl = useBaseUrl(activeBasePath.toString());
+  const activeBasePathIsRegex = typeof activeBasePath === 'object';
 
   return (
     <Link
@@ -45,8 +46,19 @@ function NavLink({
             to: toUrl,
             ...(activeBasePath
               ? {
-                  isActive: (_match, location) =>
-                    location.pathname.startsWith(activeBaseUrl),
+                  isActive: (_match, location) => {
+                    if (activeBasePathIsRegex) {
+                      return activeBasePath.test(location.pathname);
+                    }
+
+                    if (typeof activeBasePath === 'string') {
+                      return location.pathname.startsWith(activeBaseUrl);
+                    }
+
+                    throw new Error(
+                      'activeBasePath must be a string or Regular Expression',
+                    );
+                  },
                 }
               : null),
           })}

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -137,6 +137,8 @@ module.exports = {
           position: 'left', // or 'right'
           // To apply the active class styling on all
           // routes starting with this path.
+          // This can also be a Regular Expression.
+          // If so, it will be tested against the current URL
           activeBasePath: 'docs',
           className: '', // Custom CSS class (for styling any item)
         },


### PR DESCRIPTION
## Motivation

Closes #2574. Allows `activeBasePath` to be a Regular Expression as well as a string.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep

## Test Plan

Run website and make sure that nav links are highlighted correctly. Change `activeBasePath` to a Regular Expression and make sure nav links are highlighted correctly.

## Related PRs

No related PRs. I included a slight edit to the docs in this PR -- I can move that to a separate PR if necessary.