### PR TITLE
feat(v2): allow deploy without building website

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -67,6 +67,7 @@ export interface BuildCLIOptions {
   bundleAnalyzer: boolean;
   outDir: string;
   minify: boolean;
+  skipBuild: boolean;
 }
 
 export interface LoadContext {

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -71,8 +71,12 @@ cli
     '--out-dir <dir>',
     'The full path for the new output directory, relative to the current workspace (default: build).',
   )
-  .action((siteDir = '.', {outDir}) => {
-    wrapCommand(deploy)(path.resolve(siteDir), {outDir});
+  .option(
+    '--skip-build',
+    'Skip building website before deploy it (default: false)',
+  )
+  .action((siteDir = '.', {outDir, skipBuild}) => {
+    wrapCommand(deploy)(path.resolve(siteDir), {outDir, skipBuild});
   });
 
 cli

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -9,6 +9,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import shell from 'shelljs';
 import {CONFIG_FILE_NAME, GENERATED_FILES_DIR_NAME} from '../constants';
+import {loadContext} from '../server';
 import {loadConfig} from '../server/config';
 import {build} from './build';
 import {BuildCLIOptions} from '@docusaurus/types';
@@ -17,6 +18,9 @@ export async function deploy(
   siteDir: string,
   cliOptions: Partial<BuildCLIOptions> = {},
 ): Promise<void> {
+  const {outDir} = loadContext(siteDir, cliOptions.outDir);
+  const tempDir = path.join(siteDir, GENERATED_FILES_DIR_NAME);
+
   console.log('Deploy command invoked ...');
   if (!shell.which('git')) {
     throw new Error('Git not installed or on the PATH!');
@@ -94,95 +98,103 @@ export async function deploy(
   // out to deployment branch.
   const currentCommit = shell.exec('git rev-parse HEAD').stdout.trim();
 
-  // Clear Docusaurus 2 cache dir for deploy consistency.
-  const tempDir = path.join(siteDir, '.docusaurus');
-  fs.removeSync(tempDir);
+  const runDeploy = (outDir) => {
+    if (shell.cd(tempDir).code !== 0) {
+      throw new Error(
+        `Temp dir ${GENERATED_FILES_DIR_NAME} does not exists. Run build website first.`,
+      );
+    }
 
-  // Build static html files, then push to deploymentBranch branch of specified repo.
-  build(siteDir, cliOptions, false)
-    .then((outDir) => {
-      shell.cd(tempDir);
+    if (
+      shell.exec(`git clone ${remoteBranch} ${projectName}-${deploymentBranch}`)
+        .code !== 0
+    ) {
+      throw new Error('Error: git clone failed');
+    }
 
-      if (
-        shell.exec(
-          `git clone ${remoteBranch} ${projectName}-${deploymentBranch}`,
-        ).code !== 0
-      ) {
-        throw new Error('Error: git clone failed');
-      }
+    shell.cd(`${projectName}-${deploymentBranch}`);
 
-      shell.cd(`${projectName}-${deploymentBranch}`);
-
-      // If the default branch is the one we're deploying to, then we'll fail
-      // to create it. This is the case of a cross-repo publish, where we clone
-      // a github.io repo with a default master branch.
-      const defaultBranch = shell
-        .exec('git rev-parse --abbrev-ref HEAD')
-        .stdout.trim();
-      if (defaultBranch !== deploymentBranch) {
-        if (shell.exec(`git checkout origin/${deploymentBranch}`).code !== 0) {
-          if (
-            shell.exec(`git checkout --orphan ${deploymentBranch}`).code !== 0
-          ) {
-            throw new Error(`Error: Git checkout ${deploymentBranch} failed`);
-          }
-        } else if (
-          shell.exec(`git checkout -b ${deploymentBranch}`).code +
-            shell.exec(
-              `git branch --set-upstream-to=origin/${deploymentBranch}`,
-            ).code !==
-          0
+    // If the default branch is the one we're deploying to, then we'll fail
+    // to create it. This is the case of a cross-repo publish, where we clone
+    // a github.io repo with a default master branch.
+    const defaultBranch = shell
+      .exec('git rev-parse --abbrev-ref HEAD')
+      .stdout.trim();
+    if (defaultBranch !== deploymentBranch) {
+      if (shell.exec(`git checkout origin/${deploymentBranch}`).code !== 0) {
+        if (
+          shell.exec(`git checkout --orphan ${deploymentBranch}`).code !== 0
         ) {
           throw new Error(`Error: Git checkout ${deploymentBranch} failed`);
         }
+      } else if (
+        shell.exec(`git checkout -b ${deploymentBranch}`).code +
+          shell.exec(`git branch --set-upstream-to=origin/${deploymentBranch}`)
+            .code !==
+        0
+      ) {
+        throw new Error(`Error: Git checkout ${deploymentBranch} failed`);
+      }
+    }
+
+    shell.exec('git rm -rf .');
+
+    shell.cd('../..');
+
+    const fromPath = outDir;
+    const toPath = path.join(
+      GENERATED_FILES_DIR_NAME,
+      `${projectName}-${deploymentBranch}`,
+    );
+
+    fs.copy(fromPath, toPath, (error) => {
+      if (error) {
+        throw new Error(
+          `Error: Copying build assets failed with error '${error}'`,
+        );
       }
 
-      shell.exec('git rm -rf .');
+      shell.cd(toPath);
+      shell.exec('git add --all');
 
-      shell.cd('../..');
-
-      const fromPath = outDir;
-      const toPath = path.join(
-        GENERATED_FILES_DIR_NAME,
-        `${projectName}-${deploymentBranch}`,
-      );
-
-      fs.copy(fromPath, toPath, (error) => {
-        if (error) {
-          throw new Error(
-            `Error: Copying build assets failed with error '${error}'`,
-          );
+      const commitMessage =
+        process.env.CUSTOM_COMMIT_MESSAGE ||
+        `Deploy website - based on ${currentCommit}`;
+      const commitResults = shell.exec(`git commit -m "${commitMessage}"`);
+      if (
+        shell.exec(`git push --force origin ${deploymentBranch}`).code !== 0
+      ) {
+        throw new Error('Error: Git push failed');
+      } else if (commitResults.code === 0) {
+        // The commit might return a non-zero value when site is up to date.
+        let websiteURL = '';
+        if (githubHost === 'github.com') {
+          websiteURL = projectName.includes('.github.io')
+            ? `https://${organizationName}.github.io/`
+            : `https://${organizationName}.github.io/${projectName}/`;
+        } else {
+          // GitHub enterprise hosting.
+          websiteURL = `https://${githubHost}/pages/${organizationName}/${projectName}/`;
         }
-
-        shell.cd(toPath);
-        shell.exec('git add --all');
-
-        const commitMessage =
-          process.env.CUSTOM_COMMIT_MESSAGE ||
-          `Deploy website - based on ${currentCommit}`;
-        const commitResults = shell.exec(`git commit -m "${commitMessage}"`);
-        if (
-          shell.exec(`git push --force origin ${deploymentBranch}`).code !== 0
-        ) {
-          throw new Error('Error: Git push failed');
-        } else if (commitResults.code === 0) {
-          // The commit might return a non-zero value when site is up to date.
-          let websiteURL = '';
-          if (githubHost === 'github.com') {
-            websiteURL = projectName.includes('.github.io')
-              ? `https://${organizationName}.github.io/`
-              : `https://${organizationName}.github.io/${projectName}/`;
-          } else {
-            // GitHub enterprise hosting.
-            websiteURL = `https://${githubHost}/pages/${organizationName}/${projectName}/`;
-          }
-          shell.echo(`Website is live at ${websiteURL}`);
-          shell.exit(0);
-        }
-      });
-    })
-    .catch((buildError) => {
-      console.error(buildError);
-      process.exit(1);
+        shell.echo(`Website is live at ${websiteURL}`);
+        shell.exit(0);
+      }
     });
+  };
+
+  if (!cliOptions.skipBuild) {
+    // Clear Docusaurus 2 cache dir for deploy consistency.
+    fs.removeSync(tempDir);
+
+    // Build static html files, then push to deploymentBranch branch of specified repo.
+    build(siteDir, cliOptions, false)
+      .then(runDeploy)
+      .catch((buildError) => {
+        console.error(buildError);
+        process.exit(1);
+      });
+  } else {
+    // Push current build to deploymentBranch branch of specified repo.
+    runDeploy(outDir);
+  }
 }

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -110,3 +110,4 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 | Name | Default | Description |
 | --- | --- | --- |
 | `--out-dir` | `build` | The full path for the new output directory, relative to the current workspace. |
+| `--skip-build` | `false` | Deploy website without new its building. This may be useful when using custom deploy script. |

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -110,4 +110,4 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 | Name | Default | Description |
 | --- | --- | --- |
 | `--out-dir` | `build` | The full path for the new output directory, relative to the current workspace. |
-| `--skip-build` | `false` | Deploy website without new its building. This may be useful when using custom deploy script. |
+| `--skip-build` | `false` | Deploy website without building it. This may be useful when using custom deploy script. |


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2723.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Deploy with building website:

```
GIT_USER=%user% USE_SSH=true yarn deploy
```

1. Deploy without building website (before this action, you first need to run the command to build the site (`yarn build`), otherwise there will be an error):

```
GIT_USER=%user% USE_SSH=true yarn deploy --skip-build
```

Both scenarios should lead to the deployment of the website.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
