### PR TITLE
fix(v2): Declare @docusaurus-plugin-debug as dependency of preset classic

### DIFF
--- a/packages/docusaurus-preset-classic/package.json
+++ b/packages/docusaurus-preset-classic/package.json
@@ -11,6 +11,7 @@
     "@docusaurus/plugin-content-blog": "^2.0.0-alpha.56",
     "@docusaurus/plugin-content-docs": "^2.0.0-alpha.56",
     "@docusaurus/plugin-content-pages": "^2.0.0-alpha.56",
+    "@docusaurus/plugin-debug": "^2.0.0-alpha.56",
     "@docusaurus/plugin-google-analytics": "^2.0.0-alpha.56",
     "@docusaurus/plugin-google-gtag": "^2.0.0-alpha.56",
     "@docusaurus/plugin-sitemap": "^2.0.0-alpha.56",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Missed it in #2929. We should probably include `docusaurus start` in E2E test in the future to prevent this kind of bug.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Nothing breaks in CI

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
