### PR TITLE
chore(v2): ensure publishConfig.access presence with tests

### DIFF
--- a/__tests__/validate-package-json.test.ts
+++ b/__tests__/validate-package-json.test.ts
@@ -12,21 +12,63 @@ import fsCb from 'fs';
 const glob = util.promisify(globCb);
 const readFile = util.promisify(fsCb.readFile);
 
-describe('packages', () => {
-  test('should contain repository and directory for every package', async () => {
-    const allPackageJson = await glob('packages/*/package.json');
-    expect(allPackageJson.length).toBeGreaterThan(0);
+type PackageJsonFile = {
+  file: string;
+  content: any;
+};
 
-    /* eslint-disable no-await-in-loop,no-restricted-syntax */
-    for (const packageJson of allPackageJson) {
-      const content = JSON.parse(await readFile(packageJson, 'utf8'));
-      if (content.private !== true) {
-        expect(content.repository).toEqual({
+async function getPackagesJsonFiles(): Promise<PackageJsonFile[]> {
+  const files = await glob('packages/*/package.json');
+  return Promise.all(
+    files.map(async (file) => {
+      return {
+        file,
+        content: JSON.parse(await readFile(file, 'utf8')),
+      };
+    }),
+  );
+}
+
+describe('packages', () => {
+  test('should be found', async () => {
+    const packageJsonFiles = await getPackagesJsonFiles();
+    expect(packageJsonFiles.length).toBeGreaterThan(0);
+  });
+
+  test('should contain repository and directory for every package', async () => {
+    const packageJsonFiles = await getPackagesJsonFiles();
+
+    packageJsonFiles.forEach((packageJsonFile) => {
+      if (packageJsonFile.content.private !== true) {
+        expect(packageJsonFile.content.repository).toEqual({
           type: 'git',
           url: 'https://github.com/facebook/docusaurus.git',
-          directory: packageJson.replace(/\/package\.json$/, ''),
+          directory: packageJsonFile.file.replace(/\/package\.json$/, ''),
         });
       }
-    }
+    });
+  });
+
+  /*
+  If a package starts with @, if won't be published to public npm registry
+  without an additional publishConfig.acces: "public" config
+  This will make you publish an incomplete list of Docusaurus packages
+  when trying to release with lerna-publish
+   */
+  test('should have publishConfig.access: "public" when name starts with @', async () => {
+    const packageJsonFiles = await getPackagesJsonFiles();
+
+    packageJsonFiles.forEach((packageJsonFile) => {
+      if (packageJsonFile.content.name.startsWith('@')) {
+        // Unfortunately jest custom message do not exist in loops, so using an exception instead to show failing package file
+        // (see https://github.com/facebook/jest/issues/3293)
+        // expect(packageJsonFile.content.publishConfig?.access).toEqual('public');
+        if (packageJsonFile.content.publishConfig?.access !== 'public') {
+          throw new Error(
+            `Package ${packageJsonFile.file} does not have publishConfig.access: 'public'`,
+          );
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION

## Motivation

Tests to ensure that all our packages starting with @ will have the required `publishConfig.access: "public"` in package.json, otherwise these packages will fail to publish on `lerna publish`, and lead to restarting the release on a new version.