### PR TITLE
docs(v1): version page should recommend v2

### DIFF
--- a/website-1.x/pages/en/versions.js
+++ b/website-1.x/pages/en/versions.js
@@ -26,8 +26,10 @@ function Versions(props) {
           <header className="postHeader">
             <h1>{siteConfig.title} Versions</h1>
           </header>
+          <h3 id="v2">Docusaurus v2</h3>
+          <p>We recommend to use [Docusaurus v2](http://v2.docusaurus.io/).</p>
           <h3 id="latest">Current version (Stable)</h3>
-          <p>Latest version of Docusaurus.</p>
+          <p>Latest version of Docusaurus v1.</p>
           <table className="versions">
             <tbody>
               <tr>
@@ -47,7 +49,8 @@ function Versions(props) {
             </tbody>
           </table>
           <h3 id="rc">Latest Version</h3>
-          Here you can find the latest documentation and unreleased code.
+          Here you can find the latest documentation and unreleased Docusaurus
+          v1 code.
           <table className="versions">
             <tbody>
               <tr>

--- a/website-1.x/pages/en/versions.js
+++ b/website-1.x/pages/en/versions.js
@@ -27,7 +27,20 @@ function Versions(props) {
             <h1>{siteConfig.title} Versions</h1>
           </header>
           <h3 id="v2">Docusaurus v2</h3>
-          <p>We recommend to use [Docusaurus v2](http://v2.docusaurus.io/).</p>
+          <p>
+            We recommend to use{' '}
+            <a href={`https://v2.docusaurus.io/`}>Docusaurus v2</a>.
+          </p>
+          <table className="versions">
+            <tbody>
+              <tr>
+                <th>2.x</th>
+                <td>
+                  <a href={`https://v2.docusaurus.io/`}>Documentation</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
           <h3 id="latest">Current version (Stable)</h3>
           <p>Latest version of Docusaurus v1.</p>
           <table className="versions">

--- a/website-1.x/pages/en/versions.js
+++ b/website-1.x/pages/en/versions.js
@@ -36,7 +36,7 @@ function Versions(props) {
               <tr>
                 <th>2.x</th>
                 <td>
-                  <a href={`https://v2.docusaurus.io/`}>Documentation</a>
+                  <a href="https://v2.docusaurus.io">Documentation</a>
                 </td>
               </tr>
             </tbody>

--- a/website-1.x/siteConfig.js
+++ b/website-1.x/siteConfig.js
@@ -9,7 +9,7 @@
 const users = require('./data/users');
 
 const siteConfig = {
-  title: 'Docusaurus V1',
+  title: 'Docusaurus v1',
   tagline: 'Easy to Maintain Open Source Documentation Websites',
   url: 'https://docusaurus.io',
   baseUrl: process.env.BASE_URL || '/',

--- a/website-1.x/siteConfig.js
+++ b/website-1.x/siteConfig.js
@@ -9,7 +9,7 @@
 const users = require('./data/users');
 
 const siteConfig = {
-  title: 'Docusaurus v1',
+  title: 'Docusaurus',
   tagline: 'Easy to Maintain Open Source Documentation Websites',
   url: 'https://docusaurus.io',
   baseUrl: process.env.BASE_URL || '/',

--- a/website-1.x/siteConfig.js
+++ b/website-1.x/siteConfig.js
@@ -9,7 +9,7 @@
 const users = require('./data/users');
 
 const siteConfig = {
-  title: 'Docusaurus',
+  title: 'Docusaurus V1',
   tagline: 'Easy to Maintain Open Source Documentation Websites',
   url: 'https://docusaurus.io',
   baseUrl: process.env.BASE_URL || '/',


### PR DESCRIPTION
## Motivation

Because some users might think Docusaurus 1 site `/next` is actually v2, we should clarify.

https://github.com/facebook/docusaurus/issues/4042#issuecomment-760272003


https://docusaurus.io/docs/en/next/docker

![image](https://user-images.githubusercontent.com/749374/104615816-e0fb3580-5689-11eb-9aa3-26ebe44dabd5.png)

The above site is not V2 but is a bit misleading