### PR TITLE
fix(v2): increase stability of hideable navbar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -12,18 +12,17 @@ import useScrollPosition from '@theme/hooks/useScrollPosition';
 import type {useHideableNavbarReturns} from '@theme/hooks/useHideableNavbar';
 
 const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
+  const location = useLocation();
+  const [hash, setHash] = useLocationHash(location.hash);
   const [isNavbarVisible, setIsNavbarVisible] = useState(true);
-  const [isFocusedAnchor, setIsFocusedAnchor] = useState(false);
+  const isFocusedAnchor = useRef(false);
   const [lastScrollTop, setLastScrollTop] = useState(0);
   const [navbarHeight, setNavbarHeight] = useState(0);
-  const isFocusedAnchor1 = useRef(false);
   const navbarRef = useCallback((node: HTMLElement | null) => {
     if (node !== null) {
       setNavbarHeight(node.getBoundingClientRect().height);
     }
   }, []);
-  const location = useLocation();
-  const [hash, setHash] = useLocationHash(location.hash);
 
   useScrollPosition(
     ({scrollY: scrollTop}) => {
@@ -31,30 +30,20 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
         return;
       }
 
-      console.log(scrollTop, isFocusedAnchor, isFocusedAnchor1);
-
-      if (scrollTop === 0) {
-        console.log(11);
-        setIsNavbarVisible(true);
-      }
-
-      console.log(1);
-
       if (scrollTop < navbarHeight) {
-        console.log(2);
         return;
       }
 
-      if (isFocusedAnchor1.current) {
-        console.log(3);
-        isFocusedAnchor1.current = false;
-        setIsFocusedAnchor(false);
+      if (isFocusedAnchor.current) {
+        isFocusedAnchor.current = false;
         setIsNavbarVisible(false);
         setLastScrollTop(scrollTop);
         return;
       }
 
-      console.log(4);
+      if (lastScrollTop && scrollTop === 0) {
+        setIsNavbarVisible(true);
+      }
 
       const documentHeight =
         document.documentElement.scrollHeight - navbarHeight;
@@ -68,7 +57,7 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
 
       setLastScrollTop(scrollTop);
     },
-    [lastScrollTop, navbarHeight, isFocusedAnchor, isFocusedAnchor1],
+    [lastScrollTop, navbarHeight, isFocusedAnchor],
   );
 
   useEffect(() => {
@@ -76,31 +65,20 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
       return;
     }
 
-    // if (location.hash !== hash) {
-    //   console.log(222);
-    //   setIsFocusedAnchor(true);
-    //   test.current = true;
-    // } else {
     setIsNavbarVisible(true);
-    // }
-
     setHash(location.hash);
-  }, [location, hash]);
+  }, [location]);
 
   useEffect(() => {
     if (!hideOnScroll) {
       return;
     }
 
-    console.log(hash);
-
     if (!hash) {
       return;
     }
 
-    // setIsFocusedAnchor(true);
-    isFocusedAnchor1.current = true;
-    setIsNavbarVisible(false);
+    isFocusedAnchor.current = true;
   }, [hash]);
 
   return {

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -7,13 +7,11 @@
 
 import {useState, useCallback, useEffect, useRef} from 'react';
 import {useLocation} from '@docusaurus/router';
-import useLocationHash from '@theme/hooks/useLocationHash';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
 import type {useHideableNavbarReturns} from '@theme/hooks/useHideableNavbar';
 
 const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   const location = useLocation();
-  const [hash, setHash] = useLocationHash(location.hash);
   const [isNavbarVisible, setIsNavbarVisible] = useState(!hideOnScroll);
   const isFocusedAnchor = useRef(false);
   const [lastScrollTop, setLastScrollTop] = useState(0);
@@ -70,7 +68,6 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
     }
 
     setIsNavbarVisible(true);
