### PR TITLE
fixed codeblocks layout with long code

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -213,7 +213,8 @@ export default function CodeBlock({
               tabIndex={0}
               className={clsx(className, styles.codeBlock, 'thin-scrollbar', {
                 [styles.codeBlockWithTitle]: codeBlockTitle,
-              })}>
+              })}
+              style={style}>
               <div className={styles.codeBlockLines} style={style}>
                 {tokens.map((line, i) => {
                   if (line.length === 1 && line[0].content === '') {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -58,6 +58,7 @@
   float: left;
   min-width: 100%;
   padding: var(--ifm-pre-padding);
+  width: 1px;
 }
 
 @media print {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #3870 

I found a workaround to fix the layout issue. First of all, the issue was coming in case of code with long code only. I tried fixing the width to 1px and adding the style to the parent element for fixing the dark/light mode and it fixed the issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

It works for manually for all the pages which were broken otherwise for all versions like:
https://v2.docusaurus.io/docs/2.0.0-alpha.69/markdown-features/
https://v2.docusaurus.io/docs/next/markdown-features/react

