### PR TITLE
fix(v2): navbar item links should allow unknown attributes

### DIFF
--- a/packages/docusaurus-theme-classic/src/themeConfigSchema.js
+++ b/packages/docusaurus-theme-classic/src/themeConfigSchema.js
@@ -22,7 +22,10 @@ const DefaultNavbarItemSchema = Joi.object({
   activeBaseRegex: Joi.string(),
   className: Joi.string(),
   'aria-label': Joi.string(),
-});
+})
+  // We allow any unknown attributes on the links
+  // (users may need additional attributes like target, aria-role, data-customAttribute...)
+  .unknown();
 // TODO the dropdown parent item can have no href/to
 // should check should not apply to dropdown parent item
 // .xor('href', 'to');


### PR DESCRIPTION

## Motivation

Fix ability to provide link target for example https://github.com/facebook/docusaurus/issues/3139