### PR TITLE
refactor(v2): adjust dark mode toggle to site style

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
@@ -24,11 +24,9 @@
  */
 :global(.react-toggle) {
   touch-action: pan-x;
-  display: inline-block;
   position: relative;
   cursor: pointer;
   user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -61,7 +59,6 @@
   top: 0px;
   bottom: 0px;
   margin: auto 0;
-  line-height: 0;
   left: 8px;
   opacity: 0;
   transition: opacity 0.25s ease;
@@ -80,7 +77,6 @@
   top: 0px;
   bottom: 0px;
   margin: auto 0;
-  line-height: 0;
   right: 10px;
   opacity: 1;
   transition: opacity 0.25s ease;
@@ -92,7 +88,6 @@
 }
 
 :global(.react-toggle-thumb) {
-  transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
   position: absolute;
   top: 1px;
   left: 1px;
@@ -107,13 +102,12 @@
 :global([data-theme='dark'] .react-toggle .react-toggle-thumb),
 :global(.react-toggle--checked .react-toggle-thumb) {
   left: 27px;
-  border-color: #19ab27;
 }
 
 :global(.react-toggle--focus .react-toggle-thumb) {
-  box-shadow: 0px 0px 2px 3px #0099e0;
+  box-shadow: 0px 0px 2px 3px var(--ifm-color-primary);
 }
 
 :global(.react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb) {
-  box-shadow: 0px 0px 5px 5px #0099e0;
+  box-shadow: 0px 0px 5px 5px var(--ifm-color-primary);
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

As with Algolia search, we'd better personalize the dark mode switcher using the primary site color (i.e. `--ifm-color-primary`).
Also as part of this PR I also removed some unused/unnecessary CSS declarations.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try clicking on the dark mode toggle, its outline should be change to the primary color.

![2020-11-18_16-25](https://user-images.githubusercontent.com/4408379/99537405-aee89280-29bc-11eb-931e-fea056273857.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
