### PR TITLE
fix(v2): Fix plugin path resolution

### DIFF
--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -6,6 +6,7 @@
  */
 
 import Module from 'module';
+import {join} from 'path';
 import importFresh from 'import-fresh';
 import {LoadContext, Plugin, PluginConfig} from '@docusaurus/types';
 
@@ -21,7 +22,9 @@ export function initPlugins({
   // We need to fallback to createRequireFromPath since createRequire is only available in node v12.
   // See: https://nodejs.org/api/modules.html#modules_module_createrequire_filename
   const createRequire = Module.createRequire || Module.createRequireFromPath;
-  const pluginRequire = createRequire(context.siteDir);
+  const pluginRequire = createRequire(
+    join(context.siteDir, '/docusaurus.config.js'),
+  );
 
   const plugins: Plugin<any>[] = pluginConfigs
     .map((pluginItem) => {

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -9,6 +9,7 @@ import Module from 'module';
 import {join} from 'path';
 import importFresh from 'import-fresh';
 import {LoadContext, Plugin, PluginConfig} from '@docusaurus/types';
+import {CONFIG_FILE_NAME} from '../../constants';
 
 export function initPlugins({
   pluginConfigs,
@@ -22,9 +23,7 @@ export function initPlugins({
   // We need to fallback to createRequireFromPath since createRequire is only available in node v12.
   // See: https://nodejs.org/api/modules.html#modules_module_createrequire_filename
   const createRequire = Module.createRequire || Module.createRequireFromPath;
-  const pluginRequire = createRequire(
-    join(context.siteDir, '/docusaurus.config.js'),
-  );
+  const pluginRequire = createRequire(join(context.siteDir, CONFIG_FILE_NAME));
 
   const plugins: Plugin<any>[] = pluginConfigs
     .map((pluginItem) => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Actually fix #2825. It seems like `createRequire` expects a path to a nodejs module instead of a folder where the `package.json` happens to live in. The module would be `docusaurus.config.js`, which is guaranteed to exist in the root docusaurus project folder.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1. Create a new docusaurus project.
2. Install `@docusaurus/plugin-ideal-image`.
3. `yarn start`, it will fail with the error in #2825.
4. Edit `node_modules` and manually apply the fix in this PR.
5. `yarn start`, it will now succeed.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
