### PR TITLE
fix(v2): Show dropdown instead of a single button when there are two versions

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -30,7 +30,7 @@ export default function DocsVersionDropdownNavbarItem({
     // We don't want to render a version dropdown with 0 or 1 item
     // If we build the site with a single docs version (onlyIncludeVersions: ['1.0.0'])
     // We'd rather render a buttonb instead of a dropdown
-    if (versions.length <= 2) {
+    if (versions.length <= 1) {
       return undefined;
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Comment above the code says that `We don't want to render a version dropdown with 0 or 1 item`. However, the check below also include the case when we have 2 versions. I believe that this is a bug since we still want to show dropdown when there are two versions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally with only two versions left: current and alpha-64:

<img width="616" alt="Screen Shot 2020-09-22 at 10 59 36" src="https://user-images.githubusercontent.com/4290500/93899944-d542c800-fcc2-11ea-8614-fccae058379f.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
