### PR TITLE
fix(v2): DX deploy error messages should print effective env variables names

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -43,7 +43,7 @@ export default async function deploy(
     siteConfig.organizationName;
   if (!organizationName) {
     throw new Error(
-      `Missing project organization name. Did you forget to define 'organizationName' in ${CONFIG_FILE_NAME}? You may also export it via the organizationName environment variable.`,
+      `Missing project organization name. Did you forget to define 'organizationName' in ${CONFIG_FILE_NAME}? You may also export it via the ORGANIZATION_NAME environment variable.`,
     );
   }
   const projectName =
@@ -52,7 +52,7 @@ export default async function deploy(
     siteConfig.projectName;
   if (!projectName) {
     throw new Error(
-      `Missing project name. Did you forget to define 'projectName' in ${CONFIG_FILE_NAME}? You may also export it via the projectName environment variable.`,
+      `Missing project name. Did you forget to define 'projectName' in ${CONFIG_FILE_NAME}? You may also export it via the PROJECT_NAME environment variable.`,
     );
   }
 


### PR DESCRIPTION

## Motivation

The user should be able to get the real env variable names to use from the error message, otherwise, it's confusing.