### PR TITLE
fix(v2): Fix double trailingSlash in sitemap.xml

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -24,7 +24,7 @@ export default function createSitemap(
     .filter((route) => !route.endsWith('404.html'))
     .map(
       (routesPath): SitemapItemOptions => ({
-        url: `${routesPath}${trailingSlash && routesPath !== '/' ? '/' : ''}`,
+        url: `${routesPath}${trailingSlash && !routesPath.endsWith('/') ? '/' : ''}`,
         changefreq,
         priority,
       }),


### PR DESCRIPTION
Fix issue where when `trailingSlash` option is enabled, routes that already end in a `/` are shown with double slash at the end.

## Motivation

Some of my routes show in sitemap.xml without a trailing slash, so I use `trailingSlash` to make them all consistent. However, some of my paths (e.g. /docs/ created by getting_started.md) already have a trailing slash. Currently /docs/ will be rendered as `/docs//` in the sitemap which isn't correct. This fix prevents that trailing double slash when the `trailingSlash` option is enabled.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Update your docusaurus.config.js to enable sitemap's `trailingSlash` option
```
plugins: [
    [
      '@docusaurus/plugin-sitemap',
      {
        id: 'plugin-sitemap-default',
        trailingSlash: true,
      },
    ],
  ],
```
2. Create a page in `/docs` with `slug: /`
3. Generate the sitemap by creating an optimized production build
4. Verify that the `build/sitemap.xml` entry generated for `/docs/` doesn't have a trailing slash

## Related PRs
N/A