### PR TITLE
fix(v2): add support esModule to lqip-loader

### DIFF
--- a/packages/lqip-loader/src/index.js
+++ b/packages/lqip-loader/src/index.js
@@ -20,23 +20,29 @@ module.exports = function (contentBuffer) {
   config.palette = 'palette' in config ? config.palette : false;
 
   let content = contentBuffer.toString('utf8');
-  const contentIsUrlExport = /^module.exports = "data:(.*)base64,(.*)/.test(
+  const contentIsUrlExport = /^(?:export default|module.exports =) "data:(.*)base64,(.*)/.test(
     content,
   );
-  const contentIsFileExport = /^module.exports = (.*)/.test(content);
+  const contentIsFileExport = /^(?:export default|module.exports =) (.*)/.test(
+    content,
+  );
 
   let source = '';
   const SOURCE_CHUNK = 1;
 
   if (contentIsUrlExport) {
-    source = content.match(/^module.exports = (.*)/)[SOURCE_CHUNK];
+    source = content.match(/^(?:export default|module.exports =) (.*)/)[
+      SOURCE_CHUNK
+    ];
   } else {
     if (!contentIsFileExport) {
       // eslint-disable-next-line global-require
       const fileLoader = require('file-loader');
       content = fileLoader.call(this, contentBuffer);
     }
-    source = content.match(/^module.exports = (.*);/)[SOURCE_CHUNK];
+    source = content.match(/^(?:export default|module.exports =) (.*);/)[
+      SOURCE_CHUNK
+    ];
   }
 
   const outputPromises = [];


### PR DESCRIPTION
## Motivation

Currently `url-loader` and `file-loader` have the option `esModule` is `true` by default. So `@docusaurus/lqip-loader` will always throw an exception unless you explicitly set `esModule` to `false`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Use `@docusaurus/lqip-loader` alone or with `url-loader` or `file-loader` according to [README.md](https://github.com/facebook/docusaurus/blob/v2.0.0-alpha.54/packages/lqip-loader/README.md).

## Related PRs

Nothing.