### PR TITLE
chore(v2): Fix build size bot

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -10,10 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        # Workaround for https://github.com/preactjs/compressed-size-action/issues/54
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: 'build:v2:en'
           pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
-          minimum-change-threshold: 100
+          minimum-change-threshold: 30

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -20,3 +20,4 @@ jobs:
           pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 30
+          compression: 'none'


### PR DESCRIPTION


## Motivation

Due to a bug in the GH action, we didn't get appropriate size diffs!

https://github.com/preactjs/compressed-size-action/issues/54

This is a workaround