### PR TITLE
feat(v2): env variable TERSER_PARALLEL to customize TerserPlugin.parallel

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -42,7 +42,7 @@ export function excludeJS(modulePath: string): boolean {
 let terserParallel: boolean | number = true;
 if (process.env.TERSER_PARALLEL === 'false') {
   terserParallel = false;
-} else if (parseInt(process.env.TERSER_PARALLEL) > 0) {
+} else if (process.env.TERSER_PARALLEL && parseInt(process.env.TERSER_PARALLEL) > 0) {
   terserParallel = parseInt(process.env.TERSER_PARALLEL)
 }
 

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -42,8 +42,8 @@ export function excludeJS(modulePath: string): boolean {
 let terserParallel: boolean | number = true;
 if (process.env.TERSER_PARALLEL === 'false') {
   terserParallel = false;
-} else if (process.env.TERSER_PARALLEL && parseInt(process.env.TERSER_PARALLEL) > 0) {
-  terserParallel = parseInt(process.env.TERSER_PARALLEL)
+} else if (process.env.TERSER_PARALLEL && parseInt(process.env.TERSER_PARALLEL, 10) > 0) {
+  terserParallel = parseInt(process.env.TERSER_PARALLEL, 10)
 }
 
 export function createBaseConfig(

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -43,7 +43,7 @@ let terserParallel: boolean | number = true;
 if (process.env.TERSER_PARALLEL === 'false') {
   terserParallel = false;
 } else if (process.env.TERSER_PARALLEL && parseInt(process.env.TERSER_PARALLEL, 10) > 0) {
-  terserParallel = parseInt(process.env.TERSER_PARALLEL, 10)
+  terserParallel = parseInt(process.env.TERSER_PARALLEL, 10);
 }
 
 export function createBaseConfig(

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -103,7 +103,16 @@ export function createBaseConfig(
           ? [
               new TerserPlugin({
                 cache: true,
-                parallel: true,
+                // Do not run Terser in parallel when using CircleCI or similar CI environments
+                // to avoid "Error: Call retries were exceeded" errors. For more information
+                // see https://github.com/webpack-contrib/terser-webpack-plugin#parallel
+                //
+                // CI=true is true for:
+                // - https://docs.gitlab.com/ee/ci/variables/#debug-logging
+                // - https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
+                // - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+                // - https://docs.travis-ci.com/user/environment-variables/
+                parallel: process.env.CI.toLowerCase() !== 'true',
                 sourceMap: false,
                 terserOptions: {
                   parse: {

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -112,7 +112,7 @@ export function createBaseConfig(
                 // - https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
                 // - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
                 // - https://docs.travis-ci.com/user/environment-variables/
-                parallel: process.env.CI.toLowerCase() !== 'true',
+                parallel: (process.env.CI || 'false').toLowerCase() !== 'true',
                 sourceMap: false,
                 terserOptions: {
                   parse: {

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -40,9 +40,12 @@ export function excludeJS(modulePath: string): boolean {
 
 // See https://github.com/webpack-contrib/terser-webpack-plugin#parallel
 let terserParallel: boolean | number = true;
-if (process.env.TERSER_PARALLEL === 'false') {
+if (process.env.TERSER_PARALLEL === "false") {
   terserParallel = false;
-} else if (process.env.TERSER_PARALLEL && parseInt(process.env.TERSER_PARALLEL, 10) > 0) {
+} else if (
+  process.env.TERSER_PARALLEL &&
+  parseInt(process.env.TERSER_PARALLEL, 10) > 0
+) {
   terserParallel = parseInt(process.env.TERSER_PARALLEL, 10);
 }
 

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -38,6 +38,13 @@ export function excludeJS(modulePath: string): boolean {
   );
 }
 
+let terserParallel: boolean | number = true;
+if (process.env.TERSER_PARALLEL === 'false') {
+  terserParallel = false;
+} else if (parseInt(process.env.TERSER_PARALLEL) > 0) {
+  terserParallel = parseInt(process.env.TERSER_PARALLEL)
+}
+
 export function createBaseConfig(
   props: Props,
   isServer: boolean,
@@ -112,7 +119,7 @@ export function createBaseConfig(
                 // - https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
                 // - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
                 // - https://docs.travis-ci.com/user/environment-variables/
-                parallel: (process.env.CI || 'false').toLowerCase() !== 'true',
+                parallel: terserParallel,
                 sourceMap: false,
                 terserOptions: {
                   parse: {

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -38,6 +38,7 @@ export function excludeJS(modulePath: string): boolean {
   );
 }
 
+// See https://github.com/webpack-contrib/terser-webpack-plugin#parallel
 let terserParallel: boolean | number = true;
 if (process.env.TERSER_PARALLEL === 'false') {
   terserParallel = false;
@@ -110,15 +111,6 @@ export function createBaseConfig(
           ? [
               new TerserPlugin({
                 cache: true,
-                // Do not run Terser in parallel when using CircleCI or similar CI environments
-                // to avoid "Error: Call retries were exceeded" errors. For more information
-                // see https://github.com/webpack-contrib/terser-webpack-plugin#parallel
-                //
-                // CI=true is true for:
-                // - https://docs.gitlab.com/ee/ci/variables/#debug-logging
-                // - https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
-                // - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
-                // - https://docs.travis-ci.com/user/environment-variables/
                 parallel: terserParallel,
                 sourceMap: false,
                 terserOptions: {

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -40,7 +40,7 @@ export function excludeJS(modulePath: string): boolean {
 
 // See https://github.com/webpack-contrib/terser-webpack-plugin#parallel
 let terserParallel: boolean | number = true;
-if (process.env.TERSER_PARALLEL === "false") {
+if (process.env.TERSER_PARALLEL === 'false') {
   terserParallel = false;
 } else if (
   process.env.TERSER_PARALLEL &&


### PR DESCRIPTION
## Motivation

Do not run Terser in parallel when using CircleCI or similar CI environments
to avoid "Error: Call retries were exceeded" errors. For more information
see https://github.com/webpack-contrib/terser-webpack-plugin#parallel

`CI=true` is true for:
- https://docs.gitlab.com/ee/ci/variables/#debug-logging
- https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
- https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
- https://docs.travis-ci.com/user/environment-variables/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

None - hard to test because certain conditions need to be met and because it's not possible to replicate those easily without a published package.