### PR TITLE
refactor(v2): minor styling improvements

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -25,7 +25,7 @@
 
   .docSidebarContainerHidden {
     width: 30px;
-    cursor: e-resize;
+    cursor: pointer;
   }
 
   .collapsedDocSidebar {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -71,6 +71,7 @@
     position: sticky;
     bottom: 0;
     border-radius: 0;
+    border: 1px solid var(--ifm-toc-border-color);
   }
 
   .collapseSidebarButtonIcon {
@@ -80,8 +81,6 @@
 
   html[data-theme='dark'] .collapseSidebarButton {
     background-color: var(--collapse-button-bg-color-dark);
-    border: none;
-    border-left: 1px solid var(--ifm-toc-border-color);
   }
 
   html[data-theme='dark'] .collapseSidebarButton:hover,

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
@@ -104,7 +104,8 @@
   left: 27px;
 }
 
-:global(.react-toggle--focus .react-toggle-thumb) {
+:global(.react-toggle--focus .react-toggle-thumb),
+:global(.react-toggle-thumb:hover) {
   box-shadow: 0px 0px 2px 3px var(--ifm-color-primary);
 }
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -106,11 +106,11 @@ function Home() {
               />
             </h1>
             <div className={styles.indexCtas}>
-              <Link className={styles.indexCtasGetStartedButton} to="/docs">
+              <Link className="button button--primary" to="/docs">
                 <Translate>Get Started</Translate>
               </Link>
               <Link
-                className={styles.indexCtaTryNowButton}
+                className="button button--info"
                 to="https://new.docusaurus.io">
                 <Translate>Playground</Translate>
               </Link>

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -105,7 +105,7 @@
 }
 
 .indexCtas a:last-of-type {
-  margin: 0 36px;
+  margin: 20px 36px;
 }
 
 .indexCtasGitHubButtonWrapper {
@@ -146,8 +146,8 @@
     justify-content: center;
   }
 
-  .indexCtas a:last-of-type {
-    margin-top: 20px;
+  .indexCtas a {
+    margin: 20px 36px;
   }
 
   .indexCtasGitHubButton {

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -67,7 +67,6 @@
   color: var(--ifm-color-primary);
 }
 
-
 @keyframes jackInTheBox {
   from {
     opacity: 0;
@@ -98,22 +97,15 @@
 }
 
 .indexCtas {
+  --ifm-button-size-multiplier: 1.6;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   margin-top: 24px;
 }
 
-.indexCtasGetStartedButton {
-  border: 2px solid var(--ifm-color-primary);
-  line-height: 1.2em;
-  text-decoration: none !important;
-  text-transform: uppercase;
-  transition: background 0.3s, color 0.3s;
-  border-radius: 8px;
-  color: #fff;
-  font-size: 24px;
-  font-weight: bold;
-  padding: 18px 36px;
+.indexCtas a:last-of-type {
+  margin: 0 36px;
 }
 
 .indexCtasGitHubButtonWrapper {
@@ -125,16 +117,6 @@
   overflow: hidden;
 }
 
-.indexCtaTryNowButton {
-  line-height: 1.2em;
-  text-decoration: underline;
-  text-transform: uppercase;
-  transition: background 0.3s, color 0.3s;
-  color: #fff;
-  font-size: 14px;
-  font-weight: bold;
-  margin: 0 36px;
-}
 .indexCtaTryNowButton:hover {
   color: var(--ifm-color-primary);
 }
@@ -162,6 +144,10 @@
 
   .indexCtas {
     justify-content: center;
+  }
+
+  .indexCtas a:last-of-type {
+    margin-top: 20px;
   }
 
   .indexCtasGitHubButton {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Fix borders of collapse doc sidebar button

- Replace e-resize type with click when hover on expand sidebar button


| Before   | After    |
| -------- | -------- |
|![image](https://user-images.githubusercontent.com/4408379/106787186-73c33a80-6660-11eb-9d9d-9b6973886c5e.png) | ![image](https://user-images.githubusercontent.com/4408379/106787224-82a9ed00-6660-11eb-9833-5c2c4007b993.png) |

- Add hover state for dark mode switcher


- Use Infima buttons on home page

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/106787434-be44b700-6660-11eb-8df6-ab578a91eac1.png) | ![image](https://user-images.githubusercontent.com/4408379/106787365-aec56e00-6660-11eb-9dfe-be69f95660c8.png) |

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
