### PR TITLE
fix(v2): BrowserOnly should not return undefined

### DIFF
--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -14,9 +14,9 @@ function BrowserOnly({
 }: {
   children?: () => JSX.Element;
   fallback?: JSX.Element;
-}): JSX.Element | undefined {
+}): JSX.Element | null {
   if (!ExecutionEnvironment.canUseDOM || children == null) {
-    return fallback || undefined;
+    return fallback || null;
   }
 
   return <>{children()}</>;


### PR DESCRIPTION

## Motivation

This is not something to do in React

https://github.com/facebook/docusaurus/issues/3144