### PR TITLE
fix(v2): use swizzled SearchPage component if any

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/index.js
@@ -8,7 +8,7 @@
 const path = require('path');
 const fs = require('fs');
 const eta = require('eta');
-const {normalizeUrl} = require('@docusaurus/utils');
+const {normalizeUrl, getSwizzledComponent} = require('@docusaurus/utils');
 const openSearchTemplate = require('./templates/opensearch');
 const {validateThemeConfig} = require('./validateThemeConfig');
 const {memoize} = require('lodash');
@@ -29,7 +29,10 @@ function theme(context) {
     baseUrl,
     siteConfig: {title, url, favicon},
   } = context;
-  const pagePath = path.resolve(__dirname, './theme/SearchPage/index.js');
+  const pageComponent = './theme/SearchPage/index.js';
+  const pagePath =
+    getSwizzledComponent(pageComponent) ||
+    path.resolve(__dirname, pageComponent);
 
   return {
     name: 'docusaurus-theme-search-algolia',

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-alpha.66",
     "@docusaurus/types": "^2.0.0-alpha.66",
     "chalk": "^3.0.0",
     "escape-string-regexp": "^2.0.0",

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -18,7 +18,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.66",
     "@docusaurus/types": "^2.0.0-alpha.66",
     "chalk": "^3.0.0",
     "escape-string-regexp": "^2.0.0",

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -14,6 +14,7 @@ import kebabCase from 'lodash.kebabcase';
 import escapeStringRegexp from 'escape-string-regexp';
 import fs from 'fs-extra';
 import {URL} from 'url';
+import {SRC_DIR_NAME} from '@docusaurus/core/lib/constants';
 import {ReportingSeverity} from '@docusaurus/types';
 
 // @ts-expect-error: no typedefs :s
@@ -462,4 +463,18 @@ export function reportMessage(
         `unexpected reportingSeverity value: ${reportingSeverity}`,
       );
   }
+}
+
+export function getSwizzledComponent(
+  componentPath: string,
+): string | undefined {
+  const swizzledComponentPath = path.resolve(
+    process.cwd(),
+    SRC_DIR_NAME,
+    componentPath,
+  );
+
+  return fs.existsSync(swizzledComponentPath)
+    ? swizzledComponentPath
+    : undefined;
 }

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -14,7 +14,6 @@ import kebabCase from 'lodash.kebabcase';
 import escapeStringRegexp from 'escape-string-regexp';
 import fs from 'fs-extra';
 import {URL} from 'url';
-import {SRC_DIR_NAME} from '@docusaurus/core/lib/constants';
 import {ReportingSeverity} from '@docusaurus/types';
 
 // @ts-expect-error: no typedefs :s
@@ -470,7 +469,7 @@ export function getSwizzledComponent(
 ): string | undefined {
   const swizzledComponentPath = path.resolve(
     process.cwd(),
-    SRC_DIR_NAME,
+    'src',
     componentPath,
   );
 

--- a/website/docs/using-themes.md
+++ b/website/docs/using-themes.md
@@ -197,7 +197,7 @@ This theme provides a `@theme/SearchBar` component that integrates with Algolia 
 npm install --save @docusaurus/theme-search-algolia
 ```
 
-This theme also adds search page available at `/search` path with OpenSearch support.
+This theme also adds search page available at `/search` (as swizzleable `SearchPage` component) path with OpenSearch support.
 
 :::tip
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In PR #3280 it was allowed to swizzle `SearchPage` component, but newly swizzled component was not taken into account when building site.
This PR fixes #3379, after that if the search page component has been changed it will be used instead of initial one.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try swizzling the component, making changes to it, starting the site, and making sure the swizzled component is actually being used.

```
yarn swizzle @docusaurus/theme-search-algolia SearchPage
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
