### PR TITLE
feat(v2): add docusaurus script for npm users

### DIFF
--- a/packages/docusaurus-init/templates/bootstrap/package.json
+++ b/packages/docusaurus-init/templates/bootstrap/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-alpha.58",
   "private": true,
   "scripts": {
+    "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/packages/docusaurus-init/templates/classic/package.json
+++ b/packages/docusaurus-init/templates/classic/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-alpha.58",
   "private": true,
   "scripts": {
+    "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/packages/docusaurus-init/templates/facebook/package.json
+++ b/packages/docusaurus-init/templates/facebook/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-alpha.58",
   "private": true,
   "scripts": {
+    "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-alpha.58",
   "private": true,
   "scripts": {
+    "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## Motivation

NPM users should be able to run commands such as `npm run docusaurus docs:version 1.1.0`, but it fails by default while it works in yarn

https://github.com/facebook/docusaurus/issues/3100#issuecomment-663099776