### PR TITLE
chore(ci): reduce number of jobs, remove build from lighthouse pipeline

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['10', '14']
+        node: ['10']
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['10', '14']
+        node: ['14']
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/lighthouseCI.yml
+++ b/.github/workflows/lighthouseCI.yml
@@ -5,19 +5,8 @@ on: pull_request_target
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['12']
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - name: Install and Build
-        run: |
-          yarn install
-          yarn build
       - name: Wait for the Netlify Preview
         uses: jakepartusch/wait-for-netlify-action@v1
         id: netlify


### PR DESCRIPTION
## Motivation

As @slorber noticed the increased number of jobs cause the CI to choke a bit, so I was advice to reduce the job count (at least for now). 

This PR removes Node 14 from `yarn-v1 E2E` job and Node 10 from `yarn-v2 E2E` to retain at least one job on both version of Node.

Additionally I have removed the Node, `install` and `build` steps, since it looks like that they are redundant.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run the CI.

## Related PRs

* #3849
