### PR TITLE
chore(v2): ability to test the migration cli easily

### DIFF
--- a/.github/workflows/migration-cli-e2e-test.yml
+++ b/.github/workflows/migration-cli-e2e-test.yml
@@ -25,11 +25,8 @@ jobs:
       - name: Installation
         run: yarn
       - name: Migrate D1 website
-        run: yarn docusaurus-migrate migrate ./website-1.x ./test-migrated
-      - name: link
-        run: yarn lerna exec -- yarn link
-      - name: Build Test website
-        run: yarn build
-        working-directory: test-migrated
+        run: yarn test:v1Migration:migrate
+      - name: Build D1 migrated website
+        run: yarn test:v1Migration:build
         env:
           CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ packages/docusaurus-theme-classic/lib/
 packages/docusaurus-migrate/lib/
 
 website/netlifyDeploy
-_redirects
+
+website-1.x-migrated

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "tsc": "yarn build:packages && echo '\n\nDOCUSAURUS: yarn tsc is deprecated and will be removed, use yarn build:packages instead\n\n'",
     "watch": "yarn lerna run --parallel --no-private watch",
     "clear": "yarn rimraf website/.docusaurus && rimraf -rf website/node_modules/.cache && yarn lerna exec 'yarn rimraf lib' --ignore docusaurus",
