### PR TITLE
feat(v2): open external links in new tab by default

### DIFF
--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -84,7 +84,10 @@ function Link({isNavLink, ...props}: Props) {
 
   return !targetLink || !isInternal || targetLink.startsWith('#') ? (
     // eslint-disable-next-line jsx-a11y/anchor-has-content
-    <a {...props} href={targetLink} />
+    <a
+      {...(isInternal ? props : {target: '_blank', ...props})}
+      href={targetLink}
+    />
   ) : (
     <LinkComponent
       {...props}


### PR DESCRIPTION
This changes the Link component to open external URLs in new tabs. This includes links in markdown in the form of `[label](url)`, and also explicit use of the `Link` component.

You can override this behavior by passing `target: '_self'` as a prop when using `Link`.

## Motivation

Docusaurus is already opinionated about doing this, for example the Navbar and
Footer do this already for external links. This is making it consistent across the entire site.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cd website; yarn start;`

* In browser navigate to http://localhost:3000/docs/design-principles and click on "Minimal Surface Area" - Verify it opens in new tab. Do the same on other pages.
* Verify anchor links continue to use the same tab.
* Verify internal links continue to use the same tab.
* Edit docs/design-principles.md to use Link instead of markdown syntax.
  * Verify it opens in a new tab.
* Edit docs/design-principles.md to add the `target="_self"` attribute.
  * Verify it opens in the same tab.

## Related PRs

None
