### PR TITLE
fix(v2):pass siteConfig as prop to pages

### DIFF
--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -76,7 +76,7 @@ export default function pluginContentPages(
             component: source,
             exact: true,
             modules: {
-              config: `${context.generatedFilesDir}/docusaurus.config.js`,
+              config: `@generated/docusaurus.config`,
             },
           });
         }),

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -8,7 +8,12 @@
 import globby from 'globby';
 import fs from 'fs';
 import path from 'path';
-import {encodePath, fileToPath, aliasedSitePath} from '@docusaurus/utils';
+import {
+  encodePath,
+  fileToPath,
+  aliasedSitePath,
+  docuHash,
+} from '@docusaurus/utils';
 import {
   LoadContext,
   Plugin,
@@ -66,8 +71,12 @@ export default function pluginContentPages(
         return;
       }
 
-      const {addRoute} = actions;
+      const {addRoute, createData} = actions;
 
+      const configPath = await createData(
+        `${docuHash('config')}.json`,
+        JSON.stringify({siteConfig: context.siteConfig}, null, 2),
+      );
       await Promise.all(
         content.map(async (metadataItem) => {
           const {permalink, source} = metadataItem;
@@ -75,6 +84,9 @@ export default function pluginContentPages(
             path: permalink,
             component: source,
             exact: true,
+            modules: {
+              config: configPath,
+            },
           });
         }),
       );

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -8,12 +8,7 @@
 import globby from 'globby';
 import fs from 'fs';
 import path from 'path';
-import {
-  encodePath,
-  fileToPath,
-  aliasedSitePath,
-  docuHash,
-} from '@docusaurus/utils';
+import {encodePath, fileToPath, aliasedSitePath} from '@docusaurus/utils';
 import {
   LoadContext,
   Plugin,
@@ -71,12 +66,8 @@ export default function pluginContentPages(
         return;
       }
 
-      const {addRoute, createData} = actions;
+      const {addRoute} = actions;
 
-      const configPath = await createData(
-        `${docuHash('config')}.json`,
-        JSON.stringify({siteConfig: context.siteConfig}, null, 2),
-      );
       await Promise.all(
         content.map(async (metadataItem) => {
           const {permalink, source} = metadataItem;
@@ -85,7 +76,7 @@ export default function pluginContentPages(
             component: source,
             exact: true,
             modules: {
-              config: configPath,
+              config: `${context.generatedFilesDir}/docusaurus.config.js`,
             },
           });
         }),

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -62,7 +62,6 @@ const QUOTES = [
 function Home() {
   const context = useDocusaurusContext();
   const {siteConfig: {customFields = {}, tagline} = {}} = context;
-
   return (
     <Layout
       permalink="/"


### PR DESCRIPTION

## Motivation
Migrating from v1 to v2 all the components are converted to Functional Component. It fixes #2925 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
yes
## Test Plan
I checked it manually props are passed perfectly