### PR TITLE
docs(v2): add npm2yarn to typescript install command

### DIFF
--- a/website/docs/typescript-support.md
+++ b/website/docs/typescript-support.md
@@ -7,7 +7,7 @@ title: TypeScript Support
 
 Docusaurus supports writing and using TypeScript theme components. To start using TypeScript, add `@docusaurus/module-type-aliases` and some `@types` dependencies to your project:
 
-```bash
+```bash npm2yarn
 npm install --save-dev typescript @docusaurus/module-type-aliases @types/react @types/react-router-dom @types/react-helmet @tsconfig/docusaurus
 ```
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make the "TypeScript Support" doc page for V2 consistent in providing both npm and yarn command examples.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
