### PR TITLE
docs(v2): add articles section to resources page

### DIFF
--- a/website/docs/resources.md
+++ b/website/docs/resources.md
@@ -9,6 +9,10 @@ A curated list of interesting Docusaurus community projects.
 
 - [F8 2019: Using Docusaurus to Create Open Source Websites](https://www.youtube.com/watch?v=QcGJsf6mgZE)
 
+## Articles
+
+- [Live code editing in Docusaurus](https://dev.to/mrmuhammadali/live-code-editing-in-docusaurus-28k)
+
 ## Showcase
 
 See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase</a>.


### PR DESCRIPTION
## Motivation
I saw resources page but there was no section for Articles. As I recently published my article so I added this section which will help users as well as publishers of docusaurus.
