### PR TITLE
fix(v1): v1 deploy preview should be available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,7 @@ packages/docusaurus-theme-bootstrap/lib/
 packages/docusaurus-migrate/lib/
 
 website/netlifyDeployPreview
+!website/netlifyDeployPreview/index.html
+!website/netlifyDeployPreview/_redirects
 
 website-1.x-migrated

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "netlify:deployPreview:v1": "yarn netlify:deployPreview:v1:setDeployPreviewVersions && yarn netlify:deployPreview:v1:build && yarn netlify:deployPreview:v1:moveBuild",
     "netlify:deployPreview:v1:setDeployPreviewVersions": "yarn node -e 'require(\"./website-1.x/netlifyUtils\").setDeployPreviewVersions()'",
     "netlify:deployPreview:v1:build": "BASE_URL=/v1/ yarn build:v1",
-    "netlify:deployPreview:v1:moveBuild": "mv website-1.x/build/docusaurus website/netlifyDeployPreview/v1"
+    "netlify:deployPreview:v1:moveBuild": "mv website-1.x/build/docusaurus website/netlifyDeployPreview/v1",
+    "netlify:deployPreview:v1-migrated": "yarn test:v1Migration:migrate && yarn netlify:deployPreview:v1-migrated:setBaseUrl && yarn netlify:deployPreview:v1-migrated:build",
+    "netlify:deployPreview:v1-migrated:setBaseUrl": "sed -i -e 's,\"baseUrl\": \"/\",\"baseUrl\": \"/v1-migrated/\",g'  ./website-1.x-migrated/docusaurus.config.js",
+    "netlify:deployPreview:v1-migrated:build": "yarn workspace docusaurus-1-website-migrated build --out-dir=../website/netlifyDeployPreview/v1-migrated"
   },
   "devDependencies": {
     "@babel/cli": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,11 @@
     "test:v1Migration:migrate": "rimraf website-1.x-migrated && docusaurus-migrate migrate ./website-1.x ./website-1.x-migrated && sed -i -- 's/docusaurus-1-website/docusaurus-1-website-migrated/g;' website-1.x-migrated/package.json",
     "test:v1Migration:start": "yarn workspace docusaurus-1-website-migrated start",
     "test:v1Migration:build": "yarn workspace docusaurus-1-website-migrated build",
-    "test:baseUrl": "yarn build:v2:baseUrl && yarn serve:v2:baseUrl"
+    "test:baseUrl": "yarn build:v2:baseUrl && yarn serve:v2:baseUrl",
+    "netlify:deployPreview:v1": "yarn netlify:deployPreview:v1:setDeployPreviewVersions && yarn netlify:deployPreview:v1:build && yarn netlify:deployPreview:v1:moveBuild",
+    "netlify:deployPreview:v1:setDeployPreviewVersions": "yarn node -e 'require(\"./website-1.x/netlifyUtils\").setDeployPreviewVersions()'",
+    "netlify:deployPreview:v1:build": "BASE_URL=/v1/ yarn build:v1",
+    "netlify:deployPreview:v1:moveBuild": "mv website-1.x/build/docusaurus website/netlifyDeployPreview/v1"
   },
   "devDependencies": {
     "@babel/cli": "^7.9.0",

--- a/website-1.x/languages.js
+++ b/website-1.x/languages.js
@@ -182,4 +182,16 @@ const languages = [
     tag: 'zh-TW',
   },
 ];
-module.exports = languages;
+
+const onlyEnglish = [
+  {
+    enabled: true,
+    name: 'English',
+    tag: 'en',
+  },
+];
+
+// We want deploy previews to be fast
+module.exports = require('./netlifyUtils').isDeployPreview
+  ? onlyEnglish
+  : languages;

