### PR TITLE
chore(v2): migrate title tags to recommended aria-labelledby attr

### DIFF
--- a/packages/docusaurus-theme-bootstrap/src/theme/DocSidebar/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/theme/DocSidebar/index.js
@@ -88,8 +88,8 @@ const DocSidebar = ({sidebar, path}) => {
               viewBox="0 0 32 32"
               role="img"
               focusable="false">
-              <title>Menu</title>
               <path
+                aria-labelledby="Menu"
                 stroke="currentColor"
                 strokeLinecap="round"
                 strokeMiterlimit="10"

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -237,8 +237,8 @@ function DocSidebar({
               viewBox="0 0 32 32"
               role="img"
               focusable="false">
-              <title>Menu</title>
               <path
+                aria-labelledby="Menu"
                 stroke="currentColor"
                 strokeLinecap="round"
                 strokeMiterlimit="10"

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -105,8 +105,8 @@ function Navbar(): JSX.Element {
                 viewBox="0 0 30 30"
                 role="img"
                 focusable="false">
-                <title>Menu</title>
                 <path
+                  aria-labelledby="Menu"
                   stroke="currentColor"
                   strokeLinecap="round"
                   strokeMiterlimit="10"


### PR DESCRIPTION
## Motivation

Follow latest a11y standards:

> Text in a <title> element is not rendered as part of the graphic, but browsers usually display it as a tooltip. If an element can be described by visible text, it is recommended to reference that text with an aria-labelledby attribute rather than using the <title> element. [0]

[0] https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran all the tests.

## Related PRs

n/a
