### PR TITLE
fix(v2): DocSearch should keep working after a new release (part 2/2)

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -235,8 +235,7 @@ module.exports = {
       apiKey: '47ecd3b21be71c5822571b9f59e52544',
       indexName: 'docusaurus-2',
       searchParameters: {
-        // facetFilters: [`version:latest`],
-        facetFilters: [`version:${versions[0]}`],
+        facetFilters: [`version:latest`],
       },
     },
     navbar: {


### PR DESCRIPTION

## Motivation

Enable the new versions:latest Algolia search facet after it has been indexed.

Waiting for Algolia indexation to happen.

Follow-up of PR https://github.com/facebook/docusaurus/pull/3393