### PR TITLE
feat(v2): Add @theme-init components to user theme

### DIFF
--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -29,6 +29,10 @@ export default function loadThemeAlias(
   userThemePaths.forEach((themePath) => {
     const userThemeAliases = themeAlias(themePath, false);
     Object.keys(userThemeAliases).forEach((aliasKey) => {
+      if (aliasKey in aliases) {
+        const componentName = aliasKey.substring(aliasKey.indexOf('/') + 1);
+        aliases[`@theme-init/${componentName}`] = aliases[aliasKey];
+      }
       aliases[aliasKey] = userThemeAliases[aliasKey];
     });
   });

--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -8,33 +8,36 @@
 import {ThemeAlias} from '@docusaurus/types';
 import themeAlias from './alias';
 
+function buildThemeAliases(
+  themeAliases: ThemeAlias,
+  aliases: ThemeAlias = {},
+): ThemeAlias {
+  Object.keys(themeAliases).forEach((aliasKey) => {
+    if (aliasKey in aliases) {
+      const componentName = aliasKey.substring(aliasKey.indexOf('/') + 1);
+      // eslint-disable-next-line no-param-reassign
+      aliases[`@theme-init/${componentName}`] = aliases[aliasKey];
+    }
+    // eslint-disable-next-line no-param-reassign
+    aliases[aliasKey] = themeAliases[aliasKey];
+  });
+  return aliases;
+}
+
 export default function loadThemeAlias(
   themePaths: string[],
   userThemePaths: string[] = [],
 ): ThemeAlias {
-  const aliases = {};
+  let aliases = {};
 
   themePaths.forEach((themePath) => {
     const themeAliases = themeAlias(themePath);
-    Object.keys(themeAliases).forEach((aliasKey) => {
-      if (aliasKey in aliases) {
-        const componentName = aliasKey.substring(aliasKey.indexOf('/') + 1);
-        aliases[`@theme-init/${componentName}`] = aliases[aliasKey];
-      }
-
-      aliases[aliasKey] = themeAliases[aliasKey];
-    });
+    aliases = {...aliases, ...buildThemeAliases(themeAliases, aliases)};
   });
 
   userThemePaths.forEach((themePath) => {
     const userThemeAliases = themeAlias(themePath, false);
-    Object.keys(userThemeAliases).forEach((aliasKey) => {
-      if (aliasKey in aliases) {
-        const componentName = aliasKey.substring(aliasKey.indexOf('/') + 1);
-        aliases[`@theme-init/${componentName}`] = aliases[aliasKey];
-      }
-      aliases[aliasKey] = userThemeAliases[aliasKey];
-    });
+    aliases = {...aliases, ...buildThemeAliases(userThemeAliases, aliases)};
   });
 
   return aliases;


### PR DESCRIPTION
## Motivation

Swizzled components currently do not have access to `@theme-init` components as it has been introduced in PR[#2464](https://github.com/facebook/docusaurus/pull/2464) for Docusaurus components.

Having access to initial theme components allows overriding default components without having to rewrite the entire component.

This PR extend the initial PR for providing access to `@theme-init` components for custom components.

The point has been raised on the Discord channel [#docusaurus-2-dogfooding](https://discordapp.com/channels/398180168688074762/567414046073159701/718010716527001690).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested with a local instance and a custom code block:
```jsx 
import React from 'react';
import CodeBlock from '@theme-init/CodeBlock'; // access to initial theme Codeblock

const TryQueryLink = ({ gql, text }) => {
  const graphiQLPath = "/graphiql?query=";
  const encodedQuery = encodeURIComponent(gql || "");
  return <a href={`${graphiQLPath}${encodedQuery}`}>{text}</a>;
}

const graphiQLCodeBlock = (Component) => {
  const WrappedComponent = (props) => {
    let tryMe;
    const language = props.className && props.className.replace(/language-/, '') || "";
    if (props.withgraphiql && language == "graphql") {
      const match = props.metastring && props.metastring.match(/withgraphiql/, RegExp.$1);
      tryMe = <TryQueryLink
 gql={props.children} text="Try Query"/>;
    }

    return <>{tryMe}<Component {...props}/></>
  };

  return WrappedComponent;
};

export default graphiQLCodeBlock(CodeBlock);
```

![Screenshot 2020-09-25 at 17 44 35](https://user-images.githubusercontent.com/324670/94287718-eefc3d80-ff56-11ea-8433-d9085be6d439.png)
## Related PRs

- #2464: refactor(v2): add @theme-init alias to give access to initial components
