### PR TITLE
refactor(v2): add aria label to paginators

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.js
@@ -13,7 +13,7 @@ function BlogListPaginator(props) {
   const {previousPage, nextPage} = metadata;
 
   return (
-    <nav className="pagination-nav">
+    <nav className="pagination-nav" aria-label="Blog list page navigation">
       <div className="pagination-nav__item">
         {previousPage && (
           <Link className="pagination-nav__link" to={previousPage}>

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.js
@@ -12,7 +12,7 @@ function BlogPostPaginator(props) {
   const {nextItem, prevItem} = props;
 
   return (
-    <nav className="pagination-nav">
+    <nav className="pagination-nav" aria-label="Blog post page navigation">
       <div className="pagination-nav__item">
         {prevItem && (
           <Link className="pagination-nav__link" to={prevItem.permalink}>

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.js
@@ -12,7 +12,7 @@ function DocPaginator(props) {
   const {metadata} = props;
 
   return (
-    <nav className="pagination-nav">
+    <nav className="pagination-nav" aria-label="Blog list page navigation">
       <div className="pagination-nav__item">
         {metadata.previous && (
           <Link


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR adds missing `arial-label` attributes to fix a11y issue reported by Rocket Validator:

> Ensures landmarks are unique

Since there can be more than one `nav` element on one page, for all others except the first one we need to add aria label.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