--- a/website-1.x/netlifyUtils.js
+++ b/website-1.x/netlifyUtils.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// This is useful to speed up v1 deployment in Netlify PR deploy previews
+//
+// Command to test locally:
+// NETLIFY=true CONTEXT=deploy-preview yarn build:v1
+// or
+// NETLIFY=true CONTEXT=deploy-preview yarn netlify:deployPreview:v1
+//
+// See Netlify env variables here: https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
+const isDeployPreview =
+  process.env.NETLIFY === 'true' && process.env.CONTEXT === 'deploy-preview';
+if (isDeployPreview) {
+  console.log('Docusaurus v1 running as a Netlify deploy preview');
+}
+exports.isDeployPreview = isDeployPreview;
+
+// On netlify deploy previews, we don't deploy all versions to make deploy preview faster
+function updateDeployPreviewVersions(versions) {
+  const newVersions = [versions[0], versions[versions.length - 1]];
+  console.log(
+    'Netlify deploy previews will only deploy a subset of available versions: ' +
+      newVersions.join(' - '),
+  );
+  return newVersions;
+}
+
+exports.setDeployPreviewVersions = function () {
+  const versions = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'versions.json'), 'utf8'),
+  );
+  const newVersions = updateDeployPreviewVersions(versions);
+  fs.writeFileSync(
+    path.join(__dirname, 'versions.json'),
+    JSON.stringify(newVersions, null, 2),
+    'utf8',
+  );
+};

