### PR TITLE
fix(v2): remove invalid attr from mobile nav links

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -107,7 +107,7 @@ function NavItem({items, position, className, ...props}) {
   );
 }
 
-function MobileNavItem({items, className, ...props}) {
+function MobileNavItem({items, position, className, ...props}) {
   const navLinkClassNames = (extraClassName, isSubList = false) =>
     classnames(
       'menu__link',

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -108,6 +108,7 @@ function NavItem({items, position, className, ...props}) {
 }
 
 function MobileNavItem({items, position, className, ...props}) {
+  // Need to destructure position from props so that it doesn't get passed on.
   const navLinkClassNames = (extraClassName, isSubList = false) =>
     classnames(
       'menu__link',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

From Rocket Validator:

> Attribute “position” not allowed on element “a” at this point. Found 600 times on this site.

Example:

> "ist-item"><a target="_blank" rel="noopener noreferrer" href="https://github.com/facebook/docusaurus" class="menu__link header-github-link" **position="right"** aria-label="GitHub repository"></a></"

Result of regression from #2487.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Check a11y on preview website.

## Related PRs

- Initial fix #1974
