### PR TITLE
fix(v2): fixes #3505, exit start if user don't want to change port

### DIFF
--- a/packages/docusaurus/src/choosePort.ts
+++ b/packages/docusaurus/src/choosePort.ts
@@ -92,7 +92,7 @@ export default async function choosePort(
   // @ts-expect-error: bad lib typedef?
   return detect(defaultPort, host).then(
     (port) =>
-      new Promise((resolve) => {
+      new Promise((resolve, reject) => {
         if (port === defaultPort) {
           return resolve(port);
         }
@@ -116,14 +116,16 @@ export default async function choosePort(
           inquirer.prompt(question).then((answer: any) => {
             if (answer.shouldChangePort) {
               resolve(port);
-            } else {
-              resolve(null);
             }
+            reject(new Error(`Could not run app on port ${defaultPort}.`));
           });
         } else {
           console.log(chalk.red(message));
           resolve(null);
         }
+        return null;
+      }).catch((reason) => {
+        console.log(chalk.red(reason));
         return null;
       }),
     (err) => {

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -29,24 +29,26 @@ export default async function serve(
     );
   }
   const port = await choosePort(cliOptions.host, cliOptions.port);
-  const server = http.createServer((req, res) => {
-    serveHandler(req, res, {
-      cleanUrls: true,
-      public: dir,
+  if (port) {
+    const server = http.createServer((req, res) => {
+      serveHandler(req, res, {
+        cleanUrls: true,
+        public: dir,
+      });
     });
-  });
-  console.log(
-    boxen(
-      `${chalk.green(`Serving ${cliOptions.dir}!`)}\n\n- Local: http://${
-        cliOptions.host
-      }:${port}`,
-      {
-        borderColor: 'green',
-        padding: 1,
-        margin: 1,
-        align: 'center',
-      },
-    ),
-  );
-  server.listen(port);
+    console.log(
+      boxen(
+        `${chalk.green(`Serving ${cliOptions.dir}!`)}\n\n- Local: http://${
+          cliOptions.host
+        }:${port}`,
+        {
+          borderColor: 'green',
+          padding: 1,
+          margin: 1,
+          align: 'center',
+        },
+      ),
+    );
+    server.listen(port);
+  }
 }


### PR DESCRIPTION
## Motivation

This simple PR fixes the recently reported issue when user don't want to change port on which Docusaurus is running (when the port is already used). To fix this I have utilized the `reject` from the used Promise.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Few attempts to run second Docusaurus app locally.
<img width="385" alt="Screenshot 2020-10-01 175122" src="https://user-images.githubusercontent.com/719641/94833148-13509200-040f-11eb-9b8f-4a963beb5078.png">

## Related PRs

*  fixes #3505
