### PR TITLE
fix(v2): broken links detector: ignore existing folders

### DIFF
--- a/packages/docusaurus/src/server/brokenLinks.ts
+++ b/packages/docusaurus/src/server/brokenLinks.ts
@@ -130,14 +130,17 @@ async function filterExistingFileLinks({
   allCollectedLinks: Record<string, string[]>;
 }): Promise<Record<string, string[]>> {
   // not easy to make this async :'(
-  function linkFileDoesNotExist(link: string): boolean {
+  function linkFileExists(link: string): boolean {
     const filePath = `${outDir}/${removePrefix(link, baseUrl)}`;
-    const exists = fs.existsSync(filePath);
-    return !exists;
+    try {
+      return fs.statSync(filePath).isFile(); // only consider files
+    } catch (e) {
+      return false;
+    }
   }
 
   return mapValues(allCollectedLinks, (links) => {
-    return links.filter(linkFileDoesNotExist);
+    return links.filter((link) => !linkFileExists(link));
   });
 }
 


### PR DESCRIPTION

## Motivation

In the broken links detection code, we try to see if a link match an existing fs file in the build folder. We should not consider folders in this algo, only files, as this part of the code is to avoid reporting errors when user link to a static file (broken SPA paths is handled in a different way without reading the FS)