### PR TITLE
fix: update pageviews for Google Tag Manager

### DIFF
--- a/packages/docusaurus-plugin-google-gtag/src/gtag.js
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.js
@@ -24,6 +24,12 @@ export default (function () {
       // Always refer to the variable on window in-case it gets overridden elsewhere.
       window.gtag('config', trackingID, {
         page_path: location.pathname,
+        page_title: document.title
+      });
+      window.gtag('event', 'page_view', {
+        page_title: document.title,
+        page_location: location.href,
+        page_path: location.pathname
       });
     },
   };


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->
Closes #3047 

## Motivation

Was following Facebook open-source immersion program, recently did my PR to the [Material UI](https://github.com/mui-org/material-ui) repo, So thought to give a try.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Followed the [Google Analytics document](https://developers.google.com/analytics/devguides/collection/gtagjs/pages) while implementing pageviews.

Demo site with this change: https://govardhan-srinivas.github.io/docusaurus-blog-mode/
Screenshot of pageviews in google analytics
![image](https://user-images.githubusercontent.com/45192914/89706588-df17a280-d984-11ea-85a3-63d80451a503.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
