### PR TITLE
docs(v1): update phrasing for website dir relative to docs dir

### DIFF
--- a/website-1.x/docs/tutorial-create-pages.md
+++ b/website-1.x/docs/tutorial-create-pages.md
@@ -49,7 +49,7 @@ React is being used as a templating engine for rendering static markup. You can 
 
 ## Create a Documentation Page
 
-1. Create a new file in the `docs` folder called `doc9.md`. The `docs` folder is in the root of your Docusaurus project, one level above `website`.
+1. Create a new file in the `docs` folder called `doc9.md`. The `docs` folder is in the root of your Docusaurus project, same level as the `website` folder.
 1. Paste the following contents:
 
 ```


### PR DESCRIPTION
## Motivation

According to the file directory shown on this tutorial page (https://docusaurus.io/docs/en/tutorial-create-new-site), both the `docs` directory and the `website` directory are in the same level. The page currently states "_The docs folder is in the root of your Docusaurus project, one level above website._"

### Have you read the [Contributing Guidelines on issues](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#reporting-new-issues)?

Yes

## Test Plan

NIL

## Related PR
(If this PR adds or changes functionality, please take some time to update the docs at 
https://github.com/facebook/docusaurus, and link to your PR here.)