### PR TITLE
chore(v2): run Jest tests on Windows workflow

### DIFF
--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -30,3 +30,5 @@ jobs:
       run: yarn build:v2
       env:
         CI: true
+    - name: Docusaurus Jest Tests
+      run: yarn test


### PR DESCRIPTION
## Motivation

Currently many Jest tests fails on Windows due to paths issues. 

This PR adds additional test run step to Windows workflow **(and it is expected to fail)**.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

* #3460
