### PR TITLE
fix(v2): use proper element for pagination nav label

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
@@ -18,14 +18,14 @@ function BlogListPaginator(props: {readonly metadata: Metadata}): JSX.Element {
       <div className="pagination-nav__item">
         {previousPage && (
           <Link className="pagination-nav__link" to={previousPage}>
-            <h4 className="pagination-nav__label">&laquo; Newer Entries</h4>
+            <div className="pagination-nav__label">&laquo; Newer Entries</div>
           </Link>
         )}
       </div>
       <div className="pagination-nav__item pagination-nav__item--next">
         {nextPage && (
           <Link className="pagination-nav__link" to={nextPage}>
-            <h4 className="pagination-nav__label">Older Entries &raquo;</h4>
+            <div className="pagination-nav__label">Older Entries &raquo;</div>
           </Link>
         )}
       </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The `pagination-nav__label` CSS class must be used with a `div`, not an `h4`. Otherwise, it leads to the adding of extra margins (see Test plan).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before:

![image](https://user-images.githubusercontent.com/4408379/101500798-02c51680-3980-11eb-8d93-e27edd0c8457.png)

After:

![image](https://user-images.githubusercontent.com/4408379/101500827-0b1d5180-3980-11eb-912b-b400f7b36a84.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
