### PR TITLE
feat: Show icon-only for small devices

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
@@ -11,7 +11,7 @@
   }
 }
 
-@media (max-width: 360px) {
+@media only screen and (max-width: 768px) {
   .hideLogoText {
     display: none;
   }

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -67,9 +67,11 @@ const Search = (props) => {
     );
   };
 
-  const handleSearchIcon = useCallback(() => {
+  const expandInput = useCallback(() => {
     loadAlgolia();
-
+    if (props.isSearchBarExpanded) {
+      return;
+    }
     if (algoliaLoaded) {
       searchBarRef.current.focus();
     }
@@ -78,7 +80,7 @@ const Search = (props) => {
   }, [props.isSearchBarExpanded]);
 
   const handleSearchInputBlur = useCallback(() => {
-    props.handleSearchBarToggle(!props.isSearchBarExpanded);
+    props.handleSearchBarToggle(false);
   }, [props.isSearchBarExpanded]);
 
   const handleSearchInput = useCallback((e) => {
@@ -88,17 +90,13 @@ const Search = (props) => {
   });
 
   return (
-    <div className="navbar__search" key="search-box">
-      <span
-        aria-label="expand searchbar"
-        role="button"
-        className={classnames('search-icon', {
-          'search-icon-hidden': props.isSearchBarExpanded,
-        })}
-        onClick={handleSearchIcon}
-        onKeyDown={handleSearchIcon}
-        tabIndex={0}
-      />
+    <div
+      role="button"
+      tabIndex={0}
+      className="navbar__search"
+      key="search-box"
+      onClick={expandInput}
+      onKeyDown={expandInput}>
       <input
         id="search_input_react"
         type="search"

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
@@ -35,10 +35,11 @@
 
   .search-icon {
     background-color: var(--ifm-navbar-search-input-background-color);
-    width: 30px;
-    height: 30px;
-    border-radius: 15px;
+    padding: 0 0.5rem 0 2.25rem;
+    line-height: 2rem;
+    border-radius: 2rem;
     display: inline-block;
+    height: 32px;
     vertical-align: middle;
   }
 }

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
@@ -34,7 +34,11 @@
   }
 
   .search-icon {
-    display: inline;
-    vertical-align: sub;
+    background-color: var(--ifm-navbar-search-input-background-color);
+    width: 30px;
+    height: 30px;
+    border-radius: 15px;
+    display: inline-block;
+    vertical-align: middle;
   }
 }

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
@@ -21,7 +21,7 @@
   visibility: hidden;
 }
 
-@media (max-width: 360px) {
+@media only screen and (max-width: 768px) {
   .search-bar {
     width: 0 !important;
     background: none !important;

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
@@ -5,41 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.search-icon {
-  background-image: var(--ifm-navbar-search-input-icon);
-  height: auto;
-  width: 24px;
-  cursor: pointer;
-  padding: 8px;
-  line-height: 32px;
-  background-repeat: no-repeat;
-  background-position: center;
-  display: none;
-}
-
-.search-icon-hidden {
-  visibility: hidden;
-}
-
 @media only screen and (max-width: 768px) {
   .search-bar {
     width: 0 !important;
-    background: none !important;
-    padding: 0 !important;
-    transition: none !important;
+    cursor: pointer !important;
   }
 
   .search-bar-expanded {
-    width: 9rem !important;
-  }
-
-  .search-icon {
-    background-color: var(--ifm-navbar-search-input-background-color);
-    padding: 0 0.5rem 0 2.25rem;
-    line-height: 2rem;
-    border-radius: 2rem;
-    display: inline-block;
-    height: 32px;
-    vertical-align: middle;
+    width: 13rem !important;
   }
 }


### PR DESCRIPTION
## Motivation
fix #2699 

Show icon-only search bar for devices under 768px.
This fix is useful to solve an issue with long app name causing a rendering problem with search

I hope to make something right :)

Regards 
Marco

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

YES


