### PR TITLE
fix(v2): reject routeBasePath: ''

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/package.json
+++ b/packages/docusaurus-plugin-client-redirects/package.json
@@ -15,6 +15,7 @@
     "@docusaurus/core": "^2.0.0-alpha.62",
     "@docusaurus/types": "^2.0.0-alpha.62",
     "@docusaurus/utils": "^2.0.0-alpha.62",
+    "@docusaurus/utils-validation": "^2.0.0-alpha.62",
     "@hapi/joi": "^17.1.1",
     "@types/hapi__joi": "^17.1.2",
     "chalk": "^3.0.0",

--- a/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
@@ -7,7 +7,7 @@
 
 import {PluginOptions, RedirectOption, UserPluginOptions} from './types';
 import * as Joi from '@hapi/joi';
-import {PathnameValidator} from './redirectValidation';
+import {PathnameSchema} from '@docusaurus/utils-validation';
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
 
 export const DefaultPluginOptions: PluginOptions = {
@@ -18,10 +18,10 @@ export const DefaultPluginOptions: PluginOptions = {
 };
 
 const RedirectPluginOptionValidation = Joi.object<RedirectOption>({
-  to: PathnameValidator.required(),
+  to: PathnameSchema.required(),
   from: Joi.alternatives().try(
-    PathnameValidator.required(),
-    Joi.array().items(PathnameValidator.required()),
+    PathnameSchema.required(),
+    Joi.array().items(PathnameSchema.required()),
   ),
 });
 

--- a/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
@@ -6,24 +6,12 @@
  */
 
 import * as Joi from '@hapi/joi';
-import {isValidPathname} from '@docusaurus/utils';
 import {RedirectMetadata} from './types';
-
-export const PathnameValidator = Joi.string()
-  .custom((val) => {
-    if (!isValidPathname(val)) {
-      throw new Error();
-    } else {
-      return val;
-    }
-  })
-  .message(
-    '{{#label}} is not a valid pathname. Pathname should start with / and not contain any domain or query string',
-  );
+import {PathnameSchema} from '@docusaurus/utils-validation';
 
 const RedirectSchema = Joi.object<RedirectMetadata>({
-  from: PathnameValidator.required(),
-  to: PathnameValidator.required(),
+  from: PathnameSchema.required(),
+  to: PathnameSchema.required(),
 });
 
 export function validateRedirect(redirect: RedirectMetadata): void {

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/pluginOptionSchema.test.ts
@@ -22,7 +22,7 @@ test('should accept correctly defined user options', () => {
     ...DEFAULT_OPTIONS,
     feedOptions: {type: 'rss', title: 'myTitle'},
     path: 'not_blog',
-    routeBasePath: '',
+    routeBasePath: 'myBlog',
     postsPerPage: 5,
     include: ['api/*', 'docs/*'],
   };
@@ -37,7 +37,7 @@ test('should accept correctly defined user options', () => {
 test('should accept valid user options', async () => {
   const userOptions = {
     ...DEFAULT_OPTIONS,
-    routeBasePath: '',
+    routeBasePath: 'myBlog',
     beforeDefaultRemarkPlugins: [],
     beforeDefaultRehypePlugins: [markdownPluginsFunctionStub],
     remarkPlugins: [[markdownPluginsFunctionStub, {option1: '42'}]],

--- a/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
@@ -35,7 +35,10 @@ export const DEFAULT_OPTIONS = {
 
 export const PluginOptionSchema = Joi.object({
   path: Joi.string().default(DEFAULT_OPTIONS.path),
-  routeBasePath: Joi.string().allow('').default(DEFAULT_OPTIONS.routeBasePath),
+  routeBasePath: Joi.string()
+    // '' not allowed, see https://github.com/facebook/docusaurus/issues/3374
+    // .allow('')
+    .default(DEFAULT_OPTIONS.routeBasePath),
   include: Joi.array().items(Joi.string()).default(DEFAULT_OPTIONS.include),
   postsPerPage: Joi.number()
     .integer()

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -49,7 +49,10 @@ const VersionsOptionsSchema = Joi.object()
 export const OptionsSchema = Joi.object({
   path: Joi.string().default(DEFAULT_OPTIONS.path),
   editUrl: URISchema,
-  routeBasePath: Joi.string().allow('').default(DEFAULT_OPTIONS.routeBasePath),
+  routeBasePath: Joi.string()
+    // '' not allowed, see https://github.com/facebook/docusaurus/issues/3374
+    // .allow('') ""
+    .default(DEFAULT_OPTIONS.routeBasePath),
   homePageId: Joi.string().optional(),
   include: Joi.array().items(Joi.string()).default(DEFAULT_OPTIONS.include),
   sidebarPath: Joi.string().allow('').default(DEFAULT_OPTIONS.sidebarPath),

--- a/packages/docusaurus-plugin-content-pages/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-pages/src/pluginOptionSchema.ts
@@ -14,7 +14,7 @@ import {
 
 export const DEFAULT_OPTIONS: PluginOptions = {
   path: 'src/pages', // Path to data on filesystem, relative to site dir.
-  routeBasePath: '', // URL Route.
+  routeBasePath: '/', // URL Route.
   include: ['**/*.{js,jsx,ts,tsx,md,mdx}'], // Extensions to include.
   mdxPageComponent: '@theme/MDXPage',
   remarkPlugins: [],

--- a/packages/docusaurus-utils-validation/package.json
+++ b/packages/docusaurus-utils-validation/package.json
@@ -16,6 +16,7 @@
     "@types/hapi__joi": "^17.1.2"
   },
   "dependencies": {
+    "@docusaurus/utils": "^2.0.0-alpha.62",
     "@hapi/joi": "17.1.1",
     "chalk": "^3.0.0"
   },

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import * as Joi from '@hapi/joi';
+import {isValidPathname} from '@docusaurus/utils';
 
 export const PluginIdSchema = Joi.string()
   .regex(/^[a-zA-Z_\-]+$/)
@@ -39,3 +40,15 @@ export const URISchema = Joi.alternatives(
     }
   }),
 );
+
+export const PathnameSchema = Joi.string()
+  .custom((val) => {
+    if (!isValidPathname(val)) {
+      throw new Error();
+    } else {
+      return val;
+    }
+  })
+  .message(
+    '{{#label}} is not a valid pathname. Pathname should start with / and not contain any domain or query string',
+  );

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -13,7 +13,7 @@ const allDocHomesPaths = [
   '/docs/next/',
   ...versions.slice(1).map((version) => `/docs/${version}/`),
 ];
-//
+
 const isDev = process.env.NODE_ENV === 'development';
 
 const isDeployPreview =

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -13,7 +13,7 @@ const allDocHomesPaths = [
   '/docs/next/',
   ...versions.slice(1).map((version) => `/docs/${version}/`),
 ];
-
+//
 const isDev = process.env.NODE_ENV === 'development';
 
 const isDeployPreview =


### PR DESCRIPTION
## Motivation

Allowing '' leads to errors (because of https://github.com/facebook/docusaurus/issues/3374)

It is documented to use '/' for docs only, blog only modes, and '' should not be used anyway so I don't consider this to be a breaking change, as users are supposed to follow our recommendations.

I would rather only accept values starting with / (using the Joi PathnameSchema), but that would be a breaking change.

'' was allowed recently but I think it was a mistake:

https://github.com/facebook/docusaurus/pull/3120
https://github.com/facebook/docusaurus/issues/3126