### PR TITLE
fix(v2): remove event listeners on Tabs component unmount

### DIFF
--- a/packages/docusaurus-theme-bootstrap/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-bootstrap/src/theme/Tabs/index.tsx
@@ -106,6 +106,11 @@ function Tabs(props: Props): JSX.Element {
   useEffect(() => {
     window.addEventListener('keydown', handleKeyboardEvent);
     window.addEventListener('mousedown', handleMouseEvent);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyboardEvent);
+      window.removeEventListener('mousedown', handleMouseEvent);
+    };
   }, []);
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -93,6 +93,11 @@ function Tabs(props: Props): JSX.Element {
   useEffect(() => {
     window.addEventListener('keydown', handleKeyboardEvent);
     window.addEventListener('mousedown', handleMouseEvent);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyboardEvent);
+      window.removeEventListener('mousedown', handleMouseEvent);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The following warning is currently displayed in the console when using tabs:


```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function. in Tabs (created by MDXCreateElement)
```

To get rid of this error we need to remove the event listeners.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
