### PR TITLE
docs(v2): add Inline SVG color override example

### DIFF
--- a/website/docs/markdown-features.mdx
+++ b/website/docs/markdown-features.mdx
@@ -1057,7 +1057,7 @@ or
 
 Docusaurus supports inlining SVGs out of the box.
 
-```js
+```jsx
 import DocusaurusSvg from './docusaurus.svg';
 
 <DocusaurusSvg />;
@@ -1066,3 +1066,23 @@ import DocusaurusSvg from './docusaurus.svg';
 import DocusaurusSvg from '@site/static/img/docusaurus.svg';
 
 <DocusaurusSvg />
+
+This can be useful, if you want to alter the part of the SVG image via CSS. For example, you can change one of the SVG colors based on the current theme.
+
+```jsx
+import DocusaurusSvg from './docusaurus.svg';
+
+<DocusaurusSvg className="themedDocusaurus" />;
+```
+
+```css
+html[data-theme='light'] .themedDocusaurus [fill='#FFFF50'] {
+  fill: greenyellow;
+}
+
+html[data-theme='dark'] .themedDocusaurus [fill='#FFFF50'] {
+  fill: seagreen;
+}
+```
+
+<DocusaurusSvg className="themedDocusaurus" />

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -62,6 +62,14 @@ html[data-theme='dark'] .header-github-link:before {
   background-color: var(--ifm-tabs-color-active);
 }
 
+html[data-theme='light'] .themedDocusaurus [fill='#FFFF50'] {
+  fill: greenyellow;
+}
+
+html[data-theme='dark'] .themedDocusaurus [fill='#FFFF50'] {
+  fill: seagreen;
+}
+
 html[data-theme='light'] .DocSearch {
   /* --docsearch-primary-color: var(--ifm-color-primary); */
   /* --docsearch-text-color: var(--ifm-font-color-base); */


### PR DESCRIPTION
## Motivation

Currently Inline SVGs section in docs is a stub. This PR adds the example usage, which shows how user can override the single color, or even many colors of inlined SVG image, based on the currently selected theme by user. 

At the beginning I want to utilize the `class` in the CSS selector, but it requires editing a SVG file and the class name is processed (`belly` became `docusaurus_svg__belly`), so I have decided to just use `fill` as selector (for the simplicity, instead of `[class*='belly']`).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

You

## Test Plan

![inline](https://user-images.githubusercontent.com/719641/99064855-ced81a80-25a6-11eb-98e4-17d551fd76cc.gif)

## Related PRs

No.
