### PR TITLE
docs(v1): fixing a broken link in blog posts

### DIFF
--- a/website-1.x/blog/2019-12-30-docusaurus-2019-recap.md
+++ b/website-1.x/blog/2019-12-30-docusaurus-2019-recap.md
@@ -8,7 +8,7 @@ authorTwitter: yangshunz
 tags: [recap]
 ---
 
-2019 was a great year for Docusaurus - we've made tremendous progress on [Docusaurus 2](https://v2.docusaurus.io/). Current Docusaurus 1 users who aren't using the translations feature can feel free to check it out and [migrate](https://v2.docusaurus.io/docs/migrating-from-v1-to-v2) to it! Otherwise we will work with you to make that happen in 2020 :)
+2019 was a great year for Docusaurus - we've made tremendous progress on [Docusaurus 2](https://v2.docusaurus.io/). Current Docusaurus 1 users who aren't using the translations feature can feel free to check it out and [migrate](https://v2.docusaurus.io/docs/migration) to it! Otherwise we will work with you to make that happen in 2020 :)
 
 <!--truncate-->
 


### PR DESCRIPTION
Fixing this broken link in Blog post. This link changed long after the blog was published.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes