### PR TITLE
fix(v2): make optional title for footer links column

### DIFF
--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -262,7 +262,7 @@ const ThemeConfigSchema = Joi.object({
     links: Joi.array()
       .items(
         Joi.object({
-          title: Joi.string().required(),
+          title: Joi.string(),
           items: Joi.array().items(FooterLinkItemSchema).default([]),
         }),
       )


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Since the footer link item can only consist of raw HTML code, it makes sense to remove the required title for a footer column.

For example, the Gulp.js website [uses that feature](https://github.com/gulpjs/gulpjs.github.io/blob/source/docusaurus.config.js#L69-L75) to add a logo, but they can't update to the latest Docusaurus because the footer title is required to specify (more precisely, this is one reason why it is impossible to upgrade, see [the comment](https://github.com/gulpjs/gulpjs.github.io/issues/123#issuecomment-718696325) for more details).


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Remove title from footer link item, and make sure that the site start without validation errors.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
