### PR TITLE
refactor(v2): improve regex matching code-block title

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -84,7 +84,7 @@ const highlightDirectiveRegex = (lang) => {
       return getHighlightDirectiveRegex();
   }
 };
-const codeBlockTitleRegex = /title=".*"/;
+const codeBlockTitleRegex = /(?:title=")(.*)(?:")/;
 
 export default ({
   children,
@@ -125,9 +125,7 @@ export default ({
     // Tested above
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     codeBlockTitle = metastring
-      .match(codeBlockTitleRegex)![0]
-      .split('title=')[1]
-      .replace(/"+/g, '');
+      .match(codeBlockTitleRegex)![1];
   }
 
   let language =


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

#3671 can't work with Safari, this PR to fix it(still quickly+sort code)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested with Safari
![image](https://user-images.githubusercontent.com/19208123/98138817-118a5a80-1ef6-11eb-9915-768bf80daf8f.png)

## Related PRs

#3671 
