### PR TITLE
fix(v2): add support for interleaving Markdown in code blocks

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -112,6 +112,11 @@ export default ({
 
   const prismTheme = usePrismTheme();
 
+  // In case interleaved Markdown (e.g. when using CodeBlock as standalone component).
+  if (typeof children !== 'string') {
+    children = (children as string[]).join('');
+  }
+
   if (metastring && highlightLinesRangeRegex.test(metastring)) {
     // Tested above
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -113,8 +113,8 @@ export default ({
   const prismTheme = usePrismTheme();
 
   // In case interleaved Markdown (e.g. when using CodeBlock as standalone component).
-  if (typeof children !== 'string') {
-    children = (children as string[]).join('');
+  if (Array.isArray(children)) {
+    children = children.join('');
   }
 
   if (metastring && highlightLinesRangeRegex.test(metastring)) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #3746

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try to put the following MDX snippet into the document and make sure it renders correctly.

```
import CodeBlock from '@theme/CodeBlock';

| Markdown | Less      | Pretty     |
| -------- | --------- | ---------- |
| _Still_  | `renders` | **nicely** |
| 1        | 2         | <CodeBlock>sum(rate(grpc_client_msg_received_total{component="tsbd", grpc_type="server_stream"}[30s])) by (cluster_name)</CodeBlock>|
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
