### PR TITLE
fix(v2): set correct canonical url for docs home page

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
@@ -44,6 +44,10 @@ function DocPage(props) {
     isClient,
   } = useDocusaurusContext();
 
+  if (isHomePage) {
+    content.metadata.permalink = homePagePath;
+  }
+
   if (!isHomePage && Object.keys(currentRoute).length === 0) {
     return <NotFound {...props} />;
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently the canonical url for docs homepage refers to the original doc permalink, we need to adjust it. Since this affects the render of component, you need to change the canonical url in the DocPage component itself. 

```
<link data-react-helmet="true" rel="canonical" href="https://v2.docusaurus.io/docs/introduction">
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

On Preview (https://deploy-preview-2896--docusaurus-2.netlify.app/docs/):

```diff
- <link data-react-helmet="true" rel="canonical" href="https://v2.docusaurus.io/docs/introduction">
+ <link data-react-helmet="true" rel="canonical" href="https://v2.docusaurus.io/docs/">
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
