### PR TITLE
fix(v2): fix blog only contextual search

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
@@ -14,7 +14,13 @@
 try {
   module.exports = require('@theme-init/hooks/useDocs');
 } catch (e) {
-  module.exports = {};
+  // In case the docs plugin is not available, might be useful to stub some methods here
+  // https://github.com/facebook/docusaurus/issues/3947
+  const Empty = {};
+  module.exports = {
+    useAllDocsData: () => Empty,
+    useActivePluginAndVersion: () => undefined,
+  };
 }
 
 /*

--- a/website/docusaurus.config-blog-only.js
+++ b/website/docusaurus.config-blog-only.js
@@ -42,6 +42,11 @@ module.exports = {
   ],
   themeConfig: {
     image: 'img/docusaurus-soc.png',
+    algolia: {
+      apiKey: '47ecd3b21be71c5822571b9f59e52544',
+      indexName: 'docusaurus-2',
+      contextualSearch: true,
+    },
     navbar: {
       hideOnScroll: true,
       title: 'Docusaurus',


### PR DESCRIPTION

## Motivation

Search feature assumes the docs plugin is available, which is not always the case.

This is a quickfix so that the Algolia search can be used in blog-only mode without any problem.
(better solution to be found)

Fixes https://github.com/facebook/docusaurus/issues/3947



## Test Plan

blog only preview with search can build
