### PR TITLE
feat(v2): auto focus to tab if it is outside viewport

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -67,7 +67,10 @@ function Tabs(props: Props): JSX.Element {
         });
 
         selectedTab.classList.add(styles.tabItemActive);
-        setTimeout(() => selectedTab.classList.add(styles.tabItemActive), 2000);
+        setTimeout(
+          () => selectedTab.classList.remove(styles.tabItemActive),
+          2000,
+        );
       }, 150);
     }
   };

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -14,6 +14,13 @@ import clsx from 'clsx';
 
 import styles from './styles.module.css';
 
+function isInViewport(element: HTMLElement) {
+  const {top, left, bottom, right} = element.getBoundingClientRect();
+  const {innerHeight, innerWidth} = window;
+
+  return top >= 0 && right <= innerWidth && bottom <= innerHeight && left >= 0;
+}
+
 const keys = {
   left: 37,
   right: 39,
@@ -48,6 +55,20 @@ function Tabs(props: Props): JSX.Element {
 
     if (groupId != null) {
       setTabGroupChoices(groupId, selectedTabValue);
+
+      setTimeout(() => {
+        if (isInViewport(selectedTab)) {
+          return;
+        }
+
+        selectedTab.scrollIntoView({
+          block: 'center',
+          behavior: 'smooth',
+        });
+
+        selectedTab.classList.add(styles.tabItemActive);
+        setTimeout(() => selectedTab.classList.add(styles.tabItemActive), 2000);
+      }, 150);
     }
   };
 

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
@@ -9,3 +9,15 @@
   margin-top: 0 !important;
 }
 
+.tabItemActive {
+  animation: blink 0.5s ease-in-out 5;
+}
+
+@keyframes blink {
+  0% {
+    background-color: var(--ifm-hover-overlay);
+  }
+  100% {
+    background-color: rgba(0, 0, 0, 0);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Trying to fix #3728

Currently, the thing is if tab sync is enabled, and going to switch from long-content tab to short one, we will not see a new tab on the screen. This is confusing for users and they have to manually scroll to the desired tab.

I suggest avoiding this unpleasant action by automatically focusing on the tab, but __only__ if really necessary (when the new tab is outside the viewport).

I intentionally  didn't do this via the new prop because it's a useful UX improvement that anyone using the synching tabs feature will need.

To achieve this, we had to move hideable navbar state to the context provider (by analogy with the announcement bar).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![ezgif com-gif-maker (14)](https://user-images.githubusercontent.com/4408379/107401663-28070a00-6b14-11eb-9422-1ca0adb7b2f3.gif) | ![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/4408379/107401686-2d645480-6b14-11eb-92e9-bbbed6649e93.gif) |

<details>
  <summary>Used code for test</summary>
  
```js
import Tabs from '@theme/Tabs';
import TabItem from '@theme/TabItem';

<Tabs
  groupId="test"
  defaultValue="one"
  values={[
    { label: 'Long tab', value: 'one' },
    { label: 'Short tab', value: 'two' }
]}>
<TabItem value="one">

<div style={{height: '1000px', border: '1px solid'}}></div>

</TabItem>

<TabItem value="two">

<div style={{height: '100px', border: '1px solid'}}></div>

</TabItem>
</Tabs>

---

<Tabs
  groupId="test"
  defaultValue="one"
  values={[
    { label: 'Long tab', value: 'one' },
    { label: 'Short tab', value: 'two' }
]}>
<TabItem value="one">

<div style={{height: '1000px', border: '1px solid'}}></div>

</TabItem>

<TabItem value="two">

<div style={{height: '100px', border: '1px solid'}}></div>

</TabItem>
</Tabs>
```
</details>





## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
