### PR TITLE
fix(v2): docusaurus start --poll 500 should work + better config load failure error

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -101,7 +101,7 @@ export type HostPortCLIOptions = {
 export type StartCLIOptions = HostPortCLIOptions & {
   hotOnly: boolean;
   open: boolean;
-  poll: boolean;
+  poll: boolean | number;
 };
 
 export type ServeCLIOptions = HostPortCLIOptions & {

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -146,8 +146,8 @@ cli
   )
   .option('--no-open', 'Do not open page in the browser (default: false)')
   .option(
-    '--poll',
-    'Use polling rather than watching for reload (default: false)',
+    '--poll [interval]',
+    'Use polling rather than watching for reload (default: false). Can specify a poll interval in milliseconds.',
   )
   .action((siteDir = '.', {port, host, hotOnly, open, poll}) => {
     wrapCommand(start)(path.resolve(siteDir), {

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -81,10 +81,16 @@ export default async function start(
         .filter(Boolean),
     )
     .map(normalizeToSiteDir);
+
   const fsWatcher = chokidar.watch([...pluginPaths, CONFIG_FILE_NAME], {
     cwd: siteDir,
     ignoreInitial: true,
+    usePolling: !!cliOptions.poll,
+    interval: Number.isInteger(cliOptions.poll)
+      ? (cliOptions.poll as number)
+      : undefined,
   });
+
   ['add', 'change', 'unlink', 'addDir', 'unlinkDir'].forEach((event) =>
     fsWatcher.on(event, reload),
   );

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -6,7 +6,7 @@ exports[`loadConfig website with incomplete siteConfig 1`] = `
 "
 `;
 
-exports[`loadConfig website with no siteConfig 1`] = `"docusaurus.config.js not found"`;
+exports[`loadConfig website with no siteConfig 1`] = `"docusaurus.config.js not found at packages/docusaurus/src/server/__tests__/__fixtures__/nonExisting/docusaurus.config.js"`;
 
 exports[`loadConfig website with useless field (wrong field) in siteConfig 1`] = `
 "\\"favicon\\" is required

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -20,7 +20,12 @@ export default function loadConfig(siteDir: string): DocusaurusConfig {
   const configPath = path.resolve(siteDir, loadedConfigFileName);
 
   if (!fs.existsSync(configPath)) {
-    throw new Error(`${CONFIG_FILE_NAME} not found at ${configPath}`);
+    throw new Error(
+      `${CONFIG_FILE_NAME} not found at ${path.relative(
+        process.cwd(),
+        configPath,
+      )}`,
+    );
   }
 
   const loadedConfig = importFresh(configPath) as Partial<DocusaurusConfig>;

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -20,7 +20,7 @@ export default function loadConfig(siteDir: string): DocusaurusConfig {
   const configPath = path.resolve(siteDir, loadedConfigFileName);
 
   if (!fs.existsSync(configPath)) {
-    throw new Error(`${CONFIG_FILE_NAME} not found`);
+    throw new Error(`${CONFIG_FILE_NAME} not found at ${configPath}`);
   }
 
   const loadedConfig = importFresh(configPath) as Partial<DocusaurusConfig>;

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -49,7 +49,7 @@ Builds and serves a preview of your site locally with [Webpack Dev Server](https
 | `--host` | `localhost` | Specify a host to use. For example, if you want your server to be accessible externally, you can use `--host 0.0.0.0`. |
 | `--hot-only` | `false` | Enables Hot Module Replacement without page refresh as fallback in case of build failures. More information [here](https://webpack.js.org/configuration/dev-server/#devserverhotonly). |
 | `--no-open` | `false` | Do not open automatically the page in the browser. |
-| `--poll` | `false` | Use polling of files rather than watching for live reload as a fallback in environments where watching doesn't work. More information [here](https://webpack.js.org/configuration/watch/#watchoptionspoll). |
+| `--poll [optionalIntervalMs]` | `false` | Use polling of files rather than watching for live reload as a fallback in environments where watching doesn't work. More information [here](https://webpack.js.org/configuration/watch/#watchoptionspoll). |
 
 :::important
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/facebook/docusaurus/issues/3620

`docusaurus start --poll 500` should accept 500 as poll interval value

Also we should use polling for both webpack dev server and chokidar file watchers

Also improve the error message in such weird case so that user can understand we try to load the config from `500/docusaurus.config.js`  and that 500 is interpreted as the cli siteDir arg.

![image](https://user-images.githubusercontent.com/749374/96745196-26c79b00-13c6-11eb-903c-2114a739909e.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Local test and checking the correct args are forwarded to Webpack config

```
yarn start:v2
yarn start:v2 --poll
yarn start:v2 --poll 500
```
