### PR TITLE
fix(v2): do not highlight root docs path in navbar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -100,6 +100,7 @@ module.exports = {
             {
               label: versions[0],
               to: 'docs/',
+              exact: true,
             },
             ...versions.slice(1).map((version) => ({
               label: version,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes this bug on website v2:

![image](https://user-images.githubusercontent.com/4408379/82424468-e61dcb80-9a8d-11ea-8ce9-f47e408b03c5.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
