### PR TITLE
fix(v2): add routeBasePath to feed link

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -470,12 +470,12 @@ export default function pluginContentBlog(
       const feedsConfig = {
         rss: {
           type: 'application/rss+xml',
-          path: 'blog/rss.xml',
+          path: 'rss.xml',
           title: `${title} Blog RSS Feed`,
         },
         atom: {
           type: 'application/atom+xml',
-          path: 'blog/atom.xml',
+          path: 'atom.xml',
           title: `${title} Blog Atom Feed`,
         },
       };
@@ -495,7 +495,7 @@ export default function pluginContentBlog(
           attributes: {
             rel: 'alternate',
             type,
-            href: normalizeUrl([baseUrl, path]),
+            href: normalizeUrl([baseUrl, options.routeBasePath, path]),
             title,
           },
         });


### PR DESCRIPTION
## Motivation

Fix dead link element of feed when [Blog-only mode](https://v2.docusaurus.io/docs/blog#blog-only-mode) is enabled.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

open `view-source:http://localhost:3000/`

## Related PRs

nothing
