### PR TITLE
fix(v2): classify link hrefs with protocol identifier as internal

### DIFF
--- a/packages/docusaurus/src/client/exports/isInternalUrl.ts
+++ b/packages/docusaurus/src/client/exports/isInternalUrl.ts
@@ -6,5 +6,5 @@
  */
 
 export default function isInternalUrl(url: string): boolean {
-  return /^(https?:|\/\/|mailto:|tel:)/.test(url) === false;
+  return /^(\w*:|\/\/)/.test(url) === false;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, only specific protocol links (http://, https://, tel: and mailto:) in the navbar and footer are treated as external - other protocols such as ssh://, sftp:// etc are treated as internal and get prepended with `baseUrl` which breaks the links.

It would be nice to be able to have other protocols in links as well. My suggested solution is to let the `isInternalUrl` test check for any protocol identifier rather than specific ones. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Using the following navbar configuration in `docusaurus.config.js`

```javascript
    navbar: {
      hideOnScroll: true,
      title: 'Docusaurus',
      logo: {
        alt: 'Docusaurus Logo',
        src: 'img/docusaurus.svg',
        srcDark: 'img/docusaurus_keytar.svg',
      },
      links: [
        {
          href: 'https://example.com',
          label: 'https://example.com',
          position: 'left',
        },
        {
          href: 'tel:18005551042',
          label: 'tel:18005551042',
          position: 'left',
        },
        {
          href: 'mailto:user@example.com',
          label: 'mailto:user@example.com',
          position: 'left',
        },
        {
          href: 'ssh://host.example.com',
          label: 'ssh://host.example.com',
          position: 'left',
        },
        {
          to: 'versions',
          label: `v${versions[0]}`,
          position: 'right',
        },
        {
          href: 'https://github.com/facebook/docusaurus',
          position: 'right',
          className: 'header-github-link',
          'aria-label': 'GitHub repository',
        },
      ],
    }
```

### Current behavior

The concerned navbar items are output as:

```html
<li class="menu__list-item"><a href="https://example.com/" target="_blank" rel="noopener noreferrer" class="menu__link">https://example.com</a></li>
<li class="menu__list-item"><a href="tel:18005551042" target="_blank" rel="noopener noreferrer" class="menu__link">tel:18005551042</a></li>
<li class="menu__list-item"><a href="mailto:user@example.com" target="_blank" rel="noopener noreferrer" class="menu__link">mailto:user@example.com</a></li>
<li class="menu__list-item"><a target="_blank" rel="noopener noreferrer" href="http://localhost:3000/ssh://host.example.com" class="menu__link">ssh://host.example.com</a></li>
```
with `http://localhost:3000/` prepended to the `href` property on the last link.

![before](https://user-images.githubusercontent.com/49313060/87548915-769f1380-c6ad-11ea-81f4-fbb108e50a09.png)


### Behavior after the change

Navbar items are output as:

```html
<li class="menu__list-item"><a href="https://example.com/" target="_blank" rel="noopener noreferrer" class="menu__link">https://example.com</a></li>
<li class="menu__list-item"><a href="tel:18005551042" target="_blank" rel="noopener noreferrer" class="menu__link">tel:18005551042</a></li>
<li class="menu__list-item"><a href="mailto:user@example.com" target="_blank" rel="noopener noreferrer" class="menu__link">mailto:user@example.com</a></li>
<li class="menu__list-item"><a href="ssh://host.example.com/" target="_blank" rel="noopener noreferrer" class="menu__link">ssh://host.example.com</a></li>
```
and all links are working as expected.

![after](https://user-images.githubusercontent.com/49313060/87548952-7f8fe500-c6ad-11ea-8c1b-9240786c627e.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
