### PR TITLE
feat(v2): Add i18n default code translation bundles

### DIFF
--- a/packages/docusaurus-theme-classic/codeTranslations/fr.json
+++ b/packages/docusaurus-theme-classic/codeTranslations/fr.json
@@ -1,0 +1,18 @@
+{
+  "theme.NotFound.title": "Page introuvable",
+  "theme.NotFound.p1": "Nous n'avons pas trouvé ce que vous recherchez.",
+  "theme.NotFound.p2": "Veuillez contacter le propriétaire du site qui vous a lié à l'URL d'origine et leur faire savoir que leur lien est cassé.",
+  "theme.BlogListPaginator.newerEntries": "Nouvelles entrées",
+  "theme.BlogListPaginator.olderEntries": "Anciennes entrées",
+  "theme.BlogPostItem.readMore": "Lire plus",
+  "theme.BlogPostPaginator.newerPost": "Article plus récent",
+  "theme.BlogPostPaginator.olderPost": "Article plus ancien",
+  "theme.CodeBlock.copied": "Copié",
+  "theme.CodeBlock.copy": "Copier",
+  "theme.DocPaginator.previous": "Précédent",
+  "theme.DocPaginator.next": "Suivant",
+  "theme.EditThisPage.editThisPage": "Éditer cette page",
+  "theme.SkipToContent.skipToMainContent": "Aller au contenu principal",
+  "theme.Playground.liveEditor": "Éditeur en direct",
+  "theme.Playground.result": "Résultat"
+}

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import Module from 'module';
 import postcss from 'postcss';
 import rtlcss from 'rtlcss';
+import {readDefaultCodeTranslationMessages} from '@docusaurus/utils';
 
 const createRequire = Module.createRequire || Module.createRequireFromPath;
 const requireFromDocusaurusCore = createRequire(
@@ -102,6 +103,13 @@ export default function docusaurusThemeClassic(
 
     getTranslationFiles: async () => getTranslationFiles({themeConfig}),
     translateThemeConfig,
+
+    getDefaultCodeTranslationMessages: () => {
+      return readDefaultCodeTranslationMessages({
+        dirPath: path.resolve(__dirname, '..', 'codeTranslations'),
+        locale: currentLocale,
+      });
+    },
 
     getClientModules() {
       const modules = [

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -240,6 +240,12 @@ export interface Plugin<T, U = unknown> {
 
   // translations
   getTranslationFiles?(): Promise<TranslationFiles>;
+  getDefaultCodeTranslationMessages?(): Promise<
+    Record<
+      string, // id
+      string // message
+    >
+  >;
   translateContent?({
     content,
     translationFiles,

--- a/packages/docusaurus-utils/src/__tests__/__fixtures__/defaultCodeTranslations/en.json
+++ b/packages/docusaurus-utils/src/__tests__/__fixtures__/defaultCodeTranslations/en.json
@@ -1,0 +1,4 @@
+{
+  "id1": "message 1 en",
+  "id2": "message 2 en"
+}

--- a/packages/docusaurus-utils/src/__tests__/__fixtures__/defaultCodeTranslations/fr.json
+++ b/packages/docusaurus-utils/src/__tests__/__fixtures__/defaultCodeTranslations/fr.json
@@ -1,0 +1,4 @@
+{
+  "id1": "message 1 fr",
+  "id2": "message 2 fr"
+}

--- a/packages/docusaurus-utils/src/__tests__/__fixtures__/defaultCodeTranslations/fr_FR.json
+++ b/packages/docusaurus-utils/src/__tests__/__fixtures__/defaultCodeTranslations/fr_FR.json
@@ -1,0 +1,5 @@
+{
+  "id1": "message 1 fr_FR",
+  "id2": "message 2 fr_FR",
+  "id3": "message 3 fr_FR"
+}

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -6,6 +6,7 @@
  */
 
 import path from 'path';
+import fs from 'fs-extra';
 import {
   fileToPath,
   simpleHash,
@@ -33,6 +34,7 @@ import {
   findFolderContainingFile,
   getFolderContainingFile,
   updateTranslationFileMessages,
+  readDefaultCodeTranslationMessages,
 } from '../index';
 import {sum} from 'lodash';
 
@@ -716,5 +718,91 @@ describe('updateTranslationFileMessages', () => {
         t3: {message: 'prefix t3 message suffix', description: 't3 desc'},
       },
     });
+  });
+});
+
+describe('readDefaultCodeTranslationMessages', () => {
+  const dirPath = path.resolve(
+    __dirname,
+    '__fixtures__',
+    'defaultCodeTranslations',
+  );
+
+  async function readAsJSON(filename: string) {
+    return JSON.parse(
+      await fs.readFile(path.resolve(dirPath, filename), 'utf8'),
+    );
+  }
+
+  test('for empty locale', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: '',
+        dirPath,
+      }),
+    ).resolves.toEqual({});
+  });
+
+  test('for unexisting locale', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: 'es',
+        dirPath,
+      }),
+    ).resolves.toEqual({});
+  });
+
+  test('for fr but bad folder', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: '',
+        dirPath: __dirname,
+      }),
+    ).resolves.toEqual({});
+  });
+
+  test('for fr', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: 'fr',
+        dirPath,
+      }),
+    ).resolves.toEqual(await readAsJSON('fr.json'));
+  });
+
+  test('for fr_FR', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: 'fr_FR',
+        dirPath,
+      }),
+    ).resolves.toEqual(await readAsJSON('fr_FR.json'));
+  });
+
+  test('for en', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: 'en',
+        dirPath,
+      }),
+    ).resolves.toEqual(await readAsJSON('en.json'));
+  });
+
+  test('for en_US', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: 'en_US',
+        dirPath,
+      }),
+    ).resolves.toEqual(await readAsJSON('en.json'));
+  });
+
+  test('for en_WHATEVER', async () => {
+    await expect(
+      readDefaultCodeTranslationMessages({
+        locale: 'en_WHATEVER',
+        dirPath,
+      }),
+    ).resolves.toEqual(await readAsJSON('en.json'));
   });
 });

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -602,3 +602,35 @@ export function updateTranslationFileMessages(
     })),
   };
 }
