### PR TITLE
style(v2): disable Prettier checks for Markdown files of init templates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ build
 packages/docusaurus-utils/lib/
 packages/docusaurus/lib/
 packages/docusaurus-init/lib/
+packages/docusaurus-init/templates/**/*.md
 packages/docusaurus-plugin-content-blog/lib/
 packages/docusaurus-plugin-content-docs/lib/
 packages/docusaurus-plugin-content-pages/lib/

--- a/packages/docusaurus-init/templates/bootstrap/docs/doc1.md
+++ b/packages/docusaurus-init/templates/bootstrap/docs/doc1.md
@@ -28,10 +28,8 @@ To serve as an example page when styling markdown based Docusaurus sites.
 
 ## Emphasis
 
-<!-- prettier-ignore -->
 Emphasis, aka italics, with *asterisks* or _underscores_.
 
-<!-- prettier-ignore -->
 Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
 Combined emphasis with **asterisks and _underscores_**.
@@ -49,13 +47,10 @@ Strikethrough uses two tildes. ~~Scratch this.~~
    1. Ordered sub-list
 1. And another item.
 
-<!-- prettier-ignore -->
 * Unordered list can use asterisks
 
-<!-- prettier-ignore -->
 - Or minuses
 
-<!-- prettier-ignore -->
 + Or pluses
 
 ---

--- a/packages/docusaurus-init/templates/classic/docs/doc1.md
+++ b/packages/docusaurus-init/templates/classic/docs/doc1.md
@@ -28,10 +28,8 @@ To serve as an example page when styling markdown based Docusaurus sites.
 
 ## Emphasis
 
-<!-- prettier-ignore -->
 Emphasis, aka italics, with *asterisks* or _underscores_.
 
-<!-- prettier-ignore -->
 Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
 Combined emphasis with **asterisks and _underscores_**.
@@ -49,13 +47,10 @@ Strikethrough uses two tildes. ~~Scratch this.~~
    1. Ordered sub-list
 1. And another item.
 
-<!-- prettier-ignore -->
 * Unordered list can use asterisks
 
-<!-- prettier-ignore -->
 - Or minuses
 
-<!-- prettier-ignore -->
 + Or pluses
 
 ---

--- a/packages/docusaurus-init/templates/facebook/docs/doc1.md
+++ b/packages/docusaurus-init/templates/facebook/docs/doc1.md
@@ -28,10 +28,8 @@ To serve as an example page when styling markdown based Docusaurus sites.
 
 ## Emphasis
 
-<!-- prettier-ignore -->
 Emphasis, aka italics, with *asterisks* or _underscores_.
 
-<!-- prettier-ignore -->
 Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
 Combined emphasis with **asterisks and _underscores_**.
@@ -49,13 +47,10 @@ Strikethrough uses two tildes. ~~Scratch this.~~
    1. Ordered sub-list
 1. And another item.
 
-<!-- prettier-ignore -->
 * Unordered list can use asterisks
 
-<!-- prettier-ignore -->
 - Or minuses
 
-<!-- prettier-ignore -->
 + Or pluses
 
 ---


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Just small improvement after #2786 -- we can use `.prettierignore` file to specify Prettier, what files we do not want to check.

It does not make much sense to format the init templates files, so I think it is quite acceptable to completely disable any style checks for these files. Moreover, the user may not use Prettier, and they will be confused by Prettier-specific comments, IMO.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run ` yarn prettier-docs` and make sure that there are no changes.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
