### PR TITLE
docs(v2): nudge users to add site to showcase

### DIFF
--- a/website/src/data/users.js
+++ b/website/src/data/users.js
@@ -5,8 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/*
+ * ADD YOUR SITE TO DOCUSAURUS SHOWCASE:
+ *
+ * Instructions
+ * - add your site in the json array below, in alphabetical order of title
+ * - add a local image preview (decent screenshot of your Docusaurus site)
+ *
+ * The image must be added to the Github repository, and use require("image")
+ *
+ * Example PR: https://github.com/facebook/docusaurus/pull/3976
+ *
+ * If you edit this file through the Github interface, you can:
+ * - Submit first your users.js edit PR
+ * - This will create a branch on your Docusaurus fork (usually "patch-1")
+ * - Go to https://github.com/<username>/docusaurus/tree/<branch>/website/src/data/showcase
+ * - Drag-and-drop an image here to add it to your existing PR
+ *
+ */
+
+// prettier-ignore
 const users = [
-  // Please add in alphabetical order of title.
   {
     title: 'Algolia Docsearch',
     description:

--- a/website/src/pages/showcase/index.js
+++ b/website/src/pages/showcase/index.js
@@ -17,6 +17,8 @@ import users from '../../data/users';
 const TITLE = 'Showcase';
 const DESCRIPTION =
   'See the awesome websites people are building with Docusaurus';
+const EDIT_URL =
+  'https://github.com/facebook/docusaurus/edit/master/website/src/data/users.js';
 
 function Showcase() {
   return (
@@ -25,6 +27,14 @@ function Showcase() {
         <div className="text--center margin-bottom--xl">
           <h1>{TITLE}</h1>
           <p>{DESCRIPTION}</p>
+          <p>
+            <a
+              className={'button button--primary'}
+              href={EDIT_URL}
+              target={'_blank'}>
+              Add your site!
+            </a>
+          </p>
         </div>
         <div className="row">
           {users.map((user) => (


### PR DESCRIPTION

## Motivation

It's not so easy for users to add their site.

This PR:
- Add a "Add your site!" button
- Add better instructions to add a Docusaurus site to showcase
- ignore prettier formatting errors (as edits are often done through Github interface)


![image](https://user-images.githubusercontent.com/749374/103365197-ce94cf80-4abf-11eb-9089-41584dc48c47.png)


![image](https://user-images.githubusercontent.com/749374/103365217-d8b6ce00-4abf-11eb-8590-f4ae7df7e07f.png)

