### PR TITLE
refactor(v2): refactor color mode system to enable all possibilities

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.js
@@ -175,7 +175,7 @@ function Navbar() {
     siteConfig: {
       themeConfig: {
         navbar: {title, links = [], hideOnScroll = false} = {},
-        disableDarkMode = false,
+        colorMode: {disableSwitch: disableColorModeSwitch = false} = {},
       },
     },
     isClient,
@@ -265,7 +265,7 @@ function Navbar() {
           {rightLinks.map((linkItem, i) => (
             <NavItem {...linkItem} key={i} />
           ))}
-          {!disableDarkMode && (
+          {!disableColorModeSwitch && (
             <Toggle
               className={styles.displayOnlyInLargeViewport}
               aria-label="Dark mode toggle"
@@ -303,7 +303,7 @@ function Navbar() {
               <strong className="navbar__title">{title}</strong>
             )}
           </Link>
-          {!disableDarkMode && sidebarShown && (
+          {!disableColorModeSwitch && sidebarShown && (
             <Toggle
               aria-label="Dark mode toggle in sidebar"
               checked={isDarkTheme}

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
@@ -10,51 +10,62 @@ import {useState, useCallback, useEffect} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 const themes = {
-  light: '',
+  light: 'light',
   dark: 'dark',
+};
+
+// Ensure to always return a valid theme even if input is invalid
+const coerceToTheme = (theme) => {
+  return theme === themes.dark ? themes.dark : themes.light;
+};
+
+const getInitialTheme = () => {
+  if (typeof document === 'undefined') {
+    return themes.light; // SSR: we don't care
+  }
+  return coerceToTheme(document.documentElement.getAttribute('data-theme'));
+};
+
+const storeTheme = (newTheme) => {
+  try {
+    localStorage.setItem('theme', coerceToTheme(newTheme));
+  } catch (err) {
+    console.error(err);
+  }
 };
 
 const useTheme = () => {
   const {
-    siteConfig: {themeConfig: {disableDarkMode}} = {},
+    siteConfig: {
+      themeConfig: {
+        colorMode: {disableSwitch = false},
+      },
+    } = {},
   } = useDocusaurusContext();
-  const [theme, setTheme] = useState(
-    typeof document !== 'undefined'
-      ? document.documentElement.getAttribute('data-theme')
-      : themes.light,
-  );
-  const setThemeSyncWithLocalStorage = useCallback(
-    (newTheme) => {
-      try {
-        localStorage.setItem('theme', newTheme);
-      } catch (err) {
-        console.error(err);
-      }
-    },
-    [setTheme],
-  );
+  const [theme, setTheme] = useState(getInitialTheme);
+
   const setLightTheme = useCallback(() => {
     setTheme(themes.light);
-    setThemeSyncWithLocalStorage(themes.light);
+    storeTheme(themes.light);
   }, []);
   const setDarkTheme = useCallback(() => {
     setTheme(themes.dark);
-    setThemeSyncWithLocalStorage(themes.dark);
+    storeTheme(themes.dark);
   }, []);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.setAttribute('data-theme', coerceToTheme(theme));
   }, [theme]);
 
   useEffect(() => {
-    if (disableDarkMode) {
+    if (disableSwitch) {
       return;
     }
 
     try {
       const localStorageTheme = localStorage.getItem('theme');
       if (localStorageTheme !== null) {
-        setTheme(localStorageTheme);
+        setTheme(coerceToTheme(localStorageTheme));
       }
     } catch (err) {
       console.error(err);
@@ -62,7 +73,7 @@ const useTheme = () => {
   }, [setTheme]);
 
   useEffect(() => {
-    if (disableDarkMode) {
+    if (disableSwitch) {
       return;
     }
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.js
@@ -36,11 +36,7 @@ const storeTheme = (newTheme) => {
 
 const useTheme = () => {
   const {
-    siteConfig: {
-      themeConfig: {
-        colorMode: {disableSwitch = false},
-      },
-    } = {},
+    siteConfig: {themeConfig: {colorMode: {disableSwitch = false} = {}}} = {},
   } = useDocusaurusContext();
   const [theme, setTheme] = useState(getInitialTheme);
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -81,6 +81,12 @@ module.exports = {
     ],
   ],
   themeConfig: {
+    colorMode: {
+      defaultDarkMode: false,
+      respectUserPreference: true,
+      disableSwitch: false,
+    },
+
     announcementBar: {
       id: 'supportus',
       content:


### PR DESCRIPTION
**Breaking change!**

This is a proposal for now to validate the API/config.

I'll add documentation and clear user errors to make migration easier.

## Motivation

Related to:

- #2919
- #2871

The current settings are a bit confusing and do not allow maximum flexibility for all users needs

![image](https://user-images.githubusercontent.com/749374/84684072-6d991600-af38-11ea-995d-de96e9e8acb2.png)

Some things impossible with current api:

- disable the toggle, but use the dark mode by default
- disable the toggle, and respect the user preferred color
- force default light theme, ignoring the user preferred color
- set dark theme by default, but respect the user preference to light if set

The new settings should allow all possible variations and be less confusing.

```js
{
    colorMode: {
      // false = light, true = dark
      defaultDarkMode: false,

      // should we care about `prefers-color-scheme` ?
      // according to issues, users expect `defaultDarkMode` to have higher priority
      // so I think we should ignore user preference by default
      respectUserPreference: false,

      // can we toggle the color or not
      disableSwitch: false,
    },
}
```

## Test Plan

Preview and local tests
