### PR TITLE
fix(v2): fix redirect toUrl (windows + trailing slash)

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/__snapshots__/writeRedirectFiles.test.ts.snap
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/__snapshots__/writeRedirectFiles.test.ts.snap
@@ -6,11 +6,11 @@ Array [
 <html>
   <head>
     <meta charset=\\"UTF-8\\">
-    <meta http-equiv=\\"refresh\\" content=\\"0; url=/abc/\\">
-    <link rel=\\"canonical\\" href=\\"/abc/\\" />
+    <meta http-equiv=\\"refresh\\" content=\\"0; url=/abc\\">
+    <link rel=\\"canonical\\" href=\\"/abc\\" />
   </head>
   <script>
-    window.location.href = '/abc/';
+    window.location.href = '/abc';
   </script>
 </html>",
 ]
@@ -22,11 +22,11 @@ Array [
 <html>
   <head>
     <meta charset=\\"UTF-8\\">
-    <meta http-equiv=\\"refresh\\" content=\\"0; url=/abc/\\">
-    <link rel=\\"canonical\\" href=\\"/abc/\\" />
+    <meta http-equiv=\\"refresh\\" content=\\"0; url=/abc\\">
+    <link rel=\\"canonical\\" href=\\"/abc\\" />
   </head>
   <script>
-    window.location.href = '/abc/';
+    window.location.href = '/abc';
   </script>
 </html>",
 ]
@@ -38,22 +38,22 @@ Array [
 <html>
   <head>
     <meta charset=\\"UTF-8\\">
-    <meta http-equiv=\\"refresh\\" content=\\"0; url=https://docusaurus.io/abc/\\">
-    <link rel=\\"canonical\\" href=\\"https://docusaurus.io/abc/\\" />
+    <meta http-equiv=\\"refresh\\" content=\\"0; url=https://docusaurus.io/abc\\">
+    <link rel=\\"canonical\\" href=\\"https://docusaurus.io/abc\\" />
   </head>
   <script>
-    window.location.href = 'https://docusaurus.io/abc/';
+    window.location.href = 'https://docusaurus.io/abc';
   </script>
 </html>",
   "<!DOCTYPE html>
 <html>
   <head>
     <meta charset=\\"UTF-8\\">
-    <meta http-equiv=\\"refresh\\" content=\\"0; url=https://docusaurus.io/def.html/\\">
-    <link rel=\\"canonical\\" href=\\"https://docusaurus.io/def.html/\\" />
+    <meta http-equiv=\\"refresh\\" content=\\"0; url=https://docusaurus.io/def.html\\">
+    <link rel=\\"canonical\\" href=\\"https://docusaurus.io/def.html\\" />
   </head>
   <script>
-    window.location.href = 'https://docusaurus.io/def.html/';
+    window.location.href = 'https://docusaurus.io/def.html';
   </script>
 </html>",
   "<!DOCTYPE html>

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
@@ -9,7 +9,31 @@ import path from 'path';
 
 import writeRedirectFiles, {
   toRedirectFilesMetadata,
+  createToUrl,
 } from '../writeRedirectFiles';
+
+// Test to fix toUrl bugs we had:
+// - https://github.com/facebook/docusaurus/issues/3886
+// - https://github.com/facebook/docusaurus/issues/3925
+describe('createToUrl', () => {
+  test('should create appropriate redirect urls', async () => {
+    expect(createToUrl('/', '/docs/something/else')).toEqual(
+      '/docs/something/else/',
+    );
+    expect(createToUrl('/', '/docs/something/else/')).toEqual(
+      '/docs/something/else/',
+    );
+  });
+
+  test('should create appropriate redirect urls with baseUrl', async () => {
+    expect(createToUrl('/baseUrl/', '/docs/something/else')).toEqual(
+      '/baseUrl/docs/something/else/',
+    );
+    expect(createToUrl('/baseUrl/', '/docs/something/else/')).toEqual(
+      '/baseUrl/docs/something/else/',
+    );
+  });
+});
 
 describe('toRedirectFilesMetadata', () => {
   test('should create appropriate metadatas', async () => {

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
@@ -18,19 +18,25 @@ import writeRedirectFiles, {
 describe('createToUrl', () => {
   test('should create appropriate redirect urls', async () => {
     expect(createToUrl('/', '/docs/something/else')).toEqual(
-      '/docs/something/else/',
+      '/docs/something/else',
     );
     expect(createToUrl('/', '/docs/something/else/')).toEqual(
       '/docs/something/else/',
+    );
+    expect(createToUrl('/', 'docs/something/else')).toEqual(
+      '/docs/something/else',
     );
   });
 
   test('should create appropriate redirect urls with baseUrl', async () => {
     expect(createToUrl('/baseUrl/', '/docs/something/else')).toEqual(
-      '/baseUrl/docs/something/else/',
+      '/baseUrl/docs/something/else',
     );
     expect(createToUrl('/baseUrl/', '/docs/something/else/')).toEqual(
       '/baseUrl/docs/something/else/',
+    );
+    expect(createToUrl('/baseUrl/', 'docs/something/else')).toEqual(
+      '/baseUrl/docs/something/else',
     );
   });
 });

--- a/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
@@ -11,11 +11,7 @@ import {memoize} from 'lodash';
 
 import {PluginContext, RedirectMetadata} from './types';
 import createRedirectPageContent from './createRedirectPageContent';
-import {
-  addTrailingSlash,
-  getFilePathForRoutePath,
-  removeTrailingSlash,
-} from '@docusaurus/utils';
+import {getFilePathForRoutePath, normalizeUrl} from '@docusaurus/utils';
 
 export type WriteFilesPluginContext = Pick<PluginContext, 'baseUrl' | 'outDir'>;
 
@@ -25,7 +21,7 @@ export type RedirectFileMetadata = {
 };
 
 export function createToUrl(baseUrl: string, to: string) {
-  return addTrailingSlash(`${removeTrailingSlash(baseUrl)}${path.join(to)}`);
+  return normalizeUrl([baseUrl, to]);
 }
 
 export function toRedirectFilesMetadata(

--- a/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
@@ -24,6 +24,10 @@ export type RedirectFileMetadata = {
   fileContent: string;
 };
 
+export function createToUrl(baseUrl: string, to: string) {
+  return addTrailingSlash(`${removeTrailingSlash(baseUrl)}${path.join(to)}`);
+}
+
 export function toRedirectFilesMetadata(
   redirects: RedirectMetadata[],
   pluginContext: WriteFilesPluginContext,
@@ -40,9 +44,7 @@ export function toRedirectFilesMetadata(
       pluginContext.outDir,
       getFilePathForRoutePath(redirect.from),
     );
-    const toUrl = addTrailingSlash(
-      `${removeTrailingSlash(pluginContext.baseUrl)}${path.join(redirect.to)}`,
-    ).replace(/\\/g, '/');
+    const toUrl = createToUrl(pluginContext.baseUrl, redirect.to);
     const fileContent = createPageContentMemoized(toUrl);
     return {
       ...redirect,

--- a/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
@@ -42,7 +42,7 @@ export function toRedirectFilesMetadata(
     );
     const toUrl = addTrailingSlash(
       `${removeTrailingSlash(pluginContext.baseUrl)}${path.join(redirect.to)}`,
-    );
+    ).replace(/\\/g, '/');
     const fileContent = createPageContentMemoized(toUrl);
     return {
       ...redirect,


### PR DESCRIPTION
## Motivation

@docusaurs-plugin-client-redirects fails on windows because windows is special and uses \ in path instead of /.

Replacing \ with / before url encoding resolves this issue.

Resolves #3886 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
