### PR TITLE
fix(v2): load plugin commands async to fix broken plugin CLI commands `docs:version`

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -252,12 +252,16 @@ function isInternalCommand(command) {
   ].includes(command);
 }
 
-if (!isInternalCommand(process.argv.slice(2)[0])) {
-  externalCommand(cli, path.resolve('.'));
+async function run() {
+  if (!isInternalCommand(process.argv.slice(2)[0])) {
+    await externalCommand(cli, path.resolve('.'));
+  }
+
+  cli.parse(process.argv);
+
+  if (!process.argv.slice(2).length) {
+    cli.outputHelp();
+  }
 }
 
-cli.parse(process.argv);
-
-if (!process.argv.slice(2).length) {
-  cli.outputHelp();
-}
+run()

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -264,4 +264,4 @@ async function run() {
   }
 }
 
-run()
+run();


### PR DESCRIPTION
https://github.com/facebook/docusaurus/blame/master/packages/docusaurus/src/commands/external.ts#L12 changed the exported method to an async function, but the CLI loader was not updated to also run async, breaking things such as `npm run docusaurus docs:version <version>`.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
