### PR TITLE
fix(v2): Ensure that theme classic require webpack provided by `@docusaurus/core`

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -6,7 +6,15 @@
  */
 
 const path = require('path');
-const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
+const Module = require('module');
+
+const createRequire = Module.createRequire || Module.createRequireFromPath;
+const requireFromDocusaurusCore = createRequire(
+  require.resolve('@docusaurus/core/package.json'),
+);
+const ContextReplacementPlugin = requireFromDocusaurusCore(
+  'webpack/lib/ContextReplacementPlugin',
+);
 
 // Need to be inlined to prevent dark mode FOUC
 // Make sure that the 'storageKey' is the same as the one in `/theme/hooks/useTheme.js`


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This diff continues the progress of making docusaurus v2 work under yarn v2's pnp mode.

### The Problem

There is a tricky require inside `@docusaurus/theme-classic`:

```js
const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
```

`@docusaurus/theme-classic` also declares `webpack` as a peer dependency. Currently at runtime, `webpack` is _likely_ to be provided by `@docusaurus/core`, which declares it as a direct dependency. However, this setup is theoretically not guaranteed to work, and it will certainly break in Yarn v2 pnp's strict mode. To understand why it's the issue, let me draw an layout of the node_modules.

In a package manager doesn't implement any hoisting optimization, the layout will be like

```text
- node_modules
  - @docusaurus/core
    - node_modules
      - webpack
  - @docusaurus/theme-classic
    - index.js (that requires `webpack`)
```

Therefore, when `index.js` require `webpack` it will fail, because it doesn't exist in these paths:

- `project-root/@docusaurus/theme-classic/node_modules`
- `project-root/@docusaurus/node_modules`
- `project-root/node_modules`

The current setup happens to work because popular package managers implement hoisting optimization, which results in a layout like

```text
- node_modules
  - webpack
  - @docusaurus/core
  - @docusaurus/theme-classic
    - index.js (that requires `webpack`)
```

Under yarn's pnp mode, things will break. Although Yarn knows that `@docusaurus/theme-classic` declares `webpack` as a peer dependency, it still doesn't know where to find it.

### The Fix

I think the code author's intention is to use the `webpack` provided by `@docusaurus/core`. Therefore, I decide to make this more explicit by using `Module.createRequire`, which can be understood by Yarn's pnp runtime. I discussed how `createRequire` works in #2789.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Everything can still be properly loaded, and the preview site still works.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
