### PR TITLE
Implemented a method to properly format custom URLs

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.js
@@ -13,6 +13,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import DocPaginator from '@theme/DocPaginator';
 import useTOCHighlight from '@theme/hooks/useTOCHighlight';
+import formatUrl from '@docusaurus/formatUrl';
 
 import classnames from 'classnames';
 import styles from './styles.module.css';
@@ -73,6 +74,7 @@ function DocItem(props) {
       keywords,
       hide_title: hideTitle,
       hide_table_of_contents: hideTableOfContents,
+      canonical_url: canonicalURL,
     },
   } = DocContent;
 
@@ -81,6 +83,10 @@ function DocItem(props) {
   if (!isInternalUrl(metaImage)) {
     metaImageUrl = metaImage;
   }
+
+  const formattedCanonicalURL = canonicalURL
+    ? formatUrl(canonicalURL)
+    : siteUrl + permalink;
 
   return (
     <>
@@ -99,8 +105,10 @@ function DocItem(props) {
         {metaImage && (
           <meta name="twitter:image:alt" content={`Image for ${title}`} />
         )}
-        {permalink && <meta property="og:url" content={siteUrl + permalink} />}
-        {permalink && <link rel="canonical" href={siteUrl + permalink} />}
+        {permalink && (
+          <meta property="og:url" content={formattedCanonicalURL} />
+        )}
+        {permalink && <link rel="canonical" href={formattedCanonicalURL} />}
       </Head>
       <div
         className={classnames(

--- a/packages/docusaurus/src/client/exports/__tests__/formatUrl.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/formatUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import formatUrl from '../formatUrl';
+
+describe('formatUrl', () => {
+  test('should return suffixed with a slash', () => {
+    expect(formatUrl('https://foo.com')).toBe('https://foo.com/');
+  });
+
+  test('should keep URL params intact', () => {
+    expect(formatUrl('https://foo.com?a=1')).toBe('https://foo.com/?a=1');
+  });
+
+  test('should not format invalid strings', () => {
+    expect(formatUrl('foobar')).toBe('foobar');
+  });
+});

--- a/packages/docusaurus/src/client/exports/formatUrl.ts
+++ b/packages/docusaurus/src/client/exports/formatUrl.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {URL} from 'url';
+
+export default function formatUrl(urlToFormat: string): string {
+  try {
+    const parsedUrl = new URL(urlToFormat);
+
+    return parsedUrl.href;
+  } catch (e) {
+    return urlToFormat;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

To ensure user-defined URLs remain consistent, this PR introduces a method to ensure that is possible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Run tests
- Add a call to the newly added function, with a missing end slash. Log the output of the call.
- You should see a slash added.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
