### PR TITLE
docs(v2): remove duplicate link from docs about Docusaurus1

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -29,7 +29,7 @@ Use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immedi
 **Use [Docusaurus v1](https://docusaurus.io/) if:**
 
 - :x: You don't want a single-page application (SPA)
-- :x: You prefer stability over modernity (try [Docusaurus 1](https://docusaurus.io/) instead)
+- :x: You prefer stability over modernity
 - :x: You need support for IE11
 
 ## A better Docusaurus is coming to town


### PR DESCRIPTION
Link of Docusaurus1 is already mentioned in the Header. [here](https://github.com/facebook/docusaurus/pull/4128/files#diff-0890f0ba3d12d890012a1b6135b69b25354212692889e02df86a130262bb3405L29)

Having it again in the bullet points looks unorganized. So removing it


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes