### PR TITLE
Update command to check yarn installation

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -14,7 +14,7 @@ Use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immedi
 ## Requirements
 
 - [Node.js](https://nodejs.org/en/download/) version >= 10.15.1 or above (which can be checked by running `node -v`). You can use [nvm](https://github.com/nvm-sh/nvm) for managing multiple Node versions on a single machine installed
-- [Yarn](https://yarnpkg.com/en/) version >= 1.5 (which can be checked by running `yarn version`). Yarn is a performant package manager for JavaScript and replaces the `npm` client. It is not strictly necessary but highly encouraged.
+- [Yarn](https://yarnpkg.com/en/) version >= 1.5 (which can be checked by running `yarn --version`). Yarn is a performant package manager for JavaScript and replaces the `npm` client. It is not strictly necessary but highly encouraged.
 
 ## Scaffold project website
 


### PR DESCRIPTION
As listed `yarn version` works but throws an error. This PR updates the command that checks the install to be `yarn --version` per the [Yarn docs](https://classic.yarnpkg.com/en/docs/install#mac-stable)