### PR TITLE
docs: mention posthog-docusaurus plugin

### DIFF
--- a/website/docs/resources.md
+++ b/website/docs/resources.md
@@ -35,6 +35,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
 - [docusaurus2-dotenv](https://github.com/jonnynabors/docusaurus2-dotenv) - A Docusaurus 2 plugin that supports dotenv and other environment variables
+- [posthog-docusaurus](https://github.com/PostHog/posthog-docusaurus) - Integrate [PostHog](https://posthog.com/) product analytics with Docusaurus v2
 
 ## Enterprise usage
 


### PR DESCRIPTION
## Motivation

I'm using [PostHog](https://posthog.com) to track my site's traffic. I need to send a `$pageview` event each time the URL changes. For this I need to hook into docusaurus - just adding posthog's JS snippet in the footer won't cut it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes! I even signed the CLA.

## Test Plan

No code change, just added a link to the docs.