### PR TITLE
refactor(v2): render all tab panels at once

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
@@ -8,9 +8,9 @@
 import React from 'react';
 import type {Props} from '@theme/TabItem';
 
-function TabItem({children, hidden}: Props): JSX.Element {
+function TabItem({children, hidden, className}: Props): JSX.Element {
   return (
-    <div role="tabpanel" {...{hidden}}>
+    <div role="tabpanel" {...{hidden, className}}>
       {children}
     </div>
   );

--- a/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
@@ -8,8 +8,12 @@
 import React from 'react';
 import type {Props} from '@theme/TabItem';
 
-function TabItem(props: Props): JSX.Element {
-  return <div>{props.children}</div>;
+function TabItem({children, hidden}: Props): JSX.Element {
+  return (
+    <div role="tabpanel" {...{hidden}}>
+      {children}
+    </div>
+  );
 }
 
 export default TabItem;

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -19,7 +19,15 @@ const keys = {
 };
 
 function Tabs(props: Props): JSX.Element {
-  const {block, children, defaultValue, values, groupId, className} = props;
+  const {
+    lazy,
+    block,
+    children,
+    defaultValue,
+    values,
+    groupId,
+    className,
+  } = props;
   const {tabGroupChoices, setTabGroupChoices} = useUserPreferencesContext();
   const [selectedValue, setSelectedValue] = useState(defaultValue);
 
@@ -109,14 +117,24 @@ function Tabs(props: Props): JSX.Element {
           </li>
         ))}
       </ul>
-      <div className="margin-vert--md">
-        {children.map((tabItem, i) =>
-          cloneElement(tabItem, {
-            key: i,
-            hidden: tabItem.props.value !== selectedValue,
-          }),
-        )}
-      </div>
+
+      {lazy ? (
+        cloneElement(
+          children.filter(
+            (tabItem) => tabItem.props.value === selectedValue,
+          )[0],
+          {className: 'margin-vert--md'},
+        )
+      ) : (
+        <div className="margin-vert--md">
+          {children.map((tabItem, i) =>
+            cloneElement(tabItem, {
+              key: i,
+              hidden: tabItem.props.value !== selectedValue,
+            }),
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState, Children, ReactElement} from 'react';
+import React, {useState, cloneElement} from 'react';
 import useUserPreferencesContext from '@theme/hooks/useUserPreferencesContext';
 import type {Props} from '@theme/Tabs';
 
@@ -109,14 +109,13 @@ function Tabs(props: Props): JSX.Element {
           </li>
         ))}
       </ul>
-      <div role="tabpanel" className="margin-vert--md">
-        {
-          Children.toArray(children).filter(
-            (child) =>
-              (child as ReactElement<{value: string}>).props.value ===
-              selectedValue,
-          )[0]
-        }
+      <div className="margin-vert--md">
+        {children.map((tabItem, i) =>
+          cloneElement(tabItem, {
+            key: i,
+            hidden: tabItem.props.value !== selectedValue,
+          }),
+        )}
       </div>
     </div>
   );

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -374,7 +374,11 @@ declare module '@theme/NavbarItem' {
 declare module '@theme/TabItem' {
   import type {ReactNode} from 'react';
 
-  export type Props = {readonly children: ReactNode};
+  export type Props = {
+    readonly children: ReactNode;
+    readonly value: string;
+    readonly hidden: boolean;
+  };
 
   const TabItem: () => JSX.Element;
   export default TabItem;
@@ -382,10 +386,11 @@ declare module '@theme/TabItem' {
 
 declare module '@theme/Tabs' {
   import type {ReactElement} from 'react';
+  import type {Props as TabItemProps} from '@theme/TabItem';
 
   export type Props = {
     readonly block?: boolean;
-    readonly children: readonly ReactElement<{value: string}>[];
+    readonly children: readonly ReactElement<TabItemProps>[];
     readonly defaultValue?: string;
     readonly values: readonly {value: string; label: string}[];
     readonly groupId?: string;

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -378,6 +378,7 @@ declare module '@theme/TabItem' {
     readonly children: ReactNode;
     readonly value: string;
     readonly hidden: boolean;
+    readonly className: string;
   };
 
   const TabItem: () => JSX.Element;
@@ -389,6 +390,7 @@ declare module '@theme/Tabs' {
   import type {Props as TabItemProps} from '@theme/TabItem';
 
   export type Props = {
+    readonly lazy?: boolean;
     readonly block?: boolean;
     readonly children: readonly ReactElement<TabItemProps>[];
     readonly defaultValue?: string;

--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -296,6 +296,12 @@ And you will get the following:
   <TabItem value="banana">This is a banana 🍌</TabItem>
 </Tabs>
 
+:::info
+
+By default, tabs are rendered eagerly, but it is possible to load them lazily by passing the `lazy` prop to the `Tabs` component.
+
+:::
+
 ### Syncing tab choices
 
 You may want choices of the same kind of tabs to sync with each other. For example, you might want to provide different instructions for users on Windows vs users on macOS, and you want to changing all OS-specific instructions tabs in one click. To achieve that, you can give all related tabs the same `groupId` prop. Note that doing this will persist the choice in `localStorage` and all `<Tab>` instances with the same `groupId` will update automatically when the value of one of them is changed. Not that `groupID` are globally-namespaced.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I think we need to render all tab panels immediately during mounting Tabs component, because currently different side effects observer when navigating between tabs.

For example, if the tab content contains embedded code, then it will reload _every time_ we switch tabs, see the GIF on the React Native website example:

![ezgif com-gif-maker (10)](https://user-images.githubusercontent.com/4408379/98363532-270b9b80-2040-11eb-97df-17c2e3324723.gif)

In addition, filtering rendering (as now) leads to additional overhead costs, this is especially noticeable on mobile devices (you can see the delay when switching tabs)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
