### PR TITLE
refactor(v2): make accessible copy code button from keyboard

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-
 import React, {useEffect, useState, useRef} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps} from 'prism-react-renderer';
@@ -210,6 +208,7 @@ export default ({
           )}
           <div className={styles.codeBlockContent}>
             <button
+              tabIndex={0}
               ref={button}
               type="button"
               aria-label="Copy code to clipboard"
@@ -220,7 +219,6 @@ export default ({
               {showCopied ? 'Copied' : 'Copy'}
             </button>
             <div
-              tabIndex={0}
               className={clsx(className, styles.codeBlock, {
                 [styles.codeBlockWithTitle]: codeBlockTitle,
               })}>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -36,19 +36,21 @@
   color: var(--ifm-color-white);
   cursor: pointer;
   opacity: 0;
-  outline: none;
+  user-select: none;
   padding: 0.4rem 0.5rem;
   position: absolute;
   right: calc(var(--ifm-pre-padding) / 2);
   top: calc(var(--ifm-pre-padding) / 2);
-  visibility: hidden;
-  transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out,
-    bottom 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
 }
 
 .codeBlockTitle:hover + .codeBlockContent .copyButton,
 .codeBlockContent:hover > .copyButton {
-  visibility: visible;
+  outline: none;
+  opacity: 1;
+}
+
+.copyButton:focus {
   opacity: 1;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, code blocks are indicated as interactive elements (using `tabIndex="0"`), which is wrong and completely unnecessary. Instead that, we need to make the copy code button accessible from keyboard (see test plan).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/4408379/96041768-04d59200-0e75-11eb-82bb-65d1f922ebea.gif) | ![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/4408379/96041817-1880f880-0e75-11eb-8412-f5f5e1996a5d.gif) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
