### PR TITLE
docs(v2): fix migration command for earlier versions

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.60/guides/migrating-from-v1-to-v2.md
+++ b/website/versioned_docs/version-2.0.0-alpha.60/guides/migrating-from-v1-to-v2.md
@@ -673,10 +673,10 @@ To use the migration command, follow these steps:
 
 ```
 // migration command format
-npx docusaurus-migrate migrate <v1 website directory> <desired v2 website directory>
+npx @docusaurus/migrate migrate <v1 website directory> <desired v2 website directory>
 
 // example
-npx docusaurus-migrate migrate ./v1-website ./v2-website
+npx @docusaurus/migrate migrate ./v1-website ./v2-website
 ```
 
 3. To view your new website locally, go into your v2 website's directory and start your development server.

--- a/website/versioned_docs/version-2.0.0-alpha.61/guides/migrating-from-v1-to-v2.md
+++ b/website/versioned_docs/version-2.0.0-alpha.61/guides/migrating-from-v1-to-v2.md
@@ -673,10 +673,10 @@ To use the migration command, follow these steps:
 
 ```
 // migration command format
-npx docusaurus-migrate migrate <v1 website directory> <desired v2 website directory>
+npx @docusaurus/migrate migrate <v1 website directory> <desired v2 website directory>
 
 // example
-npx docusaurus-migrate migrate ./v1-website ./v2-website
+npx @docusaurus/migrate migrate ./v1-website ./v2-website
 ```
 
 3. To view your new website locally, go into your v2 website's directory and start your development server.


### PR DESCRIPTION

## Motivation
The migration command is incorrect. This PR fixes the migration command for alpha.60 and alpha.61 docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The changes can be viewed on Netlify 

## Related PRs
PR #3249 fixes the migration command for next version of docs. 
