### PR TITLE
feat(v2): Collect plugin versions to allow them to be inspected in debug plugin

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -37,6 +37,29 @@ declare module '@generated/routesChunkNames' {
   export default routesChunkNames;
 }
 
+declare module '@generated/site-metadata' {
+  /**
+   * - `type: 'package'`, plugin is in a different package.
+   * - `type: 'project'`, plugin is in the same docusaurus project.
+   * - `type: 'local'`, none of plugin's ancestor directory contains any package.json.
+   * - `type: 'synthetic'`, docusaurus generated internal plugin.
+   */
+  export type PluginVersionInformation =
+    | {readonly type: 'package'; readonly version?: string}
+    | {readonly type: 'project'}
+    | {readonly type: 'local'}
+    | {readonly type: 'synthetic'};
+
+  export type DocusaurusSiteMetadata = {
+    readonly docusaurusVersion: string;
+    readonly siteVersion?: string;
+    readonly pluginVersions: Record<string, PluginVersionInformation>;
+  };
+
+  const siteMetadata: DocusaurusSiteMetadata;
+  export default siteMetadata;
+}
+
 declare module '@theme/*';
 
 declare module '@theme-original/*';

--- a/packages/docusaurus-plugin-debug/src/theme/Debug/index.js
+++ b/packages/docusaurus-plugin-debug/src/theme/Debug/index.js
@@ -10,6 +10,7 @@ import Layout from '@theme/Layout';
 
 import registry from '@generated/registry';
 import routes from '@generated/routes';
+import siteMetadata from '@generated/site-metadata';
 
 import styles from './styles.module.css';
 
