### PR TITLE
docs(v2): fix typos in plugin-content examples

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -238,7 +238,7 @@ module.exports = {
          */
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
         /**
-         * URL route for the blog section of your site.
+         * URL route for the docs section of your site.
          * *DO NOT* include a trailing slash.
          */
         routeBasePath: 'docs',
@@ -310,7 +310,7 @@ module.exports = {
          */
         path: 'src/pages',
         /**
-         * URL route for the blog section of your site
+         * URL route for the page section of your site
          * do not include trailing slash
          */
         routeBasePath: '',

--- a/website/versioned_docs/version-2.0.0-alpha.58/using-plugins.md
+++ b/website/versioned_docs/version-2.0.0-alpha.58/using-plugins.md
@@ -238,7 +238,7 @@ module.exports = {
          */
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
         /**
-         * URL route for the blog section of your site.
+         * URL route for the docs section of your site.
          * *DO NOT* include a trailing slash.
          */
         routeBasePath: 'docs',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In ref to #2966

Also addressed a similar typo in the [#docusaurusplugin-content-docs](https://v2.docusaurus.io/docs/using-plugins#docusaurusplugin-content-docs) section. (See screenshot below)

![Screen Shot 2020-06-18 at 11 04 51 PM](https://user-images.githubusercontent.com/53072963/85101837-2de06180-b1b8-11ea-9ffc-1eae293f739f.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Please confirm 'docs' is plural and not meant to be 'doc'.

![Screen Shot 2020-06-18 at 11 09 00 PM](https://user-images.githubusercontent.com/53072963/85102086-beb73d00-b1b8-11ea-9873-8ce7bb0e45fe.png)




## Related PRs

#2966