### PR TITLE
fix(v2): docusaurus 2 PWA should work under baseurl (deploy previews)

### DIFF
--- a/website/static/manifest.json
+++ b/website/static/manifest.json
@@ -4,46 +4,46 @@
   "theme_color": "#2196f3",
   "background_color": "#424242",
   "display": "standalone",
-  "scope": "/",
-  "start_url": "/",
+  "scope": "",
+  "start_url": "",
   "icons": [
     {
-      "src": "/img/icons/icon-72x72.png",
+      "src": "img/icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/icon-96x96.png",
+      "src": "img/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/icon-128x128.png",
+      "src": "img/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/icon-144x144.png",
+      "src": "img/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/icon-152x152.png",
+      "src": "img/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/icon-192x192.png",
+      "src": "img/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/icon-384x384.png",
+      "src": "img/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png"
     },
     {
-      "src": "/img/icons/icon-512x512.png",
+      "src": "img/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Motivation

It currently does not work in deploy previews (while it should) as we moved under baseUrl the classic theme deployment.

I think the manifests paths should be relative instead (need https to test so deploy preview help to test this)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Deploy preview
