### PR TITLE
fix(v2): fix FOUC in doc sidebar and various improvements

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/sidebars/sidebars-category.js
@@ -9,30 +9,25 @@ module.exports = {
   docs: [
     {
       type: 'category',
-      collapsed: true,
       label: 'level 1',
       items: [
         'a',
         {
           type: 'category',
-          collapsed: true,
           label: 'level 2',
           items: [
             {
               type: 'category',
-              collapsed: true,
               label: 'level 3',
               items: [
                 'c',
                 {
                   type: 'category',
-                  collapsed: true,
                   label: 'level 4',
                   items: [
                     'd',
                     {
                       type: 'category',
-                      collapsed: true,
                       label: 'deeper more more',
                       items: ['e'],
                     },

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -7,6 +7,7 @@ Object {
       "collapsed": true,
       "items": Array [
         Object {
+          "collapsed": true,
           "items": Array [
             Object {
               "href": "/docs/foo/bar",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/sidebars.test.ts.snap
@@ -157,6 +157,7 @@ exports[`loadSidebars sidebars with first level not a category 1`] = `
 Object {
   "docs": Array [
     Object {
+      "collapsed": true,
       "items": Array [
         Object {
           "id": "greeting",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/version.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/version.test.ts.snap
@@ -7,6 +7,7 @@ Object {
       "collapsed": true,
       "items": Array [
         Object {
+          "collapsed": true,
           "items": Array [
             Object {
               "id": "version-1.0.0/foo/bar",

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -25,6 +25,9 @@ function isCategoryShorthand(
   return typeof item !== 'string' && !item.type;
 }
 
+// categories are collapsed by default, unless user set collapsed = false
+const defaultCategoryCollapsedValue = true;
+
 /**
  * Convert {category1: [item1,item2]} shorthand syntax to long-form syntax
  */
@@ -33,7 +36,7 @@ function normalizeCategoryShorthand(
 ): SidebarItemCategoryRaw[] {
   return Object.entries(sidebar).map(([label, items]) => ({
     type: 'category',
-    collapsed: true,
+    collapsed: defaultCategoryCollapsedValue,
     label,
     items,
   }));
@@ -118,7 +121,13 @@ function normalizeItem(item: SidebarItemRaw): SidebarItem[] {
   switch (item.type) {
     case 'category':
       assertIsCategory(item);
-      return [{...item, items: flatMap(item.items, normalizeItem)}];
+      return [
+        {
+          collapsed: defaultCategoryCollapsedValue,
+          ...item,
+          items: flatMap(item.items, normalizeItem),
+        },
+      ];
     case 'link':
       assertIsLink(item);
       return [item];

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -42,7 +42,7 @@ export interface SidebarItemCategory {
   type: 'category';
   label: string;
   items: SidebarItem[];
-  collapsed?: boolean;
+  collapsed: boolean;
 }
 
 export interface SidebarItemCategoryRaw {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -54,6 +54,9 @@ function DocSidebarItemCategory({
   // active categories are always initialized as expanded
   // the default (item.collapsed) is only used for non-active categories
   const [collapsed, setCollapsed] = useState(() => {
+    if (!collapsible) {
+      return false;
+    }
     return isActive ? false : item.collapsed;
   });
 


### PR DESCRIPTION
## Motivation

CC @jsjoeio @lex111 @yangshun , this is a fix for https://github.com/facebook/docusaurus/pull/2682#issuecomment-636631225

I investigated the reasons of the FOUC on the docs sidebar after adding the `category.collapsed = false`, but actually found multiple problems that lead me to this refactor (some of them existed before).

- Reading `window.location` to know which sidebar items are "active": that works only client-side after hydration, and was a reason of the FOUC. Replaced by `activePath` that's actually provided on both client and server (via ReactRouter <StaticRouter/>). Note it could have been possible to use `useLocation` from React-router as well.

- Bad normalization of the new category collapsed attribute. We want to ensure to always have a mandatory boolean for this setting in the metadata, otherwise we'll have to to `const collapsed = maybeCollapsed ?? true` everywhere.

- Non-recursive active sidebar item, which makes the `Guides` not being highlighted here

![image](https://user-images.githubusercontent.com/749374/83540676-eb046580-a4f8-11ea-8bbc-e23ebb8522c9.png)

- Dangerous mutations during render. On the server, JS objects are not "reset" between page renders, so mutating the sidebar objects/props on one page actually affected the rendering of all other subsequent pages.

```js
if (item.collapsed !== prevCollapsedProp) {
  setPreviousCollapsedProp(item.collapsed);
  setCollapsed(item.collapsed);
}
```

```js
if (sidebarCollapsible) {
  sidebarData.forEach(sidebarItem =>
    mutateSidebarCollapsingState(sidebarItem, path)
  );
}
```

- Categories and links melted. This leads to declaring a collapsing state in links while collapsing is only affecting categories. I've splitted this way:

```js
function DocSidebarItem(props) {
  switch (props.item.type) {
    case "category":
      return <DocSidebarItemCategory {...props} />;
    case "link":
    default:
      return <DocSidebarItemLink {...props} />;
  }
}
```

---

After this refactor, I think the `collapsed` feature works as intended and the code is cleaner than before.

Please tell me if you see a breaking change or issue with existing behavior.

