### PR TITLE
docs(v2): correct the documentation for docs-only mode

### DIFF
--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -140,12 +140,6 @@ https://{your-domain}/blog/atom.xml
 
 You can run your Docusaurus 2 site without a landing page and instead have your blog's post list page as the index page. Set the `routeBasePath` to be `'/'` to indicate it's the root path.
 
-:::caution
-
-Don't forget to delete the existing homepage at `./src/pages/index.js`
-
-:::
-
 ```js {9} title="docusaurus.config.js"
 module.exports = {
   // ...
@@ -163,9 +157,9 @@ module.exports = {
 };
 ```
 
-:::note
+:::caution
 
-Make sure there's no `index.js` page in `src/pages` or else there will be two files mapping to the same route!
+Don't forget to delete the existing homepage at `./src/pages/index.js` or else there will be two files mapping to the same route!
 
 :::
 

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -325,15 +325,9 @@ module.exports = {
 
 ## Docs-only mode
 
-If you just want the documentation feature, you can enable "docs-only mode".
+If you only want the documentation feature, you can run your Docusaurus 2 site without a landing page and display your documentation page as the index page instead.
 
-To achieve this, set the `routeBasePath` property of the `docs` object in `@docusaurus/preset-classic` in `docusaurus.config.js` to the root of your site, and also in that object set the `homePageId` property with the value of the document ID that you show as root of the docs.
-
-:::caution
-
-Don't forget to delete the existing homepage at `./src/pages/index.js`
-
-:::
+To enable docs-only mode, set the `routeBasePath` property of the `docs` object to the root of your site. Also, set the `homePageId` property to the ID of the document that you wish to show by default.
 
 :::note
 
@@ -362,8 +356,14 @@ module.exports = {
 
 Now, when visiting your site, it will show your initial document instead of a landing page.
 
+:::caution
+
+You should delete the existing homepage at `./src/pages/index.js`, or else there will be two files mapping to the same route!
+
+:::
+
 :::tip
 
-There's also a "blog-only mode", for those who only want to use the blog component of Docusaurus 2. You can use the same method detailed above, except that you need to delete the `/src/pages/index.js` file. Follow the setup instructions on [Blog-only mode](blog.md#blog-only-mode).
+There's also a "blog-only mode" for those who only want to use the blog feature of Docusaurus 2. You can use the same method detailed above. Follow the setup instructions on [Blog-only mode](blog.md#blog-only-mode).
 
 :::

--- a/website/versioned_docs/version-2.0.0-alpha.58/docs.md
+++ b/website/versioned_docs/version-2.0.0-alpha.58/docs.md
@@ -325,9 +325,9 @@ module.exports = {
 
 ## Docs-only mode
 
-If you just want the documentation feature, you can enable "docs-only mode".
+If you only want the documentation feature, you can run your Docusaurus 2 site without a landing page and display your documentation page as the index page instead.
 
-To achieve this, set the `routeBasePath` property of the `docs` object in `@docusaurus/preset-classic` in `docusaurus.config.js` to the root of your site, and also in that object set the `homePageId` property with the value of the document ID that you show as root of the docs.
+To enable docs-only mode, set the `routeBasePath` property of the `docs` object to the root of your site. Also, set the `homePageId` property to the ID of the document that you wish to show by default.
 
 :::note
 
@@ -356,8 +356,14 @@ module.exports = {
 
 Now, when visiting your site, it will show your initial document instead of a landing page.
 
+:::caution
+
+You should delete the existing homepage at `./src/pages/index.js`, or else there will be two files mapping to the same route!
+
+:::
+
 :::tip
 
-There's also a "blog-only mode", for those who only want to use the blog component of Docusaurus 2. You can use the same method detailed above, except that you need to delete the `/src/pages/index.js` file. Follow the setup instructions on [Blog-only mode](blog.md#blog-only-mode).
+There's also a "blog-only mode" for those who only want to use the blog feature of Docusaurus 2. You can use the same method detailed above. Follow the setup instructions on [Blog-only mode](blog.md#blog-only-mode).
 
 :::


### PR DESCRIPTION
## Motivation

Instruct the user to remove `/src/pages/index.js` for docs-only mode to work correctly.
Also, the documentation for `blog-only-mode` has 2 admonitions with the same content, so I removed one of them.
This PR closes #3039.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Init a new docusaurus site with `npx @docusaurus/init@next init my-website classic`
2. Follow the instructions found here https://deploy-preview-3040--docusaurus-2.netlify.app/docs/docs-introduction/#docs-only-mode
3. docs-only mode works now
