### PR TITLE
fix(v2): move anchor link to right of heading

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.js
@@ -36,6 +36,7 @@ const Heading = (Tag) =>
           })}
           id={id}
         />
+        {props.children}
         <a
           aria-hidden="true"
           tabIndex="-1"
@@ -44,7 +45,6 @@ const Heading = (Tag) =>
           title="Direct link to heading">
           #
         </a>
-        {props.children}
       </Tag>
     );
   };

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -14,9 +14,7 @@
 
 .hash-link {
   opacity: 0;
-  position: absolute;
-  margin-left: -1.25rem;
-  padding-right: 1.25rem;
+  padding-left: 0.5rem;
 }
 
 *:hover > .hash-link {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After changing the size of the header font in Infima, the anchor link of heading overlaps to it (and in the case of lower-level headings we can see that hash is too far from the heading).

Since hash link size is the same as its heading, obviously we need to calculate its own position for each heading. This is pretty time consuming using pure CSS. So I think a quick and easy fix for this behavior is to place the hash link on the right side of the headings (see test plan).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before (currently improper behavior):

![screenshot](https://user-images.githubusercontent.com/4408379/82140778-d8700800-9839-11ea-9469-6ac98ee8c72f.png)

After

![screenshot_1](https://user-images.githubusercontent.com/4408379/82140782-defe7f80-9839-11ea-8b56-34674caa3430.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
