### PR TITLE
feat(v2): automatically add base url to logo link

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.js
@@ -12,10 +12,10 @@ import isInternalUrl from '@docusaurus/isInternalUrl';
 
 const useLogo = () => {
   const {
-    siteConfig: {baseUrl, themeConfig: {navbar: {logo = {}} = {}}} = {},
+    siteConfig: {themeConfig: {navbar: {logo = {}} = {}}} = {},
   } = useDocusaurusContext();
   const {isDarkTheme} = useThemeContext();
-  const logoLink = useBaseUrl(logo.href || baseUrl);
+  const logoLink = useBaseUrl(logo.href || '/');
   let logoLinkProps = {};
 
   if (logo.target) {

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.js
@@ -15,7 +15,7 @@ const useLogo = () => {
     siteConfig: {baseUrl, themeConfig: {navbar: {logo = {}} = {}}} = {},
   } = useDocusaurusContext();
   const {isDarkTheme} = useThemeContext();
-  const logoLink = logo.href || baseUrl;
+  const logoLink = useBaseUrl(logo.href || baseUrl);
   let logoLinkProps = {};
 
   if (logo.target) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This is a request from Discord chat, I think we should take care to add the base url to the logo link automatically, this is the expected behavior I suppose.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Set document id to `navbar.logo.href` and make sure base url has been added to it.

By default a slash (`/`) will be added (standard base url).

Nevertheless, this is BC, because previously users had to manually specify the base url (in the case of using non-standard base url)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