--- a/website-1.x/siteConfig.js
+++ b/website-1.x/siteConfig.js
@@ -12,7 +12,7 @@ const siteConfig = {
   title: 'Docusaurus',
   tagline: 'Easy to Maintain Open Source Documentation Websites',
   url: 'https://docusaurus.io',
-  baseUrl: '/',
+  baseUrl: process.env.BASE_URL || '/',
   organizationName: 'facebook',
   projectName: 'docusaurus',
   cname: 'docusaurus.io',

--- a/website/netlifyDeployPreview/_redirects
+++ b/website/netlifyDeployPreview/_redirects
@@ -2,4 +2,5 @@
 /bootstrap/* /bootstrap/404.html 200
 /blog-only/* /blog-only/404.html 200
 /v1/* /v1/404.html 200
+/v1-migrated/* /v1-migrated/404.html 200
 /* /classic/

--- a/website/netlifyDeployPreview/_redirects
+++ b/website/netlifyDeployPreview/_redirects
@@ -1,4 +1,5 @@
 /classic/* /classic/404.html 200
 /bootstrap/* /bootstrap/404.html 200
 /blog-only/* /blog-only/404.html 200
+/v1/* /v1/404.html 200
 /* /classic/

--- a/website/netlifyDeployPreview/index.html
+++ b/website/netlifyDeployPreview/index.html
@@ -13,7 +13,7 @@
       <p>When in doubt, try the <a href="/classic">classic preview</a></p>
     </section>
     <section style="margin-top: 40px;">
-      <h2>Available deploy previews:</h2>
+      <h2>V2 deploy previews:</h2>
       <ul style="margin-top: 20px;">
         <li style="margin-top: 20px;">
           <a href="/classic">classic</a>: the regular Docusaurus v2 site
@@ -25,8 +25,18 @@
         <li style="margin-top: 20px;">
           <a href="/blog-only">blog-only</a>: the regular site in blog-only mode
         </li>
+      </ul>
+    </section>
+
+    <section style="margin-top: 40px;">
+      <h2>V1 deploy previews:</h2>
+      <ul style="margin-top: 20px;">
         <li style="margin-top: 20px;">
-          <a href="/v1">Docusaurus v1</a>: the legacy Docusaurus v1 site
+          <a href="/v1">v1</a>: the legacy Docusaurus v1 site
+        </li>
+        <li style="margin-top: 20px;">
+          <a href="/v1-migrated">v1-migrated</a>: the legacy Docusaurus v1 site,
+          migrated to v2 with the migration cli
         </li>
       </ul>
     </section>

--- a/website/netlifyDeployPreview/index.html
+++ b/website/netlifyDeployPreview/index.html
@@ -16,7 +16,7 @@
       <h2>Available deploy previews:</h2>
       <ul style="margin-top: 20px;">
         <li style="margin-top: 20px;">
-          <a href="/classic">classic</a>: the regular site
+          <a href="/classic">classic</a>: the regular Docusaurus v2 site
         </li>
         <li style="margin-top: 20px;">
           <a href="/bootstrap">bootstrap</a>: the regular site with the
@@ -24,6 +24,9 @@
         </li>
         <li style="margin-top: 20px;">
           <a href="/blog-only">blog-only</a>: the regular site in blog-only mode
+        </li>
+        <li style="margin-top: 20px;">
+          <a href="/v1">Docusaurus v1</a>: the legacy Docusaurus v1 site
         </li>
       </ul>
     </section>

--- a/website/package.json
+++ b/website/package.json
@@ -16,10 +16,11 @@
     "start:blogOnly": "DOCUSAURUS_CONFIG='docusaurus.config-blog-only.js' yarn start",
     "build:blogOnly": "DOCUSAURUS_CONFIG='docusaurus.config-blog-only.js' yarn build",
     "netlify:build:production": "yarn build",
-    "netlify:build:deployPreview": "yarn netlify:build:deployPreview:classic && yarn netlify:build:deployPreview:bootstrap && yarn netlify:build:deployPreview:blogOnly",
+    "netlify:build:deployPreview": "yarn netlify:build:deployPreview:v1 && yarn netlify:build:deployPreview:classic && yarn netlify:build:deployPreview:bootstrap && yarn netlify:build:deployPreview:blogOnly",
     "netlify:build:deployPreview:classic": "BASE_URL='/classic/' yarn build --out-dir netlifyDeployPreview/classic",
     "netlify:build:deployPreview:bootstrap": "BASE_URL='/bootstrap/' DOCUSAURUS_PRESET=bootstrap DISABLE_VERSIONING=true yarn build --out-dir netlifyDeployPreview/bootstrap",
     "netlify:build:deployPreview:blogOnly": "yarn build:blogOnly --out-dir netlifyDeployPreview/blog-only",
+    "netlify:build:deployPreview:v1": "yarn --cwd .. netlify:deployPreview:v1",
     "netlify:test": "yarn netlify:build:deployPreview && yarn netlify dev --debug"
   },
   "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -16,11 +16,11 @@
     "start:blogOnly": "DOCUSAURUS_CONFIG='docusaurus.config-blog-only.js' yarn start",
     "build:blogOnly": "DOCUSAURUS_CONFIG='docusaurus.config-blog-only.js' yarn build",
     "netlify:build:production": "yarn build",
-    "netlify:build:deployPreview": "yarn netlify:build:deployPreview:v1 && yarn netlify:build:deployPreview:classic && yarn netlify:build:deployPreview:bootstrap && yarn netlify:build:deployPreview:blogOnly",
+    "netlify:build:deployPreview": "yarn netlify:build:deployPreview:v1:all && yarn netlify:build:deployPreview:classic && yarn netlify:build:deployPreview:bootstrap && yarn netlify:build:deployPreview:blogOnly",
     "netlify:build:deployPreview:classic": "BASE_URL='/classic/' yarn build --out-dir netlifyDeployPreview/classic",
     "netlify:build:deployPreview:bootstrap": "BASE_URL='/bootstrap/' DOCUSAURUS_PRESET=bootstrap DISABLE_VERSIONING=true yarn build --out-dir netlifyDeployPreview/bootstrap",
     "netlify:build:deployPreview:blogOnly": "yarn build:blogOnly --out-dir netlifyDeployPreview/blog-only",
-    "netlify:build:deployPreview:v1": "yarn --cwd .. netlify:deployPreview:v1",
+    "netlify:build:deployPreview:v1:all": "yarn --cwd .. netlify:deployPreview:v1 && yarn --cwd .. netlify:deployPreview:v1-migrated",
     "netlify:test": "yarn netlify:build:deployPreview && yarn netlify dev --debug"
   },
   "dependencies": {


### PR DESCRIPTION

## Motivation

A simple v1 deploy preview should be available to review v1 PRs.

As we have multiple deploy previews now we can more easily include v1.

With only English, and only a minimal amount of version it does not increase deploy preview time significantly