### PR TITLE
refactor(v2):regex match title

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -84,7 +84,7 @@ const highlightDirectiveRegex = (lang) => {
       return getHighlightDirectiveRegex();
   }
 };
-const codeBlockTitleRegex = /title=".*"/;
+const codeBlockTitleRegex = /(?<=title=").*(?=")/;
 
 export default ({
   children,
@@ -125,9 +125,7 @@ export default ({
     // Tested above
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     codeBlockTitle = metastring
-      .match(codeBlockTitleRegex)![0]
-      .split('title=')[1]
-      .replace(/"+/g, '');
+      .match(codeBlockTitleRegex)![0];
   }
 
   let language =


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Sort+quick code

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I create simple benchmark:
```js
const str = 'something include title="...."';

const oldRegex = /title=".*"/;
const newRegex = /(?<=title=").*(?=")/;

const old = (str) => str.match(oldRegex)[0].split('title=')[1].replace(/"+/g, '');
const newF = (str) => str.match(newRegex)[0];
```

result: two function return same value
 - sort `str`:
   - `old` x 2,411,252 ops/sec ±0.38% (90 runs sampled)
   - `newF` x 12,002,531 ops/sec ±0.44% (92 runs sampled)
 - long `str`:
   - `old` x 1,569,985 ops/sec ±0.44% (92 runs sampled)
   - `newF` x 3,442,088 ops/sec ±0.43% (91 runs sampled)

