### PR TITLE
fix(v2): wrap code blocks on print

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -63,3 +63,9 @@
   min-width: 100%;
   padding: var(--ifm-pre-padding);
 }
+
+@media print {
+  .codeBlockLines {
+    white-space: pre-wrap;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently code blocks with scrollbars are cut off on print. They should be wrapped instead.
Fixes #3633. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

Before:

![Screen Shot 2020-10-26 at 00 20 44](https://user-images.githubusercontent.com/7151454/97114582-ef3d5380-1723-11eb-81af-7f87e4414e6b.png)

After:

![Screen Shot 2020-10-26 at 00 21 45](https://user-images.githubusercontent.com/7151454/97114588-fcf2d900-1723-11eb-963e-b0fa97f0daed.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
