### PR TITLE
chore(v2): enable new contextual search feature

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -43,8 +43,6 @@ function DocSearch({contextualSearch, ...props}) {
     ...props.searchParameters,
   };
 
-  console.log('searchParameters', contextualSearch, searchParameters);
-
   const {withBaseUrl} = useBaseUrlUtils();
   const history = useHistory();
   const searchButtonRef = useRef(null);

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -249,10 +249,7 @@ module.exports = {
     algolia: {
       apiKey: '47ecd3b21be71c5822571b9f59e52544',
       indexName: 'docusaurus-2',
-      // contextualSearch: true,
-      searchParameters: {
-        facetFilters: [`version:current`],
-      },
+      contextualSearch: true,
     },
     navbar: {
       hideOnScroll: true,


### PR DESCRIPTION

## Motivation

Enable contextual search (https://github.com/facebook/docusaurus/pull/3550) on our own website.

Done in 2 phases because we need to wait for Algolia crawlers to run