### PR TITLE
chore(v2): fix date-sensitive test fixture

### DIFF
--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
@@ -71,7 +71,7 @@ module.exports = {
           items: [{label: 'Twitter', to: 'https://twitter.com/docusaurus'}],
         },
       ],
-      copyright: 'Copyright © 2021 Facebook Inc.',
+      copyright: `Copyright © ${new Date().getFullYear()} Facebook Inc.`,
       logo: {src: 'img/docusaurus_monochrome.svg'},
     },
     algolia: {


### PR DESCRIPTION

## Motivation

Test is sensitive to current year: make it insensitive.

Porting code of @9oelM in closed PR https://github.com/facebook/docusaurus/pull/3984/files#diff-1fcecbf1a624edb15aef11f316e17b2deed40b10719340d05f208217b3c236ae