### PR TITLE
fix(v2): Allow footer logo at attribute to be empty

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
@@ -198,6 +198,26 @@ describe('themeConfig', () => {
     });
   });
 
+  test('should allow empty alt tags for the logo image in the footer', () => {
+    const partialConfig = {
+      footer: {
+        logo: {
+          alt: '',
+          src: '/arbitrary-logo.png',
+        },
+      },
+    };
+    const normalizedConfig = testValidateThemeConfig(partialConfig);
+
+    expect(normalizedConfig).toEqual({
+      ...normalizedConfig,
+      footer: {
+        ...normalizedConfig.footer,
+        ...partialConfig.footer,
+      },
+    });
+  });
+
   test('should accept valid prism config', () => {
     const prismConfig = {
       prism: {

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -254,7 +254,7 @@ const ThemeConfigSchema = Joi.object({
   footer: Joi.object({
     style: Joi.string().equal('dark', 'light').default('light'),
     logo: Joi.object({
-      alt: Joi.string(),
+      alt: Joi.string().allow(''),
       src: Joi.string(),
       href: Joi.string(),
     }),


### PR DESCRIPTION
## Motivation

Enable the footer logo to have an empty `alt=""` attribute. Basically, the same that https://github.com/facebook/docusaurus/pull/3352 did for the navbar logo but now for the footer.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#Attributes

> Setting this attribute to an empty string (alt="") indicates that this image is not a key part of the content (it’s decoration or a tracking pixel), and that non-visual browsers may omit it from rendering.

Since the logo normally is decorative an empty alt is fine.

Fixes #3816 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Run unit tests.
2. Create a new project and set the` footer.logo.alt` option in the Docusaurus config file to `''` (`alt: ''`)
3. `yarn start` and check that Docusaurus doesn't complain about `footer.logo.alt` being empty.