### PR TITLE
feat(v2): add option to add trailing slash to urls in sitemap

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -19,6 +19,7 @@ describe('createSitemap', () => {
         cacheTime: 600,
         changefreq: 'daily',
         priority: 0.7,
+        trailingSlash: false,
       },
     );
     expect(sitemap.toString()).toContain(
@@ -44,8 +45,31 @@ describe('createSitemap', () => {
         cacheTime: 600,
         changefreq: 'daily',
         priority: 0.7,
+        trailingSlash: false,
       },
     );
     expect(sitemap.toString()).not.toContain('404');
+  });
+
+  test('add trailing slash', () => {
+    const sitemap = createSitemap(
+      {
+        url: 'https://example.com',
+      } as DocusaurusConfig,
+      ['/', '/test'],
+      {
+        cacheTime: 600,
+        changefreq: 'daily',
+        priority: 0.7,
+        trailingSlash: true,
+      },
+    );
+
+    expect(sitemap.toString()).toContain(
+      '<loc>https://example.com/test/</loc>',
+    );
+    expect(sitemap.toString()).not.toContain(
+      '<loc>https://example.com/test</loc>',
+    );
   });
 });

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/pluginOptionSchema.test.ts
@@ -29,6 +29,7 @@ describe('normalizeSitemapPluginOptions', () => {
       cacheTime: 300,
       changefreq: 'yearly',
       priority: 0.9,
+      trailingSlash: false,
     };
     const {value} = await PluginOptionSchema.validate(userOptions);
     expect(value).toEqual(userOptions);

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -24,7 +24,9 @@ export default function createSitemap(
     .map(
       (routesPath) =>
         ({
-          url: routesPath,
+          url: `${routesPath}${
+            options.trailingSlash && routesPath !== '/' ? '/' : ''
+          }`,
           changefreq: options.changefreq,
           priority: options.priority,
         } as SitemapItemOptions),

--- a/packages/docusaurus-plugin-sitemap/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-sitemap/src/pluginOptionSchema.ts
@@ -11,6 +11,7 @@ export const DEFAULT_OPTIONS: Required<PluginOptions> = {
   cacheTime: 600 * 1000, // 600 sec - cache purge period.
   changefreq: 'weekly',
   priority: 0.5,
+  trailingSlash: false,
 };
 
 export const PluginOptionSchema = Joi.object({
@@ -19,4 +20,5 @@ export const PluginOptionSchema = Joi.object({
     .valid('always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never')
     .default(DEFAULT_OPTIONS.changefreq),
   priority: Joi.number().min(0).max(1).default(DEFAULT_OPTIONS.priority),
+  trailingSlash: Joi.bool().default(false),
 });

--- a/packages/docusaurus-plugin-sitemap/src/types.ts
+++ b/packages/docusaurus-plugin-sitemap/src/types.ts
@@ -9,4 +9,5 @@ export interface PluginOptions {
   cacheTime?: number;
   changefreq?: string;
   priority?: number;
+  trailingSlash?: boolean;
 }

--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -517,6 +517,7 @@ module.exports = {
         cacheTime: 600 * 1000, // 600 sec - cache purge period
         changefreq: 'weekly',
         priority: 0.5,
+        trailingSlash: false,
       },
     ],
   ],


### PR DESCRIPTION
## Motivation

Depending on how the website is hosted, the current sitemap generated by the plugin might create URLs that respond with a `301`. This PR allows the user to generate the sitemap with trailing slashes, making sure that the sitemap will only contain links that respond with `200`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New test for the `trailingSlash` option.

## Related PRs

N/A
