### PR TITLE
docs: Fix simple typo, localy -> locally

### DIFF
--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -118,7 +118,7 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 
 ### `docusaurus serve`
 
-Serve your built website localy.
+Serve your built website locally.
 
 | Name | Default | Description |
 | --- | --- | --- |

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -15,7 +15,7 @@ You can deploy your site to static site hosting services such as [Vercel](https:
 
 ## Testing Build Local
 
-It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build localy.
+It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build locally.
 
 ```bash npm2yarn
 npm run serve

--- a/website/versioned_docs/version-2.0.0-alpha.60/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.60/cli.md
@@ -114,7 +114,7 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 
 ### `docusaurus serve`
 
-Serve your built website localy.
+Serve your built website locally.
 
 | Name | Default | Description |
 | --- | --- | --- |

--- a/website/versioned_docs/version-2.0.0-alpha.60/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.60/deployment.md
@@ -15,7 +15,7 @@ You can deploy your site to static site hosting services such as [Vercel](https:
 
 ## Testing Build Local
 
-It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build localy.
+It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build locally.
 
 ```bash npm2yarn
 npm run serve

--- a/website/versioned_docs/version-2.0.0-alpha.61/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.61/cli.md
@@ -114,7 +114,7 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 
 ### `docusaurus serve`
 
-Serve your built website localy.
+Serve your built website locally.
 
 | Name | Default | Description |
 | --- | --- | --- |

--- a/website/versioned_docs/version-2.0.0-alpha.61/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.61/deployment.md
@@ -15,7 +15,7 @@ You can deploy your site to static site hosting services such as [Vercel](https:
 
 ## Testing Build Local
 
-It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build localy.
+It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build locally.
 
 ```bash npm2yarn
 npm run serve

--- a/website/versioned_docs/version-2.0.0-alpha.62/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.62/cli.md
@@ -118,7 +118,7 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 
 ### `docusaurus serve`
 
-Serve your built website localy.
+Serve your built website locally.
 
 | Name | Default | Description |
 | --- | --- | --- |

--- a/website/versioned_docs/version-2.0.0-alpha.62/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.62/deployment.md
@@ -15,7 +15,7 @@ You can deploy your site to static site hosting services such as [Vercel](https:
 
 ## Testing Build Local
 
-It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build localy.
+It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build locally.
 
 ```bash npm2yarn
 npm run serve

--- a/website/versioned_docs/version-2.0.0-alpha.63/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/cli.md
@@ -118,7 +118,7 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 
 ### `docusaurus serve`
 
-Serve your built website localy.
+Serve your built website locally.
 
 | Name | Default | Description |
 | --- | --- | --- |

--- a/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/deployment.md
@@ -15,7 +15,7 @@ You can deploy your site to static site hosting services such as [Vercel](https:
 
 ## Testing Build Local
 
-It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build localy.
+It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build locally.
 
 ```bash npm2yarn
 npm run serve

--- a/website/versioned_docs/version-2.0.0-alpha.64/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/cli.md
@@ -118,7 +118,7 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 
 ### `docusaurus serve`
 
-Serve your built website localy.
+Serve your built website locally.
 
 | Name | Default | Description |
 | --- | --- | --- |

--- a/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/deployment.md
@@ -15,7 +15,7 @@ You can deploy your site to static site hosting services such as [Vercel](https:
 
 ## Testing Build Local
 
-It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build localy.
+It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build locally.
 
 ```bash npm2yarn
 npm run serve


### PR DESCRIPTION
There is a small typo in website/docs/cli.md, website/docs/deployment.md, website/versioned_docs/version-2.0.0-alpha.60/cli.md, website/versioned_docs/version-2.0.0-alpha.60/deployment.md, website/versioned_docs/version-2.0.0-alpha.61/cli.md, website/versioned_docs/version-2.0.0-alpha.61/deployment.md, website/versioned_docs/version-2.0.0-alpha.62/cli.md, website/versioned_docs/version-2.0.0-alpha.62/deployment.md, website/versioned_docs/version-2.0.0-alpha.63/cli.md, website/versioned_docs/version-2.0.0-alpha.63/deployment.md, website/versioned_docs/version-2.0.0-alpha.64/cli.md, website/versioned_docs/version-2.0.0-alpha.64/deployment.md.

Should read `locally` rather than `localy`.

