### PR TITLE
fix(v2): render as regular text uncollapsible categories

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -71,7 +71,6 @@ function DocSidebarItemCategory({
   const handleItemClick = useCallback(
     (e) => {
       e.preventDefault();
-      e.target.blur();
       setCollapsed((state) => !state);
     },
     [setCollapsed],
@@ -91,9 +90,10 @@ function DocSidebarItemCategory({
         className={classnames('menu__link', {
           'menu__link--sublist': collapsible,
           'menu__link--active': collapsible && isActive,
+          [styles.menuLinkText]: !collapsible,
         })}
-        href="#!"
         onClick={collapsible ? handleItemClick : undefined}
+        href={collapsible ? '#!' : undefined}
         {...props}>
         {label}
       </a>

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -58,6 +58,14 @@
     padding: 0.5rem;
   }
 
+  .menuLinkText {
+    cursor: initial;
+  }
+
+  .menuLinkText:hover {
+    background: none;
+  }
+
   .menuWithAnnouncementBar {
     margin-bottom: var(--docusaurus-announcement-bar-height);
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When `themeConfig.sidebarCollapsible = false` is set, the category link is still clickable (if you click on it, `#!` symbols will be added to the address bar of browser), besides this, the hover state works, which should not be.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Prerequisite: mouse over a category

| Before   | After    |
| -------- | -------- |
| ![screenshot_21](https://user-images.githubusercontent.com/4408379/83749490-76523800-a66c-11ea-8925-2dc3045acdcf.png)|![screenshot_20](https://user-images.githubusercontent.com/4408379/83749481-72beb100-a66c-11ea-9e5d-638d80c1a9bd.png) |






## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
