### PR TITLE
Clarify relationship between path & editUrl

### DIFF
--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -27,7 +27,8 @@ module.exports = {
       '@docusaurus/plugin-content-docs',
       {
         /**
-         * Path to data on filesystem relative to site dir.
+         * Path to data on filesystem relative to site dir
+         * (appended to editUrl in "Edit this page" links).
          */
         path: 'docs',
         /**


### PR DESCRIPTION
## Motivation

This PR adds a single line to the Configuration code sample in `plugin-content-docs` to help users understand the relationship between the `path`  setting and the `editUrl`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

None, just added a comment line that shouldn't break anything.

## Related PRs

Per earlier discussion w/ @slorber in Per https://github.com/facebook/docusaurus/issues/2731#issuecomment-754678202
