### PR TITLE
fix(v2): BaseUrl issue banner insertion should be prevented if JS can load

### DIFF
--- a/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
+++ b/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useLayoutEffect} from 'react';
 import {useLocation} from 'react-router-dom';
 
 import Head from '../exports/Head';
@@ -27,7 +27,7 @@ const SuggestionContainerId =
 // - We can't CSR (as it means the baseurl is correct)
 function createInlineHtmlBanner(baseUrl: string) {
   return `
-<div style="border: thick solid red; background-color: rgb(255, 230, 179); margin: 20px; padding: 20px; font-size: 20px;">
+<div id="${BannerContainerId}" style="border: thick solid red; background-color: rgb(255, 230, 179); margin: 20px; padding: 20px; font-size: 20px;">
    <p style="font-weight: bold; font-size: 30px;">Your Docusaurus site did not load properly.</p>
    <p>A very common reason is a wrong site <a href="https://v2.docusaurus.io/docs/docusaurus.config.js/#baseurl" style="font-weight: bold;">baseUrl configuration</a>.</p>
    <p>Current configured baseUrl = <span style="font-weight: bold; color: red;">${baseUrl}</span> ${
@@ -63,16 +63,29 @@ document.addEventListener('DOMContentLoaded', renderBanner);
 `;
 }
 
+// Normally if the baseUrl is correct, the banner will already be hidden by the critical CSS
+// But we can still remove it totally from the DOM if it's not useful anymore
+// This is kind of a "double security"
+// It can also prevent the banner to appear if the CSS fails to load due to some network error
+function useBannerRemover() {
+  useLayoutEffect(() => {
+    document.addEventListener('DOMContentLoaded', () => {
+      document.getElementById(BannerContainerId)?.remove();
+    });
+  }, []);
+}
+
 function BaseUrlIssueBannerEnabled() {
   const {
     siteConfig: {baseUrl},
   } = useDocusaurusContext();
+  useBannerRemover();
+
   return (
     <>
       <Head>
         <script>{createInlineScript(baseUrl)}</script>
       </Head>
-      <div id={BannerContainerId} />
     </>
   );
 }

--- a/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
+++ b/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
@@ -6,19 +6,22 @@
  */
 
 import React, {useLayoutEffect} from 'react';
-import {useLocation} from 'react-router-dom';
-
-import Head from '../exports/Head';
-
+import {useLocation} from '@docusaurus/router';
+import Head from '@docusaurus/Head';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-// The critical CSS will hide the banner if it loads successfully!
+// Double-security: critical CSS will hide the banner if CSS can load!
 import './styles.module.css';
 
 const BannerContainerId = 'docusaurus-base-url-issue-banner-container';
 
+const BannerId = 'docusaurus-base-url-issue-banner';
+
 const SuggestionContainerId =
   'docusaurus-base-url-issue-banner-suggestion-container';
+
+const InsertBannerWindowAttribute = '__DOCUSAURUS_INSERT_BASEURL_BANNER';
 
 // It is important to not use React to render this banner
 // otherwise Google would index it, even if it's hidden with some critical CSS!
