### PR TITLE
refactor(v2): make accessible anchor links from keyboard

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -38,7 +38,6 @@ const Heading = (Tag: HeadingType): ((props: Props) => JSX.Element) =>
         {props.children}
         <a
           aria-hidden="true"
-          tabIndex={-1}
           className="hash-link"
           href={`#${id}`}
           title="Direct link to heading">

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -14,6 +14,7 @@
 .hash-link {
   opacity: 0;
   padding-left: 0.5rem;
+  transition: opacity var(--ifm-transition-fast);
 }
 
 .hash-link:focus,

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -16,6 +16,7 @@
   padding-left: 0.5rem;
 }
 
+.hash-link:focus,
 *:hover > .hash-link {
   opacity: 1;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After examining other docs, I realized that anchor links to headings should be accessible for keyboard navigation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview (use `tab` key)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
