### PR TITLE
chore(ci): increase Lighthouse CI max_timeout

### DIFF
--- a/.github/workflows/lighthouseCI.yml
+++ b/.github/workflows/lighthouseCI.yml
@@ -12,7 +12,7 @@ jobs:
         id: netlify
         with:
           site_name: 'docusaurus-2'
-          max_timeout: 300
+          max_timeout: 600
       - name: Audit URLs using Lighthouse
         id: lighthouse_audit
         uses: treosh/lighthouse-ci-action@v3


### PR DESCRIPTION
## Motivation

Currently Lighthouse CI test fails of on the initial PR deploy because build take more than 5 minutes:

> Build time: 7m 58s. Total deploy time: 8m 21s

This PR increased this time to `600` seconds, so 10 minutes. 

Unfortunately this is not the best way to solve the issue, but it is the best what can be achieved right now.

The other problem with the Lighthouse check is that pushing another commit to the PR will cause Lighthouse check to run immediately on the site deployed from the previous build, because it only depends on 200 response from the content located under deploy URL and deploy URL do not change between commits (do not include commit hash).

To fix this properly the website deployment should be a part of GitHub workflows, and lighthouse check should depends on that. Then the [`needs` job parameter](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds) could be used to prevent the issue described above.

Another way could be modifying Netlify or/and Lighthouse setup/config files in a way which would change the deploy URL between the commits or Netlify status can be hooked into Lighthouse workflow somehow.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run the CI.

## Related PRs

* #3863
