### PR TITLE
fix(v2): Correctly resolve sw.js path on windows

### DIFF
--- a/packages/docusaurus-plugin-pwa/src/index.js
+++ b/packages/docusaurus-plugin-pwa/src/index.js
@@ -73,7 +73,7 @@ function plugin(context, options) {
         plugins: [
           new webpack.EnvironmentPlugin({
             PWA_DEBUG: debug,
-            PWA_SERVICE_WORKER_URL: path.resolve(
+            PWA_SERVICE_WORKER_URL: path.posix.resolve(
               `${config.output.publicPath || '/'}`,
               'sw.js',
             ),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -118,7 +118,7 @@ module.exports = {
           {
             tagName: 'link',
             rel: 'manifest',
-            href: '/manifest.json',
+            href: 'manifest.json',
           },
           {
             tagName: 'meta',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -113,7 +113,7 @@ module.exports = {
           {
             tagName: 'link',
             rel: 'icon',
-            href: '/img/docusaurus.png',
+            href: 'img/docusaurus.png',
           },
           {
             tagName: 'link',
@@ -138,18 +138,18 @@ module.exports = {
           {
             tagName: 'link',
             rel: 'apple-touch-icon',
-            href: '/img/docusaurus.png',
+            href: 'img/docusaurus.png',
           },
           {
             tagName: 'link',
             rel: 'mask-icon',
-            href: '/img/docusaurus.svg',
+            href: 'img/docusaurus.svg',
             color: 'rgb(62, 204, 94)',
           },
           {
             tagName: 'meta',
             name: 'msapplication-TileImage',
-            content: '/img/docusaurus.png',
+            content: 'img/docusaurus.png',
           },
           {
             tagName: 'meta',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

Apologies, messed up here (#3431 - first attempt at a PR on GitHub) and thought it was best to re-submit.

## Motivation

To ensure that the service worker is correctly referenced on builds on Windows operating systems. I created an issue and described the problem more here - #3420

Added change to docusaurus.config.js as per @slorber's comment [here](https://github.com/facebook/docusaurus/pull/3431#issuecomment-690995916)

I don't think the posix path function in utils is going to strip the drive letter off the path if it was used, so the problem would persist because path.resolve() will always include it and the sw.js should always be relative to the root directory. The posix path function, at least to me, appear to be fixing directory separators.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested on Windows and MacOS.

`yarn start`

## Related PRs

N/A
