### PR TITLE
docs(v2): fix typo in command on installation page

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -123,7 +123,7 @@ npm install
 To check that that the update occurred successfully, run:
 
 ```bash npm2yarn
-npm docusaurus --version
+npx docusaurus --version
 ```
 
 You should see the correct version as output.

--- a/website/versioned_docs/version-2.0.0-alpha.56/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/installation.md
@@ -123,7 +123,7 @@ npm install
 To check that that the update occurred successfully, run:
 
 ```bash npm2yarn
-npm docusaurus --version
+npx docusaurus --version
 ```
 
 You should see the correct version as output.


### PR DESCRIPTION
Checking the docusaurus version should be done with

```
npx docusaurus --version
```

not 

```
npm docusaurus --version
```

otherwise it prints the version of `npm` instead of `docusaurus`.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
