### PR TITLE
docs(v2): plugins docs typo fix

### DIFF
--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -116,7 +116,7 @@ module.exports = {
         /**
          * The docusaurus versioning defaults don't make sense for all projects
          * This gives the ability customize the label and path of each version
-         * You may not like that default versin
+         * You may not like that default version
          */
         versions: {
           /*


### PR DESCRIPTION
Simple Typo Fix for word **version** in plugins Documentation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes