### PR TITLE
docs(v2): add overwriting css variables for dark mode

### DIFF
--- a/website/docs/styling-layout.md
+++ b/website/docs/styling-layout.md
@@ -59,6 +59,18 @@ Alternatively, use the following tool to generate the different shades for your 
 
 <ColorGenerator/>
 
+### Dark Mode
+
+To customize the Infima variables for dark mode you can add the following to `src/css/custom.css`.
+
+```css title="/src/css/custom.css"
+html[data-theme='dark'] {
+  --ifm-color-primary: #4e89e8;
+  --ifm-color-primary-dark: #5a91ea;
+  /* any other colors you wish to overwrite */
+}
+```
+
 <!-- TODO need more refinement here -->
 
 ## Styling approaches


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When I wanted to change the css variables used in dark mode I struggle a bit to figure out how.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yep

## Test Plan

I ran:
`yarn test`
`yarn test:build:v2`

Closes #3985 
