### PR TITLE
feat(v2): prevent using remote image urls in showcase

### DIFF
--- a/website-1.x/core/Showcase.js
+++ b/website-1.x/core/Showcase.js
@@ -7,15 +7,6 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const users = require('../data/users');
-
-users.forEach((user) => {
-  if (!user.image.startsWith('/img/users')) {
-    throw new Error(
-      `User image should be self-hosted in /img/users folder. This was not the case for ${user.image}`,
-    );
-  }
-});
 
 const UserLink = ({infoLink, image, caption}) => (
   <a className="link" href={infoLink} key={infoLink}>

--- a/website-1.x/data/users.js
+++ b/website-1.x/data/users.js
@@ -894,7 +894,7 @@ const users = [
 ];
 
 users.forEach((user) => {
-  if (!user.image || !user.image.startsWith('/img/users/')) {
+  if (!user.image || user.image.indexOf('/img/users/') !== 0) {
     throw new Error(
       `Bad user site image = ${user.image}. The image should be hosted on Docusaurus site, in /static/img/users/ folder, and not use remote http or https urls`,
     );

--- a/website-1.x/data/users.js
+++ b/website-1.x/data/users.js
@@ -894,7 +894,7 @@ const users = [
 ];
 
 users.forEach((user) => {
-  if (!user.image || user.image.indexOf('/img/users/') !== 0) {
+  if (!user.image || user.image.startsWith('/img/users/')) {
     throw new Error(
       `Bad user site image = ${user.image}. The image should be hosted on Docusaurus site, in /static/img/users/ folder, and not use remote http or https urls`,
     );

--- a/website-1.x/data/users.js
+++ b/website-1.x/data/users.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = [
+const users = [
   // Please add your logo in alphabetical order of caption.
   {
     caption: '1Hive',
@@ -892,3 +892,13 @@ module.exports = [
 
   // Please add your logo in alphabetical order of caption.
 ];
+
+users.forEach((user) => {
+  if (!user.image || !user.image.startsWith('/img/users/')) {
+    throw new Error(
+      `Bad user site image = ${user.image}. The image should be hosted on Docusaurus site, in /static/img/users/ folder, and not use remote http or https urls`,
+    );
+  }
+});
+
+module.exports = users;

--- a/website-1.x/data/users.js
+++ b/website-1.x/data/users.js
@@ -894,7 +894,7 @@ const users = [
 ];
 
 users.forEach((user) => {
-  if (!user.image || user.image.startsWith('/img/users/')) {
+  if (!user.image || !user.image.startsWith('/img/users/')) {
     throw new Error(
       `Bad user site image = ${user.image}. The image should be hosted on Docusaurus site, in /static/img/users/ folder, and not use remote http or https urls`,
     );

--- a/website/src/data/users.js
+++ b/website/src/data/users.js
@@ -269,4 +269,16 @@ const users = [
   },
 ];
 
+users.forEach((user) => {
+  if (
+    !user.preview ||
+    user.preview.startsWith('http') ||
+    user.preview.startsWith('//')
+  ) {
+    throw new Error(
+      `Bad user site image preview = ${user.preview}. The image should be hosted on Docusaurus site, and not use remote http or https urls`,
+    );
+  }
+});
+
 export default users;

--- a/website/src/data/users.js
+++ b/website/src/data/users.js
@@ -272,8 +272,8 @@ const users = [
 users.forEach((user) => {
   if (
     !user.preview ||
-    user.preview.startsWith('http') ||
-    user.preview.startsWith('//')
+    user.preview.indexOf('http') === 0 ||
+    user.preview.indexOf('//') === 0
   ) {
     throw new Error(
       `Bad user site image preview = ${user.preview}. The image should be hosted on Docusaurus site, and not use remote http or https urls`,

--- a/website/src/data/users.js
+++ b/website/src/data/users.js
@@ -272,8 +272,8 @@ const users = [
 users.forEach((user) => {
   if (
     !user.preview ||
-    user.preview.indexOf('http') === 0 ||
-    user.preview.indexOf('//') === 0
+    (user.preview instanceof String &&
+      (user.preview.startsWith('http') || user.preview.startsWith('//')))
   ) {
     throw new Error(
       `Bad user site image preview = ${user.preview}. The image should be hosted on Docusaurus site, and not use remote http or https urls`,


### PR DESCRIPTION

## Motivation

Ensure we never accept a remote url as showcase image on Docusaurus sites, as remote URLs are likely to break over time.

(example: https://github.com/facebook/docusaurus/pull/3556#pullrequestreview-504664603)
