### PR TITLE
fix(v2): don't remove viewBox from svg

### DIFF
--- a/packages/docusaurus/src/webpack/__tests__/base.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/base.test.ts
@@ -7,7 +7,13 @@
 
 import path from 'path';
 
-import {excludeJS, clientDir, getDocusaurusAliases} from '../base';
+import {
+  excludeJS,
+  clientDir,
+  getDocusaurusAliases,
+  createBaseConfig,
+} from '../base';
+import * as utils from '../utils';
 import {mapValues} from 'lodash';
 
 describe('babel transpilation exclude logic', () => {
@@ -67,5 +73,30 @@ describe('getDocusaurusAliases()', () => {
       (aliasValue) => path.relative(__dirname, aliasValue),
     );
     expect(relativeDocusaurusAliases).toMatchSnapshot();
+  });
+});
+
+describe('base webpack config', () => {
+  const props = {
+    outDir: '',
+    siteDir: '',
+    baseUrl: '',
+    generatedFilesDir: '',
+    routesPaths: '',
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should use svg rule', () => {
+    const fileLoaderUtils = utils.getFileLoaderUtils();
+    const mockSvg = jest.spyOn(fileLoaderUtils.rules, 'svg');
+    jest
+      .spyOn(utils, 'getFileLoaderUtils')
+      .mockImplementation(() => fileLoaderUtils);
+
+    createBaseConfig(props, false, false);
+    expect(mockSvg).toBeCalled();
   });
 });

--- a/packages/docusaurus/src/webpack/__tests__/utils.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/utils.test.ts
@@ -12,7 +12,7 @@ import {
 } from 'webpack';
 import path from 'path';
 
-import {applyConfigureWebpack} from '../utils';
+import {applyConfigureWebpack, getFileLoaderUtils} from '../utils';
 import {
   ConfigureWebpackFn,
   ConfigureWebpackFnMergeStrategy,
@@ -130,5 +130,21 @@ describe('extending generated webpack config', () => {
         rules: [{use: 'xxx'}, {use: 'yyy'}, {use: 'zzz'}],
       },
     });
+  });
+});
+
+describe('getFileLoaderUtils()', () => {
+  test('plugin svgo/removeViewBox should be disabled', () => {
+    const use = getFileLoaderUtils().rules.svg().use;
+    expect(use).toContainEqual(
+      expect.objectContaining({
+        loader: '@svgr/webpack',
+        options: expect.objectContaining({
+          svgoConfig: {
+            plugins: [{removeViewBox: false}],
+          },
+        }),
+      }),
+    );
   });
 });

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -151,6 +151,7 @@ export function createBaseConfig(
       rules: [
         fileLoaderUtils.rules.images(),
         fileLoaderUtils.rules.media(),
+        fileLoaderUtils.rules.svg(),
         fileLoaderUtils.rules.otherAssets(),
         {
           test: /\.(j|t)sx?$/,
@@ -182,10 +183,6 @@ export function createBaseConfig(
             sourceMap: !isProd,
             onlyLocals: isServer,
           }),
-        },
-        {
-          test: /\.svg$/,
-          use: '@svgr/webpack?-prettier,+svgo,+titleProp,+ref![path]',
         },
       ],
     },

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -298,6 +298,26 @@ export function getFileLoaderUtils(): Record<string, any> {
       };
     },
 
+    svg: (): RuleSetRule => {
+      return {
+        use: [
+          {
+            loader: '@svgr/webpack',
+            options: {
+              prettier: false,
+              svgo: true,
+              svgoConfig: {
+                plugins: [{removeViewBox: false}],
+              },
+              titleProp: true,
+              ref: ![path],
+            },
+          },
+        ],
+        test: /\.svg$/,
+      };
+    },
+
     otherAssets: (): RuleSetRule => {
       return {
         use: [loaders.file({folder: 'files'})],


### PR DESCRIPTION
## Motivation

Fix #3901 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

See instructions in #3901.
## Bug reason
**svgo** has plugin **removeViewBox** that enabled by default.