### PR TITLE
fix(v2): normalizeUrl edge cases

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -259,6 +259,22 @@ describe('load utils', () => {
   test('normalizeUrl', () => {
     const asserts = [
       {
+        input: ['/', ''],
+        output: '/',
+      },
+      {
+        input: ['', '/'],
+        output: '/',
+      },
+      {
+        input: ['/'],
+        output: '/',
+      },
+      {
+        input: [''],
+        output: '',
+      },
+      {
         input: ['/', '/'],
         output: '/',
       },

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -322,6 +322,34 @@ describe('load utils', () => {
         input: ['http://foobar.com', '', 'test', '/'],
         output: 'http://foobar.com/test/',
       },
+      {
+        input: ['/', '', 'hello', '', '/', '/', '', '/', '/world'],
+        output: '/hello/world',
+      },
+      {
+        input: ['', '', '/tt', 'ko', 'hello'],
+        output: '/tt/ko/hello',
+      },
+      {
+        input: ['', '///hello///', '', '///world'],
+        output: '/hello/world',
+      },
+      {
+        input: ['', '/hello/', ''],
+        output: '/hello/',
+      },
+      {
+        input: ['', '/', ''],
+        output: '/',
+      },
+      {
+        input: ['///', '///'],
+        output: '/',
+      },
+      {
+        input: ['/', '/hello/world/', '///'],
+        output: '/hello/world/',
+      },
     ];
     asserts.forEach((testCase) => {
       expect(normalizeUrl(testCase.input)).toBe(testCase.output);

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -306,15 +306,16 @@ export function normalizeUrl(rawUrls: string[]): string {
       continue;
     }
 
-    if (i > 0) {
-      // Removing the starting slashes for each component but the first.
-      component = component.replace(/^[/]+/, '');
+    if (component !== '/') {
+      if (i > 0) {
+        // Removing the starting slashes for each component but the first.
+        component = component.replace(/^[/]+/, '');
+      }
+
+      // Removing the ending slashes for each component but the last.
+      // For the last component we will combine multiple slashes to a single one.
+      component = component.replace(/[/]+$/, i < urls.length - 1 ? '' : '/');
     }
-
-    // Removing the ending slashes for each component but the last.
-    // For the last component we will combine multiple slashes to a single one.
-    component = component.replace(/[/]+$/, i < urls.length - 1 ? '' : '/');
-
     resultArray.push(component);
   }
 

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -282,6 +282,9 @@ export function normalizeUrl(rawUrls: string[]): string {
   const urls = rawUrls;
   const resultArray = [];
 
+  let hasStartingSlash = false;
+  let hasEndingSlash = false;
+
   // If the first part is a plain protocol, we combine it with the next part.
   if (urls[0].match(/^[^/:]+:\/*$/) && urls.length > 1) {
     const first = urls.shift();
@@ -302,6 +305,9 @@ export function normalizeUrl(rawUrls: string[]): string {
     }
 
     if (component === '') {
+      if (i === urls.length - 1 && hasEndingSlash) {
+        resultArray.push('/');
+      }
       // eslint-disable-next-line
       continue;
     }
@@ -309,13 +315,20 @@ export function normalizeUrl(rawUrls: string[]): string {
     if (component !== '/') {
       if (i > 0) {
         // Removing the starting slashes for each component but the first.
-        component = component.replace(/^[/]+/, '');
+        component = component.replace(
+          /^[/]+/,
+          // Special case where the first element of rawUrls is empty ["", "/hello"] => /hello
+          component[0] === '/' && !hasStartingSlash ? '/' : '',
+        );
       }
 
+      hasEndingSlash = component[component.length - 1] === '/';
       // Removing the ending slashes for each component but the last.
       // For the last component we will combine multiple slashes to a single one.
       component = component.replace(/[/]+$/, i < urls.length - 1 ? '' : '/');
     }
+
+    hasStartingSlash = true;
     resultArray.push(component);
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR fixes edge cases for the `normalizeUrl` util function like the ones introduced in the unit tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan


This PR fixes #3374 and undo #3377.

New unit tests added: 

```
      {
        input: ['/', ''],
        output: '/',
      },
      {
        input: ['', '/'],
        output: '/',
      },
      {
        input: ['/'],
        output: '/',
      },
      {
        input: [''],
        output: '',
      }
```

The thing was that for each part of our `rawUrls` (except for the last one)  we removed the `/` in:
```
component.replace(/[/]+$/, i < urls.length - 1 ? '' : ‘/‘)
```

I added a condition to check if the current element is a slash and if so we can continue the process.

Here is the **new logic inside our for loop**:

<p align="center">
<img src="https://user-images.githubusercontent.com/32459935/92623068-15b74480-f2c6-11ea-90ae-0ae08d6078b2.png" width="700" />
</p>

Another workaround would be to add a condition to the returned string like: `return str === '' ? '/'  : str` as I think this change target only an edge case.

**NOTE**: I am note sure about this solution ! It would be great if someone could give me their opinion on this 👍

## Related PRs

This PR undo the #3377 changes.
