### PR TITLE
fix(v2): fix missing logo in dark theme when darkSrc was not set

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -33,7 +33,7 @@ const Logo = (props: Props): JSX.Element => {
     : {};
   const sources = {
     light: useBaseUrl(logo.src),
-    dark: useBaseUrl(logo.srcDark),
+    dark: useBaseUrl(logo.srcDark || logo.src),
   };
 
   return (


### PR DESCRIPTION
## Motivation

During the work on the `Logo` component the fallback for `darkSrc` was removed (https://github.com/facebook/docusaurus/pull/3745/commits/f49c56c8578bdbeacd9c1edd82cfed5c241f8800). 

This do not affect the Docusaurus V2 website, but have caused an issue for sites using only `src` field in logo config.

#### Examples
![unknown](https://user-images.githubusercontent.com/719641/99667846-41e10580-2a6d-11eb-937d-27a2a6c956ce.png)

<img width="215" alt="Screenshot_2020-11-18_213106" src="https://user-images.githubusercontent.com/719641/99667738-1fe78300-2a6d-11eb-91bb-67737c1d0a3a.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Changes has been tested locally using Docusaurus V2 website with `darkSrc` removed from the config 😉 

## Related PRs

* #3745
