### PR TITLE
docs(v2): typo fixing double colon

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -38,7 +38,7 @@ If you do not specify `name` or `template`, it will prompt you for them. We reco
 npx @docusaurus/init@latest init my-website facebook
 ```
 
-**[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following::
+**[Experimental]:** If you want setting up a new website using [bootstrap](https://getbootstrap.com/), use the `bootstrap` template, like the following:
 
 ```bash
 npx @docusaurus/init@latest init my-website bootstrap


### PR DESCRIPTION
Removing This double colon and making it single, looks like a simple typo

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes