### PR TITLE
feat(v2): add accessible label for Algolia search button

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -81,6 +81,7 @@ function DocSearch(props) {
         onFocus={importDocSearchModalIfNeeded}
         onMouseOver={importDocSearchModalIfNeeded}
         onClick={onOpen}
+        aria-label="Search"
       />
 
       {isOpen &&


### PR DESCRIPTION
## Motivation

The Algolia search button doesn't contain text which fails lighthouse a11y tests + isn't nice for screen readers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This has just been tested manually by checking the markup and running lighthouse.

After
<img width="746" alt="Screenshot 2020-07-28 at 10 03 30" src="https://user-images.githubusercontent.com/9551929/88643599-cc19ee00-d0b9-11ea-85e4-48ba3a7fd521.png">

Before
<img width="745" alt="Screenshot 2020-07-28 at 10 03 42" src="https://user-images.githubusercontent.com/9551929/88643605-cde3b180-d0b9-11ea-950a-e30c83b5b344.png">

Markup
<img width="566" alt="Screenshot 2020-07-28 at 10 04 01" src="https://user-images.githubusercontent.com/9551929/88643610-cf14de80-d0b9-11ea-8994-3932661dc71b.png">


## Related PRs
N/A

