### PR TITLE
Support for Oribi Analytics as Docusaurus plugin

### DIFF
--- a/packages/docusaurus-plugin-oribi/README.md
+++ b/packages/docusaurus-plugin-oribi/README.md
@@ -1,0 +1,7 @@
+# `@docusaurus/plugin-oribi`
+
+Oribi analytics plugin for Docusaurus.
+
+## Usage
+
+See [plugin-oribi documentation](https://v2.docusaurus.io/docs/api/plugins/@docusaurus/plugin-oribi).

--- a/packages/docusaurus-plugin-oribi/package.json
+++ b/packages/docusaurus-plugin-oribi/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@docusaurus/plugin-oribi",
+  "version": "2.0.0-alpha.70",
+  "description": "Oribi analytics (analytics.js) plugin for Docusaurus.",
+  "main": "src/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/docusaurus.git",
+    "directory": "packages/docusaurus-plugin-oribi"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@docusaurus/core": "2.0.0-alpha.70"
+  },
+  "peerDependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
+  "engines": {
+    "node": ">=10.15.1"
+  }
+}

--- a/packages/docusaurus-plugin-oribi/src/index.js
+++ b/packages/docusaurus-plugin-oribi/src/index.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = function (context) {
+  const {siteConfig} = context;
+  const {themeConfig} = siteConfig;
+  const {googleAnalytics} = themeConfig || {};
+
+  if (!googleAnalytics) {
+    throw new Error(
+      `You need to specify 'googleAnalytics' object in 'themeConfig' with 'trackingId' field in it to use docusaurus-plugin-oribi`,
+    );
+  }
+
+  const {trackingID} = googleAnalytics;
+
+  if (!trackingID) {
+    throw new Error(
+      'You specified the `googleAnalytics` object in `themeConfig` but the `trackingID` field was missing. ' +
+        'Please ensure this is not a mistake.',
+    );
+  }
+
+  const isProd = process.env.NODE_ENV === 'production';
+
+  return {
+    name: 'docusaurus-plugin-oribi',
+    injectHtmlTags() {
+      if (!isProd) {
+        return {};
+      }
+
+      return {
+        headTags: [
+          {
+            tagName: 'script',
+            async: true,
+            innerHTML: `(function (b, o, n, g, s, r, c) {
+              if (b[s]) return;
+              b[s] = {};
+              b[s].scriptToken = "${trackingID}";
+              b[s].callsQueue = [];
+              b[s].api = function () {
+                b[s].callsQueue.push(arguments);
+              };
+              r = o.createElement(n);
+              c = o.getElementsByTagName(n)[0];
+              r.async = 1;
+              r.src = g;
+              r.id = s + n;
+              c.parentNode.insertBefore(r, c);
+            })(
+              window,
+              document,
+              "script",
+              "https://cdn.oribi.io/${trackingID}/oribi.js",
+              "ORIBI"
+            );`,
+          },
+        ],
+      };
+    },
+  };
+};


### PR DESCRIPTION
## Motivation

We are working on a project (actually a series of them) and wanted to start investigating the usefulness of Oribi.  Seeing as Docusaurus is a platform geared towards simplicity, hoping that the insights from Oribi will pair nicely.  Currently have this running as a local plugin, and considered starting our own library of plugins, but feels more natural to live alongside these others.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes, I will do better with my commit messages on future commits.

## Test Plan

This has been tested in a few different scenarios.

1. For starters, the same plugin is running on our production site as a local plugin
   - To see it running, you can checkout www.iot-ensemble.com and search the `<head>` section for 'oribi'
   - The source code for the plugin and themeConfig can be found here:  https://github.com/iot-ensemble/public-web
2. When bringing code here, I didn't see any test fixtures, so did some manual testing in the /websites directory.  Took the same theme config and setup the plugins section.
   - In the /websites/docusaurus.config.js file there is a lingering invalid token (_____xxxxxxx_____) for the oribi trackingID.  I didn't feel like leaving my personal Oribi ID in for the commit to your branches was a good idea.

## Related PRs

Unrelated to other PRs.
