### PR TITLE
chore(v2): fix build size bot again

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: 'build:v2:en'
-          pattern: '{website/build/assets/js/main*js,website/build/assets/js/1*js,website/build/assets/js/3*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
+          pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 100


### PR DESCRIPTION


## Motivation

My test did not work so well, I just wanted to track the 1.hash.js file but tracked much more.

![image](https://user-images.githubusercontent.com/749374/106638202-e8747700-6583-11eb-813e-777959a316af.png)

Revert to former config, we'll figure out how to monitor other files later
