### PR TITLE
docs(v2): update showcase instruction regarding tags + fix site tags

### DIFF
--- a/website/src/data/users.js
+++ b/website/src/data/users.js
@@ -16,6 +16,7 @@
  * Instructions:
  * - Add your site in the json array below, in alphabetical order of title
  * - Add a local image preview (decent screenshot of your Docusaurus site)
+ * - Use `tags: []`: it is our responsibility to assign site tags
  *
  * The image must be added to the GitHub repository, and use `require("image")`
  *
@@ -426,7 +427,7 @@ const users = [
     preview: require('./showcase/ocpeasy.png'),
     website: 'https://www.ocpeasy.org',
     source: 'https://github.com/ocpeasy/website',
-    tags: ['design'],
+    tags: [],
   },
   {
     title: 'Oxidizer',


### PR DESCRIPTION
## Motivation

Fix tags introduced by https://github.com/facebook/docusaurus/pull/4331

And clarify showcase instructions regarding tags