### PR TITLE
fix(v2): fix template alt image prop

### DIFF
--- a/packages/docusaurus-init/templates/bootstrap/src/pages/index.js
+++ b/packages/docusaurus-init/templates/bootstrap/src/pages/index.js
@@ -9,7 +9,7 @@ import styles from './styles.module.css';
 
 const features = [
   {
-    title: <>Easy to Use</>,
+    title: 'Easy to Use',
     imageUrl: 'img/undraw_docusaurus_mountain.svg',
     description: (
       <>
@@ -19,7 +19,7 @@ const features = [
     ),
   },
   {
-    title: <>Focus on What Matters</>,
+    title: 'Focus on What Matters',
     imageUrl: 'img/undraw_docusaurus_tree.svg',
     description: (
       <>
@@ -29,7 +29,7 @@ const features = [
     ),
   },
   {
-    title: <>Powered by React</>,
+    title: 'Powered by React',
     imageUrl: 'img/undraw_docusaurus_react.svg',
     description: (
       <>

--- a/packages/docusaurus-init/templates/classic/src/pages/index.js
+++ b/packages/docusaurus-init/templates/classic/src/pages/index.js
@@ -8,7 +8,7 @@ import styles from './styles.module.css';
 
 const features = [
   {
-    title: <>Easy to Use</>,
+    title: 'Easy to Use',
     imageUrl: 'img/undraw_docusaurus_mountain.svg',
     description: (
       <>
@@ -18,7 +18,7 @@ const features = [
     ),
   },
   {
-    title: <>Focus on What Matters</>,
+    title: 'Focus on What Matters',
     imageUrl: 'img/undraw_docusaurus_tree.svg',
     description: (
       <>
@@ -28,7 +28,7 @@ const features = [
     ),
   },
   {
-    title: <>Powered by React</>,
+    title: 'Powered by React',
     imageUrl: 'img/undraw_docusaurus_react.svg',
     description: (
       <>

--- a/packages/docusaurus-init/templates/facebook/src/pages/index.js
+++ b/packages/docusaurus-init/templates/facebook/src/pages/index.js
@@ -17,7 +17,7 @@ import styles from './styles.module.css';
 
 const features = [
   {
-    title: <>Easy to Use</>,
+    title: 'Easy to Use',
     imageUrl: 'img/undraw_docusaurus_mountain.svg',
     description: (
       <>
@@ -27,7 +27,7 @@ const features = [
     ),
   },
   {
-    title: <>Focus on What Matters</>,
+    title: 'Focus on What Matters',
     imageUrl: 'img/undraw_docusaurus_tree.svg',
     description: (
       <>
@@ -37,7 +37,7 @@ const features = [
     ),
   },
   {
-    title: <>Powered by React</>,
+    title: 'Powered by React',
     imageUrl: 'img/undraw_docusaurus_react.svg',
     description: (
       <>


### PR DESCRIPTION


## Motivation

https://github.com/facebook/docusaurus/issues/3257#issuecomment-671877147

Avoid passing a fragment as image alt prop

![image](https://user-images.githubusercontent.com/749374/89891212-f056ee00-dbd4-11ea-85d6-0bcd996a685c.png)