-    "testV1Migration": "rimraf website-1.x-migrated && docusaurus-migrate migrate ./website-1.x ./website-1.x-migrated && sed -i -- 's/docusaurus-1-website/docusaurus-1-website-migrated/g;' website-1.x-migrated/package.json",
-    "testV1Migration:start": "yarn workspace docusaurus-1-website-migrated start",
-    "testBaseUrl": "yarn build:v2:baseUrl && yarn serve:v2:baseUrl"
+    "test:v1Migration:migrate": "rimraf website-1.x-migrated && docusaurus-migrate migrate ./website-1.x ./website-1.x-migrated && sed -i -- 's/docusaurus-1-website/docusaurus-1-website-migrated/g;' website-1.x-migrated/package.json",
+    "test:v1Migration:start": "yarn workspace docusaurus-1-website-migrated start",
+    "test:v1Migration:build": "yarn workspace docusaurus-1-website-migrated build",
+    "test:baseUrl": "yarn build:v2:baseUrl && yarn serve:v2:baseUrl"
   },
   "devDependencies": {
     "@babel/cli": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
     "packages/*",
     "website",
     "website-1.x",
+    "website-1.x-migrated",
     "packages/docusaurus-init/templates/*"
   ],
   "scripts": {
-    "testBaseUrl": "yarn build:v2:baseUrl && yarn serve:v2:baseUrl",
     "start": "yarn build:packages && yarn start:v2",
     "start:v1": "yarn workspace docusaurus-1-website start",
     "start:v2": "yarn workspace docusaurus-2-website start",
@@ -38,7 +38,10 @@
     "test:build:v2": "./admin/scripts/test-release.sh",
     "tsc": "yarn build:packages && echo '\n\nDOCUSAURUS: yarn tsc is deprecated and will be removed, use yarn build:packages instead\n\n'",
     "watch": "yarn lerna run --parallel --no-private watch",
-    "clear": "yarn rimraf website/.docusaurus && rimraf -rf website/node_modules/.cache && yarn lerna exec 'yarn rimraf lib' --ignore docusaurus"
+    "clear": "yarn rimraf website/.docusaurus && rimraf -rf website/node_modules/.cache && yarn lerna exec 'yarn rimraf lib' --ignore docusaurus",
+    "testV1Migration": "rimraf website-1.x-migrated && docusaurus-migrate migrate ./website-1.x ./website-1.x-migrated && sed -i -- 's/docusaurus-1-website/docusaurus-1-website-migrated/g;' website-1.x-migrated/package.json",
+    "testV1Migration:start": "yarn workspace docusaurus-1-website-migrated start",
+    "testBaseUrl": "yarn build:v2:baseUrl && yarn serve:v2:baseUrl"
   },
   "devDependencies": {
     "@babel/cli": "^7.9.0",

--- a/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
@@ -13,11 +13,14 @@ describe('frontMatter', () => {
     expect(
       shouldQuotifyFrontMatter([
         'title',
-        'Some title front matter with allowed special chars like - .',
+        "Some title front matter with allowed special chars like sàáâãäåçèéêëìíîïðòóôõöùúûüýÿ!;,=+-_?'`&#()[]§%€$",
       ]),
     ).toEqual(false);
 
     expect(shouldQuotifyFrontMatter(['title', 'Special char :'])).toEqual(true);
+
+    expect(shouldQuotifyFrontMatter(['title', 'value!'])).toEqual(false);
+    expect(shouldQuotifyFrontMatter(['title', '!value'])).toEqual(true);
 
     expect(shouldQuotifyFrontMatter(['tags', '[tag1, tag2]'])).toEqual(false);
   });

--- a/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {shouldQuotifyFrontMatter} from '../frontMatter';
+
+describe('frontMatter', () => {
+  test('shouldQuotifyFrontMatter', () => {
+    expect(shouldQuotifyFrontMatter(['id', 'value'])).toEqual(false);
+    expect(
+      shouldQuotifyFrontMatter([
+        'title',
+        'Some title front matter with allowed special chars like - .',
+      ]),
+    ).toEqual(false);
+
+    expect(shouldQuotifyFrontMatter(['title', 'Special char :'])).toEqual(true);
+
+    expect(shouldQuotifyFrontMatter(['tags', '[tag1, tag2]'])).toEqual(false);
+  });
+});

--- a/packages/docusaurus-migrate/src/frontMatter.ts
+++ b/packages/docusaurus-migrate/src/frontMatter.ts
@@ -62,5 +62,15 @@ export function shouldQuotifyFrontMatter([key, value]: [
   if (String(value).match(/^("|').+("|')$/)) {
     return false;
   }
-  return !String(value).match(/^(\w| |\.|-)+$/m);
+  // TODO weird graymatter case
+  // title: !something need quotes
+  // but not title: something!
+  if (!String(value).trim().match(/^\w.*/)) {
+    return true;
+  }
+  // TODO this is not ideal to have to maintain such a list of allowed chars
+  // maybe we should quotify if graymatter throws instead?
+  return !String(value).match(
+    /^([\w .\-sàáâãäåçèéêëìíîïðòóôõöùúûüýÿ!;,=+_?'`&#()[\]§%€$])+$/,
+  );
 }

--- a/packages/docusaurus-migrate/src/frontMatter.ts
+++ b/packages/docusaurus-migrate/src/frontMatter.ts
@@ -50,3 +50,17 @@ export default function extractMetadata(content: string): Data {
   }
   return {metadata, rawContent: both.content};
 }
+
+// The new frontmatter parser need some special chars to
+export function shouldQuotifyFrontMatter([key, value]: [
+  string,
+  string,
+]): boolean {
+  if (key === 'tags') {
+    return false;
+  }
+  if (String(value).match(/^("|').+("|')$/)) {
+    return false;
+  }
+  return !String(value).match(/^(\w| |\.|-)+$/m);
+}

--- a/packages/docusaurus-migrate/src/index.ts
+++ b/packages/docusaurus-migrate/src/index.ts
@@ -48,7 +48,7 @@ function sanitizedFileContent(
   const extractedMetaData = Object.entries(extractedData.metadata).reduce(
     (metaData, [key, value]) => {
       return `${metaData}\n${key}: ${
-        shouldQuotifyFrontMatter([key, value]) ? value : `"${value}"`
+        shouldQuotifyFrontMatter([key, value]) ? `"${value}"` : value
       }`;
     },
     '',

--- a/packages/docusaurus-migrate/src/index.ts
+++ b/packages/docusaurus-migrate/src/index.ts
@@ -17,7 +17,7 @@ import {
   ClassicPresetEntries,
   SidebarEntries,
 } from './types';
-import extractMetadata from './frontMatter';
+import extractMetadata, {shouldQuotifyFrontMatter} from './frontMatter';
 import migratePage from './transform';
 import sanitizeMD from './sanitizeMD';
 import path from 'path';
@@ -46,13 +46,9 @@ function sanitizedFileContent(
 ): string {
   const extractedData = extractMetadata(content);
   const extractedMetaData = Object.entries(extractedData.metadata).reduce(
-    (metaData, value) => {
-      return `${metaData}\n${value[0]}: ${
-        value[0] === 'tags' ||
-        !!String(value[1]).match(/^(\w| |\.|-)+$/m) ||
-        String(value[1]).match(/^("|').+("|')$/)
-          ? value[1]
-          : `"${value[1]}"`
+    (metaData, [key, value]) => {
+      return `${metaData}\n${key}: ${
+        shouldQuotifyFrontMatter([key, value]) ? value : `"${value}"`
       }`;
     },
     '',
@@ -377,7 +373,7 @@ function createPages(newDir: string, siteDir: string): void {
 function createDefaultLandingPage(newDir: string) {
   const indexPage = `import Layout from "@theme/Layout";
       import React from "react";
-      
+
       export default () => {
         return <Layout />;
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17578,7 +17578,7 @@ react-dev-utils@^9.1.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dom@^16.8.4:
+react-dom@^16.10.2, react-dom@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -17739,7 +17739,7 @@ react-waypoint@^9.0.2:
     prop-types "^15.0.0"
     react-is "^16.6.3"
 
-react@^16.8.4:
+react@^16.10.2, react@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION

## Motivation

We should have a dev workflow to easily test the migration cli against current code (ie with symlinks instead of using the latest npm release, which might not be compatible)