### PR TITLE
docs(v2): add new community plugin for dotenv support

### DIFF
--- a/website/docs/resources.md
+++ b/website/docs/resources.md
@@ -30,6 +30,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) - Offline/local search for Docusaurus v2
 - [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
+- [docusaurus2-dotenv](https://github.com/jonnynabors/docusaurus2-dotenv) - A Docusaurus2 plugin that supports dotenv and other environment variables
 
 ## Enterprise usage
 

--- a/website/docs/resources.md
+++ b/website/docs/resources.md
@@ -30,7 +30,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) - Offline/local search for Docusaurus v2
 - [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
-- [docusaurus2-dotenv](https://github.com/jonnynabors/docusaurus2-dotenv) - A Docusaurus2 plugin that supports dotenv and other environment variables
+- [docusaurus2-dotenv](https://github.com/jonnynabors/docusaurus2-dotenv) - A Docusaurus 2 plugin that supports dotenv and other environment variables
 
 ## Enterprise usage
 


### PR DESCRIPTION
Adds a link to a new community plugin that introduces support for environment variables managed in `.env` files.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

For my particular use case of Docusaurus, I deploy several different versions of our site in various environments as well as some A/B testing. I make use of `.env` files in other React apps and wanted to Docusaurus site to behave similarly. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

The steps to install and work with the plugin can be found in the linked Github. There are no changes to the core Docusaurus source code.
