### PR TITLE
docs(v2): add a note for images not rendered on dev server

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.70/api/plugins/plugin-ideal-image.md
+++ b/website/versioned_docs/version-2.0.0-alpha.70/api/plugins/plugin-ideal-image.md
@@ -9,7 +9,9 @@ Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, a
 
 :::note
 
-When using this plugin, the images will not render on the developent server. You must create and serve a production build in order to view the images
+You must create and serve a **production build** in order to view the high-quality images.
+
+When using this plugin in **development**, only the low-quality image placeholders will be visible.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-alpha.70/api/plugins/plugin-ideal-image.md
+++ b/website/versioned_docs/version-2.0.0-alpha.70/api/plugins/plugin-ideal-image.md
@@ -6,6 +6,13 @@ slug: '/api/plugins/@docusaurus/plugin-ideal-image'
 
 Docusaurus Plugin to generate an almost ideal image (responsive, lazy-loading, and low quality placeholder) **in the production builds**.
 
+
+:::note
+
+When using this plugin, the images will not render on the developent server. You must create and serve a production build in order to view the images
+
+:::
+
 ## Installation
 
 ```bash npm2yarn


### PR DESCRIPTION
Add a note that images are not rendered on the development server

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I spent more than an hour to finally find out that the images are not rendered on the development server. Although there is a message in the description saying "in the production builds." anyone can miss it easily.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
