### PR TITLE
chore(v2): fix slow commits due to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,8 +110,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "yarn eslint --fix",
-      "yarn prettier"
+      "eslint",
+      "prettier"
     ],
     "*.md": [
       "yarn prettier-docs"

--- a/package.json
+++ b/package.json
@@ -110,11 +110,11 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint",
-      "prettier"
+      "eslint --fix",
+      "prettier --write"
     ],
-    "*.md": [
-      "yarn prettier-docs"
+    "*.{md,mdx}": [
+      "prettier --write"
     ]
   },
   "husky": {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -61,9 +61,7 @@ const QUOTES = [
 
 function Home() {
   const context = useDocusaurusContext();
-
   const {siteConfig: {customFields = {}, tagline} = {}} = context;
-
   return (
     <Layout
       permalink="/"

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -60,8 +60,10 @@ const QUOTES = [
 ];
 
 function Home() {
-  const context = useDocusaurusContexsddt();
+  const context = useDocusaurusContext();
+
   const {siteConfig: {customFields = {}, tagline} = {}} = context;
+
   return (
     <Layout
       permalink="/"

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -60,7 +60,7 @@ const QUOTES = [
 ];
 
 function Home() {
-  const context = useDocusaurusContext();
+  const context = useDocusaurusContexsddt();
   const {siteConfig: {customFields = {}, tagline} = {}} = context;
   return (
     <Layout


### PR DESCRIPTION

## Motivation

Lint staged should call eslint and prettier, but only on modified files, not running on all the files.

This makes committing much faster, as we don't have to wait for 20seconds...