### PR TITLE
fix(v2): fix theme-classic announcement bar closeable style

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -54,6 +54,8 @@
   }
   .announcementBarContent {
     width: auto;
+  }
+  .announcementBarCloseable {
     margin-right: 35px;
   }
 }


### PR DESCRIPTION
## Motivation

Refs #3388 

The theme-classic announcement bar CSS style in the media query has not been correctly updated in the mentioned above PR. This results in additional, unnecessary margin on some devices when `isCloseable` property was set to `false`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local run of Docusuaurs V2 website.

## Related PRs

* #3388 
