### PR TITLE
Fix typo in markdown-features

### DIFF
--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -571,7 +571,7 @@ module.exports = {
 If you want to add highlighting for languages not yet supported by Prism, you can swizzle `prism-include-languages`:
 
 ```bash npm2yarn
-yarn swizzle @docusaurus/theme-classic prism-include-languages
+npm run swizzle @docusaurus/theme-classic prism-include-languages
 ```
 
 It will produce `prism-include-languages.js` in your `src/theme` folder. You can add highlighting support for custom languages by editing `prism-include-languages.js`:

--- a/website/versioned_docs/version-2.0.0-alpha.58/markdown-features.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.58/markdown-features.mdx
@@ -571,7 +571,7 @@ module.exports = {
 If you want to add highlighting for languages not yet supported by Prism, you can swizzle `prism-include-languages`:
 
 ```bash npm2yarn
-yarn swizzle @docusaurus/theme-classic prism-include-languages
+npm run swizzle @docusaurus/theme-classic prism-include-languages
 ```
 
 It will produce `prism-include-languages.js` in your `src/theme` folder. You can add highlighting support for custom languages by editing `prism-include-languages.js`:


### PR DESCRIPTION
The code needed to be in npm syntax in order to work with npm2yarn

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
