### PR TITLE
chore: match fs-extra version across the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.12.1",
     "@babel/preset-typescript": "^7.12.1",
     "@types/express": "^4.17.2",
-    "@types/fs-extra": "^8.0.1",
+    "@types/fs-extra": "^9.0.4",
     "@types/inquirer": "^6.5.0",
     "@types/jest": "^25.2.1",
     "@types/loader-utils": "^1.1.3",

--- a/packages/docusaurus-1.x/package.json
+++ b/packages/docusaurus-1.x/package.json
@@ -48,7 +48,7 @@
     "escape-string-regexp": "^2.0.0",
     "express": "^4.17.1",
     "feed": "^4.2.1",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "gaze": "^1.1.3",
     "github-slugger": "^1.3.0",
     "glob": "^7.1.6",

--- a/packages/docusaurus-init/package.json
+++ b/packages/docusaurus-init/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "^4.0.1",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "inquirer": "^7.1.0",
     "lodash.kebabcase": "^4.1.1",
     "semver": "^6.3.0",

--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -24,7 +24,7 @@
     "@mdx-js/react": "^1.6.21",
     "escape-html": "^1.0.3",
     "file-loader": "^6.2.0",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "github-slugger": "^1.3.0",
     "gray-matter": "^4.0.2",
     "loader-utils": "^2.0.0",

--- a/packages/docusaurus-migrate/package.json
+++ b/packages/docusaurus-migrate/package.json
@@ -43,7 +43,6 @@
     "unist-util-visit": "^2.0.2"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.1",
     "@types/jscodeshift": "^0.7.1"
   }
 }

--- a/packages/docusaurus-plugin-client-redirects/package.json
+++ b/packages/docusaurus-plugin-client-redirects/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/utils-validation": "2.0.0-alpha.68",
     "chalk": "^3.0.0",
     "eta": "^1.11.0",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "globby": "^10.0.1",
     "joi": "^17.2.1",
     "lodash": "^4.17.20"

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -25,7 +25,7 @@
     "@docusaurus/utils-validation": "2.0.0-alpha.68",
     "chalk": "^3.0.0",
     "feed": "^4.2.1",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "globby": "^10.0.1",
     "joi": "^17.2.1",
     "loader-utils": "^1.2.3",

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -31,7 +31,7 @@
     "@docusaurus/utils-validation": "2.0.0-alpha.68",
     "chalk": "^3.0.0",
     "execa": "^3.4.0",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "globby": "^10.0.1",
     "import-fresh": "^3.2.2",
     "joi": "^17.2.1",

--- a/packages/docusaurus-plugin-ideal-image/package.json
+++ b/packages/docusaurus-plugin-ideal-image/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "fs-extra": "^9.0.0"
+    "fs-extra": "^9.0.1"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.68",

--- a/packages/docusaurus-plugin-sitemap/package.json
+++ b/packages/docusaurus-plugin-sitemap/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.68",
     "@docusaurus/types": "2.0.0-alpha.68",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "joi": "^17.2.1",
     "sitemap": "^3.2.2"
   },

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -21,7 +21,7 @@
     "@docusaurus/types": "2.0.0-alpha.68",
     "chalk": "^3.0.0",
     "escape-string-regexp": "^2.0.0",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "gray-matter": "^4.0.2",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -67,7 +67,7 @@
     "eta": "^1.11.0",
     "express": "^4.17.1",
     "file-loader": "^6.2.0",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "globby": "^10.0.1",
     "html-minifier-terser": "^5.1.1",
     "html-tags": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,17 +3265,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/fs-extra@^8.0.1":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
-  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/fs-extra@^9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.1.tgz#91c8fc4c51f6d5dbe44c2ca9ab09310bd00c7918"
-  integrity sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==
+"@types/fs-extra@^9.0.4":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.4.tgz#12553138cf0438db9a31cdc8b0a3aa9332eb67aa"
+  integrity sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==
   dependencies:
     "@types/node" "*"
 
@@ -9374,7 +9367,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1:
+fs-extra@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
   integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==


### PR DESCRIPTION
## Motivation

Currently many different version of `fs-extra` package are used in the Docusuaurs workspace. The Version list ranges from `8.1.0`, through `9.0.0` and ends at latest `9.0.1`. This PR normalizes that by bumping all none-latest `fs-extra` references in the `package.json` files. 

I have also bumped the `@types/fs-extra` package in the main `package.json` to the latest version and I have removed the redundant entry in the migration package `devDependencies`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Build and dev run of Docusuaurs V2 website locally.

## Related PRs

No.
