### PR TITLE
fix(v2): adjust anchor offset when routes switched

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
@@ -5,10 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.enhancedAnchor:target:before {
-  content: '';
-  display: block;
-  height: var(--ifm-navbar-height);
-  margin: calc(var(--ifm-navbar-height) * -1) 0 0;
-  visibility: hidden;
+.enhancedAnchor {
+  top: calc(var(--ifm-navbar-height) * -1);
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #2907

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Disable `hideOnScroll` in the config file (if enabled)
2. Build a site
3. Go to direct link to anchor
4. Click on a link that leads to anchor on another page  (or simulate this behavior via this snippet `(document.getElementById('features')).scrollIntoView()`)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
