### PR TITLE
fix(v2): Consistently use require.resolve in official plugins to resolve modules

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -396,7 +396,7 @@ export default function pluginContentBlog(
                 getCacheLoader(isServer),
                 getBabelLoader(isServer),
                 {
-                  loader: '@docusaurus/mdx-loader',
+                  loader: require.resolve('@docusaurus/mdx-loader'),
                   options: {
                     remarkPlugins,
                     rehypePlugins,

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -102,7 +102,7 @@ export default function pluginContentBlog(
       const modules = [];
 
       if (options.admonitions) {
-        modules.push('remark-admonitions/styles/infima.css');
+        modules.push(require.resolve('remark-admonitions/styles/infima.css'));
       }
 
       return modules;

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -522,7 +522,7 @@ export default function pluginContentDocs(
                 getCacheLoader(isServer),
                 getBabelLoader(isServer),
                 {
-                  loader: '@docusaurus/mdx-loader',
+                  loader: require.resolve('@docusaurus/mdx-loader'),
                   options: {
                     remarkPlugins,
                     rehypePlugins,

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -142,7 +142,7 @@ export default function pluginContentDocs(
       const modules = [];
 
       if (options.admonitions) {
-        modules.push('remark-admonitions/styles/infima.css');
+        modules.push(require.resolve('remark-admonitions/styles/infima.css'));
       }
 
       return modules;

--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -27,9 +27,9 @@ export default function (_context: LoadContext, options: PluginOptions) {
             {
               test: /\.(png|jpe?g|gif)$/i,
               use: [
-                '@docusaurus/lqip-loader',
+                require.resolve('@docusaurus/lqip-loader'),
                 {
-                  loader: '@endiliey/responsive-loader',
+                  loader: require.resolve('@endiliey/responsive-loader'),
                   options: {
                     emitFile: !isServer, // don't emit for server-side rendering
                     disable: !isProd,

--- a/packages/docusaurus-theme-bootstrap/src/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/index.js
@@ -14,7 +14,7 @@ module.exports = function () {
       return path.resolve(__dirname, './theme');
     },
     getClientModules() {
-      return ['bootstrap/dist/css/bootstrap.min.css'];
+      return [require.resolve('bootstrap/dist/css/bootstrap.min.css')];
     },
   };
 };

--- a/packages/docusaurus-theme-classic/src/index.js
+++ b/packages/docusaurus-theme-classic/src/index.js
@@ -65,7 +65,7 @@ module.exports = function (context, options) {
 
     getClientModules() {
       const modules = [
-        'infima/dist/css/default/default.css',
+        require.resolve('infima/dist/css/default/default.css'),
         path.resolve(__dirname, './prism-include-languages'),
       ];
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Continuing the effort in #2788, #2794, using `require.resolve` to resolve absolute paths for loaders and client modules to ensure it can work under yarn pnp.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The website can build, and preview can load.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