-    setHash(location.hash);
   }, [location.pathname]);
 
   useEffect(() => {
@@ -78,12 +75,8 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
       return;
     }
 
-    if (!hash) {
-      return;
-    }
-
     isFocusedAnchor.current = true;
-  }, [hash]);
+  }, [location.hash]);
 
   return {
     navbarRef,

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {useState, useCallback, useEffect} from 'react';
+import {useState, useCallback, useEffect, useRef} from 'react';
 import {useLocation} from '@docusaurus/router';
 import useLocationHash from '@theme/hooks/useLocationHash';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
@@ -16,6 +16,7 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   const [isFocusedAnchor, setIsFocusedAnchor] = useState(false);
   const [lastScrollTop, setLastScrollTop] = useState(0);
   const [navbarHeight, setNavbarHeight] = useState(0);
+  const isFocusedAnchor1 = useRef(false);
   const navbarRef = useCallback((node: HTMLElement | null) => {
     if (node !== null) {
       setNavbarHeight(node.getBoundingClientRect().height);
@@ -30,20 +31,30 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
         return;
       }
 
+      console.log(scrollTop, isFocusedAnchor, isFocusedAnchor1);
+
       if (scrollTop === 0) {
+        console.log(11);
         setIsNavbarVisible(true);
       }
 
+      console.log(1);
+
       if (scrollTop < navbarHeight) {
+        console.log(2);
         return;
       }
 
-      if (isFocusedAnchor) {
+      if (isFocusedAnchor1.current) {
+        console.log(3);
+        isFocusedAnchor1.current = false;
         setIsFocusedAnchor(false);
         setIsNavbarVisible(false);
         setLastScrollTop(scrollTop);
         return;
       }
+
+      console.log(4);
 
       const documentHeight =
         document.documentElement.scrollHeight - navbarHeight;
@@ -57,7 +68,7 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
 
       setLastScrollTop(scrollTop);
     },
-    [lastScrollTop, navbarHeight],
+    [lastScrollTop, navbarHeight, isFocusedAnchor, isFocusedAnchor1],
   );
 
   useEffect(() => {
@@ -65,20 +76,30 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
       return;
     }
 
+    // if (location.hash !== hash) {
+    //   console.log(222);
+    //   setIsFocusedAnchor(true);
+    //   test.current = true;
+    // } else {
     setIsNavbarVisible(true);
+    // }
+
     setHash(location.hash);
-  }, [location]);
+  }, [location, hash]);
 
   useEffect(() => {
     if (!hideOnScroll) {
       return;
     }
 
+    console.log(hash);
+
     if (!hash) {
       return;
     }
 
-    setIsFocusedAnchor(true);
+    // setIsFocusedAnchor(true);
+    isFocusedAnchor1.current = true;
     setIsNavbarVisible(false);
   }, [hash]);
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -14,7 +14,7 @@ import type {useHideableNavbarReturns} from '@theme/hooks/useHideableNavbar';
 const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   const location = useLocation();
   const [hash, setHash] = useLocationHash(location.hash);
-  const [isNavbarVisible, setIsNavbarVisible] = useState(true);
+  const [isNavbarVisible, setIsNavbarVisible] = useState(!hideOnScroll);
   const isFocusedAnchor = useRef(false);
   const [lastScrollTop, setLastScrollTop] = useState(0);
   const [navbarHeight, setNavbarHeight] = useState(0);
@@ -65,9 +65,13 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
       return;
     }
 
+    if (!lastScrollTop) {
+      return;
+    }
+
     setIsNavbarVisible(true);
     setHash(location.hash);
-  }, [location]);
+  }, [location.pathname]);
 
   useEffect(() => {
     if (!hideOnScroll) {

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
@@ -31,13 +31,13 @@ const useScrollPosition = (
   };
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll, {passive: true});
+    const opts: AddEventListenerOptions & EventListenerOptions = {
+      passive: true,
+    };
 
-    return () =>
-      window.removeEventListener('scroll', handleScroll, {
-        // @ts-expect-error: See https://github.com/microsoft/TypeScript/issues/32912
-        passive: true,
-      });
+    window.addEventListener('scroll', handleScroll, opts);
+
+    return () => window.removeEventListener('scroll', handleScroll, opts);
   }, deps);
 
   return scrollPosition;

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
@@ -31,7 +31,7 @@ const useScrollPosition = (
   };
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, {passive: true});
 
     return () =>
       window.removeEventListener('scroll', handleScroll, {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Another attempt to get the hideable navbar to work well and in a predictable way.

Earlier, I did not take into account the initial (zero) position of the scroll, because of which navbar was not hidden the first time when it was expected. Technically, replacing `useState` with `useRef` fix this use case.

Fixes #2907

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
