### PR TITLE
fix(v2): allow relative URLs in URISchema

### DIFF
--- a/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
+++ b/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
@@ -60,4 +60,4 @@ exports[`validation schemas RemarkPluginsSchema: for value=false 1`] = `"\\"valu
 
 exports[`validation schemas RemarkPluginsSchema: for value=null 1`] = `"\\"value\\" must be an array"`;
 
-exports[`validation schemas URISchema: for value="invalidURL" 1`] = `"\\"value\\" does not match any of the allowed types"`;
+exports[`validation schemas URISchema: for value="spaces are invalid in a URL" 1`] = `"\\"value\\" does not match any of the allowed types"`;

--- a/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
@@ -111,12 +111,16 @@ describe('validation schemas', () => {
   test('URISchema', () => {
     const validURL = 'https://docusaurus.io';
     const doubleHash = 'https://docusaurus.io#github#/:';
-    const invalidURL = 'invalidURL';
+    const invalidURL = 'spaces are invalid in a URL';
+    const relativeURL = 'relativeURL';
+    const relativeURLWithParent = '../relativeURLWithParent';
     const urlFromIssue = 'https://riot.im/app/#/room/#ligo-public:matrix.org';
     const {testFail, testOK} = createTestHelpers({schema: URISchema});
     testOK(validURL);
     testOK(doubleHash);
     testFail(invalidURL);
+    testOK(relativeURL);
+    testOK(relativeURLWithParent);
     testOK(urlFromIssue);
   });
 });

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -26,7 +26,7 @@ export const RehypePluginsSchema = MarkdownPluginsSchema;
 export const AdmonitionsSchema = Joi.object().default({});
 
 export const URISchema = Joi.alternatives(
-  Joi.string().uri(),
+  Joi.string().uri({allowRelative: true}),
   Joi.custom((val, helpers) => {
     try {
       const url = new URL(val);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, **relative links** are invalid when configuring **navbar items**.

We currently run our documentation at a sub-path of our top level domain, `https://example.org/docs`. For the **logo**, it is valid to add a relative link up to our homepage:

```js
module.exports = {
  themeConfig: {
    navbar: {
      logo: {
        href: "..",
        target: "_top",
        src: 'img/logo_black.svg',
        srcDark: 'img/logo_white.svg',
      }
...
```

This behaves well, linking up to the relative parent page and forcing a full page reload.

I would also like the following configuration to be valid, for navbar **items**:

```js
module.exports = {
  themeConfig: {
    navbar: {
      items: [{
            href: "../sibling_path",
            target: "_top",
            label: "Sibling Application",
            position: "right"
      }]
...
```

This is currently not possible to achieve within `themeConfig.navbar.items`, as an `item`s `href` value is [more strictly validated with URISchema](https://github.com/facebook/docusaurus/blob/086bee287d4f50246afbf5d09d243876b7b7df03/packages/docusaurus-theme-classic/src/validateThemeConfig.js#L37), disallowing relative URLs.

```log
A validation error occured.
The validation system was added recently to Docusaurus as an attempt to avoid user configuration errors.
We may have made some mistakes.
If you think your configuration is valid and should keep working, please open a bug report.

ValidationError: "navbar.items[2].href" does not match any of the allowed types
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Validation unit tests were updated to demonstrate that relative URLs can be configured for `URIScheme`, which is used to validate `ThemeConfig`.

The existing test case was updated to a legitimately invalid URL.

This change will be _less strict_ than master's validation, [as documented by Joi](https://joi.dev/api/?v=17.2.1#stringurioptions).

## Related PRs

I do not believe this requires any documentation changes.
