### PR TITLE
fix(v2): remove PostCSS plugin for combine duplicated selectors

### DIFF
--- a/packages/docusaurus-cssnano-preset/index.js
+++ b/packages/docusaurus-cssnano-preset/index.js
@@ -6,14 +6,12 @@
  */
 
 const advancedBasePreset = require('cssnano-preset-advanced');
-const postCssCombineDuplicatedSelectors = require('postcss-combine-duplicated-selectors');
 const postCssSortMediaQueries = require('postcss-sort-media-queries');
 const postCssRemoveOverriddenCustomProperties = require('./src/remove-overridden-custom-properties');
 
 const preset = advancedBasePreset({autoprefixer: {add: true}});
 
 preset.plugins.unshift(
-  [postCssCombineDuplicatedSelectors, {removeDuplicatedValues: true}],
   [postCssSortMediaQueries],
   [postCssRemoveOverriddenCustomProperties],
 );

--- a/packages/docusaurus-cssnano-preset/package.json
+++ b/packages/docusaurus-cssnano-preset/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "cssnano-preset-advanced": "^4.0.7",
     "postcss": "^7.0.2",
-    "postcss-combine-duplicated-selectors": "^9.1.0",
     "postcss-sort-media-queries": "^1.7.26"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15451,14 +15451,6 @@ postcss-colormin@^4.0.3:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-combine-duplicated-selectors@^9.1.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/postcss-combine-duplicated-selectors/-/postcss-combine-duplicated-selectors-9.4.0.tgz#dae866debae5f93b58e13e6cc69419105e91336a"
-  integrity sha512-rMnO1H3wgR1T6QSlK3i8Slz9p3xD+0yOi4J7qwh/5PGR3z8jbgYvRlNKAIvXDtGBQbJKoWs4df5skL3a/fdUEA==
-  dependencies:
-    postcss "^7.0.0"
-    postcss-selector-parser "^6.0.0"
-
 postcss-convert-values@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz#ca3813ed4da0f812f9d43703584e449ebe189a7f"
@@ -16032,7 +16024,7 @@ postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
+postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
   integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Should fix #4231

At the moment, when we do not control the order of including CSS files, it is better to remove this plugin, because it raises more problems than it solved for us.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See reproducible section in #4231.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