+
+export async function readDefaultCodeTranslationMessages({
+  dirPath,
+  locale,
+}: {
+  dirPath: string;
+  locale: string;
+}): Promise<Record<string, string>> {
+  const fileNamesToTry = [locale];
+
+  if (locale.includes('_')) {
+    const language = locale.split('_')[0];
+    if (language) {
+      fileNamesToTry.push(language);
+    }
+  }
+
+  // Return the content of the first file that match
+  // fr_FR.json => fr.json => nothing
+  for (const fileName of fileNamesToTry) {
+    const filePath = path.resolve(dirPath, `${fileName}.json`);
+
+    // eslint-disable-next-line no-await-in-loop
+    if (await fs.pathExists(filePath)) {
+      // eslint-disable-next-line no-await-in-loop
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      return JSON.parse(fileContent);
+    }
+  }
+
+  return {};
+}

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -32,7 +32,10 @@ import {loadHtmlTags} from './html-tags';
 import {getPackageJsonVersion} from './versions';
 import {handleDuplicateRoutes} from './duplicateRoutes';
 import {loadI18n, localizePath} from './i18n';
-import {readCodeTranslationFileContent} from './translations/translations';
+import {
+  readCodeTranslationFileContent,
+  getPluginsDefaultCodeTranslationMessages,
+} from './translations/translations';
 import {mapValues} from 'lodash';
 
 type LoadContextOptions = {
@@ -267,10 +270,15 @@ ${Object.keys(registry)
     JSON.stringify(i18n, null, 2),
   );
 
+  const codeTranslationsWithFallbacks: Record<string, string> = {
+    ...(await getPluginsDefaultCodeTranslationMessages(plugins)),
+    ...codeTranslations,
+  };
+
   const genCodeTranslations = generate(
     generatedFilesDir,
     'codeTranslations.json',
-    JSON.stringify(codeTranslations, null, 2),
+    JSON.stringify(codeTranslationsWithFallbacks, null, 2),
   );
 
   // Version metadata.

--- a/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
@@ -551,7 +551,7 @@ describe('getPluginsDefaultCodeTranslationMessages', () => {
   });
 });
 
