### PR TITLE
fix(v2): Do not automatically change tab when a non-existing option is selected

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.js
@@ -26,7 +26,8 @@ function Tabs(props) {
     const relevantTabGroupChoice = tabGroupChoices[groupId];
     if (
       relevantTabGroupChoice != null &&
-      relevantTabGroupChoice !== selectedValue
+      relevantTabGroupChoice !== selectedValue &&
+      values.some((value) => value.value === relevantTabGroupChoice)
     ) {
       setSelectedValue(relevantTabGroupChoice);
     }

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -348,6 +348,36 @@ You may want choices of the same kind of tabs to sync with each other. For examp
   <TabItem value="mac">Use Command + V to paste.</TabItem>
 </Tabs>
 
+For all tab groups that have the same `groupId`, the possible values do not need to be the same. If one tab group with chooses an value that does not exist in another tab group with the same `groupId`, the tab group with the missing value won't change its tab. You can see that from the following example. Try to select Linux, and the above tab groups doesn't change.
+
+```jsx
+<Tabs
+  groupId="operating-systems"
+  defaultValue="win"
+  values={[
+    {label: 'Windows', value: 'win'},
+    {label: 'macOS', value: 'mac'},
+    {label: 'Linux', value: 'linux'},
+  ]}>
+  <TabItem value="win">I am Windows.</TabItem>
+  <TabItem value="mac">I am macOS.</TabItem>
+  <TabItem value="linux">I am Linux.</TabItem>
+</Tabs>
+```
+
+<Tabs
+  groupId="operating-systems"
+  defaultValue="win"
+  values={[
+    {label: 'Windows', value: 'win'},
+    {label: 'macOS', value: 'mac'},
+    {label: 'Linux', value: 'linux'},
+  ]}>
+  <TabItem value="win">I am Windows.</TabItem>
+  <TabItem value="mac">I am macOS.</TabItem>
+  <TabItem value="linux">I am Linux.</TabItem>
+</Tabs>
+
 ---
 
 Tab choices with different `groupId`s will not interfere with each other:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Address #2885.

When a tab group choice is updated, the updated choice might not be available in some tab groups. In the current implementation, it will just appear that nothing is chosen, which might look confusing. This diff changes the behavior so that it will avoid updating a local tab choice when a tab group choice chooses an non-existing option.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See the added docs. When I select Linux which doesn't exist in the above two tab groups, those groups' tab choices don't change.

<img width="866" alt="Screen Shot 2020-06-05 at 20 12 38" src="https://user-images.githubusercontent.com/4290500/83931110-ecd46000-a768-11ea-9b20-3c7dbb346268.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
