### PR TITLE
fix(v2): use `require.resolve` for all webpack presets and plugins

### DIFF
--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -100,7 +100,7 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
         presets: [
           isServer
             ? [
-                '@babel/env',
+                require.resolve('@babel/preset-env'),
                 {
                   targets: {
                     node: 'current',
@@ -108,7 +108,7 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
                 },
               ]
             : [
-                '@babel/env',
+                require.resolve('@babel/preset-env'),
                 {
                   useBuiltIns: 'usage',
                   loose: true,
@@ -119,14 +119,14 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
                   exclude: ['transform-typeof-symbol'],
                 },
               ],
-          '@babel/react',
-          '@babel/preset-typescript',
+          require.resolve('@babel/preset-react'),
+          require.resolve('@babel/preset-typescript'),
         ],
         plugins: [
           // Polyfills the runtime needed for async/await, generators, and friends
           // https://babeljs.io/docs/en/babel-plugin-transform-runtime
           [
-            '@babel/plugin-transform-runtime',
+            require.resolve('@babel/plugin-transform-runtime'),
             {
               corejs: false,
               helpers: true,
@@ -143,7 +143,9 @@ export function getBabelLoader(isServer: boolean, babelOptions?: {}): Loader {
             },
           ],
           // Adds syntax support for import()
-          isServer ? 'dynamic-import-node' : '@babel/syntax-dynamic-import',
+          isServer
+            ? require.resolve('babel-plugin-dynamic-import-node')
+            : require.resolve('@babel/plugin-syntax-dynamic-import'),
         ],
       },
       babelOptions,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Issue #2576 shows that docusaurus v2 doesn't work with Yarn v2 with pnp enabled.

This diff doesn't try to resolve the issue of the plugin system caused by the incompatibility: it can be solved by using the [pnpLoose mode](https://yarnpkg.com/features/pnp#pnp-loose-mode) for now. Instead, it will fix some of the webpack plugin loading issue related to yarn pnp.

Inside the [webpack config file](https://github.com/facebook/docusaurus/blob/master/packages/docusaurus/src/webpack/utils.ts), it refers to presets and plugins by strings, like `'@babel/plugin-transform-runtime'`. This setup _happens to_ work with the traditional package managers' behavior on `node_modules`, which tries to hoist `@babel/plugin-transform-runtime` to the top-level `node_modules` if it can. However, it won't work under pnp, which expects that all dependencies are explictly declared.

In this case, since it's declared in a string form, it's webpack instead of `@docusaurus/core` that will resolve this module to an absolute path. Since `webpack` doesn't declare `@babel/plugin-transform-runtime` as dependency, the resolution failed. By using `require.resolve`, we ensure that `@docusaurus/core` will resolve the path. Since `@docusaurus/core` declared `@babel/plugin-transform-runtime` as a dependency, the resolution will succeed and results in a correct absolute path for webpack to consume.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

I have setup a [repo](https://github.com/SamChou19815/docusaurus-yarn-v2-example) to show that these are the minimal changes necessary to make docusaurus work under `pnpMode: loose`.

Also, all the tests still passes and deploy preview still works.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
