### PR TITLE
fix(v2): update SearchPage styling, fix appearance in dark mode

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -387,14 +387,24 @@ function Search() {
                   />
 
                   {breadcrumbs.length > 0 && (
-                    <span
-                      className={styles.searchResultItemPath}
-                      // Developer provided the HTML, so assume it's safe.
-                      // eslint-disable-next-line react/no-danger
-                      dangerouslySetInnerHTML={{
-                        __html: breadcrumbs.join(' › '),
-                      }}
-                    />
+                    <span className={styles.searchResultItemPath}>
+                      {breadcrumbs.map((html, index) => (
+                        <>
+                          {index !== 0 && (
+                            <span
+                              className={styles.searchResultItemPathSeparator}>
+                              {' '}
+                              ›{' '}
+                            </span>
+                          )}
+                          <span
+                            // Developer provided the HTML, so assume it's safe.
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{__html: html}}
+                          />
+                        </>
+                      ))}
+                    </span>
                   )}
 
                   {summary && (

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -393,8 +393,7 @@ function Search() {
                           {index !== 0 && (
                             <span
                               className={styles.searchResultItemPathSeparator}>
-                              {' '}
-                              ›{' '}
+                              ›
                             </span>
                           )}
                           <span

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
@@ -55,7 +55,7 @@
 }
 
 .searchResultItemPathSeparator {
-  margin: 0 0.25rem;
+  margin: 0 0.5rem;
   font-size: 1rem;
   font-weight: 600;
   color: var(--ifm-color-emphasis-400);

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
@@ -8,13 +8,18 @@
 .searchQueryInput,
 .searchVersionInput {
   border-radius: var(--ifm-global-radius);
-  border: var(--ifm-global-border-width) solid
-    var(--ifm-color-content-secondary);
+  border: 0;
   font-size: var(--ifm-font-size-base);
-  padding: 0.5rem;
+  padding: 0.8rem;
   width: 100%;
-  background: #fff;
+  background: var(--docsearch-searchbox-focus-background);
+  color: var(--docsearch-text-color);
   margin-bottom: 1rem;
+  box-shadow: var(--docsearch-searchbox-shadow);
+}
+
+.searchQueryInput::placeholder {
+  color: var(--docsearch-muted-color);
 }
 
 .searchResultsColumn {
@@ -35,7 +40,7 @@
 
 .searchResultItem {
   padding: 1rem 0;
-  border-bottom: 1px solid #dfe3e8;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
 }
 
 .searchResultItemHeading {
@@ -46,6 +51,13 @@
   font-size: 0.8rem;
   color: var(--ifm-color-content-secondary);
   display: block;
+}
+
+.searchResultItemPathSeparator {
+  margin: 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-400);
 }
 
 .searchResultItemSummary {
@@ -100,6 +112,7 @@
 }
 
 :global(.search-result-match) {
-  background: rgba(255, 215, 142, 0.22);
+  color: var(--docsearch-hit-color);
+  background: rgba(255, 215, 142, 0.25);
   padding: 0.09em 0;
 }

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
@@ -16,8 +16,15 @@
   background: var(--docsearch-searchbox-focus-background);
   color: var(--docsearch-text-color);
   margin-bottom: 1rem;
+  box-shadow: inset 0 0 0 2px var(--ifm-toc-border-color);
+  transition: var(--ifm-transition-fast) ease box-shadow;
+}
+
+.searchQueryInput:active,
+.searchQueryInput:focus,
+.searchVersionInput:active,
+.searchVersionInput:focus {
   box-shadow: var(--docsearch-searchbox-shadow);
-  outline: none;
 }
 
 .searchQueryInput::placeholder {

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
@@ -10,6 +10,7 @@
   border-radius: var(--ifm-global-radius);
   border: 0;
   font-size: var(--ifm-font-size-base);
+  font-family: var(--ifm-font-family-base);
   padding: 0.8rem;
   width: 100%;
   background: var(--docsearch-searchbox-focus-background);
@@ -87,6 +88,17 @@
     overflow: hidden;
     max-width: 40% !important;
     padding-left: 0 !important;
+  }
+}
+
+@media screen and (max-width: 576px) {
+  .searchQueryColumn {
+    max-width: 100% !important;
+  }
+
+  .searchVersionColumn {
+    max-width: 100% !important;
+    padding-left: var(--ifm-spacing-horizontal) !important;
   }
 }
 

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
@@ -16,6 +16,7 @@
   color: var(--docsearch-text-color);
   margin-bottom: 1rem;
   box-shadow: var(--docsearch-searchbox-shadow);
+  outline: none;
 }
 
 .searchQueryInput::placeholder {


### PR DESCRIPTION
## Motivation

Currently `SearchPage` styling feels a bit plain and in addition to that inputs and separator lines do not change appearance between the modes.

This PR updates the `SearchPage` component and introduces the following changes:
* more CSS variable used from Infima and Docsearch itself
* inputs borrows few styling properties the search input style from the modal
* chevron sign (breadcrumbs splitter) received it's own class to make customizing the style (or even changing it via `content`)  possible through CSS

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The changes have been tested using Docusaurus V2 website locally.

### Preview
![search](https://user-images.githubusercontent.com/719641/100489454-81b28780-3114-11eb-92da-d5c53f1ea22a.gif)

#### Mobile
<img width="347" alt="Screenshot 2020-11-28 005238" src="https://user-images.githubusercontent.com/719641/100489362-18cb0f80-3114-11eb-80cd-041f011232fe.png">

## Related PRs

* #3834