### PR TITLE
feat(v2): notify users when docusaurus version is outdated

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -13,7 +13,39 @@ const path = require('path');
 const cli = require('commander');
 const {build, swizzle, deploy, start, externalCommand} = require('../lib');
 const requiredVersion = require('../package.json').engines.node;
+const pkg = require('../package.json');
+const updateNotifier = require('update-notifier');
+const boxen = require('boxen');
 
+// notify user if @docusaurus/core is outdated
+const notifier = updateNotifier({
+  pkg,
+  updateCheckInterval: 1000 * 60 * 60 * 24, // one day
+  distTag: 'next', // check against the version that is tagged 'next' on npm
+});
+
+if (notifier.update && notifier.update.current !== notifier.update.latest) {
+  const boxenOptions = {
+    padding: 1,
+    margin: 1,
+    align: 'center',
+    borderColor: 'yellow',
+    borderStyle: 'round',
+  };
+
+  const docusaurusUpdateMessage = boxen(
+    `Update available ${chalk.dim(`${notifier.update.current}`)}${chalk.reset(
+      ' → ',
+    )}${chalk.green(`${notifier.update.latest}`)}\nRun ${chalk.cyan(
+      'yarn upgrade @docusaurus/core@next',
+    )} to update`,
+    boxenOptions,
+  );
+
+  console.log(docusaurusUpdateMessage);
+}
+
+// notify user if node version needs to be updated
 if (!semver.satisfies(process.version, requiredVersion)) {
   console.log(
     chalk.red(`\nMinimum Node version not met :(`) +

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -24,6 +24,11 @@ const notifier = updateNotifier({
   distTag: 'next', // compare with the version that is tagged 'next' on npm
 });
 
+// allow the user to be notified for updates on the first run
+if (notifier.lastUpdateCheck === Date.now()) {
+  notifier.lastUpdateCheck = 0;
+}
+
 if (notifier.update && notifier.update.current !== notifier.update.latest) {
   const boxenOptions = {
     padding: 1,

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -34,9 +34,11 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
   };
 
   const docusaurusUpdateMessage = boxen(
-    `Update available ${chalk.dim(`${notifier.update.current}`)}
-    ${chalk.reset(' → ')}${chalk.green(`${notifier.update.latest}`)}
-    \nRun ${chalk.cyan('yarn upgrade @docusaurus/core@next')} to update`,
+    `Update available ${chalk.dim(`${notifier.update.current}`)}${chalk.reset(
+      ' → ',
+    )}${chalk.green(`${notifier.update.latest}`)}\nRun ${chalk.cyan(
+      'yarn upgrade @docusaurus/core@next',
+    )} to update`,
     boxenOptions,
   );
 

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -21,7 +21,7 @@ const boxen = require('boxen');
 const notifier = updateNotifier({
   pkg,
   updateCheckInterval: 1000 * 60 * 60 * 24, // one day
-  distTag: 'next', // check against the version that is tagged 'next' on npm
+  distTag: 'next', // compare with the version that is tagged 'next' on npm
 });
 
 if (notifier.update && notifier.update.current !== notifier.update.latest) {
@@ -34,11 +34,9 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
   };
 
   const docusaurusUpdateMessage = boxen(
-    `Update available ${chalk.dim(`${notifier.update.current}`)}${chalk.reset(
-      ' → ',
-    )}${chalk.green(`${notifier.update.latest}`)}\nRun ${chalk.cyan(
-      'yarn upgrade @docusaurus/core@next',
-    )} to update`,
+    `Update available ${chalk.dim(`${notifier.update.current}`)}
+    ${chalk.reset(' → ')}${chalk.green(`${notifier.update.latest}`)}
+    \nRun ${chalk.cyan('yarn upgrade @docusaurus/core@next')} to update`,
     boxenOptions,
   );
 

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docusaurus/core",
   "description": "Easy to Maintain Open Source Documentation Websites",
-  "version": "2.0.0-alpha.58",
+  "version": "2.0.0-alpha.57",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.9.0",
-    "@babel/plugin-proposal-optional-chaining": "^7.10.3",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
+    "@babel/plugin-proposal-optional-chaining": "^7.10.3",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
@@ -50,6 +50,7 @@
     "@svgr/webpack": "^5.4.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-dynamic-import-node": "^2.3.0",
+    "boxen": "^4.2.0",
     "cache-loader": "^4.1.0",
     "chalk": "^3.0.0",
     "chokidar": "^3.3.0",
@@ -91,6 +92,7 @@
     "shelljs": "^0.8.4",
     "std-env": "^2.2.1",
     "terser-webpack-plugin": "^2.3.5",
+    "update-notifier": "^4.1.0",
     "url-loader": "^4.1.0",
     "wait-file": "^1.0.5",
     "webpack": "^4.41.2",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docusaurus/core",
   "description": "Easy to Maintain Open Source Documentation Websites",
-  "version": "2.0.0-alpha.57",
+  "version": "2.0.0-alpha.58",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18273,7 +18273,7 @@ update-check@1.5.2:
     registry-auth-token "3.3.2"
     registry-url "3.1.0"
 
-update-notifier@^4.0.0:
+update-notifier@^4.0.0, update-notifier@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.0.tgz#4866b98c3bc5b5473c020b1250583628f9a328f3"
   integrity sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==


### PR DESCRIPTION
## Motivation

Notify the user when their @docusaurus/core version is outdated. 
The interval between notifications is set to one day so that it is not too naggy.
This PR closes #2199.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan (edited)

1. Run `yarn install` in the root directory 
2. Open `package.json` file in `/packages/docusaurus`, change line 4 to `"version": "2.0.0-alpha.56",` 
3. Go to the `/website` directory in your terminal, run `yarn start`. You should see a notification like the one below!
<img src="https://user-images.githubusercontent.com/46853051/86938271-d740c480-c172-11ea-8938-bb5c54cf43d2.png" width="500" >

4. Run `yarn start` again, there should be no notification this time because the interval is set to one day

## Additional Remarks
The notify method of update-notifier does not work directly with our docusaurus command, so the implementation needed to be modified.


