### PR TITLE
fix(v1): show images after one line code block 

### DIFF
--- a/packages/docusaurus-1.x/lib/server/__tests__/utils.test.js
+++ b/packages/docusaurus-1.x/lib/server/__tests__/utils.test.js
@@ -91,4 +91,20 @@ describe('server utils', () => {
     expect(utils.getSubDir(docE, docsDir)).toBeNull();
     expect(utils.getSubDir(docE, translatedDir)).toEqual('lol/lah');
   });
+
+  describe('replaceAssetsLink', () => {
+    test('verifies asset link is replaced after code block', () => {
+      const content = '```Some block```\n![alt](assets/my.png) more text';
+      const link = utils.replaceAssetsLink(content, 'thelocation');
+      expect(link).toBe(
+        '```Some block```\n![alt](thelocation/assets/my.png) more text',
+      );
+    });
+
+    test('verifies asset link is not replaced inside a fenced code block', () => {
+      const content = '```\n![alt](assets/my.png)\n```';
+      const link = utils.replaceAssetsLink(content, 'thelocation');
+      expect(link).toBe('```\n![alt](assets/my.png)\n```');
+    });
+  });
 });

--- a/packages/docusaurus-1.x/lib/server/utils.js
+++ b/packages/docusaurus-1.x/lib/server/utils.js
@@ -69,7 +69,7 @@ function autoPrefixCss(cssContent) {
 function replaceAssetsLink(oldContent, location) {
   let fencedBlock = false;
   const lines = oldContent.split('\n').map((line) => {
-    if (line.trim().startsWith('```')) {
+    if (line.trim().startsWith('```') && line.match(/`/g).length === 3) {
       fencedBlock = !fencedBlock;
     }
     return fencedBlock


### PR DESCRIPTION
## Motivation
When a markdown line starts with a code block (```) and the end of the code block is on the same line, asset images that follow after this line cannot be loaded in the next version of the documentation.
This PR fixes/improves the fenced block detection to consider this scenario.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
- Added unit tests to cover the replaceAssetsLink function

### Commands/Steps to reproduce the issue
* git clone docusaurus project
* yarn install
* add folder "assets" in /docs directory
* add any image to the assets folder (I copied getting-started-preparation-verify.png from /website-1.x/static/img/ folder)
* add the following text to any markdown file in /docs (line must start with 3 backticks): ```Example (break it)```
* after this line reference the image from the assets folder
* The image is not loaded after the ```Example (break it)``` line for "next" version of the documentation
* If you add the image before the ```Example (break it)``` line for "next" version the image is loaded

### markdown to reproduce the issue
I took the getting-started-installation.md and added this content to show the issue:

```
Working

![this image is missing](assets/getting-started-preparation-verify.png)

```Example (break it)```

No Working

![this image is missing](assets/getting-started-preparation-verify.png)
```

![PR_issue](https://user-images.githubusercontent.com/39156165/91362999-ea2f5700-e7fb-11ea-9f5f-59a554cbc908.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

None