### PR TITLE
fix(v2): specify proper TS path in classic theme

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -98,7 +98,7 @@ export default function docusaurusThemeClassic(
     },
 
     getTypeScriptThemePath() {
-      return path.resolve(__dirname, './theme');
+      return path.resolve(__dirname, '..', 'src', 'theme');
     },
 
     getTranslationFiles: async () => getTranslationFiles({themeConfig}),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Reported from Discord chat:

> 2.0.0-alpha.70 and 2.0.0-alpha.71 no longer output *.tsx  files like the documentation says (https://v2.docusaurus.io/docs/typescript-support#swizzling-typescript-theme-components) when swizzling with the --typescript flag. They are *.js  files instead. I looked through the release notes for said versions on whether support for this has been dropped but couldn't find anything. Did I miss anything? Is this supposed to happen?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try run `yarn swizzle @docusaurus/theme-classic Footer --typescript`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
