### PR TITLE
docs(v2): Fixed Typo: Hided => Hidden

### DIFF
--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -84,7 +84,7 @@ module.exports = {
 
 ### Hideable sidebar
 
-Using the enabled `themeConfig.hideableSidebar` option, you can make the entire sidebar hided, allowing you to better focus your users on the content. This is especially useful when content consumption on medium screens (e.g. on tablets).
+Using the enabled `themeConfig.hideableSidebar` option, you can make the entire sidebar hidden, allowing you to better focus your users on the content. This is especially useful when content consumption on medium screens (e.g. on tablets).
 
 ```js {4} title="docusaurus.config.js"
 module.exports = {

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -4,6 +4,7 @@ title: Docs Introduction
 sidebar_label: Introduction
 ---
 
+
 The docs feature provides users with a way to organize Markdown files in a hierarchical format.
 
 ## Document ID

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -4,7 +4,6 @@ title: Docs Introduction
 sidebar_label: Introduction
 ---
 
-
 The docs feature provides users with a way to organize Markdown files in a hierarchical format.
 
 ## Document ID


### PR DESCRIPTION
Fixed typo in section about the hideable sidebar. 'hided' is used instead of 'hidden'.

## Motivation

Recently started familiarizing myself with Docusaurus. I was reading the documentation and noticed the typo. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Simple type fix.
