### PR TITLE
Make Firefox scrollbars aware of dark theme

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -13,6 +13,7 @@ body {
 body {
   margin: 0;
   transition: var(--ifm-transition-fast) ease color;
+  background-color: var(--ifm-background-color);
 }
 
 #__docusaurus {


### PR DESCRIPTION
## Motivation

As of right now, scrollbars remain white in Firefox when the dark theme is active. We can make Firefox change the scrollbars by adding the `background-color` property on the `body`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I tested the change in Firefox and it worked, and tested in Chrome and Edge just to check nothing changed.
I attach two screenshots showing the before and after.

![Before](https://user-images.githubusercontent.com/40642621/90968436-7be15080-e4ec-11ea-9af6-bd30e7edd8f2.PNG)
![After](https://user-images.githubusercontent.com/40642621/90968433-7a178d00-e4ec-11ea-8af3-202e40150502.PNG)