### PR TITLE
chore: ignore /coverage folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ __fixtures__
 dist
 node_modules
 build
+coverage
 jest.config.js
 jest.transform.js
 website-1.x/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 
 yarn-error.log
 build
+coverage
 .docusaurus
 .cache-loader
 types

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 dist
 node_modules
 build
+coverage
 .docusaurus
 packages/docusaurus-utils/lib/
 packages/docusaurus/lib/


### PR DESCRIPTION
When running `yarn test --coverage` it generates a code coverage report that should rather not be versioned