### PR TITLE
chore(ci): only publish @canary release if packages/** has changed

### DIFF
--- a/.github/workflows/canary-releases.yml
+++ b/.github/workflows/canary-releases.yml
@@ -6,7 +6,21 @@ on:
       - master
 
 jobs:
+  checkPackagesHaveChanged:
+    runs-on: ubuntu-latest
+    outputs:
+      packagesHaveChanged: ${{ steps.filter.outputs.packagesHaveChanged }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            packagesHaveChanged:
+              - 'packages/**'
+
   publish-canary:
+    needs: checkPackagesHaveChanged
+    if: ${{ needs.checkPackagesHaveChanged.outputs.packagesHaveChanged == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION

## Motivation


Avoid useless publication of canary releases

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

CI

## Related PRs

Inspired by https://github.com/facebook/docusaurus/pull/3884
