### PR TITLE
feat(v2): version dropdown before/after items + move site "All Versions" link

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
@@ -57,6 +57,8 @@ describe('themeConfig', () => {
           {
             type: 'docsVersionDropdown',
             position: 'left',
+            dropdownItemsBefore: [],
+            dropdownItemsAfter: [],
           },
           {
             to: 'docs/next/support',

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -21,6 +21,8 @@ export default function DocsVersionDropdownNavbarItem({
   mobile,
   docsPluginId,
   dropdownActiveClassDisabled,
+  dropdownItemsBefore,
+  dropdownItemsAfter,
   ...props
 }: Props): JSX.Element {
   const activeDocContext = useActiveDocContext(docsPluginId);
@@ -28,14 +30,7 @@ export default function DocsVersionDropdownNavbarItem({
   const latestVersion = useLatestVersion(docsPluginId);
 
   function getItems() {
-    // We don't want to render a version dropdown with 0 or 1 item
-    // If we build the site with a single docs version (onlyIncludeVersions: ['1.0.0'])
-    // We'd rather render a buttonb instead of a dropdown
-    if (versions.length <= 1) {
-      return undefined;
-    }
-
-    return versions.map((version) => {
+    const versionLinks = versions.map((version) => {
       // We try to link to the same doc, in another version
       // When not possible, fallback to the "main doc" of the version
       const versionDoc =
@@ -48,6 +43,21 @@ export default function DocsVersionDropdownNavbarItem({
         isActive: () => version === activeDocContext?.activeVersion,
       };
     });
+
+    const items = [
+      ...dropdownItemsBefore,
+      ...versionLinks,
+      ...dropdownItemsAfter,
+    ];
+
+    // We don't want to render a version dropdown with 0 or 1 item
+    // If we build the site with a single docs version (onlyIncludeVersions: ['1.0.0'])
+    // We'd rather render a buttonb instead of a dropdown
+    if (items.length <= 1) {
+      return undefined;
+    }
+
+    return items;
   }
 
   const dropdownVersion = activeDocContext.activeVersion ?? latestVersion;

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -308,10 +308,13 @@ declare module '@theme/NavbarItem/DefaultNavbarItem' {
 
 declare module '@theme/NavbarItem/DocsVersionDropdownNavbarItem' {
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
+  import type {NavLinkProps} from '@theme/NavbarItem/DefaultNavbarItem';
 
   export type Props = DefaultNavbarItemProps & {
     readonly docsPluginId?: string;
     dropdownActiveClassDisabled?: boolean;
+    dropdownItemsBefore: NavLinkProps[];
+    dropdownItemsAfter: NavLinkProps[];
   };
 
   const DocsVersionDropdownNavbarItem: (props: Props) => JSX.Element;

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -69,6 +69,8 @@ const DocsVersionDropdownNavbarItemSchema = Joi.object({
   position: NavbarItemPosition,
   docsPluginId: Joi.string(),
   dropdownActiveClassDisabled: Joi.boolean(),
+  dropdownItemsBefore: Joi.array().items(DefaultNavbarItemSchema).default([]),
+  dropdownItemsAfter: Joi.array().items(DefaultNavbarItemSchema).default([]),
 });
 
 const DocItemSchema = Joi.object({

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -25,6 +25,7 @@ interface Props {
   readonly href?: string;
   readonly activeClassName?: string;
   readonly children?: ReactNode;
+  readonly isActive?: () => boolean;
 
   // escape hatch in case broken links check is annoying for a specific link
   readonly 'data-noBrokenLinkCheck'?: boolean;
@@ -42,6 +43,7 @@ function Link({
   to,
   href,
   activeClassName,
+  isActive,
   'data-noBrokenLinkCheck': noBrokenLinkCheck,
   ...props
 }: Props): JSX.Element {
@@ -154,7 +156,7 @@ function Link({
       innerRef={handleRef}
       to={targetLink || ''}
       // avoid "React does not recognize the `activeClassName` prop on a DOM element"
-      {...(isNavLink && {activeClassName})}
+      {...(isNavLink && {isActive, activeClassName})}
     />
   );
 }

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -297,11 +297,11 @@ module.exports = {
           type: 'docsVersionDropdown',
           position: 'left',
 
-          // Add additional dropdown items at the beginning/end of the dropdown
+          // Add additional dropdown items at the beginning/end of the dropdown.
           dropdownItemsBefore: [],
           dropdownItemsAfter: [{to: '/versions', label: 'All versions'}],
 
-          // do not add the link active class when browsing docs
+          // Do not add the link active class when browsing docs.
           dropdownActiveClassDisabled: true,
         },
       ],

--- a/website/docs/theme-classic.md
+++ b/website/docs/theme-classic.md
@@ -296,7 +296,13 @@ module.exports = {
         {
           type: 'docsVersionDropdown',
           position: 'left',
-          // dropdownActiveClassDisabled: true, //
+
+          // Add additional dropdown items at the beginning/end of the dropdown
+          dropdownItemsBefore: [],
+          dropdownItemsAfter: [{to: '/versions', label: 'All versions'}],
+
+          // do not add the link active class when browsing docs
+          dropdownActiveClassDisabled: true,
         },
       ],
     },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -263,11 +263,6 @@ module.exports = {
       },
       items: [
         {
-          type: 'docsVersionDropdown',
-          position: 'left',
-          dropdownActiveClassDisabled: true,
-        },
-        {
           type: 'doc',
           position: 'left',
           docId: 'introduction',
@@ -287,10 +282,17 @@ module.exports = {
           position: 'left',
           activeBaseRegex: `/community/`,
         },
+        // right
         {
-          to: '/versions',
-          label: 'All versions',
+          type: 'docsVersionDropdown',
           position: 'right',
+          dropdownActiveClassDisabled: true,
+          dropdownItemsAfter: [
+            {
+              to: '/versions',
+              label: 'All versions',
+            },
+          ],
         },
         {
           href: 'https://github.com/facebook/docusaurus',


### PR DESCRIPTION

## Motivation

Our own site navbar is becoming crowded.

Nesting the "All Versions" link inside the dropdown permits to remove more easily a useless navbar element.

![image](https://user-images.githubusercontent.com/749374/95334807-dcff9080-08ae-11eb-96db-054ce153e206.png)


I also see this as a possible way to link to older archived versions that are not in Docusaurus site anymore. 

For example, the RN website has 64+ versions, but it's not manageable to keep so much versions, so we can only keep recent versions in Docusaurus, but still be able to link to older ones (published as standalone immutable sites).

cc @lex111 @Simek 



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview + dogfooding
