### PR TITLE
feat(v2): new docs edit options: editCurrentVersion + editLocalizedDocs

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
@@ -11,4 +11,8 @@ module.exports = {
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
   favicon: 'img/favicon.ico',
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'fr'],
+  },
 };

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md
@@ -1,1 +1,1 @@
-Hello `1.0.0` ! (translated)
+Hello `1.0.0` ! (translated en)

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/i18n/fr/docusaurus-plugin-content-docs/version-1.0.0/hello.md
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/i18n/fr/docusaurus-plugin-content-docs/version-1.0.0/hello.md
@@ -1,0 +1,1 @@
+Hello `1.0.0` ! (translated fr)

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -936,7 +936,7 @@ Object {
   \\"id\\": \\"version-1.0.0/hello\\",
   \\"isDocsHomePage\\": true,
   \\"title\\": \\"hello\\",
-  \\"description\\": \\"Hello 1.0.0 ! (translated)\\",
+  \\"description\\": \\"Hello 1.0.0 ! (translated en)\\",
   \\"source\\": \\"@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md\\",
   \\"slug\\": \\"/\\",
   \\"permalink\\": \\"/docs/1.0.0/\\",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -621,15 +621,46 @@ describe('versioned site', () => {
       source:
         '@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
       editUrl:
-        'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
+        'https://github.com/facebook/docusaurus/edit/master/website/versioned_docs/version-1.0.0/hello.md',
     });
   });
 
