### PR TITLE
fix(v2): do not create route for document that serve as docs home page

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -28,7 +28,7 @@ Object {
           "type": "link",
         },
         Object {
-          "href": "/docs/hello",
+          "href": "/docs",
           "label": "Hello, World !",
           "type": "link",
         },
@@ -40,7 +40,7 @@ Object {
       "collapsed": true,
       "items": Array [
         Object {
-          "href": "/docs/hello",
+          "href": "/docs",
           "label": "Hello, World !",
           "type": "link",
         },
@@ -86,14 +86,6 @@ Array [
           "content": "@site/docs/foo/baz.md",
         },
         "path": "/docs/foo/baz",
-      },
-      Object {
-        "component": "@theme/DocItem",
-        "exact": true,
-        "modules": Object {
-          "content": "@site/docs/hello.md",
-        },
-        "path": "/docs/hello",
       },
       Object {
         "component": "@theme/DocItem",
@@ -169,14 +161,6 @@ Array [
         },
         "path": "/docs/1.0.0/foo/baz",
       },
-      Object {
-        "component": "@theme/DocItem",
-        "exact": true,
-        "modules": Object {
-          "content": "@site/versioned_docs/version-1.0.0/hello.md",
-        },
-        "path": "/docs/1.0.0/hello",
-      },
     ],
   },
   Object {
@@ -195,14 +179,6 @@ Array [
         },
         "path": "/docs/next/foo/bar",
       },
-      Object {
-        "component": "@theme/DocItem",
-        "exact": true,
-        "modules": Object {
-          "content": "@site/docs/hello.md",
-        },
-        "path": "/docs/next/hello",
-      },
     ],
   },
   Object {
@@ -220,14 +196,6 @@ Array [
           "content": "@site/versioned_docs/version-1.0.1/foo/bar.md",
         },
         "path": "/docs/foo/bar",
-      },
-      Object {
-        "component": "@theme/DocItem",
-        "exact": true,
-        "modules": Object {
-          "content": "@site/versioned_docs/version-1.0.1/hello.md",
-        },
-        "path": "/docs/hello",
       },
     ],
   },
@@ -253,7 +221,7 @@ Object {
       "collapsed": true,
       "items": Array [
         Object {
-          "href": "/docs/next/hello",
+          "href": "/docs/next",
           "label": "hello",
           "type": "link",
         },
@@ -284,7 +252,7 @@ Object {
       "collapsed": true,
       "items": Array [
         Object {
-          "href": "/docs/1.0.0/hello",
+          "href": "/docs/1.0.0",
           "label": "hello",
           "type": "link",
         },
@@ -310,7 +278,7 @@ Object {
       "collapsed": true,
       "items": Array [
         Object {
-          "href": "/docs/hello",
+          "href": "/docs",
           "label": "hello",
           "type": "link",
         },
@@ -347,7 +315,7 @@ Object {
         "collapsed": true,
         "items": Array [
           Object {
-            "href": "/docs/1.0.0/hello",
+            "href": "/docs/1.0.0",
             "label": "hello",
             "type": "link",
           },
@@ -386,7 +354,7 @@ Object {
         "collapsed": true,
         "items": Array [
           Object {
-            "href": "/docs/hello",
+            "href": "/docs",
             "label": "hello",
             "type": "link",
           },
@@ -424,7 +392,7 @@ Object {
         "collapsed": true,
         "items": Array [
           Object {
-            "href": "/docs/next/hello",
+            "href": "/docs/next",
             "label": "hello",
             "type": "link",
           },

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -70,8 +70,6 @@ export default function pluginContentDocs(
   opts: Partial<PluginOptions>,
 ): Plugin<LoadedContent | null> {
   const options = {...DEFAULT_OPTIONS, ...opts};
-  const homePageDocsRoutePath =
-    options.routeBasePath === '' ? '/' : options.routeBasePath;
 
   if (options.admonitions) {
     options.remarkPlugins = options.remarkPlugins.concat([
@@ -97,6 +95,24 @@ export default function pluginContentDocs(
     sidebarsDir: versionedSidebarsDir,
   } = versioning;
   const versionsNames = versions.map((version) => `version-${version}`);
+
+  // Docs home page.
+  const homePageDocsRoutePath =
+    options.routeBasePath === '' ? '/' : options.routeBasePath;
+  const isDocsHomePagePath = (permalink: string) => {
+    const documentIdMatch = new RegExp(
+      `^\/(?:${homePageDocsRoutePath}\/)?(?:(?:${versions.join(
+        '|',
+      )}|next)\/)?(.*)`,
+      'i',
+    ).exec(permalink);
+
+    if (documentIdMatch) {
+      return documentIdMatch[1] === options.homePageId;
+    }
+
+    return false;
+  };
 
   return {
     name: 'docusaurus-plugin-content-docs',
@@ -268,10 +284,14 @@ export default function pluginContentDocs(
           );
         }
 
+        const {title, permalink, sidebar_label} = linkMetadata;
+
         return {
           type: 'link',
-          label: linkMetadata.sidebar_label || linkMetadata.title,
-          href: linkMetadata.permalink,
+          label: sidebar_label || title,
+          href: isDocsHomePagePath(permalink)
+            ? permalink.replace(`/${options.homePageId}`, '')
+            : permalink,
         };
       };
 
@@ -361,7 +381,6 @@ export default function pluginContentDocs(
                 baseUrl,
                 homePageDocsRoutePath,
                 versionDocsPathPrefix,
-                options.homePageId,
               ]);
               const docsBaseMetadataPath = await createData(
                 `${docuHash(metadataItem.source)}-base.json`,
@@ -404,12 +423,9 @@ export default function pluginContentDocs(
 
         return (
           routes
-            // Do not create a route for a page created specifically for docs home page.
-            .filter(
-              ({path}) =>
-                path.substr(path.lastIndexOf('/') + 1) !==
-                REVERSED_DOCS_HOME_PAGE_ID,
-            )
+            // Do not create a route for a document serve as docs home page.
+            // TODO: need way to do this filtering when generating routes for better perf.
+            .filter(({path}) => !isDocsHomePagePath(path))
             .sort((a, b) => (a.path > b.path ? 1 : b.path > a.path ? -1 : 0))
         );
       };

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -55,7 +55,7 @@ Given the example above, now when you navigate to the path `/docs` you will see 
 
 :::important
 
-The document id of `_index` is reserved exclusively for the home doc page, so it will not work as a standalone route.
+A standalone route will not be generated for the document that serves as home docs page.
 
 :::
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2830.

When we set the docs home page, we have two duplicate pages, for example, in the case of https://v2.docusaurus.io/:

- https://v2.docusaurus.io/docs/
- https://v2.docusaurus.io/docs/introduction

These two pages contain the same content (document of "introduction"), this is not good for SEO. I missed this important thing and therefore did not define the canonical URL for the `/docs` URL. However, after discussing with one our user, [we decided it was best not to create a separate route for document at all](https://github.com/facebook/docusaurus/issues/2830#issuecomment-635965464), which serves as docs home page.

Yes, this is a BC, but I guess  we can recommend in release notes that our user add a redirect using our official plugin to inform search engines about this change.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Snapshots and preview. 

On preview https://deploy-preview-2861--docusaurus-2.netlify.app/docs/introduction URL will not work.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
