### PR TITLE
docs(v2): blog.md with docs: false, for blog-only mode

### DIFF
--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -149,6 +149,7 @@ module.exports = {
     [
       '@docusaurus/preset-classic',
       {
+        docs: false,
         blog: {
           path: './blog',
           routeBasePath: '/', // Set this value to '/'.


### PR DESCRIPTION
Added ***docs: false,*** to the config for blog-only mode because we do not want any documents if we're in blog-only mode otherwise, we probably wouldn't use blog-only mode.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

To setup only a blog with Docusaurs v2.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
