### PR TITLE
fix(v1,v2): Add initial-scale=1.0 to all meta viewport tags

### DIFF
--- a/packages/docusaurus-1.x/lib/core/Head.js
+++ b/packages/docusaurus-1.x/lib/core/Head.js
@@ -34,7 +34,7 @@ class Head extends React.Component {
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         <title>{this.props.title}</title>
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="generator" content="Docusaurus" />
         <meta name="description" content={this.props.description} />
         {this.props.version && (

--- a/packages/docusaurus/src/client/templates/index.html.template.ejs
+++ b/packages/docusaurus/src/client/templates/index.html.template.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="Docusaurus">
     <title><%= htmlWebpackPlugin.options.title %></title>
     <%= htmlWebpackPlugin.options.headTags %>

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -10,7 +10,7 @@ module.exports = `
 <html <%~ it.htmlAttributes %>>
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="Docusaurus v<%= it.version %>">
     <%~ it.headTags %>
     <% it.metaAttributes.forEach((metaAttribute) => { %>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!
-->

## Motivation

When viewing my Docusaurus site (https://squirrelly.js.org) on a mobile device, it is correctly sized on first load. Almost immediately after that, however, it resizes so that it isn't the full width of the page (see below). Changing `<meta name="viewport" content="width=device-width">` to `<meta name="viewport" content="width=device-width, initial-scale=1.0">` solves the problem.

![image](https://user-images.githubusercontent.com/25597854/90325175-b0299f80-df35-11ea-9efc-b7b272440747.png)

Strangely, I can't reproduce the issue on other Docusaurus sites. However, since I believe it's best practice to include `initial-scale=1`, I figured I'd submit the PR anyway.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Visually ensure that Docusaurus doesn't change its appearance.
