### PR TITLE
fix(v2): temporary: disable crowdin until PR env variable permission fixed

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,8 @@
     "netlify:build:deployPreview:bootstrap": "cross-env BASE_URL='/bootstrap/' DOCUSAURUS_PRESET=bootstrap DISABLE_VERSIONING=true yarn build --out-dir netlifyDeployPreview/bootstrap",
     "netlify:build:deployPreview:blogOnly": "yarn build:blogOnly --out-dir netlifyDeployPreview/blog-only",
     "netlify:build:deployPreview:v1:all": "yarn --cwd .. netlify:deployPreview:v1 && yarn --cwd .. netlify:deployPreview:v1-migrated",
-    "netlify:crowdin": "cd .. && java -version && curl https://hardcore-ride-8fbb5a.netlify.app/crowdin-cli.jar --output crowdin-cli.jar && java -jar crowdin-cli.jar --version && java -jar crowdin-cli.jar download --config ./crowdin-v2.yaml",
+    "netlify:crowdin": "echo 'Crowdin temporarily disabled'",
+    "netlify:crowdin:download": "cd .. && java -version && curl https://hardcore-ride-8fbb5a.netlify.app/crowdin-cli.jar --output crowdin-cli.jar && java -jar crowdin-cli.jar --version && java -jar crowdin-cli.jar download --config ./crowdin-v2.yaml",
     "netlify:test": "yarn netlify:build:deployPreview && yarn netlify dev --debug"
   },
   "dependencies": {


### PR DESCRIPTION

## Motivation

External PRs like [these](https://github.com/facebook/docusaurus/pull/3832) are blocked due to not accessing the env variable for security reasons

This temporarily disable crowdin to make external PRs pass checks