### PR TITLE
fix(v2): animate dropdown properly

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -64,6 +64,23 @@ function DocSidebarItemCategory({
     return isActive ? false : item.collapsed;
   });
 
+  const menuListRef = useRef<HTMLUListElement>(null);
+  const [menuListHeight, setMenuListHeight] = useState<string | undefined>(
+    undefined,
+  );
+  const handleMenuListHeight = (type: 'auto' | 'calc' | 'none') => {
+    switch (type) {
+      case 'calc':
+        return setMenuListHeight(
+          `calc(${menuListRef.current?.scrollHeight}px - var(--ifm-list-item-margin))`,
+        );
+      case 'none':
+        return setMenuListHeight('0px');
+      default:
+        return setMenuListHeight(undefined);
+    }
+  };
+
   // If we navigate to a category, it should automatically expand itself
   useEffect(() => {
     const justBecameActive = isActive && !wasActive;
@@ -75,10 +92,19 @@ function DocSidebarItemCategory({
   const handleItemClick = useCallback(
     (e) => {
       e.preventDefault();
+
+      handleMenuListHeight('calc');
+
       setCollapsed((state) => !state);
     },
     [setCollapsed],
   );
+
+  useEffect(() => {
+    if (collapsed) {
+      handleMenuListHeight('none');
+    }
+  }, [collapsed]);
 
   if (items.length === 0) {
     return null;
@@ -101,7 +127,15 @@ function DocSidebarItemCategory({
         {...props}>
         {label}
       </a>
-      <ul className="menu__list">
+      <ul
+        className="menu__list"
+        ref={menuListRef}
+        style={{height: menuListHeight}}
+        onTransitionEnd={() => {
+          if (!collapsed) {
+            handleMenuListHeight('auto');
+          }
+        }}>
         {items.map((childItem) => (
           <DocSidebarItem
             tabIndex={collapsed ? '-1' : '0'}

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -68,17 +68,10 @@ function DocSidebarItemCategory({
   const [menuListHeight, setMenuListHeight] = useState<string | undefined>(
     undefined,
   );
-  const handleMenuListHeight = (type: 'auto' | 'calc' | 'none') => {
-    switch (type) {
-      case 'calc':
-        return setMenuListHeight(
-          `calc(${menuListRef.current?.scrollHeight}px - var(--ifm-list-item-margin))`,
-        );
-      case 'none':
-        return setMenuListHeight('0px');
-      default:
-        return setMenuListHeight(undefined);
-    }
+  const handleMenuListHeight = (calc = true) => {
+    setMenuListHeight(
+      calc ? `${menuListRef.current?.scrollHeight}px` : undefined,
+    );
   };
 
   // If we navigate to a category, it should automatically expand itself
@@ -93,18 +86,14 @@ function DocSidebarItemCategory({
     (e) => {
       e.preventDefault();
 
-      handleMenuListHeight('calc');
+      if (!menuListHeight) {
+        handleMenuListHeight();
+      }
 
-      setCollapsed((state) => !state);
+      setTimeout(() => setCollapsed((state) => !state), 100);
     },
-    [setCollapsed],
+    [menuListHeight],
   );
-
-  useEffect(() => {
-    if (collapsed) {
-      handleMenuListHeight('none');
-    }
-  }, [collapsed]);
 
   if (items.length === 0) {
     return null;
@@ -130,10 +119,12 @@ function DocSidebarItemCategory({
       <ul
         className="menu__list"
         ref={menuListRef}
-        style={{height: menuListHeight}}
+        style={{
+          height: menuListHeight,
+        }}
         onTransitionEnd={() => {
           if (!collapsed) {
-            handleMenuListHeight('auto');
+            handleMenuListHeight(false);
           }
         }}>
         {items.map((childItem) => (

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -97,3 +97,7 @@
   /* Same as "arrow" transition */
   transition: height var(--ifm-transition-fast) linear;
 }
+
+:global(.menu__list-item--collapsed) :global(.menu__list) {
+  height: 0px !important;
+}

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -89,3 +89,11 @@
   line-height: 0.9;
   width: 24px;
 }
+
+/* TODO: Move to Infima */
+:global(.menu__list) :global(.menu__list) {
+  overflow-y: hidden;
+  will-change: height;
+  /* Same as "arrow" transition */
+  transition: height var(--ifm-transition-fast) linear;
+}

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -156,6 +156,7 @@ function NavItemMobile({
   position: _position, // Need to destructure position from props so that it doesn't get passed on.
   ...props
 }: DesktopOrMobileNavBarItemProps) {
+  const menuListRef = useRef<HTMLUListElement>(null);
   const {pathname} = useLocation();
   const [collapsed, setCollapsed] = useState(
     () => !items?.some((item) => isSamePath(item.to, pathname)) ?? true,
@@ -191,7 +192,14 @@ function NavItemMobile({
         }}>
         {props.label}
       </NavLink>
-      <ul className="menu__list">
+      <ul
+        className="menu__list"
+        ref={menuListRef}
+        style={{
+          height: !collapsed
+            ? `${menuListRef.current?.scrollHeight}px`
+            : undefined,
+        }}>
         {items.map(({className: childItemClassName, ...childItemProps}, i) => (
           <li className="menu__list-item" key={i}>
             <NavLink


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, in Infima we have height transition CSS property, but it won't work unless the element's height is explicitly specified.
This PR sets the dropdown height at click time so that the CSS transition can work as expected.

The desktop implementation looks trickier because we can have nested dropdowns, so the final height can be dynamic (depending on whether the nested dropdown is expanded or collapsed).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

| Desktop   | Mobile    |
| -------- | -------- |
| ![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/4408379/96322374-73efe980-1021-11eb-8db7-97714b24586c.gif) | ![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/4408379/96322376-77837080-1021-11eb-9f3e-6cc4802ba67f.gif) |


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
