### PR TITLE
fix(v2): ideal image assets should be served under ./assets

### DIFF
--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -42,8 +42,8 @@ export default function (
                     // eslint-disable-next-line
                     adapter: require('@endiliey/responsive-loader/sharp'),
                     name: isProd
-                      ? 'ideal-img/[name].[hash:hex:7].[width].[ext]'
-                      : 'ideal-img/[name].[width].[ext]',
+                      ? 'assets/ideal-img/[name].[hash:hex:7].[width].[ext]'
+                      : 'assets/ideal-img/[name].[width].[ext]',
                     ...options,
                   },
                 },


### PR DESCRIPTION

## Motivation

Follow-up on https://github.com/facebook/docusaurus/issues/3156

We want all static assets to be in ./assets and have hashes, so that users can leverage CDN caching more easily

