### PR TITLE
fix(v2): fit footer in viewport when content area is too small

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -11,7 +11,6 @@ import {MDXProvider} from '@mdx-js/react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import renderRoutes from '@docusaurus/renderRoutes';
 import type {PropVersionMetadata} from '@docusaurus/plugin-content-docs-types';
-import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import DocSidebar from '@theme/DocSidebar';
 import MDXComponents from '@theme/MDXComponents';
@@ -53,93 +52,87 @@ function DocPageContent({
   }, [hiddenSidebar]);
 
   return (
-    <>
-      <Head>
-        <style>{`.main-wrapper { display: flex; }`}</style>
-      </Head>
-      <Layout
-        key={isClient}
-        searchMetadatas={{
-          version,
-          tag: docVersionSearchTag(pluginId, version),
-        }}>
-        <div className={styles.docPage}>
-          {sidebar && (
-            <div
-              className={clsx(styles.docSidebarContainer, {
-                [styles.docSidebarContainerHidden]: hiddenSidebarContainer,
-              })}
-              onTransitionEnd={(e) => {
-                if (
-                  !e.currentTarget.classList.contains(
-                    styles.docSidebarContainer,
-                  )
-                ) {
-                  return;
-                }
+    <Layout
+      key={isClient}
+      wrapperClassName="main-docs-wrapper"
+      searchMetadatas={{
+        version,
+        tag: docVersionSearchTag(pluginId, version),
+      }}>
+      <div className={styles.docPage}>
+        {sidebar && (
+          <div
+            className={clsx(styles.docSidebarContainer, {
+              [styles.docSidebarContainerHidden]: hiddenSidebarContainer,
+            })}
+            onTransitionEnd={(e) => {
+              if (
+                !e.currentTarget.classList.contains(styles.docSidebarContainer)
+              ) {
+                return;
+              }
 
-                if (hiddenSidebarContainer) {
-                  setHiddenSidebar(true);
-                }
-              }}
-              role="complementary">
-              <DocSidebar
-                key={
-                  // Reset sidebar state on sidebar changes
-                  // See https://github.com/facebook/docusaurus/issues/3414
-                  sidebarName
-                }
-                sidebar={sidebar}
-                path={currentDocRoute.path}
-                sidebarCollapsible={
-                  siteConfig.themeConfig?.sidebarCollapsible ?? true
-                }
-                onCollapse={toggleSidebar}
-                isHidden={hiddenSidebar}
-              />
+              if (hiddenSidebarContainer) {
+                setHiddenSidebar(true);
+              }
+            }}
+            role="complementary">
+            <DocSidebar
+              key={
+                // Reset sidebar state on sidebar changes
+                // See https://github.com/facebook/docusaurus/issues/3414
+                sidebarName
+              }
+              sidebar={sidebar}
+              path={currentDocRoute.path}
+              sidebarCollapsible={
+                siteConfig.themeConfig?.sidebarCollapsible ?? true
+              }
+              onCollapse={toggleSidebar}
+              isHidden={hiddenSidebar}
+            />
 
-              {hiddenSidebar && (
-                <div
-                  className={styles.collapsedDocSidebar}
-                  title={translate({
-                    id: 'theme.docs.sidebar.expandButtonTitle',
-                    message: 'Expand sidebar',
-                    description:
-                      'The ARIA label and title attribute for expand button of doc sidebar',
-                  })}
-                  aria-label={translate({
-                    id: 'theme.docs.sidebar.expandButtonAriaLabel',
-                    message: 'Expand sidebar',
-                    description:
-                      'The ARIA label and title attribute for expand button of doc sidebar',
-                  })}
-                  tabIndex={0}
-                  role="button"
-                  onKeyDown={toggleSidebar}
-                  onClick={toggleSidebar}>
-                  <IconArrow className={styles.expandSidebarButtonIcon} />
-                </div>
-              )}
-            </div>
-          )}
-          <main
-            className={clsx(styles.docMainContainer, {
-              [styles.docMainContainerEnhanced]: hiddenSidebarContainer,
-            })}>
-            <div
-              className={clsx(
-                'container padding-vert--lg',
-                styles.docItemWrapper,
-                {
-                  [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
-                },
-              )}>
-              <MDXProvider components={MDXComponents}>{children}</MDXProvider>
-            </div>
-          </main>
-        </div>
-      </Layout>
-    </>
+            {hiddenSidebar && (
+              <div
+                className={styles.collapsedDocSidebar}
+                title={translate({
+                  id: 'theme.docs.sidebar.expandButtonTitle',
+                  message: 'Expand sidebar',
+                  description:
+                    'The ARIA label and title attribute for expand button of doc sidebar',
+                })}
+                aria-label={translate({
+                  id: 'theme.docs.sidebar.expandButtonAriaLabel',
+                  message: 'Expand sidebar',
+                  description:
+                    'The ARIA label and title attribute for expand button of doc sidebar',
+                })}
+                tabIndex={0}
+                role="button"
+                onKeyDown={toggleSidebar}
+                onClick={toggleSidebar}>
+                <IconArrow className={styles.expandSidebarButtonIcon} />
+              </div>
+            )}
+          </div>
+        )}
+        <main
+          className={clsx(styles.docMainContainer, {
+            [styles.docMainContainerEnhanced]: hiddenSidebarContainer,
+          })}>
+          <div
+            className={clsx(
+              'container padding-vert--lg',
+              styles.docItemWrapper,
+              {
+                [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
+              },
+            )}>
+            <MDXProvider components={MDXComponents}>{children}</MDXProvider>
+          </div>
+        </main>
+      </div>
+    </Layout>
   );
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -11,6 +11,7 @@ import {MDXProvider} from '@mdx-js/react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import renderRoutes from '@docusaurus/renderRoutes';
 import type {PropVersionMetadata} from '@docusaurus/plugin-content-docs-types';
+import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import DocSidebar from '@theme/DocSidebar';
 import MDXComponents from '@theme/MDXComponents';
@@ -52,86 +53,93 @@ function DocPageContent({
   }, [hiddenSidebar]);
 
   return (
-    <Layout
-      key={isClient}
-      searchMetadatas={{
-        version,
-        tag: docVersionSearchTag(pluginId, version),
-      }}>
-      <div className={styles.docPage}>
-        {sidebar && (
-          <div
-            className={clsx(styles.docSidebarContainer, {
-              [styles.docSidebarContainerHidden]: hiddenSidebarContainer,
-            })}
-            onTransitionEnd={(e) => {
-              if (
-                !e.currentTarget.classList.contains(styles.docSidebarContainer)
-              ) {
-                return;
-              }
+    <>
+      <Head>
+        <style>{`.main-wrapper { display: flex; }`}</style>
+      </Head>
+      <Layout
+        key={isClient}
+        searchMetadatas={{
+          version,
+          tag: docVersionSearchTag(pluginId, version),
+        }}>
+        <div className={styles.docPage}>
+          {sidebar && (
+            <div
+              className={clsx(styles.docSidebarContainer, {
+                [styles.docSidebarContainerHidden]: hiddenSidebarContainer,
+              })}
+              onTransitionEnd={(e) => {
+                if (
+                  !e.currentTarget.classList.contains(
+                    styles.docSidebarContainer,
+                  )
+                ) {
+                  return;
+                }
 
-              if (hiddenSidebarContainer) {
-                setHiddenSidebar(true);
-              }
-            }}
-            role="complementary">
-            <DocSidebar
-              key={
-                // Reset sidebar state on sidebar changes
-                // See https://github.com/facebook/docusaurus/issues/3414
-                sidebarName
-              }
-              sidebar={sidebar}
-              path={currentDocRoute.path}
-              sidebarCollapsible={
-                siteConfig.themeConfig?.sidebarCollapsible ?? true
-              }
-              onCollapse={toggleSidebar}
-              isHidden={hiddenSidebar}
-            />
+                if (hiddenSidebarContainer) {
+                  setHiddenSidebar(true);
+                }
+              }}
+              role="complementary">
+              <DocSidebar
+                key={
+                  // Reset sidebar state on sidebar changes
+                  // See https://github.com/facebook/docusaurus/issues/3414
+                  sidebarName
+                }
+                sidebar={sidebar}
+                path={currentDocRoute.path}
+                sidebarCollapsible={
+                  siteConfig.themeConfig?.sidebarCollapsible ?? true
+                }
+                onCollapse={toggleSidebar}
+                isHidden={hiddenSidebar}
+              />
 
-            {hiddenSidebar && (
-              <div
-                className={styles.collapsedDocSidebar}
-                title={translate({
-                  id: 'theme.docs.sidebar.expandButtonTitle',
-                  message: 'Expand sidebar',
-                  description:
-                    'The ARIA label and title attribute for expand button of doc sidebar',
-                })}
-                aria-label={translate({
-                  id: 'theme.docs.sidebar.expandButtonAriaLabel',
-                  message: 'Expand sidebar',
-                  description:
-                    'The ARIA label and title attribute for expand button of doc sidebar',
-                })}
-                tabIndex={0}
-                role="button"
-                onKeyDown={toggleSidebar}
-                onClick={toggleSidebar}>
-                <IconArrow className={styles.expandSidebarButtonIcon} />
-              </div>
-            )}
-          </div>
-        )}
-        <main
-          className={clsx(styles.docMainContainer, {
-            [styles.docMainContainerEnhanced]: hiddenSidebarContainer,
-          })}>
-          <div
-            className={clsx(
-              'container padding-vert--lg',
-              styles.docItemWrapper,
-              {
-                [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
-              },
-            )}>
-            <MDXProvider components={MDXComponents}>{children}</MDXProvider>
-          </div>
-        </main>
-      </div>
-    </Layout>
+              {hiddenSidebar && (
+                <div
+                  className={styles.collapsedDocSidebar}
+                  title={translate({
+                    id: 'theme.docs.sidebar.expandButtonTitle',
+                    message: 'Expand sidebar',
+                    description:
+                      'The ARIA label and title attribute for expand button of doc sidebar',
+                  })}
+                  aria-label={translate({
+                    id: 'theme.docs.sidebar.expandButtonAriaLabel',
+                    message: 'Expand sidebar',
+                    description:
+                      'The ARIA label and title attribute for expand button of doc sidebar',
+                  })}
+                  tabIndex={0}
+                  role="button"
+                  onKeyDown={toggleSidebar}
+                  onClick={toggleSidebar}>
+                  <IconArrow className={styles.expandSidebarButtonIcon} />
+                </div>
+              )}
+            </div>
+          )}
+          <main
+            className={clsx(styles.docMainContainer, {
+              [styles.docMainContainerEnhanced]: hiddenSidebarContainer,
+            })}>
+            <div
+              className={clsx(
+                'container padding-vert--lg',
+                styles.docItemWrapper,
+                {
+                  [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
+                },
+              )}>
+              <MDXProvider components={MDXComponents}>{children}</MDXProvider>
+            </div>
+          </main>
+        </div>
+      </Layout>
+    </>
   );
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -9,6 +9,10 @@
   --doc-sidebar-width: 300px;
 }
 
+:global(.main-docs-wrapper) {
+  display: flex;
+}
+
 .docPage,
 .docMainContainer {
   display: flex;

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -9,12 +9,13 @@
   --doc-sidebar-width: 300px;
 }
 
-@media (min-width: 997px) {
-  .docPage {
-    display: flex;
-    width: 100%;
-  }
+.docPage,
+.docMainContainer {
+  display: flex;
+  width: 100%;
+}
 
+@media (min-width: 997px) {
   .docMainContainer {
     flex-grow: 1;
     max-width: calc(100% - var(--doc-sidebar-width));
@@ -72,10 +73,6 @@
 }
 
 @media (max-width: 996px) {
-  .docPage {
-    display: inherit;
-  }
-
   .docSidebarContainer {
     margin-top: 0;
   }

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -12,6 +12,7 @@
 @media (min-width: 997px) {
   .docPage {
     display: flex;
+    width: 100%;
   }
 
   .docMainContainer {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -13,7 +13,8 @@
   .sidebar {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    max-height: 100vh;
+    height: 100%;
     position: sticky;
     top: 0;
     padding-top: var(--ifm-navbar-height);

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -23,5 +23,4 @@ body {
 
 .main-wrapper {
   flex: 1 0 auto;
-  display: flex;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -23,4 +23,5 @@ body {
 
 .main-wrapper {
   flex: 1 0 auto;
+  display: flex;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Remove the minimum doc sidebar height equal to the viewport (i.e. 100vh) to make visible footer in it if there is very small content on any doc page (see screenshots below).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before:

The footer is not visible in viewport, although there is very little doc content. 

![image](https://user-images.githubusercontent.com/4408379/109388103-185e3280-7916-11eb-9587-118de01bee66.png)

After:

The footer is visible on screen with small content area (no need to scroll the page for this).

![image](https://user-images.githubusercontent.com/4408379/109388028-b7365f00-7915-11eb-801e-343866f5a1fc.png)

```
---
id: empty
title: Empty page
---

```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
