### PR TITLE
fix(v2): i18n should not crash theme without footer

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
@@ -87,3 +87,24 @@ describe('translateThemeConfig', () => {
     ).toMatchSnapshot();
   });
 });
+
+describe('getTranslationFiles and translateThemeConfig isomorphism', () => {
+  function verifyIsomorphism(themeConfig: ThemeConfig) {
+    const translationFiles = getTranslationFiles({themeConfig});
+    const translatedThemeConfig = translateThemeConfig({
+      themeConfig,
+      translationFiles,
+    });
+    expect(translatedThemeConfig).toEqual(themeConfig);
+  }
+
+  test('should be verified for main sample', () => {
+    verifyIsomorphism(ThemeConfigSample);
+  });
+
+  // undefined footer should not make the translation code crash
+  // See https://github.com/facebook/docusaurus/issues/3936
+  test('should be verified for sample without footer', () => {
+    verifyIsomorphism({...ThemeConfigSample, footer: undefined});
+  });
+});

--- a/packages/docusaurus-theme-classic/src/translations.ts
+++ b/packages/docusaurus-theme-classic/src/translations.ts
@@ -129,13 +129,17 @@ export function getTranslationFiles({
 }: {
   themeConfig: ThemeConfig;
 }): TranslationFile[] {
-  return [
+  const translationFiles: (TranslationFile | undefined)[] = [
     {path: 'navbar', content: getNavbarTranslationFile(themeConfig.navbar)},
-    themeConfig.footer && {
-      path: 'footer',
-      content: getFooterTranslationFile(themeConfig.footer),
-    },
-  ].filter(Boolean);
+    themeConfig.footer
+      ? {
+          path: 'footer',
+          content: getFooterTranslationFile(themeConfig.footer),
+        }
+      : undefined,
+  ];
+
+  return translationFiles.filter(Boolean) as TranslationFile[];
 }
 
 export function translateThemeConfig({
@@ -156,8 +160,8 @@ export function translateThemeConfig({
       themeConfig.navbar,
       translationFilesMap.navbar.content,
     ),
-    footer:
-      themeConfig.footer &&
-      translateFooter(themeConfig.footer, translationFilesMap.footer.content),
+    footer: themeConfig.footer
+      ? translateFooter(themeConfig.footer, translationFilesMap.footer.content)
+      : undefined,
   };
 }

--- a/packages/docusaurus-theme-classic/src/translations.ts
+++ b/packages/docusaurus-theme-classic/src/translations.ts
@@ -131,8 +131,11 @@ export function getTranslationFiles({
 }): TranslationFile[] {
   return [
     {path: 'navbar', content: getNavbarTranslationFile(themeConfig.navbar)},
-    {path: 'footer', content: getFooterTranslationFile(themeConfig.footer)},
-  ];
+    themeConfig.footer && {
+      path: 'footer',
+      content: getFooterTranslationFile(themeConfig.footer),
+    },
+  ].filter(Boolean);
 }
 
 export function translateThemeConfig({
@@ -153,9 +156,8 @@ export function translateThemeConfig({
       themeConfig.navbar,
       translationFilesMap.navbar.content,
     ),
-    footer: translateFooter(
-      themeConfig.footer,
-      translationFilesMap.footer.content,
-    ),
+    footer:
+      themeConfig.footer &&
+      translateFooter(themeConfig.footer, translationFilesMap.footer.content),
   };
 }

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -66,7 +66,7 @@ export type ThemeConfig = {
   colorMode: any;
   announcementBar: any;
   prism: any;
-  footer: Footer;
+  footer: Footer | undefined;
   hideableSidebar: any;
 };
 


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/3936

Theme code should not crash if there is no footer in themeConfig

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

unit
