### PR TITLE
fix(v2): ignore style imports in excerpt

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -386,6 +386,7 @@ describe('load utils', () => {
         input: `
           import Component from '@site/src/components/Component';
           import Component from '@site/src/components/Component'
+          import './styles.css';
 
           export function ItemCol(props) { return <Item {...props} className={'col col--6 margin-bottom--lg'}/> }
 

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -204,7 +204,7 @@ export function createExcerpt(fileString: string): string | undefined {
     }
 
     // Skip import/export declaration.
-    if (/^.*import\s.*from.*;?|export\s.*{.*};?/.test(fileLine)) {
+    if (/^\s*?import\s.*(from.*)?;?|export\s.*{.*};?/.test(fileLine)) {
       continue;
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ignoring style imports when generating excerpt, since this use case was not considered previously.
I noticed that the [Infima website is importing a style file](https://github.com/facebookincubator/infima/blob/master/website/docs/layout/grid.mdx
), and as a result, the meta description is incorrect.

I also increased the precision of the regex to only consider whitespace characters when checking import/export declarations.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
