### PR TITLE
fix(v2): Properly declare peerDependencies

### DIFF
--- a/packages/docusaurus-preset-bootstrap/package.json
+++ b/packages/docusaurus-preset-bootstrap/package.json
@@ -14,7 +14,9 @@
     "@docusaurus/theme-bootstrap": "^2.0.0-alpha.55"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0"
+    "@docusaurus/core": "^2.0.0",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
   },
   "engines": {
     "node": ">=10.9.0"

--- a/packages/docusaurus-preset-classic/package.json
+++ b/packages/docusaurus-preset-classic/package.json
@@ -18,7 +18,9 @@
     "@docusaurus/theme-search-algolia": "^2.0.0-alpha.55"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0"
+    "@docusaurus/core": "^2.0.0",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
   },
   "engines": {
     "node": ">=10.9.0"

--- a/packages/docusaurus-theme-bootstrap/package.json
+++ b/packages/docusaurus-theme-bootstrap/package.json
@@ -17,8 +17,7 @@
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",
     "react": "^16.8.4",
-    "react-dom": "^16.8.4",
-    "webpack": "^4.41.2"
+    "react-dom": "^16.8.4"
   },
   "engines": {
     "node": ">=10.9.0"

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -16,14 +16,14 @@
     "parse-numeric-range": "^0.0.2",
     "prism-react-renderer": "^1.1.0",
     "prismjs": "^1.20.0",
+    "prop-types": "^15.7.2",
     "react-router-dom": "^5.1.2",
     "react-toggle": "^4.1.1"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",
     "react": "^16.8.4",
-    "react-dom": "^16.8.4",
-    "webpack": "^4.41.2"
+    "react-dom": "^16.8.4"
   },
   "engines": {
     "node": ">=10.9.0"

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.55",
+    "@docusaurus/theme-live-codeblock": "^2.0.0-alpha.55",
     "@docusaurus/plugin-ideal-image": "^2.0.0-alpha.55",
     "@docusaurus/preset-classic": "^2.0.0-alpha.55",
     "classnames": "^2.2.6",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

If a package `a` declare a peerDependency  `b`, then package that depends on `a` should either declare `b` as a dependency or peerDependency. i.e. no implicit transitive peer dependencies. See https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0

### Fixed issues:

- `theme-classic`, `theme-bootstrap` lists `react` and `react-dom` as peer dependencies, so their presets should also list `react` and `react-dom` as peer dependencies. This eliminates the following warnings:
```text
warning " > @docusaurus/preset-classic@2.0.0-alpha.55" has unmet peer dependency "react@^16.8.4".
warning " > @docusaurus/preset-classic@2.0.0-alpha.55" has unmet peer dependency "react-dom@^16.8.4".
warning " > @docusaurus/theme-bootstrap@2.0.0-alpha.55" has unmet peer dependency "react@^16.8.4".
warning " > @docusaurus/theme-bootstrap@2.0.0-alpha.55" has unmet peer dependency "react-dom@^16.8.4".
warning " > @docusaurus/theme-classic@2.0.0-alpha.55" has unmet peer dependency "react@^16.8.4".
warning " > @docusaurus/theme-classic@2.0.0-alpha.55" has unmet peer dependency "react-dom@^16.8.4".
```
- Remove `webpack` as a peer dependency for `theme-classic`, since we explicitly use `webpack` from core in #2795, so there is no need to expect parent of `theme-classic` to give us `webpack`. This eliminates the following warning:
```text
warning " > @docusaurus/theme-classic@2.0.0-alpha.55" has unmet peer dependency "webpack@^4.41.2".
```
- Remove `webpack` as a peer dependency for `theme-bootstrap`, since it doesn't actually use it. This eliminates the following warning:
```text
warning " > @docusaurus/theme-bootstrap@2.0.0-alpha.55" has unmet peer dependency "webpack@^4.41.2".
```
- Add `prop-types` as a dependency of `theme-classic`. `theme-classic` has a dependency (`react-toggle`) that list `prop-types` as a peerDependency. This eliminates the following warning:
```text
warning "workspace-aggregator-052d4f38-24ac-4105-b7a7-b24c2ddc4001 > @docusaurus/theme-classic > react-toggle@4.1.1" has unmet peer dependency "prop-types@^15.3.0 || ^16.0.0".
```
- Add `@docusaurus/theme-live-codeblock` as a dependency to `website`, since `website` actually depends on it [here](https://github.com/facebook/docusaurus/blob/a7e4013d3ba6497a4310d74cd2cf3bd3e1a2e154/website/docusaurus.config.js#L25). This eliminates the following warnings:
```text
warning " > @docusaurus/theme-search-algolia@2.0.0-alpha.55" has unmet peer dependency "react@^16.8.4".
warning " > @docusaurus/theme-search-algolia@2.0.0-alpha.55" has unmet peer dependency "react-dom@^16.8.4".
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This changes result in no yarn.lock change in this repo, which means that it won't break existing resolution behavior. But you see fewer warnings about bad peer dependencies in `yarn install`.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
