### PR TITLE
fix(v2): always extract translations from site/src

### DIFF
--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -15,7 +15,7 @@ import {
   getPluginsDefaultCodeTranslationMessages,
   applyDefaultCodeTranslations,
 } from '../server/translations/translations';
-import {extractPluginsSourceCodeTranslations} from '../server/translations/translationsExtractor';
+import {extractSiteSourceCodeTranslations} from '../server/translations/translationsExtractor';
 import {getCustomBabelConfigFilePath, getBabelOptions} from '../webpack/utils';
 
 async function writePluginTranslationFiles({
@@ -74,7 +74,8 @@ Available locales=[${context.i18n.locales.join(',')}]`,
     isServer: true,
     babelOptions: getCustomBabelConfigFilePath(siteDir),
   });
-  const extractedCodeTranslations = await extractPluginsSourceCodeTranslations(
+  const extractedCodeTranslations = await extractSiteSourceCodeTranslations(
+    siteDir,
     plugins,
     babelOptions,
   );

--- a/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
@@ -9,11 +9,12 @@ import fs from 'fs-extra';
 import tmp from 'tmp-promise';
 import {
   extractSourceCodeFileTranslations,
-  extractPluginsSourceCodeTranslations,
+  extractSiteSourceCodeTranslations,
 } from '../translationsExtractor';
 import {getBabelOptions} from '../../../webpack/utils';
 import path from 'path';
 import {InitPlugin} from '../../plugins/init';
+import {SRC_DIR_NAME} from '../../../constants';
 
 const TestBabelOptions = getBabelOptions({
   isServer: true,
@@ -231,8 +232,32 @@ export default function MyComponent<T>(props: ComponentProps<T>) {
   });
 });
 
-describe('extractPluginsSourceCodeTranslations', () => {
+describe('extractSiteSourceCodeTranslations', () => {
   test('should extract translation from all plugins source code', async () => {
+    const siteDir = await createTmpDir();
+
+    const siteComponentFile1 = path.join(
+      siteDir,
+      SRC_DIR_NAME,
+      'site-component-1.jsx',
+    );
+    await fs.ensureDir(path.dirname(siteComponentFile1));
+    await fs.writeFile(
+      siteComponentFile1,
+      `
+export default function MySiteComponent1() {
+  return (
+      <Translate
+        id="siteComponentFileId1"
+        description="site component 1 desc"
+      >
+        site component 1 message
+      </Translate>
+  );
+}
+`,
+    );
+
     function createTestPlugin(pluginDir: string): InitPlugin {
       // @ts-expect-error: good enough for this test
       return {
@@ -323,11 +348,16 @@ export default function MyComponent(props: Props) {
     const plugin2 = createTestPlugin(plugin2Dir);
 
     const plugins = [plugin1, plugin2];
-    const translations = await extractPluginsSourceCodeTranslations(
+    const translations = await extractSiteSourceCodeTranslations(
+      siteDir,
       plugins,
       TestBabelOptions,
     );
     expect(translations).toEqual({
+      siteComponentFileId1: {
+        description: 'site component 1 desc',
+        message: 'site component 1 message',
+      },
       plugin1Id1: {
         description: 'plugin1 description 1',
         message: 'plugin1 message 1',

--- a/website/src/components/TeamProfileCards/index.js
+++ b/website/src/components/TeamProfileCards/index.js
@@ -68,8 +68,9 @@ export function ActiveTeamRow() {
         name="Alexey Pyltsyn"
         githubUrl="https://github.com/lex111">
         <Translate id="team.profile.Alexey Pyltsyn.body">
-          Obsessed open-source enthusiast 👋 Eternal amateur at everything 🤷‍♂️
-          Maintainer of Russian docs on PHP, React, Kubernetes and much more 🧐
+          sdsdg Obsessed open-source enthusiast 👋 Eternal amateur at everything
+          🤷‍♂️ Maintainer of Russian docs on PHP, React, Kubernetes and much more
+          🧐
         </Translate>
       </TeamProfileCardCol>
       <TeamProfileCardCol

--- a/website/src/components/TeamProfileCards/index.js
+++ b/website/src/components/TeamProfileCards/index.js
@@ -68,9 +68,8 @@ export function ActiveTeamRow() {
         name="Alexey Pyltsyn"
         githubUrl="https://github.com/lex111">
         <Translate id="team.profile.Alexey Pyltsyn.body">
-          sdsdg Obsessed open-source enthusiast 👋 Eternal amateur at everything
-          🤷‍♂️ Maintainer of Russian docs on PHP, React, Kubernetes and much more
-          🧐
+          Obsessed open-source enthusiast 👋 Eternal amateur at everything 🤷‍♂️
+          Maintainer of Russian docs on PHP, React, Kubernetes and much more 🧐
         </Translate>
       </TeamProfileCardCol>
       <TeamProfileCardCol


### PR DESCRIPTION

## Motivation

Translations should always be extracted from `website/src` as it's were most React components will end up.

Fixes https://github.com/facebook/docusaurus/issues/4341
