### PR TITLE
chore(v2): Fix a lot of eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,16 +88,11 @@ module.exports = {
 
     // TODO re-enable some these as errors
     // context: https://github.com/facebook/docusaurus/pull/2949
-    '@typescript-eslint/no-var-requires': WARNING,
     '@typescript-eslint/ban-ts-comment': WARNING,
     '@typescript-eslint/ban-types': WARNING,
-    'import/no-duplicates': WARNING,
     'import/prefer-default-export': WARNING,
     'import/no-extraneous-dependencies': WARNING,
-    'prefer-const': WARNING,
     'no-useless-escape': WARNING,
-    'prefer-object-spread': WARNING,
-    'no-return-await': WARNING,
     'prefer-template': WARNING,
     'no-shadow': WARNING,
     'no-param-reassign': WARNING,
@@ -113,7 +108,6 @@ module.exports = {
     'no-useless-return': WARNING,
     '@typescript-eslint/no-empty-function': WARNING,
     'global-require': WARNING,
-    'import/newline-after-import': WARNING,
     'prefer-destructuring': WARNING,
     yoda: WARNING,
     'no-control-regex': WARNING,
@@ -131,6 +125,14 @@ module.exports = {
       ],
       rules: {
         'header/header': OFF,
+      },
+    },
+    {
+      files: ['*.js'],
+      rules: {
+        // Make JS code directly runnable in Node.
+        '@typescript-eslint/no-var-requires': OFF,
+        '@typescript-eslint/explicit-module-boundary-types': OFF,
       },
     },
   ],

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
@@ -17,7 +17,7 @@ function createTestPluginContext(
   return {
     outDir: '/tmp',
     baseUrl: 'https://docusaurus.io',
-    routesPaths: routesPaths,
+    routesPaths,
     options: normalizePluginOptions(options),
   };
 }
@@ -192,7 +192,7 @@ describe('collectRedirects', () => {
                   `/def?queryString=toto`,
                 ];
               }
-              return;
+              return undefined;
             },
           },
           ['/'],
