### PR TITLE
fix(v2): make locale dropdown accessible from keyboard

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem.tsx
@@ -50,6 +50,7 @@ export default function LocaleDropdownNavbarItem({
   return (
     <DefaultNavbarItem
       {...props}
+      href="#"
       mobile={mobile}
       label={
         <span>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Locale dropdown is currently not available for keyboard navigation, to fix this we need to add a `href` attribute.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

![image](https://user-images.githubusercontent.com/4408379/106899441-695b7c00-6706-11eb-9554-e5714419c4c0.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
