### PR TITLE
fix(v2): prevent useless blog pages to be in search results

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -26,7 +26,11 @@ function BlogListPage(props: Props): JSX.Element {
     <Layout
       title={title}
       description={blogDescription}
-      wrapperClassName="blog-wrapper">
+      wrapperClassName="blog-wrapper"
+      searchMetadatas={{
+        // assign unique search tag to exclude this page from search results!
+        tag: 'blog_posts_list',
+      }}>
       <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--2">

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
@@ -54,7 +54,11 @@ function BlogTagsListPage(props: Props): JSX.Element {
     <Layout
       title="Tags"
       description="Blog Tags"
-      wrapperClassName="blog-wrapper">
+      wrapperClassName="blog-wrapper"
+      searchMetadatas={{
+        // assign unique search tag to exclude this page from search results!
+        tag: 'blog_tags_list',
+      }}>
       <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--2">

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -59,7 +59,11 @@ function BlogTagsPostPage(props: Props): JSX.Element {
     <Layout
       title={`Posts tagged "${tagName}"`}
       description={`Blog | Tagged "${tagName}"`}
-      wrapperClassName="blog-wrapper">
+      wrapperClassName="blog-wrapper"
+      searchMetadatas={{
+        // assign unique search tag to exclude this page from search results!
+        tag: 'blog_tags_posts',
+      }}>
       <div className="container margin-vert--lg">
         <div className="row">
           <div className="col col--2">


### PR DESCRIPTION


## Motivation

Prevent duplicate search results related to tags pages

![image](https://user-images.githubusercontent.com/749374/109843400-4e1f5600-7c4b-11eb-9721-b3a696523d68.png)
