### PR TITLE
docs(v2): deployment, add required Github token scope infos

### DIFF
--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -203,7 +203,7 @@ jobs:
 
 Continuous integration (CI) services are typically used to perform routine tasks whenever new commits are checked in to source control. These tasks can be any combination of running unit tests and integration tests, automating builds, publishing packages to NPM, and deploying changes to your website. All you need to do to automate the deployment of your website is to invoke the `yarn deploy` script whenever your website is updated. The following section covers how to do just that using [Travis CI](https://travis-ci.com/), a popular continuous integration service provider.
 
-1. Go to https://github.com/settings/tokens and generate a new [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
+1. Go to https://github.com/settings/tokens and generate a new [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/). When creating the token, grant it the `repo` scope so that it has the permissions it needs.
 1. Using your GitHub account, [add the Travis CI app](https://github.com/marketplace/travis-ci) to the repository you want to activate.
 1. Open your Travis CI dashboard. The URL looks like https://travis-ci.com/USERNAME/REPO, and navigate to the `More options` > `Setting` > `Environment Variables` section of your repository.
 1. Create a new environment variable named `GH_TOKEN` with your newly generated token as its value, then `GH_EMAIL` (your email address) and `GH_NAME` (your GitHub username).
@@ -231,7 +231,7 @@ Now, whenever a new commit lands in `master`, Travis CI will run your suite of t
 
 1.  Sign Up at [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) if you haven't already.
 1.  Create an organization and within the organization create a project and connect your repository from GitHub.
-1.  Go to https://github.com/settings/tokens and generate a new [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with repository scope.
+1.  Go to https://github.com/settings/tokens and generate a new [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with the `repo` scope.
 1.  In the project page (which looks like https://dev.azure.com/ORG_NAME/REPO_NAME/_build) create a new pipeline with the following text. Also, click on edit and add a new environment variable named `GH_TOKEN` with your newly generated token as its value, then `GH_EMAIL` (your email address) and `GH_NAME` (your GitHub username). Make sure to mark them as secret. Alternatively, you can also add a file named `azure-pipelines.yml` at yout repository root.
 
 ```yaml title="azure-pipelines.yml"


### PR DESCRIPTION
Fixes #3189

## Motivation

Fix #3189 - clarify the necessary 'scope' required on the personal access token for deploying to GitHub pages through both Travis CI and Azure Pipelines

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

Because this is a documentation-only change, I haven't done any testing on the software itself. However, I performed manual testing to ensure the documentation change listed here is correct. The testing included:  

* Creating a test Docusaurus repository
* Creating a personal access token
    * Testing using different 'scopes' on the personal access token
    * Noted the minimum 'scope' required to successfully deploy
* Deploying successfully to GitHub pages

## Related PRs

N/A
