### PR TITLE
misc: fix unbound env variable in test release script

### DIFF
--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -27,7 +27,7 @@ git diff --name-only -- '*.json' | sed 's, ,\\&,g' | xargs git checkout --
 npm_config_registry="$CUSTOM_REGISTRY_URL" npx @docusaurus/init@"$NEW_VERSION" init test-website classic
 
 # Stop Docker container
-if (! $KEEP_CONTAINER) && ( $(docker container inspect "$CONTAINER_NAME" > /dev/null 2>&1) ); then
+if [[ -z "${KEEP_CONTAINER:-}" ]] && ( $(docker container inspect "$CONTAINER_NAME" > /dev/null 2>&1) ); then
   # Remove Docker container
   docker container stop $CONTAINER_NAME > /dev/null
 fi


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, in test release script Docker container never stops due to Bash error:

> KEEP_CONTAINER: unbound variable
> error Command failed with exit code 1.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- `yarn test:build:v2` - Docker container will stop

- `KEEP_CONTAINER=true yarn test:build:v2` - Docker container won't stop

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
