### PR TITLE
Added few lines for logo in dark theme

### DIFF
--- a/website/docs/theme-bootstrap.md
+++ b/website/docs/theme-bootstrap.md
@@ -43,7 +43,7 @@ const Example = () => {
 
 ### Navbar title & logo
 
-You can add a logo and title to the navbar via `themeConfig.navbar`. Logo can be placed in [static folder](static-assets.md). Logo URL is set to base URL of your site by default. Although you can specify your own URL for the logo, if it is an external link, it will open in a new tab. In addition, you can override a value for the target attribute of logo link, it can come in handy if you are hosting docs website in a subdirectory of your main website, and in which case you probably do not need a link in the logo to the main website will open in a new tab.
+You can add a logo and title to the navbar via `themeConfig.navbar`. Logo can be placed in [static folder](static-assets.md). Logo URL is set to base URL of your site by default. Although you can specify your own URL for the logo, if it is an external link, it will open in a new tab. In addition, you can override a value for the target attribute of logo link, it can come in handy if you are hosting docs website in a subdirectory of your main website, and in which case you probably do not need a link in the logo to the main website will open in a new tab. If you are willing to use dark mode, then you must add Logo for dark theme to. Add `srcDark` via `themeConfig.navbar.logo` and use your prefred logo for dark theme.
 
 ```js {5-11} title="docusaurus.config.js"
 module.exports = {
@@ -54,6 +54,7 @@ module.exports = {
       logo: {
         alt: 'Site Logo',
         src: 'img/logo.svg',
+        srcDark: 'img/logo.svg',
         href: 'https://v2.docusaurus.io/', // Default to `siteConfig.baseUrl`.
         target: '_self', // By default, this value is calculated based on the `href` attribute (the external link will open in a new tab, all others in the current one).
       },


### PR DESCRIPTION
There is no description about dark theme logo. I have added 2 to 3 lines which guide user to add `srcDark` in navbar.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

As they are just documentation changes, I hope no need of test plan.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
