### PR TITLE
fix(v2): Allow null as valid for title of item in footer links. 

### DIFF
--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -287,7 +287,7 @@ const ThemeConfigSchema = Joi.object({
     links: Joi.array()
       .items(
         Joi.object({
-          title: Joi.string(),
+          title: Joi.string().allow(null),
           items: Joi.array().items(FooterLinkItemSchema).default([]),
         }),
       )


### PR DESCRIPTION
## Motivation

I want to make the category title in the footer links disappear. This is particularly useful when you do not have many links, so displaying category headings for the links isn't necessarily appropriate. Conveniently, the footer plugin already handles this by testing if the title is null and if so skipping writing the h4 section. Thus, the only change is to allow a null value for the title in the classic theme validation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have tested this change change by setting a footer title to both to null:
```
 footer: {
      style: 'dark',
      copyright: `Copyright © ${new Date().getFullYear()}`,
      links: [
        {
          title: null,
          items: [
            {
              label: 'Some Page',
              to: 'page',
            },
          ],
        },
       ],
}
```
and verifying that there are no error and that the title is not displayed.