### PR TITLE
fix(v2): strip images and footnotes for excerpt correctly

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -312,7 +312,7 @@ describe('load utils', () => {
           import Component from '@site/src/components/Component';
           import Component from '@site/src/components/Component'
 
-          Lorem **ipsum** dolor sit \`amet\`, consectetur _adipiscing_ elit. [**Vestibulum**](https://wiktionary.org/wiki/vestibulum) ex urna, ~molestie~ et sagittis ut, varius ac justo :wink:.
+          Lorem **ipsum** dolor sit \`amet\`[^1], consectetur _adipiscing_ elit. [**Vestibulum**](https://wiktionary.org/wiki/vestibulum) ex urna[^bignote], ~molestie~ et sagittis ut, varius ac justo :wink:.
 
           Nunc porttitor libero nec vulputate venenatis. Nam nec rhoncus mauris. Morbi tempus est et nibh maximus, tempus venenatis arcu lobortis.
         `,
@@ -342,6 +342,20 @@ describe('load utils', () => {
           Nunc porttitor libero nec vulputate venenatis. Nam nec rhoncus mauris. Morbi tempus est et nibh maximus, tempus venenatis arcu lobortis.
         `,
         output: 'Lorem ipsum dolor sit amet',
+      },
+      // Content beginning with blockquote
+      {
+        input: `
+          > Lorem ipsum dolor sit amet
+        `,
+        output: 'Lorem ipsum dolor sit amet',
+      },
+      // Content beginning with image (eg. blog post)
+      {
+        input: `
+          ![Lorem ipsum](/img/lorem-ipsum.svg)
+        `,
+        output: 'Lorem ipsum',
       },
     ];
 

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -204,16 +204,16 @@ export function createExcerpt(fileString: string): string | undefined {
       .replace(/^\#{1,6}\s*([^#]*)\s*(\#{1,6})?/gm, '$1')
       // Remove emphasis and strikethroughs.
       .replace(/([\*_~]{1,3})(\S.*?\S{0,1})\1/g, '$2')
+      // Remove images.
+      .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, '$1')
+      // Remove footnotes.
+      .replace(/\[\^.+?\](\: .*?$)?/g, '')
       // Remove inline links.
       .replace(/\[(.*?)\][\[\(].*?[\]\)]/g, '$1')
       // Remove inline code.
       .replace(/`(.+?)`/g, '$1')
-      // Remove images.
-      .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, '')
       // Remove blockquotes.
       .replace(/^\s{0,3}>\s?/g, '')
-      // Remove footnotes.
-      .replace(/\[\^.+?\](\: .*?$)?/g, '')
       // Remove admonition definition.
       .replace(/(:{3}.*)/, '')
       // Remove Emoji names within colons include preceding whitespace.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Just minor fixes to remove Markdown markup for cleaner excerpt


For example, this Markdown snippet

```
![First Birthday Slash](/img/docusaurus-slash-first-birthday.svg)
```

produces following excerpt:

```
!First Birthday Slash
```

Pay attention to the question mark at the beginning that string - it should not be there.

This is due to the incorrect order of replacements (first we need to strip images links, and then other (inline) links). The same applies to footnotes, I added tests for them.

I also added a test for blockquote, because we have not tested this case before.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See tests and preview. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
