### PR TITLE
docs(v2): typo fix in Migration Docs

### DIFF
--- a/website/docs/migration/migration-manual.md
+++ b/website/docs/migration/migration-manual.md
@@ -4,7 +4,7 @@ title: Manual migration
 slug: /migration/manual
 ---
 
-This manual migration process should be run after the [automated migration prcess](./migration-automated.md), to complete the missing parts, or debug issues in the migration CLI output.
+This manual migration process should be run after the [automated migration process](./migration-automated.md), to complete the missing parts, or debug issues in the migration CLI output.
 
 ## Project setup
 


### PR DESCRIPTION
Simple Typo Fix for word **Process** in migrations Documentation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes