### PR TITLE
feat(v2): Error when hooks depends on context is used outside of Layout

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/ThemeContext.js
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeContext.js
@@ -7,10 +7,6 @@
 
 import React from 'react';
 
-const ThemeContext = React.createContext({
-  isDarkTheme: false,
-  setLightTheme: () => {},
-  setDarkTheme: () => {},
-});
+const ThemeContext = React.createContext();
 
 export default ThemeContext;

--- a/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.js
+++ b/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.js
@@ -7,14 +7,6 @@
 
 import {createContext} from 'react';
 
-const UserPreferencesContext = createContext({
-  // Tab group choice.
-  tabGroupChoices: {},
-  setTabGroupChoices: () => {},
-
-  // Announcement bar.
-  isAnnouncementBarClosed: false,
-  closeAnnouncementBar: () => {},
-});
+const UserPreferencesContext = createContext();
 
 export default UserPreferencesContext;

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.js
@@ -10,7 +10,13 @@ import {useContext} from 'react';
 import ThemeContext from '@theme/ThemeContext';
 
 function useThemeContext() {
-  return useContext(ThemeContext);
+  const context = useContext(ThemeContext);
+  if (context == null) {
+    throw new Error(
+      '`useThemeContext` is used outside of `Layout` Component. See https://v2.docusaurus.io/docs/theme-classic#usethemecontext.',
+    );
+  }
+  return context;
 }
 
 export default useThemeContext;

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.js
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.js
@@ -10,7 +10,13 @@ import {useContext} from 'react';
 import UserPreferencesContext from '@theme/UserPreferencesContext';
 
 function useUserPreferencesContext() {
-  return useContext(UserPreferencesContext);
+  const context = useContext(UserPreferencesContext);
+  if (context == null) {
+    throw new Error(
+      '`useUserPreferencesContext` is used outside of `Layout` Component.',
+    );
+  }
+  return context;
 }
 
 export default useUserPreferencesContext;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Close #2912 to give user a clear direction.

I didn't create a docs pointer for the `useUserPreferencesContext` hook since it's more internal and unlike to be used by pages in top level.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

Try to add `useThemeHook` `useUserPreferencesContext` to `website/src/pages/index.js` and see it crash.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
