### PR TITLE
fix(v2): limit images height on showcase page

### DIFF
--- a/website/src/pages/showcase/styles.module.css
+++ b/website/src/pages/showcase/styles.module.css
@@ -9,7 +9,7 @@
   height: 100%;
 }
 
-.card_image {
+:global(.card__image) {
   max-height: 175px;
   overflow: hidden;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation


Actually applies the changes in #3696 from @Simek (because it doesn't work now).

Do not forget: since we are using CSS modules, we need to use `:global` to actually override the regular CSS classes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
