### PR TITLE
fix(v2): do not show sidebar on reserved docs home page

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -342,7 +342,7 @@ export default function pluginContentDocs(
         const versionsRegex = new RegExp(versionsNames.join('|'), 'i');
 
         const routes = await Promise.all(
-          metadataItems.map(async (metadataItem, i) => {
+          metadataItems.map(async (metadataItem) => {
             const isDocsHomePage =
               metadataItem.id.replace(versionsRegex, '').replace(/^\//, '') ===
               options.homePageId;
@@ -353,10 +353,6 @@ export default function pluginContentDocs(
                   ? ''
                   : metadataItem.version!) ?? '';
 
-              // To show the sidebar, get the sidebar key of available sibling item.
-              metadataItem.sidebar = (
-                metadataItems[i - 1] ?? metadataItems[i + 1]
-              ).sidebar;
               const docsBaseMetadata = createDocsBaseMetadata(
                 metadataItem.version!,
               );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Closes #2784.

In fact, doc sidebar had to be redefined only for reserved docs home page route (i.e. `_index`) so that sidebar will be shown for this kind of document (which is not supposed to be defined in any sidebar).

I had not considered that there could be multiple sidebars, which caused the bug described in #2784.

However, I have now realized that it was counterintuitive to display the sidebar on the reserved docs home page route, so this whole mess was due to my overengineering, which I want to fix in this PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See #2784

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
