### PR TITLE
docs(sidebar): Improve nested object specs in docs.md for sidebar

### DIFF
--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -96,6 +96,28 @@ module.exports = {
 };
 ```
 
+### Nested sidebar items
+
+Using nested object notation, it is possible to embed sub-pages in Docusaurus, as such:
+
+```js {4} title="sidebars.js"
+{
+  type: "category",
+  label: "Guides",
+  items: [
+    "guides/creating-pages",
+    "styling-layout",
+    "static-assets",
+    {
+      Docs: ["docs-introduction", "markdown-features", "versioning"],
+    },
+    "blog",
+    "search",
+    "deployment",
+  ]
+}
+```
+
 ### Sidebar object
 
 A sidebar object is defined like this:


### PR DESCRIPTION
Previous version of docs did not contain proper specifications on nested objects in Docusaurus sidebars. See related issue: [#3855](https://github.com/facebook/docusaurus/issues/3855)

## Motivation

There were no previous clear instructions on the matter of nested objects/items in the Docusaurus sidebar. Although minor, I believe it will help a great number of users, as I was struggling with this problem myself. Hope this helps! Let me know if anything must be fixed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Since the code changed was just MD in the docs, I made sure it was of the proper, adequate standard by comparing the grammar, voice, and narration style throughout the rest of the Docusaurus documentation. This way, I made sure to maintain the same tone that makes the docs so engaging 👍 .

**Example of what was covered in the newly added portion of documentation:**

<img width="827" alt="Screen Shot 2020-12-01 at 12 06 19" src="https://user-images.githubusercontent.com/48065878/100779197-a1c0a000-33cd-11eb-9a95-960511df4fe0.png">


## Related PRs

No related Pull Requests for this one. :)
