### PR TITLE
fix(v2): avoid duplication search input in navbar

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -32,7 +32,9 @@ const Search = (props) => {
       inputSelector: '#search_input_react',
       algoliaOptions: algolia.algoliaOptions,
       autocompleteOptions: {
+        openOnFocus: true,
         autoselect: false,
+        hint: false,
       },
       // Override algolia's default selection event, allowing us to do client-side
       // navigation and avoiding a full page refresh.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In #2756, I defined options for Algolia's autocomplete, but I didn’t take into account that [docsearch does not set default values for rest params](https://github.com/algolia/docsearch/blob/3268a6b227f5e486b59115419cfbea2d17ae0959/src/lib/DocSearch.js#L40-L44) (custom and default options usually merge).
As a result, on mobiles there was a strange thing after closing the search input:

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/4408379/82152491-3b799300-986a-11ea-9bf0-26f7d48e71a3.gif)

This is because the `hint` option duplicates the search input :man_shrugging: 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try using the search on preview from your mobile.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
