### PR TITLE
feat(v2): Implement proof-of-concept Docusaurus Debug Dashboard

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,7 @@ packages/docusaurus-plugin-client-redirects/lib/
 packages/docusaurus-plugin-content-blog/lib/
 packages/docusaurus-plugin-content-docs/lib/
 packages/docusaurus-plugin-content-pages/lib/
+packages/docusaurus-plugin-debug/lib/
 packages/docusaurus-plugin-sitemap/lib/
 packages/docusaurus-plugin-ideal-image/lib/
 packages/docusaurus-plugin-ideal-image/copyUntypedFiles.js

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ packages/docusaurus-plugin-client-redirects/lib/
 packages/docusaurus-plugin-content-blog/lib/
 packages/docusaurus-plugin-content-docs/lib/
 packages/docusaurus-plugin-content-pages/lib/
+packages/docusaurus-plugin-debug/lib/
 packages/docusaurus-plugin-sitemap/lib/
 packages/docusaurus-plugin-ideal-image/lib/

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,7 @@ packages/docusaurus-init/templates/**/*.md
 packages/docusaurus-plugin-content-blog/lib/
 packages/docusaurus-plugin-content-docs/lib/
 packages/docusaurus-plugin-content-pages/lib/
+packages/docusaurus-plugin-debug/lib/
 packages/docusaurus-plugin-sitemap/lib/
 packages/docusaurus-plugin-ideal-image/lib/
 __fixtures__

--- a/packages/docusaurus-plugin-debug/package.json
+++ b/packages/docusaurus-plugin-debug/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@docusaurus/plugin-debug",
+  "version": "2.0.0-alpha.56",
+  "description": "Debug plugin for Docusaurus",
+  "main": "lib/index.js",
+  "scripts": {
+    "tsc": "tsc"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@docusaurus/types": "^2.0.0-alpha.56",
+    "@docusaurus/utils": "^2.0.0-alpha.56"
+  },
+  "peerDependencies": {
+    "@docusaurus/core": "^2.0.0",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
+  "engines": {
+    "node": ">=10.15.1"
+  }
+}

--- a/packages/docusaurus-plugin-debug/src/index.ts
+++ b/packages/docusaurus-plugin-debug/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {LoadContext, Plugin} from '@docusaurus/types';
+import {normalizeUrl} from '@docusaurus/utils';
+
+import path from 'path';
+
+export default function pluginContentPages({
+  siteConfig: {baseUrl},
+}: LoadContext): Plugin<void> {
+  return {
+    name: 'docusaurus-plugin-debug',
+
+    getThemePath() {
+      return path.resolve(__dirname, '../src/theme');
+    },
+
+    contentLoaded({actions: {addRoute}}) {
+      addRoute({
+        path: normalizeUrl([baseUrl, '__docusaurus/debug']),
+        component: '@theme/Debug',
+        exact: true,
+      });
+    },
+  };
+}

--- a/packages/docusaurus-plugin-debug/src/theme/Debug/index.js
+++ b/packages/docusaurus-plugin-debug/src/theme/Debug/index.js
@@ -34,7 +34,7 @@ function Debug() {
             {routes.map(({path, exact}) => (
               <li key={path}>
                 <div>Route: {path}</div>
-                <div>Is exact: {Boolean(exact)}</div>
+                <div>Is exact: {String(Boolean(exact))}</div>
               </li>
             ))}
           </ul>

--- a/packages/docusaurus-plugin-debug/src/theme/Debug/index.js
+++ b/packages/docusaurus-plugin-debug/src/theme/Debug/index.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Layout from '@theme/Layout';
+
+import registry from '@generated/registry';
+import routes from '@generated/routes';
+
+import styles from './styles.module.css';
+
+function Debug() {
+  return (
+    <Layout permalink="__docusaurus/debug" title="Debug">
+      <main className={styles.Container}>
+        <section>
+          <h2>Registry</h2>
+          <ul>
+            {Object.values(registry).map(([, aliasedPath, resolved]) => (
+              <li key={aliasedPath}>
+                <div>Aliased Path: {aliasedPath}</div>
+                <div>Resolved Path: {resolved}</div>
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h2>Routes</h2>
+          <ul>
+            {routes.map(({path, exact}) => (
+              <li key={path}>
+                <div>Route: {path}</div>
+                <div>Is exact: {Boolean(exact)}</div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+    </Layout>
+  );
+}
+
+export default Debug;

--- a/packages/docusaurus-plugin-debug/src/theme/Debug/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/Debug/styles.module.css
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.Container {
+  display: flex;
+  margin: 1em;
+}

--- a/packages/docusaurus-plugin-debug/tsconfig.json
+++ b/packages/docusaurus-plugin-debug/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./lib/.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "lib"
+  }
+}

--- a/packages/docusaurus-preset-classic/src/index.js
+++ b/packages/docusaurus-preset-classic/src/index.js
@@ -24,6 +24,7 @@ module.exports = function preset(context, opts = {}) {
       isProd &&
         googleAnalytics &&
         require.resolve('@docusaurus/plugin-google-analytics'),
+      !isProd && require.resolve('@docusaurus/plugin-debug'),
       isProd && gtag && require.resolve('@docusaurus/plugin-google-gtag'),
       isProd && [require.resolve('@docusaurus/plugin-sitemap'), opts.sitemap],
     ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR implements the docusaurus debug dashboard proposal in #2267.

It utilizes the generated files to produce some useful information. Currently, it only includes resolutions of aliased path and routes list, but we can do more fancy analysis in the future. In the future, we can also make `@docusaurus/core` to generate more files so that more useful debug information can be displayed.

I included it in the classic preset only in dev to reduce bundle size.

I will add it to the docs once the maintainers think this is a good start.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

`yarn start` and goto http://localhost:3000/__docusaurus/debug

<img width="1792" alt="Screen Shot 2020-06-13 at 01 44 12" src="https://user-images.githubusercontent.com/4290500/84561072-6810b580-ad17-11ea-9136-bb93b02f7072.png">

Check the preview url to ensure it's not in prod mode.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
