### PR TITLE
fix(v2): inability for users to pin their docusaurus version

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/package.json
+++ b/packages/docusaurus-plugin-client-redirects/package.json
@@ -12,8 +12,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.60",
-    "@docusaurus/utils": "^2.0.0-alpha.60",
+    "@docusaurus/types": "2.0.0-alpha.60",
+    "@docusaurus/utils": "2.0.0-alpha.60",
     "@hapi/joi": "^17.1.1",
     "@types/hapi__joi": "^17.1.2",
     "chalk": "^3.0.0",

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -15,10 +15,10 @@
     "@types/hapi__joi": "^17.1.2"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-alpha.60",
-    "@docusaurus/mdx-loader": "^2.0.0-alpha.60",
-    "@docusaurus/types": "^2.0.0-alpha.60",
-    "@docusaurus/utils": "^2.0.0-alpha.60",
+    "@docusaurus/core": "2.0.0-alpha.60",
+    "@docusaurus/mdx-loader": "2.0.0-alpha.60",
+    "@docusaurus/types": "2.0.0-alpha.60",
+    "@docusaurus/utils": "2.0.0-alpha.60",
     "@hapi/joi": "^17.1.1",
     "feed": "^4.1.0",
     "fs-extra": "^8.1.0",

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -12,16 +12,16 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-alpha.60",
+    "@docusaurus/module-type-aliases": "2.0.0-alpha.60",
     "@types/hapi__joi": "^17.1.2",
     "commander": "^5.0.0",
     "picomatch": "^2.1.1"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-alpha.60",
-    "@docusaurus/mdx-loader": "^2.0.0-alpha.60",
-    "@docusaurus/types": "^2.0.0-alpha.60",
-    "@docusaurus/utils": "^2.0.0-alpha.60",
+    "@docusaurus/core": "2.0.0-alpha.60",
+    "@docusaurus/mdx-loader": "2.0.0-alpha.60",
+    "@docusaurus/types": "2.0.0-alpha.60",
+    "@docusaurus/utils": "2.0.0-alpha.60",
     "@hapi/joi": "17.1.1",
     "execa": "^3.4.0",
     "fs-extra": "^8.1.0",

--- a/packages/docusaurus-plugin-content-pages/package.json
+++ b/packages/docusaurus-plugin-content-pages/package.json
@@ -15,8 +15,8 @@
     "@types/hapi__joi": "^17.1.2"
   },
   "dependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.60",
-    "@docusaurus/utils": "^2.0.0-alpha.60",
+    "@docusaurus/types": "2.0.0-alpha.60",
+    "@docusaurus/utils": "2.0.0-alpha.60",
     "@hapi/joi": "17.1.1",
     "globby": "^10.0.1"
   },

--- a/packages/docusaurus-plugin-debug/package.json
+++ b/packages/docusaurus-plugin-debug/package.json
@@ -12,8 +12,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.60",
-    "@docusaurus/utils": "^2.0.0-alpha.60"
+    "@docusaurus/types": "2.0.0-alpha.60",
+    "@docusaurus/utils": "2.0.0-alpha.60"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",

--- a/packages/docusaurus-plugin-ideal-image/package.json
+++ b/packages/docusaurus-plugin-ideal-image/package.json
@@ -12,11 +12,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.60",
+    "@docusaurus/types": "2.0.0-alpha.60",
     "fs-extra": "^9.0.0"
   },
   "dependencies": {
-    "@docusaurus/lqip-loader": "^2.0.0-alpha.60",
+    "@docusaurus/lqip-loader": "2.0.0-alpha.60",
     "@endiliey/react-ideal-image": "^0.0.11",
     "@endiliey/responsive-loader": "^1.3.2",
     "react-waypoint": "^9.0.2",

--- a/packages/docusaurus-plugin-sitemap/package.json
+++ b/packages/docusaurus-plugin-sitemap/package.json
@@ -15,7 +15,7 @@
     "@types/hapi__joi": "^17.1.2"
   },
   "dependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.60",
