### PR TITLE
refactor(v2): add ExecutionEnvironment, BrowserOnly, isInternalUrl to type aliases

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -157,10 +157,34 @@ declare module '@docusaurus/useDocusaurusContext' {
 }
 
 declare module '@docusaurus/useBaseUrl' {
-  export default function (
+  export default function useBaseUrl(
     relativePath: string | undefined,
     opts?: {absolute?: true; forcePrependBaseUrl?: true},
   ): string;
+}
+
+declare module '@docusaurus/ExecutionEnvironment' {
+  const ExecutionEnvironment: {
+    canUseDOM: boolean;
+    canUseEventListeners: boolean;
+    canUseIntersectionObserver: boolean;
+    canUseViewport: boolean;
+  };
+  export default ExecutionEnvironment;
+}
+
+declare module '@docusaurus/BrowserOnly' {
+  export type Props = {
+    children?: () => JSX.Element;
+    fallback?: JSX.Element;
+  };
+  const BrowserOnly: (props: Props) => JSX.Element | null;
+  export default BrowserOnly;
+}
+
+declare module '@docusaurus/isInternalUrl' {
+  export function hasProtocol(url: string): boolean;
+  export default function isInternalUrl(url?: string): boolean;
 }
 
 declare module '*.module.css' {


### PR DESCRIPTION
## Motivation

add missing `ExecutionEnvironment`, `BrowserOnly`, `isInternalUrl` to known type aliases

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

if it compiles its working

## Related tickets

ref; #3424
