### PR TITLE
feat(v2): add typescript support for live code blocks (#2824)

### DIFF
--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
@@ -71,7 +71,7 @@ module.exports = {
           items: [{label: 'Twitter', to: 'https://twitter.com/docusaurus'}],
         },
       ],
-      copyright: 'Copyright © 2020 Facebook Inc.',
+      copyright: `Copyright © ${new Date().getFullYear()} Facebook Inc.`,
       logo: {src: 'img/docusaurus_monochrome.svg'},
     },
     algolia: {

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@babel/standalone": "^7.12.12",
     "@docusaurus/core": "2.0.0-alpha.70",
     "@philpl/buble": "^0.19.7",
     "clsx": "^1.1.1",

--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -292,6 +292,31 @@ function Clock(props) {
 }
 ```
 
+Typescript is also supported. Simply replace `jsx live` with `tsx live`, then you are good to go.
+
+```tsx live
+() => {
+  const [date, setDate] = useState<Readonly<Date>>(new Date());
+  useEffect(() => {
+    var timerID: number = setInterval(() => tick(), 1000);
+
+    return function cleanup() {
+      clearInterval(timerID);
+    };
+  }, []);
+
+  function tick(): void {
+    setDate(new Date());
+  }
+
+  return (
+    <div>
+      <h2>It is {date.toLocaleTimeString()}.</h2>
+    </div>
+  );
+}
+```
+
 :::caution react-live and imports
 
 It is not possible to import components directly from the react-live code editor, you have to define available imports upfront.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,6 +1178,11 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/standalone@^7.12.12":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.12.tgz#f858ab1c76d9c4c23fe0783a0330ad37755f0176"
+  integrity sha512-sHuNDN9NvPHsDAmxPD3RpsIeqCoFSW+ySa6+3teInrYe9y0Gn5swLQ2ZE7Zk6L8eBBESZM2ob1l98qWauQfDMA==
+
 "@babel/template@^7.10.4", "@babel/template@^7.7.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"


### PR DESCRIPTION
## Motivation
Originally from #2824. For the live code blocks, we are using https://github.com/FormidableLabs/react-live, and it does not support Typescript, and they said they have absolutely no plans to support Typescript (See https://github.com/FormidableLabs/react-live/issues/8)

However there is a need from the users (hopefully many... 😅) of Docusaurus who potentially would need Typescript support. Some projects written by our users (example: https://hookstate.js.org/ by @avkonst) are based on Typescript, so it would make a sense to support Typescript out of the box.

## Concerns

I'm trying to introduce `@babel/standalone` to transpile Typescript and it works super nicely, but I am not sure how much bundle size it will add to the project. Will see results from the CI (update: seems like it's fine?)

If this is too much of a burden to include Typescript support in the official plugin due to the bundle size, I'm more than happy to close this PR and release it as a personal one instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

To demonstrate that Typescript is supported to any potential users and to prove that it works, I simply added one code block that uses Typescript on https://deploy-preview-3984--docusaurus-2.netlify.app/classic/docs/next/markdown-features/code-blocks. I tested it and it should work, but if not, please tell me.

![Screen Shot 2021-01-02 at 11 03 23 PM](https://user-images.githubusercontent.com/22465806/103458799-de761300-4d4e-11eb-95da-fffa15bdd907.png)

Will close #2824 if merged