### PR TITLE
Revert "refactor(v2): improve regex matching code-block title"

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -84,7 +84,7 @@ const highlightDirectiveRegex = (lang) => {
       return getHighlightDirectiveRegex();
   }
 };
-const codeBlockTitleRegex = /(?<=title=").*(?=")/;
+const codeBlockTitleRegex = /title=".*"/;
 
 export default ({
   children,
@@ -125,7 +125,9 @@ export default ({
     // Tested above
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     codeBlockTitle = metastring
-      .match(codeBlockTitleRegex)![0];
+      .match(codeBlockTitleRegex)![0]
+      .split('title=')[1]
+      .replace(/"+/g, '');
   }
 
   let language =


### PR DESCRIPTION
Reverts facebook/docusaurus#3671

Fixes #3680 (see https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group for more details)