### PR TITLE
feat(v2): editUrl functions should receive md doc permalink

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -184,26 +184,31 @@ describe('loadBlog', () => {
     expect(editUrlFunction).toHaveBeenCalledWith({
       blogDirPath: 'blog',
       blogPath: 'date-matter.md',
+      permalink: '/blog/date-matter',
       locale: 'en',
     });
     expect(editUrlFunction).toHaveBeenCalledWith({
       blogDirPath: 'blog',
       blogPath: 'draft.md',
+      permalink: '/blog/draft',
       locale: 'en',
     });
     expect(editUrlFunction).toHaveBeenCalledWith({
       blogDirPath: 'blog',
       blogPath: 'complex-slug.md',
+      permalink: '/blog/hey/my super path/héllô',
       locale: 'en',
     });
     expect(editUrlFunction).toHaveBeenCalledWith({
       blogDirPath: 'blog',
       blogPath: 'simple-slug.md',
+      permalink: '/blog/simple/slug',
       locale: 'en',
     });
     expect(editUrlFunction).toHaveBeenCalledWith({
       blogDirPath: 'i18n/en/docusaurus-plugin-content-blog',
       blogPath: '2018-12-14-Happy-First-Birthday-Slash.md',
+      permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
       locale: 'en',
     });
   });

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -27,6 +27,7 @@ export type FeedType = 'rss' | 'atom';
 export type EditUrlFunction = (editUrlParams: {
   blogDirPath: string;
   blogPath: string;
+  permalink: string;
   locale: string;
 }) => string | undefined;
 

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -321,6 +321,7 @@ describe('simple site', () => {
       version: 'current',
       versionDocsDirPath: 'docs',
       docPath: path.posix.join('foo', 'baz.md'),
+      permalink: '/docs/foo/bazSlug.html',
       locale: 'en',
     });
   });
@@ -672,6 +673,7 @@ describe('versioned site', () => {
       version: '1.0.0',
       versionDocsDirPath: 'versioned_docs/version-1.0.0',
       docPath: path.join('hello.md'),
+      permalink: '/docs/1.0.0/hello',
       locale: 'en',
     });
   });

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -119,32 +119,6 @@ export function processDocMetadata({
   // ex: myDoc -> .
   const docsFileDirName = path.dirname(source);
 
-  const relativeFilePath = path.relative(docsDirPath, filePath);
-
-  function getDocEditUrl() {
-    if (typeof options.editUrl === 'function') {
-      return options.editUrl({
-        version: versionMetadata.versionName,
-        versionDocsDirPath: posixPath(
-          path.relative(siteDir, versionMetadata.docsDirPath),
-        ),
-        docPath: posixPath(relativeFilePath),
-        locale: context.i18n.currentLocale,
-      });
-    } else if (typeof options.editUrl === 'string') {
-      const isLocalized = docsDirPath === versionMetadata.docsDirPathLocalized;
-      const baseVersionEditUrl =
-        isLocalized && options.editLocalizedFiles
-          ? versionMetadata.versionEditUrlLocalized
-          : versionMetadata.versionEditUrl;
-      return getEditUrl(relativeFilePath, baseVersionEditUrl);
-    } else {
-      return undefined;
-    }
-  }
-
-  const docsEditUrl = getDocEditUrl();
-
   const {frontMatter = {}, excerpt} = parseMarkdownString(content);
   const {sidebar_label, custom_edit_url} = frontMatter;
 
@@ -194,6 +168,31 @@ export function processDocMetadata({
 
   const permalink = normalizeUrl([versionMetadata.versionPath, docSlug]);
 
+  function getDocEditUrl() {
+    const relativeFilePath = path.relative(docsDirPath, filePath);
+
+    if (typeof options.editUrl === 'function') {
+      return options.editUrl({
+        version: versionMetadata.versionName,
+        versionDocsDirPath: posixPath(
+          path.relative(siteDir, versionMetadata.docsDirPath),
+        ),
+        docPath: posixPath(relativeFilePath),
+        permalink,
+        locale: context.i18n.currentLocale,
+      });
+    } else if (typeof options.editUrl === 'string') {
+      const isLocalized = docsDirPath === versionMetadata.docsDirPathLocalized;
+      const baseVersionEditUrl =
+        isLocalized && options.editLocalizedFiles
+          ? versionMetadata.versionEditUrlLocalized
+          : versionMetadata.versionEditUrl;
+      return getEditUrl(relativeFilePath, baseVersionEditUrl);
+    } else {
+      return undefined;
+    }
+  }
+
   // Assign all of object properties during instantiation (if possible) for
   // NodeJS optimization.
   // Adding properties to object after instantiation will cause hidden
@@ -207,7 +206,7 @@ export function processDocMetadata({
     source: aliasedSitePath(filePath, siteDir),
     slug: docSlug,
     permalink,
-    editUrl: custom_edit_url !== undefined ? custom_edit_url : docsEditUrl,
+    editUrl: custom_edit_url !== undefined ? custom_edit_url : getDocEditUrl(),
     version: versionMetadata.versionName,
     lastUpdatedBy: lastUpdate.lastUpdatedBy,
     lastUpdatedAt: lastUpdate.lastUpdatedAt,

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -35,6 +35,7 @@ export type EditUrlFunction = (editUrlParams: {
   version: string;
   versionDocsDirPath: string;
   docPath: string;
+  permalink: string;
   locale: string;
 }) => string | undefined;
 

--- a/website/docs/api/plugins/plugin-content-blog.md
+++ b/website/docs/api/plugins/plugin-content-blog.md
@@ -38,7 +38,7 @@ module.exports = {
         /**
          * For advanced cases, compute the edit url for each markdown file yourself.
          */
-        editUrl: ({locale, blogDirPath, blogPath}) => {
+        editUrl: ({locale, blogDirPath, blogPath, permalink}) => {
           return `https://github.com/facebook/docusaurus/edit/master/website/${blogDirPath}/${blogPath}`;
         },
         /**

--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -38,7 +38,13 @@ module.exports = {
         /**
          * For advanced cases, compute the edit url for each markdown file yourself.
          */
-        editUrl: function ({locale, version, versionDocsDirPath, docPath}) {
+        editUrl: function ({
+          locale,
+          version,
+          versionDocsDirPath,
+          docPath,
+          permalink,
+        }) {
           return `https://github.com/facebook/docusaurus/edit/master/website/${versionDocsDirPath}/${docPath}`;
         },
         /**


### PR DESCRIPTION


## Motivation

The `editUrl` fn should provide the user with the doc/blog permalink.

This is useful for future integrations with online editing sandboxes like StackBlitz and CodeSandbox, as it allows to load the site on the correct page by passing a querystring param.

cc @EricSimons

## Test Plan

tests
