### PR TITLE
style(v2): add className to tab container

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -82,7 +82,7 @@ function Tabs(props: Props): JSX.Element {
   };
 
   return (
-    <div>
+    <div className="tabs--container">
       <ul
         role="tablist"
         aria-orientation="horizontal"

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -82,7 +82,7 @@ function Tabs(props: Props): JSX.Element {
   };
 
   return (
-    <div className="tabs--container">
+    <div className="tabs-container">
       <ul
         role="tablist"
         aria-orientation="horizontal"


### PR DESCRIPTION
## Motivation

I like the classic theme and would like to theme the Tabs component. The Tabs component's wrapper div doesn't have a class name on it and that would be useful. 

This PR adds a classname. No CSS is added.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Ensure there is no side effect: the class name isn't used in the repo
