### PR TITLE
fix(v2): reset sidebar state on sidebar changes

### DIFF
--- a/packages/docusaurus-theme-bootstrap/src/theme/DocPage/index.js
+++ b/packages/docusaurus-theme-bootstrap/src/theme/DocPage/index.js
@@ -23,7 +23,11 @@ function DocPageContent({currentDocRoute, versionMetadata, children}) {
       <div className="d-flex vh-100 overflow-hidden">
         {sidebar && (
           <div className="vh-100" role="complementary">
-            <DocSidebar path={currentDocRoute.path} sidebar={sidebar} />
+            <DocSidebar
+              key={sidebarName}
+              path={currentDocRoute.path}
+              sidebar={sidebar}
+            />
           </div>
         )}
         <main className="vh-100 w-100 d-flex flex-column align-items-center overflow-auto p-5">

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -69,6 +69,11 @@ function DocPageContent({
           {sidebar && (
             <div className={styles.docSidebarContainer} role="complementary">
               <DocSidebar
+                key={
+                  // Reset sidebar state on sidebar changes
+                  // See https://github.com/facebook/docusaurus/issues/3414
+                  sidebarName
+                }
                 sidebar={sidebar}
                 path={currentDocRoute.path}
                 sidebarCollapsible={


### PR DESCRIPTION
## Motivation

When rendering sidebar 1, and navigating to a page using sidebar 2, we should unmount/remount sidebar instead of trying to update it in place, or it can mess up with sidebar state.

Should fix https://github.com/facebook/docusaurus/issues/3414

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

preview

