### PR TITLE
chore(v2): update codesandbox redirect

### DIFF
--- a/admin/new.docusaurus.io/README.md
+++ b/admin/new.docusaurus.io/README.md
@@ -3,3 +3,7 @@
 This is a Netlify deployment that only redirects to the official CodeSandbox template.
 
 https://codesandbox.io/s/github/facebook/docusaurus/tree/master/examples/classic
+
+The Netlify deployment (Joel can give access): https://app.netlify.com/sites/docusaurus-new/overview
+
+Builds are stopped because we shouldn't need to redeploy the \_redirects file. You can just trigger a manual build if needed.

--- a/admin/new.docusaurus.io/_redirects
+++ b/admin/new.docusaurus.io/_redirects
@@ -1,2 +1,1 @@
-
-/*  https://codesandbox.io/s/github/facebook/docusaurus/tree/master/examples/classic
+/*  https://codesandbox.io/s/docusaurus


### PR DESCRIPTION

## Motivation

Update the codesandbox url, as we have an official template now: https://github.com/codesandbox/codesandbox-client/pull/5136