### PR TITLE
fix(v2): change description for blog post paginator

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
@@ -16,7 +16,7 @@ function BlogPostPaginator(props): JSX.Element {
       <div className="pagination-nav__item">
         {prevItem && (
           <Link className="pagination-nav__link" to={prevItem.permalink}>
-            <div className="pagination-nav__sublabel">Previous Post</div>
+            <div className="pagination-nav__sublabel">Newer Post</div>
             <div className="pagination-nav__label">
               &laquo; {prevItem.title}
             </div>
@@ -26,7 +26,7 @@ function BlogPostPaginator(props): JSX.Element {
       <div className="pagination-nav__item pagination-nav__item--next">
         {nextItem && (
           <Link className="pagination-nav__link" to={nextItem.permalink}>
-            <div className="pagination-nav__sublabel">Next Post</div>
+            <div className="pagination-nav__sublabel">Older Post</div>
             <div className="pagination-nav__label">
               {nextItem.title} &raquo;
             </div>


### PR DESCRIPTION
## Motivation

This PR closes #2698. Originally, "Next Post" links to an older blog post and "Previous Post" links to a newer blog post. This PR changes the description to "Older Post" and "Newer Post" respectively to avoid confusion. 

I noticed that [blog list paginator](https://v2.docusaurus.io/blog) has "Older Entries" on the right hand side, so I kept the same ordering for blog page paginator.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes.

## Test Plan

The changes can be viewed at https://deploy-preview-3029--docusaurus-2.netlify.app/blog/2018/12/14/Happy-First-Birthday-Slash
![image](https://user-images.githubusercontent.com/46853051/86790173-ad1bd380-c09a-11ea-9d17-8ea9e3d49b61.png)




