### PR TITLE
docs(v2): add require.resolve to plugin imports on remaining pages

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.56/blog.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/blog.md
@@ -170,7 +170,7 @@ module.exports = {
   // ...
   plugins: [
     [
-      '@docusaurus/plugin-content-blog',
+      require.resolve('@docusaurus/plugin-content-blog'),
       {
         /**
          * URL route for the blog section of your site.

--- a/website/versioned_docs/version-2.0.0-alpha.56/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/configuration.md
@@ -42,8 +42,8 @@ List the [theme](using-themes.md), [plugins](using-plugins.md), and [presets](pr
 module.exports = {
   // ...
   plugins: [
-    '@docusaurus/plugin-content-blog',
-    '@docusaurus/plugin-content-pages',
+    require.resolve('@docusaurus/plugin-content-blog'),
+    require.resolve('@docusaurus/plugin-content-pages'),
   ],
   themes: ['@docusaurus/theme-classic'],
 };
@@ -67,7 +67,7 @@ module.exports = {
   // ...
   plugins: [
     [
-      '@docusaurus/plugin-content-blog',
+      require.resolve('@docusaurus/plugin-content-blog'),
       {
         path: 'blog',
         routeBasePath: 'blog',

--- a/website/versioned_docs/version-2.0.0-alpha.56/presets.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/presets.md
@@ -63,7 +63,7 @@ This is equivalent of doing:
 ```jsx title="docusaurus.config.js"
 module.exports = {
   themes: ['@docusaurus/themes-cool', '@docusaurus/themes-bootstrap'],
-  plugins: ['@docusaurus/plugin-blog'],
+  plugins: [require.resolve('@docusaurus/plugin-blog')],
 };
 ```
 

--- a/website/versioned_docs/version-2.0.0-alpha.56/styling-layout.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/styling-layout.md
@@ -145,7 +145,7 @@ npm install --save docusaurus-plugin-sass
 ```jsx {3} title="docusaurus.config.js"
 module.exports = {
   // ...
-  plugins: ['docusaurus-plugin-sass'],
+  plugins: [require.resolve('docusaurus-plugin-sass')],
   // ...
 };
 ```

--- a/website/versioned_docs/version-2.0.0-alpha.56/using-themes.md
+++ b/website/versioned_docs/version-2.0.0-alpha.56/using-themes.md
@@ -54,7 +54,7 @@ For example, a Docusaurus blog consists of a blog plugin and a blog theme.
 ```js title="docusaurus.config.js"
 {
   theme: ['theme-blog'],
-  plugins: ['plugin-content-blog'],
+  plugins: [require.resolve('plugin-content-blog')],
 }
 ```
 
@@ -63,7 +63,7 @@ And if you want to use Bootstrap styling, you can swap out the theme with `theme
 ```js title="docusaurus.config.js"
 {
   theme: ['theme-blog-bootstrap'],
-  plugins: ['plugin-content-blog'],
+  plugins: [require.resolve('plugin-content-blog')],
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Plugin imports on some pages are not wrapped in `require.resolve` yet.
This PR adds `require.resolve` to plugin imports on the remaining pages (for v2.0.0-alpha.56 docs).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes 

## Test Plan

The changes can be viewed on Netlify here: 
https://deploy-preview-2946--docusaurus-2.netlify.app/

## Related PRs
This PR is similar to #2941, but for the remaining pages.  
