### PR TITLE
fix(v2): do not treat at-rules during CSS minification

### DIFF
--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -440,6 +440,7 @@ export function getMinimizer(useSimpleCssMinifier = false): Plugin[] {
               2: {
                 all: true,
                 restructureRules: true,
+                removeUnusedAtRules: false,
               },
             },
           },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #3836

This disables the `removeUnusedAtRules` option in [advanced CSS minifier](https://github.com/jakubpawlowicz/clean-css#level-2-optimizations) as it does not work correctly for us.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested on https://github.com/semoal/docusaurus-css-minifier-bug (after that, the building of site goes without fatal errors).

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
