### PR TITLE
fix(v2): do not set height for mobile dropdown during build

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -179,6 +179,10 @@ function NavItemMobile({
     );
   }
 
+  const menuListHeight = menuListRef.current?.scrollHeight
+    ? `${menuListRef.current?.scrollHeight}px`
+    : undefined;
+
   return (
     <li
       className={clsx('menu__list-item', {
@@ -197,9 +201,7 @@ function NavItemMobile({
         className="menu__list"
         ref={menuListRef}
         style={{
-          height: !collapsed
-            ? `${menuListRef.current?.scrollHeight}px`
-            : undefined,
+          height: !collapsed ? menuListHeight : undefined,
         }}>
         {items.map(({className: childItemClassName, ...childItemProps}, i) => (
           <li className="menu__list-item" key={i}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Follow-up of #3603.

Fix HTML issue reported by Rocket Validator (_CSS: “height”: Too many values or values are not recognized_)

> `rsions</a><ul class="menu__list" style="height:undefinedpx"><li cl`

Explanation: this happens because during the build website currently calculate mobile dropdown  height for work of CSS transition, but the element does not exist on prerendering, so we get `undefined`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview (see source code)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
