### PR TITLE
fix(v2): avoid misuse section tag in blog posts

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -110,9 +110,9 @@ function BlogPostItem(props: Props): JSX.Element {
 
       <article className={!isBlogPostPage ? 'margin-bottom--xl' : undefined}>
         {renderPostHeader()}
-        <section className="markdown">
+        <div className="markdown">
           <MDXProvider components={MDXComponents}>{children}</MDXProvider>
-        </section>
+        </div>
         {(tags.length > 0 || truncated) && (
           <footer className="row margin-vert--lg">
             {tags.length > 0 && (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I think we'd better use a regular `div` instead of `section` tag for blog post content, as we currently have HTML error like this:

![image](https://user-images.githubusercontent.com/4408379/106470092-28b6f500-64b1-11eb-8fa5-ec9ae5f6c4d5.png)

This is because `section` requires mandatory headings (`hX`). So therefore wise to opt out of using this tag as we cannot guarantee that this rule will be followed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Validator's happy.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
