### PR TITLE
feat(v2): add additional wrapper class to blog pages

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -23,7 +23,10 @@ function BlogListPage(props: Props): JSX.Element {
   const isBlogOnlyMode = permalink === '/';
   const title = isBlogOnlyMode ? siteTitle : blogTitle;
   return (
-    <Layout title={title} description={blogDescription}>
+    <Layout
+      title={title}
+      description={blogDescription}
+      wrapperClassName="blog-wrapper">
       <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--2">

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
@@ -21,7 +21,10 @@ function BlogPostPage(props: Props): JSX.Element {
   const {hide_table_of_contents: hideTableOfContents} = frontMatter;
 
   return (
-    <Layout title={title} description={description}>
+    <Layout
+      title={title}
+      description={description}
+      wrapperClassName="blog-wrapper">
       {BlogPostContents && (
         <div className="container margin-vert--lg">
           <div className="row">

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
@@ -50,7 +50,10 @@ function BlogTagsListPage(props: Props): JSX.Element {
     .filter((item) => item != null);
 
   return (
-    <Layout title="Tags" description="Blog Tags">
+    <Layout
+      title="Tags"
+      description="Blog Tags"
+      wrapperClassName="blog-wrapper">
       <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--2">

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -24,7 +24,8 @@ function BlogTagsPostPage(props: Props): JSX.Element {
   return (
     <Layout
       title={`Posts tagged "${tagName}"`}
-      description={`Blog | Tagged "${tagName}"`}>
+      description={`Blog | Tagged "${tagName}"`}
+      wrapperClassName="blog-wrapper">
       <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--2">


### PR DESCRIPTION
## Motivation

Additional wrapper class name, specific only to the blog related pages, should make easier for developers to introduce the CSS tweaks that should only be related to the Blog pages.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have tested this change using Docusaurus V2 website locally:
<img width="328" alt="Screenshot 2020-11-02 174308" src="https://user-images.githubusercontent.com/719641/97895384-0091eb80-1d34-11eb-83ed-3d35f6887091.png">

## Related PRs

None?
