### PR TITLE
docs(v2): add documentation for multiple blogs

### DIFF
--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -163,6 +163,20 @@ Make sure there's no `index.js` page in `src/pages` or else there will be two fi
 
 :::
 
+```js {4-10} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  plugins: [
+    [
+      '@docusaurus/plugin-content-blog',
+      {
+        routeBasePath: 'my-blog', // URL route for your blog
+        path: './my-blog', // path to your blog folder
+      },
+    ],
+  ],
+}
+
 <!--
 
 Adding a blog using the blog plugin.
@@ -173,3 +187,4 @@ References
 - [v1 doc](https://docusaurus.io/docs/en/next/adding-blog)
 
 -->
+```

--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -192,7 +192,3 @@ References
 - [v1 doc](https://docusaurus.io/docs/en/next/adding-blog)
 
 -->
-
-```
-
-```

--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -165,17 +165,26 @@ Make sure there's no `index.js` page in `src/pages` or else there will be two fi
 
 ### Multiple blogs
 
-You can add another blog by specifying your own blog plugin in the `plugins` option. Set the `routeBasePath` to the URL route that you want your blog to be accessed on. Also, set `path` to the path to your blog folder.
+By default, the classic theme assumes only one blog per website and hence includes only one instance of the blog plugin. If you would like to have multiple blogs on a single website, it's possible too! You can add another blog by specifying another blog plugin in the `plugins` option for `docusaurus.config.js`.
 
-```js {4-10} title="docusaurus.config.js"
+Set the `routeBasePath` to the URL route that you want your second blog to be accessed on. Note that the `routeBasePath` here has to be different from the first blog or else there could be a collision of paths! Also, set `path` to the path to the directory containing your second blog's entries.
+
+```js title="docusaurus.config.js"
 module.exports = {
   // ...
   plugins: [
     [
       '@docusaurus/plugin-content-blog',
       {
-        routeBasePath: 'my-blog', // URL route for your blog
-        path: './my-blog', // path to your blog folder
+        /**
+         * URL route for the blog section of your site.
+         * *DO NOT* include a trailing slash.
+         */
+        routeBasePath: 'my-second-blog',
+        /**
+         * Path to data on filesystem relative to site dir.
+         */
+        path: './my-second-blog',
       },
     ],
   ],

--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -163,6 +163,10 @@ Make sure there's no `index.js` page in `src/pages` or else there will be two fi
 
 :::
 
+### Multiple blogs
+
+You can add another blog by specifying your own blog plugin in the `plugins` option. Set the `routeBasePath` to the URL route that you want your blog to be accessed on. Also, set `path` to the path to your blog folder.
+
 ```js {4-10} title="docusaurus.config.js"
 module.exports = {
   // ...
@@ -175,7 +179,8 @@ module.exports = {
       },
     ],
   ],
-}
+};
+```
 
 <!--
 
@@ -187,4 +192,7 @@ References
 - [v1 doc](https://docusaurus.io/docs/en/next/adding-blog)
 
 -->
+
+```
+
 ```

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -116,14 +116,14 @@ jobs:
           node-version: '12.x'
       - name: Test Build
         run: |
-            if [ -e yarn.lock ]; then
-            yarn install --frozen-lockfile
-            elif [ -e package-lock.json ]; then
-            npm ci
-            else
-            npm i
-            fi
-            npm run build
+          if [ -e yarn.lock ]; then
+          yarn install --frozen-lockfile
+          elif [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+          npm run build
   gh-release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -160,7 +160,6 @@ jobs:
           npm i
           fi
           npx docusaurus deploy
-
 ```
 
 1. Now when a new pull request arrives towards your repository in branch `documentation` it will automatically ensure that Docusaurus build is successful.

--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -301,7 +301,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docuaurus/plugin-content-pages',
+      '@docusaurus/plugin-content-pages',
       {
         /**
          * Path to data on filesystem

--- a/website/versioned_docs/version-2.0.0-alpha.48/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.48/using-plugins.md
@@ -287,7 +287,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docuaurus/plugin-content-pages',
+      '@docusaurus/plugin-content-pages',
       {
         /**
          * Path to data on filesystem

--- a/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.50/using-plugins.md
@@ -279,7 +279,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docuaurus/plugin-content-pages',
+      '@docusaurus/plugin-content-pages',
       {
         /**
          * Path to data on filesystem

--- a/website/versioned_docs/version-2.0.0-alpha.54/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.54/using-plugins.md
@@ -288,7 +288,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docuaurus/plugin-content-pages',
+      '@docusaurus/plugin-content-pages',
       {
         /**
          * Path to data on filesystem

--- a/website/versioned_docs/version-2.0.0-alpha.55/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.55/using-plugins.md
@@ -289,7 +289,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docuaurus/plugin-content-pages',
+      '@docusaurus/plugin-content-pages',
       {
         /**
          * Path to data on filesystem

--- a/website/versioned_docs/version-2.0.0-alpha.56/blog.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/blog.md
@@ -159,6 +159,25 @@ Make sure there's no `index.js` page in `src/pages` or else there will be two fi
 
 :::
 
+### Multiple blogs
+
+You can add another blog by specifying your own blog plugin in the `plugins` option. Set the `routeBasePath` to the URL route that you want your blog to be accessed on. Also, set `path` to the path to your blog folder.
+
+```js {4-10} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  plugins: [
+    [
+      '@docusaurus/plugin-content-blog',
+      {
+        routeBasePath: 'my-blog', // URL route for your blog
+        path: './my-blog', // path to your blog folder
+      },
+    ],
+  ],
+};
+```
+
 <!--
 
 Adding a blog using the blog plugin.

--- a/website/versioned_docs/version-2.0.0-alpha.56/blog.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/blog.md
@@ -161,17 +161,26 @@ Make sure there's no `index.js` page in `src/pages` or else there will be two fi
 
 ### Multiple blogs
 
-You can add another blog by specifying your own blog plugin in the `plugins` option. Set the `routeBasePath` to the URL route that you want your blog to be accessed on. Also, set `path` to the path to your blog folder.
+By default, the classic theme assumes only one blog per website and hence includes only one instance of the blog plugin. If you would like to have multiple blogs on a single website, it's possible too! You can add another blog by specifying another blog plugin in the `plugins` option for `docusaurus.config.js`.
 
-```js {4-10} title="docusaurus.config.js"
+Set the `routeBasePath` to the URL route that you want your second blog to be accessed on. Note that the `routeBasePath` here has to be different from the first blog or else there could be a collision of paths! Also, set `path` to the path to the directory containing your second blog's entries.
+
+```js title="docusaurus.config.js"
 module.exports = {
   // ...
   plugins: [
     [
       '@docusaurus/plugin-content-blog',
       {
-        routeBasePath: 'my-blog', // URL route for your blog
-        path: './my-blog', // path to your blog folder
+        /**
+         * URL route for the blog section of your site.
+         * *DO NOT* include a trailing slash.
+         */
+        routeBasePath: 'my-second-blog',
+        /**
+         * Path to data on filesystem relative to site dir.
+         */
+        path: './my-second-blog',
       },
     ],
   ],

--- a/website/versioned_docs/version-2.0.0-alpha.56/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/using-plugins.md
@@ -301,7 +301,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docuaurus/plugin-content-pages',
+      '@docusaurus/plugin-content-pages',
       {
         /**
          * Path to data on filesystem


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Add documentation about how to set up multiple blogs. 

This PR closes #2481. It also fixes a minor typo. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The changes can be viewed on Netlify here: 
https://deploy-preview-2933--docusaurus-2.netlify.app/docs/blog/#multiple-blogs

## Related Information

As noted in #2883, the user needs to add `require.resolve(<plugin-name>)` to the plugin name, in addition to the instructions stated in the documentation.
But I have excluded this to maintain consistency with the [plugins documentation](https://v2.docusaurus.io/docs/using-plugins/).

Should I make another PR to add in `require.resolve` for all plugin names? 
