### PR TITLE
docs(v2): remove unnecessary brace from installation doc

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -112,7 +112,7 @@ Docusaurus is a modern static website generator so we need to build the website 
 npm run build
 ```
 
-and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Vercel](https://vercel.com/) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.mdx)) for more details.
+and contents will be generated within the `/build` directory, which can be copied to any static file hosting service like [GitHub pages](https://pages.github.com/), [Vercel](https://vercel.com/) or [Netlify](https://www.netlify.com/). Check out the docs on [deployment](deployment.mdx) for more details.
 
 ## Updating your Docusaurus version
 


### PR DESCRIPTION
Removing this extra curly brace from documentation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes