### PR TITLE
fix(v2): fix hreflang headers

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
@@ -26,6 +26,9 @@ function AlternateLangHeaders(): JSX.Element {
     i18n: {defaultLocale, locales},
   } = useDocusaurusContext();
   const alternatePageUtils = useAlternatePageUtils();
+
+  // Note: it is fine to use both "x-default" and "en" to target the same url
+  // See https://www.searchviu.com/en/multiple-hreflang-tags-one-url/
   return (
     <Head>
       {locales.map((locale) => (
@@ -36,9 +39,17 @@ function AlternateLangHeaders(): JSX.Element {
             locale,
             fullyQualified: true,
           })}
-          hrefLang={locale === defaultLocale ? 'x-default' : locale}
+          hrefLang={locale}
         />
       ))}
+      <link
+        rel="alternate"
+        href={alternatePageUtils.createUrl({
+          locale: defaultLocale,
+          fullyQualified: true,
+        })}
+        hrefLang="x-default"
+      />
     </Head>
   );
 }


### PR DESCRIPTION

## Motivation

According to SEO tools it seems we should rather use hreflang=en for the English / default pages of the doc.
And we can actually use both x-default + en

https://www.searchviu.com/en/multiple-hreflang-tags-one-url/
https://sitebulb.com/hints/international/hreflang-annotation-also-x-default/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Ahrefs SEO tools

