### PR TITLE
fix(v2): remove unnecessary backtick in output

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -574,7 +574,7 @@ Array [
 exports[`site with wrong sidebar file 1`] = `
 "Bad sidebars file.
 These sidebar document ids do not exist:
-- goku\`,
+- goku,
 
 Available document ids=
 - foo/bar

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -317,7 +317,7 @@ export function createSidebarsUtils(sidebars: Sidebars) {
       throw new Error(
         `Bad sidebars file.
 These sidebar document ids do not exist:
-- ${invalidSidebarDocIds.sort().join('\n- ')}\`,
+- ${invalidSidebarDocIds.sort().join('\n- ')},
 
 Available document ids=
 - ${validDocIds.sort().join('\n- ')}`,


### PR DESCRIPTION
## Motivation
On reading the output that gets printed when there are inexistent IDs, I noticed an additional backtick getting printed after the list  of IDs. So, I thought of proposing a change that removes it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes.

## Test Plan
Facing issues with testing the change locally. Hopefully, it should work properly. I'll update once I'm able to test this locally.

## Related PRs
N/A