### PR TITLE
fix(v2): website editUrl should target upstream docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -228,13 +228,15 @@ const LocaleConfigs = isI18nStaging
           // routeBasePath: '/',
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: ({locale, versionDocsDirPath, docPath}) => {
+          editUrl: ({locale, docPath}) => {
             if (locale !== 'en') {
               return `https://crowdin.com/project/docusaurus-v2/${locale}`;
             }
-            return `https://github.com/facebook/docusaurus/edit/master/website/${versionDocsDirPath}/${docPath}`;
+            // We want users to submit doc updates to the upstream/next version!
+            // Otherwise we risk losing the update on the next release.
+            const nextVersionDocsDirPath = 'docs';
+            return `https://github.com/facebook/docusaurus/edit/master/website/${nextVersionDocsDirPath}/${docPath}`;
           },
-          editCurrentVersion: true,
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
           remarkPlugins: [


### PR DESCRIPTION

## Motivation

As I introduced the `editUrl` fn, I didn't see I broke the fact that edit buttons should lead to the upstream docs, so we receive doc update PRs to update alpha 70 instead of the docs of the upcoming release.

We prefer to receive docs PR to upstream docs, because if the user does not modify the upstream docs, the update will be lost on next release.