### PR TITLE
Make classic theme DocSidebar dropdown work with no JS

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -103,47 +103,46 @@ function DocSidebarItemCategory({
   }
 
   return (
-    <ul className={clsx({[styles.onlycss]: enableCSSStyles})}>
-      <li
-        className={clsx('menu__list-item', {
-          'menu__list-item--collapsed': collapsed,
+    <li
+      className={clsx('menu__list-item', {
+        'menu__list-item--collapsed': collapsed,
+        [styles.onlycss]: enableCSSStyles,
+      })}
+      key={label}>
+      <a
+        className={clsx('menu__link', {
+          'menu__link--sublist': collapsible,
+          'menu__link--active': collapsible && isActive,
+          [styles.menuLinkText]: !collapsible,
         })}
-        key={label}>
-        <a
-          className={clsx('menu__link', {
-            'menu__link--sublist': collapsible,
-            'menu__link--active': collapsible && isActive,
-            [styles.menuLinkText]: !collapsible,
-          })}
-          onClick={collapsible ? handleItemClick : undefined}
-          href={collapsible ? '#!' : undefined}
-          {...props}>
-          {label}
-        </a>
-        <ul
-          className="menu__list"
-          ref={menuListRef}
-          style={{
-            height: menuListHeight,
-          }}
-          onTransitionEnd={() => {
-            if (!collapsed) {
-              handleMenuListHeight(false);
-            }
-          }}>
-          {items.map((childItem) => (
-            <DocSidebarItem
-              tabIndex={collapsed ? '-1' : '0'}
-              key={childItem.label}
-              item={childItem}
-              onItemClick={onItemClick}
-              collapsible={collapsible}
-              activePath={activePath}
-            />
-          ))}
-        </ul>
-      </li>
-    </ul>
+        onClick={collapsible ? handleItemClick : undefined}
+        href={collapsible ? '#!' : undefined}
+        {...props}>
+        {label}
+      </a>
+      <ul
+        className="menu__list"
+        ref={menuListRef}
+        style={{
+          height: menuListHeight,
+        }}
+        onTransitionEnd={() => {
+          if (!collapsed) {
+            handleMenuListHeight(false);
+          }
+        }}>
+        {items.map((childItem) => (
+          <DocSidebarItem
+            tabIndex={collapsed ? '-1' : '0'}
+            key={childItem.label}
+            item={childItem}
+            onItemClick={onItemClick}
+            collapsible={collapsible}
+            activePath={activePath}
+          />
+        ))}
+      </ul>
+    </li>
   );
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -64,6 +64,8 @@ function DocSidebarItemCategory({
     return isActive ? false : item.collapsed;
   });
 
+  const [enableCSSStyles, setEnableCSSStyles] = useState(true);
+
   const menuListRef = useRef<HTMLUListElement>(null);
   const [menuListHeight, setMenuListHeight] = useState<string | undefined>(
     undefined,
@@ -77,6 +79,7 @@ function DocSidebarItemCategory({
   // If we navigate to a category, it should automatically expand itself
   useEffect(() => {
     const justBecameActive = isActive && !wasActive;
+    setEnableCSSStyles(false);
     if (justBecameActive && collapsed) {
       setCollapsed(false);
     }
@@ -100,45 +103,47 @@ function DocSidebarItemCategory({
   }
 
   return (
-    <li
-      className={clsx('menu__list-item', {
-        'menu__list-item--collapsed': collapsed,
-      })}
-      key={label}>
-      <a
-        className={clsx('menu__link', {
-          'menu__link--sublist': collapsible,
-          'menu__link--active': collapsible && isActive,
-          [styles.menuLinkText]: !collapsible,
+    <ul className={clsx({[styles.onlycss]: enableCSSStyles})}>
+      <li
+        className={clsx('menu__list-item', {
+          'menu__list-item--collapsed': collapsed,
         })}
-        onClick={collapsible ? handleItemClick : undefined}
-        href={collapsible ? '#!' : undefined}
-        {...props}>
-        {label}
-      </a>
-      <ul
-        className="menu__list"
-        ref={menuListRef}
-        style={{
-          height: menuListHeight,
-        }}
-        onTransitionEnd={() => {
-          if (!collapsed) {
-            handleMenuListHeight(false);
-          }
-        }}>
-        {items.map((childItem) => (
-          <DocSidebarItem
-            tabIndex={collapsed ? '-1' : '0'}
-            key={childItem.label}
-            item={childItem}
-            onItemClick={onItemClick}
-            collapsible={collapsible}
-            activePath={activePath}
-          />
-        ))}
-      </ul>
-    </li>
+        key={label}>
+        <a
+          className={clsx('menu__link', {
+            'menu__link--sublist': collapsible,
+            'menu__link--active': collapsible && isActive,
+            [styles.menuLinkText]: !collapsible,
+          })}
+          onClick={collapsible ? handleItemClick : undefined}
+          href={collapsible ? '#!' : undefined}
+          {...props}>
+          {label}
+        </a>
+        <ul
+          className="menu__list"
+          ref={menuListRef}
+          style={{
+            height: menuListHeight,
+          }}
+          onTransitionEnd={() => {
+            if (!collapsed) {
+              handleMenuListHeight(false);
+            }
+          }}>
+          {items.map((childItem) => (
+            <DocSidebarItem
+              tabIndex={collapsed ? '-1' : '0'}
+              key={childItem.label}
+              item={childItem}
+              onItemClick={onItemClick}
+              collapsible={collapsible}
+              activePath={activePath}
+            />
+          ))}
+        </ul>
+      </li>
+    </ul>
   );
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -136,3 +136,24 @@
 :global(.menu__list-item--collapsed) :global(.menu__list) {
   height: 0px !important;
 }
+
+ul.onlycss li{
+  display: none;
+}
+
+ul.onlycss > li {
+  display: block;
+}
+
+ul.onlycss > li:focus-within > ul > li {
+  display: block;
+}
+
+
+ul.onlycss > li:focus-within :global(.menu__list) {
+  height: auto !important; 
+}
+
+ul {
+  list-style: none;
+}

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -137,23 +137,14 @@
   height: 0px !important;
 }
 
-ul.onlycss li{
+li.onlycss > ul {
   display: none;
 }
 
-ul.onlycss > li {
+li.onlycss:focus-within > ul {
   display: block;
 }
 
-ul.onlycss > li:focus-within > ul > li {
-  display: block;
-}
-
-
-ul.onlycss > li:focus-within :global(.menu__list) {
-  height: auto !important; 
-}
-
-ul {
-  list-style: none;
+li.onlycss:focus-within :global(.menu__list) {
+  height: auto !important;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Issue #3030 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added `onlycss` class and `enableCSSStyles` state in the `DocSidebarItemCategory` component. To check that the feature works, we disable JS in the browser first, disable cache, enable slow 3G data throttling.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
