### PR TITLE
docs(v2): Include new.docusaurus.io CodeSandbox in issue templates + README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -4,6 +4,18 @@ about: Submit a bug report to help us improve
 labels: 'bug, needs triage'
 ---
 
+<!--
+
+  ! PLEASE HELP US HELP YOU !
+
+  Bugs are fixed faster if you include:
+  - a repro repository to inspect the code
+  - an url to see the problem live (if possible)
+
+  Pro tip: create a reproducible demo of the bug with https://new.docusaurus.io
+
+-->
+
 ## 🐛 Bug Report
 
 (A clear and concise description of what the bug is)
@@ -13,6 +25,8 @@ labels: 'bug, needs triage'
 (Write your answer here.)
 
 ## To Reproduce
+
+If possible, use https://new.docusaurus.io to create a CodeSandbox reproducible demo of the bug.
 
 (Write your steps here:)
 
@@ -45,13 +59,17 @@ labels: 'bug, needs triage'
 
 <!-- Include as many relevant details about the environment you experienced the bug in -->
 
+- Public source code:
+- Public site url:
 - Docusaurus version used:
 - Environment name and version (e.g. Chrome 78.0.3904.108, Node.js 10.17.0):
 - Operating system and version (desktop or mobile):
 
 ## Reproducible Demo
 
-(Paste the link to an example repo, including a `siteConfig.js`, and exact instructions to reproduce the issue.)
+If possible, use https://new.docusaurus.io to create a CodeSandbox reproducible demo of the bug.
+
+(Paste the link to an example repo, including a `docusaurus.config.js`, and exact instructions to reproduce the issue.)
 
 <!--
   What happens if you skip this step?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,15 +1,17 @@
 ---
-name: ❓ Questions/Help
-about: If you have questions, please check Stack Overflow or Discord or Twitter
+name: 🚫 Questions/Help
+about: 🚫 Please ask questions on GitHub discussions, Discord or Stack Overflow
 labels: 'questions, needs triage'
 ---
 
-## ❓ Questions and Help
+## 🚫 Questions and Help
 
-### Please note that this issue tracker is not a help form and this issue will be closed.
+### Please note that this issue tracker is 🚫 NOT a help form 🚫 and this issue will be closed.
 
-Please contact us instead. We have a few channels:
+For beginners questions: ask the Docusaurus community:
 
+- [Discord](https://discord.gg/docusaurus) (most active channel)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus)
 - [Twitter](https://twitter.com/docusaurus)
-- [Discord](https://discord.gg/docusaurus)
+
+For advanced/unanswered questions: ask on [GitHub Discussions](https://github.com/facebook/docusaurus/discussions).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 Docusaurus is a project for building, deploying, and maintaining open source project websites easily.
 
+Try Docusaurus on **CodeSandbox** immediately with [new.docusaurus.io](http://new.docusaurus.io/)
+
 - **Simple to Start**
 
 > Docusaurus is built in a way so that it can [get running](https://docusaurus.io/docs/en/installation/) in as little time as possible. We've built Docusaurus to handle the website build process so you can focus on your project.


### PR DESCRIPTION


## Motivation

The CodeSandbox should be used for:
- people that want to assess Docusaurus easily
- people that want to submit good bug reports