### PR TITLE
fix(v2): make config validation less strict

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
@@ -45,16 +45,19 @@ export const PluginOptionSchema = Joi.object({
   showReadingTime: Joi.bool().default(DEFAULT_OPTIONS.showReadingTime),
   remarkPlugins: Joi.array()
     .items(
-      Joi.alternatives().try(
-        Joi.function(),
-        Joi.array()
-          .items(Joi.function().required(), Joi.object().required())
-          .length(2),
-      ),
+      Joi.array()
+        .items(Joi.function().required(), Joi.object().required())
+        .length(2),
+      Joi.function(),
     )
     .default(DEFAULT_OPTIONS.remarkPlugins),
   rehypePlugins: Joi.array()
-    .items(Joi.string())
+    .items(
+      Joi.array()
+        .items(Joi.function().required(), Joi.object().required())
+        .length(2),
+      Joi.function(),
+    )
     .default(DEFAULT_OPTIONS.rehypePlugins),
   editUrl: Joi.string().uri(),
   truncateMarker: Joi.object().default(DEFAULT_OPTIONS.truncateMarker),

--- a/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
@@ -28,7 +28,7 @@ export const DEFAULT_OPTIONS = {
 
 export const PluginOptionSchema = Joi.object({
   path: Joi.string().default(DEFAULT_OPTIONS.path),
-  routeBasePath: Joi.string().default(DEFAULT_OPTIONS.routeBasePath),
+  routeBasePath: Joi.string().allow('').default(DEFAULT_OPTIONS.routeBasePath),
   include: Joi.array().items(Joi.string()).default(DEFAULT_OPTIONS.include),
   postsPerPage: Joi.number()
     .integer()

--- a/packages/docusaurus-plugin-content-docs/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-docs/src/pluginOptionSchema.ts
@@ -37,12 +37,19 @@ export const PluginOptionSchema = Joi.object({
   docItemComponent: Joi.string().default(DEFAULT_OPTIONS.docItemComponent),
   remarkPlugins: Joi.array()
     .items(
-      Joi.array().items(Joi.function(), Joi.object()).length(2),
+      Joi.array()
+        .items(Joi.function().required(), Joi.object().required())
+        .length(2),
       Joi.function(),
     )
     .default(DEFAULT_OPTIONS.remarkPlugins),
   rehypePlugins: Joi.array()
-    .items(Joi.string())
+    .items(
+      Joi.array()
+        .items(Joi.function().required(), Joi.object().required())
+        .length(2),
+      Joi.function(),
+    )
     .default(DEFAULT_OPTIONS.rehypePlugins),
   showLastUpdateTime: Joi.bool().default(DEFAULT_OPTIONS.showLastUpdateTime),
   showLastUpdateAuthor: Joi.bool().default(

--- a/packages/docusaurus-plugin-content-docs/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-docs/src/pluginOptionSchema.ts
@@ -29,7 +29,7 @@ export const DEFAULT_OPTIONS: PluginOptions = {
 export const PluginOptionSchema = Joi.object({
   path: Joi.string().default(DEFAULT_OPTIONS.path),
   editUrl: Joi.string().uri(),
-  routeBasePath: Joi.string().default(DEFAULT_OPTIONS.routeBasePath),
+  routeBasePath: Joi.string().allow('').default(DEFAULT_OPTIONS.routeBasePath),
   homePageId: Joi.string().default(DEFAULT_OPTIONS.homePageId),
   include: Joi.array().items(Joi.string()).default(DEFAULT_OPTIONS.include),
   sidebarPath: Joi.string().default(DEFAULT_OPTIONS.sidebarPath),

--- a/packages/docusaurus-theme-classic/src/themeConfigSchema.js
+++ b/packages/docusaurus-theme-classic/src/themeConfigSchema.js
@@ -135,7 +135,7 @@ const ThemeConfigSchema = Joi.object({
         'themeConfig.navbar.links has been renamed as themeConfig.navbar.items',
     }),
     items: Joi.array().items(NavbarItemSchema),
-    title: Joi.string().required(),
+    title: Joi.string().allow('', null),
     logo: Joi.object({
       alt: Joi.string(),
       src: Joi.string().required(),

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -71,7 +71,7 @@ const ConfigSchema = Joi.object({
   stylesheets: Joi.array().items(
     Joi.string(),
     Joi.object({
-      href: Joi.string().uri().required(),
+      href: Joi.string().required(),
       type: Joi.string().required(),
     }).unknown(),
   ),

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -6,8 +6,8 @@
  */
 
 import {DocusaurusConfig} from '@docusaurus/types';
-import Joi from '@hapi/joi';
 import {CONFIG_FILE_NAME} from '../constants';
+import Joi from '@hapi/joi';
 
 export const DEFAULT_CONFIG: Pick<
   DocusaurusConfig,

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -66,14 +66,14 @@ const ConfigSchema = Joi.object({
       src: Joi.string().required(),
       async: Joi.bool(),
       defer: Joi.bool(),
-    }).oxor('async', 'defer'),
+    }),
   ),
   stylesheets: Joi.array().items(
     Joi.string(),
     Joi.object({
       href: Joi.string().uri().required(),
       type: Joi.string().required(),
-    }),
+    }).unknown(),
   ),
   tagline: Joi.string(),
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -17578,7 +17578,7 @@ react-dev-utils@^9.1.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dom@^16.10.2, react-dom@^16.8.4:
+react-dom@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -17739,7 +17739,7 @@ react-waypoint@^9.0.2:
     prop-types "^15.0.0"
     react-is "^16.6.3"
 
-react@^16.10.2, react@^16.8.4:
+react@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
## Motivation

This PR modifies the config validation for the following fields:
1. navbar.title
2. rehypePlugins
3. routeBasePath
4. scripts 
5. stylesheets

### navbar.title
It allows the following values for navbar.title: `''`, `null`, `undefined`. This fixes #3117. 

### rehypePlugins
The schema for rehypePlugins has been modified. It now accepts an array, whose items are either:
- a function (because the rehypePlugins are of function type).
- an array of [function, object] in Babel style (See https://v2.docusaurus.io/docs/markdown-features/#configuring-plugin-options for an example)

This fixes #3125.

### routeBasePath
It accepts the empty string `''` now. This is useful for removing `/docs` from url while having a landing page. This fixes #3126. 

### scripts and stylesheets
scripts accepts both defer and async now. 
stylesheets accepts unknown fields now.
This fixes #3128 

## Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

### navbar.title
1. In `/website/docusaurus.config.js`, change navbar.title to `''` or `null`, or remove the field.
2. There should be no validation errors in all cases.

### rehypePlugins
1. Follow the steps to reproduce #3125
2. There should be no validation errors thrown now
(I didn't add an automated test for rehype plugin because the dependency will only be used for testing)


### routeBasePath
1. Follow the steps to reproduce #3126. For step 3, set `routeBasePath: ''`
2. There should be no validation error raised

### scripts and stylesheets
1. Refer to the steps to reproduce #3128. Add the config for scripts and stylesheets to D2 website.
2. There should be no validation errors raised.