### PR TITLE
chore(v2): PostCSS peer dep fix

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -92,6 +92,7 @@
     "null-loader": "^4.0.0",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "pnp-webpack-plugin": "^1.6.4",
+    "postcss": "^8.2.6",
     "postcss-loader": "^4.1.0",
     "postcss-preset-env": "^6.7.0",
     "prompts": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16289,7 +16289,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.1
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.2.4:
+postcss@^8.2.4, postcss@^8.2.6:
   version "8.2.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.6.tgz#5d69a974543b45f87e464bc4c3e392a97d6be9fe"
   integrity sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==


### PR DESCRIPTION
## Motivation

Fixes the project on Yarn v2, because postcss-loader has a peer on postcss, but it isnt provided by docusaurus, only implied by postcss-preset-env, so it breaks.  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Its just a lockfile change, shouldnt break anything

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
