### PR TITLE
chore(v2): fix async tests

### DIFF
--- a/packages/docusaurus-1.x/lib/server/__tests__/utils.test.js
+++ b/packages/docusaurus-1.x/lib/server/__tests__/utils.test.js
@@ -39,11 +39,7 @@ describe('server utils', () => {
     const css = await utils.minifyCss(testCss);
     expect(css).toMatchSnapshot();
 
-    try {
-      await utils.minifyCss(notCss);
-    } catch (error) {
-      expect(error).toMatchSnapshot();
-    }
+    await expect(utils.minifyCss(notCss)).rejects.toMatchSnapshot();
   });
 
   test('autoprefix css', async () => {

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -110,13 +110,13 @@ Array [
 `;
 
 exports[`site with wrong sidebar file 1`] = `
-[Error: Bad sidebars file. The document id 'goku' was used in the sidebar, but no document with this id could be found.
+"Bad sidebars file. The document id 'goku' was used in the sidebar, but no document with this id could be found.
 Available document ids=
 - foo/bar
 - foo/baz
 - hello
 - ipsum
-- lorem]
+- lorem"
 `;
 
 exports[`versioned website content 1`] = `

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -45,7 +45,7 @@ test('site with wrong sidebar file', async () => {
   const plugin = pluginContentDocs(context, {
     sidebarPath,
   });
-  return plugin.loadContent().catch((e) => expect(e).toMatchSnapshot());
+  await expect(plugin.loadContent()).rejects.toThrowErrorMatchingSnapshot();
 });
 
 describe('empty/no docs website', () => {

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/metadata.test.ts
@@ -177,16 +177,16 @@ describe('simple site', () => {
       routeBasePath,
     };
 
-    return processMetadata({
-      source: 'invalid-id.md',
-      refDir: path.join(badSiteDir, 'docs'),
-      context,
-      options,
-      env,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Document id cannot include "/".]`,
-      ),
+    await expect(
+      processMetadata({
+        source: 'invalid-id.md',
+        refDir: path.join(badSiteDir, 'docs'),
+        context,
+        options,
+        env,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Document id cannot include \\"/\\"."`,
     );
   });
 
@@ -196,16 +196,16 @@ describe('simple site', () => {
       routeBasePath,
     };
 
-    return processMetadata({
-      source: 'invalid-slug.md',
-      refDir: path.join(badSiteDir, 'docs'),
-      context,
-      options,
-      env,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Document slug cannot include "/".]`,
-      ),
+    await expect(
+      processMetadata({
+        source: 'invalid-slug.md',
+        refDir: path.join(badSiteDir, 'docs'),
+        context,
+        options,
+        env,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Document slug cannot include \\"/\\"."`,
     );
   });
 });


### PR DESCRIPTION

For async tests, doing expectation in catch code is bad because if the promise resolves instead of rejecting, the test still pass, while it's expected to fail.
