### PR TITLE
docs(v2): Fix file path in "Wrapper your site with `<Root>`" (website/docs/using-themes.md)

### DIFF
--- a/website/docs/using-themes.md
+++ b/website/docs/using-themes.md
@@ -75,7 +75,7 @@ And if you want to use Bootstrap styling, you can swap out the theme with `theme
 
 A `<Root>` theme component is rendered at the very top of your Docusaurus site.
 
-It allows you to wrap your site with additional logic, by creating a file at `website/src/theme/Root.js`:
+It allows you to wrap your site with additional logic, by creating a file at `src/theme/Root.js`:
 
 ```js title="website/src/theme/Root.js"
 import React from 'react';

--- a/website/versioned_docs/version-2.0.0-alpha.70/using-themes.md
+++ b/website/versioned_docs/version-2.0.0-alpha.70/using-themes.md
@@ -75,7 +75,7 @@ And if you want to use Bootstrap styling, you can swap out the theme with `theme
 
 A `<Root>` theme component is rendered at the very top of your Docusaurus site.
 
-It allows you to wrap your site with additional logic, by creating a file at `website/src/theme/Root.js`:
+It allows you to wrap your site with additional logic, by creating a file at `src/theme/Root.js`:
 
 ```js title="website/src/theme/Root.js"
 import React from 'react';


### PR DESCRIPTION
## Motivation

- I wanted to inject <script/> tag to put Google Adsense
- I followed [this guide](https://v2.docusaurus.io/docs/using-themes#wrapper-your-site-with-root) to wrap my site, it's not working as I wished.
  (try to put code into `website/src/theme/Root.js`)
- turns out, it worked putting code into `src/theme/Root.js`
- this wrong contents of guide makes me waste several hours
- let me share [my docusaurus blog code](https://github.com/geoseong/geoseong.github.io/tree/docusaurus-blog) with corrected content

```
I am "version-2.0.0-alpha.70" user, so I updated the contents of "version-2.0.0-alpha.70" and after.
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

**YES**

## Test Plan

**Before**
![image](https://user-images.githubusercontent.com/19166187/106389836-e34ee500-6428-11eb-8711-4398a3e5c266.png)

**After**
![image](https://user-images.githubusercontent.com/19166187/106389852-fc579600-6428-11eb-9401-f3bc5a75cebe.png)


## Related PRs

I think there's no relation with it