### PR TITLE
Allow relative links in footer.

### DIFF
--- a/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
+++ b/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
@@ -60,4 +60,4 @@ exports[`validation schemas RemarkPluginsSchema: for value=false 1`] = `"\\"valu
 
 exports[`validation schemas RemarkPluginsSchema: for value=null 1`] = `"\\"value\\" must be an array"`;
 
-exports[`validation schemas URISchema: for value="invalidURL" 1`] = `"\\"value\\" does not match any of the allowed types"`;
+exports[`validation schemas URISchema: for value="https://invalid:url/index.html" 1`] = `"\\"value\\" does not match any of the allowed types"`;

--- a/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
@@ -111,7 +111,7 @@ describe('validation schemas', () => {
   test('URISchema', () => {
     const validURL = 'https://docusaurus.io';
     const doubleHash = 'https://docusaurus.io#github#/:';
-    const invalidURL = 'invalidURL';
+    const invalidURL = 'https://invalid:url/index.html';
     const urlFromIssue = 'https://riot.im/app/#/room/#ligo-public:matrix.org';
     const {testFail, testOK} = createTestHelpers({schema: URISchema});
     testOK(validURL);

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -27,7 +27,7 @@ export const RehypePluginsSchema = MarkdownPluginsSchema;
 export const AdmonitionsSchema = Joi.object().default({});
 
 export const URISchema = Joi.alternatives(
-  Joi.string().uri(),
+  Joi.string().uri({allowRelative: true}),
   Joi.custom((val, helpers) => {
     try {
       const url = new URL(val);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I have a big write-up on Stack Overflow about what I'm trying to do: https://stackoverflow.com/questions/63268853/how-do-i-link-to-non-docusaurus-defined-routes-from-a-docusuarus-footer

The TL;DR is that my Docusaurus docs are compiled and static files are saved to a /docs directory of my webserver, but the rest of my site is developed outside of Docusaurus.  I'd like to link to local resources like /contact-us or /about-us from my Docusaurus footer, but `/about-us` is currently an "invalid" `href` value, and if I try to use the `to: '/about-us'` syntax, the React router tries to snag my click.

This change allows for such local links by adding the `allowRelative` flag to the URI validator. https://github.com/sideway/joi/blob/master/API.md#stringurioptions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I verified that I could add a footer link of the form:

```
            {
              label: 'About Us',
              href: '/about-us',
            },
```

and the config validator didn't complain, and the react router didn't try to snag my click.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
