### PR TITLE
chore: add missing v1 generated files to ignores

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,6 +14,8 @@ packages/docusaurus/lib/
 packages/docusaurus-*/lib/*
 !packages/docusaurus-1.x/lib/*
 packages/docusaurus-1.x/lib/core/__tests__/split-tab.test.js
+packages/docusaurus-1.x/lib/core/metadata.js
+packages/docusaurus-1.x/lib/core/MetadataBlog.js
 packages/docusaurus-*/lib-next/
 packages/docusaurus-plugin-ideal-image/copyUntypedFiles.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ test-website
 packages/docusaurus/lib/
 packages/docusaurus-*/lib/*
 !packages/docusaurus-1.x/lib/*
+packages/docusaurus-1.x/lib/core/metadata.js
+packages/docusaurus-1.x/lib/core/MetadataBlog.js
 packages/docusaurus-*/lib-next/
 
 website/netlifyDeployPreview/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,8 @@ coverage
 packages/docusaurus/lib/
 packages/docusaurus-*/lib/*
 !packages/docusaurus-1.x/lib/*
+packages/docusaurus-1.x/lib/core/metadata.js
+packages/docusaurus-1.x/lib/core/MetadataBlog.js
 packages/docusaurus-*/lib-next/
 packages/docusaurus-init/templates/**/*.md
 __fixtures__


### PR DESCRIPTION
## Motivation

@slorber reported that after latest changes to ignores two generated files from v1 build are marked as `unversioned`. This PR fix that issue by adding the files to ignores.

Earlier they were part of removed `.gitignore` from v1 package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

V1 build locally and run of `git ls-files . --exclude-standard --others`, `yarn prettier` and `yarn lint`.

## Related PRs

* #3865
