### PR TITLE
refactor(v2): align search icon to center on mobiles

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.module.css
@@ -53,6 +53,7 @@
   }
 
   .searchInput {
+    background-position-x: 0.85rem;
     width: 0;
     transition: width 0.3s ease-in-out;
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

See Test plan.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
|  ![screenshot_7](https://user-images.githubusercontent.com/4408379/82995573-7028df80-a00c-11ea-98ea-2fa6cda61dcb.png) | ![screenshot_8](https://user-images.githubusercontent.com/4408379/82995542-643d1d80-a00c-11ea-97de-6aea0409e3d7.png) |



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
