### PR TITLE
Go to configured page set in sidebar config

### DIFF
--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -73,11 +73,11 @@ declare module '@theme/DocPaginator' {
 }
 
 declare module '@theme/DocSidebar' {
-  import type {PropSidebarItem} from '@docusaurus/plugin-content-docs-types';
+  // import type {PropSidebarItem} from '@docusaurus/plugin-content-docs-types';
 
   export type Props = {
     readonly path: string;
-    readonly sidebar: readonly PropSidebarItem[];
+    readonly sidebar: any;
     readonly sidebarCollapsible?: boolean;
     readonly onCollapse: () => void;
     readonly isHidden: boolean;

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -15,12 +15,14 @@ module.exports = {
     {
       type: 'category',
       label: 'Getting Started',
+      go_to: 'configuration',
       collapsed: false,
       items: ['installation', 'configuration', 'typescript-support'],
     },
     {
       type: 'category',
       label: 'Guides',
+      go_to: 'deployment',
       items: [
         'guides/creating-pages',
         'styling-layout',
@@ -37,6 +39,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Advanced Guides',
+      go_to: 'using-themes',
       items: ['using-plugins', 'using-themes', 'presets'],
     },
   ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

Using the enabled config `go_to` option, you can make the sidebar on collapsed go to the selected link allowing the user to have one less click to they content they were going to look at; if the developer doesn't want to specify the link the application will run as normally:
```js {4} title="docusaurus.config.js"
module.exports = {
    docs: [
    {
      type: 'category',
      label: 'Docusaurus',
      go_to: 'introduction',
      items: ['introduction', 'design-principles', 'contributing'],
    },
    // ...
  },
};
``` 

Preview
![ezgif com-gif-maker](https://user-images.githubusercontent.com/43492172/101593910-a4129380-39a5-11eb-8837-fe6e56a2a764.gif)

***NOTE***
In ```packages/docusaurus-theme-classic/src/types.d.ts``` I changed the proptype to `any` so I could test the go_to feature, I know adding that back in will be mandatory for this the be merged, is there a way to add the `go_to` prop to `PropSidebarItem`?

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
