### PR TITLE
fix(v2): Added back support for optional logo field in theme-classic navbarConfig

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLogo.ts
@@ -13,7 +13,7 @@ import useThemeConfig from '../../utils/useThemeConfig';
 
 const useLogo = (): useLogoReturns => {
   const {
-    navbar: {logo},
+    navbar: {logo = {}},
   } = useThemeConfig();
   const {isDarkTheme} = useThemeContext();
   const logoLink = useBaseUrl(logo.href || '/');

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -39,6 +39,7 @@ const DEFAULT_CONFIG = {
   navbar: {
     hideOnScroll: false,
     items: [],
+    logo: {},
   },
 };
 exports.DEFAULT_CONFIG = DEFAULT_CONFIG;

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -39,7 +39,6 @@ const DEFAULT_CONFIG = {
   navbar: {
     hideOnScroll: false,
     items: [],
-    logo: {},
   },
 };
 exports.DEFAULT_CONFIG = DEFAULT_CONFIG;
@@ -249,7 +248,7 @@ const ThemeConfigSchema = Joi.object({
       srcDark: Joi.string(),
       href: Joi.string(),
       target: Joi.string(),
-    }).default({}),
+    }),
   }).default(DEFAULT_CONFIG.navbar),
   footer: Joi.object({
     style: Joi.string().equal('dark', 'light').default('light'),

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -248,7 +248,7 @@ const ThemeConfigSchema = Joi.object({
       srcDark: Joi.string(),
       href: Joi.string(),
       target: Joi.string(),
-    }),
+    }).default({}),
   }).default(DEFAULT_CONFIG.navbar),
   footer: Joi.object({
     style: Joi.string().equal('dark', 'light').default('light'),


### PR DESCRIPTION

## Motivation

Fix #3610.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Comment out the `logo` field in docusaurus website's docusaurus.config.js, like:

```js
  // ...
  navbar: {
      hideOnScroll: true,
      title: 'Docusaurus',
      /* logo: {
        alt: 'Docusaurus Logo',
        src: 'img/docusaurus.svg',
        srcDark: 'img/docusaurus_keytar.svg',
      },
      */
  // ...
  }
```

Without this change, site will crash:
<img width="1792" alt="Screen Shot 2020-10-19 at 14 56 12" src="https://user-images.githubusercontent.com/4290500/96499541-8df51c00-121b-11eb-9113-f966f18ab791.png">

With this change, site will load as usual, without the logo:
<img width="1792" alt="Screen Shot 2020-10-19 at 14 55 59" src="https://user-images.githubusercontent.com/4290500/96499533-8c2b5880-121b-11eb-8fc2-0b0ed194b6ca.png">

## Related PRs

N/A