### PR TITLE
fix(v2): update notifier dist tag

### DIFF
--- a/packages/docusaurus-init/templates/README.MD
+++ b/packages/docusaurus-init/templates/README.MD
@@ -1,6 +1,6 @@
 # Templates
 
-Official templates provided by Docusaurus. They are designed to be selected when using the `npx @docusaurus/init@next init [name] [template]` CLI command.
+Official templates provided by Docusaurus. They are designed to be selected when using the `npx @docusaurus/init init [name] [template]` CLI command.
 
 ## Guide to Test Templates for Developer
 

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -29,7 +29,6 @@ const boxen = require('boxen');
 const notifier = updateNotifier({
   pkg,
   updateCheckInterval: 1000 * 60 * 60 * 24, // one day
-  distTag: 'next', // compare with the version that is tagged 'next' on npm
 });
 
 // allow the user to be notified for updates on the first run
@@ -50,7 +49,7 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
     `Update available ${chalk.dim(`${notifier.update.current}`)}${chalk.reset(
       ' → ',
     )}${chalk.green(`${notifier.update.latest}`)}\nRun ${chalk.cyan(
-      'yarn upgrade @docusaurus/core@next',
+      'yarn upgrade @docusaurus/core',
     )} to update`,
     boxenOptions,
   );


### PR DESCRIPTION

## Motivation

We are not using the @next npm dist tag anymore.

Fix https://github.com/facebook/docusaurus/issues/3821