### PR TITLE
chore(v1): upgrade v1 Crowdin cli + CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,22 +81,22 @@ jobs:
             if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(docusaurus-1\.x\/.*)|(website-1\.x\/.*)"; then
               echo "Skipping deploy. No relevant v1 website files have changed"
             elif [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
-              echo "Deploying website..."
+              echo "Deploying website v1..."
+              cd website-1.x
+
               # install Docusaurus and generate file of English strings
-              cd website-1.x && yarn run write-translations
-              # install Crowdin
-              sudo apt-get update
-              sudo apt-get install default-jre rsync
-              wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
-              sudo dpkg -i crowdin.deb
-              sleep 5
+              yarn run write-translations
+
               # upload translation strings and download translations
-              yarn run crowdin-upload
+              yarn crowdin-upload
+
               # download only enabled languages
-              for lang in fr ko ru ro pt-BR zh-CN
-              do
-                  yarn crowdin-download -l $lang
-              done
+              yarn crowdin-download
+              # for lang in fr ko ru ro pt-BR zh-CN
+              # do
+              #    yarn crowdin-download -l $lang
+              # done
+
               # publish
               GIT_USER=docusaurus-bot USE_SSH=false yarn run publish-gh-pages
             else

--- a/crowdin-v1.yml
+++ b/crowdin-v1.yml
@@ -1,6 +1,6 @@
-project_identifier_env: CROWDIN_DOCUSAURUS_PROJECT_ID
-api_key_env: CROWDIN_DOCUSAURUS_API_KEY
-base_path: "./"
+project_id: '290988'
+api_token_env: 'CROWDIN_PERSONAL_TOKEN'
+base_path: "."
 preserve_hierarchy: true
 
 files:
@@ -9,30 +9,13 @@ files:
     translation: '/website-1.x/translated_docs/%locale%/**/%original_file_name%'
     languages_mapping: &anchor
       locale:
-        'af': 'af'
-        'ar': 'ar'
-        'bs-BA': 'bs-BA'
-        'ca': 'ca'
-        'cs': 'cs'
-        'da': 'da'
-        'de': 'de'
-        'el': 'el'
         'es-ES': 'es-ES'
-        'fa': 'fa-IR'
-        'fi': 'fi'
         'fr': 'fr'
-        'he': 'he'
-        'hu': 'hu'
-        'id': 'id-ID'
         'it': 'it'
         'ja': 'ja'
         'ko': 'ko'
-        'mr': 'mr-IN'
         'nl': 'nl'
-        'no': 'no-NO'
-        'pl': 'pl'
         'pt-BR': 'pt-BR'
-        'pt-PT': 'pt-PT'
         'ro': 'ro'
         'ru': 'ru'
         'sk': 'sk-SK'

--- a/website-1.x/netlify.toml
+++ b/website-1.x/netlify.toml
@@ -3,12 +3,7 @@
 
 [build]
   base = "/"
-  command = "yarn workspace docusaurus-1-website netlify:build:deployPreview"
-  publish = "website-1.x/build/docusaurus"
-
-[context.deploy-preview]
-  base = "/"
-  command = "yarn workspace docusaurus-1-website netlify:build:deployPreview"
+  command = "yarn workspace docusaurus-1-website netlify:build"
   publish = "website-1.x/build/docusaurus"
 
 [context.production]

--- a/website-1.x/netlify.toml
+++ b/website-1.x/netlify.toml
@@ -1,10 +1,9 @@
 
 # Note: this file's config override the Netlify UI admin config
 
-# default/production build
 [build]
   base = "/"
-  command = "yarn workspace docusaurus-1-website netlify:build:production"
+  command = "yarn workspace docusaurus-1-website netlify:build:deployPreview"
   publish = "website-1.x/build/docusaurus"
 
 [context.deploy-preview]
@@ -12,4 +11,5 @@
   command = "yarn workspace docusaurus-1-website netlify:build:deployPreview"
   publish = "website-1.x/build/docusaurus"
 
-
+[context.production]
+  command = "yarn workspace docusaurus-1-website netlify:build:production"

--- a/website-1.x/netlify.toml
+++ b/website-1.x/netlify.toml
@@ -10,3 +10,4 @@
 [context.deploy-preview]
   command = "yarn workspace docusaurus-1-website netlify:build:deployPreview"
 
+

--- a/website-1.x/netlify.toml
+++ b/website-1.x/netlify.toml
@@ -1,0 +1,12 @@
+
+# Note: this file's config override the Netlify UI admin config
+
+# default/production build
+[build]
+  base = "/"
+  command = "yarn workspace docusaurus-1-website netlify:build:production"
+  publish = "website-1.x/build/docusaurus"
+
+[context.deploy-preview]
+  command = "yarn workspace docusaurus-1-website netlify:build:deployPreview"
+

--- a/website-1.x/netlify.toml
+++ b/website-1.x/netlify.toml
@@ -8,6 +8,8 @@
   publish = "website-1.x/build/docusaurus"
 
 [context.deploy-preview]
+  base = "/"
   command = "yarn workspace docusaurus-1-website netlify:build:deployPreview"
+  publish = "website-1.x/build/docusaurus"
 
 

--- a/website-1.x/package.json
+++ b/website-1.x/package.json
@@ -12,8 +12,8 @@
     "rename-version": "docusaurus-rename-version",
     "crowdin-upload": "cd .. && crowdin upload sources --auto-update -b master --config crowdin-v1.yml",
     "crowdin-download": "cd .. && crowdin download -b master --config crowdin-v1.yml",
-    "netlify:build:production": "yarn crowdin download && yarn build",
-    "netlify:build:deployPreview": "yarn build"
+    "netlify:build": "yarn build",
+    "netlify:build:production": "yarn crowdin download && yarn build"
   },
   "dependencies": {
     "docusaurus": "2.0.0-alpha.70"

--- a/website-1.x/package.json
+++ b/website-1.x/package.json
@@ -11,7 +11,9 @@
     "docusaurus-version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version",
     "crowdin-upload": "cd .. && crowdin upload sources --auto-update -b master --config crowdin-v1.yml",
-    "crowdin-download": "cd .. && crowdin download -b master --config crowdin-v1.yml"
+    "crowdin-download": "cd .. && crowdin download -b master --config crowdin-v1.yml",
+    "netlify:build:production": "yarn crowdin download && yarn build",
+    "netlify:build:deployPreview": "yarn build"
   },
   "dependencies": {
     "docusaurus": "2.0.0-alpha.70"

--- a/website-1.x/package.json
+++ b/website-1.x/package.json
@@ -10,8 +10,8 @@
     "write-translations": "docusaurus-write-translations",
     "docusaurus-version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version",
-    "crowdin-upload": "crowdin --config ../crowdin.yaml upload sources --auto-update -b master",
-    "crowdin-download": "crowdin --config ../crowdin.yaml download -b master"
+    "crowdin-upload": "cd .. && crowdin upload sources --auto-update -b master --config crowdin-v1.yml",
+    "crowdin-download": "cd .. && crowdin download -b master --config crowdin-v1.yml"
   },
   "dependencies": {
     "docusaurus": "2.0.0-alpha.70"


### PR DESCRIPTION

## Motivation

As we are moving v1 site to http://v1.docusaurus.io/, probably using a Netlify deployment, it's a good time to upgrade the Crowdin cli (v2 installed as deb on CircleCI) to v3/npm package that can easily run on Netlify
