### PR TITLE
fix(v2): Add hooks to detect window resize, toggle off sidebar and navbar in desktop

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useUserPreferencesContext from '@theme/hooks/useUserPreferencesContext';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
-import useWindowSize, {desktopSize} from '@theme/hooks/useWindowSize';
+import useWindowSize, {windowSizes} from '@theme/hooks/useWindowSize';
 import useLogo from '@theme/hooks/useLogo';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
 import Link from '@docusaurus/Link';
@@ -180,7 +180,7 @@ function DocSidebar(props) {
   const windowSize = useWindowSize();
 
   useEffect(() => {
-    if (windowSize === desktopSize && showResponsiveSidebar) {
+    if (windowSize === windowSizes.desktop && showResponsiveSidebar) {
       setShowResponsiveSidebar(false);
     }
   }, [windowSize]);

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -10,6 +10,7 @@ import clsx from 'clsx';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useUserPreferencesContext from '@theme/hooks/useUserPreferencesContext';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
+import useWindowSize, {desktopSize} from '@theme/hooks/useWindowSize';
 import useLogo from '@theme/hooks/useLogo';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
 import Link from '@docusaurus/Link';
@@ -176,6 +177,13 @@ function DocSidebar(props) {
   } = props;
 
   useLockBodyScroll(showResponsiveSidebar);
+  const windowSize = useWindowSize();
+
+  useEffect(() => {
+    if (windowSize === desktopSize && showResponsiveSidebar) {
+      setShowResponsiveSidebar(false);
+    }
+  }, [windowSize]);
 
   if (!currentSidebar) {
     return null;

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.js
@@ -180,7 +180,7 @@ function DocSidebar(props) {
   const windowSize = useWindowSize();
 
   useEffect(() => {
-    if (windowSize === windowSizes.desktop && showResponsiveSidebar) {
+    if (windowSize === windowSizes.desktop) {
       setShowResponsiveSidebar(false);
     }
   }, [windowSize]);

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -16,7 +16,7 @@ import Toggle from '@theme/Toggle';
 import useThemeContext from '@theme/hooks/useThemeContext';
 import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
-import useWindowSize, {desktopSize} from '@theme/hooks/useWindowSize';
+import useWindowSize, {windowSizes} from '@theme/hooks/useWindowSize';
 import useLogo from '@theme/hooks/useLogo';
 
 import styles from './styles.module.css';
@@ -205,7 +205,7 @@ function Navbar() {
   const windowSize = useWindowSize();
 
   useEffect(() => {
-    if (windowSize === desktopSize) {
+    if (windowSize === windowSizes.desktop) {
       setSidebarShown(false);
     }
   }, [windowSize, sidebarShown]);

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useState, useEffect} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -16,6 +16,7 @@ import Toggle from '@theme/Toggle';
 import useThemeContext from '@theme/hooks/useThemeContext';
 import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
+import useWindowSize, {desktopSize} from '@theme/hooks/useWindowSize';
 import useLogo from '@theme/hooks/useLogo';
 
 import styles from './styles.module.css';
@@ -200,6 +201,14 @@ function Navbar() {
     (e) => (e.target.checked ? setDarkTheme() : setLightTheme()),
     [setLightTheme, setDarkTheme],
   );
+
+  const windowSize = useWindowSize();
+
+  useEffect(() => {
+    if (windowSize === desktopSize && sidebarShown) {
+      setSidebarShown(false);
+    }
+  }, [windowSize]);
 
   const {leftLinks, rightLinks} = splitLinks(links);
 

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -208,7 +208,7 @@ function Navbar() {
     if (windowSize === windowSizes.desktop) {
       setSidebarShown(false);
     }
-  }, [windowSize, sidebarShown]);
+  }, [windowSize]);
 
   const {leftLinks, rightLinks} = splitLinks(links);
 

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -205,10 +205,10 @@ function Navbar() {
   const windowSize = useWindowSize();
 
   useEffect(() => {
-    if (windowSize === desktopSize && sidebarShown) {
+    if (windowSize === desktopSize) {
       setSidebarShown(false);
     }
-  }, [windowSize]);
+  }, [windowSize, sidebarShown]);
 
   const {leftLinks, rightLinks} = splitLinks(links);
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.js
@@ -15,9 +15,10 @@ function useWindowSize() {
   const isClient = typeof window === 'object';
 
   function getSize() {
-    return isClient
-      ? (window.innerWidth > desktopThresholdWidth && desktopSize) || mobileSize
-      : undefined;
+    if (isClient) {
+      return undefined;
+    }
+    return window.innerWidth > desktopThresholdWidth ? desktopSize : mobileSize;
   }
 
   const [windowSize, setWindowSize] = useState(getSize);

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useEffect, useState} from 'react';
+
+const desktopThresholdWidth = 996;
+const desktopSize = 'desktop';
+const mobileSize = 'mobile';
+
+function useWindowSize() {
+  const isClient = typeof window === 'object';
+
+  function getSize() {
+    return isClient
+      ? (window.innerWidth > desktopThresholdWidth && desktopSize) || mobileSize
+      : undefined;
+  }
+
+  const [windowSize, setWindowSize] = useState(getSize);
+
+  useEffect(() => {
+    if (!isClient) {
+      return false;
+    }
+
+    function handleResize() {
+      setWindowSize(getSize());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+}
+
+export {desktopSize, mobileSize};
+export default useWindowSize;

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.js
@@ -8,17 +8,22 @@
 import {useEffect, useState} from 'react';
 
 const desktopThresholdWidth = 996;
-const desktopSize = 'desktop';
-const mobileSize = 'mobile';
+
+const windowSizes = {
+  desktop: 'desktop',
+  mobile: 'mobile',
+};
 
 function useWindowSize() {
-  const isClient = typeof window === 'object';
+  const isClient = typeof window !== 'undefined';
 
   function getSize() {
-    if (isClient) {
+    if (!isClient) {
       return undefined;
     }
-    return window.innerWidth > desktopThresholdWidth ? desktopSize : mobileSize;
+    return window.innerWidth > desktopThresholdWidth
+      ? windowSizes.desktop
+      : windowSizes.mobile;
   }
 
   const [windowSize, setWindowSize] = useState(getSize);
@@ -39,5 +44,5 @@ function useWindowSize() {
   return windowSize;
 }
 
-export {desktopSize, mobileSize};
+export {windowSizes};
 export default useWindowSize;


### PR DESCRIPTION
## Motivation
Resolve #2750 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Change browser size to mobile (<=996px)
2. Open one of the nav bar or doc sidebar using the mobile toggling button
3. Resize to desktop width (> 996px)
4. Observe reset of mobile navigation

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
