### PR TITLE
fix(v2): fix broken links on versions page

### DIFF
--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -197,7 +197,7 @@ You can also import your own components defined in other files or third-party co
 
 You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, so you install them like other npm packages using npm. Docusaurus supports both [Remark](https://github.com/remarkjs/remark) and [Rehype](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install your [Remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+First, install your [Remark](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) plugins.
 
 For example:
 

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -36,9 +36,7 @@ function Version() {
               <tr>
                 <th>{latestVersion}</th>
                 <td>
-                  <Link to={useBaseUrl('/docs/introduction')}>
-                    Documentation
-                  </Link>
+                  <Link to={useBaseUrl('/docs')}>Documentation</Link>
                 </td>
                 <td>
                   <a href={`${repoUrl}/releases/tag/v${latestVersion}`}>
@@ -57,9 +55,7 @@ function Version() {
               <tr>
                 <th>master</th>
                 <td>
-                  <Link to={useBaseUrl('/docs/next/introduction')}>
-                    Documentation
-                  </Link>
+                  <Link to={useBaseUrl('/docs/next')}>Documentation</Link>
                 </td>
                 <td>
                   <a href={repoUrl}>Source Code</a>
@@ -81,7 +77,7 @@ function Version() {
                   <tr key={version}>
                     <th>{version}</th>
                     <td>
-                      <Link to={useBaseUrl(`/docs/${version}/introduction`)}>
+                      <Link to={useBaseUrl(`/docs/${version}`)}>
                         Documentation
                       </Link>
                     </td>

--- a/website/versioned_docs/version-2.0.0-alpha.50/markdown-features.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.50/markdown-features.mdx
@@ -193,7 +193,7 @@ You can also import your own components defined in other files or third-party co
 
 You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, so you install them like other npm packages using npm. Docusaurus supports both [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install your [remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+First, install your [remark](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) plugins.
 
 For example:
 

--- a/website/versioned_docs/version-2.0.0-alpha.54/markdown-features.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.54/markdown-features.mdx
@@ -192,7 +192,7 @@ You can also import your own components defined in other files or third-party co
 
 You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, so you install them like other npm packages using npm. Docusaurus supports both [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install your [remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+First, install your [remark](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins) and [rehype](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) plugins.
 
 For example:
 

--- a/website/versioned_docs/version-2.0.0-alpha.55/markdown-features.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.55/markdown-features.mdx
@@ -197,7 +197,7 @@ You can also import your own components defined in other files or third-party co
 
 You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, so you install them like other npm packages using npm. Docusaurus supports both [Remark](https://github.com/remarkjs/remark) and [Rehype](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install your [Remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+First, install your [Remark](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) plugins.
 
 For example:
 

--- a/website/versioned_docs/version-2.0.0-alpha.56/markdown-features.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.56/markdown-features.mdx
@@ -197,7 +197,7 @@ You can also import your own components defined in other files or third-party co
 
 You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, so you install them like other npm packages using npm. Docusaurus supports both [Remark](https://github.com/remarkjs/remark) and [Rehype](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install your [Remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+First, install your [Remark](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) plugins.
 
 For example:
 

--- a/website/versioned_docs/version-2.0.0-alpha.58/markdown-features.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.58/markdown-features.mdx
@@ -197,7 +197,7 @@ You can also import your own components defined in other files or third-party co
 
 You can expand the MDX functionalities, using plugins. An MDX plugin is usually a npm package, so you install them like other npm packages using npm. Docusaurus supports both [Remark](https://github.com/remarkjs/remark) and [Rehype](https://github.com/rehypejs/rehype) plugins that work with MDX.
 
-First, install your [Remark](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins) plugins.
+First, install your [Remark](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins) and [Rehype](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) plugins.
 
 For example:
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR fixes broken links on https://v2.docusaurus.io/versions/, and closes #3016. 

It also fixes broken links to Remark and Rehype, as they have renamed their master branch.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
1. Go to https://deploy-preview-3017--docusaurus-2.netlify.app/versions
2. The 'Documentation' links should work
3. Go to https://deploy-preview-3017--docusaurus-2.netlify.app/docs/markdown-features/#configuring-plugins
4. The links at the following line should work 
![image](https://user-images.githubusercontent.com/46853051/86212238-3b2f2000-bbaa-11ea-81a7-a2761bf87922.png)
