### PR TITLE
fix(v2): fix index page features.length when 0

### DIFF
--- a/packages/docusaurus-init/templates/bootstrap/src/pages/index.js
+++ b/packages/docusaurus-init/templates/bootstrap/src/pages/index.js
@@ -74,7 +74,7 @@ function Home() {
         </div>
       </header>
       <main>
-        {features && features.length && (
+        {features && features.length > 0 && (
           <section className={styles.features}>
             <div className="container">
               <div className="row">

--- a/packages/docusaurus-init/templates/classic/src/pages/index.js
+++ b/packages/docusaurus-init/templates/classic/src/pages/index.js
@@ -78,7 +78,7 @@ function Home() {
         </div>
       </header>
       <main>
-        {features && features.length && (
+        {features && features.length > 0 && (
           <section className={styles.features}>
             <div className="container">
               <div className="row">

--- a/packages/docusaurus-init/templates/facebook/src/pages/index.js
+++ b/packages/docusaurus-init/templates/facebook/src/pages/index.js
@@ -87,7 +87,7 @@ function Home() {
         </div>
       </header>
       <main>
-        {features && features.length && (
+        {features && features.length > 0 && (
           <section className={styles.features}>
             <div className="container">
               <div className="row">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

If features is an empty array, a "0" is displayed instead of the feature list : 

![image](https://user-images.githubusercontent.com/1398469/82054070-a71efd00-96be-11ea-84ef-521ef9c418f5.png)

This is because :
```
const features = []

features && features.length && 'anything' // will return "0"
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

I don't think it really needs a test plan, but feel free to correct me if you really want this tested

