### PR TITLE
fix(v2): do not remove duplicate CSS properties in during minification

### DIFF
--- a/packages/docusaurus-cssnano-preset/index.js
+++ b/packages/docusaurus-cssnano-preset/index.js
@@ -13,7 +13,7 @@ const postCssRemoveOverriddenCustomProperties = require('./src/remove-overridden
 const preset = advancedBasePreset({autoprefixer: {add: true}});
 
 preset.plugins.unshift(
-  [postCssCombineDuplicatedSelectors, {removeDuplicatedProperties: true}],
+  [postCssCombineDuplicatedSelectors, {removeDuplicatedValues: true}],
   [postCssSortMediaQueries],
   [postCssRemoveOverriddenCustomProperties],
 );

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -67,7 +67,7 @@ export function getStyleLoaders(
             autoprefixer: {
               flexbox: 'no-2009',
             },
-            stage: 3,
+            stage: 4,
           }),
         ],
       },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Probably at this stage we cannot remove duplicate CSS properties, since this breaks the work of the third-party deps, particularly Algolia search.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
