### PR TITLE
docs(v2): fix docusaurus init issue when not using @latest

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init init [name] [template]
+npx @docusaurus/init@latest init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init init my-website classic
+npx @docusaurus/init@latest init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init init my-website facebook
+npx @docusaurus/init@latest init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init init my-website bootstrap
+npx @docusaurus/init@latest init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.62/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.62/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init init [name] [template]
+npx @docusaurus/init@latest init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init init my-website classic
+npx @docusaurus/init@latest init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init init my-website facebook
+npx @docusaurus/init@latest init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init init my-website bootstrap
+npx @docusaurus/init@latest init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.63/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.63/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init init [name] [template]
+npx @docusaurus/init@latest init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init init my-website classic
+npx @docusaurus/init@latest init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init init my-website facebook
+npx @docusaurus/init@latest init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init init my-website bootstrap
+npx @docusaurus/init@latest init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.64/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.64/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init init [name] [template]
+npx @docusaurus/init@latest init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init init my-website classic
+npx @docusaurus/init@latest init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init init my-website facebook
+npx @docusaurus/init@latest init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init init my-website bootstrap
+npx @docusaurus/init@latest init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.65/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.65/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init init [name] [template]
+npx @docusaurus/init@latest init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init init my-website classic
+npx @docusaurus/init@latest init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init init my-website facebook
+npx @docusaurus/init@latest init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init init my-website bootstrap
+npx @docusaurus/init@latest init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.66/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.66/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init init [name] [template]
+npx @docusaurus/init@latest init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init init my-website classic
+npx @docusaurus/init@latest init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init init my-website facebook
+npx @docusaurus/init@latest init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init init my-website bootstrap
+npx @docusaurus/init@latest init my-website bootstrap
 ```
 
 ## Project structure

--- a/website/versioned_docs/version-2.0.0-alpha.68/installation.md
+++ b/website/versioned_docs/version-2.0.0-alpha.68/installation.md
@@ -15,13 +15,13 @@ Docusaurus is essentially a set of npm [packages](https://github.com/facebook/do
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx @docusaurus/init init [name] [template]
+npx @docusaurus/init@latest init [name] [template]
 ```
 
 Example:
 
 ```bash
-npx @docusaurus/init init my-website classic
+npx @docusaurus/init@latest init my-website classic
 ```
 
 If you do not specify `name` or `template`, it will prompt you for them. We recommend the `classic` template so that you can get started quickly and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -29,13 +29,13 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 **[FB-Only]:** If you are setting up a new Docusaurus website for a Facebook open source project, use the `facebook` template instead, which comes with some useful Facebook-specific defaults:
 
 ```bash
-npx @docusaurus/init init my-website facebook
+npx @docusaurus/init@latest init my-website facebook
 ```
 
 **[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
 
 ```bash
-npx @docusaurus/init init my-website bootstrap
+npx @docusaurus/init@latest init my-website bootstrap
 ```
 
 ## Project structure


### PR DESCRIPTION

## Motivation

`npx @docusaurus/init` seems to fail on some older Node versions, as npx tries to run a local `init` binary (the part after the /).

See also the output of `npx @docusaurus/echo test` on holder node here:

![image](https://user-images.githubusercontent.com/749374/99991992-040a1700-2db6-11eb-8b5f-e404fe1d6562.png)


As we  don't  plan to require newer node versions, we now document to use `npx @docusaurus/init@latest` instead, as it seems to work fine even in older node versions.

Note: previously we installed with the `@next` tag (which we removed), so now we are just changing the dist tag from next to latest.

Related to https://github.com/facebook/docusaurus/issues/3799



