### PR TITLE
fix(v2): fix navbar items issue on Windows?

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -7,12 +7,14 @@
 
 import React from 'react';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
-import LocaleDropdownNavbarItem from '@theme/NavbarItem/LocaleDropdownNavbarItem';
 import type {Props} from '@theme/NavbarItem';
 
 const NavbarItemComponents = {
   default: () => DefaultNavbarItem,
-  localeDropdown: () => LocaleDropdownNavbarItem,
+
+  localeDropdown: () => () =>
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('@theme/NavbarItem/LocaleDropdownNavbarItem').default,
 
   // Need to lazy load these items as we don't know for sure the docs plugin is loaded
   // See https://github.com/facebook/docusaurus/issues/3360

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -7,14 +7,12 @@
 
 import React from 'react';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import LocaleDropdownNavbarItem from '@theme/NavbarItem/LocaleDropdownNavbarItem';
 import type {Props} from '@theme/NavbarItem';
 
 const NavbarItemComponents = {
   default: () => DefaultNavbarItem,
-
-  localeDropdown: () => () =>
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require('@theme/NavbarItem/LocaleDropdownNavbarItem').default,
+  localeDropdown: () => LocaleDropdownNavbarItem,
 
   // Need to lazy load these items as we don't know for sure the docs plugin is loaded
   // See https://github.com/facebook/docusaurus/issues/3360

--- a/packages/docusaurus/src/server/themes/alias.ts
+++ b/packages/docusaurus/src/server/themes/alias.ts
@@ -32,6 +32,7 @@ export default function themeAlias(
     const aliasName = posixPath(
       normalizeUrl(['@theme', fileName]).replace(/\/$/, ''),
     );
+    console.log(aliasName);
     aliases[aliasName] = filePath;
 
     if (addOriginalAlias) {

--- a/packages/docusaurus/src/server/themes/alias.ts
+++ b/packages/docusaurus/src/server/themes/alias.ts
@@ -10,6 +10,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import {fileToPath, posixPath, normalizeUrl} from '@docusaurus/utils';
 import {ThemeAlias} from '@docusaurus/types';
+import {sortBy} from 'lodash';
 
 export default function themeAlias(
   themePath: string,
@@ -23,16 +24,21 @@ export default function themeAlias(
     cwd: themePath,
   });
 
+  // See https://github.com/facebook/docusaurus/pull/3922
+  // ensure @theme/NavbarItem alias is created after @theme/NavbarItem/LocaleDropdown
+  const sortedThemeComponentFiles = sortBy(themeComponentFiles, (file) =>
+    file.endsWith('/index.js'),
+  );
+
   const aliases: ThemeAlias = {};
 
-  themeComponentFiles.forEach((relativeSource) => {
+  sortedThemeComponentFiles.forEach((relativeSource) => {
     const filePath = path.join(themePath, relativeSource);
     const fileName = fileToPath(relativeSource);
 
     const aliasName = posixPath(
       normalizeUrl(['@theme', fileName]).replace(/\/$/, ''),
     );
-    console.log(aliasName);
     aliases[aliasName] = filePath;
 
     if (addOriginalAlias) {


### PR DESCRIPTION
## Motivation

Fix weird theme alias issue on Windows:
https://github.com/facebook/docusaurus/runs/1552317907

![image](https://user-images.githubusercontent.com/749374/102124744-f261df80-3e48-11eb-8d39-dee301c2ae5d.png)

On Windows, the aliases are created in a different order and can shadow each others:

![image](https://user-images.githubusercontent.com/749374/102126199-16bebb80-3e4b-11eb-8da2-914e8c992d24.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

CI