### PR TITLE
Added additional head tag to noindex, follow the search page

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/index.js
@@ -67,6 +67,13 @@ function theme(context) {
               href: normalizeUrl([baseUrl, OPEN_SEARCH_FILENAME]),
             },
           },
+          {
+            tagName: 'meta',
+            attributes: {
+              name: 'robots',
+              content: 'noindex, follow',
+            },
+          },
         ],
       };
     },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensures that search pages can't get indexed by search engines, as this is [considered bad UX when coming from a search engine such as Google](https://www.practicalecommerce.com/should-internal-search-results-pages-be-indexed)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

* Check out this PR, build and start the development server
* Navigate to `http://localhost:3000/search`
* Check the source of the page. You should see a `<meta name="robots" content="noindex, follow" />` tag in the `<head>` section.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
