### PR TITLE
Add more static classes to Classic Theme components.

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.js
@@ -6,6 +6,7 @@
  */
 
 import React, {useState, useEffect} from 'react';
+import classnames from 'classnames';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import styles from './styles.module.css';
@@ -48,11 +49,11 @@ function AnnouncementBar() {
 
   return (
     <div
-      className={styles.announcementBar}
+      className={classnames('announcment-bar', styles.announcementBar)}
       style={{backgroundColor, color: textColor}}
       role="banner">
       <div
-        className={styles.announcementBarContent}
+        className={classnames('announcment-bar__content', styles.announcementBarContent)}
         dangerouslySetInnerHTML={{__html: content}}
       />
 

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
@@ -22,7 +22,7 @@ function BlogListPage(props) {
 
   return (
     <Layout title={title} description="Blog">
-      <div className="container margin-vert--lg">
+      <div className="container margin-vert--lg blogList">
         <div className="row">
           <div className="col col--8 col--offset-2">
             {items.map(({content: BlogPostContent}) => (

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.js
@@ -19,7 +19,7 @@ function BlogPostPage(props) {
   return (
     <Layout title={title} description={description}>
       {BlogPostContents && (
-        <div className="container margin-vert--lg">
+        <div className="container margin-vert--lg blogPost">
           <div className="row">
             <div className="col col--8 col--offset-2">
               <BlogPostItem
@@ -50,7 +50,7 @@ function BlogPostPage(props) {
                 )}
               </div>
               {(nextItem || prevItem) && (
-                <div className="margin-vert--xl">
+                <div className="margin-vert--xl pagination">
                   <BlogPostPaginator nextItem={nextItem} prevItem={prevItem} />
                 </div>
               )}

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
@@ -49,7 +49,7 @@ function BlogTagsListPage(props) {
 
   return (
     <Layout title="Tags" description="Blog Tags">
-      <div className="container margin-vert--lg">
+      <div className="container margin-vert--lg blogTagsList">
         <div className="row">
           <div className="col col--8 col--offset-2">
             <h1>Tags</h1>

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
@@ -23,7 +23,7 @@ function BlogTagsPostPage(props) {
     <Layout
       title={`Posts tagged "${tagName}"`}
       description={`Blog | Tagged "${tagName}"`}>
-      <div className="container margin-vert--lg">
+      <div className="container margin-vert--lg blogTagsPosts">
         <div className="row">
           <div className="col col--8 col--offset-2">
             <h1>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.js
@@ -216,16 +216,16 @@ export default ({children, className: languageClassName, metastring}) => {
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <>
           {codeBlockTitle && (
-            <div style={style} className={styles.codeBlockTitle}>
+            <div style={style} className={classnames('codeBlockTitle', styles.codeBlockTitle)}>
               {codeBlockTitle}
             </div>
           )}
-          <div className={styles.codeBlockContent}>
+          <div className={classnames('codeBlockContent', styles.codeBlockContent)}>
             <button
               ref={button}
               type="button"
               aria-label="Copy code to clipboard"
-              className={classnames(styles.copyButton, {
+              className={classnames('copyButton', styles.copyButton, {
                 [styles.copyButtonWithTitle]: codeBlockTitle,
               })}
               onClick={handleCopyCode}>
@@ -233,10 +233,10 @@ export default ({children, className: languageClassName, metastring}) => {
             </button>
             <div
               tabIndex="0"
-              className={classnames(className, styles.codeBlock, {
+              className={classnames(className, 'codeBlock', styles.codeBlock, {
                 [styles.codeBlockWithTitle]: codeBlockTitle,
               })}>
-              <div ref={target} className={styles.codeBlockLines} style={style}>
+              <div ref={target} className={classnames('codeBlockLines', styles.codeBlockLines)} style={style}>
                 {tokens.map((line, i) => {
                   if (line.length === 1 && line[0].content === '') {
                     line[0].content = '\n'; // eslint-disable-line no-param-reassign

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -24,8 +24,8 @@ const TOP_OFFSET = 100;
 function DocTOC({headings}) {
   useTOCHighlight(LINK_CLASS_NAME, ACTIVE_LINK_CLASS_NAME, TOP_OFFSET);
   return (
-    <div className="col col--3">
-      <div className={styles.tableOfContents}>
+    <div className="col col--3 tableOfContents__container">
+      <div className={classnames('tableOfContents', styles.tableOfContents)}>
         <Headings headings={headings} />
       </div>
     </div>
@@ -108,8 +108,8 @@ function DocItem(props) {
           styles.docItemWrapper,
         )}>
         <div className="row">
-          <div className={classnames('col', styles.docItemCol)}>
-            <div className={styles.docItemContainer}>
+          <div className={classnames('col', 'docItemCol', styles.docItemCol)}>
+            <div className={classnames('docItemContainer', styles.docItemContainer)}>
               <article>
                 {version && (
                   <div>
@@ -120,7 +120,7 @@ function DocItem(props) {
                 )}
                 {!hideTitle && (
                   <header>
-                    <h1 className={styles.docTitle}>{title}</h1>
+                    <h1 className={classnames('docTitle', styles.docTitle)}>{title}</h1>
                   </header>
                 )}
                 <div className="markdown">
@@ -128,7 +128,7 @@ function DocItem(props) {
                 </div>
               </article>
               {(editUrl || lastUpdatedAt || lastUpdatedBy) && (
-                <div className="margin-vert--xl">
+                <div className="margin-vert--xl docEditContainer">
                   <div className="row">
                     <div className="col">
                       {editUrl && (
@@ -155,7 +155,7 @@ function DocItem(props) {
                       )}
                     </div>
                     {(lastUpdatedAt || lastUpdatedBy) && (
-                      <div className="col text--right">
+                      <div className="col text--right docLastUpdated">
                         <em>
                           <small>
                             Last updated{' '}
@@ -194,7 +194,7 @@ function DocItem(props) {
                   </div>
                 </div>
               )}
-              <div className="margin-vert--lg">
+              <div className="margin-vert--lg pagination">
                 <DocPaginator metadata={metadata} />
               </div>
             </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import classnames from 'classnames';
 import {MDXProvider} from '@mdx-js/react';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -39,9 +40,9 @@ function DocPage(props) {
 
   return (
     <Layout version={version} key={isClient}>
-      <div className={styles.docPage}>
+      <div className={classnames('docPage', styles.docPage)}>
         {sidebar && (
-          <div className={styles.docSidebarContainer}>
+          <div className={classnames('docSidebarContainer', styles.docSidebarContainer)}>
             <DocSidebar
               docsSidebars={docsSidebars}
               path={currentRoute.path}
@@ -50,7 +51,7 @@ function DocPage(props) {
             />
           </div>
         )}
-        <main className={styles.docMainContainer}>
+        <main className={classnames('docMainContainer', styles.docMainContainer)}>
           <MDXProvider components={MDXComponents}>
             {renderRoutes(baseRoute.routes)}
           </MDXProvider>

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -155,7 +155,7 @@ function DocSidebar(props) {
   }
 
   return (
-    <div className={styles.sidebar}>
+    <div className={classnames('sidebar', styles.sidebar)}>
       {hideOnScroll && (
         <Link
           tabIndex="-1"

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import classnames from 'classnames';
 import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
@@ -27,7 +28,7 @@ export default {
     }
     return <Link {...props} />;
   },
-  pre: (props) => <div className={styles.mdxCodeBlock} {...props} />,
+  pre: (props) => <div className={classnames('mdxCodeBlock', styles.mdxCodeBlock)} {...props} />,
   h1: Heading('h1'),
   h2: Heading('h2'),
   h3: Heading('h3'),

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -240,7 +240,7 @@ function Navbar() {
             ))}
           {!disableDarkMode && (
             <Toggle
-              className={styles.displayOnlyInLargeViewport}
+              className={classnames('navbar__theme-toggle', styles.displayOnlyInLargeViewport)}
               aria-label="Dark mode toggle"
               checked={isDarkTheme}
               onChange={onToggleChange}
@@ -278,6 +278,7 @@ function Navbar() {
           </Link>
           {!disableDarkMode && sidebarShown && (
             <Toggle
+              className="navbar__theme-toggle"
               aria-label="Dark mode toggle in sidebar"
               checked={isDarkTheme}
               onChange={onToggleChange}

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.js
@@ -13,8 +13,8 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import classnames from 'classnames';
 import styles from './styles.module.css';
 
-const Moon = () => <span className={classnames(styles.toggle, styles.moon)} />;
-const Sun = () => <span className={classnames(styles.toggle, styles.sun)} />;
+const Moon = () => <span className={classnames('toggle__moon', styles.toggle, styles.moon)} />;
+const Sun = () => <span className={classnames('toggle__sun', styles.toggle, styles.sun)} />;
 
 export default function (props) {
   const {isClient} = useDocusaurusContext();


### PR DESCRIPTION
## Motivation

During my own attempt to implement customisations to the Classic Theme, I found it very difficult to modify some of the styles due to them being given different scopes in hot reload development as opposed to during a build, where they are appended with hashes.

My current solution has been to create a very hacky swizzle of the `ThemeProvider` component, which injects a style tag into the HTML body with the classes added which I want to over-ride. A reduction of that solution is below (only look if you appreciate "creative" programming):

```js
import React from 'react';
import cssesc from 'cssesc';

import ThemeProvider_Original from '../../../node_modules/@docusaurus/theme-classic/src/theme/ThemeProvider';
import styles_DocPage from '../../../node_modules/@docusaurus/theme-classic/src/theme/DocPage/styles.module.css';

const esc = name => cssesc(name, {isIdentifier: true});

const styles = `
.${esc(styles_DocPage.docSidebarContainer)} {
  border-right: none;
}
`;

export default function(props) {
  return (
    <>
      <style dangerouslySetInnerHTML={{__html: styles}} />
      <ThemeProvider_Original {...props} />
    </>
  );
}
```

So that's what it took just to remove the border on the left-side docs menu.

This PR proposes to ease the simple use of the standard `custom.css` instead, by providing more static classes to the Classic Theme components. These will not be scoped by Webpack/CSS Loader, and so will be more easily overridden in `custom.css` (albeit sometimes using `!important` - can the load order be fixed so `custom.css` is always last?).

I have done my best to identify all the potential points where a user might want to hook in with their own styles. I am not attached to the class names themselves, I was trying to understand the logic of underscores, hyphens, camels, and kebabs but it was really not clear.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes, Facebook now has the right to claim my first born son.

## Test Plan

These are non-breaking changes that are 100% backward compatible. I ran all the tests and linters though. Works a treat on my local development env and I can do away with my magical swizzled component at this point.

## Related PRs

None. No docs about the standard styles exist AFAIK, so I guess they don't need updating.