### PR TITLE
fix(v1): Fix v1 site deployment with Crowdin again...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           name: Deploy v1 Website
           # Skip the deploy if we don't have the right org (facebook), or if this is just a pull request
           command: |
-            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(docusaurus-1\.x\/.*)|(website-1\.x\/.*)"; then
+            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(crowdin-v1.yml)|(docusaurus-1\.x\/.*)|(website-1\.x\/.*)"; then
               echo "Skipping deploy. No relevant v1 website files have changed"
             elif [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CIRCLE_PR_USERNAME ]]; then
               echo "Deploying website v1..."
@@ -88,9 +88,12 @@ jobs:
               yarn run write-translations
 
               # upload translation strings and download translations
-              # TODO we have a weird Crowdin error "Project already contains the file", trying to resolve that with support
-              # In the meantime we should not block the v1 site deployment
-              yarn crowdin-upload || echo "Crowdin source upload failure, but we'll continue..."
+              # IMPORTANT: if this fails due to a Crowdin error like "Project already contains the file"
+              # Sometimes Crowdin refuse to upload the new versioned docs for obscure reasons
+              # Workaround: upload manually the new versioned files through the Crowdin UI...
+              # If the files already exist on Crowdin, the source upload will now work...
+              # All this has been extensively reported to their support already.
+              yarn crowdin-upload
 
               # download only enabled languages
               yarn crowdin-download

--- a/crowdin-v1.yml
+++ b/crowdin-v1.yml
@@ -3,34 +3,36 @@ api_token_env: 'CROWDIN_PERSONAL_TOKEN'
 base_path: "."
 preserve_hierarchy: true
 
+languages_mapping: &languages_mapping
+  locale:
+    'es-ES': 'es-ES'
+    'fr': 'fr'
+    'it': 'it'
+    'ja': 'ja'
+    'ko': 'ko'
+    'nl': 'nl'
+    'pt-BR': 'pt-BR'
+    'ro': 'ro'
+    'ru': 'ru'
+    'sk': 'sk-SK'
+    'sr': 'sr'
+    'sv-SE': 'sv-SE'
+    'tr': 'tr'
+    'uk': 'uk'
+    'vi': 'vi'
+    'zh-CN': 'zh-CN'
+    'zh-TW': 'zh-TW'
+
 files:
   -
     source: '/website-1.x/docs/**/*.md'
     translation: '/website-1.x/translated_docs/%locale%/**/%original_file_name%'
-    languages_mapping: &anchor
-      locale:
-        'es-ES': 'es-ES'
-        'fr': 'fr'
-        'it': 'it'
-        'ja': 'ja'
-        'ko': 'ko'
-        'nl': 'nl'
-        'pt-BR': 'pt-BR'
-        'ro': 'ro'
-        'ru': 'ru'
-        'sk': 'sk-SK'
-        'sr': 'sr'
-        'sv-SE': 'sv-SE'
-        'tr': 'tr'
-        'uk': 'uk'
-        'vi': 'vi'
-        'zh-CN': 'zh-CN'
-        'zh-TW': 'zh-TW'
+    languages_mapping: *languages_mapping
   -
     source: '/website-1.x/versioned_docs/**/*.md'
     translation: '/website-1.x/translated_docs/%locale%/**/%original_file_name%'
-    languages_mapping: *anchor
+    languages_mapping: *languages_mapping
   -
     source: '/website-1.x/i18n/en.json'
     translation: '/website-1.x/i18n/%locale%.json'
-    languages_mapping: *anchor
+    languages_mapping: *languages_mapping


### PR DESCRIPTION

## Motivation

Follow-up of https://github.com/facebook/docusaurus/pull/4396

Crowdin has a weird behavior on our v1 site and refuse to upload new versioned source files (even if you use a random filename + random file content).

```
❌ Project already contains the file 'master/website-1.x/versioned_docs/version-1.14.7/tutorial-create-pages.md'
```

The workaround is... to upload the files through their UI... 

For some reasons, our v2 deployment does not seem affected by this issue.

I've reported the issue to their support, hopefully, they'll be able to fix this.

Note: it's important that all files are uploaded to crowdin otherwise the localized v1 site has missing pages and broken links on localized sites (ie the latest version is not included in the localized sites)