-describe.only('applyDefaultCodeTranslations', () => {
+describe('applyDefaultCodeTranslations', () => {
   const consoleSpy = jest.spyOn(console, 'warn').mockImplementation() as any;
   beforeEach(() => {
     consoleSpy.mockClear();
@@ -609,12 +609,7 @@ describe.only('applyDefaultCodeTranslations', () => {
       },
     });
     expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy.mock.calls[0][0]).toMatchInlineSnapshot(`
-      "[33mUnused default message codes found.[39m
-      [33mPlease report this Docusaurus issue.[39m
-      [33m- unknownId[39m
-      [33m[39m"
-    `);
+    expect(consoleSpy.mock.calls[0][0]).toMatch(/unknownId/);
   });
 
   test('for realistic scenario', () => {
@@ -656,12 +651,7 @@ describe.only('applyDefaultCodeTranslations', () => {
       },
     });
     expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy.mock.calls[0][0]).toMatchInlineSnapshot(`
-      "[33mUnused default message codes found.[39m
-      [33mPlease report this Docusaurus issue.[39m
-      [33m- idUnknown1[39m
-      [33m- idUnknown2[39m
-      [33m[39m"
-    `);
+    expect(consoleSpy.mock.calls[0][0]).toMatch(/idUnknown1/);
+    expect(consoleSpy.mock.calls[0][0]).toMatch(/idUnknown2/);
   });
 });

--- a/packages/docusaurus/src/server/translations/translations.ts
+++ b/packages/docusaurus/src/server/translations/translations.ts
@@ -8,7 +8,11 @@ import path from 'path';
 import fs from 'fs-extra';
 import {InitPlugin} from '../plugins/init';
 import {mapValues, difference} from 'lodash';
-import {TranslationFileContent, TranslationFile} from '@docusaurus/types';
+import {
+  TranslationFileContent,
+  TranslationFile,
+  TranslationMessage,
+} from '@docusaurus/types';
 import {getPluginI18nPath, toMessageRelativeFilePath} from '@docusaurus/utils';
 import * as Joi from 'joi';
 import chalk from 'chalk';
@@ -258,4 +262,47 @@ export async function localizePluginTranslationFile({
   } else {
     return translationFile;
   }
+}
+
+export async function getPluginsDefaultCodeTranslationMessages(
+  plugins: InitPlugin[],
+): Promise<Record<string, string>> {
+  const pluginsMessages = await Promise.all(
+    plugins.map((plugin) => plugin.getDefaultCodeTranslationMessages?.() ?? {}),
+  );
+
+  return pluginsMessages.reduce((allMessages, pluginMessages) => {
+    return {...allMessages, ...pluginMessages};
+  }, {});
+}
+
+export function applyDefaultCodeTranslations({
+  extractedCodeTranslations,
+  defaultCodeMessages,
+}: {
+  extractedCodeTranslations: Record<string, TranslationMessage>;
+  defaultCodeMessages: Record<string, string>;
+}): Record<string, TranslationMessage> {
+  const unusedDefaultCodeMessages = difference(
+    Object.keys(defaultCodeMessages),
+    Object.keys(extractedCodeTranslations),
+  );
+  if (unusedDefaultCodeMessages.length > 0) {
+    console.warn(
+      chalk.yellow(`Unused default message codes found.
+Please report this Docusaurus issue.
+- ${unusedDefaultCodeMessages.join('\n- ')}
+`),
+    );
+  }
+
+  return mapValues(
+    extractedCodeTranslations,
+    (messageTranslation, messageId) => {
+      return {
+        ...messageTranslation,
+        message: defaultCodeMessages[messageId] ?? messageTranslation.message,
+      };
+    },
+  );
 }


### PR DESCRIPTION

## Motivation

For strings hardcoded in a theme (like "next"/"previous" pagination labels), we can pre-translate them in the current locale so that the user does not have to.

These "provided translation bundles" serve for 2 things:
- init the files with fallback messages when using `docusaurus write-translations --locale fr`
- fallback message values when running `docusaurus start --locale fr` even if `fr/code.json` does not exist

## Test Plan

Tests
