### PR TITLE
chore(v2): remove useless stylelint-copyright peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,9 +118,6 @@
     "stylelint": "^13.2.1",
     "typescript": "^3.9.5"
   },
-  "peerDependencies": {
-    "stylelint-copyright": "2.0.0-alpha.66"
-  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",


### PR DESCRIPTION

## Motivation

The dep stayed on older version alpha 66 after this change: https://github.com/facebook/docusaurus/pull/3766#discussion_r527910313

But it seems declaring the peer deps here is not required, so maybe we can just remove it?