### PR TITLE
feat(v2): onBrokenMarkdownLinks config

### DIFF
--- a/packages/docusaurus-init/templates/bootstrap/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/bootstrap/docusaurus.config.js
@@ -4,6 +4,7 @@ module.exports = {
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
   onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'facebook', // Usually your GitHub org/user name.
   projectName: 'docusaurus', // Usually your repo name.

--- a/packages/docusaurus-init/templates/classic/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/classic/docusaurus.config.js
@@ -4,6 +4,7 @@ module.exports = {
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
   onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'facebook', // Usually your GitHub org/user name.
   projectName: 'docusaurus', // Usually your repo name.

--- a/packages/docusaurus-init/templates/facebook/docusaurus.config.js
+++ b/packages/docusaurus-init/templates/facebook/docusaurus.config.js
@@ -13,6 +13,7 @@ module.exports = {
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
   onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'facebook', // Usually your GitHub org/user name.
   projectName: 'docusaurus', // Usually your repo name.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
@@ -31,6 +31,7 @@ module.exports = {
     facebookAppId: '199138890728411',
   },
   onBrokenLinks: 'log',
+  onBrokenMarkdownLinks: 'log',
   presets: [
     [
       '@docusaurus/preset-classic',

--- a/packages/docusaurus-migrate/src/index.ts
+++ b/packages/docusaurus-migrate/src/index.ts
@@ -302,6 +302,7 @@ export function createConfigFile({
     favicon: siteConfig.favicon ?? '',
     customFields: customConfigFields,
     onBrokenLinks: 'log',
+    onBrokenMarkdownLinks: 'log',
     presets: [
       [
         '@docusaurus/preset-classic',

--- a/packages/docusaurus-migrate/src/types.ts
+++ b/packages/docusaurus-migrate/src/types.ts
@@ -38,6 +38,7 @@ export interface VersionTwoConfig {
   noIndex?: boolean;
   githubHost?: string;
   onBrokenLinks: string;
+  onBrokenMarkdownLinks: string;
   plugins: Array<[string, {[key: string]: any}]>;
   themes?: [];
   presets: [[string, ClassicPresetEntries]];

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -11,7 +11,12 @@ import {
   STATIC_DIR_NAME,
   DEFAULT_PLUGIN_ID,
 } from '@docusaurus/core/lib/constants';
-import {normalizeUrl, docuHash, aliasedSitePath} from '@docusaurus/utils';
+import {
+  normalizeUrl,
+  docuHash,
+  aliasedSitePath,
+  reportMessage,
+} from '@docusaurus/utils';
 import {LoadContext, Plugin, RouteConfig} from '@docusaurus/types';
 
 import {loadSidebars, createSidebarsUtils} from './sidebars';
@@ -39,13 +44,12 @@ import {OptionsSchema} from './options';
 import {flatten, keyBy, compact} from 'lodash';
 import {toGlobalDataVersion} from './globalData';
 import {toVersionMetadataProp} from './props';
-import chalk from 'chalk';
 
 export default function pluginContentDocs(
   context: LoadContext,
   options: PluginOptions,
 ): Plugin<LoadedContent, typeof OptionsSchema> {
-  const {siteDir, generatedFilesDir, baseUrl} = context;
+  const {siteDir, generatedFilesDir, baseUrl, siteConfig} = context;
 
   const versionsMetadata = readVersionsMetadata({context, options});
 
@@ -311,11 +315,13 @@ export default function pluginContentDocs(
         sourceToPermalink,
         versionsMetadata,
         onBrokenMarkdownLink: (brokenMarkdownLink) => {
-          // TODO make this warning configurable?
-          console.warn(
-            chalk.yellow(
-              `Docs markdown link couldn't be resolved: (${brokenMarkdownLink.link}) in ${brokenMarkdownLink.filePath} for version ${brokenMarkdownLink.version.versionName}`,
-            ),
+          if (siteConfig.onBrokenLinks === 'ignore') {
+            return;
+          }
+
+          reportMessage(
+            `Docs markdown link couldn't be resolved: (${brokenMarkdownLink.link}) in ${brokenMarkdownLink.filePath} for version ${brokenMarkdownLink.version.versionName}`,
+            siteConfig.onBrokenLinks,
           );
         },
       };

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -315,10 +315,7 @@ export default function pluginContentDocs(
         sourceToPermalink,
         versionsMetadata,
         onBrokenMarkdownLink: (brokenMarkdownLink) => {
-          if (
-            siteConfig.onBrokenMarkdownLinks === 'ignore' ||
-            !siteConfig.onBrokenMarkdownLinks
-          ) {
+          if (siteConfig.onBrokenMarkdownLinks === 'ignore') {
             return;
           }
 

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -315,13 +315,16 @@ export default function pluginContentDocs(
         sourceToPermalink,
         versionsMetadata,
         onBrokenMarkdownLink: (brokenMarkdownLink) => {
-          if (siteConfig.onBrokenLinks === 'ignore') {
+          if (
+            siteConfig.onBrokenMarkdownLinks === 'ignore' ||
+            !siteConfig.onBrokenMarkdownLinks
+          ) {
             return;
           }
 
           reportMessage(
             `Docs markdown link couldn't be resolved: (${brokenMarkdownLink.link}) in ${brokenMarkdownLink.filePath} for version ${brokenMarkdownLink.version.versionName}`,
-            siteConfig.onBrokenLinks,
+            siteConfig.onBrokenMarkdownLinks,
           );
         },
       };

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -21,6 +21,7 @@ export interface DocusaurusConfig {
   title: string;
   url: string;
   onBrokenLinks: ReportingSeverity;
+  onBrokenMarkdownLinks: ReportingSeverity;
   onDuplicateRoutes: ReportingSeverity;
   noIndex: boolean;
   organizationName?: string;

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -18,6 +18,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/types": "^2.0.0-alpha.66",
+    "chalk": "^3.0.0",
     "escape-string-regexp": "^2.0.0",
     "fs-extra": "^8.1.0",
     "gray-matter": "^4.0.2",

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import chalk from 'chalk';
 import path from 'path';
 import matter from 'gray-matter';
 import {createHash} from 'crypto';
@@ -13,6 +14,7 @@ import kebabCase from 'lodash.kebabcase';
 import escapeStringRegexp from 'escape-string-regexp';
 import fs from 'fs-extra';
 import {URL} from 'url';
+import {ReportingSeverity} from '@docusaurus/types';
 
 // @ts-expect-error: no typedefs :s
 import resolvePathnameUnsafe from 'resolve-pathname';
@@ -435,4 +437,29 @@ export function getElementsAround<T extends unknown>(
   const previous = aroundIndex === min ? undefined : array[aroundIndex - 1];
   const next = aroundIndex === max ? undefined : array[aroundIndex + 1];
   return {previous, next};
+}
+
+export function reportMessage(
+  message: string,
+  reportingSeverity: ReportingSeverity,
+): void {
+  switch (reportingSeverity) {
+    case 'ignore':
+      break;
+    case 'log':
+      console.log(chalk.bold.blue('info ') + chalk.blue(message));
+      break;
+    case 'warn':
+      console.warn(chalk.bold.yellow('warn ') + chalk.yellow(message));
+      break;
+    case 'error':
+      console.error(chalk.bold.red('error ') + chalk.red(message));
+      break;
+    case 'throw':
+      throw new Error(message);
+    default:
+      throw new Error(
+        `unexpected reportingSeverity value: ${reportingSeverity}`,
+      );
+  }
 }

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -22,6 +22,7 @@ Object {
   "favicon": "img/docusaurus.ico",
   "noIndex": false,
   "onBrokenLinks": "throw",
+  "onBrokenMarkdownLinks": "warn",
   "onDuplicateRoutes": "warn",
   "organizationName": "endiliey",
   "plugins": Array [

--- a/packages/docusaurus/src/server/brokenLinks.ts
+++ b/packages/docusaurus/src/server/brokenLinks.ts
@@ -10,8 +10,8 @@ import resolvePathname from 'resolve-pathname';
 import fs from 'fs-extra';
 import {mapValues, pickBy, flatten, countBy} from 'lodash';
 import {RouteConfig, ReportingSeverity} from '@docusaurus/types';
-import {removePrefix, removeSuffix} from '@docusaurus/utils';
-import {getAllFinalRoutes, reportMessage} from './utils';
+import {removePrefix, removeSuffix, reportMessage} from '@docusaurus/utils';
+import {getAllFinalRoutes} from './utils';
 import path from 'path';
 
 function toReactRouterRoutes(routes: RouteConfig[]): RRRouteConfig[] {

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -68,7 +68,7 @@ const ConfigSchema = Joi.object({
     .default(DEFAULT_CONFIG.onBrokenLinks),
   onBrokenMarkdownLinks: Joi.string()
     .equal('ignore', 'log', 'warn', 'error', 'throw')
-    .default(DEFAULT_CONFIG.onBrokenLinks),
+    .default(DEFAULT_CONFIG.onBrokenMarkdownLinks),
   onDuplicateRoutes: Joi.string()
     .equal('ignore', 'log', 'warn', 'error', 'throw')
     .default(DEFAULT_CONFIG.onDuplicateRoutes),

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -17,6 +17,7 @@ import {
 export const DEFAULT_CONFIG: Pick<
   DocusaurusConfig,
   | 'onBrokenLinks'
+  | 'onBrokenMarkdownLinks'
   | 'onDuplicateRoutes'
   | 'plugins'
   | 'themes'
@@ -27,6 +28,7 @@ export const DEFAULT_CONFIG: Pick<
   | 'noIndex'
 > = {
   onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
   onDuplicateRoutes: 'warn',
   plugins: [],
   themes: [],
@@ -62,6 +64,9 @@ const ConfigSchema = Joi.object({
   title: Joi.string().required(),
   url: URISchema.required(),
   onBrokenLinks: Joi.string()
+    .equal('ignore', 'log', 'warn', 'error', 'throw')
+    .default(DEFAULT_CONFIG.onBrokenLinks),
+  onBrokenMarkdownLinks: Joi.string()
     .equal('ignore', 'log', 'warn', 'error', 'throw')
     .default(DEFAULT_CONFIG.onBrokenLinks),
   onDuplicateRoutes: Joi.string()

--- a/packages/docusaurus/src/server/duplicateRoutes.ts
+++ b/packages/docusaurus/src/server/duplicateRoutes.ts
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import {RouteConfig, ReportingSeverity} from '@docusaurus/types';
-import {getAllFinalRoutes, reportMessage} from './utils';
+import {reportMessage} from '@docusaurus/utils';
+import {getAllFinalRoutes} from './utils';
 
 export function getAllDuplicateRoutes(
   pluginsRouteConfigs: RouteConfig[],

--- a/packages/docusaurus/src/server/utils.ts
+++ b/packages/docusaurus/src/server/utils.ts
@@ -4,9 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import chalk from 'chalk';
 import flatMap from 'lodash.flatmap';
-import {RouteConfig, ReportingSeverity} from '@docusaurus/types';
+import {RouteConfig} from '@docusaurus/types';
 
 // Recursively get the final routes (routes with no subroutes)
 export function getAllFinalRoutes(routeConfig: RouteConfig[]): RouteConfig[] {
@@ -14,29 +13,4 @@ export function getAllFinalRoutes(routeConfig: RouteConfig[]): RouteConfig[] {
     return route.routes ? flatMap(route.routes, getFinalRoutes) : [route];
   }
   return flatMap(routeConfig, getFinalRoutes);
-}
-
-export function reportMessage(
-  message: string,
-  reportingSeverity: ReportingSeverity,
-): void {
-  switch (reportingSeverity) {
-    case 'ignore':
-      break;
-    case 'log':
-      console.log(chalk.bold.blue('info ') + chalk.blue(message));
-      break;
-    case 'warn':
-      console.warn(chalk.bold.yellow('warn ') + chalk.yellow(message));
-      break;
-    case 'error':
-      console.error(chalk.bold.red('error ') + chalk.red(message));
-      break;
-    case 'throw':
-      throw new Error(message);
-    default:
-      throw new Error(
-        `unexpected reportingSeverity value: ${reportingSeverity}`,
-      );
-  }
 }

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -108,6 +108,14 @@ The broken links detection is only available for a production build (`docusaurus
 
 :::
 
+### `onBrokenMarkdownLinks`
+
+- Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`
+
+The behavior of Docusaurus, when it detects any broken markdown link.
+
+By default, it prints a warning, to let you know about your broken markdown link, but you can change this security if needed.
+
 ### `onDuplicateRoutes`
 
 - Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`

--- a/website/docusaurus.config-blog-only.js
+++ b/website/docusaurus.config-blog-only.js
@@ -13,6 +13,7 @@ module.exports = {
   baseUrl: '/blog-only/',
   url: 'https://v2.docusaurus.io',
   onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/docusaurus.ico',
   themes: ['@docusaurus/theme-live-codeblock'],
   plugins: [],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -49,6 +49,7 @@ module.exports = {
   baseUrl,
   url: 'https://v2.docusaurus.io',
   onBrokenLinks: isVersioningDisabled ? 'warn' : 'throw',
+  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/docusaurus.ico',
   customFields: {
     description:

--- a/website/versioned_docs/version-2.0.0-alpha.66/api/docusaurus.config.js.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/api/docusaurus.config.js.md
@@ -108,6 +108,14 @@ The broken links detection is only available for a production build (`docusaurus
 
 :::
 
+### `onBrokenMarkdownLinks`
+
+- Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`
+
+The behavior of Docusaurus, when it detects any broken markdown link.
+
+By default, it prints a warning, to let you know about your broken markdown link, but you can change this security if needed.
+
 ### `onDuplicateRoutes`
 
 - Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`

--- a/website/versioned_docs/version-2.0.0-alpha.66/api/docusaurus.config.js.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/api/docusaurus.config.js.md
@@ -108,14 +108,6 @@ The broken links detection is only available for a production build (`docusaurus
 
 :::
 
-### `onBrokenMarkdownLinks`
-
-- Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`
-
-The behavior of Docusaurus, when it detects any broken markdown link.
-
-By default, it prints a warning, to let you know about your broken markdown link, but you can change this security if needed.
-
 ### `onDuplicateRoutes`
 
 - Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixing issue #3652 

#### Little additional info: 

We have a website which uses Docusaurus v2, and recently, we are letting people to contribute to the project and translate existing pages to their own language in separate folders; This means relative markdown links are still there in newly translated pages while those pages might not exist in the language's folder (as I mentioned, those links are relatively written there)

An example of this behaviour would be this: [Click Here](https://wiki.open.mp/docs/translations/tr/scripting/functions/AddMenuItem#i%CC%87lgili-fonksiyonlar), and first item of that list does not exist. This was just an example that leads to printing only one error to stdout, for the real issue please refer to #3652

And at the end, there was a comment there saying this: https://github.com/facebook/docusaurus/blob/master/packages/docusaurus-plugin-content-docs/src/index.ts#L314

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

I'd be lying if I say I've read it fully and carefully, but I tried to cherry pick needed parts but scrolling through, sorry :)

## Test Plan

Not sure how exactly we are supposed to test that, but I guess running an instance of Docusaurus with `"onBrokenLinks": "ignore"` in site configurations and a dummy doc page with a broken relative link would be fine.

Here's a screenshot (I've heard rumors it has bonus points!)
![Docusaurus SS](https://amii.ir/files/docusaurus-ss.png)

## Related PRs

None I guess?
