### PR TITLE
docs(v1, v2): Update Deploy to Vercel guide

### DIFF
--- a/docs/getting-started-publishing.md
+++ b/docs/getting-started-publishing.md
@@ -25,32 +25,32 @@ At this point, you can grab all of the files inside the `website/build` director
 
 ### Hosting on a Service:
 
-- [ZEIT Now](#using-zeit-now)
+- [Vercel](#using-vercel)
 - [GitHub Pages](#using-github-pages)
 - [Netlify](#hosting-on-netlify)
 - [Render](#hosting-on-render)
 
-### Using ZEIT Now
+### Using Vercel
 
-Deploying your Docusaurus project to [ZEIT Now](https://zeit.co/now) will provide you with [various benefits](https://zeit.co/now) in the areas of performance and ease of use.
+Deploying your Docusaurus project to [Vercel](https://vercel.com) will provide you with various benefits in the areas of performance and ease of use.
 
 Most importantly, however, deploying a Docusaurus project only takes a couple of seconds:
 
-1. First, install their [command-line interface](https://zeit.co/download):
+1. First, install their [command-line interface](https://vercel.com/download):
 
 ```bash
-npm i -g now
+npm i -g vercel
 ```
 
 2. Run a single command inside the root directory of your project:
 
 ```bash
-now
+vercel
 ```
 
 **That's all.** Your docs will automatically be deployed.
 
-> Note that the directory structure Now supports is slightly different from the default directory structure of a Docusaurus project - The `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the [now-examples repository for a Docusaurus project](https://github.com/zeit/now-examples/tree/master/docusaurus).
+> Note that the directory structure Now supports is slightly different from the default directory structure of a Docusaurus project - The `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the [now-examples repository for a Docusaurus project](https://github.com/vercel/vercel/tree/master/examples/docusaurus).
 
 ### Using GitHub Pages
 
@@ -289,9 +289,15 @@ steps:
     displayName: 'yarn install and build'
 ```
 
-### Hosting on ZEIT Now
+### Hosting on Vercel
 
-With [ZEIT Now](#using-zeit-now), you can deploy your site and connect it to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
+Deploying your Docusaurus project to [Vercel](https://vercel.com/) will provide you with [various benefits](https://vercel.com/) in the areas of performance and ease of use.
+
+To deploy your Docusaurus project with a [Vercel for Git Integration](https://vercel.com/docs/git-integrations), make sure it has been pushed to a Git repository.
+
+Import the project into Vercel using the [Import Flow](https://vercel.com/import/git). During the import, you will find all relevant options preconfigured for you; however, you can choose to change any of these options, a list of which can be found [here](https://vercel.com/docs/build-step#build-&-development-settings).
+
+After your project has been imported, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/platform/deployments#preview), and all changes made to the [Production Branch](https://vercel.com/docs/git-integrations#production-branch) (commonly "main") will result in a [Production Deployment](https://vercel.com/docs/platform/deployments#production).
 
 ### Hosting on Netlify
 

--- a/website/versioned_docs/version-2.0.0-alpha.62/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.62/deployment.md
@@ -286,23 +286,11 @@ Make sure to disable Netlify setting `Pretty URLs` to prevent lowercased URLs, u
 
 Deploying your Docusaurus project to [Vercel](https://vercel.com/) will provide you with [various benefits](https://vercel.com/) in the areas of performance and ease of use.
 
-Most importantly, however, deploying a Docusaurus project only takes a couple of seconds:
+To deploy your Docusaurus project with a [Vercel for Git Integration](https://vercel.com/docs/git-integrations), make sure it has been pushed to a Git repository.
 
-1. First, install their [command-line interface](https://vercel.com/download):
+Import the project into Vercel using the [Import Flow](https://vercel.com/import/git). During the import, you will find all relevant options preconfigured for you; however, you can choose to change any of these options, a list of which can be found [here](https://vercel.com/docs/build-step#build-&-development-settings).
 
-```bash
-npm i -g vercel
-```
-
-1. Run a single command inside the root directory of your project:
-
-```bash
-vercel
-```
-
-**That's all.** Your docs will automatically be deployed.
-
-Now you can connect your site to [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab) to automatically receive a new deployment every time you push a commit.
+After your project has been imported, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/platform/deployments#preview), and all changes made to the [Production Branch](https://vercel.com/docs/git-integrations#production-branch) (commonly "main") will result in a [Production Deployment](https://vercel.com/docs/platform/deployments#production).
 
 ## Deploying to Render
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Hello from the Vercel team again!

I have added an additional update to the [Deploy to Vercel](https://v2.docusaurus.io/docs/deployment#deploying-to-vercel) docs — it looks like the latest version-2.0.0-alpha.62 is not getting the latest changes I made to previous versions of  Docusaurus 2 documentation. Is this process automated somewhere?

I have also added changes to related docs in the latest Docusaurus 1 documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
