### PR TITLE
refactor(v2): add support for dark mode to live code blocks

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
@@ -13,17 +13,17 @@
 }
 
 .playgroundEditorHeader {
-  background: rgb(32, 35, 42);
-  color: #999;
+  background: var(--ifm-color-emphasis-600);
+  color: var(--ifm-color-content-inverse);
 }
 
 .playgroundPreviewHeader {
-  background: rgb(236, 236, 236);
-  color: rgb(109, 109, 109);
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-content);
 }
 
 .playgroundPreview {
-  border: 1px solid #f0f0f0;
+  border: 1px solid var(--ifm-color-emphasis-200);
   border-bottom-left-radius: var(--ifm-global-radius);
   border-bottom-right-radius: var(--ifm-global-radius);
   position: relative;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently the headings of live code blocks have the same styling for both modes, which doesn't look very good.

For example, in light mode the playground header background should not be so dark:

![image](https://user-images.githubusercontent.com/4408379/82163324-237a3180-98b3-11ea-9f02-656158e3b021.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before:

![image](https://user-images.githubusercontent.com/4408379/82163147-ff6a2080-98b1-11ea-82a7-4dab52cd4117.png)

After:

| Light   | Dark    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/82163278-c8483f00-98b2-11ea-93bf-c8afa5e15b99.png) | ![image](https://user-images.githubusercontent.com/4408379/82163292-df872c80-98b2-11ea-8f91-9a0e7e0a916b.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
