### PR TITLE
feat(v2): add search page 🔎

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -46,6 +46,7 @@ import {
 } from './types';
 import {Configuration} from 'webpack';
 import {docsVersion} from './version';
+import {VERSIONS_JSON_FILE} from './constants';
 
 const DEFAULT_OPTIONS: PluginOptions = {
   path: 'docs', // Path to data on filesystem, relative to site dir.
@@ -94,6 +95,10 @@ export default function pluginContentDocs(
 
   return {
     name: 'docusaurus-plugin-content-docs',
+
+    getThemePath() {
+      return path.resolve(__dirname, './theme');
+    },
 
     extendCli(cli) {
       cli
@@ -418,7 +423,16 @@ export default function pluginContentDocs(
     configureWebpack(_config, isServer, utils) {
       const {getBabelLoader, getCacheLoader} = utils;
       const {rehypePlugins, remarkPlugins} = options;
+      // Suppress warnings about non-existing of versions file.
+      const stats = {
+        warningsFilter: [VERSIONS_JSON_FILE],
+      };
+
       return {
+        stats,
+        devServer: {
+          stats,
+        },
         resolve: {
           alias: {
             '~docs': dataDir,

--- a/packages/docusaurus-plugin-content-docs/src/theme/hooks/useVersioning.ts
+++ b/packages/docusaurus-plugin-content-docs/src/theme/hooks/useVersioning.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+let versions: string[] = [];
+
+try {
+  versions = require('@site/versions.json');
+} catch (e) {}
+
+function useVersioning() {
+  return {
+    versioningEnabled: versions.length > 0,
+    versions,
+    latestVersion: versions[0],
+  };
+}
+
+export default useVersioning;

--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -8,11 +8,15 @@
   },
   "license": "MIT",
   "dependencies": {
+    "algoliasearch": "^3.24.5",
+    "algoliasearch-helper": "^3.1.1",
     "classnames": "^2.2.6",
-    "docsearch.js": "^2.6.3"
+    "docsearch.js": "^2.6.3",
+    "eta": "^1.1.1"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",
+    "@docusaurus/utils": "^2.0.0-alpha.54",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/packages/docusaurus-theme-search-algolia/src/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/index.js
@@ -6,13 +6,29 @@
  */
 
 const path = require('path');
+const fs = require('fs');
+const eta = require('eta');
+const {normalizeUrl} = require('@docusaurus/utils');
+const openSearchTemplate = require('./templates/opensearch');
 
-module.exports = function () {
+const OPEN_SEARCH_FILENAME = 'opensearch.xml';
+
+module.exports = function (context) {
+  const {
+    baseUrl,
+    siteConfig: {title, url, favicon},
+  } = context;
+  const pagePath = path.resolve(__dirname, './pages/search/index.js');
+
   return {
     name: 'docusaurus-theme-search-algolia',
 
     getThemePath() {
       return path.resolve(__dirname, './theme');
+    },
+
+    getPathsToWatch() {
+      return [pagePath];
     },
 
     configureWebpack() {
@@ -32,6 +48,45 @@ module.exports = function () {
             },
           },
         },
+      };
+    },
+
+    async contentLoaded({actions: {addRoute}}) {
+      addRoute({
+        path: normalizeUrl([baseUrl, 'search']),
+        component: pagePath,
+        exact: true,
+      });
+    },
+
+    async postBuild({outDir}) {
+      try {
+        fs.writeFileSync(
+          path.join(outDir, OPEN_SEARCH_FILENAME),
+          eta.render(openSearchTemplate.trim(), {
+            title,
+            url,
+            favicon: normalizeUrl([url, favicon]),
+          }),
+        );
+      } catch (err) {
+        throw new Error(`Generating OpenSearch file failed: ${err}`);
+      }
+    },
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'search',
+              type: 'application/opensearchdescription+xml',
+              title,
+              href: normalizeUrl([baseUrl, OPEN_SEARCH_FILENAME]),
+            },
+          },
+        ],
       };
     },
   };

--- a/packages/docusaurus-theme-search-algolia/src/pages/search/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/pages/search/index.js
@@ -1,0 +1,354 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useEffect, useState, useReducer, useRef} from 'react';
+
+import algoliaSearch from 'algoliasearch/lite';
+import algoliaSearchHelper from 'algoliasearch-helper';
+import classnames from 'classnames';
+
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useVersioning from '@theme/hooks/useVersioning';
+import useSearchQuery from '@theme/hooks/useSearchQuery';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+
+import styles from './styles.module.css';
+
+function Search() {
+  const {
+    siteConfig: {
+      themeConfig: {algolia: {appId = 'BH4D9OD16A', apiKey, indexName} = {}},
+    } = {},
+  } = useDocusaurusContext();
+  const {searchValue, updateSearchPath} = useSearchQuery();
+  const {versioningEnabled, versions, latestVersion} = useVersioning();
+  const [searchVersion, setSearchVersion] = useState(latestVersion);
+  const [searchQuery, setSearchQuery] = useState(searchValue);
+  const initialSearchResultState = {
+    items: [],
+    query: null,
+    totalResults: null,
+    totalPages: null,
+    lastPage: null,
+    hasMore: null,
+    loading: null,
+  };
+  const [searchResultState, searchResultStateDispatcher] = useReducer(
+    (prevState, {type, value: state}) => {
+      switch (type) {
+        case 'reset': {
+          return initialSearchResultState;
+        }
+        case 'loading': {
+          return {...prevState, loading: true};
+        }
+        case 'update': {
+          if (searchQuery !== state.query) {
+            return prevState;
+          }
+
+          return {
+            ...state,
+            items:
+              state.lastPage === 0
+                ? state.items
+                : prevState.items.concat(state.items),
+          };
+        }
+        case 'advance': {
+          const hasMore = prevState.totalPages > prevState.lastPage + 1;
+
+          return {
+            ...prevState,
+            lastPage: hasMore ? prevState.lastPage + 1 : prevState.lastPage,
+            hasMore,
+          };
+        }
+        default:
+          return prevState;
+      }
+    },
+    initialSearchResultState,
+  );
+  const algoliaClient = algoliaSearch(appId, apiKey);
+  const algoliaHelper = algoliaSearchHelper(algoliaClient, indexName, {
+    hitsPerPage: 15,
+    advancedSyntax: true,
+    facets: searchVersion ? ['version'] : [],
+  });
+
+  algoliaHelper.on(
+    'result',
+    ({results: {query, hits, page, nbHits, nbPages}}) => {
+      if (query === '' || !(hits instanceof Array)) {
+        searchResultStateDispatcher({type: 'reset'});
+        return;
+      }
+
+      const sanitizeValue = (value) => {
+        return value.replace(
+          /algolia-docsearch-suggestion--highlight/g,
+          'search-result-match',
+        );
+      };
+
+      const items = hits.map(
+        ({
+          url,
+          _highlightResult: {hierarchy},
+          _snippetResult: snippet = {},
+        }) => {
+          const {pathname, hash} = new URL(url);
+          const titles = Object.keys(hierarchy).map((key) => {
+            return sanitizeValue(hierarchy[key].value);
+          });
+
+          return {
+            title: titles.pop(),
+            url: pathname + hash,
+            summary: snippet.content
+              ? `${sanitizeValue(snippet.content.value)}...`
+              : '',
+            breadcrumbs: titles,
+          };
+        },
+      );
+
+      searchResultStateDispatcher({
+        type: 'update',
+        value: {
+          items,
+          query,
+          totalResults: nbHits,
+          totalPages: nbPages,
+          lastPage: page,
+          hasMore: nbPages > page + 1,
+          loading: false,
+        },
+      });
+    },
+  );
+
+  const [loaderRef, setLoaderRef] = useState(null);
+  const prevY = useRef(0);
+  const observer = useRef(
+    ExecutionEnvironment.canUseDOM &&
+      new IntersectionObserver(
+        (entries) => {
+          const {
+            isIntersecting,
+            boundingClientRect: {y: currentY},
+          } = entries[0];
+
+          if (isIntersecting && prevY.current > currentY) {
+            searchResultStateDispatcher({type: 'advance'});
+          }
+
+          prevY.current = currentY;
+        },
+        {threshold: 1},
+      ),
+  );
+
+  const getTitle = () =>
+    searchQuery
+      ? `Search results for "${searchQuery}"`
+      : 'Search the documentation';
+
+  const makeSearch = (page = 0) => {
+    if (searchVersion) {
+      algoliaHelper
+        .setQuery(searchQuery)
+        .addFacetRefinement('version', searchVersion)
+        .setPage(page)
+        .search();
+    } else {
+      algoliaHelper.setQuery(searchQuery).setPage(page).search();
+    }
+  };
+
+  const handleSearchInputChange = (e) => {
+    const searchInputValue = e.target.value;
+
+    if (e.target.tagName === 'SELECT') {
+      setSearchVersion(searchInputValue);
+    } else {
+      setSearchQuery(searchInputValue);
+    }
+  };
+
+  useEffect(() => {
+    if (!loaderRef) {
+      return undefined;
+    }
+
+    observer.current.observe(loaderRef);
+
+    return () => {
+      observer.current.unobserve(loaderRef);
+    };
+  }, [loaderRef]);
+
+  useEffect(() => {
+    updateSearchPath(searchQuery);
+
+    searchResultStateDispatcher({type: 'reset'});
+
+    if (searchQuery) {
+      searchResultStateDispatcher({type: 'loading'});
+
+      setTimeout(() => {
+        makeSearch();
+      }, 300);
+    }
+  }, [searchQuery, searchVersion]);
+
+  useEffect(() => {
+    if (!searchResultState.lastPage || searchResultState.lastPage === 0) {
+      return;
+    }
+
+    makeSearch(searchResultState.lastPage);
+  }, [searchResultState.lastPage]);
+
+  return (
+    <Layout title={getTitle()}>
+      <div className="container margin-vert--lg">
+        <h1>{getTitle()}</h1>
+
+        <form className="row" onSubmit={(e) => e.preventDefault()}>
+          <div
+            className={classnames('col', styles.searchQueryColumn, {
+              'col--9': versioningEnabled,
+              'col--12': !versioningEnabled,
+            })}>
+            <input
+              type="search"
+              name="q"
+              className={styles.searchQueryInput}
+              placeholder="Type your search here"
+              aria-label="Search"
+              onChange={handleSearchInputChange}
+              value={searchQuery}
+              autoComplete="off"
+            />
+          </div>
+
+          {versioningEnabled && (
+            <div
+              className={classnames(
+                'col',
+                'col--3',
+                'padding-left--none',
+                styles.searchVersionColumn,
+              )}>
+              <select
+                onChange={handleSearchInputChange}
+                defaultValue={searchVersion}
+                className={styles.searchVersionInput}>
+                {versions.map((version, i) => (
+                  <option key={i} value={version}>
+                    {version}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </form>
+
+        <div className={classnames('row', 'margin-vert--sm')}>
+          <div
+            className={classnames('col', 'col--8', styles.searchResultsColumn)}>
+            {!!searchResultState.totalResults && (
+              <strong>{searchResultState.totalResults} documents found</strong>
+            )}
+          </div>
+
+          <div className={classnames('col', 'col--4', styles.searchLogoColumn)}>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://www.algolia.com/"
+              aria-label="Search">
+              <svg
+                viewBox="0 0 168 24"
+                className={styles.algoliaLogo}
+                xmlns="http://www.w3.org/2000/svg"
+                aria-label="Search by Algolia">
+                <g fill="none">
+                  <path
+                    className={styles.algoliaLogoPathFill}
+                    d="M120.925 18.804c-4.386.02-4.386-3.54-4.386-4.106l-.007-13.336 2.675-.424v13.254c0 .322 0 2.358 1.718 2.364v2.248zm-10.846-2.18c.821 0 1.43-.047 1.855-.129v-2.719a6.334 6.334 0 0 0-1.574-.199 5.7 5.7 0 0 0-.897.069 2.699 2.699 0 0 0-.814.24c-.24.116-.439.28-.582.491-.15.212-.219.335-.219.656 0 .628.219.991.616 1.23s.938.362 1.615.362zm-.233-9.7c.883 0 1.629.109 2.231.328.602.218 1.088.525 1.444.915.363.396.609.922.76 1.483.157.56.232 1.175.232 1.85v6.874a32.5 32.5 0 0 1-1.868.314c-.834.123-1.772.185-2.813.185-.69 0-1.327-.069-1.895-.198a4.001 4.001 0 0 1-1.471-.636 3.085 3.085 0 0 1-.951-1.134c-.226-.465-.343-1.12-.343-1.803 0-.656.13-1.073.384-1.525a3.24 3.24 0 0 1 1.047-1.106c.445-.287.95-.492 1.532-.615a8.8 8.8 0 0 1 1.82-.185 8.404 8.404 0 0 1 1.972.24v-.438c0-.307-.035-.6-.11-.874a1.88 1.88 0 0 0-.384-.73 1.784 1.784 0 0 0-.724-.493 3.164 3.164 0 0 0-1.143-.205c-.616 0-1.177.075-1.69.164a7.735 7.735 0 0 0-1.26.307l-.321-2.192c.335-.117.834-.233 1.478-.349a10.98 10.98 0 0 1 2.073-.178zm52.842 9.626c.822 0 1.43-.048 1.854-.13V13.7a6.347 6.347 0 0 0-1.574-.199c-.294 0-.595.021-.896.069a2.7 2.7 0 0 0-.814.24 1.46 1.46 0 0 0-.582.491c-.15.212-.218.335-.218.656 0 .628.218.991.615 1.23.404.245.938.362 1.615.362zm-.226-9.694c.883 0 1.629.108 2.231.327.602.219 1.088.526 1.444.915.355.39.609.923.759 1.483a6.8 6.8 0 0 1 .233 1.852v6.873c-.41.088-1.034.19-1.868.314-.834.123-1.772.184-2.813.184-.69 0-1.327-.068-1.895-.198a4.001 4.001 0 0 1-1.471-.635 3.085 3.085 0 0 1-.951-1.134c-.226-.465-.343-1.12-.343-1.804 0-.656.13-1.073.384-1.524.26-.45.608-.82 1.047-1.107.445-.286.95-.491 1.532-.614a8.803 8.803 0 0 1 2.751-.13c.329.034.671.096 1.04.185v-.437a3.3 3.3 0 0 0-.109-.875 1.873 1.873 0 0 0-.384-.731 1.784 1.784 0 0 0-.724-.492 3.165 3.165 0 0 0-1.143-.205c-.616 0-1.177.075-1.69.164a7.75 7.75 0 0 0-1.26.307l-.321-2.193c.335-.116.834-.232 1.478-.348a11.633 11.633 0 0 1 2.073-.177zm-8.034-1.271a1.626 1.626 0 0 1-1.628-1.62c0-.895.725-1.62 1.628-1.62.904 0 1.63.725 1.63 1.62 0 .895-.733 1.62-1.63 1.62zm1.348 13.22h-2.689V7.27l2.69-.423v11.956zm-4.714 0c-4.386.02-4.386-3.54-4.386-4.107l-.008-13.336 2.676-.424v13.254c0 .322 0 2.358 1.718 2.364v2.248zm-8.698-5.903c0-1.156-.253-2.119-.746-2.788-.493-.677-1.183-1.01-2.067-1.01-.882 0-1.574.333-2.065 1.01-.493.676-.733 1.632-.733 2.788 0 1.168.246 1.953.74 2.63.492.683 1.183 1.018 2.066 1.018.882 0 1.574-.342 2.067-1.019.492-.683.738-1.46.738-2.63zm2.737-.007c0 .902-.13 1.584-.397 2.33a5.52 5.52 0 0 1-1.128 1.906 4.986 4.986 0 0 1-1.752 1.223c-.685.286-1.739.45-2.265.45-.528-.006-1.574-.157-2.252-.45a5.096 5.096 0 0 1-1.744-1.223c-.487-.527-.863-1.162-1.137-1.906a6.345 6.345 0 0 1-.41-2.33c0-.902.123-1.77.397-2.508a5.554 5.554 0 0 1 1.15-1.892 5.133 5.133 0 0 1 1.75-1.216c.679-.287 1.425-.423 2.232-.423.808 0 1.553.142 2.237.423a4.88 4.88 0 0 1 1.753 1.216 5.644 5.644 0 0 1 1.135 1.892c.287.738.431 1.606.431 2.508zm-20.138 0c0 1.12.246 2.363.738 2.882.493.52 1.13.78 1.91.78.424 0 .828-.062 1.204-.178.377-.116.677-.253.917-.417V9.33a10.476 10.476 0 0 0-1.766-.226c-.971-.028-1.71.37-2.23 1.004-.513.636-.773 1.75-.773 2.788zm7.438 5.274c0 1.824-.466 3.156-1.404 4.004-.936.846-2.367 1.27-4.296 1.27-.705 0-2.17-.137-3.34-.396l.431-2.118c.98.205 2.272.26 2.95.26 1.074 0 1.84-.219 2.299-.656.459-.437.684-1.086.684-1.948v-.437a8.07 8.07 0 0 1-1.047.397c-.43.13-.93.198-1.492.198-.739 0-1.41-.116-2.018-.349a4.206 4.206 0 0 1-1.567-1.025c-.431-.45-.774-1.017-1.013-1.694-.24-.677-.363-1.885-.363-2.773 0-.834.13-1.88.384-2.577.26-.696.629-1.298 1.129-1.796.493-.498 1.095-.881 1.8-1.162a6.605 6.605 0 0 1 2.428-.457c.87 0 1.67.109 2.45.24.78.129 1.444.265 1.985.415V18.17zM6.972 6.677v1.627c-.712-.446-1.52-.67-2.425-.67-.585 0-1.045.13-1.38.391a1.24 1.24 0 0 0-.502 1.03c0 .425.164.765.494 1.02.33.256.835.532 1.516.83.447.192.795.356 1.045.495.25.138.537.332.862.582.324.25.563.548.718.894.154.345.23.741.23 1.188 0 .947-.334 1.691-1.004 2.234-.67.542-1.537.814-2.601.814-1.18 0-2.16-.229-2.936-.686v-1.708c.84.628 1.814.942 2.92.942.585 0 1.048-.136 1.388-.407.34-.271.51-.646.51-1.125 0-.287-.1-.55-.302-.79-.203-.24-.42-.42-.655-.542-.234-.123-.585-.29-1.053-.503a61.27 61.27 0 0 1-.582-.271 13.67 13.67 0 0 1-.55-.287 4.275 4.275 0 0 1-.567-.351 6.92 6.92 0 0 1-.455-.4c-.18-.17-.31-.34-.39-.51-.08-.17-.155-.37-.224-.598a2.553 2.553 0 0 1-.104-.742c0-.915.333-1.638.998-2.17.664-.532 1.523-.798 2.576-.798.968 0 1.793.17 2.473.51zm7.468 5.696v-.287c-.022-.607-.187-1.088-.495-1.444-.309-.357-.75-.535-1.324-.535-.532 0-.99.194-1.373.583-.382.388-.622.949-.717 1.683h3.909zm1.005 2.792v1.404c-.596.34-1.383.51-2.362.51-1.255 0-2.255-.377-3-1.132-.744-.755-1.116-1.744-1.116-2.968 0-1.297.34-2.316 1.021-3.055.68-.74 1.548-1.11 2.6-1.11 1.033 0 1.852.323 2.458.966.606.644.91 1.572.91 2.784 0 .33-.033.676-.096 1.038h-5.314c.107.702.405 1.239.894 1.611.49.372 1.106.558 1.85.558.862 0 1.58-.202 2.155-.606zm6.605-1.77h-1.212c-.596 0-1.045.116-1.349.35-.303.234-.454.532-.454.894 0 .372.117.664.35.877.235.213.575.32 1.022.32.51 0 .912-.142 1.204-.424.293-.281.44-.651.44-1.108v-.91zm-4.068-2.554V9.325c.627-.361 1.457-.542 2.489-.542 2.116 0 3.175 1.026 3.175 3.08V17h-1.548v-.957c-.415.68-1.143 1.02-2.186 1.02-.766 0-1.38-.22-1.843-.661-.462-.442-.694-1.003-.694-1.684 0-.776.293-1.38.878-1.81.585-.431 1.404-.647 2.457-.647h1.34V11.8c0-.554-.133-.971-.399-1.253-.266-.282-.707-.423-1.324-.423a4.07 4.07 0 0 0-2.345.718zm9.333-1.93v1.42c.394-1 1.101-1.5 2.123-1.5.148 0 .313.016.494.048v1.531a1.885 1.885 0 0 0-.75-.143c-.542 0-.989.24-1.34.718-.351.479-.527 1.048-.527 1.707V17h-1.563V8.91h1.563zm5.01 4.084c.022.82.272 1.492.75 2.019.479.526 1.15.79 2.01.79.639 0 1.235-.176 1.788-.527v1.404c-.521.319-1.186.479-1.995.479-1.265 0-2.276-.4-3.031-1.197-.755-.798-1.133-1.792-1.133-2.984 0-1.16.38-2.151 1.14-2.975.761-.825 1.79-1.237 3.088-1.237.702 0 1.346.149 1.93.447v1.436a3.242 3.242 0 0 0-1.77-.495c-.84 0-1.513.266-2.019.798-.505.532-.758 1.213-.758 2.042zM40.24 5.72v4.579c.458-1 1.293-1.5 2.505-1.5.787 0 1.42.245 1.899.734.479.49.718 1.17.718 2.042V17h-1.564v-5.106c0-.553-.14-.98-.422-1.284-.282-.303-.652-.455-1.11-.455-.531 0-1.002.202-1.411.606-.41.405-.615 1.022-.615 1.851V17h-1.563V5.72h1.563zm14.966 10.02c.596 0 1.096-.253 1.5-.758.404-.506.606-1.157.606-1.955 0-.915-.202-1.62-.606-2.114-.404-.495-.92-.742-1.548-.742-.553 0-1.05.224-1.491.67-.442.447-.662 1.133-.662 2.058 0 .958.212 1.67.638 2.138.425.469.946.703 1.563.703zM53.004 5.72v4.42c.574-.894 1.388-1.341 2.44-1.341 1.022 0 1.857.383 2.506 1.149.649.766.973 1.781.973 3.047 0 1.138-.309 2.109-.925 2.912-.617.803-1.463 1.205-2.537 1.205-1.075 0-1.894-.447-2.457-1.34V17h-1.58V5.72h1.58zm9.908 11.104l-3.223-7.913h1.739l1.005 2.632 1.26 3.415c.096-.32.48-1.458 1.15-3.415l.909-2.632h1.66l-2.92 7.866c-.777 2.074-1.963 3.11-3.559 3.11a2.92 2.92 0 0 1-.734-.079v-1.34c.17.042.351.064.543.064 1.032 0 1.755-.57 2.17-1.708z"
+                  />
+                  <path
+                    fill="#5468FF"
+                    d="M78.988.938h16.594a2.968 2.968 0 0 1 2.966 2.966V20.5a2.967 2.967 0 0 1-2.966 2.964H78.988a2.967 2.967 0 0 1-2.966-2.964V3.897A2.961 2.961 0 0 1 78.988.938z"
+                  />
+                  <path
+                    fill="white"
+                    d="M89.632 5.967v-.772a.978.978 0 0 0-.978-.977h-2.28a.978.978 0 0 0-.978.977v.793c0 .088.082.15.171.13a7.127 7.127 0 0 1 1.984-.28c.65 0 1.295.088 1.917.259.082.02.164-.04.164-.13m-6.248 1.01l-.39-.389a.977.977 0 0 0-1.382 0l-.465.465a.973.973 0 0 0 0 1.38l.383.383c.062.061.15.047.205-.014.226-.307.472-.601.746-.874.281-.28.568-.526.883-.751.068-.042.075-.137.02-.2m4.16 2.453v3.341c0 .096.104.165.192.117l2.97-1.537c.068-.034.089-.117.055-.184a3.695 3.695 0 0 0-3.08-1.866c-.068 0-.136.054-.136.13m0 8.048a4.489 4.489 0 0 1-4.49-4.482 4.488 4.488 0 0 1 4.49-4.482 4.488 4.488 0 0 1 4.489 4.482 4.484 4.484 0 0 1-4.49 4.482m0-10.85a6.363 6.363 0 1 0 0 12.729 6.37 6.37 0 0 0 6.372-6.368 6.358 6.358 0 0 0-6.371-6.36"
+                  />
+                </g>
+              </svg>
+            </a>
+          </div>
+        </div>
+
+        {searchResultState.items.length > 0 ? (
+          <section>
+            {searchResultState.items.map(
+              ({title, url, summary, breadcrumbs}, i) => (
+                <article key={i} className={styles.searchResultItem}>
+                  <Link
+                    to={url}
+                    className={styles.searchResultItemHeading}
+                    dangerouslySetInnerHTML={{__html: title}}
+                  />
+
+                  {breadcrumbs.length > 0 && (
+                    <span
+                      className={styles.searchResultItemPath}
+                      dangerouslySetInnerHTML={{
+                        __html: breadcrumbs.join(' › '),
+                      }}
+                    />
+                  )}
+
+                  {summary && (
+                    <p
+                      className={styles.searchResultItemSummary}
+                      dangerouslySetInnerHTML={{__html: summary}}
+                    />
+                  )}
+                </article>
+              ),
+            )}
+          </section>
+        ) : (
+          [
+            searchQuery && !searchResultState.loading && (
+              <p key="no-results">No results were found</p>
+            ),
+            !!searchResultState.loading && (
+              <div key="spinner" className={styles.loadingSpinner} />
+            ),
+          ]
+        )}
+
+        {searchResultState.hasMore && (
+          <div className={styles.loader} ref={setLoaderRef}>
+            <span>Fetching new results...</span>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+export default Search;

--- a/packages/docusaurus-theme-search-algolia/src/pages/search/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/pages/search/styles.module.css
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.searchQueryInput,
+.searchVersionInput {
+  border-radius: var(--ifm-global-radius);
+  border: var(--ifm-global-border-width) solid
+    var(--ifm-color-content-secondary);
+  font-size: var(--ifm-font-size-base);
+  padding: 0.5rem;
+  width: 100%;
+  background: #fff;
+}
+
+.searchResultsColumn {
+  font-size: 0.9rem;
+}
+
+.searchLogoColumn {
+  text-align: right;
+}
+
+.algoliaLogo {
+  max-width: 150px;
+}
+
+.algoliaLogoPathFill {
+  fill: var(--ifm-font-color-base);
+}
+
+.searchResultItem {
+  padding: 1rem 0;
+  border-bottom: 1px solid #dfe3e8;
+}
+
+.searchResultItemHeading {
+  font-size: var(--ifm-h2-font-size);
+}
+
+.searchResultItemPath {
+  font-size: 0.8rem;
+  color: var(--ifm-color-content-secondary);
+  display: block;
+}
+
+.searchResultItemSummary {
+  margin: 0.5rem 0 0 0;
+  font-style: italic;
+}
+
+@media only screen and (max-width: 996px) {
+  .searchQueryColumn {
+    max-width: 60% !important;
+  }
+
+  .searchVersionColumn {
+    max-width: 40% !important;
+  }
+
+  .algoliaLogo {
+    width: 100%;
+  }
+
+  .searchResultsColumn {
+    max-width: 60% !important;
+  }
+
+  .searchLogoColumn {
+    overflow: hidden;
+    max-width: 40% !important;
+    padding-left: 0 !important;
+  }
+}
+
+.loadingSpinner {
+  pointer-events: none;
+  width: 3rem;
+  height: 3rem;
+  border: 0.4em solid transparent;
+  border-color: #eee;
+  border-top-color: var(--ifm-color-primary);
+  border-radius: 50%;
+  animation: loadingspin 1s linear infinite;
+  margin: 0 auto;
+}
+
+@keyframes loadingspin {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loader {
+  margin-top: 2rem;
+}
+
+:global(.search-result-match) {
+  background: rgba(255, 215, 142, 0.22);
+  padding: 0.09em 0;
+}

--- a/packages/docusaurus-theme-search-algolia/src/templates/opensearch.js
+++ b/packages/docusaurus-theme-search-algolia/src/templates/opensearch.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = `
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName><%= it.title %></ShortName>
+  <Description>Search <%= it.title %></Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon"><%= it.favicon %></Image>
+  <Url type="text/html" method="get" template="<%= it.url %>/search?q={searchTerms}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="<%= it.url %>/opensearch.xml" />
+  <moz:SearchForm><%= it.url %></moz:SearchForm>
+</OpenSearchDescription>
+`;

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useHistory} from '@docusaurus/router';
+import useSearchQuery from '@theme/hooks/useSearchQuery';
 
 import './styles.css';
 
@@ -21,6 +22,7 @@ const Search = (props) => {
     themeConfig: {algolia},
   } = siteConfig;
   const history = useHistory();
+  const {navigateToSearchPage} = useSearchQuery();
 
   function initAlgolia(focus) {
     window.docsearch({
@@ -29,6 +31,9 @@ const Search = (props) => {
       indexName: algolia.indexName,
       inputSelector: '#search_input_react',
       algoliaOptions: algolia.algoliaOptions,
+      autocompleteOptions: {
+        autoselect: false,
+      },
       // Override algolia's default selection event, allowing us to do client-side
       // navigation and avoiding a full page refresh.
       handleSelected: (_input, _event, suggestion) => {
@@ -87,6 +92,12 @@ const Search = (props) => {
     loadAlgolia(needFocus);
   });
 
+  const handleSearchInputPressEnter = useCallback((e) => {
+    if (e.key === 'Enter') {
+      navigateToSearchPage(e.target.value);
+    }
+  });
+
   return (
     <div className="navbar__search" key="search-box">
       <span
@@ -112,6 +123,7 @@ const Search = (props) => {
         onMouseOver={handleSearchInput}
         onFocus={handleSearchInput}
         onBlur={handleSearchInputBlur}
+        onKeyDown={handleSearchInputPressEnter}
         ref={searchBarRef}
       />
     </div>

--- a/packages/docusaurus-theme-search-algolia/src/theme/hooks/useSearchQuery.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/hooks/useSearchQuery.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useHistory, useLocation} from '@docusaurus/router';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+const SEARCH_PARAM_QUERY = 'q';
+
+function useSearchQuery() {
+  const history = useHistory();
+  const location = useLocation();
+
+  return {
+    searchValue:
+      (ExecutionEnvironment.canUseDOM &&
+        new URLSearchParams(location.search).get(SEARCH_PARAM_QUERY)) ||
+      '',
+    updateSearchPath: (searchValue) => {
+      const searchParams = new URLSearchParams(location.search);
+
+      if (searchValue) {
+        searchParams.set(SEARCH_PARAM_QUERY, searchValue);
+      } else {
+        searchParams.delete(SEARCH_PARAM_QUERY);
+      }
+
+      history.replace({
+        search: searchParams.toString(),
+      });
+    },
+    navigateToSearchPage: (searchValue) => {
+      history.push(`/search?q=${searchValue}`);
+    },
+  };
+}
+
+export default useSearchQuery;

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -124,42 +124,48 @@ export async function start(
 
   // https://webpack.js.org/configuration/dev-server
   const devServerConfig: WebpackDevServer.Configuration = {
-    compress: true,
-    clientLogLevel: 'error',
-    hot: true,
-    hotOnly: cliOptions.hotOnly,
-    // Use 'ws' instead of 'sockjs-node' on server since we're using native
-    // websockets in `webpackHotDevClient`.
-    transportMode: 'ws',
-    // Prevent a WS client from getting injected as we're already including
-    // `webpackHotDevClient`.
-    injectClient: false,
-    quiet: true,
-    headers: {
-      'access-control-allow-origin': '*',
-    },
-    publicPath: baseUrl,
-    watchOptions: {
-      ignored: /node_modules/,
-      poll: cliOptions.poll,
-    },
-    historyApiFallback: {
-      rewrites: [{from: /\/*/, to: baseUrl}],
-    },
-    disableHostCheck: true,
-    // Disable overlay on browser since we use CRA's overlay error reporting.
-    overlay: false,
-    host,
-    before: (app, server) => {
-      app.use(baseUrl, express.static(path.resolve(siteDir, STATIC_DIR_NAME)));
+    ...{
+      compress: true,
+      clientLogLevel: 'error',
+      hot: true,
+      hotOnly: cliOptions.hotOnly,
+      // Use 'ws' instead of 'sockjs-node' on server since we're using native
+      // websockets in `webpackHotDevClient`.
+      transportMode: 'ws',
+      // Prevent a WS client from getting injected as we're already including
+      // `webpackHotDevClient`.
+      injectClient: false,
+      quiet: true,
+      headers: {
+        'access-control-allow-origin': '*',
+      },
+      publicPath: baseUrl,
+      watchOptions: {
+        ignored: /node_modules/,
+        poll: cliOptions.poll,
+      },
+      historyApiFallback: {
+        rewrites: [{from: /\/*/, to: baseUrl}],
+      },
+      disableHostCheck: true,
+      // Disable overlay on browser since we use CRA's overlay error reporting.
+      overlay: false,
+      host,
+      before: (app, server) => {
+        app.use(
+          baseUrl,
+          express.static(path.resolve(siteDir, STATIC_DIR_NAME)),
+        );
 
-      // This lets us fetch source contents from webpack for the error overlay.
-      app.use(evalSourceMapMiddleware(server));
-      // This lets us open files from the runtime error overlay.
-      app.use(errorOverlayMiddleware());
+        // This lets us fetch source contents from webpack for the error overlay.
+        app.use(evalSourceMapMiddleware(server));
+        // This lets us open files from the runtime error overlay.
+        app.use(errorOverlayMiddleware());
 
-      // TODO: add plugins beforeDevServer and afterDevServer hook
+        // TODO: add plugins beforeDevServer and afterDevServer hook
+      },
     },
+    ...config.devServer,
   };
   const compiler = webpack(config);
   const devServer = new WebpackDevServer(compiler, devServerConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3182,6 +3182,13 @@ ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+algoliasearch-helper@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.1.1.tgz#4cdfbaed6670d82626ac1fae001ccbf53192f497"
+  integrity sha512-Jkqlp8jezQRixf7sbQ2zFXHpdaT41g9sHBqT6pztv5nfDmg94K+pwesAy6UbxRY78IL54LIaV1FLttMtT+IzzA==
+  dependencies:
+    events "^1.1.1"
+
 algoliasearch@^3.24.5:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
@@ -6728,7 +6735,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
   integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
 
-events@^1.1.0:
+events@^1.1.0, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation


I am pleased to present the fully fledged search page - awesomeness killer-feature!

As far as I know, none of the major static site generators that use Algolia have a "real" search page. But why?  It is so convenient especially  for docs websites, so I tried to solve that shortfall.


So now users will be able to see _all_ the search results for a specific query, and not just those five result items that were shown in navbar.

In addition, the search page supports selecting of a specific version to search, which may be useful to someone.

Last but not least, it is [OpenSearch support (aka Tab To Search)](https://www.chromium.org/tab-to-search)..yeah we can search by own documentation just by pressing the Tab button in your brower after that!

See all use cases in the screenshots below.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

**LIVE DEMO: https://hardcore-saha-310ffe.netlify.app/search**
> For OpenSearch to work, you need to specify the working site url in the config file, so it was necessary to create a separate built on Netify available by that link.
> So https://deploy-preview-2756--docusaurus-2.netlify.app/ not support OpenSearch

* * *

General view (light mode):

![image](https://user-images.githubusercontent.com/4408379/82127221-918efd80-97ba-11ea-937b-d7fa577c6c92.png)

In navbar by pressing the Enter key:

![screencast-nimbus-capture-2020 05 16-21_03_43 (2)](https://user-images.githubusercontent.com/4408379/82127267-d7e45c80-97ba-11ea-99a0-ddf6cdd36688.gif)

With OpenSearch in Chrome:

![screencast-nimbus-capture-2020 05 16-21_02_49 (1)](https://user-images.githubusercontent.com/4408379/82127264-d3b83f00-97ba-11ea-89b6-168a8da21dc2.gif)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
