### PR TITLE
docs(v2): fix statements background, update footer background

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -21,14 +21,14 @@ html[data-theme='dark'] {
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgb(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.1);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
 html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgb(0, 0, 0, 0.3);
+  background-color: rgba(0, 0, 0, 0.3);
 }
 
 .header-github-link:hover {
@@ -47,6 +47,10 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 html[data-theme='dark'] .header-github-link:before {
   background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
     no-repeat;
+}
+
+.footer--dark {
+  --ifm-footer-background-color: #2b3137;
 }
 
 .unique-tabs .tabs__item {

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -10,7 +10,7 @@
 }
 
 .sectionAlt {
-  background-color: var(--ifm-color-emphasis-inverse-alpha-30);
+  background-color: var(--ifm-color-emphasis-100);
 }
 
 .sectionInner {


### PR DESCRIPTION
## Motivation

This PR introduces small design changes to the V2 website:
* fixes the users statements background (previously used CSS variable do not exist anymore in Infima)
* fixes the CSS warnings according to usage of `rgb` with a transparency channel
* updates the "dark" footer background to match the color used for the homepage hero section (the shade change is subtle)

#### Preview
<img width="886" alt="Screenshot 2020-11-17 151010" src="https://user-images.githubusercontent.com/719641/99400268-0a485100-28e7-11eb-8848-a970db8cec80.png">
<img width="910" alt="Screenshot 2020-11-17 151021" src="https://user-images.githubusercontent.com/719641/99400270-0b797e00-28e7-11eb-93bb-06311adf50fa.png">

#### Comparison
<img width="1864" alt="Screenshot 2020-11-17 151942" src="https://user-images.githubusercontent.com/719641/99401367-6495e180-28e8-11eb-983f-5df87597179d.png">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Changes have been testes locally, by running the Docusuaurs V2 website.

## Related PRs

No.
