### PR TITLE
chore(v2): v2 website should make it easy to contribute to upstream docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -201,7 +201,7 @@ module.exports = {
               : undefined,
           versions: {
             current: {
-              label: `${getNextAlphaVersionName()} (next)`,
+              label: `${getNextAlphaVersionName()} (unreleased)`,
             },
           },
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,6 +8,23 @@
 const path = require('path');
 const versions = require('./versions.json');
 
+// This probably only makes sense for the alpha phase, temporary
+function getNextAlphaVersionName() {
+  const expectedPrefix = '2.0.0-alpha.';
+
+  const lastReleasedVersion = versions[0];
+  if (!lastReleasedVersion.includes(expectedPrefix)) {
+    throw new Error(
+      'this code is only meant to be used during the 2.0 alpha phase.',
+    );
+  }
+  const alphaBuild = parseInt(
+    lastReleasedVersion.replace(expectedPrefix, ''),
+    10,
+  );
+  return `${expectedPrefix}${alphaBuild + 1}`;
+}
+
 const allDocHomesPaths = [
   '/docs/',
   '/docs/next/',
@@ -177,18 +194,14 @@ module.exports = {
           showLastUpdateTime: true,
           remarkPlugins: [require('./src/plugins/remark-npm2yarn')],
           disableVersioning: isVersioningDisabled,
-          lastVersion: isDev || isDeployPreview ? 'current' : undefined,
+          lastVersion: 'current',
           onlyIncludeVersions:
             !isVersioningDisabled && (isDev || isDeployPreview)
               ? ['current', ...versions.slice(0, 2)]
               : undefined,
           versions: {
             current: {
-              // path: isDev || isDeployPreview ? '' : 'next',
-              label:
-                isDev || isDeployPreview
-                  ? `Next (${isDeployPreview ? 'deploy preview' : 'dev'})`
-                  : 'Next',
+              label: `${getNextAlphaVersionName()} (next)`,
             },
           },
         },


### PR DESCRIPTION
## Motivation

By default, in prod, the "latest version" is the last release, not "next".

This lead to the editUrl targeting docs of a specific version, not upstream docs. 

This leads to maintainers asking to port the doc fixes to upstream docs, and sometimes merging by mistake to the versioned docs, so the doc fix would disappear.

Here is an example: https://github.com/facebook/docusaurus/pull/3428#issuecomment-700158389

By defaulting to the next version in prod, we nudge contributors and maintainers to contribute to upstream docs in priority.

![image](https://user-images.githubusercontent.com/749374/94724377-7f24f300-035a-11eb-9765-0c69665f6cce.png)

The label `(unreleased)` can help make it obvious that it's the doc for an unreleased version, so that the user can switch if needed. 

But anyway, between one alpha to another, the docs do not change that much, so I think this new behavior is fine for the whole alpha phase.

@lex111 @yangshun any opinion?