### PR TITLE
chore(ci): run V1 Build and Migration CLI tests conditionally on CI

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Navigate to website directory
+        run: cd website
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          pattern: '{website/build/main*js,website/build/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
+          pattern: '{build/main*js,build/styles*css,build/index.html,build/blog/**/introducing-docusaurus/*,build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 100

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -10,11 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Navigate to website directory
-        run: cd website
       - uses: preactjs/compressed-size-action@v2
         with:
+          build-script: "build:v2"
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          pattern: '{build/main*js,build/styles*css,build/index.html,build/blog/**/introducing-docusaurus/*,build/docs/introduction/index.html}'
+          pattern: '{website/build/main*js,website/build/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 100

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          build-script: "build:v2"
+          build-script: "build:v2:en"
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           pattern: '{website/build/main*js,website/build/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          build-script: "build:v2:en"
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          build-script: 'build:v2:en'
           pattern: '{website/build/main*js,website/build/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 100

--- a/.github/workflows/lighthouseCI.yml
+++ b/.github/workflows/lighthouseCI.yml
@@ -23,6 +23,7 @@ jobs:
         id: netlify
         with:
           site_name: 'docusaurus-2'
+          max_timeout: 300
       - name: Audit URLs using Lighthouse
         id: lighthouse_audit
         uses: treosh/lighthouse-ci-action@v3

--- a/.github/workflows/migration-cli-e2e-test.yml
+++ b/.github/workflows/migration-cli-e2e-test.yml
@@ -1,15 +1,25 @@
 name: Migration CLI E2E Test
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      migration: ${{ steps.filter.outputs.migration }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            migration:
+              - 'packages/docusaurus-migration/**'
   build:
+    needs: check
+    if: ${{ needs.check.outputs.migration == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -1,9 +1,6 @@
 name: Windows Build Test
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -16,6 +13,13 @@ jobs:
         node: ['10']
     steps:
       - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            v1:
+              - 'packages/docusaurus-1.x/**'
+              - 'packages/docusaurus-init-1.x/**'
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
@@ -23,6 +27,7 @@ jobs:
       - name: Installation
         run: yarn || yarn || yarn # 3 attempts to avoid timeout errors...
       - name: Docusaurus 1 Build
+        if: steps.filter.outputs.v1 == 'true'
         run: yarn build:v1
       - name: Docusaurus 2 Build
         run: yarn build:v2

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:v2": "yarn workspace docusaurus-2-website build",
     "build:v2:baseUrl": "yarn workspace docusaurus-2-website build:baseUrl",
     "build:v2:blogOnly": "yarn workspace docusaurus-2-website build:blogOnly",
+    "build:v2:en": "yarn workspace docusaurus-2-website build --locale en",
     "serve:v1": "serve website-1.x/build/docusaurus",
     "serve:v2": "yarn workspace docusaurus-2-website serve",
     "serve:v2:baseUrl": "serve website",


### PR DESCRIPTION
## Motivation

This PR is an attempt to optimize CI workflows a bit more to improve the time required to check every PR.

I have utilized the [`@dorny/paths-filter`](https://github.com/dorny/paths-filter) action to add check based on the modified files in the PR so now:
* V1 build won't be running on Windows Pipeline until `packages/docusuaurs-1.x` or `packages/docusuaurs-init-1.x` files have been changed.
* Migration CLI job won't run until `packages/docusuaurs-migration` includes the changes.

This is the first time I have used this action, so the initial version might be not correct. Any tips and ideas for further optimizations are welcome!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run the CI! 😉 

## Related PRs

* #3861
