### PR TITLE
fix(v2): add missing 'react' and 'webpack' peer dependencies

### DIFF
--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -42,6 +42,10 @@
     "unist-builder": "^2.0.3",
     "unist-util-remove-position": "^2.0.1"
   },
+ "peerDependencies": {
+    "react": "^16.13.1",
+    "react-dom": "^16.8.4"
+  },
   "engines": {
     "node": ">=10.15.1"
   }

--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -44,7 +44,8 @@
   },
  "peerDependencies": {
     "react": "^16.13.1",
-    "react-dom": "^16.8.4"
+    "react-dom": "^16.8.4",
+    "webpack": "^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=10.15.1"

--- a/packages/docusaurus-plugin-google-analytics/package.json
+++ b/packages/docusaurus-plugin-google-analytics/package.json
@@ -15,6 +15,10 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.66"
   },
+  "peerDependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
   "engines": {
     "node": ">=10.15.1"
   }

--- a/packages/docusaurus-plugin-google-gtag/package.json
+++ b/packages/docusaurus-plugin-google-gtag/package.json
@@ -15,6 +15,10 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.66"
   },
+  "peerDependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
   "engines": {
     "node": ">=10.15.1"
   }

--- a/packages/docusaurus-plugin-sitemap/package.json
+++ b/packages/docusaurus-plugin-sitemap/package.json
@@ -23,6 +23,10 @@
     "fs-extra": "^8.1.0",
     "sitemap": "^3.2.2"
   },
+  "peerDependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
   "engines": {
     "node": ">=10.15.1"
   }


### PR DESCRIPTION
## Motivation
- `mdx-loader`, `plugin-google-analytics`, `plugin-google-gtag`, and `docusaurus-plugin-sitemap` depends on `@docusaurus/core`, which peer-depends on `react` and `react-dom` (`@mdx-js/react` peer-depends on `react@^16.13.1`)
- `mdx-loader` depends on `file-loader` and `url-loader`, which peer-depends on `webpack`
(Write your motivation here.)

so they should be listed as peer dependencies.

Note other packages also list them as peer dependencies: https://github.com/facebook/docusaurus/blob/32425497f7f6251ad34ca9ca56db1eed9e7a97d7/packages/docusaurus-plugin-debug/package.json#L25-L28

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan
Check following warnings are not shown in Yarn 2 E2E test (https://github.com/facebook/docusaurus/pull/3675/checks?check_run_id=1343372025#step:6:308):
```
  ➤ YN0002: │ @docusaurus/plugin-google-analytics@npm:2.0.0-alpha.66.NEW doesn't provide react-dom@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/plugin-google-analytics@npm:2.0.0-alpha.66.NEW doesn't provide react@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/plugin-google-gtag@npm:2.0.0-alpha.66.NEW doesn't provide react-dom@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/plugin-google-gtag@npm:2.0.0-alpha.66.NEW doesn't provide react@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/plugin-sitemap@npm:2.0.0-alpha.66.NEW doesn't provide react-dom@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/plugin-sitemap@npm:2.0.0-alpha.66.NEW doesn't provide react@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/mdx-loader@npm:2.0.0-alpha.66.NEW doesn't provide react-dom@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/mdx-loader@npm:2.0.0-alpha.66.NEW doesn't provide react@^16.8.4 requested by @docusaurus/core@npm:2.0.0-alpha.66.NEW
  ➤ YN0002: │ @docusaurus/mdx-loader@npm:2.0.0-alpha.66.NEW doesn't provide react@^16.13.1 requested by @mdx-js/react@npm:1.6.19
  ➤ YN0002: │ @docusaurus/mdx-loader@npm:2.0.0-alpha.66.NEW doesn't provide webpack@^4.0.0 || ^5.0.0 requested by file-loader@npm:6.2.0
  ➤ YN0002: │ @docusaurus/mdx-loader@npm:2.0.0-alpha.66.NEW doesn't provide webpack@^4.0.0 || ^5.0.0 requested by url-loader@npm:4.1.1
```

## Related PRs
