### PR TITLE
refactor(v2): remove extra active CSS class for menu item links

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -89,7 +89,6 @@ function DocSidebarItem({
             {...(isInternalUrl(href)
               ? {
                   isNavLink: true,
-                  activeClassName: 'menu__link--active',
                   exact: true,
                   onClick: onItemClick,
                 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In #2652, I actually added a new prop to define the active menu item manually, so this class is now duplicated.

https://github.com/facebook/docusaurus/blob/00a8e9e3654e49c502d4e6e21b978e36b1419fe9/packages/docusaurus-theme-classic/src/theme/DocPage/index.js#L58

https://github.com/facebook/docusaurus/blob/00a8e9e3654e49c502d4e6e21b978e36b1419fe9/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js#L86

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
