### PR TITLE
fix(v2): fix build size bot monitoring of js/css assets

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: 'build:v2:en'
-          pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/assets/1*js,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
+          pattern: '{website/build/assets/js/main*js,website/build/assets/js/1*js,website/build/assets/js/3*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 100

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: 'build:v2:en'
-          pattern: '{website/build/main*js,website/build/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
+          pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/assets/1*js,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 100


### PR DESCRIPTION


## Motivation

Build size bot got broken by https://github.com/facebook/docusaurus/pull/3998

Note: we should likely figure out a way to output better chunk names as we have large bundles named "1" and "3" and even worst namings.
 
Probably worth investing in this after the Webpack 5 migration