### PR TITLE
misc: restore build size bot

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,0 +1,26 @@
+
+name: Build Size Report
+
+on:
+  # Note! you can't safely use "pull_request_target" here
+  # This workflow is mostly be useful for "internal PRs"
+  # External PRs won't be able to post a PR comment
+  # See https://github.com/preactjs/compressed-size-action/issues/54
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          build-script: 'build:v2:en'
+          pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
+          strip-hash: '\.([^;]\w{7})\.'
+          minimum-change-threshold: 30
+          compression: 'none'

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -3,7 +3,7 @@ name: Build Size Report
 
 on:
   # Note! you can't safely use "pull_request_target" here
-  # This workflow is mostly be useful for "internal PRs"
+  # This workflow is mostly useful for "internal PRs"
   # External PRs won't be able to post a PR comment
   # See https://github.com/preactjs/compressed-size-action/issues/54
   # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests


### PR DESCRIPTION
After investigating a security issue using `pull_request_target`, we decided to finally keep build size bot but using `pull_request`.

It solves the security issue, but this means the build size bot won't be able to post a PR comment if the PR is from a fork.

See https://github.com/preactjs/compressed-size-action/issues/54
See https://securitylab.github.com/research/github-actions-preventing-pwn-requests