### PR TITLE
docs(v1): fix typo on Add Versions doc page

### DIFF
--- a/website-1.x/docs/tutorial-version.md
+++ b/website-1.x/docs/tutorial-version.md
@@ -15,7 +15,7 @@ Assume you are happy with the current state of the documentation and want to fre
 npm run examples versions
 ```
 
-That command generates a `versions.js` file, which will be used to list down all the versions of docs in the project.
+That command generates a `versions.json` file, which will be used to list down all the versions of docs in the project.
 
 Next, you run a command with the version you want to create, like `1.0.0`.
 


### PR DESCRIPTION
The file generated when you run `npm run examples versions` is a versions.json file and not a version.js file

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
