### PR TITLE
fix(v2): remove aria-hidden attr from anchor link of heading

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -36,11 +36,7 @@ const Heading = (Tag: HeadingType): ((props: Props) => JSX.Element) =>
           id={id}
         />
         {props.children}
-        <a
-          aria-hidden="true"
-          className="hash-link"
-          href={`#${id}`}
-          title="Direct link to heading">
+        <a className="hash-link" href={`#${id}`} title="Direct link to heading">
           #
         </a>
       </Tag>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes a11y error of "ARIA hidden element must not contain focusable elements".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
