### PR TITLE
Modified KEY name

### DIFF
--- a/website/docs/theme-bootstrap.md
+++ b/website/docs/theme-bootstrap.md
@@ -72,7 +72,7 @@ module.exports = {
   // ...
   themeConfig: {
     navbar: {
-      links: [
+      items: [
         {
           // Client-side routing, used for navigating within the website.
           // The baseUrl will be automatically prepended to this value.


### PR DESCRIPTION
I've just modified the key name because in docusaurus in alpha 2.0.0.67-alpha had still shown in the docs links as a KEY of the themeConfig.navabar.links.

But I got the console log shown like as below

```
ValidationError: themeConfig.navbar.links has been renamed as themeConfig.navbar.items
```

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
