### PR TITLE
feat(V2): add custom wrapper class to SearchPage, fix title

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -294,7 +294,7 @@ function Search() {
   }, [searchValue]);
 
   return (
-    <Layout title={getTitle()} wrapperClassName="search-results-wrapper">
+    <Layout title={getTitle()} wrapperClassName="search-page-wrapper">
       <Head>
         {/*
          We should not index search pages

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -294,7 +294,7 @@ function Search() {
   }, [searchValue]);
 
   return (
-    <Layout title={getTitle()}>
+    <Layout title={getTitle()} wrapperClassName="search-results-wrapper">
       <Head>
         {/*
          We should not index search pages

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -102,6 +102,8 @@ function Search() {
   const {
     siteConfig: {
       themeConfig: {algolia: {appId = 'BH4D9OD16A', apiKey, indexName} = {}},
+      title: siteTitle,
+      titleDelimiter,
     } = {},
   } = useDocusaurusContext();
   const docsSearchVersionsHelpers = useDocsSearchVersionsHelpers();
@@ -294,8 +296,9 @@ function Search() {
   }, [searchValue]);
 
   return (
-    <Layout title={getTitle()} wrapperClassName="search-page-wrapper">
+    <Layout wrapperClassName="search-page-wrapper">
       <Head>
+        <title>{`${getTitle()} ${titleDelimiter} ${siteTitle}`}</title>
         {/*
          We should not index search pages
           See https://github.com/facebook/docusaurus/pull/3233


### PR DESCRIPTION
## Motivation

Currently there is not possible to customize the `SearchPage` styling without swizzling the component.

This PR adds the custom wrapper class name to the `SearchPage`, so it will be possible to add custom styles which only apply to this page.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local run of Docusaurus V2 website.

#### Preview

<img width="1666" alt="Screenshot 2020-11-27 204101" src="https://user-images.githubusercontent.com/719641/100480372-52d6ea00-30f1-11eb-9023-24c5d90c0ded.png">

## Related PRs

No.