### PR TITLE
fix(v2): set theme color mode for SSR

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
@@ -21,9 +21,9 @@ const coerceToTheme = (theme) => {
   return theme === themes.dark ? themes.dark : themes.light;
 };
 
-const getInitialTheme = () => {
+const getInitialTheme = (defaultMode) => {
   if (!ExecutionEnvironment.canUseDOM) {
-    return themes.light; // SSR: we don't care
+    return coerceToTheme(defaultMode);
   }
   return coerceToTheme(document.documentElement.getAttribute('data-theme'));
 };
@@ -38,9 +38,9 @@ const storeTheme = (newTheme) => {
 
 const useTheme = (): useThemeReturns => {
   const {
-    colorMode: {disableSwitch, respectPrefersColorScheme},
+    colorMode: {defaultMode, disableSwitch, respectPrefersColorScheme},
   } = useThemeConfig();
-  const [theme, setTheme] = useState(getInitialTheme);
+  const [theme, setTheme] = useState(getInitialTheme(defaultMode));
 
   const setLightTheme = useCallback(() => {
     setTheme(themes.light);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Based on "bug report" from[ Discord chat](https://discord.com/channels/398180168688074762/567414046073159701/818516542806294588). 

Indeed, since the user defines site preferred color mode in config file, we can take this information to set the color mode (used by `useTheme`) during site build. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try use `colorMode.defaultMode` with `dark` value and build the site.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
