### PR TITLE
feat(v2): allow adding components to react-live scope

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "dependencies": {
     "@philpl/buble": "^0.19.7",
-    "@mdx-js/react": "^1.5.8",
     "classnames": "^2.2.6",
     "clipboard": "^2.0.6",
     "parse-numeric-range": "^0.0.2",

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@philpl/buble": "^0.19.7",
+    "@mdx-js/react": "^1.5.8",
     "classnames": "^2.2.6",
     "clipboard": "^2.0.6",
     "parse-numeric-range": "^0.0.2",

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -11,31 +11,17 @@ import usePrismTheme from '@theme/hooks/usePrismTheme';
 import Playground from '@theme/Playground';
 import ReactLiveScope from '@theme/ReactLiveScope';
 import CodeBlock from '@theme-init/CodeBlock';
-import {useMDXComponents} from '@mdx-js/react';
-
-// Returns components that are available to use by the react-live playground
-// It's not possible to import anything in the live playground,
-// we need to provide the available imports manually
-// See https://github.com/facebook/docusaurus/issues/2807
-const useReactLiveScope = () => {
-  const mdxComponents = useMDXComponents();
-  return {
-    ...mdxComponents,
-    ...ReactLiveScope,
-  };
-};
 
 const withLiveEditor = (Component) => {
   const WrappedComponent = (props) => {
     const {isClient} = useDocusaurusContext();
     const prismTheme = usePrismTheme();
-    const reactLiveScope = useReactLiveScope();
 
     if (props.live) {
       return (
         <Playground
           key={isClient}
-          scope={reactLiveScope}
+          scope={ReactLiveScope}
           theme={prismTheme}
           {...props}
         />

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -9,18 +9,33 @@ import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import usePrismTheme from '@theme/hooks/usePrismTheme';
 import Playground from '@theme/Playground';
+import ReactLiveScope from '@theme/ReactLiveScope';
 import CodeBlock from '@theme-init/CodeBlock';
+import {useMDXComponents} from '@mdx-js/react';
+
+// Returns components that are available to use by the react-live playground
+// It's not possible to import anything in the live playground,
+// we need to provide the available imports manually
+// See https://github.com/facebook/docusaurus/issues/2807
+const useReactLiveScope = () => {
+  const mdxComponents = useMDXComponents();
+  return {
+    ...mdxComponents,
+    ...ReactLiveScope,
+  };
+};
 
 const withLiveEditor = (Component) => {
   const WrappedComponent = (props) => {
     const {isClient} = useDocusaurusContext();
     const prismTheme = usePrismTheme();
+    const reactLiveScope = useReactLiveScope();
 
     if (props.live) {
       return (
         <Playground
           key={isClient}
-          scope={{...React}}
+          scope={reactLiveScope}
           theme={prismTheme}
           {...props}
         />

--- a/packages/docusaurus-theme-live-codeblock/src/theme/ReactLiveScope/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/ReactLiveScope/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+// Add react-live imports you need here
+const ReactLiveScope = {
+  React,
+  ...React,
+};
+
+export default ReactLiveScope;

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -736,7 +736,9 @@ function Clock(props) {
 ```
 
 :::caution react-live and imports
+
 It is not possible to import components directly from the react-live code editor, you have to define available imports upfront.
+
 :::
 
 By default, all React imports are available. If you need more imports available, swizzle the react-live scope:

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -735,7 +735,9 @@ function Clock(props) {
 }
 ```
 
-:::caution It is not possible to import components directly from the react-live code editor, you have to define available imports upfront. :::
+:::caution react-live and imports
+It is not possible to import components directly from the react-live code editor, you have to define available imports upfront.
+:::
 
 By default, all React imports are available. If you need more imports available, swizzle the react-live scope:
 
@@ -743,7 +745,7 @@ By default, all React imports are available. If you need more imports available,
 npm run swizzle @docusaurus/theme-live-codeblock ReactLiveScope
 ```
 
-```jsx
+```jsx {3-15,21} title="src/theme/ReactLiveScope/index.js"
 import React from 'react';
 
 const ButtonExample = (props) => (
@@ -770,7 +772,7 @@ const ReactLiveScope = {
 export default ReactLiveScope;
 ```
 
-The `ButtonExample` is now available to use:
+The `ButtonExample` component is now available to use:
 
 ```jsx live
 function MyPlayground(props) {

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -735,6 +735,53 @@ function Clock(props) {
 }
 ```
 
+:::caution It is not possible to import components directly from the react-live code editor, you have to define available imports upfront. :::
+
+By default, all React imports are available. If you need more imports available, swizzle the react-live scope:
+
+```bash npm2yarn
+npm run swizzle @docusaurus/theme-live-codeblock ReactLiveScope
+```
+
+```jsx
+import React from 'react';
+
+const ButtonExample = (props) => (
+  <button
+    {...props}
+    style={{
+      backgroundColor: 'white',
+      border: 'solid red',
+      borderRadius: 20,
+      padding: 10,
+      cursor: 'pointer',
+      ...props.style,
+    }}
+  />
+);
+
+// Add react-live imports you need here
+const ReactLiveScope = {
+  React,
+  ...React,
+  ButtonExample,
+};
+
+export default ReactLiveScope;
+```
+
+The `ButtonExample` is now available to use:
+
+```jsx live
+function MyPlayground(props) {
+  return (
+    <div>
+      <ButtonExample onClick={() => alert('hey!')}>Click me</ButtonExample>
+    </div>
+  );
+}
+```
+
 ### Multi-language support code blocks
 
 With MDX, you can easily create interactive components within your documentation, for example, to display code in multiple programming languages and switching between them using a tabs component.

--- a/website/src/theme/ReactLiveScope/components.js
+++ b/website/src/theme/ReactLiveScope/components.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const ButtonExample = (props) => (
+  <button
+    {...props}
+    style={{
+      backgroundColor: 'white',
+      border: 'solid red',
+      borderRadius: 20,
+      padding: 10,
+      cursor: 'pointer',
+      ...props.style,
+    }}
+  />
+);

--- a/website/src/theme/ReactLiveScope/index.js
+++ b/website/src/theme/ReactLiveScope/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import * as components from './components';
+
+// Add react-live imports you need here
+const ReactLiveScope = {
+  React,
+  ...React,
+  ...components,
+};
+
+export default ReactLiveScope;


### PR DESCRIPTION


## Motivation

Currently, the react-live scope only exposes the React exports, so we can use React, useState etc, but we can't import any other code easily.

If you build a react component library, and want to allow users to play with the components in a live editor, it's important to have a documented way to provide those components in the react-live scope.

See https://github.com/facebook/docusaurus/issues/2807


## Test Plan

Dogfooding by using this feature on the Docusaurus website directly

## Notes

Swizzling of the react-live scope object is not an ideal solution, as it's global and needs more work from the user, but I think it's good enough to solve the usecase for now.

When we'll have a way to wrap root component, users could use the MDXProvider to reuse the components of the MDX scope for react-live too, instead of swizzling. 

Gatsby has a cool feature that permits to make available in react-live scope anything that is imported in the MDX file. Unfortunately, this feature is not so simple to port to Docusaurus (involves extracting imports in mdx string using a babel plugin, writing them to disk etc... see https://github.com/facebook/docusaurus/issues/2807#issuecomment-635268531)
