### PR TITLE
feat(v2): supports string type for the Layout's keywords props

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
@@ -49,7 +49,10 @@ export default function LayoutHead(props: Props): JSX.Element {
           <meta property="og:description" content={description} />
         )}
         {keywords && keywords.length && (
-          <meta name="keywords" content={keywords.join(',')} />
+          <meta
+            name="keywords"
+            content={Array.isArray(keywords) ? keywords.join(',') : keywords}
+          />
         )}
         {metaImage && <meta property="og:image" content={metaImageUrl} />}
         {metaImage && <meta name="twitter:image" content={metaImageUrl} />}

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -237,7 +237,7 @@ declare module '@theme/Layout' {
     noFooter?: boolean;
     description?: string;
     image?: string;
-    keywords?: string[];
+    keywords?: string | string[];
     permalink?: string;
     wrapperClassName?: string;
     searchMetadatas?: {


### PR DESCRIPTION
## Motivation

According to the W3C's [keywords meta tag spec](https://www.w3.org/wiki/HTML/Elements/meta%20?iframe=true&width=100%&height=100%#Example_A), it accepts a string type content. Most developers are already familiar with the `string` type content. So for better DX, we can provide both `string` and `array` types for the value of the Layout's keywords props.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- Add the feature to `packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx`.
- `cd packages/docusaurus-theme-classic` then `yarn link`
- `cd website`, link the package then `yarn start`
- Ensure both `string` and `array` values are work for the Layout's keywords props

