### PR TITLE
feat(v2): Provide docs plugin theme typing

### DIFF
--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-alpha.61",
   "description": "Docs content plugin for Docusaurus",
   "main": "lib/index.js",
+  "types": "src/plugin-content-docs.d.ts",
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch"

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -22,7 +22,6 @@ import {
   PluginOptions,
   LoadedContent,
   SourceToPermalink,
-  PermalinkToSidebar,
   DocMetadataBase,
   DocMetadata,
   GlobalPluginData,
@@ -32,6 +31,7 @@ import {
   DocFile,
   DocsMarkdownOption,
 } from './types';
+import {PermalinkToSidebar} from '@docusaurus/plugin-content-docs-types';
 import {RuleSetRule} from 'webpack';
 import {cliDocsVersionCommand} from './cli';
 import {VERSIONS_JSON_FILE} from './constants';

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable camelcase */
+
+declare module '@docusaurus/plugin-content-docs-types' {
+  export type VersionName = string;
+
+  export type PermalinkToSidebar = {
+    [permalink: string]: string;
+  };
+
+  export type PropVersionMetadata = {
+    version: VersionName;
+    docsSidebars: PropSidebars;
+    permalinkToSidebar: PermalinkToSidebar;
+  };
+
+  export type PropSidebarItemLink = {
+    type: 'link';
+    href: string;
+    label: string;
+  };
+
+  export type PropSidebarItemCategory = {
+    type: 'category';
+    label: string;
+    items: PropSidebarItem[];
+    collapsed?: boolean;
+  };
+
+  export type PropSidebarItem = PropSidebarItemLink | PropSidebarItemCategory;
+
+  export type PropSidebars = {
+    [sidebarId: string]: PropSidebarItem[];
+  };
+}
+
+declare module '@theme/DocItem' {
+  import type {MarkdownRightTableOfContents} from '@docusaurus/types';
+
+  export type DocumentRoute = {
+    readonly component: () => JSX.Element;
+    readonly exact: boolean;
+    readonly path: string;
+  };
+
+  export type FrontMatter = {
+    readonly id: string;
+    readonly title: string;
+    readonly image?: string;
+    readonly keywords?: readonly string[];
+    readonly hide_title?: boolean;
+    readonly hide_table_of_contents?: boolean;
+  };
+
+  export type Metadata = {
+    readonly description?: string;
+    readonly title?: string;
+    readonly permalink?: string;
+    readonly editUrl?: string;
+    readonly lastUpdatedAt?: number;
+    readonly lastUpdatedBy?: string;
+    readonly version?: string;
+  };
+
+  export type Props = {
+    readonly route: DocumentRoute;
+    readonly content: {
+      readonly frontMatter: FrontMatter;
+      readonly metadata: Metadata;
+      readonly rightToc: MarkdownRightTableOfContents;
+      (): JSX.Element;
+    };
+  };
+
+  const DocItem: (props: Props) => JSX.Element;
+  export default DocItem;
+}
+
+declare module '@theme/DocPage' {
+  import type {PropVersionMetadata} from '@docusaurus/plugin-content-docs-types';
+  import type {DocumentRoute} from '@theme/DocItem';
+
+  export type Props = {
+    readonly location: {readonly pathname: string};
+    readonly versionMetadata: PropVersionMetadata;
+    readonly route: {
+      readonly path: string;
+      readonly component: () => JSX.Element;
+      readonly routes: readonly DocumentRoute[];
+    };
+  };
+
+  const DocPage: (props: Props) => JSX.Element;
+  export default DocPage;
+}

--- a/packages/docusaurus-plugin-content-docs/src/props.ts
+++ b/packages/docusaurus-plugin-content-docs/src/props.ts
@@ -7,13 +7,15 @@
 
 import {
   LoadedVersion,
-  PropSidebars,
   SidebarItemDoc,
   SidebarItemLink,
-  PropVersionMetadata,
   SidebarItem,
-  PropSidebarItem,
 } from './types';
+import {
+  PropSidebars,
+  PropVersionMetadata,
+  PropSidebarItem,
+} from '@docusaurus/plugin-content-docs-types';
 import {keyBy, mapValues} from 'lodash';
 
 export function toSidebarsProp(loadedVersion: LoadedVersion): PropSidebars {

--- a/packages/docusaurus-plugin-content-docs/src/slug.ts
+++ b/packages/docusaurus-plugin-content-docs/src/slug.ts
@@ -20,7 +20,7 @@ export default function getSlug({
   baseID: string;
   frontmatterSlug?: string;
   dirName: string;
-}) {
+}): string {
   const baseSlug: string = frontmatterSlug || baseID;
   let slug: string;
   if (baseSlug.startsWith('/')) {

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -119,11 +119,6 @@ export type DocMetadata = DocMetadataBase & {
 export type SourceToPermalink = {
   [source: string]: string;
 };
-
-export type PermalinkToSidebar = {
-  [permalink: string]: string;
-};
-
 export type LoadedVersion = VersionMetadata & {
   versionPath: string;
   mainDocId: string;
@@ -153,27 +148,6 @@ export type GlobalVersion = {
 export type GlobalPluginData = {
   path: string;
   versions: GlobalVersion[];
-};
-
-export type PropVersionMetadata = {
-  version: VersionName;
-  docsSidebars: PropSidebars;
-  permalinkToSidebar: PermalinkToSidebar;
-};
-
-export type PropSidebarItemLink = SidebarItemLink; // same
-
-export type PropSidebarItemCategory = {
-  type: 'category';
-  label: string;
-  items: PropSidebarItem[];
-  collapsed?: boolean;
-};
-
-export type PropSidebarItem = PropSidebarItemLink | PropSidebarItemCategory;
-
-export type PropSidebars = {
-  [sidebarId: string]: PropSidebarItem[];
 };
 
 export type BrokenMarkdownLink = {

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -38,6 +38,7 @@
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",
     "@docusaurus/plugin-content-blog": "^2.0.0-alpha.61",
+    "@docusaurus/plugin-content-docs": "^2.0.0-alpha.61",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -12,12 +12,13 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import DocPaginator from '@theme/DocPaginator';
 import DocVersionSuggestions from '@theme/DocVersionSuggestions';
+import type {Props} from '@theme/DocItem';
 import TOC from '@theme/TOC';
 
 import clsx from 'clsx';
 import styles from './styles.module.css';
 
-function DocItem(props): JSX.Element {
+function DocItem(props: Props): JSX.Element {
   const {siteConfig = {}} = useDocusaurusContext();
   const {url: siteUrl, title: siteTitle} = siteConfig;
   const {content: DocContent} = props;

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -5,24 +5,33 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ReactNode} from 'react';
 import {MDXProvider} from '@mdx-js/react';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import renderRoutes from '@docusaurus/renderRoutes';
+import type {PropVersionMetadata} from '@docusaurus/plugin-content-docs-types';
 import Layout from '@theme/Layout';
 import DocSidebar from '@theme/DocSidebar';
 import MDXComponents from '@theme/MDXComponents';
 import NotFound from '@theme/NotFound';
+import type {DocumentRoute} from '@theme/DocItem';
+import type {Props} from '@theme/DocPage';
 import {matchPath} from '@docusaurus/router';
 
 import styles from './styles.module.css';
+
+type DocPageContentProps = {
+  readonly currentDocRoute: DocumentRoute;
+  readonly versionMetadata: PropVersionMetadata;
+  readonly children: ReactNode;
+};
 
 function DocPageContent({
   currentDocRoute,
   versionMetadata,
   children,
-}): JSX.Element {
+}: DocPageContentProps): JSX.Element {
   const {siteConfig, isClient} = useDocusaurusContext();
   const {permalinkToSidebar, docsSidebars, version} = versionMetadata;
   const sidebarName = permalinkToSidebar[currentDocRoute.path];
@@ -49,7 +58,7 @@ function DocPageContent({
   );
 }
 
-function DocPage(props) {
+function DocPage(props: Props): JSX.Element {
   const {
     route: {routes: docRoutes},
     versionMetadata,

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -8,3 +8,4 @@
 /* eslint-disable spaced-comment */
 /// <reference types="@docusaurus/module-type-aliases" />
 /// <reference types="@docusaurus/plugin-content-blog" />
+/// <reference types="@docusaurus/plugin-content-docs" />


### PR DESCRIPTION
## Motivation

Following #3267, this PR adds type definitions for docs plugin.

I moved some type definitions frin `docusaurus-plugin-content-docs/src/types.ts` into a type-exporting-only dummy module `@docusaurus/plugin-content-docs-types` in `docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts`, so that its types can be used by both code in the docs plugin and the module type declaration file. This also allows types defined in `@docusaurus/plugin-content-docs-types` to be used in theme-classic.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This PR contains no runtime changes. Check CI to see everything type checks.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
