### PR TITLE
docs(v2): minor typo fix

### DIFF
--- a/website/src/pages/examples/markdownPageExample.md
+++ b/website/src/pages/examples/markdownPageExample.md
@@ -53,7 +53,7 @@ import Chapter2 from './_chapter2.mdx';
 <Chapter2 />;
 ```
 
-import Chapter1 from './\_chapter1.mdx';
+import Chapter1 from './\_chapter1.md';
 
 <Chapter1/>
 

--- a/website/src/pages/examples/markdownPageExample.md
+++ b/website/src/pages/examples/markdownPageExample.md
@@ -53,7 +53,7 @@ import Chapter2 from './_chapter2.mdx';
 <Chapter2 />;
 ```
 
-import Chapter1 from './\_chapter2.mdx';
+import Chapter1 from './\_chapter1.mdx';
 
 <Chapter1/>
 


### PR DESCRIPTION
Markdown import example in website/src/pages/examples/markdownPageExample.md imports the wrong chapter.
See this comment https://github.com/facebook/docusaurus/commit/f234c407f1f279a76ab388df2bab4f33e8eadf85#r42067403

### Have you read the [ Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
(Yes)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
