### PR TITLE
fix: Allow docusaurus-migrate to create relative paths #3239

### DIFF
--- a/packages/docusaurus-migrate/src/index.ts
+++ b/packages/docusaurus-migrate/src/index.ts
@@ -639,7 +639,7 @@ function migrateLatestSidebar(
       path.join(siteDir, 'sidebars.json'),
       path.join(newDir, 'sidebars.json'),
     );
-    classicPreset.docs.sidebarPath = path.join(newDir, 'sidebars.json');
+    classicPreset.docs.sidebarPath = path.join(path.relative(newDir, path.join(siteDir, '..')), 'sidebars.json');
   } catch {
     console.log(
       chalk.yellow(`Sidebar not found. Skipping migration for sidebar`),
@@ -660,7 +660,7 @@ function migrateLatestSidebar(
     fs.mkdirpSync(path.join(newDir, 'src', 'css'));
     fs.writeFileSync(path.join(newDir, 'src', 'css', 'customTheme.css'), css);
     classicPreset.theme.customCss = path.join(
-      newDir,
+      path.relative(newDir, path.join(siteDir, '..')),
       'src',
       'css',
       'customTheme.css',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #3239 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![passing](https://user-images.githubusercontent.com/25523604/90894576-7564b300-e3de-11ea-9616-8bf2798c9a00.PNG)
![without](https://user-images.githubusercontent.com/25523604/90894581-772e7680-e3de-11ea-8e35-95e47f607826.PNG)
![with](https://user-images.githubusercontent.com/25523604/90894582-77c70d00-e3de-11ea-8a40-f514b198a574.PNG)


As it can be seen (in case of customCss), previously the path was **absolute**, but it is now **relative**, as expected of the bugfix. Changed it by following a manner similar to *docs*, which parsed the relative path correctly.

The existing tests already gave coverage on the lines changed, so didn't add any new test (ran migration.test.ts). 



## Related PRs

None
