### PR TITLE
docs(v2): wrap all plugin imports in require.resolve()

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -18,7 +18,7 @@ Then you add it in your site's `docusaurus.config.js`'s `plugins` option:
 ```jsx {3} title="docusaurus.config.js"
 module.exports = {
   // ...
-  plugins: ['@docusaurus/plugin-content-pages'],
+  plugins: [require.resolve('@docusaurus/plugin-content-pages')],
 };
 ```
 
@@ -44,7 +44,7 @@ module.exports = {
   // ...
   plugins: [
     [
-      '@docusaurus/plugin-xxx',
+      require.resolve('@docusaurus/plugin-xxx'),
       {
         /* options */
       },
@@ -63,7 +63,7 @@ module.exports = {
 
     // With options object (babel style)
     [
-      '@docusaurus/plugin-sitemap',
+      require.resolve('@docusaurus/plugin-sitemap'),
       {
         cacheTime: 600 * 1000,
       },
@@ -142,7 +142,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-content-blog',
+      require.resolve('@docusaurus/plugin-content-blog'),
       {
         /**
          * Path to data on filesystem relative to site dir.
@@ -226,7 +226,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-content-docs',
+      require.resolve('@docusaurus/plugin-content-docs'),
       {
         /**
          * Path to data on filesystem relative to site dir.
@@ -301,7 +301,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-content-pages',
+      require.resolve('@docusaurus/plugin-content-pages'),
       {
         /**
          * Path to data on filesystem
@@ -341,7 +341,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 
 ```js title="docusaurus.config.js"
 module.exports = {
-  plugins: ['@docusaurus/plugin-google-analytics'],
+  plugins: [require.resolve('@docusaurus/plugin-google-analytics')],
   themeConfig: {
     googleAnalytics: {
       trackingID: 'UA-141789564-1',
@@ -372,7 +372,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 
 ```js title="docusaurus.config.js"
 module.exports = {
-  plugins: ['@docusaurus/plugin-google-gtag'],
+  plugins: [require.resolve('@docusaurus/plugin-google-gtag')],
   themeConfig: {
     gtag: {
       trackingID: 'UA-141789564-1',
@@ -403,7 +403,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-sitemap',
+      require.resolve('@docusaurus/plugin-sitemap'),
       {
         cacheTime: 600 * 1000, // 600 sec - cache purge period
         changefreq: 'weekly',
@@ -427,7 +427,7 @@ Modify your `docusaurus.config.js`
 ```diff
 module.exports = {
   ...
-+ plugins: ['@docusaurus/plugin-ideal-image'],
++ plugins: [require.resolve('@docusaurus/plugin-ideal-image')],
   ...
 }
 ```
@@ -487,7 +487,7 @@ Main usecase: you have `/myDocusaurusPage`, and you want to redirect to this pag
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-client-redirects',
+      require.resolve('@docusaurus/plugin-client-redirects'),
       {
         fromExtensions: ['html'],
       },
@@ -502,7 +502,7 @@ Second usecase: you have `/myDocusaurusPage.html`, and you want to redirect to t
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-client-redirects',
+      require.resolve('@docusaurus/plugin-client-redirects'),
       {
         toExtensions: ['html'],
       },
@@ -519,7 +519,7 @@ Let's imagine you change the url of an existing page, you might want to make sur
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-client-redirects',
+      require.resolve('@docusaurus/plugin-client-redirects'),
       {
         redirects: [
           {
@@ -539,7 +539,7 @@ It's possible to use a function to create the redirects for each existing path:
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-client-redirects',
+      require.resolve('@docusaurus/plugin-client-redirects'),
       {
         createRedirects: function (existingPath) {
           if (existingPath === '/docs/newDocPath') {
@@ -558,7 +558,7 @@ Finally, it's possible to use all options at the same time:
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-client-redirects',
+      require.resolve('@docusaurus/plugin-client-redirects'),
       {
         fromExtensions: ['html', 'htm'],
         toExtensions: ['exe', 'zip'],

--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -18,7 +18,7 @@ Then you add it in your site's `docusaurus.config.js`'s `plugins` option:
 ```jsx {3} title="docusaurus.config.js"
 module.exports = {
   // ...
-  plugins: [require.resolve('@docusaurus/plugin-content-pages')],
+  plugins: ['@docusaurus/plugin-content-pages'],
 };
 ```
 
@@ -44,7 +44,7 @@ module.exports = {
   // ...
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-xxx'),
+      '@docusaurus/plugin-xxx',
       {
         /* options */
       },
@@ -63,7 +63,7 @@ module.exports = {
 
     // With options object (babel style)
     [
-      require.resolve('@docusaurus/plugin-sitemap'),
+      '@docusaurus/plugin-sitemap',
       {
         cacheTime: 600 * 1000,
       },
@@ -142,7 +142,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-content-blog'),
+      '@docusaurus/plugin-content-blog',
       {
         /**
          * Path to data on filesystem relative to site dir.
@@ -226,7 +226,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-content-docs'),
+      '@docusaurus/plugin-content-docs',
       {
         /**
          * Path to data on filesystem relative to site dir.
@@ -301,7 +301,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-content-pages'),
+      '@docusaurus/plugin-content-pages',
       {
         /**
          * Path to data on filesystem
@@ -341,7 +341,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 
 ```js title="docusaurus.config.js"
 module.exports = {
-  plugins: [require.resolve('@docusaurus/plugin-google-analytics')],
+  plugins: ['@docusaurus/plugin-google-analytics'],
   themeConfig: {
     googleAnalytics: {
       trackingID: 'UA-141789564-1',
@@ -372,7 +372,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 
 ```js title="docusaurus.config.js"
 module.exports = {
-  plugins: [require.resolve('@docusaurus/plugin-google-gtag')],
+  plugins: ['@docusaurus/plugin-google-gtag'],
   themeConfig: {
     gtag: {
       trackingID: 'UA-141789564-1',
@@ -403,7 +403,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-sitemap'),
+      '@docusaurus/plugin-sitemap',
       {
         cacheTime: 600 * 1000, // 600 sec - cache purge period
         changefreq: 'weekly',
@@ -427,7 +427,7 @@ Modify your `docusaurus.config.js`
 ```diff
 module.exports = {
   ...
-+ plugins: [require.resolve('@docusaurus/plugin-ideal-image')],
++ plugins: ['@docusaurus/plugin-ideal-image'],
   ...
 }
 ```
@@ -487,7 +487,7 @@ Main usecase: you have `/myDocusaurusPage`, and you want to redirect to this pag
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-client-redirects'),
+      '@docusaurus/plugin-client-redirects',
       {
         fromExtensions: ['html'],
       },
@@ -502,7 +502,7 @@ Second usecase: you have `/myDocusaurusPage.html`, and you want to redirect to t
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-client-redirects'),
+      '@docusaurus/plugin-client-redirects',
       {
         toExtensions: ['html'],
       },
@@ -519,7 +519,7 @@ Let's imagine you change the url of an existing page, you might want to make sur
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-client-redirects'),
+      '@docusaurus/plugin-client-redirects',
       {
         redirects: [
           {
@@ -539,7 +539,7 @@ It's possible to use a function to create the redirects for each existing path:
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-client-redirects'),
+      '@docusaurus/plugin-client-redirects',
       {
         createRedirects: function (existingPath) {
           if (existingPath === '/docs/newDocPath') {
@@ -558,7 +558,7 @@ Finally, it's possible to use all options at the same time:
 module.exports = {
   plugins: [
     [
-      require.resolve('@docusaurus/plugin-client-redirects'),
+      '@docusaurus/plugin-client-redirects',
       {
         fromExtensions: ['html', 'htm'],
         toExtensions: ['exe', 'zip'],

--- a/website/versioned_docs/version-2.0.0-alpha.56/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/using-plugins.md
@@ -18,7 +18,7 @@ Then you add it in your site's `docusaurus.config.js`'s `plugins` option:
 ```jsx {3} title="docusaurus.config.js"
 module.exports = {
   // ...
-  plugins: ['@docusaurus/plugin-content-pages'],
+  plugins: [require.resolve('@docusaurus/plugin-content-pages')],
 };
 ```
 
@@ -44,7 +44,7 @@ module.exports = {
   // ...
   plugins: [
     [
-      '@docusaurus/plugin-xxx',
+      require.resolve('@docusaurus/plugin-xxx'),
       {
         /* options */
       },
@@ -59,7 +59,7 @@ Example:
 module.exports = {
   plugins: [
     // Basic usage.
-    '@docusaurus/plugin-google-analytics',
+    require.resolve('@docusaurus/plugin-google-analytics'),
 
     // With options object (babel style)
     [
@@ -142,7 +142,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-content-blog',
+      require.resolve('@docusaurus/plugin-content-blog'),
       {
         /**
          * Path to data on filesystem relative to site dir.
@@ -226,7 +226,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-content-docs',
+      require.resolve('@docusaurus/plugin-content-docs'),
       {
         /**
          * Path to data on filesystem relative to site dir.
@@ -301,7 +301,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-content-pages',
+      require.resolve('@docusaurus/plugin-content-pages'),
       {
         /**
          * Path to data on filesystem
@@ -341,7 +341,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 
 ```js title="docusaurus.config.js"
 module.exports = {
-  plugins: ['@docusaurus/plugin-google-analytics'],
+  plugins: [require.resolve('@docusaurus/plugin-google-analytics')],
   themeConfig: {
     googleAnalytics: {
       trackingID: 'UA-141789564-1',
@@ -372,7 +372,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 
 ```js title="docusaurus.config.js"
 module.exports = {
-  plugins: ['@docusaurus/plugin-google-gtag'],
+  plugins: [require.resolve('@docusaurus/plugin-google-gtag')],
   themeConfig: {
     gtag: {
       trackingID: 'UA-141789564-1',
@@ -403,7 +403,7 @@ If you have installed `@docusaurus/preset-classic`, you don't need to install it
 module.exports = {
   plugins: [
     [
-      '@docusaurus/plugin-sitemap',
+      require.resolve('@docusaurus/plugin-sitemap'),
       {
         cacheTime: 600 * 1000, // 600 sec - cache purge period
         changefreq: 'weekly',
@@ -427,7 +427,7 @@ Modify your `docusaurus.config.js`
 ```diff
 module.exports = {
   ...
-+ plugins: ['@docusaurus/plugin-ideal-image'],
++ plugins: [require.resolve('@docusaurus/plugin-ideal-image')],
   ...
 }
 ```


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

As per the breaking change in 2.0.0-alpha56 plugin call need to be wrapped in `require.resolve(...)`. Add this to the examples.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
