### PR TITLE
chore(internal): fix CI on merge after build size addition

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,11 +1,8 @@
 name: Build Size
 
 on:
-  # Trigger the workflow on push or pull request,
+  # Trigger the workflow on pull request,
   # but only for the master branch
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Motivation

This PR fixes the CI on merge by removing the build size check from push pipeline.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Successful CI on merge of this PR.

## Related PRs

* Refs #3744