@@ -17,7 +18,28 @@ function Debug() {
   return (
     <Layout permalink="__docusaurus/debug" title="Debug">
       <main className={styles.Container}>
-        <section>
+        <section className={styles.Section}>
+          <h2>Site Metadata</h2>
+          <div>Docusaurus Version: {siteMetadata.docusaurusVersion}</div>
+          <div>
+            Site Version: {siteMetadata.siteVersion || 'No version specified'}
+          </div>
+          <h3>Plugins and themes:</h3>
+          <ul>
+            {Object.entries(siteMetadata.pluginVersions).map(
+              ([name, versionInformation]) => (
+                <li key={name}>
+                  <div>Name: {name}</div>
+                  <div>Type: {versionInformation.type}</div>
+                  {versionInformation.version && (
+                    <div>Version: {versionInformation.version}</div>
+                  )}
+                </li>
+              ),
+            )}
+          </ul>
+        </section>
+        <section className={styles.Section}>
           <h2>Registry</h2>
           <ul>
             {Object.values(registry).map(([, aliasedPath, resolved]) => (
@@ -28,7 +50,7 @@ function Debug() {
             ))}
           </ul>
         </section>
-        <section>
+        <section className={styles.Section}>
           <h2>Routes</h2>
           <ul>
             {routes.map(({path, exact}) => (

--- a/packages/docusaurus-plugin-debug/src/theme/Debug/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/Debug/styles.module.css
@@ -7,5 +7,11 @@
 
 .Container {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   margin: 1em;
+}
+
+.Section {
+  width: 500px;
 }

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -6,7 +6,8 @@
  */
 
 import {generate} from '@docusaurus/utils';
-import path from 'path';
+import {DocusaurusSiteMetadata} from '@generated/site-metadata';
+import path, {join} from 'path';
 import {
   BUILD_DIR_NAME,
   CONFIG_FILE_NAME,
@@ -26,6 +27,7 @@ import {
   Props,
 } from '@docusaurus/types';
 import {loadHtmlTags} from './html-tags';
+import {getPackageJsonVersion} from './versions';
 
 export function loadContext(
   siteDir: string,
@@ -96,6 +98,7 @@ export async function load(
   const {stylesheets = [], scripts = []} = siteConfig;
   plugins.push({
     name: 'docusaurus-bootstrap-plugin',
+    version: {type: 'synthetic'},
     configureWebpack: () => ({
       resolve: {
         alias,
@@ -178,12 +181,32 @@ ${Object.keys(registry)
 
   const genRoutes = generate(generatedFilesDir, 'routes.js', routesConfig);
 
+  // Version metadata.
+  const siteMetadata: DocusaurusSiteMetadata = {
+    docusaurusVersion: getPackageJsonVersion(
+      join(__dirname, '../../package.json'),
+    )!,
+    siteVersion: getPackageJsonVersion(join(siteDir, 'package.json')),
+    pluginVersions: {},
+  };
+  plugins
+    .filter(({version: {type}}) => type !== 'synthetic')
+    .forEach(({name, version}) => {
+      siteMetadata.pluginVersions[name] = version;
+    });
+  const genSiteMetadata = generate(
+    generatedFilesDir,
+    'site-metadata.json',
+    JSON.stringify(siteMetadata, null, 2),
+  );
+
   await Promise.all([
     genClientModules,
     genSiteConfig,
     genRegistry,
     genRoutesChunkNames,
     genRoutes,
+    genSiteMetadata,
   ]);
 
   const props: Props = {

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -10,12 +10,11 @@ import fs from 'fs-extra';
 import path from 'path';
 import {
   LoadContext,
-  Plugin,
   PluginConfig,
   PluginContentLoadedActions,
   RouteConfig,
 } from '@docusaurus/types';
-import initPlugins from './init';
+import initPlugins, {PluginWithVersionInformation} from './init';
 
 export function sortConfig(routeConfigs: RouteConfig[]): void {
   // Sort the route config. This ensures that route with nested
@@ -53,11 +52,14 @@ export async function loadPlugins({
   pluginConfigs: PluginConfig[];
   context: LoadContext;
 }): Promise<{
-  plugins: Plugin<unknown>[];
+  plugins: PluginWithVersionInformation[];
   pluginsRouteConfigs: RouteConfig[];
 }> {
   // 1. Plugin Lifecycle - Initialization/Constructor.
-  const plugins: Plugin<unknown>[] = initPlugins({pluginConfigs, context});
+  const plugins: PluginWithVersionInformation[] = initPlugins({
+    pluginConfigs,
+    context,
+  });
 
   // 2. Plugin Lifecycle - loadContent.
   // Currently plugins run lifecycle methods in parallel and are not order-dependent.

--- a/packages/docusaurus/src/server/types.d.ts
+++ b/packages/docusaurus/src/server/types.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// triple slash is important to keep,
+// see https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
+// eslint-disable-next-line
+/// <reference types="@docusaurus/module-type-aliases" />

--- a/packages/docusaurus/src/server/versions/__fixtures__/package.json
+++ b/packages/docusaurus/src/server/versions/__fixtures__/package.json
@@ -1,0 +1,3 @@
+{
+  "version": "random-version"
+}

--- a/packages/docusaurus/src/server/versions/__tests/index.test.ts
+++ b/packages/docusaurus/src/server/versions/__tests/index.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {getPluginVersion} from '..';
+import {join} from 'path';
+
+describe('getPluginVersion', () => {
+  it('Can detect external packages plugins versions of correctly.', () => {
+    expect(
+      getPluginVersion(
+        join(__dirname, '..', '__fixtures__', 'dummy-plugin.js'),
+        // Make the plugin appear external.
+        join(__dirname, '..', '..', '..', '..', '..', '..', 'website'),
+      ),
+    ).toEqual({type: 'package', version: 'random-version'});
+  });
+
+  it('Can detect project plugins versions correctly.', () => {
+    expect(
+      getPluginVersion(
+        join(__dirname, '..', '__fixtures__', 'dummy-plugin.js'),
+        // Make the plugin appear project local.
+        join(__dirname, '..', '__fixtures__'),
+      ),
+    ).toEqual({type: 'project'});
+  });
+
+  it('Can detect local packages versions correctly.', () => {
+    expect(getPluginVersion('/', '/')).toEqual({type: 'local'});
+  });
+});

--- a/packages/docusaurus/src/server/versions/index.ts
+++ b/packages/docusaurus/src/server/versions/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {PluginVersionInformation} from '@generated/site-metadata';
+import {existsSync, lstatSync} from 'fs-extra';
+import {dirname, join} from 'path';
+
+export function getPackageJsonVersion(
+  packageJsonPath: string,
+): string | undefined {
+  if (existsSync(packageJsonPath)) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+    const {version} = require(packageJsonPath);
+    return typeof version === 'string' ? version : undefined;
+  }
+  return undefined;
+}
+
+export function getPluginVersion(
+  pluginPath: string,
+  siteDir: string,
+): PluginVersionInformation {
+  let potentialPluginPackageJsonDirectory = dirname(pluginPath);
+  while (potentialPluginPackageJsonDirectory !== '/') {
+    const packageJsonPath = join(
+      potentialPluginPackageJsonDirectory,
+      'package.json',
+    );
+    if (existsSync(packageJsonPath) && lstatSync(packageJsonPath).isFile()) {
+      if (potentialPluginPackageJsonDirectory === siteDir) {
+        // If the plugin belongs to the same docusaurus project, we classify it as local plugin.
+        return {type: 'project'};
+      }
+      return {
+        type: 'package',
+        version: getPackageJsonVersion(packageJsonPath),
+      };
+    }
+    potentialPluginPackageJsonDirectory = dirname(
+      potentialPluginPackageJsonDirectory,
+    );
+  }
+  // In rare cases where a plugin is a path where no parent directory contains package.json, we can only classify it as local.
+  return {type: 'local'};
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Implements the proposal in #3042.

`@docusaurus/core` will collect and generate all the plugin version at start time, and put them into `.docusaurus/site-metadata.json`. To find the version of the plugin, I choose to walked up the directory of the resolved path until it hits a directory with package.json.

The version information has 4 possible categories:

- `package`: plugin is external to the current docusaurus project, with will be attached with a version string if it can be found in package.json
- `project`: plugin is inside the same docusaurus project
- `local`: some random place on the filesystem that doesn't have any package.json in its ancestor directories.
- `synthetic`: only used to workaround the synthetic `docusaurus-bootstrap-plugin`: https://github.com/facebook/docusaurus/blob/6e43c9bd34fc3afbde07da52f91220de0582d204/packages/docusaurus/src/server/index.ts#L97-L131

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Added unit test to test the version resolution behavior.
- works on debug page:

<img width="1792" alt="Screen Shot 2020-07-11 at 15 48 37" src="https://user-images.githubusercontent.com/4290500/87233598-ec963880-c396-11ea-9d66-69d0c96f16b4.png">

- generated `site-metadata.json` for v2 website:

```json
{
  "docusaurusVersion": "2.0.0-alpha.58",
  "siteVersion": "2.0.0-alpha.58",
  "pluginVersions": {
    "docusaurus-plugin-content-docs": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-plugin-content-blog": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-plugin-content-pages": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-plugin-debug": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-theme-classic": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-theme-search-algolia": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-plugin-client-redirects": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-plugin-ideal-image": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-plugin-pwa": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    },
    "docusaurus-theme-live-codeblock": {
      "type": "package",
      "version": "2.0.0-alpha.58"
    }
  }
}
```


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
