### PR TITLE
fix(v2): Add missing dependencies to packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,7 +97,7 @@ module.exports = {
     // TODO re-enable some these as errors
     // context: https://github.com/facebook/docusaurus/pull/2949
     '@typescript-eslint/ban-types': WARNING,
-    'import/no-extraneous-dependencies': WARNING,
+    'import/no-extraneous-dependencies': ERROR,
     'no-useless-escape': WARNING,
     'prefer-template': WARNING,
     'no-param-reassign': WARNING,

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -29,7 +29,8 @@
     "loader-utils": "^1.2.3",
     "lodash.kebabcase": "^4.1.1",
     "reading-time": "^1.2.0",
-    "remark-admonitions": "^1.2.1"
+    "remark-admonitions": "^1.2.1",
+    "webpack": "^4.41.2"
   },
   "peerDependencies": {
     "react": "^16.8.4",

--- a/packages/docusaurus-plugin-content-pages/package.json
+++ b/packages/docusaurus-plugin-content-pages/package.json
@@ -25,7 +25,8 @@
     "loader-utils": "^1.2.3",
     "minimatch": "^3.0.4",
     "remark-admonitions": "^1.2.1",
-    "slash": "^3.0.0"
+    "slash": "^3.0.0",
+    "webpack": "^4.41.2"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",

--- a/packages/docusaurus-plugin-ideal-image/package.json
+++ b/packages/docusaurus-plugin-ideal-image/package.json
@@ -12,15 +12,16 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@docusaurus/types": "^2.0.0-alpha.61",
     "fs-extra": "^9.0.0"
   },
   "dependencies": {
     "@docusaurus/lqip-loader": "^2.0.0-alpha.61",
+    "@docusaurus/types": "^2.0.0-alpha.61",
     "@endiliey/react-ideal-image": "^0.0.11",
     "@endiliey/responsive-loader": "^1.3.2",
     "react-waypoint": "^9.0.2",
-    "sharp": "^0.25.2"
+    "sharp": "^0.25.2",
+    "webpack": "^4.41.2"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",

--- a/packages/docusaurus-plugin-pwa/package.json
+++ b/packages/docusaurus-plugin-pwa/package.json
@@ -13,6 +13,7 @@
     "@babel/preset-env": "^7.9.0",
     "@hapi/joi": "^17.1.1",
     "babel-loader": "^8.1.0",
+    "clsx": "^1.1.1",
     "core-js": "^2.6.5",
     "terser-webpack-plugin": "^2.3.5",
     "webpack": "^4.41.2",

--- a/packages/docusaurus-theme-bootstrap/package.json
+++ b/packages/docusaurus-theme-bootstrap/package.json
@@ -11,6 +11,7 @@
     "@mdx-js/react": "^1.5.8",
     "bootstrap": "^4.4.1",
     "classnames": "^2.2.6",
+    "clsx": "^1.1.1",
     "prism-react-renderer": "^1.1.0",
     "reactstrap": "^8.4.1"
   },

--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -9,15 +9,16 @@
   "license": "MIT",
   "dependencies": {
     "@docsearch/react": "^1.0.0-alpha.27",
+    "@docusaurus/utils": "^2.0.0-alpha.61",
     "@hapi/joi": "^17.1.1",
     "algoliasearch": "^4.0.0",
     "algoliasearch-helper": "^3.1.1",
     "clsx": "^1.1.1",
-    "eta": "^1.1.1"
+    "eta": "^1.1.1",
+    "lodash": "^4.17.19"
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0",
-    "@docusaurus/utils": "2.0.0-alpha.60",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// ESLint doesn't understand types dependencies in d.ts
+// eslint-disable-next-line import/no-extraneous-dependencies
 import {Loader, Configuration} from 'webpack';
 import {Command} from 'commander';
 import {ParsedUrlQueryInput} from 'querystring';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR adds missing dependencies to relevant package.json and change the eslint lint rule that checks this from warning to error so that we will never regress later.

Note that there is no change in yarn.lock, which shows that the change likely won't cause any node_modules's size increase. Any decent package manager would be able to dedupe all the webpack dependencies into a single on in common cases.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI. Preview works.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
