### PR TITLE
fix(v2): fix warning and improve styling inline TOC

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/TOCInline/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOCInline/styles.module.css
@@ -7,8 +7,6 @@
 
 .tableOfContentsInline ul {
   list-style-type: disc;
-}
-
-.table-of-contents__link--inline {
-  color: var(--ifm-toc-link-color);
+  font-size: initial;
+  padding-top: 0;
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -15,7 +15,9 @@ You should not have to write your `docusaurus.config.js` from scratch even if yo
 
 However, it can be helpful if you have a high-level understanding of how the configurations are designed and implemented.
 
-The high-level overview of Docusaurus configuration can be categorized into: <TOCInline toc={toc[0].children} />
+The high-level overview of Docusaurus configuration can be categorized into:
+
+<TOCInline toc={toc[0].children} />
 
 For exact reference to each of the configurable fields, you may refer to [**`docusaurus.config.js` API reference**](api/docusaurus.config.js.md).
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, when going on Configuration page in dv mode, we get a couple of warnings:

```
Warning: validateDOMNesting(...): <ul> cannot appear as a descendant of <p>.
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

This is because only inline elements should be inside the `p` tag. Unfortunately, this cannot be solved by anything other than placing the `TOCInline` component on a new line.

I also decided to restyle the inline TOC as a regular list because it doesn't look very good right now.

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/106732287-95510180-6621-11eb-8cc0-a82fe4076d2f.png) | ![image](https://user-images.githubusercontent.com/4408379/106732361-ab5ec200-6621-11eb-846d-3effa03ccbea.png) |

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
