### PR TITLE
chore(v2): fix theme classic navbar style docs

### DIFF
--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -318,6 +318,24 @@ module.exports = {
 };
 ```
 
+### Navbar style
+
+You can set the static Navbar style without disabling the theme switching ability. The selected style will always apply no matter which theme user have selected.
+
+Currently, there are two possible style options: `dark` and `primary` (based on the `--ifm-color-primary` color). You can see the styles preview in the [Infima documentation](https://facebookincubator.github.io/infima/docs/components/navbar/).
+
+```js {5} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  themeConfig: {
+    navbar: {
+      style: 'primary',
+    },
+    // ...
+  },
+};
+```
+
 <!--
 
 ## Footer

--- a/website/versioned_docs/version-2.0.0-alpha.63/theme-classic.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/theme-classic.md
@@ -304,24 +304,6 @@ module.exports = {
 };
 ```
 
-### Navbar style
-
-You can set the static Navbar style without disabling the theme switching ability. The selected style will always apply no matter which theme user have selected.
-
-Currently, there are two possible style options: `dark` and `primary` (based on the `--ifm-color-primary` color). You can see the styles preview in the [Infima documentation](https://facebookincubator.github.io/infima/docs/components/navbar/).
-
-```js {5} title="docusaurus.config.js"
-module.exports = {
-  // ...
-  themeConfig: {
-    navbar: {
-      style: 'primary',
-    },
-    // ...
-  },
-};
-```
-
 <!--
 
 ## Footer

--- a/website/versioned_docs/version-2.0.0-alpha.64/theme-classic.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/theme-classic.md
@@ -318,6 +318,24 @@ module.exports = {
 };
 ```
 
+### Navbar style
+
+You can set the static Navbar style without disabling the theme switching ability. The selected style will always apply no matter which theme user have selected.
+
+Currently, there are two possible style options: `dark` and `primary` (based on the `--ifm-color-primary` color). You can see the styles preview in the [Infima documentation](https://facebookincubator.github.io/infima/docs/components/navbar/).
+
+```js {5} title="docusaurus.config.js"
+module.exports = {
+  // ...
+  themeConfig: {
+    navbar: {
+      style: 'primary',
+    },
+    // ...
+  },
+};
+```
+
 <!--
 
 ## Footer


### PR DESCRIPTION
## Motivation

Refs #3432

This PR fixes the theme classic navbar style docs. The section has been incorrectly added to the versioned docs instead of current ones (which make the section not visible in the current docs). 

The `alpha-63` changes has been reverted and the section has been added to `alpha-64` and `next` docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local test run on Docuusuaurus V2 website.

## Related PRs

* #3432
