### PR TITLE
refactor(v2): add missing main landmark for needed pages

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.js
@@ -24,7 +24,7 @@ function BlogListPage(props) {
     <Layout title={title} description="Blog">
       <div className="container margin-vert--lg">
         <div className="row">
-          <div className="col col--8 col--offset-2">
+          <main className="col col--8 col--offset-2">
             {items.map(({content: BlogPostContent}) => (
               <BlogPostItem
                 key={BlogPostContent.metadata.permalink}
@@ -35,7 +35,7 @@ function BlogListPage(props) {
               </BlogPostItem>
             ))}
             <BlogListPaginator metadata={metadata} />
-          </div>
+          </main>
         </div>
       </div>
     </Layout>

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.js
@@ -51,10 +51,10 @@ function BlogTagsListPage(props) {
     <Layout title="Tags" description="Blog Tags">
       <div className="container margin-vert--lg">
         <div className="row">
-          <div className="col col--8 col--offset-2">
+          <main className="col col--8 col--offset-2">
             <h1>Tags</h1>
             <div className="margin-vert--lg">{tagsSection}</div>
-          </div>
+          </main>
         </div>
       </div>
     </Layout>

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.js
@@ -25,7 +25,7 @@ function BlogTagsPostPage(props) {
       description={`Blog | Tagged "${tagName}"`}>
       <div className="container margin-vert--lg">
         <div className="row">
-          <div className="col col--8 col--offset-2">
+          <main className="col col--8 col--offset-2">
             <h1>
               {count} {pluralize(count, 'post')} tagged with &quot;{tagName}
               &quot;
@@ -42,7 +42,7 @@ function BlogTagsPostPage(props) {
                 </BlogPostItem>
               ))}
             </div>
-          </div>
+          </main>
         </div>
       </div>
     </Layout>

--- a/website/src/pages/feedback/index.js
+++ b/website/src/pages/feedback/index.js
@@ -29,7 +29,7 @@ function Feedback() {
       permalink="/feedback"
       title="Feedback"
       description="Docusaurus 2 Feedback page">
-      <div
+      <main
         className={classnames(
           'container',
           'margin-vert--xl',

--- a/website/src/pages/showcase/index.js
+++ b/website/src/pages/showcase/index.js
@@ -21,7 +21,7 @@ const DESCRIPTION =
 function Showcase() {
   return (
     <Layout title={TITLE} description={DESCRIPTION}>
-      <div className="container margin-vert--lg">
+      <main className="container margin-vert--lg">
         <div className="text--center margin-bottom--xl">
           <h1>{TITLE}</h1>
           <p>{DESCRIPTION}</p>
@@ -71,7 +71,7 @@ function Showcase() {
             </div>
           ))}
         </div>
-      </div>
+      </main>
     </Layout>
   );
 }

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -26,7 +26,7 @@ function Version() {
       title="Versions"
       permalink="/versions"
       description="Docusaurus 2 Versions page listing all documented site versions">
-      <div className="container margin-vert--lg">
+      <main className="container margin-vert--lg">
         <h1>Docusaurus documentation versions</h1>
         <div className="margin-bottom--lg">
           <h3 id="latest">Latest version (Stable)</h3>
@@ -96,7 +96,7 @@ function Version() {
             </table>
           </div>
         )}
-      </div>
+      </main>
     </Layout>
   );
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR adds missing `main` elements to fix a11y issue reported by Rocket Validator:

> Document must have one main landmark 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
