### PR TITLE
fix(v2): treat inline code in raw HTML as native element

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
@@ -16,7 +16,7 @@ export default {
   code: (props) => {
     const {children} = props;
     if (typeof children === 'string') {
-      if (children.indexOf('\n') === -1) {
+      if (!children.includes('\n')) {
         return <code {...props} />;
       }
       return <CodeBlock {...props} />;

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
@@ -16,6 +16,9 @@ export default {
   code: (props) => {
     const {children} = props;
     if (typeof children === 'string') {
+      if (children.indexOf('\n') === -1) {
+        return <code {...props} />;
+      }
       return <CodeBlock {...props} />;
     }
     return children;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

One of our users complained that inline code in raw HTML was not rendered correctly. I advised him to use Markdown syntax to define tables, to which he replied that in this case lists cannot be used. That's fair, raw HTML gives you more opportunities and flexibility,  so we should take this into account.

I mean, inline code in raw HTML should be rendered using regular HTML element, rather `CodeBlock` component (see screenshots below).


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
<table>
  <tr>
    <th>Argument</th>
  </tr>
  <tr>
    <td><code>name</code></td>
  </tr>
</table>
```

| Before   | After    |
| -------- | -------- |
| ![Screenshot from 2020-06-01 13-35-52](https://user-images.githubusercontent.com/4408379/83401170-e9f60a00-a40c-11ea-9ce9-8fc341a41149.png) | ![image](https://user-images.githubusercontent.com/4408379/83401103-c0d57980-a40c-11ea-9ae9-e98766e0ea1a.png) |


In other words, after that inline code in tables defined in different ways (Markdown and HTML) are rendered identically.

```
| Argument |
| -------- |
| `name`   |
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
