### PR TITLE
fix(v2): dropdown navbar item: validation too strict

### DIFF
--- a/packages/docusaurus-theme-classic/src/themeConfigSchema.js
+++ b/packages/docusaurus-theme-classic/src/themeConfigSchema.js
@@ -9,6 +9,9 @@ const Joi = require('@hapi/joi');
 
 const NavbarItemPosition = Joi.string().equal('left', 'right').default('left');
 
+// TODO we should probably create a custom navbar item type "dropdown"
+// having this recursive structure is bad because we only support 2 levels
+// + parent/child don't have exactly the same props
 const DefaultNavbarItemSchema = Joi.object({
   items: Joi.array().optional().items(Joi.link('...')),
   to: Joi.string(),
@@ -19,7 +22,10 @@ const DefaultNavbarItemSchema = Joi.object({
   activeBaseRegex: Joi.string(),
   className: Joi.string(),
   'aria-label': Joi.string(),
-}).xor('href', 'to');
+});
+// TODO the dropdown parent item can have no href/to
+// should check should not apply to dropdown parent item
+// .xor('href', 'to');
 
 const DocsVersionNavbarItemSchema = Joi.object({
   type: Joi.string().equal('docsVersion').required(),


### PR DESCRIPTION

## Motivation

The new validation is too strict and wouldn't allow a valid configuration where the parent dropdown item has no href/to attribute.

The config of this user, which is legit and works in former versions, wouldn't be accepted anymore:
https://github.com/facebook/docusaurus/issues/3067#issuecomment-661949863

![image](https://user-images.githubusercontent.com/749374/88315848-2e1fcf80-cd17-11ea-8aa7-e92a3e703c48.png)
