### PR TITLE
fix(v2): add missing `lodash.flatmap` dependency

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -74,6 +74,7 @@
     "inquirer": "^7.2.0",
     "is-root": "^2.1.0",
     "lodash": "^4.5.2",
+    "lodash.flatmap": "^4.5.0",
     "lodash.has": "^4.5.2",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The dependency to `lodash.flatmap` was added in https://github.com/facebook/docusaurus/commit/300aecb8bc87b0f9114cb854b52b91a8004210b9#diff-42a2e682d62828c66fd6c3ed3d4e932e, but wasn't added to `package.json`.

This causes error in Yarn 2:
> Error: @docusaurus/core tried to access lodash.flatmap, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

In the "Start test-website project" step of Yarn 2 E2E test, verify the following error is not printed:
> Error: @docusaurus/core tried to access lodash.flatmap, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

https://github.com/facebook/docusaurus/pull/3191/checks?check_run_id=939419200#step:7:7

## Related PRs

Related issue: #3003
