### PR TITLE
refactor(v2): merge linkify function used in blog and docs

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
@@ -5,14 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {resolve} from 'url';
-import {
-  DocsMarkdownOption,
-  VersionMetadata,
-  BrokenMarkdownLink,
-} from '../types';
+import {DocsMarkdownOption} from '../types';
 import {getDocsDirPaths} from '../versions';
-import {aliasedSitePath} from '@docusaurus/utils';
+import {replaceMarkdownLinks} from '@docusaurus/utils/lib/markdownLinks';
 
 function getVersion(filePath: string, options: DocsMarkdownOption) {
   const versionFound = options.versionsMetadata.find((version) =>
@@ -28,66 +23,32 @@ function getVersion(filePath: string, options: DocsMarkdownOption) {
   return versionFound;
 }
 
-function replaceMarkdownLinks(
-  fileString: string,
-  filePath: string,
-  version: VersionMetadata,
-  options: DocsMarkdownOption,
-) {
-  const {siteDir, sourceToPermalink, onBrokenMarkdownLink} = options;
-  const {docsDirPath, docsDirPathLocalized} = version;
-
-  // Replace internal markdown linking (except in fenced blocks).
-  let fencedBlock = false;
-  const lines = fileString.split('\n').map((line) => {
-    if (line.trim().startsWith('```')) {
-      fencedBlock = !fencedBlock;
-    }
-    if (fencedBlock) {
-      return line;
-    }
-
-    let modifiedLine = line;
-    // Replace inline-style links or reference-style links e.g:
-    // This is [Document 1](doc1.md) -> we replace this doc1.md with correct link
-    // [doc1]: doc1.md -> we replace this doc1.md with correct link
-    const mdRegex = /(?:(?:\]\()|(?:\]:\s?))(?!https)([^'")\]\s>]+\.mdx?)/g;
-    let mdMatch = mdRegex.exec(modifiedLine);
-    while (mdMatch !== null) {
-      // Replace it to correct html link.
-      const mdLink = mdMatch[1];
-
-      const aliasedSource = (source: string) =>
-        aliasedSitePath(source, siteDir);
-
-      const permalink =
-        sourceToPermalink[aliasedSource(resolve(filePath, mdLink))] ||
-        sourceToPermalink[aliasedSource(`${docsDirPathLocalized}/${mdLink}`)] ||
-        sourceToPermalink[aliasedSource(`${docsDirPath}/${mdLink}`)];
-
-      if (permalink) {
-        modifiedLine = modifiedLine.replace(mdLink, permalink);
-      } else {
-        const brokenMarkdownLink: BrokenMarkdownLink = {
-          version,
-          filePath,
-          link: mdLink,
-        };
-        onBrokenMarkdownLink(brokenMarkdownLink);
-      }
-      mdMatch = mdRegex.exec(modifiedLine);
-    }
-    return modifiedLine;
-  });
-
-  return lines.join('\n');
-}
-
 export function linkify(
   fileString: string,
   filePath: string,
   options: DocsMarkdownOption,
 ): string {
   const version = getVersion(filePath, options);
-  return replaceMarkdownLinks(fileString, filePath, version, options);
+  return replaceMarkdownLinks(
+    fileString,
+    filePath,
+    {
+      // TODO: refactor names and we can pass version here
+      contentPath: version.docsDirPath,
+      contentPathLocalized: version.docsDirPathLocalized,
+    },
+    {
+      siteDir: options.siteDir,
+      sourceToPermalink: options.sourceToPermalink,
+      onBrokenMarkdownLink(brokenMarkdownLink) {
+        options.onBrokenMarkdownLink({
+          // TODO: refactor version to contentPaths
+          version,
+          filePath: brokenMarkdownLink.filePath,
+          link: brokenMarkdownLink.link,
+        });
+      },
+    },
+    (permalink) => permalink,
+  );
 }

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {resolve} from 'url';
+import {aliasedSitePath} from './index';
+
+export type ContentPaths = {
+  contentPath: string;
+  contentPathLocalized: string;
+};
+
+export type BrokenMarkdownLink<T extends ContentPaths> = {
+  filePath: string;
+  contentPaths: T;
+  link: string;
+};
+
+export type ReplaceMarkdownLinksParams<
+  T extends ContentPaths,
+  S extends unknown
+> = {
+  siteDir: string;
+  sourceToPermalink: Record<string, S>;
+  onBrokenMarkdownLink: (brokenMarkdownLink: BrokenMarkdownLink<T>) => void;
+};
+
+export function replaceMarkdownLinks<T extends ContentPaths, S extends unknown>(
+  fileString: string,
+  filePath: string,
+  contentPaths: T,
+  options: ReplaceMarkdownLinksParams<T, S>,
+  getPermalink: (alias: S) => string,
+): string {
+  const {siteDir, sourceToPermalink, onBrokenMarkdownLink} = options;
+  const {contentPath, contentPathLocalized} = contentPaths;
+
+  // Replace internal markdown linking (except in fenced blocks).
+  let fencedBlock = false;
+  const lines = fileString.split('\n').map((line) => {
+    if (line.trim().startsWith('```')) {
+      fencedBlock = !fencedBlock;
+    }
+    if (fencedBlock) {
+      return line;
+    }
+
+    let modifiedLine = line;
+    // Replace inline-style links or reference-style links e.g:
+    // This is [Document 1](doc1.md) -> we replace this doc1.md with correct link
+    // [doc1]: doc1.md -> we replace this doc1.md with correct link
+    const mdRegex = /(?:(?:\]\()|(?:\]:\s?))(?!https)([^'")\]\s>]+\.mdx?)/g;
+    let mdMatch = mdRegex.exec(modifiedLine);
+    while (mdMatch !== null) {
+      // Replace it to correct html link.
+      const mdLink = mdMatch[1];
+
+      const aliasedSource = (source: string) =>
+        aliasedSitePath(source, siteDir);
+
+      const permalink =
+        sourceToPermalink[aliasedSource(resolve(filePath, mdLink))] ||
+        sourceToPermalink[aliasedSource(`${contentPathLocalized}/${mdLink}`)] ||
+        sourceToPermalink[aliasedSource(`${contentPath}/${mdLink}`)];
+
+      if (permalink) {
+        modifiedLine = modifiedLine.replace(mdLink, getPermalink(permalink));
+      } else {
+        const brokenMarkdownLink: BrokenMarkdownLink<T> = {
+          contentPaths,
+          filePath,
+          link: mdLink,
+        };
+        onBrokenMarkdownLink(brokenMarkdownLink);
+      }
+      mdMatch = mdRegex.exec(modifiedLine);
+    }
+    return modifiedLine;
+  });
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Motivation

This change extract code used for linking in blog and docs, to utils that it can be latter used in other plugins eg. pages

I decided to not refactor to much to ease code review, but i added few TODO that some of properties between docs and blog should be aligned. 

if you prefer that properties should be renamed in this PR, I'm going to merge to this one #4402

Support for pages can/should be done in separate PR as its a feature not a refactor

https://github.com/facebook/docusaurus/blob/c32d8bd11659c442fccb75fc38325ca37fa15cf2/packages/docusaurus-plugin-content-pages/src/markdownLoader.ts#L14-L19

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

ay

## Test Plan

there is no change in functionality and all unit test should pass, linking still should work in docs and in blog, 

it can be tested by clicking in one of links in docs, eg. 
https://deploy-preview-4391--docusaurus-2.netlify.app/classic/docs/contributing#get-involved
