### PR TITLE
fix(v2): apply default `appId` to Algolia search

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -139,7 +139,7 @@ See: https://v2.docusaurus.io/docs/search/#using-algolia-docsearch`);
     return null;
   }
 
-  return <DocSearch {...siteConfig.themeConfig.algolia} />;
+  return <DocSearch appId="BH4D9OD16A" {...siteConfig.themeConfig.algolia} />;
 }
 
 export default SearchBar;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This default `appId` hints the browser that the website will load data from this Algolia application, resulting in a faster search.

There was an issue when this `appId` fell back to the default one because [the preconnect `link` targeted an undefined endpoint](https://github.com/facebook/docusaurus/blob/0eb9c207cf57a29dbd1f319a69eac6e71d77bd70/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js#L74).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

See generated `<link rel="preconnect">` in source code.

## Related PRs

- #2815
