### PR TITLE
fix(v2): Allow the alt for the logo to be empty

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
@@ -93,6 +93,22 @@ describe('themeConfig', () => {
     });
   });
 
+  test('should allow empty alt tags for the logo image in the header', () => {
+    const altTagConfig = {
+      navbar: {
+        logo: {
+          alt: '',
+          src: '/arbitrary-logo.png',
+        },
+        hideOnScroll: false,
+      },
+    };
+    expect(testValidateThemeConfig(altTagConfig)).toEqual({
+      colorMode: DEFAULT_COLOR_MODE_CONFIG,
+      ...altTagConfig,
+    });
+  });
+
   test('should accept valid prism config', () => {
     const prismConfig = {
       prism: {

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -181,7 +181,7 @@ const ThemeConfigSchema = Joi.object({
     items: Joi.array().items(NavbarItemSchema),
     title: Joi.string().allow('', null),
     logo: Joi.object({
-      alt: Joi.string(),
+      alt: Joi.string().allow(''),
       src: Joi.string().required(),
       srcDark: Joi.string(),
       href: Joi.string(),


### PR DESCRIPTION
## Motivation

See
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#Attributes

> Setting this attribute to an empty string (alt="") indicates that
> this image is not a key part of the content (it’s decoration or a
> tracking pixel), and that non-visual browsers may omit it from
> rendering.

Since the logo is indeed decorative and redundant with the actual
project name, an empty alt is fine.

We could also consider just making the attribute optional and defaulting to an empty string, since the logo is going to be redundant with `title` in the general case. I'm happy to update the PR to that, but since just allowing the empty string was the approach described in #3350, I went with that for now.

Fixes #3350.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run the unit tests. Set up a new project, set the alt property for the logo in the navbar and footer to an empty string, then verify that it is not rejected.

