### PR TITLE
refactor(v2): Improve SSR error message: log page path

### DIFF
--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -26,7 +26,7 @@ import {
   createStatefulLinksCollector,
   ProvideLinksCollector,
 } from './LinksCollector';
-
+import chalk from 'chalk';
 // eslint-disable-next-line no-restricted-imports
 import {memoize} from 'lodash';
 
@@ -41,8 +41,21 @@ function renderSSRTemplate(ssrTemplate, data) {
   return compiled(data, eta.defaultConfig);
 }
 
-// Renderer for static-site-generator-webpack-plugin (async rendering via promises).
 export default async function render(locals) {
+  try {
+    return await doRender(locals);
+  } catch (e) {
+    console.error(
+      chalk.red(
+        `Docusaurus Node/SSR could not render static page with path=${locals.path} because of error: ${e.message}`,
+      ),
+    );
+    throw e;
+  }
+}
+
+// Renderer for static-site-generator-webpack-plugin (async rendering via promises).
+async function doRender(locals) {
   const {
     routesLocation,
     headTags,


### PR DESCRIPTION

## Motivation

Put bad markup in a MDX file:

![image](https://user-images.githubusercontent.com/749374/96494485-b5151300-1246-11eb-90cc-1d5deb0d4a2f.png)


On build, you get this kind of unactionable error:

![image](https://user-images.githubusercontent.com/749374/96494346-85fea180-1246-11eb-8055-d429c38d448d.png)


To make this error more actionable, we should log the page path for which we couldn't render:

![image](https://user-images.githubusercontent.com/749374/96494644-ebeb2900-1246-11eb-8640-3d5ae6d09d07.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

local test


