### PR TITLE
fix(v2): allow using inline code in summary tag

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.js
@@ -9,8 +9,17 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
-
+import {MDXProvider} from '@mdx-js/react';
 import styles from './styles.module.css';
+
+const InlineCodeBlock = (props) => <code {...props} />;
+
+// On some elements, <code> should not wire the prism JS editor
+// instead we should use a regular inline code block
+// context: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/233#issuecomment-636998272
+const InlineCodeBlockProvider = ({children}) => (
+  <MDXProvider components={{code: InlineCodeBlock}}>{children}</MDXProvider>
+);
 
 export default {
   code: (props) => {
@@ -20,6 +29,11 @@ export default {
     }
     return children;
   },
+  summary: (props) => (
+    <InlineCodeBlockProvider>
+      <summary {...props} />
+    </InlineCodeBlockProvider>
+  ),
   a: (props) => {
     if (/\.[^./]+$/.test(props.href)) {
       // eslint-disable-next-line jsx-a11y/anchor-has-content


### PR DESCRIPTION
People want to be able to use inline code blocks inside JSX elements like details/summary blocks. 
[Context: typescript-cheatsheets](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/233#issuecomment-636998272)

![image](https://user-images.githubusercontent.com/749374/83551693-f9f31400-a508-11ea-80e0-e7efa527b38b.png)


Unfortunately, MDX does not support interleaving MDX strings inside MDX components so well:
https://github.com/mdx-js/mdx/issues/628

--- 

The following fails:

```
<details>
  <summary>No need for `readonly`</summary>
</details>
```

![image](https://user-images.githubusercontent.com/749374/83551917-3fafdc80-a509-11ea-9838-77ad812d27c2.png)

--- 

The following almost works but there's an unwanted line break:

```
<details>
  <summary>

No need for `readonly`

</summary>
</details>
```

![image](https://user-images.githubusercontent.com/749374/83551993-61a95f00-a509-11ea-9641-34e123745b7b.png)


---

The following unfortunately loads the full prisma code editor inside the summary:

```
<details>
  <summary><b>No need for <code>readonly</code></b></summary>
</details>
```

![image](https://user-images.githubusercontent.com/749374/83552138-95848480-a509-11ea-9ee3-8cb11071162c.png)




---

# Proposed solution:

Let the user write:

```
<details>
  <summary><b>No need for <code>readonly</code></b></summary>
</details>
```

And never use a prisma code editor when inside a summary, as it does not make much sense to do so anyway.

![image](https://user-images.githubusercontent.com/749374/83552679-70dcdc80-a50a-11ea-8f1a-1f522f50e4de.png)


There are possible potential other elements than `summary` on which we could apply the `InlineCodeBlockProvider`, not sure it's worth to add an exhaustive list right now.

Another option could be to write `<code inline>inline code content</code>`

This feature is "temporary" until proper MDX interleaving support