### PR TITLE
feat(v2): add icon to generic sidebar link

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -157,6 +157,7 @@ function DocSidebarItemLink({
       <Link
         className={clsx('menu__link', {
           'menu__link--active': isActive,
+          [styles.menuLinkExternal]: !isInternalUrl(href),
         })}
         to={href}
         {...(isInternalUrl(href) && {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -119,5 +119,19 @@
 }
 
 :global(.menu__list-item--collapsed) :global(.menu__list) {
-  height: 0px !important;
+  height: 0 !important;
+}
+
+.menuLinkExternal {
+  align-items: center;
+}
+.menuLinkExternal:after {
+  content: '';
+  height: 1.15rem;
+  width: 1.15rem;
+  min-width: 1.15rem;
+  margin: 0 auto 0 3%;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24'%3E%3Cpath fill='rgba(0,0,0,0.5)' d='M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z'/%3E%3C/svg%3E")
+    no-repeat;
+  filter: var(--ifm-menu-link-sublist-icon-filter);
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I've noticed that many docs sites have external links in the sidebar that are visually different from the usual ones.
Typically an icon serves as a visual marker for external link, so I added one to the corresponding sidebar item type.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![image](https://user-images.githubusercontent.com/4408379/108624892-c8d0c000-7458-11eb-81e8-543521ed7d60.png)

```js
{
  type: 'link',
  label: 'External link',
  href: 'https://example.com',
},
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
