### PR TITLE
fix(v2): make scrollbar styles consistent

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
@@ -13,6 +13,24 @@
   top: calc(var(--ifm-navbar-height) + 2rem);
 }
 
+.sidebar::-webkit-scrollbar {
+  width: 7px;
+}
+
+.sidebar::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 10px;
+}
+
+.sidebar::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 10px;
+}
+
+.sidebar::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
 .sidebarItemTitle {
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Closes #3628.
Makes the blog sidebar scrollbar the same as the docs sidebar scrollbar.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Preview:
<br>
<img width="1278" alt="Screen Shot 2020-10-31 at 4 50 03 PM" src="https://user-images.githubusercontent.com/50968964/97789739-2c2c9e80-1b99-11eb-8982-8abd20c859df.png">


## Related PRs

No related PRs.