### PR TITLE
docs(v2): add useThemeContext note

### DIFF
--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -94,6 +94,18 @@ const Example = () => {
 };
 ```
 
+:::note
+
+The component calling `useThemeContext` must be a child of the `Layout` component.
+
+```jsx
+<Layout>
+  <Example />
+</Layout>
+```
+
+:::
+
 ## Navbar
 
 ### Navbar title & logo

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -99,9 +99,13 @@ const Example = () => {
 The component calling `useThemeContext` must be a child of the `Layout` component.
 
 ```jsx
-<Layout>
-  <Example />
-</Layout>
+function ExamplePage() {
+  return (
+    <Layout>
+      <Example />
+    </Layout>
+  );
+}
 ```
 
 :::


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

A few people were having issues using theme information because they were trying to access it in the page component instead of in a component that is wrapped by the layout or theme provider component. The note I added to the docs will hopefully clarify this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Updated section
I added a note to the bottom which includes an example of how the component should be nested.
![Doc Screen Shot](https://user-images.githubusercontent.com/38243574/84614316-4f132a80-aef8-11ea-8aeb-5d3beefdbc8e.png)

### Related issues
facebook/docusaurus#2912
facebook/docusaurus#2646
