### PR TITLE
docs(v2): adding and specifying powershell and cmd for deployment in windows section

### DIFF
--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -94,7 +94,7 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash'}, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ]}> <TabItem value="bash">
+<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash', }, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ] }><TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -102,8 +102,12 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 
 **Windows**
 
-```batch
+```batch title="cmd"
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
+```
+
+```powershell title="powershell"
+cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
 ```
 
 ### Triggering deployment with GitHub Actions

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -94,21 +94,28 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-**Bash**
+<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash'}, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ]}> <TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
 ```
 
-**Windows**
+  </TabItem>
+  <TabItem value="powershell">
 
-```batch title="cmd"
+```powershell
+cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
+```
+
+  </TabItem>
+  <TabItem value="cmd">
+
+```batch
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
-```powershell title="powershell"
-cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
-```
+  </TabItem>
+</Tabs>
 
 ### Triggering deployment with GitHub Actions
 

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -94,27 +94,27 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', }, ]}> <TabItem value="bash">
+<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
 ```
 
-  </TabItem>
-  <TabItem value="windows">
+</TabItem>
+<TabItem value="windows">
 
 ```batch
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
-  </TabItem>
-  <TabItem value="powershell">
+</TabItem>
+<TabItem value="powershell">
 
 ```powershell
 cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
 ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ### Triggering deployment with GitHub Actions

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -94,10 +94,17 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash', }, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ] }><TabItem value="bash">
+<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', }, ]}> <TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
+```
+
+  </TabItem>
+  <TabItem value="windows">
+
+```batch
+cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
   </TabItem>
@@ -105,13 +112,6 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 
 ```powershell
 cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
-```
-
-  </TabItem>
-  <TabItem value="cmd">
-
-```batch
-cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
   </TabItem>

--- a/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
@@ -102,8 +102,12 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 
 **Windows**
 
-```batch
+```batch title="cmd"
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
+```
+
+```powershell title="powershell"
+cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
 ```
 
 ### Triggering deployment with GitHub Actions

--- a/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
@@ -94,27 +94,27 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', }, ]}> <TabItem value="bash">
+<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
 ```
 
-  </TabItem>
-  <TabItem value="windows">
+</TabItem>
+<TabItem value="windows">
 
 ```batch
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
-  </TabItem>
-  <TabItem value="powershell">
+</TabItem>
+<TabItem value="powershell">
 
 ```powershell
 cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
 ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ### Triggering deployment with GitHub Actions

--- a/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
@@ -94,21 +94,28 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-**Bash**
+<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash', }, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ] }><TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
 ```
 
-**Windows**
+  </TabItem>
+  <TabItem value="powershell">
 
-```batch title="cmd"
+```powershell
+cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
+```
+
+  </TabItem>
+  <TabItem value="cmd">
+
+```batch
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
-```powershell title="powershell"
-cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
-```
+  </TabItem>
+</Tabs>
 
 ### Triggering deployment with GitHub Actions
 

--- a/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
@@ -94,10 +94,17 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash', }, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ] }><TabItem value="bash">
+<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', }, ]}> <TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
+```
+
+  </TabItem>
+  <TabItem value="windows">
+
+```batch
+cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
   </TabItem>
@@ -105,13 +112,6 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 
 ```powershell
 cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
-```
-
-  </TabItem>
-  <TabItem value="cmd">
-
-```batch
-cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
   </TabItem>

--- a/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
@@ -102,8 +102,12 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 
 **Windows**
 
-```batch
+```batch title="cmd"
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
+```
+
+```powershell title="powershell"
+cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
 ```
 
 ### Triggering deployment with GitHub Actions

--- a/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
@@ -94,27 +94,27 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', }, ]}> <TabItem value="bash">
+<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
 ```
 
-  </TabItem>
-  <TabItem value="windows">
+</TabItem>
+<TabItem value="windows">
 
 ```batch
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
-  </TabItem>
-  <TabItem value="powershell">
+</TabItem>
+<TabItem value="powershell">
 
 ```powershell
 cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
 ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ### Triggering deployment with GitHub Actions

--- a/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
@@ -94,21 +94,28 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-**Bash**
+<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash', }, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ] }><TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
 ```
 
-**Windows**
+  </TabItem>
+  <TabItem value="powershell">
 
-```batch title="cmd"
+```powershell
+cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
+```
+
+  </TabItem>
+  <TabItem value="cmd">
+
+```batch
 cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
-```powershell title="powershell"
-cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
-```
+  </TabItem>
+</Tabs>
 
 ### Triggering deployment with GitHub Actions
 

--- a/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
@@ -94,10 +94,17 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'bash', value: 'bash', }, { label: 'powershell', value: 'powershell', }, { label: 'cmd', value: 'cmd', }, ] }><TabItem value="bash">
+<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', }, ]}> <TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy
+```
+
+  </TabItem>
+  <TabItem value="windows">
+
+```batch
+cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
   </TabItem>
@@ -105,13 +112,6 @@ GIT_USER=<GITHUB_USERNAME> yarn deploy
 
 ```powershell
 cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
-```
-
-  </TabItem>
-  <TabItem value="cmd">
-
-```batch
-cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 ```
 
   </TabItem>


### PR DESCRIPTION
- Specified batch command is for cmd
- Added powershell as an option for deployment, changed outer quotes to single in deployment command
- This affects the following versioned docs:
  - 2.0.0-alpha.63
  - 2.0.0-alpha.64
  - Next (Dev)
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Refs: #3389

The documentation for deploying in a Windows environment may not be as specific as it needs to be, example issue: #3389. Because of this I have added a powershell command for Windows and have specified that one is for command prompt (title cmd) and the other is for PowerShell (title powershell). 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
1. ran `yarn build`
2. `cd website`
3. `yarn start`
4. Implemented changes
5. Confirmed changes were made on versioned docs specified above

**Current (before changes):**
![image](https://user-images.githubusercontent.com/47301461/93482921-14cd7680-f8b5-11ea-823e-bcd7328e9e2e.png)

**Proposed (after changes):**
![image](https://user-images.githubusercontent.com/47301461/93482312-6b868080-f8b4-11ea-805e-01511a48aed7.png)

## Related PRs.
N/A

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
