### PR TITLE
fix(v2): restore Algolia search

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
@@ -16,5 +16,5 @@ export default function useAlgoliaContextualFacetFilters() {
 
   const tagsFilter = tags.map((tag) => `docusaurus_tag:${tag}`);
 
-  return [languageFilter, tagsFilter];
+  return [...(locale ? languageFilter : []), tagsFilter];
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #3826

If i18n is not used, `locale` will be `undefined` then, so we shouldn't include it in Algolia's facet filters.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
