### PR TITLE
feat(v2): allow specifying max depth for TOC

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`inline code should be escaped 1`] = `
+exports[`toc plugin inline code should be escaped 1`] = `
 "export const toc = [
 	{
 		value: '<code>&lt;Head /&gt;</code>',
@@ -42,7 +42,54 @@ exports[`inline code should be escaped 1`] = `
 "
 `;
 
-exports[`non text phrasing content 1`] = `
+exports[`toc plugin maximum deeply headings 1`] = `
+"export const toc = [
+	{
+		value: 'Bravo',
+		id: 'bravo',
+		children: [
+			{
+				value: 'Charlie',
+				id: 'charlie',
+				children: [
+					{
+						value: 'Delta',
+						id: 'delta',
+						children: [
+							{
+								value: 'Echo',
+								id: 'echo',
+								children: [
+									{
+										value: 'Foxtrot',
+										id: 'foxtrot',
+										children: []
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+];
+
+# Alpha
+
+## Bravo
+
+### Charlie
+
+#### Delta
+
+##### Echo
+
+###### Foxtrot
+"
+`;
+
+exports[`toc plugin non text phrasing content 1`] = `
 "export const toc = [
 	{
 		value: '<em>Emphasis</em>',

--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/fixtures/maximum-depth-6.md
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/fixtures/maximum-depth-6.md
@@ -1,0 +1,11 @@
+# Alpha
+
+## Bravo
+
+### Charlie
+
+#### Delta
+
+##### Echo
+
+###### Foxtrot

--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/fixtures/test.md
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/fixtures/test.md
@@ -1,0 +1,11 @@
+# Alpha
+
+## Bravo
+
+### Charlie
+
+#### Delta
+
+##### Echo
+
+###### Foxtrot

--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/index.test.js
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/index.test.js
@@ -23,20 +23,20 @@ const processFixture = async (name, options) => {
 
   return result.toString();
 };
+describe('toc plugin', () => {
+  test('non text phrasing content', async () => {
+    const result = await processFixture('non-text-content');
+    expect(result).toMatchSnapshot();
+  });
 
-test('non text phrasing content', async () => {
-  const result = await processFixture('non-text-content');
-  expect(result).toMatchSnapshot();
-});
+  test('inline code should be escaped', async () => {
+    const result = await processFixture('inline-code');
+    expect(result).toMatchSnapshot();
+  });
 
-test('inline code should be escaped', async () => {
-  const result = await processFixture('inline-code');
-  expect(result).toMatchSnapshot();
-});
-
-test('text content', async () => {
-  const result = await processFixture('just-content');
-  expect(result).toMatchInlineSnapshot(`
+  test('text content', async () => {
+    const result = await processFixture('just-content');
+    expect(result).toMatchInlineSnapshot(`
     "export const toc = [
     	{
     		value: 'Endi',
@@ -78,11 +78,11 @@ test('text content', async () => {
     ## I ♥ unicode.
     "
   `);
-});
+  });
 
-test('should export even with existing name', async () => {
-  const result = await processFixture('name-exist');
-  expect(result).toMatchInlineSnapshot(`
+  test('should export even with existing name', async () => {
+    const result = await processFixture('name-exist');
+    expect(result).toMatchInlineSnapshot(`
     "export const toc = [
     	{
     		value: 'Thanos',
@@ -109,14 +109,14 @@ test('should export even with existing name', async () => {
     ### Avengers
     "
   `);
-});
+  });
 
-test('should export with custom name', async () => {
-  const options = {
-    name: 'customName',
-  };
-  const result = await processFixture('just-content', options);
-  expect(result).toMatchInlineSnapshot(`
+  test('should export with custom name', async () => {
+    const options = {
+      name: 'customName',
+    };
+    const result = await processFixture('just-content', options);
+    expect(result).toMatchInlineSnapshot(`
     "export const customName = [
     	{
     		value: 'Endi',
@@ -158,11 +158,11 @@ test('should export with custom name', async () => {
     ## I ♥ unicode.
     "
   `);
-});
+  });
 
-test('should insert below imports', async () => {
-  const result = await processFixture('insert-below-imports');
-  expect(result).toMatchInlineSnapshot(`
+  test('should insert below imports', async () => {
+    const result = await processFixture('insert-below-imports');
+    expect(result).toMatchInlineSnapshot(`
     "import something from 'something';
 
     import somethingElse from 'something-else';
@@ -195,11 +195,11 @@ test('should insert below imports', async () => {
     Content.
     "
   `);
-});
+  });
 
-test('empty headings', async () => {
-  const result = await processFixture('empty-headings');
-  expect(result).toMatchInlineSnapshot(`
+  test('empty headings', async () => {
+    const result = await processFixture('empty-headings');
+    expect(result).toMatchInlineSnapshot(`
     "export const toc = [];
 
     # Ignore this
@@ -209,4 +209,10 @@ test('empty headings', async () => {
     ## ![](an-image.svg)
     "
   `);
+  });
+
+  test('maximum deeply headings', async () => {
+    const result = await processFixture('maximum-depth-6', {maxDepth: 6});
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/docusaurus-mdx-loader/src/remark/toc/index.js
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/index.js
@@ -58,11 +58,12 @@ const getOrCreateExistingTargetIndex = (children, name) => {
   return targetIndex;
 };
 
-const plugin = (options = {}) => {
+const toc = (options = {}) => {
   const name = options.name || 'toc';
+  const maxDepth = options.maxDepth || 3;
 
   const transformer = (node) => {
-    const headings = search(node);
+    const headings = search(node, maxDepth);
     const {children} = node;
     const targetIndex = getOrCreateExistingTargetIndex(children, name);
 
@@ -76,4 +77,4 @@ const plugin = (options = {}) => {
   return transformer;
 };
 
-module.exports = plugin;
+module.exports = toc;

--- a/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/index.js
+++ b/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/index.js
@@ -12,7 +12,7 @@ const visit = require('unist-util-visit');
 // We wrap the JSX syntax in code blocks so that translation tools don't mess-up with the markup
 // But the JSX inside such code blocks should still be evaluated as JSX
 // See https://github.com/facebook/docusaurus/pull/4278
-function plugin() {
+function unwrapMdxCodeBlocks() {
   const transformer = (root) => {
     visit(root, 'code', (node, _index, parent) => {
       if (node.lang === 'mdx-code-block') {
@@ -31,4 +31,4 @@ function plugin() {
   return transformer;
 }
 
-module.exports = plugin;
+module.exports = unwrapMdxCodeBlocks;

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
@@ -54,7 +54,7 @@ const nodeForImport = {
     "import Tabs from '@theme/Tabs';\nimport TabItem from '@theme/TabItem';",
 };
 
-module.exports = (options = {}) => {
+module.exports = function npm2Yarn(options = {}) {
   const {sync = false} = options;
   let transformed = false;
   const transformer = (node) => {

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -14,7 +14,10 @@ export const PluginIdSchema = Joi.string()
 
 const MarkdownPluginsSchema = Joi.array()
   .items(
-    Joi.array().ordered(Joi.function().required(), Joi.object().required()),
+    Joi.array().ordered(
+      Joi.alternatives().try(Joi.function(), Joi.string()).required(),
+      Joi.object().required(),
+    ),
     Joi.function(),
     Joi.object(),
   )

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -241,6 +241,7 @@ const LocaleConfigs = isI18nStaging
           showLastUpdateTime: true,
           remarkPlugins: [
             [require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}],
+            ['toc', {maxDepth: 4}],
           ],
           disableVersioning: isVersioningDisabled,
           lastVersion: isDev ? 'current' : undefined,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Trying to finally fix #2700.

This PR also introduces the ability to override options for the our own custom Remark plugins (see config file). Perhaps this will come in handy in #4222 to make custom headings ids configurable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
