### PR TITLE
fix(v2): i18n translation extractor should handle JSX formatting edge cases better

### DIFF
--- a/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
@@ -160,7 +160,16 @@ export default function MyComponent() {
       <Translate
         id={prefix + "codeId comp"}
         description={prefix + "code description"}
-      >{prefix + "code message"}</Translate>
+      >
+      {prefix + "code message"}
+      </Translate>
+      <Translate>
+
+        {
+
+          prefix + \`Static template literal with unusual formatting!\`
+        }
+      </Translate>
     </div>
   );
 }
@@ -182,6 +191,9 @@ export default function MyComponent() {
         'prefix codeId fn': {
           message: 'prefix code message',
           description: 'prefix code description',
+        },
+        'prefix Static template literal with unusual formatting!': {
+          message: 'prefix Static template literal with unusual formatting!',
         },
       },
       warnings: [],

--- a/packages/docusaurus/src/server/translations/translationsExtractor.ts
+++ b/packages/docusaurus/src/server/translations/translationsExtractor.ts
@@ -195,15 +195,15 @@ function extractSourceCodeAstTranslations(
           // Remove empty/useless text nodes that might be around our translation!
           // Makes the translation system more reliable to JSX formatting issues
           .filter(
-            (childrenPath) =>
+            (childrenPath: NodePath) =>
               !(
-                t.isJSXText(childrenPath) &&
+                t.isJSXText(childrenPath.node) &&
                 childrenPath.node.value.replace('\n', '').trim() === ''
               ),
           )
           .pop();
 
-        if (singleChildren && t.isJSXText(singleChildren)) {
+        if (singleChildren && t.isJSXText(singleChildren.node)) {
           const message = singleChildren.node.value.trim().replace(/\s+/g, ' ');
 
           const id = evaluateJSXProp('id');

--- a/packages/docusaurus/src/server/translations/translationsExtractor.ts
+++ b/packages/docusaurus/src/server/translations/translationsExtractor.ts
@@ -189,14 +189,22 @@ function extractSourceCodeAstTranslations(
         path.node.openingElement.name.type === 'JSXIdentifier' &&
         path.node.openingElement.name.name === 'Translate'
       ) {
-        // TODO support multiple childrens here?
-        if (
-          path.node.children.length === 1 &&
-          t.isJSXText(path.node.children[0])
-        ) {
-          const message = path.node.children[0].value
-            .trim()
-            .replace(/\s+/g, ' ');
+        // We only handle the optimistic case where we have a single non-empty content
+        const singleChildren: NodePath | undefined = path
+          .get('children')
+          // Remove empty/useless text nodes that might be around our translation!
+          // Makes the translation system more reliable to JSX formatting issues
+          .filter(
+            (childrenPath) =>
+              !(
+                t.isJSXText(childrenPath) &&
+                childrenPath.node.value.replace('\n', '').trim() === ''
+              ),
+          )
+          .pop();
+
+        if (singleChildren && t.isJSXText(singleChildren)) {
+          const message = singleChildren.node.value.trim().replace(/\s+/g, ' ');
 
           const id = evaluateJSXProp('id');
           const description = evaluateJSXProp('description');
@@ -206,12 +214,12 @@ function extractSourceCodeAstTranslations(
             ...(description && {description}),
           };
         } else if (
-          path.node.children.length === 1 &&
-          t.isJSXExpressionContainer(path.node.children[0]) &&
-          (path.get('children.0.expression') as NodePath).evaluate().confident
+          singleChildren &&
+          t.isJSXExpressionContainer(singleChildren) &&
+          (singleChildren.get('expression') as NodePath).evaluate().confident
         ) {
-          const message = (path.get(
-            'children.0.expression',
+          const message = (singleChildren.get(
+            'expression',
           ) as NodePath).evaluate().value;
 
           const id = evaluateJSXProp('id');


### PR DESCRIPTION
## Motivation

Jest has this JSX content that would not be extracted properly by the i18n translation extractor:

```
          <Translate>
            {`Find out what's new with Jest.
- Follow[Jest](https://twitter.com/fbjest) on Twitter.
- Subscribe to the[Jest blog](/blog/).
- Look at the[changelog](https://github.com/facebook/jest/blob/master/CHANGELOG.md).`}
          </Translate>
```

This is become Babel AST parses this as 3 childrens: `[empty text node, JSX expression, empty text node]` 

In such case we'll filter out the empty text nodes to focus mainly on the important node containing the translations

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

unit tests

