### PR TITLE
fix(internal): fix clear script from the main package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "jest",
     "test:build:v2": "./admin/scripts/test-release.sh",
     "watch": "yarn lerna run --parallel --no-private watch",
-    "clear": "yarn workspace docusaurus-2-website clear && yarn lerna exec 'yarn rimraf lib' --ignore docusaurus",
+    "clear": "yarn workspace docusaurus-2-website clear && yarn lerna exec --ignore docusaurus yarn rimraf lib",
     "test:v1Migration:migrate": "rimraf website-1.x-migrated && docusaurus-migrate migrate ./website-1.x ./website-1.x-migrated && sed -i -- 's/docusaurus-1-website/docusaurus-1-website-migrated/g;' website-1.x-migrated/package.json",
     "test:v1Migration:start": "yarn workspace docusaurus-1-website-migrated start",
     "test:v1Migration:build": "yarn workspace docusaurus-1-website-migrated build",


### PR DESCRIPTION
## Motivation

Currently the `rimraf` portion of the `clear` script from the main package.json is not working correctly.

<img width="738" alt="Screenshot 2020-11-12 190606" src="https://user-images.githubusercontent.com/719641/98979723-fdf57a00-251b-11eb-94fa-1a9e47f96c4c.png">

More information: https://www.npmjs.com/package/@lerna/exec

The forwarding dashes (`--`) has been removed due to warning appearing on run:

<img width="1010" alt="Screenshot 2020-11-12 192327" src="https://user-images.githubusercontent.com/719641/98980188-8ecc5580-251c-11eb-8e7a-e9b1a698e6e7.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Successful run of `clear` command from main `package.json` file:

<img width="598" alt="Screenshot 2020-11-12 192001" src="https://user-images.githubusercontent.com/719641/98979822-1d8ca280-251c-11eb-8815-45f7e34f18e7.png">

## Related PRs

No.
