### PR TITLE
fix: add serve to internalCommand

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -194,7 +194,7 @@ cli.arguments('<command>').action((cmd) => {
 });
 
 function isInternalCommand(command) {
-  return ['start', 'build', 'swizzle', 'deploy'].includes(command);
+  return ['start', 'build', 'swizzle', 'deploy', 'serve'].includes(command);
 }
 
 if (!isInternalCommand(process.argv.slice(2)[0])) {


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Right now `docusaurus serve my-dir` doesn't work because it's not registered as an internal command, thus always forced to invoked w/ `path.resolve('.')`. This fixes that

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manually verified in formatjs

## Related PRs


