### PR TITLE
fix(v2): prevent click on item menu with children on mobiles

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -192,7 +192,8 @@ function NavItemMobile({
         role="button"
         className={navLinkClassNames(className, true)}
         {...props}
-        onClick={() => {
+        onClick={(e) => {
+          e.preventDefault();
           setCollapsed((state) => !state);
         }}>
         {props.children ?? props.label}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Because currently the Versions menu item cannot be expanded on mobiles.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
