### PR TITLE
fix(v2): Code blocks should be LTR by default

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -207,7 +207,7 @@ export default function CodeBlock({
               {codeBlockTitle}
             </div>
           )}
-          <div className={styles.codeBlockContent}>
+          <div className={clsx(styles.codeBlockContent, language)}>
             <div
               /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
               tabIndex={0}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -7,6 +7,7 @@
 
 .codeBlockContent {
   position: relative;
+  direction: ltr;
 }
 
 .codeBlockTitle {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -7,6 +7,7 @@
 
 .codeBlockContent {
   position: relative;
+  /*rtl:ignore*/
   direction: ltr;
 }
 

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
@@ -24,6 +24,8 @@
 
 .playgroundEditor {
   font-family: var(--ifm-font-family-monospace) !important;
+  /*rtl:ignore*/
+  direction: ltr;
 }
 
 .playgroundPreview {


### PR DESCRIPTION

## Motivation

Code blocks should rather be LTR by default.

Using RTLCSS ignore directive to force the RTL style: https://rtlcss.com/learn/usage-guide/control-directives/

Not totally sure RTL code blocks make any sense, but asked a question here: https://github.com/shadeed/rtl-styling/issues/13

Added the language as className in case the user wants to override this on a per-language basis