### PR TITLE
chore(v2): fix PRs not able to add lighthouse/buildsize comment from works

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,9 +1,7 @@
 name: Build Size
 
 on:
-  # Trigger the workflow on pull request,
-  # but only for the master branch
-  pull_request:
+  pull_request_target:
     branches:
       - master
 

--- a/.github/workflows/lighthouseCI.yml
+++ b/.github/workflows/lighthouseCI.yml
@@ -1,5 +1,7 @@
 name: Lighthouse CI
-on: pull_request
+
+on: pull_request_target
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,8 +55,8 @@ jobs:
                 ' ',
                 `*Lighthouse ran on [${Object.keys(links)[0]}](${Object.keys(links)[0]})*`
             ].join('\n')
-             core.setOutput("comment", comment); 
-            
+             core.setOutput("comment", comment);
+
       - name: Add Lighthouse stats as comment
         id: comment_to_pr
         uses: marocchino/sticky-pull-request-comment@v2.0.0


### PR DESCRIPTION

## Motivation

A PR opened from a fork will trigger CI but the CI workflows can't comment on the original PR, due to security reasons.

This change should fix it.

Refs:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
https://github.community/t/github-actions-are-severely-limited-on-prs/18179/19