### PR TITLE
fix(v2): allow async/await in live code editor

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/custom-buble.js
+++ b/packages/docusaurus-theme-live-codeblock/src/custom-buble.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// fork of Buble which removes Buble's large dependency and weighs in
+// at a smaller size of ~51kB
+// https://github.com/FormidableLabs/react-live#what-bundle-size-can-i-expect
+const {transform, features: bubleFeatures} = require('@philpl/buble');
+
+// This file is designed to mimic what's written in
+// https://github.com/kitten/buble/blob/mini/src/index.js, with custom transforms options,
+// so that webpack can consume it correctly.
+exports.features = bubleFeatures;
+
+exports.transform = function customTransform(source, options) {
+  return transform(source, {...options, transforms: {asyncAwait: false}});
+};

--- a/packages/docusaurus-theme-live-codeblock/src/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/index.js
@@ -19,10 +19,7 @@ module.exports = function () {
       return {
         resolve: {
           alias: {
-            // fork of Buble which removes Buble's large dependency and weighs in
-            // at a smaller size of ~51kB
-            // https://github.com/FormidableLabs/react-live#what-bundle-size-can-i-expect
-            buble: '@philpl/buble',
+            buble: path.resolve(__dirname, './custom-buble.js'),
           },
         },
       };


### PR DESCRIPTION
## Motivation

So.. as proposed by #3053, we are using a live code editor using `react-live`, and since transpiling javascript on the fly could easily turned into a heavy job, this library uses `https://github.com/bublejs/buble` for it, which relatively has a bundle size as mentioned in https://github.com/FormidableLabs/react-live#what-bundle-size-can-i-expect.

However, to further reduce the bundle size, @endiliey decided to use [@philpl/buble](http://npm.im/@philpl/buble) which discards some codes on ESNext transpilation, resulting in a notably smaller bundle size.

However this introduced some problem, which I encountered while using docusaurus@v2 and is well-explained by #3053: the live code editor cannot run the code that contains `async` or `await` keywords.

Therefore, the simplest fix would be still using [@philpl/buble](http://npm.im/@philpl/buble), but applying a custom option to bypass transpiling `async` and `await` keywords, which would still work in most up-to-date modern browsers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Launched Docusaurus locally and tested it.

![Kapture 2020-12-26 at 13 48 58](https://user-images.githubusercontent.com/22465806/103145852-0c25ef80-4784-11eb-8b9f-93911321469b.gif)

closes #3053 if merged