### PR TITLE
chore(v2): ensure that the react-router and *-dom version matches

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -39,7 +39,7 @@
     "prism-react-renderer": "^1.1.1",
     "prismjs": "^1.22.0",
     "prop-types": "^15.7.2",
-    "react-router-dom": "^5.1.2",
+    "react-router-dom": "^5.2.0",
     "react-toggle": "^4.1.1"
   },
   "devDependencies": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -95,7 +95,7 @@
     "react-loadable-ssr-addon": "^0.3.0",
     "react-router": "^5.2.0",
     "react-router-config": "^5.1.1",
-    "react-router-dom": "^5.1.2",
+    "react-router-dom": "^5.2.0",
     "resolve-pathname": "^3.0.0",
     "semver": "^6.3.0",
     "serve-handler": "^6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16839,7 +16839,7 @@ react-router-config@^5.1.1:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-react-router-dom@^5.1.2:
+react-router-dom@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
   integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==


### PR DESCRIPTION
## Motivation

Currently the lock has been pointing to the correct version of `react-router-dom`, while in the `package.json` files there was a mismatch between versions of `react-router` and `react-router-dom`. Those packages are complementary and should be kept in sync - https://github.com/ReactTraining/react-router/commit/21a62e55c0d6196002bd4ab5b3350514976928cf.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local run of Docusaurus V2 website.

## Related PRs

* #3727 (https://github.com/facebook/docusaurus/pull/3727/files#diff-358cd23f806686eb2ec4d0a9a516f32d9c08f7d8c7bf6905dde0d907902f2454R94)
