### PR TITLE
fix(v2): Add all webpack module aliases to type declaration file

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -41,3 +41,15 @@ declare module '@theme/*' {
   const component: any;
   export default component;
 }
+
+declare module '@docusaurus/*';
+
+declare module '*.module.css' {
+  const classes: {readonly [key: string]: string};
+  export default classes;
+}
+
+declare module '*.css' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

With these additions, all typescript red squiggly lines will be gone once user install `@docusaurus/module-type-aliases` and create a `types.d.ts` that references `@docusaurus/module-type-aliases`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Add `types.d.ts` with content `/// <reference types="@docusaurus/module-type-aliases" />` to the root of `packages/docusaurus-theme-classic`.
2. Change some components' extension to tsx
3. Imports that contains `@docusaurus/...`, `styles.module.css` and `styles.css` no longer has red squiggly lines.

<img width="642" alt="Screen Shot 2020-04-27 at 21 58 32" src="https://user-images.githubusercontent.com/4290500/80438479-4a57d000-88d2-11ea-8ee2-fa48be9e2830.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