@@ -27,7 +30,7 @@ const SuggestionContainerId =
 // - We can't CSR (as it means the baseurl is correct)
 function createInlineHtmlBanner(baseUrl: string) {
   return `
-<div id="${BannerContainerId}" style="border: thick solid red; background-color: rgb(255, 230, 179); margin: 20px; padding: 20px; font-size: 20px;">
+<div id="${BannerId}" style="border: thick solid red; background-color: rgb(255, 230, 179); margin: 20px; padding: 20px; font-size: 20px;">
    <p style="font-weight: bold; font-size: 30px;">Your Docusaurus site did not load properly.</p>
    <p>A very common reason is a wrong site <a href="https://v2.docusaurus.io/docs/docusaurus.config.js/#baseurl" style="font-weight: bold;">baseUrl configuration</a>.</p>
    <p>Current configured baseUrl = <span style="font-weight: bold; color: red;">${baseUrl}</span> ${
@@ -41,16 +44,24 @@ function createInlineHtmlBanner(baseUrl: string) {
 // fn needs to work for older browsers!
 function createInlineScript(baseUrl: string) {
   return `
-function renderBanner() {
-  var banner = document.getElementById('${BannerContainerId}');
-  if (!banner) {
+window['${InsertBannerWindowAttribute}'] = true;
+
+document.addEventListener('DOMContentLoaded', maybeInsertBanner);
+
+function maybeInsertBanner() {
+  var shouldInsert = window['${InsertBannerWindowAttribute}'];
+  shouldInsert && insertBanner();
+}
+
+function insertBanner() {
+  var bannerContainer = document.getElementById('${BannerContainerId}');
+  if (!bannerContainer) {
     return;
   }
   var bannerHtml = ${JSON.stringify(createInlineHtmlBanner(baseUrl))
     // See https://redux.js.org/recipes/server-rendering/#security-considerations
     .replace(/</g, '\\\u003c')};
-  banner.innerHTML = bannerHtml;
-
+  bannerContainer.innerHTML = bannerHtml;
   var suggestionContainer = document.getElementById('${SuggestionContainerId}');
   var actualHomePagePath = window.location.pathname;
   var suggestedBaseUrl = actualHomePagePath.substr(-1) === '/'
@@ -58,40 +69,34 @@ function renderBanner() {
         : actualHomePagePath + '/';
   suggestionContainer.innerHTML = suggestedBaseUrl;
 }
-
-document.addEventListener('DOMContentLoaded', renderBanner);
 `;
-}
-
-// Normally if the baseUrl is correct, the banner will already be hidden by the critical CSS
-// But we can still remove it totally from the DOM if it's not useful anymore
-// This is kind of a "double security"
-// It can also prevent the banner to appear if the CSS fails to load due to some network error
-function useBannerRemover() {
-  useLayoutEffect(() => {
-    document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById(BannerContainerId)?.remove();
-    });
-  }, []);
 }
 
 function BaseUrlIssueBannerEnabled() {
   const {
     siteConfig: {baseUrl},
   } = useDocusaurusContext();
-  useBannerRemover();
+
+  // useLayoutEffect fires before DOMContentLoaded.
+  // It gives the opportunity to avoid inserting the banner in the first place
+  useLayoutEffect(() => {
+    window[InsertBannerWindowAttribute] = false;
+  }, []);
 
   return (
     <>
-      <Head>
-        <script>{createInlineScript(baseUrl)}</script>
-      </Head>
+      {!ExecutionEnvironment.canUseDOM && (
+        <Head>
+          <script>{createInlineScript(baseUrl)}</script>
+        </Head>
+      )}
+      <div id={BannerContainerId} />
     </>
   );
 }
 
 // We want to help the users with a bad baseUrl configuration (very common error)
-// Help message is inlined, and hides if the external CSS is able to load successfully
+// Help message is inlined, and hidden if JS or CSS is able to load
 // Note: it might create false positives (ie network failures): not a big deal
 // Note: we only inline this for the homepage to avoid polluting all the site's pages
 // See https://github.com/facebook/docusaurus/pull/3621

--- a/website/dogfooding/clientModuleExample.ts
+++ b/website/dogfooding/clientModuleExample.ts
@@ -8,9 +8,9 @@
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 export function onRouteUpdate({location}: {location: Location}) {
-  console.log('onRouteUpdate', {location});
+  // console.log('onRouteUpdate', {location});
 }
 
 if (ExecutionEnvironment.canUseDOM) {
-  console.log('client module example log');
+  // console.log('client module example log');
 }


### PR DESCRIPTION

## Motivation

Follow-up of:
https://github.com/facebook/docusaurus/pull/4125
https://github.com/facebook/docusaurus/pull/4136

Change BaseUrl issue banner integration so that it's not indexed by SEO. 

Instead of trying to insert it, and then remove it, we now prevent it from being inserted in the first place for the optimistic case (React can hydrate successfully).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

SEO tools
