### PR TITLE
chore(ci): temporarily disable bootstrap deploy preview

### DIFF
--- a/website/netlifyDeployPreview/index.html
+++ b/website/netlifyDeployPreview/index.html
@@ -20,7 +20,7 @@
         </li>
         <li style="margin-top: 20px;">
           <a href="/bootstrap">bootstrap</a>: the regular site with the
-          bootstrap theme (WIP)
+          bootstrap theme (WIP / disabled)
         </li>
         <li style="margin-top: 20px;">
           <a href="/blog-only">blog-only</a>: the regular site in blog-only mode

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "netlify:build:production": "yarn docusaurus write-translations && yarn netlify:crowdin:install && yarn netlify:crowdin:uploadSources && yarn netlify:crowdin:downloadTranslations && yarn build",
     "netlify:build:deployPreview": "yarn docusaurus write-translations --locale fr --messagePrefix '(fr) ' && yarn netlify:build:deployPreview:v1:all && yarn netlify:build:deployPreview:classic && yarn netlify:build:deployPreview:bootstrap && yarn netlify:build:deployPreview:blogOnly",
     "netlify:build:deployPreview:classic": "cross-env BASE_URL='/classic/' yarn build --out-dir netlifyDeployPreview/classic",
-    "netlify:build:deployPreview:bootstrap": "cross-env BASE_URL='/bootstrap/' DOCUSAURUS_PRESET=bootstrap DISABLE_VERSIONING=true yarn build --out-dir netlifyDeployPreview/bootstrap",
+    "netlify:build:deployPreview:bootstrap": "echo 'netlify:build:deployPreview:bootstrap temporarily disabled' || cross-env BASE_URL='/bootstrap/' DOCUSAURUS_PRESET=bootstrap DISABLE_VERSIONING=true yarn build --out-dir netlifyDeployPreview/bootstrap",
     "netlify:build:deployPreview:blogOnly": "yarn build:blogOnly --out-dir netlifyDeployPreview/blog-only",
     "netlify:build:deployPreview:v1:all": "yarn --cwd .. netlify:deployPreview:v1 && yarn --cwd .. netlify:deployPreview:v1-migrated",
     "netlify:crowdin:install": "cd .. && java -version && curl https://hardcore-ride-8fbb5a.netlify.app/crowdin-cli.jar --output crowdin-cli.jar && java -jar crowdin-cli.jar --version",


### PR DESCRIPTION

## Motivation

Bootstrap theme deploy preview is a burden currently, so let's disable it until we have time to invest in it and make it production ready