### PR TITLE
docs(v2): deployment should use mdx extension

### DIFF
--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -124,7 +124,7 @@ To learn more about swizzling, check [here](#).
 
 ### `docusaurus deploy`
 
-Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.md/#deploying-to-github-pages) for more details.
+Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.mdx#deploying-to-github-pages) for more details.
 
 #### Options
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deployment.md) for more information.
+It is recommended to check the [deployment docs](deploy.mdx) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deploy.mdx) for more information.
+It is recommended to check the [deployment docs](deployment.mdx)) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -93,7 +93,14 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
+<Tabs 
+  defaultValue="bash"
+  values={[ 
+    { label: 'Bash', value: 'bash' },
+    { label: 'Windows', value: 'windows' }, 
+    { label: 'PowerShell', value: 'powershell' } 
+]}>
+<TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.md) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.mdx)) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.63/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/cli.md
@@ -107,7 +107,7 @@ To learn more about swizzling, check [here](#).
 
 ### `docusaurus deploy`
 
-Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.md/#deploying-to-github-pages) for more details.
+Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.mdx#deploying-to-github-pages) for more details.
 
 #### Options
 

--- a/website/versioned_docs/version-2.0.0-alpha.63/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deployment.md) for more information.
+It is recommended to check the [deployment docs](deploy.mdx) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.63/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deploy.mdx) for more information.
+It is recommended to check the [deployment docs](deployment.mdx)) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.63/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.63/deployment.mdx
@@ -93,7 +93,14 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
+<Tabs 
+  defaultValue="bash"
+  values={[ 
+    { label: 'Bash', value: 'bash' },
+    { label: 'Windows', value: 'windows' }, 
+    { label: 'PowerShell', value: 'powershell' } 
+]}>
+<TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy

--- a/website/versioned_docs/version-2.0.0-alpha.63/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.md) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.63/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.mdx)) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.64/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/cli.md
@@ -107,7 +107,7 @@ To learn more about swizzling, check [here](#).
 
 ### `docusaurus deploy`
 
-Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.md/#deploying-to-github-pages) for more details.
+Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.mdx#deploying-to-github-pages) for more details.
 
 #### Options
 

--- a/website/versioned_docs/version-2.0.0-alpha.64/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deployment.md) for more information.
+It is recommended to check the [deployment docs](deploy.mdx) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.64/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deploy.mdx) for more information.
+It is recommended to check the [deployment docs](deployment.mdx)) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.64/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.64/deployment.mdx
@@ -93,7 +93,14 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
+<Tabs 
+  defaultValue="bash"
+  values={[ 
+    { label: 'Bash', value: 'bash' },
+    { label: 'Windows', value: 'windows' }, 
+    { label: 'PowerShell', value: 'powershell' } 
+]}>
+<TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy

--- a/website/versioned_docs/version-2.0.0-alpha.64/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.md) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.64/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.mdx)) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.65/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.65/cli.md
@@ -108,7 +108,7 @@ To learn more about swizzling, check [here](#).
 
 ### `docusaurus deploy`
 
-Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.md/#deploying-to-github-pages) for more details.
+Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.mdx#deploying-to-github-pages) for more details.
 
 #### Options
 

--- a/website/versioned_docs/version-2.0.0-alpha.65/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.65/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deployment.md) for more information.
+It is recommended to check the [deployment docs](deploy.mdx) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.65/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.65/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deploy.mdx) for more information.
+It is recommended to check the [deployment docs](deployment.mdx)) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.65/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.65/deployment.mdx
@@ -93,7 +93,14 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
+<Tabs 
+  defaultValue="bash"
+  values={[ 
+    { label: 'Bash', value: 'bash' },
+    { label: 'Windows', value: 'windows' }, 
+    { label: 'PowerShell', value: 'powershell' } 
+]}>
+<TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy

--- a/website/versioned_docs/version-2.0.0-alpha.65/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.65/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.md) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.65/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.65/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.mdx)) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.66/cli.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/cli.md
@@ -108,7 +108,7 @@ To learn more about swizzling, check [here](#).
 
 ### `docusaurus deploy`
 
-Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.md/#deploying-to-github-pages) for more details.
+Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the docs on [deployment](deployment.mdx#deploying-to-github-pages) for more details.
 
 #### Options
 

--- a/website/versioned_docs/version-2.0.0-alpha.66/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deployment.md) for more information.
+It is recommended to check the [deployment docs](deploy.mdx) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.66/configuration.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/configuration.md
@@ -34,7 +34,7 @@ They are used in a number of places such as your site's title and headings, brow
 
 Deployment configurations such as `projectName` and `organizationName` are used when you deploy your site with the `deploy` command.
 
-It is recommended to check the [deployment docs](deploy.mdx) for more information.
+It is recommended to check the [deployment docs](deployment.mdx)) for more information.
 
 ### Theme, plugin, and preset configurations
 

--- a/website/versioned_docs/version-2.0.0-alpha.66/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.66/deployment.mdx
@@ -93,7 +93,14 @@ Optional parameters, also set as environment variables:
 
 Finally, to deploy your site to GitHub Pages, run:
 
-<Tabs defaultValue="bash" values={[ { label: 'Bash', value: 'bash', }, { label: 'Windows', value: 'windows', }, { label: 'PowerShell', value: 'powershell', },]}><TabItem value="bash">
+<Tabs 
+  defaultValue="bash"
+  values={[ 
+    { label: 'Bash', value: 'bash' },
+    { label: 'Windows', value: 'windows' }, 
+    { label: 'PowerShell', value: 'powershell' } 
+]}>
+<TabItem value="bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy

--- a/website/versioned_docs/version-2.0.0-alpha.66/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.md) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
 
 ## Updating your Docusaurus version
 

--- a/website/versioned_docs/version-2.0.0-alpha.66/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/installation.md
@@ -100,7 +100,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deploy.mdx) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Now](https://zeit.co/now) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.mdx)) for more details.
 
 ## Updating your Docusaurus version
 


### PR DESCRIPTION
## Motivation

- it uses `<Tabs/>`
- Prettier does not format correctly .md extensions containing too much JSX
- IDE syntax highlighting is broken
- My i18n PR fails due to Crowdin doing weird interpretations of this markup

I prefer to change it in upstream branch to avoid conflicts later.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

