### PR TITLE
feat(v2): add style property to theme-classic navbar

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
@@ -33,6 +33,7 @@ describe('themeConfig', () => {
       },
       image: 'img/docusaurus-soc.png',
       navbar: {
+        style: 'primary',
         hideOnScroll: true,
         title: 'Docusaurus',
         logo: {

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -43,7 +43,12 @@ function Navbar(): JSX.Element {
   const {
     siteConfig: {
       themeConfig: {
-        navbar: {title = '', items = [], hideOnScroll = false} = {},
+        navbar: {
+          title = '',
+          items = [],
+          hideOnScroll = false,
+          style = undefined,
+        } = {},
         colorMode: {disableSwitch: disableColorModeSwitch = false} = {},
       },
     },
@@ -83,7 +88,9 @@ function Navbar(): JSX.Element {
   return (
     <nav
       ref={navbarRef}
-      className={clsx('navbar', 'navbar--light', 'navbar--fixed-top', {
+      className={clsx('navbar', 'navbar--fixed-top', {
+        'navbar--dark': style === 'dark',
+        'navbar--primary': style === 'primary',
         'navbar-sidebar--show': sidebarShown,
         [styles.navbarHideable]: hideOnScroll,
         [styles.navbarHidden]: !isNavbarVisible,

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -189,6 +189,7 @@ const ThemeConfigSchema = Joi.object({
     isCloseable: Joi.bool().default(true),
   }).optional(),
   navbar: Joi.object({
+    style: Joi.string().equal('dark', 'primary'),
     hideOnScroll: Joi.bool().default(false),
     // TODO temporary (@alpha-58)
     links: Joi.any().forbidden().messages({

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -240,6 +240,7 @@ module.exports = {
       },
     },
     navbar: {
+      style: 'primary',
       hideOnScroll: true,
       title: 'Docusaurus',
       logo: {

--- a/website/versioned_docs/version-2.0.0-alpha.63/theme-classic.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/theme-classic.md
@@ -304,6 +304,24 @@ module.exports = {
 };
 ```
 
+### Navbar force style
+
+This might be useful if you prefer static Navbar design without disabling the theme switching ability. You can force single theme to always apply no matter which theme user have selected.
+
+Currently, two possible style options are `dark` and `primary`.
+
+```js {5} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  themeConfig: {
+    navbar: {
+      style: 'primary',
+    },
+    // ...
+  },
+};
+```
+
 <!--
 
 ## Footer


### PR DESCRIPTION
## Motivation

There are Docusaurus users which will prefer the static Navbar design. The idea for this was based on Footer `style` property, but due to `infima` restrictions this PR evolved a bit.

The current implementation offers users two style override options - `dark` and `primary`. There are based on the classes that `infima` provides (I'm not familiar with this package at all). 

I would be wisely to implement `light` theme too, but at this moment I'm not sure how to o this cleanly (what's the best way). I have also removed `'navbar--light'` class because it was always (so wrongly) included and there is no CSS code associated with that class.

This PR also updates the docs and adds new section related to this property.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Feature has been test on the local Docusaurus V2 website.

## Preview

### Dark
<img width="1218" alt="dforcedark" src="https://user-images.githubusercontent.com/719641/92820769-9c554a00-f3ca-11ea-855a-e3f0b0ff34bd.png">

### Primary
<img width="1222" alt="Screenshot 2020-09-11 005013" src="https://user-images.githubusercontent.com/719641/92820805-a9723900-f3ca-11ea-909f-0da4919a4c6e.png">
