### PR TITLE
fix(v2): add https support in webpack devserver

### DIFF
--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -142,6 +142,7 @@ export default async function start(
       // `webpackHotDevClient`.
       injectClient: false,
       quiet: true,
+      https: protocol === 'https',
       headers: {
         'access-control-allow-origin': '*',
       },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Add https option in the dev server config, protocol is defined in the config file which can be http or https. Rather than directly checking from process.env we can check from the protocol.
After this change, one can start a dev server over https.

Fixes #3301 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Running `HTTPS=true yarn start` will start the server and load the website on `https://localhost:3000`

![Screenshot 2020-08-19 at 7 42 18 PM](https://user-images.githubusercontent.com/11339463/90700716-87b2e580-e254-11ea-9432-05a65eb8132d.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