@@ -210,7 +210,7 @@ describe('collectRedirects', () => {
               if (routePath === '/') {
                 return [[`/fromPath`]] as any;
               }
-              return;
+              return undefined;
             },
           },
           ['/'],

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/redirectValidation.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/redirectValidation.test.ts
@@ -51,14 +51,14 @@ describe('validateRedirect', () => {
 
     expect(() =>
       validateRedirect({
-        from: null as any,
+        from: (null as unknown) as string,
         to: '/toSomePath?queryString=xyz',
       }),
     ).toThrowErrorMatchingSnapshot();
 
     expect(() =>
       validateRedirect({
-        from: ['heyho'] as any,
+        from: (['heyho'] as unknown) as string,
         to: '/toSomePath?queryString=xyz',
       }),
     ).toThrowErrorMatchingSnapshot();

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
@@ -69,7 +69,7 @@ describe('toRedirectFilesMetadata', () => {
 
 describe('writeRedirectFiles', () => {
   test('write the files', async () => {
-    const outDir = '/tmp/docusaurus_tests_' + Math.random();
+    const outDir = `/tmp/docusaurus_tests_${Math.random()}`;
 
     const filesMetadata = [
       {
@@ -94,7 +94,7 @@ describe('writeRedirectFiles', () => {
   });
 
   test('avoid overwriting existing files', async () => {
-    const outDir = '/tmp/docusaurus_tests_' + Math.random();
+    const outDir = `/tmp/docusaurus_tests_${Math.random()}`;
 
     const filesMetadata = [
       {

--- a/packages/docusaurus-plugin-client-redirects/src/extensionRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/extensionRedirects.ts
@@ -53,7 +53,7 @@ export function createToExtensionsRedirects(
     if (extensionFound) {
       const routePathWithoutExtension = removeSuffix(path, extensionFound);
       return [routePathWithoutExtension].map((from) => ({
-        from: from,
+        from,
         to: path,
       }));
     }
@@ -78,12 +78,11 @@ export function createFromExtensionsRedirects(
   const createPathRedirects = (path: string): RedirectMetadata[] => {
     if (path === '' || path.endsWith('/') || alreadyEndsWithAnExtension(path)) {
       return [];
-    } else {
-      return extensions.map((ext) => ({
-        from: `${path}.${ext}`,
-        to: path,
-      }));
     }
+    return extensions.map((ext) => ({
+      from: `${path}.${ext}`,
+      to: path,
+    }));
   };
 
   return flatten(paths.map(createPathRedirects));

--- a/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
@@ -21,7 +21,7 @@ export const DefaultPluginOptions: PluginOptions = {
 };
 
 function isRedirectsCreator(
-  value: any,
+  value: unknown,
 ): value is CreateRedirectsFnOption | undefined {
   if (value === null || typeof value === 'undefined') {
     return true;

--- a/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
@@ -21,7 +21,7 @@ const RedirectSchema = Yup.object<RedirectMetadata>({
   to: PathnameValidator.required(),
 });
 
-export function validateRedirect(redirect: RedirectMetadata) {
+export function validateRedirect(redirect: RedirectMetadata): void {
   try {
     RedirectSchema.validateSync(redirect, {
       strict: true,

--- a/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
@@ -54,7 +54,9 @@ export function toRedirectFilesMetadata(
   return redirects.map(createFileMetadata);
 }
 
-export async function writeRedirectFile(file: RedirectFileMetadata) {
+export async function writeRedirectFile(
+  file: RedirectFileMetadata,
+): Promise<void> {
   try {
     // User-friendly security to prevent file overrides
     if (await fs.pathExists(file.fileAbsolutePath)) {
@@ -79,6 +81,6 @@ export async function writeRedirectFile(file: RedirectFileMetadata) {
 
 export default async function writeRedirectFiles(
   redirectFiles: RedirectFileMetadata[],
-) {
+): Promise<void> {
   await Promise.all(redirectFiles.map(writeRedirectFile));
 }

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -11,11 +11,9 @@
     "access": "public"
   },
   "license": "MIT",
-  "devDependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.58"
-  },
   "dependencies": {
     "@docusaurus/mdx-loader": "^2.0.0-alpha.58",
+    "@docusaurus/types": "^2.0.0-alpha.58",
     "@docusaurus/utils": "^2.0.0-alpha.58",
     "feed": "^4.1.0",
     "fs-extra": "^8.1.0",

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -19,7 +19,7 @@ import {
 } from '@docusaurus/utils';
 import {LoadContext} from '@docusaurus/types';
 
-export function truncate(fileString: string, truncateMarker: RegExp) {
+export function truncate(fileString: string, truncateMarker: RegExp): string {
   return fileString.split(truncateMarker, 1).shift()!;
 }
 
@@ -37,7 +37,7 @@ function toUrl({date, link}: DateLink) {
 export async function generateBlogFeed(
   context: LoadContext,
   options: PluginOptions,
-) {
+): Promise<Feed | null> {
   if (!options.feedOptions) {
     throw new Error(
       'Invalid options - `feedOptions` is not expected to be null.',
@@ -76,7 +76,7 @@ export async function generateBlogFeed(
     } = post;
     feed.addItem({
       title,
-      id: id,
+      id,
       link: normalizeUrl([siteUrl, permalink]),
       date,
       description,
@@ -90,7 +90,7 @@ export async function generateBlogPosts(
   blogDir: string,
   {siteConfig, siteDir}: LoadContext,
   options: PluginOptions,
-) {
+): Promise<BlogPost[]> {
   const {
     include,
     routeBasePath,
@@ -181,14 +181,16 @@ export function linkify(
   siteDir: string,
   blogPath: string,
   blogPosts: BlogPost[],
-) {
+): string {
   let fencedBlock = false;
   const lines = fileContent.split('\n').map((line) => {
     if (line.trim().startsWith('```')) {
       fencedBlock = !fencedBlock;
     }
 
-    if (fencedBlock) return line;
+    if (fencedBlock) {
+      return line;
+    }
 
     let modifiedLine = line;
     const mdRegex = /(?:(?:\]\()|(?:\]:\s?))(?!https)([^'")\]\s>]+\.mdx?)/g;

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -12,12 +12,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.58",
     "commander": "^5.0.0",
     "picomatch": "^2.1.1"
   },
   "dependencies": {
     "@docusaurus/mdx-loader": "^2.0.0-alpha.58",
+    "@docusaurus/types": "^2.0.0-alpha.58",
     "@docusaurus/utils": "^2.0.0-alpha.58",
     "execa": "^3.4.0",
     "fs-extra": "^8.1.0",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -310,7 +310,7 @@ describe('versioned website', () => {
         permalink: '/docs/next/',
       },
     });
-    expect(docsMetadata['hello']).toEqual({
+    expect(docsMetadata.hello).toEqual({
       id: 'hello',
       isDocsHomePage: true,
       permalink: '/docs/next/',

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -68,7 +68,7 @@ const DEFAULT_OPTIONS: PluginOptions = {
 function getFirstDocLinkOfSidebar(
   sidebarItems: DocsSidebarItem[],
 ): string | null {
-  for (let sidebarItem of sidebarItems) {
+  for (const sidebarItem of sidebarItems) {
     if (sidebarItem.type === 'category') {
       const url = getFirstDocLinkOfSidebar(sidebarItem.items);
       if (url) {
@@ -534,7 +534,7 @@ Available document ids=
                   options: {
                     siteDir,
                     docsDir,
-                    sourceToPermalink: sourceToPermalink,
+                    sourceToPermalink,
                     versionedDir,
                   },
                 },

--- a/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
@@ -17,7 +17,7 @@ export default function (
   siteDir: string,
   sourceToPermalink: SourceToPermalink,
   versionedDir?: string,
-) {
+): string {
   // Determine the source dir. e.g: /website/docs, /website/versioned_docs/version-1.0.0
   let sourceDir: string | undefined;
   const thisSource = filePath;
@@ -40,7 +40,9 @@ export default function (
       if (line.trim().startsWith('```')) {
         fencedBlock = !fencedBlock;
       }
-      if (fencedBlock) return line;
+      if (fencedBlock) {
+        return line;
+      }
 
       let modifiedLine = line;
       // Replace inline-style links or reference-style links e.g:

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -135,7 +135,7 @@ function normalizeItem(item: SidebarItemRaw): SidebarItem[] {
     case 'doc':
       assertIsDoc(item);
       return [item];
-    default:
+    default: {
       const extraMigrationError =
         item.type === 'subcategory'
           ? "Docusaurus v2: 'subcategory' has been renamed as 'category'"
@@ -145,6 +145,7 @@ function normalizeItem(item: SidebarItemRaw): SidebarItem[] {
           item.type
         }]. Sidebar item=${JSON.stringify(item)} ${extraMigrationError}`,
       );
+    }
   }
 }
 
@@ -168,7 +169,7 @@ function normalizeSidebar(sidebars: SidebarRaw): Sidebar {
 
 export default function loadSidebars(sidebarPaths?: string[]): Sidebar {
   // We don't want sidebars to be cached because of hot reloading.
-  let allSidebars: SidebarRaw = {};
+  const allSidebars: SidebarRaw = {};
 
   if (!sidebarPaths || !sidebarPaths.length) {
     return {} as Sidebar;

--- a/packages/docusaurus-plugin-content-docs/src/version.ts
+++ b/packages/docusaurus-plugin-content-docs/src/version.ts
@@ -19,7 +19,7 @@ export function docsVersion(
   version: string | null | undefined,
   siteDir: string,
   options: PathOptions,
-) {
+): void {
   if (!version) {
     throw new Error(
       'No version tag specified!. Pass the version you wish to create as an argument. Ex: 1.0.0',

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -28,7 +28,7 @@ describe('createSitemap', () => {
 
   test('empty site', () => {
     expect(() => {
-      createSitemap({} as any, [], {} as any);
+      createSitemap({} as DocusaurusConfig, [], {} as any);
     }).toThrowErrorMatchingInlineSnapshot(
       `"url in docusaurus.config.js cannot be empty/undefined"`,
     );

--- a/packages/docusaurus-plugin-sitemap/src/index.ts
+++ b/packages/docusaurus-plugin-sitemap/src/index.ts
@@ -9,7 +9,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import {PluginOptions} from './types';
 import createSitemap from './createSitemap';
-import {LoadContext, Props} from '@docusaurus/types';
+import {LoadContext, Props, Plugin} from '@docusaurus/types';
 
 const DEFAULT_OPTIONS: PluginOptions = {
   cacheTime: 600 * 1000, // 600 sec - cache purge period.
@@ -20,7 +20,7 @@ const DEFAULT_OPTIONS: PluginOptions = {
 export default function pluginSitemap(
   _context: LoadContext,
   opts: Partial<PluginOptions>,
-) {
+): Plugin<void> {
   const options = {...DEFAULT_OPTIONS, ...opts};
 
   return {

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -197,7 +197,7 @@ export function createExcerpt(fileString: string): string | undefined {
 
   const fileLines = fileContent.split('\n');
 
-  for (let fileLine of fileLines) {
+  for (const fileLine of fileLines) {
     const cleanedLine = fileLine
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
@@ -338,14 +338,17 @@ export function normalizeUrl(rawUrls: string[]): string {
  * don't expose user's site structure.
  * Example: some/path/to/website/docs/foo.md -> @site/docs/foo.md
  */
-export function aliasedSitePath(filePath: string, siteDir: string) {
+export function aliasedSitePath(filePath: string, siteDir: string): string {
   const relativePath = path.relative(siteDir, filePath);
   // Cannot use path.join() as it resolves '../' and removes
   // the '@site'. Let webpack loader resolve it.
   return `@site/${relativePath}`;
 }
 
-export function getEditUrl(fileRelativePath: string, editUrl?: string) {
+export function getEditUrl(
+  fileRelativePath: string,
+  editUrl?: string,
+): string | undefined {
   return editUrl
     ? normalizeUrl([editUrl, posixPath(fileRelativePath)])
     : undefined;
@@ -362,22 +365,22 @@ export function isValidPathname(str: string): boolean {
   }
 }
 
-export function addTrailingSlash(str: string) {
+export function addTrailingSlash(str: string): string {
   return str.endsWith('/') ? str : `${str}/`;
 }
 
-export function removeTrailingSlash(str: string) {
+export function removeTrailingSlash(str: string): string {
   return removeSuffix(str, '/');
 }
 
-export function removeSuffix(str: string, suffix: string) {
+export function removeSuffix(str: string, suffix: string): string {
   if (suffix === '') {
     return str; // always returns "" otherwise!
   }
   return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str;
 }
 
-export function getFilePathForRoutePath(routePath: string) {
+export function getFilePathForRoutePath(routePath: string): string {
   const fileName = path.basename(routePath);
   const filePath = path.dirname(routePath);
   return path.join(filePath, `${fileName}/index.html`);

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -30,8 +30,7 @@
     "url": "https://github.com/facebook/docusaurus/issues"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-alpha.58",
-    "@docusaurus/types": "^2.0.0-alpha.58"
+    "@docusaurus/module-type-aliases": "^2.0.0-alpha.58"
   },
   "dependencies": {
     "@babel/core": "^7.9.0",
@@ -41,6 +40,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime": "^7.9.2",
+    "@docusaurus/types": "^2.0.0-alpha.58",
     "@docusaurus/utils": "^2.0.0-alpha.58",
     "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
     "@svgr/webpack": "^5.4.0",

--- a/packages/docusaurus/src/babel/preset.ts
+++ b/packages/docusaurus/src/babel/preset.ts
@@ -50,6 +50,7 @@ function getTransformOptions(isServer: boolean): TransformOptions {
           // By default, it assumes @babel/runtime@7.0.0. Since we use >7.0.0, better to
           // explicitly specify the version so that it can reuse the helper better
           // See https://github.com/babel/babel/issues/10261
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
           version: require('@babel/runtime/package.json').version,
           regenerator: true,
           useESModules: true,
@@ -74,8 +75,8 @@ function getTransformOptions(isServer: boolean): TransformOptions {
 }
 
 function babelPresets(api: ConfigAPI): TransformOptions {
-  const caller = api.caller((caller) => caller?.name);
-  return getTransformOptions(caller === 'server');
+  const callerName = api.caller((caller) => caller?.name);
+  return getTransformOptions(callerName === 'server');
 }
 
 export = babelPresets;

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -15,7 +15,7 @@ import PendingNavigation from './PendingNavigation';
 
 import './client-lifecycles-dispatcher';
 
-function App() {
+function App(): JSX.Element {
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {

--- a/packages/docusaurus/src/client/docusaurus.ts
+++ b/packages/docusaurus/src/client/docusaurus.ts
@@ -15,6 +15,7 @@ const fetched = {};
 const loaded = {};
 
 declare global {
+  // eslint-disable-next-line camelcase
   const __webpack_require__: any;
   interface Navigator {
     connection: any;

--- a/packages/docusaurus/src/client/exports/Head.tsx
+++ b/packages/docusaurus/src/client/exports/Head.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import {Helmet} from 'react-helmet';
 
-function Head(props) {
+function Head(props): JSX.Element {
   return <Helmet {...props} />;
 }
 

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -23,7 +23,7 @@ interface Props {
   readonly href: string;
 }
 
-function Link({isNavLink, ...props}: Props) {
+function Link({isNavLink, ...props}: Props): JSX.Element {
   const {to, href} = props;
   const targetLink = to || href;
   const isInternal = isInternalUrl(targetLink);

--- a/packages/docusaurus/src/client/exports/Noop.ts
+++ b/packages/docusaurus/src/client/exports/Noop.ts
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export default () => null;
+export default (): null => null;

--- a/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.ts
@@ -7,6 +7,7 @@
 
 import useBaseUrl from '../useBaseUrl';
 import useDocusaurusContext from '../useDocusaurusContext';
+
 jest.mock('../useDocusaurusContext', () => jest.fn(), {virtual: true});
 
 const mockedContext = <jest.Mock>useDocusaurusContext;

--- a/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
+++ b/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
@@ -7,8 +7,9 @@
 
 import {useContext} from 'react';
 import context from './context';
+import {DocusaurusContext} from '@docusaurus/types';
 
-function useDocusaurusContext() {
+function useDocusaurusContext(): DocusaurusContext {
   return useContext(context);
 }
 

--- a/packages/docusaurus/src/client/prefetch.ts
+++ b/packages/docusaurus/src/client/prefetch.ts
@@ -22,7 +22,7 @@ function support(feature) {
   return false;
 }
 
-function linkPrefetchStrategy(url) {
+function linkPrefetchStrategy(url: string) {
   return new Promise((resolve, reject) => {
     if (typeof document === 'undefined') {
       reject();
@@ -43,7 +43,7 @@ function linkPrefetchStrategy(url) {
   });
 }
 
-function xhrPrefetchStrategy(url) {
+function xhrPrefetchStrategy(url: string) {
   return new Promise((resolve, reject) => {
     const req = new XMLHttpRequest();
     req.open('GET', url, true);
@@ -67,7 +67,7 @@ const supportedPrefetchStrategy = support('prefetch')
 
 const preFetched = {};
 
-function prefetch(url) {
+function prefetch(url: string): Promise<void> {
   return new Promise((resolve) => {
     if (preFetched[url]) {
       resolve();
@@ -79,6 +79,7 @@ function prefetch(url) {
         resolve();
         preFetched[url] = true;
       })
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       .catch(() => {}); // 404s are logged to the console anyway.
   });
 }

--- a/packages/docusaurus/src/client/preload.ts
+++ b/packages/docusaurus/src/client/preload.ts
@@ -15,7 +15,7 @@ import {matchRoutes} from 'react-router-config';
  * @param {string} pathname the route pathname, example: /docs/installation
  * @returns {Promise} Promise object represents whether pathname has been preloaded
  */
-export default function preload(routes, pathname) {
+export default function preload(routes, pathname: string) {
   const matches = matchRoutes(routes, pathname);
 
   return Promise.all(

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -36,7 +36,7 @@ function compile(config: Configuration[]): Promise<any> {
       }
       if (stats.hasWarnings()) {
         // Custom filtering warnings (see https://github.com/webpack/webpack/issues/7841).
-        let warnings = stats.toJson('errors-warnings').warnings;
+        let {warnings} = stats.toJson('errors-warnings');
         const warningsFilter = ((config[0].stats as Stats.ToJsonOptionsObject)
           ?.warningsFilter || []) as any[];
 
@@ -142,7 +142,9 @@ export async function build(
   ) {
     const serverBundle = path.join(outDir, serverConfig.output.filename);
     fs.pathExists(serverBundle).then((exist) => {
-      exist && fs.unlink(serverBundle);
+      if (exist) {
+        fs.unlink(serverBundle);
+      }
     });
   }
 
@@ -162,6 +164,8 @@ export async function build(
       relativeDir,
     )}.\n`,
   );
-  forceTerminate && !cliOptions.bundleAnalyzer && process.exit(0);
+  if (forceTerminate && !cliOptions.bundleAnalyzer) {
+    process.exit(0);
+  }
   return outDir;
 }

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {normalizeUrl} from '@docusaurus/utils';
+import {normalizeUrl, posixPath} from '@docusaurus/utils';
 import chalk = require('chalk');
 import chokidar from 'chokidar';
 import express from 'express';
@@ -22,7 +22,6 @@ import merge from 'webpack-merge';
 import HotModuleReplacementPlugin from 'webpack/lib/HotModuleReplacementPlugin';
 import {load} from '../server';
 import {StartCLIOptions} from '@docusaurus/types';
-import {posixPath} from '@docusaurus/utils';
 import {CONFIG_FILE_NAME, STATIC_DIR_NAME, DEFAULT_PORT} from '../constants';
 import {createClientConfig} from '../webpack/client';
 import {applyConfigureWebpack} from '../webpack/utils';

--- a/packages/docusaurus/src/server/client-modules/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/client-modules/__tests__/index.test.ts
@@ -7,9 +7,9 @@
 
 import {loadClientModules} from '../index';
 
-const pluginEmpty = require('./__fixtures__/plugin-empty');
-const pluginFooBar = require('./__fixtures__/plugin-foo-bar');
-const pluginHelloWorld = require('./__fixtures__/plugin-hello-world');
+import pluginEmpty from './__fixtures__/plugin-empty';
+import pluginFooBar from './__fixtures__/plugin-foo-bar';
+import pluginHelloWorld from './__fixtures__/plugin-hello-world';
 
 describe('loadClientModules', () => {
   test('empty', () => {

--- a/packages/docusaurus/src/server/client-modules/index.ts
+++ b/packages/docusaurus/src/server/client-modules/index.ts
@@ -7,7 +7,7 @@
 
 import {Plugin} from '@docusaurus/types';
 
-export function loadClientModules(plugins: Plugin<any>[]): string[] {
+export function loadClientModules(plugins: Plugin<unknown>[]): string[] {
   return ([] as string[]).concat(
     ...plugins
       .map<any>(

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -32,10 +32,10 @@ const DEFAULT_CONFIG: {
   plugins: PluginConfig[];
   themes: PluginConfig[];
   customFields: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
   themeConfig: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
 } = {
   plugins: [],

--- a/packages/docusaurus/src/server/html-tags/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/html-tags/__tests__/index.test.ts
@@ -7,10 +7,10 @@
 
 import {loadHtmlTags} from '../index';
 
-const pluginEmpty = require('./__fixtures__/plugin-empty');
-const pluginPreBodyTags = require('./__fixtures__/plugin-preBodyTags');
-const pluginHeadTags = require('./__fixtures__/plugin-headTags');
-const pluginPostBodyTags = require('./__fixtures__/plugin-postBodyTags');
+import pluginEmpty from './__fixtures__/plugin-empty';
+import pluginPreBodyTags from './__fixtures__/plugin-preBodyTags';
+import pluginHeadTags from './__fixtures__/plugin-headTags';
+import pluginPostBodyTags from './__fixtures__/plugin-postBodyTags';
 
 describe('loadHtmlTags', () => {
   test('empty plugin', () => {

--- a/packages/docusaurus/src/server/html-tags/htmlTags.ts
+++ b/packages/docusaurus/src/server/html-tags/htmlTags.ts
@@ -23,7 +23,7 @@ function assertIsHtmlTagObject(val: any): asserts val is HtmlTagObject {
   }
 }
 
-export function htmlTagObjectToString(tagDefinition: any): string {
+export function htmlTagObjectToString(tagDefinition: unknown): string {
   assertIsHtmlTagObject(tagDefinition);
   if (htmlTags.indexOf(tagDefinition.tagName) === -1) {
     throw new Error(
@@ -40,13 +40,9 @@ export function htmlTagObjectToString(tagDefinition: any): string {
       if (tagAttributes[attributeName] === true) {
         return attributeName;
       }
-      return attributeName + '="' + tagAttributes[attributeName] + '"';
+      return `${attributeName}="${tagAttributes[attributeName]}"`;
     });
-  return (
-    '<' +
-    [tagDefinition.tagName].concat(attributes).join(' ') +
-    '>' +
-    ((!isVoidTag && tagDefinition.innerHTML) || '') +
-    (isVoidTag ? '' : '</' + tagDefinition.tagName + '>')
-  );
+  return `<${[tagDefinition.tagName].concat(attributes).join(' ')}>${
+    (!isVoidTag && tagDefinition.innerHTML) || ''
+  }${isVoidTag ? '' : `</${tagDefinition.tagName}>`}`;
 }

--- a/packages/docusaurus/src/server/html-tags/index.ts
+++ b/packages/docusaurus/src/server/html-tags/index.ts
@@ -31,13 +31,13 @@ export function loadHtmlTags(plugins: Plugin<any>[]): InjectedHtmlTags {
         plugin.injectHtmlTags() || {};
       return {
         headTags: headTags
-          ? acc.headTags + '\n' + createHtmlTagsString(headTags)
+          ? `${acc.headTags}\n${createHtmlTagsString(headTags)}`
           : acc.headTags,
         preBodyTags: preBodyTags
-          ? acc.preBodyTags + '\n' + createHtmlTagsString(preBodyTags)
+          ? `${acc.preBodyTags}\n${createHtmlTagsString(preBodyTags)}`
           : acc.preBodyTags,
         postBodyTags: postBodyTags
-          ? acc.postBodyTags + '\n' + createHtmlTagsString(postBodyTags)
+          ? `${acc.postBodyTags}\n${createHtmlTagsString(postBodyTags)}`
           : acc.postBodyTags,
       };
     },

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -17,7 +17,7 @@ import {
 } from '@docusaurus/types';
 import {initPlugins} from './init';
 
-export function sortConfig(routeConfigs: RouteConfig[]) {
+export function sortConfig(routeConfigs: RouteConfig[]): void {
   // Sort the route config. This ensures that route with nested
   // routes is always placed last.
   routeConfigs.sort((a, b) => {
@@ -55,11 +55,11 @@ export async function loadPlugins({
   pluginConfigs: PluginConfig[];
   context: LoadContext;
 }): Promise<{
-  plugins: Plugin<any>[];
+  plugins: Plugin<unknown>[];
   pluginsRouteConfigs: RouteConfig[];
 }> {
   // 1. Plugin Lifecycle - Initialization/Constructor.
-  const plugins: Plugin<any>[] = initPlugins({pluginConfigs, context});
+  const plugins: Plugin<unknown>[] = initPlugins({pluginConfigs, context});
 
   // 2. Plugin Lifecycle - loadContent.
   // Currently plugins run lifecycle methods in parallel and are not order-dependent.
@@ -71,7 +71,7 @@ export async function loadPlugins({
         return null;
       }
 
-      return await plugin.loadContent();
+      return plugin.loadContent();
     }),
   );
 
@@ -116,7 +116,7 @@ export async function loadPlugins({
         return null;
       }
 
-      return await plugin.routesLoaded(pluginsRouteConfigs);
+      return plugin.routesLoaded(pluginsRouteConfigs);
     }),
   );
 

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -29,8 +29,7 @@ export function loadPresets(
     if (typeof presetItem === 'string') {
       presetModuleImport = presetItem;
     } else if (Array.isArray(presetItem)) {
-      presetModuleImport = presetItem[0];
-      presetOptions = presetItem[1] || {};
+      [presetModuleImport, presetOptions = {}] = presetItem;
     } else {
       throw new Error('Invalid presets format detected in config.');
     }
@@ -41,8 +40,12 @@ export function loadPresets(
       presetOptions,
     );
 
-    preset.plugins && unflatPlugins.push(preset.plugins);
-    preset.themes && unflatThemes.push(preset.themes);
+    if (preset.plugins) {
+      unflatPlugins.push(preset.plugins);
+    }
+    if (preset.themes) {
+      unflatThemes.push(preset.themes);
+    }
   });
 
   return {

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -18,7 +18,7 @@ import {
   ChunkNames,
 } from '@docusaurus/types';
 
-function isModule(value: any): value is Module {
+function isModule(value: unknown): value is Module {
   if (isString(value)) {
     return true;
   }
@@ -111,12 +111,11 @@ export async function loadRoutes(
       return newValue;
     }
 
-    routesChunkNames[routePath] = Object.assign(
-      {},
-      routesChunkNames[routePath],
-      genRouteChunkNames({component}, 'component', component),
-      genRouteChunkNames(modules, 'module', routePath),
-    );
+    routesChunkNames[routePath] = {
+      ...routesChunkNames[routePath],
+      ...genRouteChunkNames({component}, 'component', component),
+      ...genRouteChunkNames(modules, 'module', routePath),
+    };
 
     const routesStr = routes
       ? `routes: [${routes.map(generateRouteCode).join(',')}],`

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -21,7 +21,7 @@ const CSS_REGEX = /\.css$/;
 const CSS_MODULE_REGEX = /\.module\.css$/;
 export const clientDir = path.join(__dirname, '..', 'client');
 
-export function excludeJS(modulePath: string) {
+export function excludeJS(modulePath: string): boolean {
   // always transpile client dir
   if (modulePath.startsWith(clientDir)) {
     return false;

--- a/packages/docusaurus/src/webpack/plugins/CleanWebpackPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/CleanWebpackPlugin.ts
@@ -180,7 +180,7 @@ class CleanWebpackPlugin {
     this.removeFiles = this.removeFiles.bind(this);
   }
 
-  apply(compiler: Compiler) {
+  apply(compiler: Compiler): void {
     if (!compiler.options.output || !compiler.options.output.path) {
       // eslint-disable-next-line no-console
       console.warn(
@@ -197,7 +197,7 @@ class CleanWebpackPlugin {
      *
      * Check for hooks in-order to support old plugin system
      */
-    const hooks = compiler.hooks;
+    const {hooks} = compiler;
 
     if (this.cleanOnceBeforeBuildPatterns.length !== 0) {
       if (hooks) {
@@ -229,7 +229,7 @@ class CleanWebpackPlugin {
    *
    * Warning: It is recommended to initially clean your build directory outside of webpack to minimize unexpected behavior.
    */
-  handleInitial() {
+  handleInitial(): void {
     if (this.initialClean) {
       return;
     }
@@ -239,7 +239,7 @@ class CleanWebpackPlugin {
     this.removeFiles(this.cleanOnceBeforeBuildPatterns);
   }
 
-  handleDone(stats: Stats) {
+  handleDone(stats: Stats): void {
     /**
      * Do nothing if there is a webpack error
      */
@@ -304,7 +304,7 @@ class CleanWebpackPlugin {
     }
   }
 
-  removeFiles(patterns: string[]) {
+  removeFiles(patterns: string[]): void {
     try {
       const deleted = delSync(patterns, {
         force: this.dangerouslyAllowCleanPatternsOutsideProject,

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -53,6 +53,7 @@ export function getStyleLoaders(
         // https://github.com/facebook/create-react-app/issues/2677
         ident: 'postcss',
         plugins: () => [
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
           require('postcss-preset-env')({
             autoprefixer: {
               flexbox: 'no-2009',
@@ -76,12 +77,10 @@ export function getCacheLoader(
 
   return {
     loader: require.resolve('cache-loader'),
-    options: Object.assign(
-      {
-        cacheIdentifier: `cache-loader:${cacheLoaderVersion}${isServer}`,
-      },
-      cacheOptions,
-    ),
+    options: {
+      cacheIdentifier: `cache-loader:${cacheLoaderVersion}${isServer}`,
+      ...cacheOptions,
+    },
   };
 }
 

--- a/packages/lqip-loader/src/__tests__/index.test.ts
+++ b/packages/lqip-loader/src/__tests__/index.test.ts
@@ -32,8 +32,8 @@ describe('lqip-loader', () => {
       const vibrant = new Vibrant(imgPath, {});
 
       return vibrant.getPalette().then((palette) => {
-        correctTestSwatch = Object.assign({}, palette);
-        testSwatchWithNull = Object.assign({}, palette, {Vibrant: null});
+        correctTestSwatch = {...palette};
+        testSwatchWithNull = {...palette, Vibrant: null};
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix a lot of eslint warnings to avoid spamming the terminal.

Before

```console
✖ 892 problems (0 errors, 892 warnings)
```

After

```console
✖ 217 problems (0 errors, 217 warnings)
```

All of the fixes are low-effort ones, major ones are including:

- Disable some TS rules that don't make sense for JS code.
- Adding missing type annotation, which can be already easily inferred by TS.
- Change some `any` type to `unknown` type.
- Small syntax change: `prefer-template`, `prefer-destructuring`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- Everything type checks
- Existing tests can pass
- Preview site doesn't break.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
