### PR TITLE
chore(v2): Merge devDependencies in theme-classic

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -27,7 +27,8 @@
     "react-toggle": "^4.1.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-alpha.58"
+    "@docusaurus/module-type-aliases": "^2.0.0-alpha.58",
+    "@types/hapi__joi": "^17.1.2"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",
@@ -36,8 +37,5 @@
   },
   "engines": {
     "node": ">=10.15.1"
-  },
-  "devDependencies": {
-    "@types/hapi__joi": "^17.1.2"
   }
 }


### PR DESCRIPTION
## Motivation

It's annoying to see `Duplicate object key` warnings in vscode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
