### PR TITLE
feat(v2): add fonts loaders + webpack resolve.roots

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -19,6 +19,7 @@ import {
   getCustomBabelConfigFilePath,
   getMinimizer,
 } from './utils';
+import {STATIC_ASSETS_DIR_NAME} from '../constants';
 
 const CSS_REGEX = /\.css$/;
 const CSS_MODULE_REGEX = /\.module\.css$/;
@@ -91,6 +92,14 @@ export function createBaseConfig(
     resolve: {
       extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
       symlinks: true,
+      roots: [
+        // Allow resolution of url("/fonts/xyz.ttf") by webpack
+        // See https://webpack.js.org/configuration/resolve/#resolveroots
+        // See https://github.com/webpack-contrib/css-loader/issues/1256
+        path.join(siteDir, STATIC_ASSETS_DIR_NAME),
+        siteDir,
+        process.cwd(),
+      ],
       alias: {
         '@site': siteDir,
         '@generated': generatedFilesDir,
@@ -152,6 +161,7 @@ export function createBaseConfig(
     module: {
       rules: [
         fileLoaderUtils.rules.images(),
+        fileLoaderUtils.rules.fonts(),
         fileLoaderUtils.rules.media(),
         fileLoaderUtils.rules.svg(),
         fileLoaderUtils.rules.otherAssets(),

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -235,7 +235,7 @@ export function compile(config: Configuration[]): Promise<Stats.ToJsonOutput> {
   });
 }
 
-type AssetFolder = 'images' | 'files' | 'medias';
+type AssetFolder = 'images' | 'files' | 'fonts' | 'medias';
 
 // Inspired by https://github.com/gatsbyjs/gatsby/blob/8e6e021014da310b9cc7d02e58c9b3efe938c665/packages/gatsby/src/utils/webpack-utils.ts#L447
 export function getFileLoaderUtils(): Record<string, any> {
@@ -288,6 +288,13 @@ export function getFileLoaderUtils(): Record<string, any> {
       return {
         use: [loaders.url({folder: 'images'})],
         test: /\.(ico|jpg|jpeg|png|gif|webp)(\?.*)?$/,
+      };
+    },
+
+    fonts: (): RuleSetRule => {
+      return {
+        use: [loaders.url({folder: 'fonts'})],
+        test: /\.(woff|woff2|eot|ttf|otf)$/,
       };
     },
 


### PR DESCRIPTION
## Motivation

After upgrading css-loader here: https://github.com/facebook/docusaurus/pull/4081

The `url(/my/font.ttf)` are not  resolved by Webpack, while it was not the case before.

Exemple in:

```css
@font-face {
  font-family: "Iran Sans";
  font-style: normal;
  font-weight: 100;
  src: url("/fonts/IRANSans5.5/IRANSansWeb_UltraLight.eot"),
    /* IE9 Compat Modes */
      url("/fonts/IRANSans5.5/IRANSansWeb_UltraLight.eot?#iefix")
      format("embedded-opentype"),
    /* IE6-IE8 */ url("/fonts/IRANSans5.5/IRANSansWeb_UltraLight.woff2")
      format("woff2"),
    /* Super Modern Browsers */
      url("/fonts/IRANSans5.5/IRANSansWeb_UltraLight.woff") format("woff"),
    /* Modern Browsers */ url("/fonts/IRANSans5.5/IRANSansWeb_UltraLight.ttf")
      format("truetype");
} 
```

The CSS above now fails to build, because `/fonts/IRANSans5.5/IRANSansWeb_UltraLight.eot` can't be resolved (due to not resolving from the static folder, and also because there's no loader for .eot files.

I think it's not a bad idea to go through the Webpack assets pipeline in such case (as it hash the assets, allowing easier/better caching) so we won't disable this, but need to keep the existing userland CSS retrocompatible.

More context discussed here: https://github.com/webpack-contrib/css-loader/issues/1256

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Tested locally using a site using the CSS above:
https://github.com/massoudmaboudi/datagit_v2.docusaurus

After this change, the site can now build again after upgrading Docusaurus while it can't without this change.

