### PR TITLE
refactor(v2): precompile ETA templates

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/src/createRedirectPageContent.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/createRedirectPageContent.ts
@@ -7,15 +7,25 @@
 
 import * as eta from 'eta';
 import redirectPageTemplate from './templates/redirectPage.template.html';
+import {memoize} from 'lodash';
 
 type CreateRedirectPageOptions = {
   toUrl: string;
 };
 
+const getCompiledRedirectPageTemplate = memoize(() => {
+  return eta.compile(redirectPageTemplate.trim());
+});
+
+function renderRedirectPageTemplate(data: object) {
+  const compiled = getCompiledRedirectPageTemplate();
+  return compiled(data, eta.defaultConfig);
+}
+
 export default function createRedirectPageContent({
   toUrl,
 }: CreateRedirectPageOptions) {
-  return eta.render(redirectPageTemplate.trim(), {
+  return renderRedirectPageTemplate({
     toUrl: encodeURI(toUrl),
   });
 }

--- a/packages/docusaurus-theme-search-algolia/src/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/index.js
@@ -11,6 +11,16 @@ const eta = require('eta');
 const {normalizeUrl} = require('@docusaurus/utils');
 const openSearchTemplate = require('./templates/opensearch');
 const {validateThemeConfig} = require('./validateThemeConfig');
+const {memoize} = require('lodash');
+
+const getCompiledOpenSearchTemplate = memoize(() => {
+  return eta.compile(openSearchTemplate.trim());
+});
+
+function renderOpenSearchTemplate(data) {
+  const compiled = getCompiledOpenSearchTemplate();
+  return compiled(data, eta.defaultConfig);
+}
 
 const OPEN_SEARCH_FILENAME = 'opensearch.xml';
 
@@ -44,13 +54,14 @@ function theme(context) {
       try {
         fs.writeFileSync(
           path.join(outDir, OPEN_SEARCH_FILENAME),
-          eta.render(openSearchTemplate.trim(), {
+          renderOpenSearchTemplate({
             title,
             url,
             favicon: normalizeUrl([url, favicon]),
           }),
         );
       } catch (err) {
+        console.error(err);
         throw new Error(`Generating OpenSearch file failed: ${err}`);
       }
     },

--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -31,18 +31,15 @@ import ssrTemplate from './templates/ssr.html.template';
 // eslint-disable-next-line no-restricted-imports
 import {memoize} from 'lodash';
 
-const customEtaConfig = {
-  name: 'ssr-template',
-  rmWhitespace: true,
-};
-
 const getCompiledSSRTemplate = memoize(() => {
-  return eta.compile(ssrTemplate.trim(), customEtaConfig);
+  return eta.compile(ssrTemplate.trim(), {
+    rmWhitespace: true,
+  });
 });
 
 function renderSSRTemplate(data) {
   const compiled = getCompiledSSRTemplate();
-  return compiled(data, {...eta.defaultConfig, ...customEtaConfig});
+  return compiled(data, eta.defaultConfig);
 }
 
 // Renderer for static-site-generator-webpack-plugin (async rendering via promises).

--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -28,6 +28,23 @@ import {
 } from './LinksCollector';
 import ssrTemplate from './templates/ssr.html.template';
 
+// eslint-disable-next-line no-restricted-imports
+import {memoize} from 'lodash';
+
+const customEtaConfig = {
+  name: 'ssr-template',
+  rmWhitespace: true,
+};
+
+const getCompiledSSRTemplate = memoize(() => {
+  return eta.compile(ssrTemplate.trim(), customEtaConfig);
+});
+
+function renderSSRTemplate(data) {
+  const compiled = getCompiledSSRTemplate();
+  return compiled(data, {...eta.defaultConfig, ...customEtaConfig});
+}
+
 // Renderer for static-site-generator-webpack-plugin (async rendering via promises).
 export default async function render(locals) {
   const {
@@ -76,26 +93,19 @@ export default async function render(locals) {
   const stylesheets = (bundles.css || []).map((b) => b.file);
   const scripts = (bundles.js || []).map((b) => b.file);
 
-  const renderedHtml = eta.render(
-    ssrTemplate.trim(),
-    {
-      appHtml,
-      baseUrl,
-      htmlAttributes: htmlAttributes || '',
-      bodyAttributes: bodyAttributes || '',
-      headTags,
-      preBodyTags,
-      postBodyTags,
-      metaAttributes,
-      scripts,
-      stylesheets,
-      version: packageJson.version,
-    },
-    {
-      name: 'ssr-template',
-      rmWhitespace: true,
-    },
-  );
+  const renderedHtml = renderSSRTemplate({
+    appHtml,
+    baseUrl,
+    htmlAttributes: htmlAttributes || '',
+    bodyAttributes: bodyAttributes || '',
+    headTags,
+    preBodyTags,
+    postBodyTags,
+    metaAttributes,
+    scripts,
+    stylesheets,
+    version: packageJson.version,
+  });
 
   // Minify html with https://github.com/DanielRuf/html-minifier-terser
   return minify(renderedHtml, {


### PR DESCRIPTION

## Motivation

ETA has a caching system but reading the doc, it's not totally clear if we leverage it correctly (+ current code did .trim() on each SSR page: useless work)

I just precompiled the templates lazily in a memoize call to see if it can improve build times.

cc @nebrelbug if you can review and tell me what you think. I'm not sure we leveraged Eta caching anyway (despite providing a template name), as the default cache option is not documented here: https://eta.js.org/docs/api/configuration

Do you think this PR has an impact?