### PR TITLE
fix(v2): fix website versions page

### DIFF
--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -20,7 +20,6 @@ function Version() {
   const pastVersions = versions.filter(
     (version) => version !== latestVersion && version.name !== 'current',
   );
-  const stableVersion = pastVersions.shift();
   const repoUrl = `https://github.com/${siteConfig.organizationName}/${siteConfig.projectName}`;
 
   return (
@@ -30,7 +29,7 @@ function Version() {
       <main className="container margin-vert--lg">
         <h1>Docusaurus documentation versions</h1>
 
-        {stableVersion && (
+        {latestVersion && (
           <div className="margin-bottom--lg">
             <h3 id="next">Current version (Stable)</h3>
             <p>
@@ -39,12 +38,12 @@ function Version() {
             <table>
               <tbody>
                 <tr>
-                  <th>{stableVersion.name}</th>
+                  <th>{latestVersion.label}</th>
                   <td>
-                    <Link to={stableVersion.path}>Documentation</Link>
+                    <Link to={latestVersion.path}>Documentation</Link>
                   </td>
                   <td>
-                    <a href={`${repoUrl}/releases/tag/v${stableVersion.name}`}>
+                    <a href={`${repoUrl}/releases/tag/v${latestVersion.name}`}>
                       Release Notes
                     </a>
                   </td>
@@ -54,23 +53,25 @@ function Version() {
           </div>
         )}
 
-        <div className="margin-bottom--lg">
-          <h3 id="latest">Next version (Unreleased)</h3>
-          <p>
-            Here you can find the documentation for work-in-process unreleased
-            version.
-          </p>
-          <table>
-            <tbody>
-              <tr>
-                <th>{latestVersion.label}</th>
-                <td>
-                  <Link to={latestVersion.path}>Documentation</Link>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        {currentVersion !== latestVersion && (
+          <div className="margin-bottom--lg">
+            <h3 id="latest">Next version (Unreleased)</h3>
+            <p>
+              Here you can find the documentation for work-in-process unreleased
+              version.
+            </p>
+            <table>
+              <tbody>
+                <tr>
+                  <th>{currentVersion.label}</th>
+                  <td>
+                    <Link to={currentVersion.path}>Documentation</Link>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
 
         {pastVersions.length > 0 && (
           <div className="margin-bottom--lg">


### PR DESCRIPTION

## Motivation


The current versions page is wrong:

![image](https://user-images.githubusercontent.com/749374/108200977-7f623700-711f-11eb-8c9f-9bc6ad594863.png)

This  is likely because we use a little trick in dev so what you see in dev and prod is not 100% identical:

`lastVersion: isDev ? 'current' : undefined,`


I've made it so that the versions page show decent infos in both cases.

Dev:

![image](https://user-images.githubusercontent.com/749374/108201085-a456aa00-711f-11eb-9644-58069d251e6d.png)


Prod:

![image](https://user-images.githubusercontent.com/749374/108201138-b33d5c80-711f-11eb-9dc1-dcdeada5c260.png)
