### PR TITLE
docs: update broken link on resources page

### DIFF
--- a/website/community/resources.md
+++ b/website/community/resources.md
@@ -12,7 +12,7 @@ A curated list of interesting Docusaurus community projects.
 
 ## Articles
 
-- [Live code editing in Docusaurus](https://dev.to/mrmuhammadali/live-code-editing-in-docusaurus-28k)
+- [Live code editing in Docusaurus](https://dev.to/mrmuhammadali/live-code-editing-in-docusaurus-ux-at-its-best-2hj1)
 
 ## Showcase
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Article link was 404ing because of a title change, so this pull request updates the broken link

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan
N/a

## Related PRs
N/a