### PR TITLE
docs(v2): From docusaurus-migrate to @docusaurus/migrate

### DIFF
--- a/website/docs/migration/migration-automated.md
+++ b/website/docs/migration/migration-automated.md
@@ -61,7 +61,7 @@ You can add option flags to the migration CLI to automatically migrate Markdown 
 
 ```bash
 # example using options
-npx docusaurus-migrate migrate --mdx --page ./v1-website ./v2-website
+npx @docusaurus/migrate migrate --mdx --page ./v1-website ./v2-website
 ```
 
 :::danger


### PR DESCRIPTION
I am trying Docusaurus migrate of my website built with v1. I think that **docusaurus-migrate** is an old package, I've copy-pasted this `npx` command but it not works, I think that it could be **@docusaurus/migrate** package