### PR TITLE
docs(v2): remove @next tags needed to install v2 packages

### DIFF
--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -24,19 +24,6 @@ Once your website is bootstrapped, the website source will contain the Docusauru
 
 Below is a list of Docusaurus CLI commands and their usages:
 
-<!-- TODO: init docs after the init command is implemented
-
-### `docusaurus init`
-
-The `docusaurus init` command is intended to be used with `docusaurus` installed globally:
-
-```shell
-$ yarn global add docusaurus
-# or
-$ npm install --global docusaurus
-```
--->
-
 ### `docusaurus start`
 
 Builds and serves a preview of your site locally with [Webpack Dev Server](https://webpack.js.org/configuration/dev-server).
@@ -87,9 +74,7 @@ Compiles your site for production.
 
 :::info
 
-For advanced minification of CSS bundle, we use the [advanced cssnano preset](https://github.com/cssnano/cssnano/tree/master/packages/cssnano-preset-advanced) (along with additional several PostCSS plugins) and [level 2 optimization of clean-css](https://github.com/jakubpawlowicz/clean-css#level-2-optimizations).
-If as a result of this advanced CSS minification you find broken CSS, build your website with the environment variable `USE_SIMPLE_CSS_MINIFIER=true` to minify CSS with the [default cssnano preset](https://github.com/cssnano/cssnano/tree/master/packages/cssnano-preset-default).
-**Please [fill out an issue](https://github.com/facebook/docusaurus/issues/new?labels=bug%2C+needs+triage&template=bug.md) if you experience CSS minification bugs.**
+For advanced minification of CSS bundle, we use the [advanced cssnano preset](https://github.com/cssnano/cssnano/tree/master/packages/cssnano-preset-advanced) (along with additional several PostCSS plugins) and [level 2 optimization of clean-css](https://github.com/jakubpawlowicz/clean-css#level-2-optimizations). If as a result of this advanced CSS minification you find broken CSS, build your website with the environment variable `USE_SIMPLE_CSS_MINIFIER=true` to minify CSS with the [default cssnano preset](https://github.com/cssnano/cssnano/tree/master/packages/cssnano-preset-default). **Please [fill out an issue](https://github.com/facebook/docusaurus/issues/new?labels=bug%2C+needs+triage&template=bug.md) if you experience CSS minification bugs.**
 
 :::
 

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init@next init my-website facebook
+npx @docusaurus/init init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init@next init my-website bootstrap
+npx @docusaurus/init init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.62/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.62/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init@next init my-website facebook
+npx @docusaurus/init init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init@next init my-website bootstrap
+npx @docusaurus/init init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.63/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init@next init my-website facebook
+npx @docusaurus/init init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init@next init my-website bootstrap
+npx @docusaurus/init init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.64/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init@next init my-website facebook
+npx @docusaurus/init init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init@next init my-website bootstrap
+npx @docusaurus/init init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.65/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.65/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init@next init my-website facebook
+npx @docusaurus/init init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init@next init my-website bootstrap
+npx @docusaurus/init init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.66/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init@next init my-website facebook
+npx @docusaurus/init init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init@next init my-website bootstrap
+npx @docusaurus/init init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.68/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.68/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init@next init [name] [template]
+npx @docusaurus/init init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init@next init my-website classic
+npx @docusaurus/init init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init@next init my-website facebook
+npx @docusaurus/init init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init@next init my-website bootstrap
+npx @docusaurus/init init my-website bootstrap
 ```
 
 ## Project structure


### PR DESCRIPTION

## Motivation

We don't need to install `@docusaurus/x@next` anymore because the `next` npm tag has been removed from v2 packages, to make things less confusing.

This is only  removing the usage from docs (+ other  minor docs changes)

Fixes:
- https://github.com/facebook/docusaurus/issues/3780
- https://github.com/facebook/docusaurus/issues/3756
- https://github.com/facebook/docusaurus/issues/3755
