### PR TITLE
chore(v2): disable Crowdin for deploy previews

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "start:blogOnly": "cross-env DOCUSAURUS_CONFIG='docusaurus.config-blog-only.js' yarn start",
     "build:blogOnly": "cross-env DOCUSAURUS_CONFIG='docusaurus.config-blog-only.js' yarn build",
     "netlify:build:production": "yarn docusaurus write-translations && yarn netlify:crowdin:install && yarn netlify:crowdin:uploadSources && yarn netlify:crowdin:downloadTranslations && yarn build",
-    "netlify:build:deployPreview": "yarn docusaurus write-translations --locale fr --messagePrefix '(fr) ' && yarn netlify:crowdin:install && yarn netlify:crowdin:downloadTranslationsFailSafe && yarn netlify:build:deployPreview:v1:all && yarn netlify:build:deployPreview:classic && yarn netlify:build:deployPreview:bootstrap && yarn netlify:build:deployPreview:blogOnly",
+    "netlify:build:deployPreview": "yarn docusaurus write-translations --locale fr --messagePrefix '(fr) ' && yarn netlify:build:deployPreview:v1:all && yarn netlify:build:deployPreview:classic && yarn netlify:build:deployPreview:bootstrap && yarn netlify:build:deployPreview:blogOnly",
     "netlify:build:deployPreview:classic": "cross-env BASE_URL='/classic/' yarn build --out-dir netlifyDeployPreview/classic",
     "netlify:build:deployPreview:bootstrap": "cross-env BASE_URL='/bootstrap/' DOCUSAURUS_PRESET=bootstrap DISABLE_VERSIONING=true yarn build --out-dir netlifyDeployPreview/bootstrap",
     "netlify:build:deployPreview:blogOnly": "yarn build:blogOnly --out-dir netlifyDeployPreview/blog-only",


### PR DESCRIPTION
## Motivation

Crowdin makes deploy previews slower for little additional value

+ Crowdin has a weird way to handle concurrency, and it seems you can only download from one process at a time...

![image](https://user-images.githubusercontent.com/749374/100767120-adc25700-33f9-11eb-8537-f4ee01d03f7e.png)
