### PR TITLE
feat(v2): Allow swizzling prism-include-languages in theme-classic

### DIFF
--- a/packages/docusaurus-theme-classic/src/prism-include-languages.js
+++ b/packages/docusaurus-theme-classic/src/prism-include-languages.js
@@ -6,21 +6,6 @@
  */
 
 import Prism from 'prism-react-renderer/prism';
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
-import siteConfig from '@generated/docusaurus.config';
+import prismIncludeLanguages from '@theme/prism-include-languages';
 
-(() => {
-  if (ExecutionEnvironment.canUseDOM) {
-    const {
-      themeConfig: {prism: {additionalLanguages = []} = {}},
-    } = siteConfig;
-
-    window.Prism = Prism;
-
-    additionalLanguages.forEach((lang) => {
-      require(`prismjs/components/prism-${lang}`); // eslint-disable-line
-    });
-
-    delete window.Prism;
-  }
-})();
+prismIncludeLanguages(Prism);

--- a/packages/docusaurus-theme-classic/src/theme/prism-include-languages.js
+++ b/packages/docusaurus-theme-classic/src/theme/prism-include-languages.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import siteConfig from '@generated/docusaurus.config';
+
+const prismIncludeLanguages = (Prism) => {
+  if (ExecutionEnvironment.canUseDOM) {
+    const {
+      themeConfig: {prism: {additionalLanguages = []} = {}},
+    } = siteConfig;
+
+    window.Prism = Prism;
+
+    additionalLanguages.forEach((lang) => {
+      require(`prismjs/components/prism-${lang}`); // eslint-disable-line
+    });
+
+    delete window.Prism;
+  }
+};
+
+export default prismIncludeLanguages;

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -538,6 +538,27 @@ module.exports = {
 };
 ```
 
+If you want to add highlighting for languages not yet supported by Prism, you can swizzle `prism-include-languages` by
+
+```bash
+yarn swizzle @docusaurus/theme-classic prism-include-languages
+```
+
+It will produce `prism-include-languages.js` in your `src/theme` folder. You can add highlighting support for custom languages by editing `prism-include-languages.js`:
+
+```js {6} title="src/theme/prism-include-languages.js"
+    // ...
+
+    additionalLanguages.forEach((lang) => {
+      require(`prismjs/components/prism-${lang}`); // eslint-disable-line
+    });
+    require('/path/to/your/prism-language-definition');
+
+    // ...
+```
+
+You can refer to [PrismJS's official language definitions](https://github.com/PrismJS/prism/tree/master/components) when you are writing your own language definitions.
+
 ### Line highlighting
 
 You can bring emphasis to certain lines of code by specifying line ranges after the language meta string (leave a space after the language).

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -538,26 +538,29 @@ module.exports = {
 };
 ```
 
-If you want to add highlighting for languages not yet supported by Prism, you can swizzle `prism-include-languages` by
+If you want to add highlighting for languages not yet supported by Prism, you can swizzle `prism-include-languages`:
 
-```bash
+```bash npm2yarn
 yarn swizzle @docusaurus/theme-classic prism-include-languages
 ```
 
 It will produce `prism-include-languages.js` in your `src/theme` folder. You can add highlighting support for custom languages by editing `prism-include-languages.js`:
 
-```js {6} title="src/theme/prism-include-languages.js"
+```js {8} title="src/theme/prism-include-languages.js"
+const prismIncludeLanguages = (Prism) => {
     // ...
 
     additionalLanguages.forEach((lang) => {
       require(`prismjs/components/prism-${lang}`); // eslint-disable-line
     });
+
     require('/path/to/your/prism-language-definition');
 
     // ...
+}
 ```
 
-You can refer to [PrismJS's official language definitions](https://github.com/PrismJS/prism/tree/master/components) when you are writing your own language definitions.
+You can refer to [Prism's official language definitions](https://github.com/PrismJS/prism/tree/master/components) when you are writing your own language definitions.
 
 ### Line highlighting
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Right now it's hard to include custom languages syntax highlighting support. It's almost impossible to do it in a simple config due to context replacement issue. Right now there are two alternatives that both have some issues:

1. Swizzle `CodeBlock` component. Issue: A local `CodeBlock` might eventually diverge from the CodeBlock in `theme-classic`.
2. Write a plugin. This is the approach I am currently using. See [(1)](https://github.com/SamChou19815/website/blob/master/packages/lib-docusaurus-plugin/index.ts) and [(2)](https://github.com/SamChou19815/website/blob/master/packages/lib-docusaurus-plugin/prism-include-languages.js). However, whether the `Prism` object used by `theme-classic` will be correctly patched is completely at the mercy of package manager's hoisting behavior:

Suppose you do this in your plugin

```js
import Prism from 'prism-react-renderer/prism';
```

If you declare `prism-react-renderer` as a dependency of your plugin, then you might end up patching a `prism-react-renderer` that is not used by `theme-classic`, since you might get a node_modules layout like:

```text
- your-plugin
  - node_modules
    - prism-react-renderer
- @docusaurus/theme-classic
  - node_modules
    - prism-react-renderer
```

If you declare `prism-react-renderer` as a peer dependency or doesn't declare as a dependency, then you are still relying on package manager's hoisting behavior that produces this node_modules layout:

```text
- node_modules
  - your-plugin
  - prism-react-renderer
  - @docusaurus/theme-classic
```

However, it's completely legal for a package manager to produce this:

```text
- node_modules
  - your-plugin
  - @docusaurus/theme-classic
    - node_modules
      - prism-react-renderer
```

Then your plugin cannot find `prism-react-renderer` any more.

The root of the issue is that we need a way that is guaranteed to use `prism-react-renderer` from `@docusaurus/theme-classic`, while still being able to be customized easily in userland. This leaves us with only one alternative that doesn't require significant refactoring: _Swizzling_.

This diff moves the main implementation of `prism-include-languages` into `src/theme` folder so that it can be swizzled. The API of `@theme/prism-include-languages` is likely to be very stable so swizzling it wouldn't produce a huge risk of divergence.

### Questions for maintainers

1. I noticed in the [discussion](https://github.com/facebook/docusaurus/discussions/2790) that docusaurus might try to move away from swizzling. So I wonder whether this diff is a good idea.
2. If this is approved, should we still keep the `additionalLanguages` config?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Swizzle `prism-include-languages` by `yarn workspace docusaurus-2-website swizzle @docusaurus/theme-classic prism-include-languages`
2. Edit `docusaurus.config.js` to include swift as an additional language:
```diff
    prism: {
      theme: require('prism-react-renderer/themes/github'),
      darkTheme: require('prism-react-renderer/themes/dracula'),
+     additionalLanguages: ['swift']
    },
```
3. Add some random swift code to a docs page, like
```swift
protocol Foo {}
```
4. `yarn start`, and see the code is correctly syntax highlighted.
<img width="832" alt="Screen Shot 2020-05-29 at 11 55 55" src="https://user-images.githubusercontent.com/4290500/83280077-1d822b80-a1a4-11ea-8373-615171e93361.png">
5. Edit the swizzled `prism-include-languages` to make it an empty function.

6. Restart, now it's no longer syntax highlighted, which shows that the swizzled component has been correctly picked up.
<img width="843" alt="Screen Shot 2020-05-29 at 11 56 20" src="https://user-images.githubusercontent.com/4290500/83280081-1fe48580-a1a4-11ea-81c1-7e188141c5d5.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
