### PR TITLE
fix(v2): restore infinite scroll pagination on search page

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -239,9 +239,8 @@ function Search() {
       : 'Search the documentation';
 
   const makeSearch = (page = 0) => {
-    algoliaHelper.setQuery(searchQuery).setPage(page);
-
     algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', 'default');
+
     Object.entries(docsSearchVersionsHelpers.searchVersions).forEach(
       ([pluginId, searchVersion]) => {
         algoliaHelper.addDisjunctiveFacetRefinement(
@@ -251,7 +250,7 @@ function Search() {
       },
     );
 
-    algoliaHelper.search();
+    algoliaHelper.setQuery(searchQuery).setPage(page).search();
   };
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

PR #3604 broke the infinite scroll pagination functionality on the search page, because the page is always 0. To fix it we first need set facet refinements, and then query, page, etc.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
