### PR TITLE
fix(v2): use absolute path to manifest file

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -136,7 +136,7 @@ module.exports = {
           {
             tagName: 'link',
             rel: 'manifest',
-            href: 'manifest.json',
+            href: '/manifest.json',
           },
           {
             tagName: 'meta',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -136,7 +136,7 @@ module.exports = {
           {
             tagName: 'link',
             rel: 'manifest',
-            href: '/manifest.json',
+            href: `${baseUrl}manifest.json`,
           },
           {
             tagName: 'meta',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

If you visit any page other than the home page, for example https://v2.docusaurus.io/docs/, then you can see the following error in the console:

> Failed to load resource: the server responded with a status of 404 ()   manifest.json

Or something like this:

> Manifest: Line: 1, column: 1, Syntax error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview (see motivation section).

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
