### PR TITLE
fix: feedback page hydration

### DIFF
--- a/website/src/theme/NotFound.tsx
+++ b/website/src/theme/NotFound.tsx
@@ -10,26 +10,26 @@ import Layout from '@theme/Layout';
 import Feedback from '../pages/feedback';
 
 function NotFound({location}: {location: {pathname: string}}): JSX.Element {
-  if (/^\/feedback/.test(location.pathname)) {
-    return <Feedback />;
-  }
-
-  return (
-    <Layout title="Page Not Found">
-      <div className="container margin-vert--xl" data-canny>
-        <div className="row">
-          <div className="col col--6 col--offset-3">
-            <h1 className="hero__title">Page Not Found</h1>
-            <p>We could not find what you were looking for.</p>
-            <p>
-              Please contact the owner of the site that linked you to the
-              original URL and let them know their link is broken.
-            </p>
+  if (/^\/\bfeedback\b/.test(location.pathname)) {
+    return <Feedback />
+  } else {
+    return (
+      <Layout title="Page Not Found">
+        <div className="container margin-vert--xl" data-canny>
+          <div className="row">
+            <div className="col col--6 col--offset-3">
+              <h1 className="hero__title">Page Not Found</h1>
+              <p>We could not find what you were looking for.</p>
+              <p>
+                Please contact the owner of the site that linked you to the
+                original URL and let them know their link is broken.
+              </p>
+            </div>
           </div>
         </div>
-      </div>
-    </Layout>
-  );
+      </Layout>
+    );
+  }
 }
 
 export default NotFound;


### PR DESCRIPTION
## Motivation

Closes #2828 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

When accessed directly with a "deep link",  there should not be any hydration problem in feedback, 

`https://{host}/feedback/p/api-documentation-swagger`

Most render the feedback page accordingly.

Moreover, I added the metacharacter `\b` to the regex expression, so it renders the not found page when accessing an incorrect feedback page. This is the current behavior,

`https://v2.docusaurus.io/feedback1/p/api-documentation-swagger` renders,
![screencapture-localhost-3000-feedback1-p-api-documentation-swagger-2020-08-11-23_13_15](https://user-images.githubusercontent.com/8043309/89971726-08a52800-dc2a-11ea-8259-d04fb56b6ccf.png)

Expected render,
![screencapture-localhost-3000-feedback1-p-api-documentation-swagger-2020-08-11-23_13_40](https://user-images.githubusercontent.com/8043309/89971753-178bda80-dc2a-11ea-8370-4f36d4f68510.png)

## Related PRs
