### PR TITLE
chore(v2): windows, 3*yarn install attempts, to avoid timeout failures?

### DIFF
--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Installation
-      run: yarn
+      run: yarn || yarn || yarn # 3 attemps to avoid timeout errors...
     - name: Docusaurus 1 Build
       run: yarn build:v1
     - name: Docusaurus 2 Build


### PR DESCRIPTION
## Motivation

Windows CI fails randomly when executing `yarn`, so let's try to add 2 additional retries and see if it fails less...

https://github.com/facebook/docusaurus/runs/970974830?check_suite_focus=true

![image](https://user-images.githubusercontent.com/749374/89893649-04045380-dbd9-11ea-8cc5-030bc2993073.png)
