### PR TITLE
refactor(v2): keep TOC at top when hideable navbar is on

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
@@ -24,3 +24,8 @@
 .navbarHidden {
   top: calc(var(--ifm-navbar-height) * -1) !important;
 }
+
+.navbarHidden ~ :global(.main-wrapper) :global(#docusaurus-toc) {
+  transform: translateY(-61px);
+  transition: transform 0.2s ease 0s;
+}

--- a/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
@@ -44,7 +44,7 @@ function Headings({headings, isChild}: TOCProps & {isChild?: boolean}) {
 function TOC({headings}: TOCProps): JSX.Element {
   useTOCHighlight(LINK_CLASS_NAME, ACTIVE_LINK_CLASS_NAME, TOP_OFFSET);
   return (
-    <div className={styles.tableOfContents}>
+    <div id="docusaurus-toc" className={styles.tableOfContents}>
       <Headings headings={headings} />
     </div>
   );

--- a/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
@@ -11,6 +11,7 @@
   overflow-y: auto;
   position: sticky;
   top: calc(var(--ifm-navbar-height) + 2rem);
+  transition: transform 0.2s ease 0s;
 }
 
 .tableOfContents::-webkit-scrollbar {
@@ -40,4 +41,3 @@
     padding: 0 0.3rem;
   }
 }
-  


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

:warning: This is just POC!

A little trick I picked up from the [Ionic docs](https://ionicframework.com/docs/) :smile: 

The point is that in the case when the hideable navbar is enabled we see a large empty space in front of the TOC, this is _not very good_. Instead that, we can keep the TOC always at the top, it will change position depending on the state of hideable navbar. In my opinion, this is great in terms of UI/UX! Just compare in test plan section to see difference.

* * *

It's easy to implement using `id`/ `~` selectors, and of course, `:global` directive. This is a quick, but probably bad way to achieve this improvement. It is difficult for me to figure out how to do this properly. @slorber any ideas?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current behavior:
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/4408379/95030150-47011580-06b6-11eb-8f3f-a8fdd6233375.gif)

Improved behavior:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/4408379/95030155-4bc5c980-06b6-11eb-9488-feaa56e0c734.gif)



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
