### PR TITLE
fix(v2): fixed props being passed to @svgr/webpack loader

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -218,7 +218,7 @@ export function createBaseConfig(
         },
         {
           test: /\.svg$/,
-          use: '@svgr/webpack?-prettier-svgo,+titleProp,+ref![path]',
+          use: '@svgr/webpack?-prettier,-svgo,+titleProp,+ref![path]',
         },
       ],
     },


### PR DESCRIPTION
Without comma option `-prettier-svgo` is parsed as `'prettier-svgo': false`

## Motivation

Fix problems that svgo introduces when inlining SVG pictures.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Pretty print options are consumed by `@svgr` directly in node_modules/ directory.

