### PR TITLE
feat(v2): defer mode

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -70,7 +70,7 @@
     "globby": "^10.0.1",
     "html-minifier-terser": "^5.0.5",
     "html-tags": "^3.1.0",
-    "html-webpack-plugin": "^4.0.4",
+    "html-webpack-plugin": "^4.3.0",
     "import-fresh": "^3.2.1",
     "inquirer": "^7.2.0",
     "is-root": "^2.1.0",

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -29,7 +29,7 @@ module.exports = `
       <%~ it.appHtml %>
     </div>
     <% it.scripts.forEach((script) => { %>
-      <script type="text/javascript" src="<%= it.baseUrl %><%= script %>"></script>
+      <script type="text/javascript" src="<%= it.baseUrl %><%= script %>" defer></script>
     <% }); %>
     <%~ it.postBodyTags %>
   </body>

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -105,6 +105,7 @@ export default async function start(
         inject: false,
         filename: 'index.html',
         title: siteConfig.title,
+        scriptLoading: 'defer',
         headTags,
         preBodyTags,
         postBodyTags,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11210,10 +11210,10 @@ html-void-elements@^1.0.0:
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
-html-webpack-plugin@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.4.tgz#90cdfb168094e93e047174d9baca098ec5540636"
-  integrity sha512-BREQzUbFfIQS39KqxkT2L1Ot0tuu1isako1CaCQLrgEQ43zi2ScHAe3SMTnVBWsStnIsGtl8jprDdxwZkNhrwQ==
+html-webpack-plugin@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.3.0.tgz#53bf8f6d696c4637d5b656d3d9863d89ce8174fd"
+  integrity sha512-C0fzKN8yQoVLTelcJxZfJCE+aAvQiY2VUf3UuKrR4a9k5UMWYOtpDLsaXwATbcVCnI05hUS7L9ULQHWLZhyi3w==
   dependencies:
     "@types/html-minifier-terser" "^5.0.0"
     "@types/tapable" "^1.0.5"


### PR DESCRIPTION

## Motivation

Webpack JS assets are added to the page using defer, making them less "critical" for the browser.

As Docusaurus v2 can almost work without any JS, we can see React hydration as non-mandatory progressive enhancement

For now it's just a POC

