### PR TITLE
fix(v2): dynamic dark mode detection without toggle widget

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
@@ -38,7 +38,7 @@ const storeTheme = (newTheme) => {
 
 const useTheme = (): useThemeReturns => {
   const {
-    colorMode: {disableSwitch = false, respectPrefersColorScheme = true},
+    colorMode: {disableSwitch, respectPrefersColorScheme},
   } = useThemeConfig();
   const [theme, setTheme] = useState(getInitialTheme);
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
@@ -38,7 +38,7 @@ const storeTheme = (newTheme) => {
 
 const useTheme = (): useThemeReturns => {
   const {
-    colorMode: {disableSwitch = false},
+    colorMode: {disableSwitch = false, respectPrefersColorScheme = true},
   } = useThemeConfig();
   const [theme, setTheme] = useState(getInitialTheme);
 
@@ -71,7 +71,7 @@ const useTheme = (): useThemeReturns => {
   }, [setTheme]);
 
   useEffect(() => {
-    if (disableSwitch) {
+    if (disableSwitch && !respectPrefersColorScheme) {
       return;
     }
 


### PR DESCRIPTION
## Motivation

Dynamic automatic dark mode detection is disabled when the manual switch is hidden. But I want to enjoy the benefits of automatic dark-mode switching without showing the manual toggle.

See details in #3876 

close #3876 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

With the following config:

```
    colorMode: {
      defaultMode: 'light',
      disableSwitch: true, // Don't show manual switch
      respectPrefersColorScheme: true, // But respect user preference!
    },
```

[🎥 before this fix](https://files.hmil.fr/cloud/docusaurus_dark-mode_toggle-off.webm)  
[🎥 after this fix](https://files.hmil.fr/cloud/docusaurus_dark-mode_toggle-off_fixed.webm)

Not shown in the screencasts: Currently, the correct color theme gets applied but only if you do a hard reload of the page. The difference that this fix makes is that you don't have to reload the page anymore.

## Related PRs

none
