### PR TITLE
fix(v2): fix error with required href attr of link in mobiles

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -184,6 +184,7 @@ function NavItemMobile({
         'menu__list-item--collapsed': collapsed,
       })}>
       <NavLink
+        role="button"
         className={navLinkClassNames(className, true)}
         {...props}
         onClick={() => {

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -146,7 +146,8 @@ function Link({
     // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a
       href={targetLink}
-      {...(!isInternal && {target: '_blank', rel: 'noopener noreferrer'})}
+      {...(targetLinkUnprefixed &&
+        !isInternal && {target: '_blank', rel: 'noopener noreferrer'})}
       {...props}
     />
   ) : (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, the versions dropdown link on mobiles lacks the required attribute  `href`, about this HTML error reported Rocket Validator:

> Element “a” is missing required attribute “href”.
> `...ollapsed"><a target="_blank" rel="noopener noreferrer" class="menu__link menu__link--sublist">Versions`


To get rid of this error, we need to set ARIA role on the link.

Also in this PR I fixed adding redundant attributes (`target="_blank" rel="noopener noreferrer"`) if `to`/`href` prop not passed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