-  test('translated doc with editUrl localized', async () => {
+  test('translated en doc with editUrl and editCurrentVersion=true', async () => {
     const {siteDir, context, options, version100} = await loadSite({
       options: {
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
-        // editCurrentVersion: true,
+        editCurrentVersion: true,
+      },
+    });
+
+    const testUtilsLocal = createTestUtils({
+      siteDir,
+      context,
+      options,
+      versionMetadata: version100,
+    });
+
+    await testUtilsLocal.testMeta(path.join('hello.md'), {
+      id: 'version-1.0.0/hello',
+      unversionedId: 'hello',
+      isDocsHomePage: false,
+      permalink: '/docs/1.0.0/hello',
+      slug: '/hello',
+      title: 'hello',
+      description: 'Hello 1.0.0 ! (translated en)',
+      version: '1.0.0',
+      source:
+        '@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
+      editUrl:
+        'https://github.com/facebook/docusaurus/edit/master/website/docs/hello.md',
+    });
+  });
+
+  test('translated fr doc with editUrl and editLocalizedDocs=true', async () => {
+    const {siteDir, context, options, version100} = await loadSite({
+      options: {
+        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
+        editLocalizedDocs: true,
       },
       locale: 'fr',
     });
@@ -654,6 +685,39 @@ describe('versioned site', () => {
         '@site/i18n/fr/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
       editUrl:
         'https://github.com/facebook/docusaurus/edit/master/website/i18n/fr/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
+    });
+  });
+
+  test('translated fr doc with editUrl and editLocalizedDocs=true + editCurrentVersion=true', async () => {
+    const {siteDir, context, options, version100} = await loadSite({
+      options: {
+        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
+        editCurrentVersion: true,
+        editLocalizedDocs: true,
+      },
+      locale: 'fr',
+    });
+
+    const testUtilsLocal = createTestUtils({
+      siteDir,
+      context,
+      options,
+      versionMetadata: version100,
+    });
+
+    await testUtilsLocal.testMeta(path.join('hello.md'), {
+      id: 'version-1.0.0/hello',
+      unversionedId: 'hello',
+      isDocsHomePage: false,
+      permalink: '/fr/docs/1.0.0/hello',
+      slug: '/hello',
+      title: 'hello',
+      description: 'Hello 1.0.0 ! (translated fr)',
+      version: '1.0.0',
+      source:
+        '@site/i18n/fr/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
+      editUrl:
+        'https://github.com/facebook/docusaurus/edit/master/website/i18n/fr/docusaurus-plugin-content-docs/current/hello.md',
     });
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -14,6 +14,7 @@ import {
   DocMetadataBase,
   MetadataOptions,
   VersionMetadata,
+  PluginOptions,
 } from '../types';
 import {LoadContext} from '@docusaurus/types';
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
@@ -42,6 +43,7 @@ ${markdown}
     source,
     content,
     lastUpdate: {},
+    docsDirPath: 'docs',
     filePath: source,
   };
 };
@@ -111,19 +113,19 @@ function createTestUtils({
 }
 
 describe('simple site', () => {
-  async function loadSite() {
+  async function loadSite(
+    loadSiteOptions: {options: Partial<PluginOptions>} = {options: {}},
+  ) {
     const siteDir = path.join(fixtureDir, 'simple-site');
     const context = await loadContext(siteDir);
     const options = {
       id: DEFAULT_PLUGIN_ID,
       ...DEFAULT_OPTIONS,
+      ...loadSiteOptions.options,
     };
     const versionsMetadata = readVersionsMetadata({
       context,
-      options: {
-        id: DEFAULT_PLUGIN_ID,
-        ...DEFAULT_OPTIONS,
-      },
+      options,
     });
     expect(versionsMetadata.length).toEqual(1);
     const [currentVersion] = versionsMetadata;
@@ -191,12 +193,14 @@ describe('simple site', () => {
   });
 
   test('homePageId doc', async () => {
-    const {siteDir, context, options, currentVersion} = await loadSite();
+    const {siteDir, context, options, currentVersion} = await loadSite({
+      options: {homePageId: 'hello'},
+    });
 
     const testUtilsLocal = createTestUtils({
       siteDir,
       context,
-      options: {...options, homePageId: 'hello'},
+      options,
       versionMetadata: currentVersion,
     });
 
@@ -213,12 +217,14 @@ describe('simple site', () => {
   });
 
   test('homePageId doc nested', async () => {
-    const {siteDir, context, options, currentVersion} = await loadSite();
+    const {siteDir, context, options, currentVersion} = await loadSite({
+      options: {homePageId: 'foo/bar'},
+    });
 
     const testUtilsLocal = createTestUtils({
       siteDir,
       context,
-      options: {...options, homePageId: 'foo/bar'},
+      options,
       versionMetadata: currentVersion,
     });
 
@@ -235,15 +241,16 @@ describe('simple site', () => {
   });
 
   test('docs with editUrl', async () => {
-    const {siteDir, context, options, currentVersion} = await loadSite();
+    const {siteDir, context, options, currentVersion} = await loadSite({
+      options: {
+        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
+      },
+    });
 
     const testUtilsLocal = createTestUtils({
       siteDir,
       context,
-      options: {
-        ...options,
-        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
-      },
+      options,
       versionMetadata: currentVersion,
     });
 
@@ -278,16 +285,17 @@ describe('simple site', () => {
   });
 
   test('docs with last update time and author', async () => {
-    const {siteDir, context, options, currentVersion} = await loadSite();
+    const {siteDir, context, options, currentVersion} = await loadSite({
+      options: {
+        showLastUpdateAuthor: true,
+        showLastUpdateTime: true,
+      },
+    });
 
     const testUtilsLocal = createTestUtils({
       siteDir,
       context,
-      options: {
-        ...options,
-        showLastUpdateAuthor: true,
-        showLastUpdateTime: true,
-      },
+      options,
       versionMetadata: currentVersion,
     });
 
@@ -361,15 +369,16 @@ describe('simple site', () => {
   });
 
   test('docs with slug on doc home', async () => {
-    const {siteDir, context, options, currentVersion} = await loadSite();
+    const {siteDir, context, options, currentVersion} = await loadSite({
+      options: {
+        homePageId: 'homePageId',
+      },
+    });
 
     const testUtilsLocal = createTestUtils({
       siteDir,
       context,
-      options: {
-        ...options,
-        homePageId: 'homePageId',
-      },
+      options,
       versionMetadata: currentVersion,
     });
     expect(() => {
@@ -388,19 +397,23 @@ describe('simple site', () => {
 });
 
 describe('versioned site', () => {
-  async function loadSite() {
+  async function loadSite(
+    loadSiteOptions: {options: Partial<PluginOptions>; locale?: string} = {
+      options: {},
+    },
+  ) {
     const siteDir = path.join(fixtureDir, 'versioned-site');
-    const context = await loadContext(siteDir);
+    const context = await loadContext(siteDir, {
+      locale: loadSiteOptions.locale,
+    });
     const options = {
       id: DEFAULT_PLUGIN_ID,
       ...DEFAULT_OPTIONS,
+      ...loadSiteOptions.options,
     };
     const versionsMetadata = readVersionsMetadata({
       context,
-      options: {
-        id: DEFAULT_PLUGIN_ID,
-        ...DEFAULT_OPTIONS,
-      },
+      options,
     });
     expect(versionsMetadata.length).toEqual(4);
     const [
@@ -495,7 +508,7 @@ describe('versioned site', () => {
       permalink: '/docs/1.0.0/hello',
       slug: '/hello',
       title: 'hello',
-      description: 'Hello 1.0.0 ! (translated)',
+      description: 'Hello 1.0.0 ! (translated en)',
       version: '1.0.0',
       source:
         '@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
@@ -582,15 +595,17 @@ describe('versioned site', () => {
   });
 
   test('translated doc with editUrl', async () => {
-    const {siteDir, context, options, version100} = await loadSite();
+    const {siteDir, context, options, version100} = await loadSite({
+      options: {
+        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
+        // editCurrentVersion: true,
+      },
+    });
 
     const testUtilsLocal = createTestUtils({
       siteDir,
       context,
-      options: {
-        ...options,
-        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
-      },
+      options,
       versionMetadata: version100,
     });
 
@@ -601,12 +616,44 @@ describe('versioned site', () => {
       permalink: '/docs/1.0.0/hello',
       slug: '/hello',
       title: 'hello',
-      description: 'Hello 1.0.0 ! (translated)',
+      description: 'Hello 1.0.0 ! (translated en)',
       version: '1.0.0',
       source:
         '@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
       editUrl:
         'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
+    });
+  });
+
+  test('translated doc with editUrl localized', async () => {
+    const {siteDir, context, options, version100} = await loadSite({
+      options: {
+        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website',
+        // editCurrentVersion: true,
+      },
+      locale: 'fr',
+    });
+
+    const testUtilsLocal = createTestUtils({
+      siteDir,
+      context,
+      options,
+      versionMetadata: version100,
+    });
+
+    await testUtilsLocal.testMeta(path.join('hello.md'), {
+      id: 'version-1.0.0/hello',
+      unversionedId: 'hello',
+      isDocsHomePage: false,
+      permalink: '/fr/docs/1.0.0/hello',
+      slug: '/hello',
+      title: 'hello',
+      description: 'Hello 1.0.0 ! (translated fr)',
+      version: '1.0.0',
+      source:
+        '@site/i18n/fr/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
+      editUrl:
+        'https://github.com/facebook/docusaurus/edit/master/website/i18n/fr/docusaurus-plugin-content-docs/version-1.0.0/hello.md',
     });
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
@@ -39,6 +39,7 @@ describe('normalizeDocsPluginOptions', () => {
       includeCurrentVersion: false,
       disableVersioning: true,
       editCurrentVersion: true,
+      editLocalizedDocs: true,
       versions: {
         current: {
           path: 'next',

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
@@ -38,6 +38,7 @@ describe('normalizeDocsPluginOptions', () => {
       excludeNextVersionDocs: true,
       includeCurrentVersion: false,
       disableVersioning: true,
+      editCurrentVersion: true,
       versions: {
         current: {
           path: 'next',

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
@@ -381,6 +381,107 @@ describe('versioned site, pluginId=default', () => {
     ]);
   });
 
+  test('readVersionsMetadata versioned site with editUrl', async () => {
+    const {
+      defaultOptions,
+      defaultContext,
+      vCurrent,
+      v101,
+      v100,
+      vwithSlugs,
+    } = await loadSite();
+
+    const versionsMetadata = readVersionsMetadata({
+      options: {
+        ...defaultOptions,
+        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
+      },
+      context: defaultContext,
+    });
+
+    expect(versionsMetadata).toEqual([
+      {
+        ...vCurrent,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/docs',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/current',
+      },
+      {
+        ...v101,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/versioned_docs/version-1.0.1',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/version-1.0.1',
+      },
+      {
+        ...v100,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/versioned_docs/version-1.0.0',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/version-1.0.0',
+      },
+      {
+        ...vwithSlugs,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/versioned_docs/version-withSlugs',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/version-withSlugs',
+      },
+    ]);
+  });
+
+  test('readVersionsMetadata versioned site with editUrl and editCurrentVersion=true', async () => {
+    const {
+      defaultOptions,
+      defaultContext,
+      vCurrent,
+      v101,
+      v100,
+      vwithSlugs,
+    } = await loadSite();
+
+    const versionsMetadata = readVersionsMetadata({
+      options: {
+        ...defaultOptions,
+        editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
+        editCurrentVersion: true,
+      },
+      context: defaultContext,
+    });
+
+    expect(versionsMetadata).toEqual([
+      {
+        ...vCurrent,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/docs',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/current',
+      },
+      {
+        ...v101,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/docs',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/current',
+      },
+      {
+        ...v100,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/docs',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/current',
+      },
+      {
+        ...vwithSlugs,
+        versionEditUrl:
+          'https://github.com/facebook/docusaurus/edit/master/website/docs',
+        versionEditUrlLocalized:
+          'https://github.com/facebook/docusaurus/edit/master/website/i18n/en/docusaurus-plugin-content-docs/current',
+      },
+    ]);
+  });
+
   test('readVersionsMetadata versioned site with onlyIncludeVersions option', async () => {
     const {defaultOptions, defaultContext, v101, vwithSlugs} = await loadSite();
 

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -111,14 +111,17 @@ export function processDocMetadata({
   options: MetadataOptions;
 }): DocMetadataBase {
   const {source, content, lastUpdate, filePath} = docFile;
-  const {editUrl, homePageId} = options;
+  const {homePageId} = options;
   const {siteDir} = context;
 
   // ex: api/myDoc -> api
   // ex: myDoc -> .
   const docsFileDirName = path.dirname(source);
 
-  const docsEditUrl = getEditUrl(path.relative(siteDir, filePath), editUrl);
+  const docsEditUrl = getEditUrl(
+    path.relative(versionMetadata.docsDirPath, filePath),
+    versionMetadata.versionEditUrl,
+  );
 
   const {frontMatter = {}, excerpt} = parseMarkdownString(content);
   const {sidebar_label, custom_edit_url} = frontMatter;

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -122,9 +122,10 @@ export function processDocMetadata({
 
   const isLocalized = docsDirPath === versionMetadata.docsDirPathLocalized;
 
-  const versionEditUrl = isLocalized
-    ? versionMetadata.versionEditUrlLocalized
-    : versionMetadata.versionEditUrl;
+  const versionEditUrl =
+    isLocalized && options.editLocalizedDocs
+      ? versionMetadata.versionEditUrlLocalized
+      : versionMetadata.versionEditUrl;
 
   const docsEditUrl = getEditUrl(relativeFilePath, versionEditUrl);
 

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -70,18 +70,18 @@ export async function readDocFile(
   source: string,
   options: LastUpdateOptions,
 ): Promise<DocFile> {
-  const folderPath = await getFolderContainingFile(
+  const docsDirPath = await getFolderContainingFile(
     getDocsDirPaths(versionMetadata),
     source,
   );
 
-  const filePath = path.join(folderPath, source);
+  const filePath = path.join(docsDirPath, source);
 
   const [content, lastUpdate] = await Promise.all([
     fs.readFile(filePath, 'utf-8'),
     readLastUpdateData(filePath, options),
   ]);
-  return {source, content, lastUpdate, filePath};
+  return {source, content, lastUpdate, docsDirPath, filePath};
 }
 
 export async function readVersionDocs(
@@ -110,7 +110,7 @@ export function processDocMetadata({
   context: LoadContext;
   options: MetadataOptions;
 }): DocMetadataBase {
-  const {source, content, lastUpdate, filePath} = docFile;
+  const {source, content, lastUpdate, docsDirPath, filePath} = docFile;
   const {homePageId} = options;
   const {siteDir} = context;
 
@@ -118,10 +118,15 @@ export function processDocMetadata({
   // ex: myDoc -> .
   const docsFileDirName = path.dirname(source);
 
-  const docsEditUrl = getEditUrl(
-    path.relative(versionMetadata.docsDirPath, filePath),
-    versionMetadata.versionEditUrl,
-  );
+  const relativeFilePath = path.relative(docsDirPath, filePath);
+
+  const isLocalized = docsDirPath === versionMetadata.docsDirPathLocalized;
+
+  const versionEditUrl = isLocalized
+    ? versionMetadata.versionEditUrlLocalized
+    : versionMetadata.versionEditUrl;
+
+  const docsEditUrl = getEditUrl(relativeFilePath, versionEditUrl);
 
   const {frontMatter = {}, excerpt} = parseMarkdownString(content);
   const {sidebar_label, custom_edit_url} = frontMatter;

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -38,6 +38,7 @@ export const DEFAULT_OPTIONS: Omit<PluginOptions, 'id'> = {
   lastVersion: undefined,
   versions: {},
   editCurrentVersion: false,
+  editLocalizedDocs: false,
 };
 
 const VersionOptionsSchema = Joi.object({
@@ -53,6 +54,7 @@ export const OptionsSchema = Joi.object({
   path: Joi.string().default(DEFAULT_OPTIONS.path),
   editUrl: URISchema,
   editCurrentVersion: Joi.boolean().default(DEFAULT_OPTIONS.editCurrentVersion),
+  editLocalizedDocs: Joi.boolean().default(DEFAULT_OPTIONS.editLocalizedDocs),
   routeBasePath: Joi.string()
     // '' not allowed, see https://github.com/facebook/docusaurus/issues/3374
     // .allow('') ""

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -37,6 +37,7 @@ export const DEFAULT_OPTIONS: Omit<PluginOptions, 'id'> = {
   disableVersioning: false,
   lastVersion: undefined,
   versions: {},
+  editCurrentVersion: false,
 };
 
 const VersionOptionsSchema = Joi.object({
@@ -50,7 +51,8 @@ const VersionsOptionsSchema = Joi.object()
 
 export const OptionsSchema = Joi.object({
   path: Joi.string().default(DEFAULT_OPTIONS.path),
-  editUrl: URISchema,
+  editUrl: URISchema.default(DEFAULT_OPTIONS),
+  editCurrentVersion: Joi.boolean().default(DEFAULT_OPTIONS.editCurrentVersion),
   routeBasePath: Joi.string()
     // '' not allowed, see https://github.com/facebook/docusaurus/issues/3374
     // .allow('') ""

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -51,7 +51,7 @@ const VersionsOptionsSchema = Joi.object()
 
 export const OptionsSchema = Joi.object({
   path: Joi.string().default(DEFAULT_OPTIONS.path),
-  editUrl: URISchema.default(DEFAULT_OPTIONS),
+  editUrl: URISchema,
   editCurrentVersion: Joi.boolean().default(DEFAULT_OPTIONS.editCurrentVersion),
   routeBasePath: Joi.string()
     // '' not allowed, see https://github.com/facebook/docusaurus/issues/3374

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -9,7 +9,8 @@
 /// <reference types="@docusaurus/module-type-aliases" />
 
 export type DocFile = {
-  filePath: string;
+  docsDirPath: string; // /!\ may be localized
+  filePath: string; // /!\ may be localized
   source: string;
   content: string;
   lastUpdate: LastUpdateData;
@@ -22,6 +23,7 @@ export type VersionMetadata = {
   versionLabel: string; // Version 1.0.0
   versionPath: string; // /baseUrl/docs/1.0.0
   versionEditUrl: string | undefined;
+  versionEditUrlLocalized: string | undefined;
   isLast: boolean;
   docsDirPath: string; // "versioned_docs/version-1.0.0"
   docsDirPathLocalized: string; // "i18n/fr/version-1.0.0/default"

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -22,8 +22,8 @@ export type VersionMetadata = {
   versionName: VersionName; // 1.0.0
   versionLabel: string; // Version 1.0.0
   versionPath: string; // /baseUrl/docs/1.0.0
-  versionEditUrl: string | undefined;
-  versionEditUrlLocalized: string | undefined;
+  versionEditUrl?: string | undefined;
+  versionEditUrlLocalized?: string | undefined;
   isLast: boolean;
   docsDirPath: string; // "versioned_docs/version-1.0.0"
   docsDirPathLocalized: string; // "i18n/fr/version-1.0.0/default"
@@ -36,6 +36,7 @@ export type MetadataOptions = {
   homePageId?: string;
   editUrl?: string;
   editCurrentVersion: boolean;
+  editLocalizedDocs: boolean;
   showLastUpdateTime?: boolean;
   showLastUpdateAuthor?: boolean;
 };

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -21,6 +21,7 @@ export type VersionMetadata = {
   versionName: VersionName; // 1.0.0
   versionLabel: string; // Version 1.0.0
   versionPath: string; // /baseUrl/docs/1.0.0
+  versionEditUrl: string | undefined;
   isLast: boolean;
   docsDirPath: string; // "versioned_docs/version-1.0.0"
   docsDirPathLocalized: string; // "i18n/fr/version-1.0.0/default"
@@ -32,6 +33,7 @@ export type MetadataOptions = {
   routeBasePath: string;
   homePageId?: string;
   editUrl?: string;
+  editCurrentVersion: boolean;
   showLastUpdateTime?: boolean;
   showLastUpdateAuthor?: boolean;
 };

--- a/packages/docusaurus-plugin-content-docs/src/versions.ts
+++ b/packages/docusaurus-plugin-content-docs/src/versions.ts
@@ -211,8 +211,6 @@ function getVersionEditUrls({
     return undefined;
   }
 
-  // TODO we could allow to configure the edit url we want for each version
-
   const editDirPath = editCurrentVersion ? currentVersionPath : docsDirPath;
   const editDirPathLocalized = editCurrentVersion
     ? getDocsDirPathLocalized({
@@ -223,18 +221,24 @@ function getVersionEditUrls({
       })
     : docsDirPathLocalized;
 
-  const versionPathSegment = posixPath(path.relative(siteDir, editDirPath));
+  const versionPathSegment = posixPath(
+    path.relative(siteDir, path.resolve(siteDir, editDirPath)),
+  );
   const versionPathSegmentLocalized = posixPath(
-    path.relative(siteDir, editDirPathLocalized),
+    path.relative(siteDir, path.resolve(siteDir, editDirPathLocalized)),
   );
 
   const versionEditUrl = normalizeUrl([editUrl, versionPathSegment]);
+
   const versionEditUrlLocalized = normalizeUrl([
     editUrl,
     versionPathSegmentLocalized,
   ]);
 
-  return {versionEditUrl, versionEditUrlLocalized};
+  return {
+    versionEditUrl,
+    versionEditUrlLocalized,
+  };
 }
 
 function createVersionMetadata({

--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -36,6 +36,11 @@ module.exports = {
          */
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
         /**
+         * Will make the edit url of versioned docs target
+         * the current version doc instead of the versioned doc.
+         */
+        editCurrentVersion: false,
+        /**
          * URL route for the docs section of your site.
          * *DO NOT* include a trailing slash.
          */

--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -36,10 +36,17 @@ module.exports = {
          */
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
         /**
-         * Will make the edit url of versioned docs target
-         * the current version doc instead of the versioned doc.
+         * When docs are versioned, the edit url will link to the doc
+         * in current version, instead of the versioned doc.
+         * Useful if you don't want users to submit doc pull-requests to older versions.
          */
         editCurrentVersion: false,
+        /**
+         * When docs are localized, the edit url will target the localized doc,
+         * instead of the original unlocalized doc.
+         * Useful if you commit localized docs to git, instead of using a translation service.
+         */
+        editLocalizedDocs: false,
         /**
          * URL route for the docs section of your site.
          * *DO NOT* include a trailing slash.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -213,14 +213,14 @@ module.exports = {
             [require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}],
           ],
           disableVersioning: isVersioningDisabled,
-          // lastVersion: 'current',
+          lastVersion: isDev ? 'current' : undefined,
           onlyIncludeVersions:
             !isVersioningDisabled && (isDev || isDeployPreview)
               ? ['current', ...versions.slice(0, 2)]
               : undefined,
           versions: {
             current: {
-              label: `${getNextAlphaVersionName()} (unreleased)`,
+              label: `${getNextAlphaVersionName()} 🚧`,
             },
           },
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -77,6 +77,7 @@ module.exports = {
         id: 'community',
         path: 'community',
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
+        editCurrentVersion: true,
         routeBasePath: 'community',
         sidebarPath: require.resolve('./sidebarsCommunity.js'),
         showLastUpdateAuthor: true,
@@ -205,13 +206,14 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
             'https://github.com/facebook/docusaurus/edit/master/website/',
+          editCurrentVersion: true,
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
           remarkPlugins: [
             [require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}],
           ],
           disableVersioning: isVersioningDisabled,
-          lastVersion: 'current',
+          // lastVersion: 'current',
           onlyIncludeVersions:
             !isVersioningDisabled && (isDev || isDeployPreview)
               ? ['current', ...versions.slice(0, 2)]


### PR DESCRIPTION

## Motivation

```js
        /**
         * When docs are versioned, the edit url will link to the doc
         * in current version, instead of the versioned doc.
         * Useful if you don't want users to submit doc pull-requests to older versions.
         */
        editCurrentVersion: false,
        /**
         * When docs are localized, the edit url will target the localized doc,
         * instead of the original unlocalized doc.
         * Useful if you commit localized docs to git, instead of using a translation service.
         */
        editLocalizedDocs: false,
```

##  `editCurrentVersion: true`

With Docusaurus v1, even with versioning enabled, the edit button always targeted the "upstream" docs (ie the ./docs folder), not the versioned folders.

With Docusaurus v2, this behavior has changed, and this can be annoying because users end up submitting docs pull requests to the "last version" (the version of your last release), so you end up merging doc updates for a specific version, but lose those edits in the upstream version.

`editCurrentVersion: true` will restore the v1 behavior


##  `editLocalizedDocs: true`

Also, for i18n support, you may want the edit button to target either the original untranslated doc, or the localized doc. It does not make sense to always target the localized doc, and really depends on the usecase:
- committing translated docs to git: it may be useful to edit localized files through the github edit interface
- using a SaaS service that has a specific edit URL pattern: the localized files are not on git, so we'll likely need to link to a specific translation SaaS url. We'll likely need to improve existing system and make it more flexible and usable in any kind of saas (ie using a function in config?)

