### PR TITLE
fix(v2): fix broken build when swizzled NotFound component exist

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -76,7 +76,7 @@
     "react-dev-utils": "^10.2.1",
     "react-helmet": "^6.0.0-beta",
     "react-loadable": "^5.5.0",
-    "react-loadable-ssr-addon": "^0.2.0",
+    "react-loadable-ssr-addon": "^0.2.2",
     "react-router": "^5.1.2",
     "react-router-config": "^5.1.1",
     "react-router-dom": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14303,10 +14303,10 @@ react-live@^2.2.1:
     react-simple-code-editor "^0.10.0"
     unescape "^1.0.1"
 
-react-loadable-ssr-addon@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/react-loadable-ssr-addon/-/react-loadable-ssr-addon-0.2.0.tgz#fbf4ebfa9cfd6eadb3c346f0459e1cee01c9cae8"
-  integrity sha512-gTfPaxWZa5mHKeSOE61RpoLe7hyjcJHgNa5m0ZZGV3OCkWsOKlfYgoBxXzu9ENg/ePR/kFd5H3ncF4K5eyyNTQ==
+react-loadable-ssr-addon@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/react-loadable-ssr-addon/-/react-loadable-ssr-addon-0.2.2.tgz#f536ed677c688994d440236164964300590ab771"
+  integrity sha512-Xk6lqe4Vr14SLSbB93U5JzewdKS77dqslQkhttJ5zpkXbacDF/yjjFT44/EXSqwIWN4gEEerJ5b4IU8v/1NyXw==
 
 react-loadable@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Finally resolve #2229 

I [fixed the bug  causing issue error in the `react-loadable-ssr-addon` lib](https://github.com/themgoncalves/react-loadable-ssr-addon/pull/20), although I did not establish the _exact_ reasons, but it doesn’t matter, the main thing is that the website building is now successful.

Actually, because we use the caret versions range, the `react-loadable-ssr-addon` dependency is already updated, but this PR explicitly bumps a new version to formally close the issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Checkout to [this branch](https://github.com/facebook/docusaurus/tree/repro-2244/website-build-fail)
1. Inside `website-build-fail` dir, run `yarn build`
1. Make sure the website was built successfully

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
