### PR TITLE
docs(v2): fix npm/yarn command example for swizzling TypeScript theme components

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.70/typescript-support.md
+++ b/website/versioned_docs/version-2.0.0-alpha.70/typescript-support.md
@@ -29,7 +29,7 @@ Now you can start writing TypeScript theme components.
 For themes that supports TypeScript theme components, you can add the `--typescript` flag to the end of swizzling command to get TypeScript source code. For example, the following command will generate `index.tsx` and `styles.module.css` into `src/theme/Footer`.
 
 ```bash npm2yarn
-npm run swizzle @docusaurus/theme-classic Footer --typescript
+npm run swizzle @docusaurus/theme-classic Footer -- --typescript
 ```
 
 At this moment, the only official Docusaurus theme that supports TypeScript theme components is `@docusaurus/theme-classic`. If you are a Docusaurus theme package author who wants to add TypeScript support, see the [Lifecycle APIs docs](./lifecycle-apis.md#gettypescriptthemepath).


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The example was not working, because there was no extra `--` in front of `--typescript`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Testing is pretty simple: run the previous example on the command line which does not work as the `--typescript` is interpreted as part of the npm command, and run the new example with an extra `--` which does work as the `--typescript` is interpreted as an option for the docusaurus command.