### PR TITLE
docs(v2): normalize showcase preview images height

### DIFF
--- a/website/src/pages/showcase/index.js
+++ b/website/src/pages/showcase/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect} from 'react';
+import React from 'react';
 
 import Image from '@theme/IdealImage';
 import Layout from '@theme/Layout';

--- a/website/src/pages/showcase/styles.module.css
+++ b/website/src/pages/showcase/styles.module.css
@@ -8,3 +8,8 @@
 .showcaseUser {
   height: 100%;
 }
+
+.card_image {
+  max-height: 175px;
+  overflow: hidden;
+}


### PR DESCRIPTION
### Motivation

Currently on the V2 showcase page website preview images height is not restricted in any way which in some cases results in stretching preview cards too much. 

This PR add small CSS tweak to the card image wrapper so it won't exceed height of `175px`. The height was chosen arbitrary based on the current available images in the showcase directory. Image still can have smaller height that decaled and it will not affect the presentation.

The changeset also includes a removal of unused hook from the showcase page file.

#### Before
<img width="878" alt="Screenshot 2020-11-05 150913" src="https://user-images.githubusercontent.com/719641/98251900-a1bdb380-1f79-11eb-8ce3-915521f0ddb7.png">

#### After
<img width="873" alt="Screenshot 2020-11-05 150931" src="https://user-images.githubusercontent.com/719641/98251908-a3877700-1f79-11eb-83b0-08d1bc76db8e.png">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Changes has been tested on the Docusuaurs V2 website locally.

## Related PRs

No.