### PR TITLE
docs(v1): Docker: remind the user to use the --host flag

### DIFF
--- a/website-1.x/docs/getting-started-docker.md
+++ b/website-1.x/docs/getting-started-docker.md
@@ -21,7 +21,7 @@ To run the local web server:
 
    This will start a docker container with the image `docusaurus-doc`. To see more detailed container info run `docker ps` .
 
-To access docusaurus from outside the docker container you must add the `--host` flag to the `docusaurus-start` command as described in: [API Commands](api-commands.md#docusaurus-start)
+To access Docusaurus from outside the docker container you must add the `--host` flag to the `docusaurus-start` command as described in: [API Commands](api-commands.md#docusaurus-start)
 
 ## Use docker-compose
 

--- a/website-1.x/docs/getting-started-docker.md
+++ b/website-1.x/docs/getting-started-docker.md
@@ -21,6 +21,8 @@ To run the local web server:
 
    This will start a docker container with the image `docusaurus-doc`. To see more detailed container info run `docker ps` .
 
+To access docusaurus from outside the docker container you must add the `--host` flag to the `docusaurus-start` command as described in: [API Commands](api-commands.md#docusaurus-start)
+
 ## Use docker-compose
 
 We can also use `docker-compose` to configure our application. This feature of docker allows you to run the web server and any additional services with a single command.


### PR DESCRIPTION
Currently this part of the docs doesn't remind the user to use the --host flag. If the user doesn't use it, then the website will not be accessible outside of the docker container. This is what the user ultimately wants, to avoid using node and ruby and develop/productivize his website in a container.

## Motivation

A clarification in the documentation is missing..

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Related PRs

Related issue: https://github.com/facebook/docusaurus/issues/4042