### PR TITLE
fix(v2): resolve webpack loaders from siteDir/node_modules

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -92,6 +92,7 @@ export function createBaseConfig(
     },
     resolveLoader: {
       plugins: [PnpWebpackPlugin.moduleLoader(module)],
+      modules: ['node_modules', path.join(siteDir, 'node_modules')],
     },
     optimization: {
       removeAvailableModules: false,


### PR DESCRIPTION
## Motivation
Fix url-loader not found if the `docs` folder is outside siteDir. Fixes #2724.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Tested on react-native site migration repo
