### PR TITLE
fix(v2): fix empty link error message

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`transformAsset plugin fail if asset url is absent 1`] = `"Markdown link url is mandatory. filePath=packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/fixtures/noUrl.md, title=null"`;
+exports[`transformAsset plugin fail if asset url is absent 1`] = `"Markdown link url is mandatory. filePath=packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/fixtures/noUrl.md, title=asset, line=1"`;
 
 exports[`transformAsset plugin pathname protocol 1`] = `
 "[asset](pathname:///asset/unchecked.pdf)

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.js
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.js
@@ -119,10 +119,16 @@ async function convertToAssetLinkIfNeeded({
 
 async function processLinkNode({node, index, parent, filePath, staticDir}) {
   if (!node.url) {
+    // try to improve error feedback
+    // see https://github.com/facebook/docusaurus/issues/3309#issuecomment-690371675
+    const title =
+      node.title || (node.children[0] && node.children[0].value) || '?';
+    const line =
+      (node.position && node.position.start && node.position.start.line) || '?';
     throw new Error(
       `Markdown link url is mandatory. filePath=${toRelativePath(
         filePath,
-      )}, title=${node.title}`,
+      )}, title=${title}, line=${line}`,
     );
   }
 


### PR DESCRIPTION
## Motivation


Fix and improve existing error message when a markdown link is empty

https://github.com/facebook/docusaurus/issues/3309#issuecomment-689595523

![image](https://user-images.githubusercontent.com/749374/92915117-8d9f7f00-f42c-11ea-907f-d2cf61d7146a.png)


After:

![image](https://user-images.githubusercontent.com/749374/92915147-93956000-f42c-11ea-9880-fb3892fb3ce1.png)