+    "@docusaurus/types": "2.0.0-alpha.60",
     "@hapi/joi": "17.1.1",
     "fs-extra": "^8.1.0",
     "sitemap": "^3.2.2"

--- a/packages/docusaurus-preset-bootstrap/package.json
+++ b/packages/docusaurus-preset-bootstrap/package.json
@@ -8,10 +8,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@docusaurus/plugin-content-blog": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-content-docs": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-content-pages": "^2.0.0-alpha.60",
-    "@docusaurus/theme-bootstrap": "^2.0.0-alpha.60"
+    "@docusaurus/plugin-content-blog": "2.0.0-alpha.60",
+    "@docusaurus/plugin-content-docs": "2.0.0-alpha.60",
+    "@docusaurus/plugin-content-pages": "2.0.0-alpha.60",
+    "@docusaurus/theme-bootstrap": "2.0.0-alpha.60"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",

--- a/packages/docusaurus-preset-classic/package.json
+++ b/packages/docusaurus-preset-classic/package.json
@@ -8,15 +8,15 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@docusaurus/plugin-content-blog": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-content-docs": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-content-pages": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-debug": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-google-analytics": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-google-gtag": "^2.0.0-alpha.60",
-    "@docusaurus/plugin-sitemap": "^2.0.0-alpha.60",
-    "@docusaurus/theme-classic": "^2.0.0-alpha.60",
-    "@docusaurus/theme-search-algolia": "^2.0.0-alpha.60"
+    "@docusaurus/plugin-content-blog": "2.0.0-alpha.60",
+    "@docusaurus/plugin-content-docs": "2.0.0-alpha.60",
+    "@docusaurus/plugin-content-pages": "2.0.0-alpha.60",
+    "@docusaurus/plugin-debug": "2.0.0-alpha.60",
+    "@docusaurus/plugin-google-analytics": "2.0.0-alpha.60",
+    "@docusaurus/plugin-google-gtag": "2.0.0-alpha.60",
+    "@docusaurus/plugin-sitemap": "2.0.0-alpha.60",
+    "@docusaurus/theme-classic": "2.0.0-alpha.60",
+    "@docusaurus/theme-search-algolia": "2.0.0-alpha.60"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -28,7 +28,7 @@
     "react-toggle": "^4.1.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-alpha.60",
+    "@docusaurus/module-type-aliases": "2.0.0-alpha.60",
     "@types/hapi__joi": "^17.1.2"
   },
   "peerDependencies": {

--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",
-    "@docusaurus/utils": "^2.0.0-alpha.54",
+    "@docusaurus/utils": "2.0.0-alpha.60",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/facebook/docusaurus/issues"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-alpha.60",
+    "@docusaurus/module-type-aliases": "2.0.0-alpha.60",
     "@types/detect-port": "^1.3.0",
     "@types/hapi__joi": "^17.1.2"
   },
@@ -45,8 +45,8 @@
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime": "^7.9.2",
     "@babel/runtime-corejs3": "^7.10.4",
-    "@docusaurus/types": "^2.0.0-alpha.60",
-    "@docusaurus/utils": "^2.0.0-alpha.60",
+    "@docusaurus/types": "2.0.0-alpha.60",
+    "@docusaurus/utils": "2.0.0-alpha.60",
     "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
     "@hapi/joi": "^17.1.1",
     "@svgr/webpack": "^5.4.0",


### PR DESCRIPTION
## Motivation

These changes allow users to pin their version of Docusaurus. If a users `package.json` had the following:

```
"dependencies": {
  "@docusaurus/core": "2.0.0-alpha.59",
  "@docusaurus/preset-classic": "2.0.0-alpha.59",
  ...
}
```

They'd expect the version of all `@docusaurus` packages to be `2.0.0-alpha.59`, but that's not the case because for example `packages/docusaurus/package.json` has `"@docusaurus/types": "^2.0.0-alpha.59"` and because of the caret version range `2.0.0-alpha.60` of `@docusaurus/types` is installed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

Closes #3161 