### PR TITLE
fix(v2): disable tabbing on hidden doc sidebar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -29,6 +29,7 @@
     opacity: 0;
     height: 0;
     overflow: hidden;
+    visibility: hidden;
   }
 
   .sidebarLogo {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When the doc sidebar is hidden, we shouldn't be able to navigate through the menu items from the keyboard (by pressing Tab key).

Follow-up of #3615 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
