### PR TITLE
chore(v2): downgrade babel-plugin-dynamic-import-node to 2.3.0

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -51,7 +51,7 @@
     "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
     "@svgr/webpack": "^5.4.0",
     "babel-loader": "^8.2.1",
-    "babel-plugin-dynamic-import-node": "^2.3.3",
+    "babel-plugin-dynamic-import-node": "^2.3.0",
     "boxen": "^4.2.0",
     "cache-loader": "^4.1.0",
     "chalk": "^3.0.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

As a result #3727 there was one regression - broken import from PWA plugin. This was not noticed right away, because the site was built without any errors (CI passes), but in [the deploy logs](https://app.netlify.com/sites/docusaurus-2/deploys/5fac6095a6917d00083ff9fb) I saw following:

```
1:12:43 AM: (undefined) ../packages/docusaurus-plugin-pwa/src/renderReloadPopup.js 6:554-564
1:12:43 AM: Critical dependency: the request of a dependency is an expression
```

Strangely enough, this is not a fatal error, but just a warning (why?). Anyway, this error was caused by an update of the `babel-plugin-dynamic-import-node` dependency, so I roll it back to the previous version.

@slorber however, I wonder why this error/warning is raised, perhaps we are using dynamic import incorrectly? (see https://github.com/airbnb/babel-plugin-dynamic-import-node/issues/90)

https://github.com/facebook/docusaurus/blob/9b3da59886fec5554c6c628b04d889e2641e217d/packages/docusaurus-plugin-pwa/src/renderReloadPopup.js#L24

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Preview.

## Test Plan

See Netlify deploy logs for this PR https://app.netlify.com/sites/docusaurus-2/deploys/5fadacdeaea4f30007353674

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
