### PR TITLE
docs(v2): Fix link to slash introduction svg

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.68/introduction.md
+++ b/website/versioned_docs/version-2.0.0-alpha.68/introduction.md
@@ -28,7 +28,7 @@ Most users are already using v2 ([trends](https://www.npmtrends.com/docusaurus-v
 
 ## A better Docusaurus is coming to town
 
-<img alt="Docusaurus " src={require('@docusaurus/useBaseUrl').default('img/slash-introducing.svg')} />
+![Docusaurus Slash Introduction](/img/slash-introducing.svg)
 
 Docusaurus 1 used to be a pure documentation site generator. In Docusaurus 2, we rebuilt it from the ground up, allowing for more customizability but preserved the best parts of Docusaurus 1 - easy to get started, versioned docs, and i18n (_coming soon_).
 

--- a/website/versioned_docs/version-2.0.0-alpha.69/introduction.md
+++ b/website/versioned_docs/version-2.0.0-alpha.69/introduction.md
@@ -28,7 +28,7 @@ Most users are already using v2 ([trends](https://www.npmtrends.com/docusaurus-v
 
 ## A better Docusaurus is coming to town
 
-<img alt="Docusaurus " src={require('@docusaurus/useBaseUrl').default('img/slash-introducing.svg')} />
+![Docusaurus Slash Introduction](/img/slash-introducing.svg)
 
 Docusaurus 1 used to be a pure documentation site generator. In Docusaurus 2, we rebuilt it from the ground up, allowing for more customizability but preserved the best parts of Docusaurus 1 - easy to get started, versioned docs, and i18n (_coming soon_).
 

--- a/website/versioned_docs/version-2.0.0-alpha.70/introduction.md
+++ b/website/versioned_docs/version-2.0.0-alpha.70/introduction.md
@@ -28,7 +28,7 @@ Most users are already using v2 ([trends](https://www.npmtrends.com/docusaurus-v
 
 ## A better Docusaurus is coming to town
 
-<img alt="Docusaurus " src={require('@docusaurus/useBaseUrl').default('img/slash-introducing.svg')} />
+![Docusaurus Slash Introduction](/img/slash-introducing.svg)
 
 Docusaurus 1 used to be a pure documentation site generator. In Docusaurus 2, we rebuilt it from the ground up, allowing for more customizability but preserved the best parts of Docusaurus 1 - easy to get started, versioned docs, and i18n (_coming soon_).
 


### PR DESCRIPTION
## Motivation

According to #4126, we shouldn't be using `baseUrl` for the images in markdowns. It also broke the image on the old versioned docs (You can also see this on https://v2.docusaurus.io/docs/):

<img width="1258" alt="Screen Shot 2021-02-16 at 10 38 16" src="https://user-images.githubusercontent.com/4290500/108085329-376de200-7043-11eb-9338-d2b783146719.png">

I replaced the `img` tag with markdown image link, to make it consistent with the latest docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Now fixed:

<img width="1216" alt="Screen Shot 2021-02-16 at 10 38 37" src="https://user-images.githubusercontent.com/4290500/108085283-2a50f300-7043-11eb-94ea-1522b92d5b82.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
