### PR TITLE
docs(v2): make .nojekyll warning more obvious

### DIFF
--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -45,7 +45,7 @@ module.exports = {
 };
 ```
 
-:::tip
+:::warning
 
 By default, GitHub Pages runs published files through [Jekyll](https://jekyllrb.com/). Since Jekyll will discard any files that begin with `_`, it is recommended that you disable Jekyll by adding an empty file named `.nojekyll` file to your `static` directory.
 

--- a/website/docs/static-assets.md
+++ b/website/docs/static-assets.md
@@ -62,3 +62,4 @@ Keep in mind that:
 
 - By default, none of the files in `static` folder will be post-processed or minified.
 - Missing files references via hardcoded absolute paths will not be detected at compilation time, and will result in a 404 error.
+- By default, GitHub Pages runs published files through [Jekyll](https://jekyllrb.com/). Since Jekyll will discard any files that begin with `_`, it is recommended that you disable Jekyll by adding an empty file named `.nojekyll` file to your `static` directory if you are using GitHub pages for hosting.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

We should make this more obvious and also put it within the "static assets" page.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Netlify

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
