### PR TITLE
docs(v2): typo in i18n docs

### DIFF
--- a/website/docs/i18n/i18n-introduction.md
+++ b/website/docs/i18n/i18n-introduction.md
@@ -69,7 +69,7 @@ You will have to work with 2 kind of translation files.
 
 This is the main content of your Docusaurus website.
 
-Markdown and MDX documents are translated as a whole, to fully preserve the translation context, instead of splitting each sentance as a separate string.
+Markdown and MDX documents are translated as a whole, to fully preserve the translation context, instead of splitting each sentence as a separate string.
 
 #### JSON files
 


### PR DESCRIPTION
Fixing a typo of word **sentence**  in i18n documentation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes