### PR TITLE
refactor(v2): improve notifier message

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -8,6 +8,7 @@
  */
 
 const chalk = require('chalk');
+const fs = require('fs-extra');
 const semver = require('semver');
 const path = require('path');
 const cli = require('commander');
@@ -49,6 +50,10 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
     .filter((p) => p.startsWith('@docusaurus'))
     .map((p) => p.concat('@latest'))
     .join(' ');
+  const isYarnUsed = fs.existsSync(path.resolve(process.cwd(), 'yarn.lock'));
+  const upgradeCommand = isYarnUsed
+    ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
+    : `npm i ${siteDocusaurusPackagesForUpdate}`;
 
   const boxenOptions = {
     padding: 1,
@@ -64,7 +69,7 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
     )}${chalk.green(
       `${notifier.update.latest}`,
     )}\n\nTo upgrade Docusaurus packages with the latest version, run the following command:\n${chalk.cyan(
-      `yarn upgrade ${siteDocusaurusPackagesForUpdate}`,
+      `${upgradeCommand}`,
     )}`,
     boxenOptions,
   );

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -11,6 +11,8 @@ const chalk = require('chalk');
 const semver = require('semver');
 const path = require('path');
 const cli = require('commander');
+const updateNotifier = require('update-notifier');
+const boxen = require('boxen');
 const {
   build,
   swizzle,
@@ -21,15 +23,18 @@ const {
   clear,
   writeTranslations,
 } = require('../lib');
-const requiredVersion = require('../package.json').engines.node;
-const pkg = require('../package.json');
-const updateNotifier = require('update-notifier');
-const boxen = require('boxen');
+const {
+  name,
+  version,
+  engines: {node: requiredVersion},
+} = require('../package.json');
 
-// notify user if @docusaurus/core is outdated
+// notify user if @docusaurus packages is outdated
 const notifier = updateNotifier({
-  pkg,
-  updateCheckInterval: 1000 * 60 * 60 * 24, // one day
+  pkg: {
+    name,
+    version,
+  },
 });
 
 // allow the user to be notified for updates on the first run
@@ -38,6 +43,13 @@ if (notifier.lastUpdateCheck === Date.now()) {
 }
 
 if (notifier.update && notifier.update.current !== notifier.update.latest) {
+  // eslint-disable-next-line import/no-dynamic-require
+  const sitePkg = require(path.resolve(process.cwd(), 'package.json'));
+  const siteDocusaurusPackagesForUpdate = Object.keys(sitePkg.dependencies)
+    .filter((p) => p.startsWith('@docusaurus'))
+    .map((p) => p.concat('@latest'))
+    .join(' ');
+
   const boxenOptions = {
     padding: 1,
     margin: 1,
@@ -49,9 +61,11 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
   const docusaurusUpdateMessage = boxen(
     `Update available ${chalk.dim(`${notifier.update.current}`)}${chalk.reset(
       ' → ',
-    )}${chalk.green(`${notifier.update.latest}`)}\nRun ${chalk.cyan(
-      'yarn upgrade @docusaurus/core',
-    )} to update`,
+    )}${chalk.green(
+      `${notifier.update.latest}`,
+    )}\n\nTo upgrade Docusaurus packages with the latest version, run the following command:\n${chalk.cyan(
+      `yarn upgrade ${siteDocusaurusPackagesForUpdate}`,
+    )}`,
     boxenOptions,
   );
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

According to[ this article](https://dev.to/wgao19/why-running-yarn-upgrade-does-not-update-my-package-json-3mon
), if the project has previously uses a package with caret version, then updating without specifying the version range will not update the `package.json` file.
Therefore, we need to explicitly specify the version in notifier message in order to update the core package correctly.

And since usually not only the core package is used, in the message I also included other packages from @docusaurus scope so that they are also upgraded.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

With two basic packages:

![image](https://user-images.githubusercontent.com/4408379/108592562-6c4da200-737f-11eb-9276-1b0385363b69.png)

With several packages:

![image](https://user-images.githubusercontent.com/4408379/108592578-87201680-737f-11eb-83c1-78a471957fa7.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
