### PR TITLE
fix(v2): add landmark for skip to content link

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -25,13 +25,15 @@ function SkipToContent(): JSX.Element {
   };
 
   return (
-    <button
-      type="button"
-      tabIndex={0}
-      className={styles.skipToContent}
-      onKeyDown={handleSkip}>
-      Skip to main content
-    </button>
+    <nav aria-label="Skip navigation links">
+      <button
+        type="button"
+        tabIndex={0}
+        className={styles.skipToContent}
+        onKeyDown={handleSkip}>
+        Skip to main content
+      </button>
+    </nav>
   );
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In #3640 I added skip to content link, but did not validate this feature from a11y point of view. Using Rocket Validator, I found out the following related issue:

> All page content must be contained by landmarks
> `<button type="button" tabindex="0" class="skipToContent_3oI8">Skip to main content</button>`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
