### PR TITLE
Added information about setting `/` in routeBasePath

### DIFF
--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -38,6 +38,7 @@ module.exports = {
         /**
          * URL route for the docs section of your site.
          * *DO NOT* include a trailing slash.
+         * INFO: It is possible to set just `/` for shipping docs without base path.
          */
         routeBasePath: 'docs',
         include: ['**/*.md', '**/*.mdx'], // Extensions to include.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Hello everyone! This is my first contribution here :) 

I added this small information because I spent some hours seeking how to display just docs without things like blogs & pages. 
The biggest obstacle for me was, how to configure  `routeBasePath` to follow my assumptions. As the value `''` not works, and the current documentation mention `*DO NOT* include a trailing slash` didn't know what should I do.

I've started cloning the docs plugin and hacking it locally, then I found:

https://github.com/facebook/docusaurus/blob/69bf68a/packages/docusaurus-plugin-content-docs/src/options.ts#L54-L57

I followed that [link](https://github.com/facebook/docusaurus/issues/3374) and read:

> I think this is the reason why blog/docs option routeBasePath: '' fail, while routeBasePath: '/' works.

So, now I added this information into the next documentation version. if any want you, I may add it also into other versions.
**I hope that information saves someone some time. 😄** 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

✅ yes

## Test Plan

It is just documentation. May I recommend to set some values like:
'' -> will faile as follow (#3374)
'/' -> will works and ship docs under `localhost:3000/`
'docs' -> will works as defult.

## Related PRs

not found