### PR TITLE
feat(v2): add support for sync to npm2yarn tabs

### DIFF
--- a/packages/docusaurus-remark-plugin-npm2yarn/README.md
+++ b/packages/docusaurus-remark-plugin-npm2yarn/README.md
@@ -34,15 +34,15 @@ module.exports = {
       {
         docs: {
           // ...
-          remarkPlugins: [require('@docusaurus/remark-plugin-npm2yarn')],
+          remarkPlugins: [[require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}]],
         },
         blog: {
           // ...
-          remarkPlugins: [require('@docusaurus/remark-plugin-npm2yarn')],
+          remarkPlugins: [[require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}]],
         },
         pages: {
           // ...
-          remarkPlugins: [require('@docusaurus/remark-plugin-npm2yarn')],
+          remarkPlugins: [[require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}]],
         },
         // ...
       },
@@ -51,3 +51,9 @@ module.exports = {
   // ...
 };
 ```
+
+## Options
+
+| Property | Type      | Default | Description                                                                                                               |
+|----------|-----------|---------|---------------------------------------------------------------------------------------------------------------------------|
+| `sync`   | `boolean` | `false` | Syncing tab choices (yarn and npm). See https://v2.docusaurus.io/docs/markdown-features/#syncing-tab-choices for details. |

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
@@ -10,14 +10,15 @@ const npmToYarn = require('npm-to-yarn');
 // E.g. global install: 'npm i' -> 'yarn'
 const convertNpmToYarn = (npmCode) => npmToYarn(npmCode, 'yarn');
 
-const transformNode = (node) => {
+const transformNode = (node, isSync) => {
+  const groupIdProp = isSync ? 'groupId="npm2yarn" ' : '';
   const npmCode = node.value;
   const yarnCode = convertNpmToYarn(node.value);
   return [
     {
       type: 'jsx',
       value:
-        `<Tabs defaultValue="npm" ` +
+        `<Tabs defaultValue="npm" ${groupIdProp}` +
         `values={[
     { label: 'npm', value: 'npm', },
     { label: 'Yarn', value: 'yarn', },
@@ -53,12 +54,13 @@ const nodeForImport = {
     "import Tabs from '@theme/Tabs';\nimport TabItem from '@theme/TabItem';",
 };
 
-module.exports = () => {
+module.exports = (options = {}) => {
+  const {sync = false} = options;
   let transformed = false;
   const transformer = (node) => {
     if (matchNode(node)) {
       transformed = true;
-      return transformNode(node);
+      return transformNode(node, sync);
     }
     if (Array.isArray(node.children)) {
       let index = 0;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -194,7 +194,9 @@ module.exports = {
             'https://github.com/facebook/docusaurus/edit/master/website/',
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
-          remarkPlugins: [require('@docusaurus/remark-plugin-npm2yarn')],
+          remarkPlugins: [
+            [require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}],
+          ],
           disableVersioning: isVersioningDisabled,
           lastVersion: 'current',
           onlyIncludeVersions:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Add support for tab choices synchronization to npm/yarn tabs (see https://v2.docusaurus.io/docs/markdown-features/#syncing-tab-choices for more details).

I did it via option to make the plugin behavior more flexible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
