### PR TITLE
fix(v2): make proper h1 font size on mobiles

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -7,14 +7,7 @@
 
 .docTitle {
   font-size: 3rem;
-  margin-bottom: 3rem;
-}
-
-@media only screen and (max-width: 996px) {
-  .docTitle {
-    font-size: 2rem;
-    margin-bottom: 2rem;
-  }
+  margin-bottom: calc(var(--ifm-leading-desktop) * var(--ifm-leading));
 }
 
 .docItemContainer {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

According to Infima styles https://github.com/facebookincubator/infima/blob/master/packages/core/styles/content/markdown.css#L36-L41


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/82725193-e9aa9000-9ce3-11ea-86b9-0d5847f03b74.png) |  ![image](https://user-images.githubusercontent.com/4408379/82725197-f29b6180-9ce3-11ea-857a-d1bfb5777f7c.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
