### PR TITLE
docs(v2): v2 migration should mention RSS feed url change

### DIFF
--- a/website/docs/migration/migration-manual.md
+++ b/website/docs/migration/migration-manual.md
@@ -572,6 +572,12 @@ The Docusaurus front matter fields for the blog have been changed from camelCase
 
 The fields `authorFBID` and `authorTwitter` have been deprecated. They are only used for generating the profile image of the author which can be done via the `author_image_url` field.
 
+## Deployment
+
+The `CNAME` file used by GitHub Pages is not generated anymore, so be sure you have created it in `/static/CNAME` if you use a custom domain.
+
+The blog RSS feed is now hosted at `/blog/rss.xml` instead of `/blog/feed.xml`. You may want to configure server-side redirects so that users' subscriptions keep working.
+
 ## Test your site
 
 After migration, your folder structure should look like this:

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -10,3 +10,6 @@
 /fr/*         /fr/404.html          404
 
 
+# Redirect Docusaurus v1 blog RSS feed
+/blog/feed.xml   /blog/rss.xml
+


### PR DESCRIPTION

## Motivation

When migrating to Docusaurus v2, v1 users should not lose their v1 RSS feed subscribers