### PR TITLE
fix(v2): fixing typo in error message

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -354,7 +354,7 @@ describe('simple site', () => {
         }),
       );
     }).toThrowErrorMatchingInlineSnapshot(
-      `"The docs homepage (homePageId=homePageId) is not allowed to have a frontmatter slug=/x/y => you have to chooser either homePageId or slug, not both"`,
+      `"The docs homepage (homePageId=homePageId) is not allowed to have a frontmatter slug=/x/y => you have to choose either homePageId or slug, not both"`,
     );
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -142,7 +142,7 @@ export function processDocMetadata({
   const isDocsHomePage = unversionedId === (homePageId ?? '_index');
   if (frontMatter.slug && isDocsHomePage) {
     throw new Error(
-      `The docs homepage (homePageId=${homePageId}) is not allowed to have a frontmatter slug=${frontMatter.slug} => you have to chooser either homePageId or slug, not both`,
+      `The docs homepage (homePageId=${homePageId}) is not allowed to have a frontmatter slug=${frontMatter.slug} => you have to choose either homePageId or slug, not both`,
     );
   }
 


### PR DESCRIPTION
Simple Typo fix of an error Message. 

Original Message
```
Error: The docs homepage (homePageId=some-id) is not allowed to have a frontmatter slug=/ => you have to chooser either homePageId or slug, not both
```

Fixing here the word **chooser** to **choose**


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes