### PR TITLE
refactor(v2): use transform instead of top position for hideable navbar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
@@ -18,9 +18,10 @@
 }
 
 .navbarHideable {
-  transition: top 0.2s ease-in-out;
+  transform: translateY(0);
+  transition: transform var(--ifm-transition-fast) ease;
 }
 
 .navbarHidden {
-  top: calc(var(--ifm-navbar-height) * -1) !important;
+  transform: translateY(calc(var(--ifm-navbar-height) * -1));
 }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
@@ -18,10 +18,10 @@
 }
 
 .navbarHideable {
-  transform: translateY(0);
+  transform: translate3d(0, 0, 0);
   transition: transform var(--ifm-transition-fast) ease;
 }
 
 .navbarHidden {
-  transform: translateY(calc(var(--ifm-navbar-height) * -1));
+  transform: translate3d(0, calc(var(--ifm-navbar-height) * -1), 0);
 }

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -12,7 +12,7 @@ import type {useHideableNavbarReturns} from '@theme/hooks/useHideableNavbar';
 
 const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   const location = useLocation();
-  const [isNavbarVisible, setIsNavbarVisible] = useState(!hideOnScroll);
+  const [isNavbarVisible, setIsNavbarVisible] = useState(hideOnScroll);
   const isFocusedAnchor = useRef(false);
   const [lastScrollTop, setLastScrollTop] = useState(0);
   const [navbarHeight, setNavbarHeight] = useState(0);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Animating the `top` property will have some graphics performance impacts, basically animating top will trigger the browser to [perform layout operations](https://csstriggers.com/top).

Instead use transform with translate3d so the operation can likely be [carried out by the compositor thread](https://csstriggers.com/transform) with the help of the GPU.

As result, we get smoother transition (navbar hide animation) on mobiles:

| Before   | After    |
| -------- | -------- |
| ![ezgif com-gif-maker (15)](https://user-images.githubusercontent.com/4408379/107229800-4d6e1800-6a2f-11eb-8e0d-99a05057f482.gif) | ![ezgif com-gif-maker (16)](https://user-images.githubusercontent.com/4408379/107229773-46dfa080-6a2f-11eb-9950-614eba15e7fb.gif) |

UPD: As per the discussion in https://github.com/tailwindlabs/tailwindcss/pull/1380, I changed `translateY` to `translate3d` https://twitter.com/adamwathan/status/1280902295081926656

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
