### PR TITLE
fix(v2): navbar dropdown crash when item.to is undefined

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/utils.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/utils.test.js
@@ -19,4 +19,14 @@ describe('isSamePath', () => {
   test('should be false for compared path with double trailing slash', () => {
     expect(isSamePath('/docs', '/docs//')).toBeFalsy();
   });
+
+  test('should be true for twice undefined/null', () => {
+    expect(isSamePath(undefined, undefined)).toBeTruthy();
+    expect(isSamePath(undefined, undefined)).toBeTruthy();
+  });
+
+  test('should be false when one undefined', () => {
+    expect(isSamePath('/docs', undefined)).toBeFalsy();
+    expect(isSamePath(undefined, '/docs')).toBeFalsy();
+  });
 });

--- a/packages/docusaurus-theme-classic/src/__tests__/utils.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/utils.test.js
@@ -19,4 +19,7 @@ describe('isSamePath', () => {
   test('should be false for compared path with double trailing slash', () => {
     expect(isSamePath('/docs', '/docs//')).toBeFalsy();
   });
+  test('should not fail if path is "undefined" when it is absent in case of dropdown in Navbar ', () => {
+    expect(isSamePath(undefined, undefined)).toBeTruthy();
+  });
 });

--- a/packages/docusaurus-theme-classic/src/__tests__/utils.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/utils.test.js
@@ -19,7 +19,4 @@ describe('isSamePath', () => {
   test('should be false for compared path with double trailing slash', () => {
     expect(isSamePath('/docs', '/docs//')).toBeFalsy();
   });
-  test('should not fail if path is "undefined" when it is absent in case of dropdown in Navbar ', () => {
-    expect(isSamePath(undefined, undefined)).toBeTruthy();
-  });
 });

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -159,7 +159,7 @@ function NavItemMobile({
   const menuListRef = useRef<HTMLUListElement>(null);
   const {pathname} = useLocation();
   const [collapsed, setCollapsed] = useState(
-    () => !items?.filter((item) => item.to).some((item) => isSamePath(item.to, pathname)) ?? true,
+    () => !items?.some((item) => isSamePath(item.to, pathname)) ?? true,
   );
 
   const navLinkClassNames = (extraClassName?: string, isSubList = false) =>

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -159,7 +159,7 @@ function NavItemMobile({
   const menuListRef = useRef<HTMLUListElement>(null);
   const {pathname} = useLocation();
   const [collapsed, setCollapsed] = useState(
-    () => !items?.some((item) => isSamePath(item.to, pathname)) ?? true,
+    () => !items?.filter((item) => item.to).some((item) => isSamePath(item.to, pathname)) ?? true,
   );
 
   const navLinkClassNames = (extraClassName?: string, isSubList = false) =>

--- a/packages/docusaurus-theme-classic/src/utils/index.ts
+++ b/packages/docusaurus-theme-classic/src/utils/index.ts
@@ -7,6 +7,6 @@
 
 // Compare the 2 paths, ignoring trailing /
 export const isSamePath = (path1, path2) => {
-  const normalize = (str) => (str.endsWith('/') ? str : `${str}/`);
-  return path1 && path2 ? normalize(path1) === normalize(path2) : true;
+  const normalize = (str) => (str?.endsWith('/') ? str : `${str}/`); //
+  return  normalize(path1) === normalize(path2)
 };

--- a/packages/docusaurus-theme-classic/src/utils/index.ts
+++ b/packages/docusaurus-theme-classic/src/utils/index.ts
@@ -8,5 +8,5 @@
 // Compare the 2 paths, ignoring trailing /
 export const isSamePath = (path1, path2) => {
   const normalize = (str) => (str.endsWith('/') ? str : `${str}/`);
-  return normalize(path1) === normalize(path2);
+  return path1 && path2 ? normalize(path1) === normalize(path2) : true;
 };

--- a/packages/docusaurus-theme-classic/src/utils/index.ts
+++ b/packages/docusaurus-theme-classic/src/utils/index.ts
@@ -7,6 +7,6 @@
 
 // Compare the 2 paths, ignoring trailing /
 export const isSamePath = (path1, path2) => {
-  const normalize = (str) => (str?.endsWith('/') ? str : `${str}/`); //
-  return  normalize(path1) === normalize(path2)
+  const normalize = (str) => (str?.endsWith('/') ? str : `${str}/`);
+  return  normalize(path1) === normalize(path2);
 };

--- a/packages/docusaurus-theme-classic/src/utils/index.ts
+++ b/packages/docusaurus-theme-classic/src/utils/index.ts
@@ -6,7 +6,12 @@
  */
 
 // Compare the 2 paths, ignoring trailing /
-export const isSamePath = (path1, path2) => {
-  const normalize = (str) => (str?.endsWith('/') ? str : `${str}/`);
-  return  normalize(path1) === normalize(path2);
+export const isSamePath = (
+  path1: string | undefined,
+  path2: string | undefined,
+) => {
+  const normalize = (pathname: string | undefined) => {
+    return !pathname || pathname?.endsWith('/') ? pathname : `${pathname}/`;
+  };
+  return normalize(path1) === normalize(path2);
 };


### PR DESCRIPTION
## Motivation
According to the docs, you can create a [dropdown](https://v2.docusaurus.io/docs/2.0.0-alpha.66/theme-classic/#navbar-dropdown) in the Navbar. With alpha.66 this fails because there's a path normalizer, which doesn't handle undefined if Navbar item is dropdown instead of a link which has a path.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes and already contributed once.

## Test Plan
I've written a test:
```js
test('should not fail if path is "undefined" when it is absent in case of dropdown in Navbar ', () => {
    expect(isSamePath(undefined, undefined)).toBeTruthy();
  });
```
Before my fix:
![image](https://user-images.githubusercontent.com/10460752/97720206-49456c80-1ac8-11eb-8489-a222d68bc9f1.png)

After my fix:
![image](https://user-images.githubusercontent.com/10460752/97720241-52363e00-1ac8-11eb-84f7-aa9e23a1aab5.png)

## Related PRs

This fix actually makes docs relevant as currently, dropdown wouldn't work.