### PR TITLE
docs(v2): Fix examples by importing React

### DIFF
--- a/website/docs/using-themes.md
+++ b/website/docs/using-themes.md
@@ -143,6 +143,7 @@ Here is an example to display some text just above the footer, with minimal code
 ```js title="src/theme/Footer.js"
 // Note: importing from "@theme/Footer" would fail due to the file importing itself
 import OriginalFooter from '@theme-original/Footer';
+import React from 'react';
 
 export default function Footer(props) {
   return (
@@ -162,6 +163,7 @@ Here's an example of using this feature to enhance the default theme `CodeBlock`
 
 ```js
 import InitialCodeBlock from '@theme-init/CodeBlock';
+import React from 'react';
 
 export default function CodeBlock(props) {
   return props.live ? (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Code examples fail without `import React from 'react';`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tried implementing on my project with the copied code from docs. `yarn start` succeeded, but served blank screen.

## Related PRs

Didn't find any.
