### PR TITLE
feat(v2): Handle fs imports for @mdx-js/runtime usage

### DIFF
--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -24,6 +24,9 @@ export default function createClientConfig(
   const config = createBaseConfig(props, false, minify);
 
   const clientConfig = merge(config, {
+    node: {
+      fs: 'empty',
+    },
     entry: [
       // Instead of the default WebpackDevServer client, we use a custom one
       // like CRA to bring better experience.


### PR DESCRIPTION
## Motivation

I want to move mdx parsing to client via `@mdx-js/runtime` and it requires that fs is somehow mocked for client

https://github.com/mdx-js/mdx/issues/913

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Try use `import MDX from '@mdx-js/runtime'` in any .mdx file. Should build without errors.

## Related PRs

Nope
