### PR TITLE
fix(v2): Use require.resolve to resolve plugin path in presets

### DIFF
--- a/packages/docusaurus-preset-bootstrap/src/index.js
+++ b/packages/docusaurus-preset-bootstrap/src/index.js
@@ -7,11 +7,11 @@
 
 module.exports = function preset(context, opts = {}) {
   return {
-    themes: [['@docusaurus/theme-bootstrap', opts.theme]],
+    themes: [[require.resolve('@docusaurus/theme-bootstrap'), opts.theme]],
     plugins: [
-      ['@docusaurus/plugin-content-pages', opts.pages],
-      ['@docusaurus/plugin-content-blog', opts.blog],
-      ['@docusaurus/plugin-content-docs', opts.docs],
+      [require.resolve('@docusaurus/plugin-content-pages'), opts.pages],
+      [require.resolve('@docusaurus/plugin-content-blog'), opts.blog],
+      [require.resolve('@docusaurus/plugin-content-docs'), opts.docs],
     ],
   };
 };

--- a/packages/docusaurus-preset-classic/src/index.js
+++ b/packages/docusaurus-preset-classic/src/index.js
@@ -13,17 +13,19 @@ module.exports = function preset(context, opts = {}) {
 
   return {
     themes: [
-      ['@docusaurus/theme-classic', opts.theme],
+      [require.resolve('@docusaurus/theme-classic'), opts.theme],
       // Don't add this if algolia config is not defined.
-      algolia && '@docusaurus/theme-search-algolia',
+      algolia && require.resolve('@docusaurus/theme-search-algolia'),
     ],
     plugins: [
-      ['@docusaurus/plugin-content-docs', opts.docs],
-      ['@docusaurus/plugin-content-blog', opts.blog],
-      ['@docusaurus/plugin-content-pages', opts.pages],
-      isProd && googleAnalytics && '@docusaurus/plugin-google-analytics',
-      isProd && gtag && '@docusaurus/plugin-google-gtag',
-      isProd && ['@docusaurus/plugin-sitemap', opts.sitemap],
+      [require.resolve('@docusaurus/plugin-content-docs'), opts.docs],
+      [require.resolve('@docusaurus/plugin-content-blog'), opts.blog],
+      [require.resolve('@docusaurus/plugin-content-pages'), opts.pages],
+      isProd &&
+        googleAnalytics &&
+        require.resolve('@docusaurus/plugin-google-analytics'),
+      isProd && gtag && require.resolve('@docusaurus/plugin-google-gtag'),
+      isProd && [require.resolve('@docusaurus/plugin-sitemap'), opts.sitemap],
     ],
   };
 };

--- a/website/docs/presets.md
+++ b/website/docs/presets.md
@@ -40,8 +40,11 @@ Presets in some way are a shorthand function to add plugins and themes to your d
 ```js
 module.exports = function preset(context, opts = {}) {
   return {
-    themes: ['@docusaurus/themes-cool', '@docusaurus/themes-bootstrap'],
-    plugins: ['@docusaurus/plugin-blog'],
+    themes: [
+      require.resolve('@docusaurus/themes-cool'),
+      require.resolve('@docusaurus/themes-bootstrap'),
+    ],
+    plugins: [require.resolve('@docusaurus/plugin-blog')],
   };
 };
 ```


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This diff continues the progress of making docusaurus v2 work under yarn v2's pnp mode.

- In #2788, I ensured that all webpack presets and plugins can be correctly resolved by `@docusaurus/core`.
- In #2789, I ensured that all user defined plugins can be correctly resolved by `@docusaurus/core`.

It would almost resolve almost all module resolution issues with yarn v2 pnp, except for presets. Docusaurus's presets still use plain string to refer to modules, which will make pnp module resolution fail.

In this diff, I fixed all the presets to use `require.resolve` in this repo. I also updated the docs to educate preset writers to use `require.resolve` in their code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Everything can still be properly loaded, and the preview site still works.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
