### PR TITLE
refactor(v2): change the label for docs introduction

### DIFF
--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -1,5 +1,5 @@
 ---
-id: docs-pages-introduction
+id: docs-introduction
 title: Docs Introduction
 sidebar_label: Introduction
 ---

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -1,5 +1,5 @@
 ---
-id: docs
+id: docs-pages-introduction
 title: Docs Introduction
 sidebar_label: Introduction
 ---

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -14,7 +14,7 @@ module.exports = {
       'styling-layout',
       'static-assets',
       {
-        Docs: ['docs', 'markdown-features', 'versioning'],
+        Docs: ['docs-pages-introduction', 'markdown-features', 'versioning'],
       },
       'blog',
       'search',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -14,7 +14,7 @@ module.exports = {
       'styling-layout',
       'static-assets',
       {
-        Docs: ['docs-pages-introduction', 'markdown-features', 'versioning'],
+        Docs: ['docs-introduction', 'markdown-features', 'versioning'],
       },
       'blog',
       'search',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Rename the docs sidebar label, for me sounds weird the route `docs/docs` in  docs introduction
![image](https://user-images.githubusercontent.com/14113480/80893284-57e0d180-8ca7-11ea-858b-603fe3055495.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
go to /docs/docs

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
