### PR TITLE
fix(v2): make doc container full width when hidden sidebar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -115,7 +115,10 @@ function DocPageContent({
             )}
           </div>
         )}
-        <main className={styles.docMainContainer}>
+        <main
+          className={clsx(styles.docMainContainer, {
+            [styles.docMainContainerEnhanced]: hiddenSidebarContainer,
+          })}>
           <div
             className={clsx(
               'container padding-vert--lg',

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -19,6 +19,10 @@
     max-width: calc(100% - var(--doc-sidebar-width));
   }
 
+  .docMainContainerEnhanced {
+    max-width: none;
+  }
+
   .docSidebarContainer {
     width: var(--doc-sidebar-width);
     margin-top: calc(-1 * var(--ifm-navbar-height));


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

PR #4241 was merged too quickly so I didn't have time to test it as it introduced a small regression for collapsible doc sidebar.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After (centered)   |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/108354089-0683dd80-71fa-11eb-9eca-ecb5b9c3f364.png) | ![image](https://user-images.githubusercontent.com/4408379/108354120-156a9000-71fa-11eb-9127-28ddd6cb84b6.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
