### PR TITLE
docs(v2): update grammar in plugin-content-pages example

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.58/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.58/using-plugins.md
@@ -310,7 +310,7 @@ module.exports = {
          */
         path: 'src/pages',
         /**
-         * URL route for the blog section of your site
+         * URL route for the page section of your site
          * do not include trailing slash
          */
         routeBasePath: '',


### PR DESCRIPTION
fixed grammar error in @docusaurus/plugin-content-pages example from 'blog' to 'page'

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

While reading through the docs I found a small grammar error here: [#docusaurusplugin-content-pages](https://v2.docusaurus.io/docs/using-plugins/#docusaurusplugin-content-pages)

I've concluded it to be a grammar error due to the fact that we see the exact same sentence in the blog example.

![Screen Shot 2020-06-18 at 8 54 46 PM](https://user-images.githubusercontent.com/53072963/85095374-0da7a700-b1a6-11ea-9baa-8cc46f846006.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes, small change. 👍 


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
