### PR TITLE
chore(v2): Adopt corejs 3 and only import at entry point

### DIFF
--- a/packages/docusaurus-plugin-pwa/src/index.js
+++ b/packages/docusaurus-plugin-pwa/src/index.js
@@ -25,8 +25,8 @@ function getSWBabelLoader() {
         [
           require.resolve('@babel/preset-env'),
           {
-            useBuiltIns: 'usage',
-            corejs: '2',
+            useBuiltIns: 'entry',
+            corejs: '3',
             // See https://twitter.com/jeffposnick/status/1280223070876315649
             targets: 'chrome >= 56',
           },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime": "^7.9.2",
+    "@babel/runtime-corejs3": "^7.10.4",
     "@docusaurus/types": "^2.0.0-alpha.58",
     "@docusaurus/utils": "^2.0.0-alpha.58",
     "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",

--- a/packages/docusaurus/src/babel/preset.ts
+++ b/packages/docusaurus/src/babel/preset.ts
@@ -27,9 +27,9 @@ function getTransformOptions(isServer: boolean): TransformOptions {
         : [
             require.resolve('@babel/preset-env'),
             {
-              useBuiltIns: 'usage',
+              useBuiltIns: 'entry',
               loose: true,
-              corejs: '2',
+              corejs: '3',
               // Do not transform modules to CJS
               modules: false,
               // Exclude transforms that make all code slower

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,6 +1163,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz#f29fc1990307c4c57b10dbd6ce667b27159d9e0d"
+  integrity sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.7.4":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.7.7.tgz#78fcbd472daec13abc42678bfc319e58a62235a3"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Core JS 2 is deprecated. It would be good if we don't stick with it forever.

I also changed to `useBuiltIns` to be `entry` for the purpose of Yarn pnp. If we use `usage`, babel will inject imports of core-js in literally every JS file. It will trick Yarn to believe that every single JS module depends on core-js, and therefore every package depends on core-js. Since core-js is not declared as a dependency for every package, it will trigger a lot of require errors. To patch that, you need to declare it on every package you use, like [this](https://github.com/SamChou19815/website/blob/88d052290e9f67557cc5971e2c469a6f3f68347a/.yarnrc.yml#L2-L35), which doesn't scale.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- [x] Preview is not broken.
- [x] All E2E tests are passing.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
