### PR TITLE
refactor(v2): legacy export = syntax

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -7,19 +7,31 @@
 
 import {loader} from 'webpack';
 import {truncate, linkify} from './blogUtils';
-const {parseQuery, getOptions} = require('loader-utils');
+import {parseQuery, getOptions} from 'loader-utils';
 
-export = function (fileString: string) {
+const markdownLoader: loader.Loader = function (source) {
+  const fileString = source as string;
   const callback = this.async();
   const {truncateMarker, siteDir, contentPath, blogPosts} = getOptions(this);
+
   // Linkify posts
-  let finalContent = linkify(fileString, siteDir, contentPath, blogPosts);
+  let finalContent = linkify(
+    fileString as string,
+    siteDir,
+    contentPath,
+    blogPosts,
+  );
 
   // Truncate content if requested (e.g: file.md?truncated=true).
-  const {truncated} = this.resourceQuery && parseQuery(this.resourceQuery);
+  const truncated: string | undefined = this.resourceQuery
+    ? parseQuery(this.resourceQuery).truncated
+    : undefined;
+
   if (truncated) {
     finalContent = truncate(finalContent, truncateMarker);
   }
 
   return callback && callback(null, finalContent);
-} as loader.Loader;
+};
+
+export default markdownLoader;

--- a/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
@@ -9,9 +9,11 @@ import {getOptions} from 'loader-utils';
 import {loader} from 'webpack';
 import linkify from './linkify';
 
-export = function (fileString: string) {
+const markdownLoader: loader.Loader = function (source) {
+  const fileString = source as string;
   const callback = this.async();
   const {docsDir, siteDir, versionedDir, sourceToPermalink} = getOptions(this);
+
   return (
     callback &&
     callback(
@@ -26,4 +28,6 @@ export = function (fileString: string) {
       ),
     )
   );
-} as loader.Loader;
+};
+
+export default markdownLoader;


### PR DESCRIPTION
The `export = function() {}` syntax is not really something std JS, afaik it existed in TS before ES imports