### PR TITLE
fix(v2): Algolia: allow contextualSearch + facetFilters

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.js
@@ -118,20 +118,4 @@ describe('validateThemeConfig', () => {
       },
     });
   });
-
-  test('contextualSearch + searchParameters.facetFilters config', () => {
-    const algolia = {
-      indexName: 'index',
-      apiKey: 'apiKey',
-      contextualSearch: true,
-      searchParameters: {
-        facetFilters: ['version:1.0'],
-      },
-    };
-    expect(() =>
-      testValidateThemeConfig({algolia}),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"If you are using algolia.contextualSearch: true, you should not provide algolia.searchParameters.facetFilters, as it is computed for you dynamically"`,
-    );
-  });
 });

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 import Head from '@docusaurus/Head';
 import useSearchQuery from '@theme/hooks/useSearchQuery';
 import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
-import {useAlgoliaContextualSearchParameters} from '../../utils/algoliaSearchUtils';
+import useAlgoliaContextualFacetFilters from '@theme/hooks/useAlgoliaContextualFacetFilters';
 
 let DocSearchModal = null;
 
@@ -35,12 +35,20 @@ function ResultsFooter({state, onClose}) {
 function DocSearch({contextualSearch, ...props}) {
   const {siteMetadata} = useDocusaurusContext();
 
-  const contextualSearchParameters = useAlgoliaContextualSearchParameters();
+  const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
+
+  const configFacetFilters = props.searchParameters?.facetFilters ?? [];
+
+  const facetFilters = contextualSearch
+    ? // Merge contextual search filters with config filters
+      [...contextualSearchFacetFilters, ...configFacetFilters]
+    : // ... or use config facetFilters
+      configFacetFilters;
 
   // we let user override default searchParameters if he wants to
   const searchParameters = {
-    ...(contextualSearch ? contextualSearchParameters : {}),
     ...props.searchParameters,
+    facetFilters,
   };
 
   const {withBaseUrl} = useBaseUrlUtils();

--- a/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
@@ -7,13 +7,13 @@
 
 import useContextualSearchFilters from '@theme/hooks/useContextualSearchFilters';
 
-// Translate search-engine agnostic seach filters to Algolia search filters
-export function useAlgoliaContextualSearchParameters() {
+// Translate search-engine agnostic search filters to Algolia search filters
+export default function useAlgoliaContextualFacetFilters() {
   const {language, tags} = useContextualSearchFilters();
 
   const languageFilter = `language:${language}`;
 
   const tagsFilter = tags.map((tag) => `docusaurus_tag:${tag}`);
 
-  return {facetFilters: [languageFilter, tagsFilter]};
+  return [languageFilter, tagsFilter];
 }

--- a/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.js
@@ -41,17 +41,5 @@ exports.validateThemeConfig = function validateThemeConfig({
   validate,
   themeConfig,
 }) {
-  const normalizedThemeConfig = validate(Schema, themeConfig);
-
-  if (
-    normalizedThemeConfig &&
-    normalizedThemeConfig.algolia.contextualSearch &&
-    normalizedThemeConfig.algolia.searchParameters &&
-    normalizedThemeConfig.algolia.searchParameters.facetFilters
-  ) {
-    throw new Error(
-      'If you are using algolia.contextualSearch: true, you should not provide algolia.searchParameters.facetFilters, as it is computed for you dynamically',
-    );
-  }
-  return normalizedThemeConfig;
+  return validate(Schema, themeConfig);
 };

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -74,7 +74,7 @@ module.exports = {
 
 :::caution
 
-If you decide to use contextual search, you can't provide `algolia.searchParameters.facetFilters`, as we compute this `facetFilters` attribute for you dynamically.
+When using `contextualSearch: true`, the contextual facet filters will be merged with the ones provided with `algolia.searchParameters.facetFilters`.
 
 :::
 


### PR DESCRIPTION

## Motivation

Merge contextual search facetFilters with config-provided facetFilters.

Remove security: not a big deal because users will notice easily if their search is broken due to an extra useless config filter.

Fixes https://github.com/facebook/docusaurus/issues/3790 

## Test Plan

preview + locally


## Related PRs

https://github.com/facebook/docusaurus/pull/3550