### PR TITLE
fix(v1): Temp fix v1 site deployment: fail-safe on Crowdin upload translations error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,9 @@ jobs:
               yarn run write-translations
 
               # upload translation strings and download translations
-              yarn crowdin-upload
+              # TODO we have a weird Crowdin error "Project already contains the file", trying to resolve that with support
+              # In the meantime we should not block the v1 site deployment
+              yarn crowdin-upload || echo "Crowdin source upload failure, but we'll continue..."
 
               # download only enabled languages
               yarn crowdin-download


### PR DESCRIPTION
## Motivation

For some reasons the Crowdin cli refuse to upload 1.14.7 translations with an obscure error message, and prevents the v1 site to deploy.

I'm figuring this out with their support.

---

![image](https://user-images.githubusercontent.com/749374/110782272-39544b00-8267-11eb-8846-d47298c9d8ae.png)

Yet the v1 project does not contain those files:

https://crowdin.com/project/docusaurus

![image](https://user-images.githubusercontent.com/749374/110782313-45400d00-8267-11eb-95bb-ae19ef711e49.png)

---

Using a fail-safe translation upload so that the v1 site deployment is able to complete even if there are some crowdin errors