### PR TITLE
fix(v2): improve Footer structure, add class names, use Infima transition

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -90,7 +90,7 @@ function Footer(): JSX.Element | null {
           </div>
         )}
         {(logo || copyright) && (
-          <div className="text--center">
+          <div className="footer__bottom text--center">
             {logo && logo.src && (
               <div className="margin-bottom--sm">
                 {logo.href ? (
@@ -106,14 +106,16 @@ function Footer(): JSX.Element | null {
                 )}
               </div>
             )}
-
-            <div
-              // Developer provided the HTML, so assume it's safe.
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{
-                __html: copyright ?? '',
-              }}
-            />
+            {copyright ? (
+              <div
+                className="footer__copyright"
+                // Developer provided the HTML, so assume it's safe.
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                  __html: copyright,
+                }}
+              />
+            ) : null}
           </div>
         )}
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
@@ -7,7 +7,7 @@
 
 .footerLogoLink {
   opacity: 0.5;
-  transition: opacity 0.15s ease-in-out;
+  transition: opacity var(--ifm-transition-fast) var(--ifm-transition-timing-default);
 }
 
 .footerLogoLink:hover {


### PR DESCRIPTION
## Motivation

This PR includes few small improvements to the `theme-classic` Footer component:
* add distinctive `className`s for copyright element and bottom content wrapper to allow easier Footer customization
* do not render empty copyright element when there is no `copyright` specified
* use default values from Infima for logo transition delay and function

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local build and run of v2 website.

#### HTML preview

<img width="698" alt="Screenshot 2020-12-04 182901" src="https://user-images.githubusercontent.com/719641/101194699-9f28a980-365e-11eb-8009-7dfe13c87d27.png">

## Related PRs

No.
