### PR TITLE
fix(v2): Fixes serve cli --port option

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:v2:baseUrl": "yarn workspace docusaurus-2-website build:baseUrl",
     "build:v2:blogOnly": "yarn workspace docusaurus-2-website build:blogOnly",
     "serve:v1": "serve website-1.x/build/docusaurus",
-    "serve:v2": "serve website/build",
+    "serve:v2": "yarn workspace docusaurus-2-website serve",
     "serve:v2:baseUrl": "serve website",
     "serve:v2:ssl": "yarn serve:v2:ssl:gencert && yarn serve:v2:ssl:message && yarn serve:v2:ssl:serve",
     "serve:v2:ssl:gencert": "openssl req -x509 -nodes -days 365 -newkey rsa:4096 -subj \"/C=US/ST=Docusaurus/L=Anywhere/O=Dis/CN=localhost\" -keyout ./website/.docusaurus/selfsigned.key -out ./website/.docusaurus/selfsigned.crt",

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -91,13 +91,21 @@ export type PresetConfig =
   | [string]
   | string;
 
-export interface StartCLIOptions {
-  port: string;
-  host: string;
+export type HostPortCLIOptions = {
+  host?: string;
+  port?: string;
+};
+
+export type StartCLIOptions = HostPortCLIOptions & {
   hotOnly: boolean;
   open: boolean;
   poll: boolean;
-}
+};
+
+export type ServeCLIOptions = HostPortCLIOptions & {
+  build: boolean;
+  dir: string;
+};
 
 export interface BuildCLIOptions {
   bundleAnalyzer: boolean;

--- a/packages/docusaurus/src/commands/commandUtils.ts
+++ b/packages/docusaurus/src/commands/commandUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import choosePort from '../choosePort';
+import {HostPortCLIOptions} from '@docusaurus/types';
+import {DEFAULT_PORT} from '../constants';
+
+export function getCLIOptionHost(
+  hostOption: HostPortCLIOptions['host'],
+): string {
+  return hostOption || 'localhost';
+}
+
+export async function getCLIOptionPort(
+  portOption: HostPortCLIOptions['port'],
+  host: string,
+): Promise<number | null> {
+  const basePort = portOption ? parseInt(portOption, 10) : DEFAULT_PORT;
+  return choosePort(host, basePort);
+}

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -12,11 +12,12 @@ import chalk from 'chalk';
 import path from 'path';
 
 import build from './build';
-import choosePort from '../choosePort';
+import {getCLIOptionHost, getCLIOptionPort} from './commandUtils';
+import {ServeCLIOptions} from '@docusaurus/types';
 
 export default async function serve(
   siteDir: string,
-  cliOptions: {port: string; build: boolean; dir: string; host: string},
+  cliOptions: ServeCLIOptions,
 ): Promise<void> {
   let dir = path.join(siteDir, cliOptions.dir);
   if (cliOptions.build) {
@@ -28,10 +29,9 @@ export default async function serve(
       false,
     );
   }
-  const port: number | null = await choosePort(
-    cliOptions.host,
-    Number(cliOptions.port),
-  );
+
+  const host: string = getCLIOptionHost(cliOptions.host);
+  const port: number | null = await getCLIOptionPort(cliOptions.port, host);
 
   if (port === null) {
     process.exit();

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -16,7 +16,7 @@ import choosePort from '../choosePort';
 
 export default async function serve(
   siteDir: string,
-  cliOptions: {port: number; build: boolean; dir: string; host: string},
+  cliOptions: {port: string; build: boolean; dir: string; host: string},
 ): Promise<void> {
   let dir = path.join(siteDir, cliOptions.dir);
   if (cliOptions.build) {
@@ -28,7 +28,15 @@ export default async function serve(
       false,
     );
   }
-  const port = await choosePort(cliOptions.host, cliOptions.port);
+  const port: number | null = await choosePort(
+    cliOptions.host,
+    Number(cliOptions.port),
+  );
+
+  if (port === null) {
+    process.exit();
+  }
+
   const server = http.createServer((req, res) => {
     serveHandler(req, res, {
       cleanUrls: true,

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -21,27 +21,14 @@ import merge from 'webpack-merge';
 import HotModuleReplacementPlugin from 'webpack/lib/HotModuleReplacementPlugin';
 import {load} from '../server';
 import {StartCLIOptions} from '@docusaurus/types';
-import {CONFIG_FILE_NAME, STATIC_DIR_NAME, DEFAULT_PORT} from '../constants';
+import {CONFIG_FILE_NAME, STATIC_DIR_NAME} from '../constants';
 import createClientConfig from '../webpack/client';
 import {applyConfigureWebpack} from '../webpack/utils';
-import choosePort from '../choosePort';
-
-function getHost(reqHost: string | undefined): string {
-  return reqHost || 'localhost';
-}
-
-async function getPort(
-  reqPort: string | undefined,
-  host: string,
-): Promise<number | null> {
-  const basePort = reqPort ? parseInt(reqPort, 10) : DEFAULT_PORT;
-  const port = await choosePort(host, basePort);
-  return port;
-}
+import {getCLIOptionHost, getCLIOptionPort} from './commandUtils';
 
 export default async function start(
   siteDir: string,
-  cliOptions: Partial<StartCLIOptions> = {},
+  cliOptions: Partial<StartCLIOptions>,
 ): Promise<void> {
   process.env.NODE_ENV = 'development';
   process.env.BABEL_ENV = 'development';
@@ -82,8 +69,8 @@ export default async function start(
 
   const protocol: string = process.env.HTTPS === 'true' ? 'https' : 'http';
 
-  const host: string = getHost(cliOptions.host);
-  const port: number | null = await getPort(cliOptions.port, host);
+  const host: string = getCLIOptionHost(cliOptions.host);
+  const port: number | null = await getCLIOptionPort(cliOptions.port, host);
 
   if (port === null) {
     process.exit();

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
+    "serve": "docusaurus serve",
     "start:baseUrl": "BASE_URL='/build/' yarn start",
     "build:baseUrl": "BASE_URL='/build/' yarn build",
     "start:bootstrap": "DOCUSAURUS_PRESET=bootstrap yarn start",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The command `serve` was not equipped to handle the value of port being `null`. 
Also there was a typing mismatch where `port` input from CLI (`string`) was type-casted as a `number`.   

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The expected behavior can be seen here. 
![serve_fix](https://user-images.githubusercontent.com/54525505/94964436-42502c00-0513-11eb-8be3-9ccc3bc91a60.png)


## Related PRs

Fixes issue #3505 . 
