### PR TITLE
fix(v2): remove .html extension in pathnames

### DIFF
--- a/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
+++ b/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
@@ -34,7 +34,7 @@ describe('normalizeLocation', () => {
     });
   });
 
-  test('untouched pathnames', () => {
+  test('pathnames without html extension', () => {
     expect(
       normalizeLocation({
         pathname: '/docs/introduction',
@@ -54,7 +54,7 @@ describe('normalizeLocation', () => {
         hash: '#bar',
       }),
     ).toEqual({
-      pathname: '/docs/introduction/foo.html',
+      pathname: '/docs/introduction/foo',
       search: '',
       hash: '#bar',
     });

--- a/packages/docusaurus/src/client/normalizeLocation.ts
+++ b/packages/docusaurus/src/client/normalizeLocation.ts
@@ -17,7 +17,10 @@ function normalizeLocation(location) {
   }
 
   let pathname = location.pathname || '/';
-  pathname = pathname.trim().replace(/\/index\.html$/, '');
+  pathname = pathname
+    .trim()
+    .replace(/\/index\.html$/, '')
+    .replace('.html', '');
 
   if (pathname === '') {
     pathname = '/';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR should resolve #2697.

This quick fix do not hesitate to improve the PR! 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

_All actions are performed using website v2 as an example_.

1. Build website running `yarn build`
2. With npm [serve]() package serve newly generated website in browser (eg. at URL http://localhost:5000) 
3. Compare with the results below:

| Original URL | Normalized URL |
| - | -|
| http://localhost:5000/docs/markdown-features.html |  http://localhost:5000/docs/markdown-feature|
| http://localhost:5000/docs/markdown-features/index.html | http://localhost:5000/docs/markdown-feature |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
