### PR TITLE
chore: add Yarn v2 cache directory to ignores

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 __fixtures__
 dist
 node_modules
+.yarn
 build
 coverage
 jest.config.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+.yarn
 build
 coverage
 .docusaurus


### PR DESCRIPTION
## Motivation

It looks like it `.yarn` directory should also be added to the `.eslintignore` and `.prettierignore`, because currently some of build commands includes formatting steps, and some unnecessary files are being reformatted.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local test run of Docuausurs workspace using Yarn v2.

## Related PRs

* https://github.com/facebook/docusaurus/commit/3e101f86b784d9c34648a67bb32c706afe3884f5#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947R9 (https://github.com/facebook/docusaurus/pull/3849)
