### PR TITLE
docs(v2):Fixed Github action workflow in Documentation

### DIFF
--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -114,8 +114,15 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-          run: |
+      - name: Test Build
+        run: |
+            if [ -e yarn.lock ]; then
+            yarn install --frozen-lockfile
+            elif [ -e package-lock.json ]; then
             npm ci
+            else
+            npm i
+            fi
             npm run build
   gh-release:
     if: github.event_name != 'pull_request'
@@ -145,8 +152,15 @@ jobs:
         run: |
           git config --global user.email "actions@gihub.com"
           git config --global user.name "gh-actions"
+          if [ -e yarn.lock ]; then
+          yarn install --frozen-lockfile
+          elif [ -e package-lock.json ]; then
           npm ci
+          else
+          npm i
+          fi
           npx docusaurus deploy
+
 ```
 
 1. Now when a new pull request arrives towards your repository in branch `documentation` it will automatically ensure that Docusaurus build is successful.


### PR DESCRIPTION
## Motivation
It fixes a typo in documentation of version 2 with the GitHub action workflow.
The `run` attribute in the workflow should either be `- run: something` or with a name. It also handles the workflow if lockfile is absent. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
I tried it on repo and it worked well.
![image](https://user-images.githubusercontent.com/32068075/84115947-8a22e300-aa4c-11ea-912e-d6c07f447fd6.png)
It is related to #2846

