### PR TITLE
Allow some sidebars to be collapsible, but others not.

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.js
@@ -41,6 +41,9 @@ function DocPage(props) {
     : permalinkToSidebar[currentRoute.path];
   const {
     siteConfig: {themeConfig: {sidebarCollapsible = true} = {}} = {},
+    siteConfig: {
+      themeConfig: {sidebarCollapsibleOverrides = []},
+    },
     isClient,
   } = useDocusaurusContext();
 
@@ -61,7 +64,11 @@ function DocPage(props) {
               docsSidebars={docsSidebars}
               path={isHomePage ? homePagePath : currentRoute.path}
               sidebar={sidebar}
-              sidebarCollapsible={sidebarCollapsible}
+              sidebarCollapsible={
+                sidebarCollapsibleOverrides.includes(sidebar)
+                  ? !sidebarCollapsible
+                  : sidebarCollapsible
+              }
             />
           </div>
         )}

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -303,6 +303,21 @@ module.exports = {
 };
 ```
 
+#### Overriding themeConfig.sidebarCollapsible on some sidebars
+
+If you have multiple sidebars, and would like to collapse some but not others, you can override the `themeConfig.sidebarCollapsible` behavior on a per-sidebar basis. Set `themeConfig.sidebarCollapsibleOverrides` to a list of names of sidebars that should behave the opposite of what you have `themeConfig.sidebarCollapsible` set to.
+
+```js {5} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  themeConfig: {
+    sidebarCollapsible: false,
+    sidebarCollapsibleOverrides: ['secondSidebar'],
+    // ...
+  },
+};
+```
+
 #### Expanded categories by default
 
 For docs that have collapsible categories, you may want more fine-grain control over certain categories. If you want specific categories to be always expanded, you can set `collapsed` to `false`:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

My docs site has several sidebars like https://prismatic.io/docs/getting-started/setting-up that look look best with `themeConfig.sidebarCollapsible=false`, but other sidebars have gotten rather long, like https://prismatic.io/docs/api/api-overview, and are in need `themeConfig.sidebarCollapsible=true`.  As of right now that option is all-or-nothing.

I'd like the ability to say "by default, I'd like `themeConfig.sidebarCollapsible=false`, but for these two sidebars I'd like `themeConfig.sidebarCollapsible=true`".

This commit allows a user to override `themeConfig.sidebarCollapsible` for a defined list of sidebars.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

I tested this by updating the "community" sidebar to have some headers, and then setting `sidebarCollapsibleOverrides: ['community'],`. I verified that the `docs` sidebar was still collapsible, but the `community` sidebar wasn't.  I then added `themeConfig.sidebarCollapsible=false` and verified that the inverse was true about the two sidebars.

I also removed both configuration values and verified that docs looked as they did previously, so this doesn't introduce any regressions.

## Related PRs

N/A
