### PR TITLE
docs(v2): update docs about creating a new plugin

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -84,7 +84,14 @@ A plugin is a module which exports a function that takes two parameters and retu
 
 The exported modules for plugins are called with two parameters: `context` and `options` and returns a JavaScript object with defining the [lifecycle APIs](./lifecycle-apis.md).
 
-```js title="docusaurus.config.js"
+For example if you have a reference to a local folder such as this in your
+docusaurus.config.js:
+
+    plugins: [path.resolve(__dirname, 'my-plugin')],
+
+Then in the folder `my-plugin` you can create an index.js such as this
+
+```js title="index.js"
 module.exports = function(context, options) {
   // ...
   return {
@@ -95,6 +102,9 @@ module.exports = function(context, options) {
   };
 };
 ```
+
+The `my-plugin` folder could also be a fully fledged package with it's own 
+package.json and a `src/index.js` file for example
 
 #### `context`
 


### PR DESCRIPTION


## Motivation

I was reading the docs about creating a new plugin, and it referred to "docusaurus.config.js" as the file that contains the plugin code. I thought this was somewhat strange as it seems like the plugin code should just be an index.js or similar, so I modified the docs a little bit to help.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

N/A
