### PR TITLE
refactor(v2): make semicolon optional in imports for excerpt

### DIFF
--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -183,7 +183,7 @@ export function getSubFolder(file: string, refDir: string): string | null {
 }
 
 // Regex for an import statement.
-const importRegexString = '^(.*import){1}(.+){0,1}\\s[\'"](.+)[\'"];';
+const importRegexString = '^(.*import){1}(.+){0,1}\\s[\'"](.+)[\'"];?';
 
 export function parse(
   fileString: string,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This request came from Discord chat, since import declarations might work without a trailing semicolon, you need to consider this when making excerpt.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The same as in Test plan for #2380, but in addition it will work even if a semicolon is not specified.

## Related PRs

- Based on #2380
