### PR TITLE
fix(v2): fix i18n build logging. 

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -228,16 +228,14 @@ async function buildLocale({
   });
 
   console.log(
-    `${chalk.green(
-      `[${locale}] Success!`,
-    )} Generated static files in ${chalk.cyan(
+    `${chalk.green(`Success!`)} Generated static files in ${chalk.cyan(
       path.relative(process.cwd(), outDir),
     )}.`,
   );
 
   if (isLastLocale) {
     console.log(
-      `Use ${chalk.greenBright(
+      `\nUse ${chalk.greenBright(
         '`npm run serve`',
       )} to test your build locally.\n`,
     );

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -29,7 +29,9 @@ import loadConfig from '../server/config';
 export default async function build(
   siteDir: string,
   cliOptions: Partial<BuildCLIOptions> = {},
-  forceTerminate: boolean = true, // TODO not sure what's the purpose of this arg ?
+
+  // TODO what's the purpose of this arg ?
+  forceTerminate: boolean = true,
 ): Promise<string> {
   async function tryToBuildLocale({
     locale,
@@ -225,11 +227,12 @@ async function buildLocale({
     baseUrl,
   });
 
-  const relativeDir = path.relative(process.cwd(), outDir);
   console.log(
     `${chalk.green(
       `[${locale}] Success!`,
-    )} Generated static files in ${chalk.cyan(relativeDir)}.`,
+    )} Generated static files in ${chalk.cyan(
+      path.relative(process.cwd(), outDir),
+    )}.`,
   );
 
   if (isLastLocale) {

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -29,12 +29,24 @@ import loadConfig from '../server/config';
 export default async function build(
   siteDir: string,
   cliOptions: Partial<BuildCLIOptions> = {},
-  forceTerminate: boolean = true,
+  forceTerminate: boolean = true, // TODO not sure what's the purpose of this arg ?
 ): Promise<string> {
-  async function tryToBuildLocale(locale: string, forceTerm) {
+  async function tryToBuildLocale({
+    locale,
+    isLastLocale,
+  }: {
+    locale: string;
+    isLastLocale: boolean;
+  }) {
     try {
-      const result = await buildLocale(siteDir, locale, cliOptions, forceTerm);
-      console.log(chalk.green(`Site successfully built in locale=${locale}`));
+      const result = await buildLocale({
+        siteDir,
+        locale,
+        cliOptions,
+        forceTerminate,
+        isLastLocale,
+      });
+      // console.log(chalk.green(`Site successfully built in locale=${locale}`));
       return result;
     } catch (e) {
       console.error(`error building locale=${locale}`);
@@ -46,13 +58,13 @@ export default async function build(
     locale: cliOptions.locale,
   });
   if (cliOptions.locale) {
-    return tryToBuildLocale(cliOptions.locale, forceTerminate);
+    return tryToBuildLocale({locale: cliOptions.locale, isLastLocale: true});
   } else {
     if (i18n.locales.length > 1) {
       console.log(
         chalk.yellow(
-          `\nSite will be built with all these locales:
-- ${i18n.locales.join('\n- ')}\n`,
+          `\nSite will be built for all these locales:
+- ${i18n.locales.join('\n- ')}`,
         ),
       );
     }
@@ -67,24 +79,29 @@ export default async function build(
     const results = await mapAsyncSequencial(orderedLocales, (locale) => {
       const isLastLocale =
         i18n.locales.indexOf(locale) === i18n.locales.length - 1;
-      // TODO check why we need forceTerminate
-      const forceTerm = isLastLocale && forceTerminate;
-      return tryToBuildLocale(locale, forceTerm);
+      return tryToBuildLocale({locale, isLastLocale});
     });
     return results[0]!;
   }
 }
 
-async function buildLocale(
-  siteDir: string,
-  locale: string,
-  cliOptions: Partial<BuildCLIOptions> = {},
-  forceTerminate: boolean = true,
-): Promise<string> {
+async function buildLocale({
+  siteDir,
+  locale,
+  cliOptions,
+  forceTerminate,
+  isLastLocale,
+}: {
+  siteDir: string;
+  locale: string;
+  cliOptions: Partial<BuildCLIOptions>;
+  forceTerminate: boolean;
+  isLastLocale: boolean;
+}): Promise<string> {
   process.env.BABEL_ENV = 'production';
   process.env.NODE_ENV = 'production';
   console.log(
-    chalk.blue(`[${locale}] Creating an optimized production build...`),
+    chalk.blue(`\n[${locale}] Creating an optimized production build...`),
   );
 
   const props: Props = await load(siteDir, {
@@ -210,13 +227,20 @@ async function buildLocale(
 
   const relativeDir = path.relative(process.cwd(), outDir);
   console.log(
-    `\n${chalk.green('Success!')} Generated static files in ${chalk.cyan(
-      relativeDir,
-    )}. Use ${chalk.greenBright(
-      '`npm run serve`',
-    )} to test your build locally.\n`,
+    `${chalk.green(
+      `[${locale}] Success!`,
+    )} Generated static files in ${chalk.cyan(relativeDir)}.`,
   );
-  if (forceTerminate && !cliOptions.bundleAnalyzer) {
+
+  if (isLastLocale) {
+    console.log(
+      `Use ${chalk.greenBright(
+        '`npm run serve`',
+      )} to test your build locally.\n`,
+    );
+  }
+
+  if (forceTerminate && isLastLocale && !cliOptions.bundleAnalyzer) {
     process.exit(0);
   }
 


### PR DESCRIPTION

## Motivation

We shouldn't print "run npm serve" more than once:

![image](https://user-images.githubusercontent.com/749374/102648824-7a592980-4168-11eb-8c50-a4ac5ca1432f.png)
