### PR TITLE
feat(v2): add canonical URL to <head>

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -100,6 +100,7 @@ function DocItem(props) {
           <meta name="twitter:image:alt" content={`Image for ${title}`} />
         )}
         {permalink && <meta property="og:url" content={siteUrl + permalink} />}
+        {permalink && <link rel="canonical" href={siteUrl + permalink} />}
       </Head>
       <div
         className={classnames(

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.js
@@ -75,6 +75,7 @@ function Layout(props) {
           {permalink && (
             <meta property="og:url" content={siteUrl + permalink} />
           )}
+          {permalink && <link rel="canonical" href={siteUrl + permalink} />}
           <meta name="twitter:card" content="summary_large_image" />
         </Head>
         <AnnouncementBar />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Currently Docusaurus does not support canonical URLs. From a search engine standpoint, a canonical URL is an important piece of information and can help direct them to the correct content. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
* Visit any static page or doc page
* View source, search for `<link rel="canonical" href="<URL of the page you're currently viewing>" />`

## Related PRs

This PR is a good first step to further implement https://github.com/facebook/docusaurus/issues/2603, as it introduces a good default value.
