### PR TITLE
fix(v2): baseUrl is wrongly appended to anchor links

### DIFF
--- a/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.ts
@@ -40,6 +40,7 @@ describe('useBaseUrl', () => {
     expect(useBaseUrl('/hello/byebye', {absolute: true})).toEqual(
       'https://v2.docusaurus.io/hello/byebye',
     );
+    expect(useBaseUrl('#hello')).toEqual('#hello');
   });
 
   test('non-empty base URL', () => {
@@ -69,6 +70,7 @@ describe('useBaseUrl', () => {
     );
     expect(useBaseUrl('/docusaurus/')).toEqual('/docusaurus/');
     expect(useBaseUrl('/docusaurus/hello')).toEqual('/docusaurus/hello');
+    expect(useBaseUrl('#hello')).toEqual('#hello');
   });
 });
 
@@ -99,6 +101,7 @@ describe('useBaseUrlUtils().withBaseUrl()', () => {
     expect(withBaseUrl('/hello/byebye', {absolute: true})).toEqual(
       'https://v2.docusaurus.io/hello/byebye',
     );
+    expect(withBaseUrl('#hello')).toEqual('#hello');
   });
 
   test('non-empty base URL', () => {
@@ -129,5 +132,6 @@ describe('useBaseUrlUtils().withBaseUrl()', () => {
     );
     expect(withBaseUrl('/docusaurus/')).toEqual('/docusaurus/');
     expect(withBaseUrl('/docusaurus/hello')).toEqual('/docusaurus/hello');
+    expect(withBaseUrl('#hello')).toEqual('#hello');
   });
 });

--- a/packages/docusaurus/src/client/exports/useBaseUrl.ts
+++ b/packages/docusaurus/src/client/exports/useBaseUrl.ts
@@ -23,6 +23,11 @@ function addBaseUrl(
     return url;
   }
 
+  // it never makes sense to add a base url to a local anchor url
+  if (url.startsWith('#')) {
+    return url;
+  }
+
   // it never makes sense to add a base url to an url with a protocol
   if (hasProtocol(url)) {
     return url;
@@ -32,11 +37,8 @@ function addBaseUrl(
     return baseUrl + url;
   }
 
-  const shouldAddBaseUrl =
-    // We should avoid adding the baseurl twice if it's already there
-    !url.startsWith(baseUrl) &&
-    // It does not make sense to add baseUrl to a anchor link
-    !url.startsWith('#');
+  // We should avoid adding the baseurl twice if it's already there
+  const shouldAddBaseUrl = !url.startsWith(baseUrl);
 
   const basePath = shouldAddBaseUrl ? baseUrl + url.replace(/^\//, '') : url;
 

--- a/packages/docusaurus/src/client/exports/useBaseUrl.ts
+++ b/packages/docusaurus/src/client/exports/useBaseUrl.ts
@@ -32,9 +32,11 @@ function addBaseUrl(
     return baseUrl + url;
   }
 
-  // sometimes we try to add baseurl to an url that already has a baseurl
-  // we should avoid adding the baseurl twice
-  const shouldAddBaseUrl = !url.startsWith(baseUrl);
+  const shouldAddBaseUrl =
+    // We should avoid adding the baseurl twice if it's already there
+    !url.startsWith(baseUrl) &&
+    // It does not make sense to add baseUrl to a anchor link
+    !url.startsWith('#');
 
   const basePath = shouldAddBaseUrl ? baseUrl + url.replace(/^\//, '') : url;
 


### PR DESCRIPTION

## Motivation

It never makes sense to add a base url to a local anchor url like `#site-configuration`

fixes https://github.com/facebook/docusaurus/issues/3110
