### PR TITLE
fix(v2): fix LTR PostCSS bug on Netlify and monorepo symlinks

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -157,14 +157,11 @@ export default function docusaurusThemeClassic(
       if (direction === 'rtl') {
         postCssOptions.plugins.push(
           postcss.plugin('RtlCssPlugin', () => {
+            const resolvedInfimaFile = require.resolve(
+              getInfimaCSSFile(direction),
+            );
             function isInfimaCSSFile(file) {
-              return (
-                file.endsWith(getInfimaCSSFile(direction)) ||
-                // special case for our own monorepo using symlinks!
-                file.endsWith(
-                  'infima/packages/core/dist/css/default/default-rtl.css',
-                )
-              );
+              return file === resolvedInfimaFile;
             }
 
             return function (root: any) {


### PR DESCRIPTION


## Motivation


`infima/packages/core/dist/css/default/default-rtl.css` is not a "reliable" path to check for the Infima CSS bundle.

On Infima repo, it broke because  Netlify fetches the Infima repo as `repo` (ie not `infima`) and the CSS file is at `/opt/build/repo/packages/core/dist/css/default/default-rtl.css`

This broke the RTL support on Infima website deploy preview: https://github.com/facebookincubator/infima/pull/84

The current method will be more reliable, as we are now comparing strictly 2 absolute file paths.



