### PR TITLE
feat(v2): add optional custom wrapper class name for pages based on theme classic Layout

### DIFF
--- a/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
+++ b/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
@@ -13,6 +13,7 @@ declare module '@theme/MDXPage' {
       readonly frontMatter: {
         readonly title: string;
         readonly description: string;
+        readonly wrapperClassName: string;
       };
       readonly metadata: {readonly permalink: string};
       readonly rightToc: readonly MarkdownRightTableOfContents[];

--- a/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
+++ b/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
@@ -13,7 +13,7 @@ declare module '@theme/MDXPage' {
       readonly frontMatter: {
         readonly title: string;
         readonly description: string;
-        readonly wrapperClassName: string;
+        readonly wrapperClassName?: string;
       };
       readonly metadata: {readonly permalink: string};
       readonly rightToc: readonly MarkdownRightTableOfContents[];

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import clsx from 'clsx';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -43,6 +44,7 @@ function Layout(props: Props): JSX.Element {
     image,
     keywords,
     permalink,
+    wrapperClassName,
   } = props;
   const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
   const metaImage = image || defaultImage;
@@ -87,7 +89,7 @@ function Layout(props: Props): JSX.Element {
 
       <AnnouncementBar />
       <Navbar />
-      <div className="main-wrapper">{children}</div>
+      <div className={clsx('main-wrapper', wrapperClassName)}>{children}</div>
       {!noFooter && <Footer />}
     </Providers>
   );

--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
@@ -14,11 +14,15 @@ import type {Props} from '@theme/MDXPage';
 function MDXPage(props: Props): JSX.Element {
   const {content: MDXPageContent} = props;
   const {frontMatter, metadata} = MDXPageContent;
-  const {title, description} = frontMatter;
+  const {title, description, wrapperClassName} = frontMatter;
   const {permalink} = metadata;
 
   return (
-    <Layout title={title} description={description} permalink={permalink}>
+    <Layout
+      title={title}
+      description={description}
+      permalink={permalink}
+      wrapperClassName={wrapperClassName}>
       <main>
         <div className="container margin-vert--lg padding-vert--lg">
           <MDXProvider components={MDXComponents}>

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -245,6 +245,7 @@ declare module '@theme/Layout' {
     image?: string;
     keywords?: string[];
     permalink?: string;
+    wrapperClassName?: string;
   };
 
   const Layout: (props: Props) => JSX.Element;

--- a/website/src/pages/examples/markdownPageExample.md
+++ b/website/src/pages/examples/markdownPageExample.md
@@ -1,6 +1,7 @@
 ---
 title: Markdown Page example title
 description: Markdown Page example description
+wrapperClassName: docusaurus-markdown-example
 ---
 
 # Markdown page


### PR DESCRIPTION
## Motivation

Some custom pages may require different layout or additional customizations to the main page wrapper.

This small PR introduces an ability to specify an optional, custom `wrapperClassName` to the theme classic `Layout` component.

I have **NOT** updated the docs because I was not able to find the page which describes all other optional `Layout` props. ["Theme classic"](https://v2.docusaurus.io/docs/theme-classic) and ["Creating pages"](https://v2.docusaurus.io/docs/creating-pages) only briefly mention `Layout` usage. The most properties is used in the ["Migration guide"](https://v2.docusaurus.io/docs/migrating-from-v1-to-v2#pages) but still without a description.

I can add the note about this feature if you will be able to tell me where to put it. Alternatively, I can (in a later time) try to add `Layout` component related section to the Theme Classic page. 🙂 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Feature has been tested with the local Docusaurus V2 website.
<img width="367" alt="Screenshot 2020-09-16 124227" src="https://user-images.githubusercontent.com/719641/93327524-c370a900-f81a-11ea-9123-d6ec8383aa1d.png">

## Related PRs

* react-native-website-migration/react-native-website#23
