### PR TITLE
Enhancement: improved the accessibility of codeblocks

### DIFF
--- a/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
@@ -23,7 +23,7 @@ export default ({children, className}) => {
           {tokens.map((line, i) => (
             <div key={i} {...getLineProps({line, key: i})}>
               {line.map((token, key) => (
-                <span key={key} {...getTokenProps({token, key})} />
+                <code key={key} {...getTokenProps({token, key})} />
               ))}
             </div>
           ))}

--- a/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
@@ -19,18 +19,25 @@ export default ({children, className}) => {
       code={children}
       language={language}>
       {({style, tokens, getLineProps, getTokenProps}) => (
-        <pre className={className} style={{...style, padding: '20px'}}>
-          {tokens.map((line, i) => (
-            <div key={i} {...getLineProps({line, key: i})} aria-hidden="true">
-              {line.map((token, key) => (
-                <span
-                  key={key}
-                  {...getTokenProps({token, key})}
-                  aria-hidden="true"
-                />
-              ))}
-            </div>
-          ))}
+        <pre
+          style={{
+            margin: '0px',
+            padding: '0px',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}>
+          <code style={{...style, padding: '20px', display: 'inline-flex'}}>
+            {tokens.map((line, i) => (
+              <div
+                key={i}
+                {...getLineProps({line, key: i})}
+                className={className}>
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({token, key})} />
+                ))}
+              </div>
+            ))}
+          </code>
         </pre>
       )}
     </Highlight>

--- a/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
@@ -19,25 +19,17 @@ export default ({children, className}) => {
       code={children}
       language={language}>
       {({style, tokens, getLineProps, getTokenProps}) => (
-        <pre
-          style={{
-            margin: '0px',
-            padding: '0px',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-          }}>
-          <code style={{...style, padding: '20px', display: 'inline-flex'}}>
-            {tokens.map((line, i) => (
-              <div
-                key={i}
-                {...getLineProps({line, key: i})}
-                className={className}>
-                {line.map((token, key) => (
-                  <span key={key} {...getTokenProps({token, key})} />
-                ))}
-              </div>
-            ))}
-          </code>
+        <pre style={{...style, padding: '20px', display: 'inline-flex'}}>
+          {tokens.map((line, i) => (
+            <code
+              key={i}
+              {...getLineProps({line, key: i})}
+              className={className}>
+              {line.map((token, key) => (
+                <span key={key} {...getTokenProps({token, key})} />
+              ))}
+            </code>
+          ))}
         </pre>
       )}
     </Highlight>

--- a/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
@@ -21,9 +21,13 @@ export default ({children, className}) => {
       {({style, tokens, getLineProps, getTokenProps}) => (
         <pre className={className} style={{...style, padding: '20px'}}>
           {tokens.map((line, i) => (
-            <div key={i} {...getLineProps({line, key: i})}>
+            <div key={i} {...getLineProps({line, key: i})} aria-hidden="true">
               {line.map((token, key) => (
-                <span key={key} {...getTokenProps({token, key})} />
+                <span
+                  key={key}
+                  {...getTokenProps({token, key})}
+                  aria-hidden="true"
+                />
               ))}
             </div>
           ))}

--- a/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/theme/CodeBlock/index.js
@@ -23,7 +23,7 @@ export default ({children, className}) => {
           {tokens.map((line, i) => (
             <div key={i} {...getLineProps({line, key: i})}>
               {line.map((token, key) => (
-                <code key={key} {...getTokenProps({token, key})} />
+                <span key={key} {...getTokenProps({token, key})} />
               ))}
             </div>
           ))}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -246,7 +246,7 @@ export default ({
                   return (
                     <div key={i} {...lineProps}>
                       {line.map((token, key) => (
-                        <span key={key} {...getTokenProps({token, key})} />
+                        <code key={key} {...getTokenProps({token, key})} />
                       ))}
                     </div>
                   );

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -244,12 +244,12 @@ export default ({
                   }
 
                   return (
-                    <div key={i} {...lineProps}>
+                    <div key={i} {...lineProps} aria-hidden="true">
                       {line.map((token, key) => (
-                        <code
+                        <span
                           key={key}
                           {...getTokenProps({token, key})}
-                          style={{backgroundColor: 'transparent'}}
+                          aria-hidden="true"
                         />
                       ))}
                     </div>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -246,7 +246,11 @@ export default ({
                   return (
                     <div key={i} {...lineProps}>
                       {line.map((token, key) => (
-                        <code key={key} {...getTokenProps({token, key})} />
+                        <code
+                          key={key}
+                          {...getTokenProps({token, key})}
+                          style={{backgroundColor: 'transparent'}}
+                        />
                       ))}
                     </div>
                   );

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -244,15 +244,22 @@ export default ({
                   }
 
                   return (
-                    <div key={i} {...lineProps} aria-hidden="true">
-                      {line.map((token, key) => (
-                        <span
-                          key={key}
-                          {...getTokenProps({token, key})}
-                          aria-hidden="true"
-                        />
-                      ))}
-                    </div>
+                    <pre
+                      style={{
+                        margin: '0px',
+                        padding: '0px',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                      }}>
+                      <code
+                        key={i}
+                        {...lineProps}
+                        style={{display: 'inline-flex'}}>
+                        {line.map((token, key) => (
+                          <span key={key} {...getTokenProps({token, key})} />
+                        ))}
+                      </code>
+                    </pre>
                   );
                 })}
               </div>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -244,20 +244,13 @@ export default ({
                   }
 
                   return (
-                    <pre
-                      style={{
-                        margin: '0px',
-                        padding: '0px',
-                        whiteSpace: 'pre-wrap',
-                        wordBreak: 'break-word',
-                      }}>
-                      <code
-                        key={i}
-                        {...lineProps}
-                        style={{display: 'inline-flex'}}>
-                        {line.map((token, key) => (
-                          <span key={key} {...getTokenProps({token, key})} />
-                        ))}
+                    <pre className={styles.preTag}>
+                      <code className={styles.codeTag}>
+                        <div key={i} {...lineProps}>
+                          {line.map((token, key) => (
+                            <span key={key} {...getTokenProps({token, key})} />
+                          ))}
+                        </div>
                       </code>
                     </pre>
                   );

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -61,3 +61,15 @@
   min-width: 100%;
   padding: var(--ifm-pre-padding);
 }
+
+.preTag{
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 0px;
+  margin: 0px;
+}
+
+.codeTag{
+  display: inline-flex;
+}
+


### PR DESCRIPTION
solves #3119

As highlighted at https://github.com/facebook/docusaurus/issues/3119 Changing code block from initial span to code HTML tag improves accessibility for screen readers most especially.