### PR TITLE
docs(v2): Add docusaurus2-graphql-doc-generator to community resources

### DIFF
--- a/website/community/resources.md
+++ b/website/community/resources.md
@@ -39,6 +39,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
 - [docusaurus-plugin-remote-content](https://github.com/rdilweb/docusaurus-plugin-remote-content) - A Docusaurus v2 plugin that allows you to fetch content from remote sources
+- [docusaurus2-graphql-doc-generator](https://github.com/edno/docusaurus2-graphql-doc-generator) - A Docusaurus v2 plugin for generating documentation from a GraphQL schema
 
 ## Enterprise usage
 


### PR DESCRIPTION
## Motivation

As a team developing a GraphQL gateway, we wanted to be able to have an easy way to discover and search through the API without having to explore it using GraphiQL. Since, we were already using Docusaurus as documentation portal, it seems to be a perfect fit for generating API documentation.

We have developed a small plugin that converts a GraphQL schema into hyperlinked markdown pages compatible with Docusaurus docs.

![screenshot-localhost_8080-2021 02 20-09_44_02](https://user-images.githubusercontent.com/324670/108590383-9002ef00-7363-11eb-8fd9-68b8d9ff9611.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests can be found in https://github.com/edno/docusaurus2-graphql-doc-generator/tree/main/tests

## Related PRs

None
