### PR TITLE
docs(v1):Removed useless s in command 'examples version'

### DIFF
--- a/website-1.x/docs/tutorial-version.md
+++ b/website-1.x/docs/tutorial-version.md
@@ -12,7 +12,7 @@ With an example site deployed, we can now try out one of the killer features of 
 Assume you are happy with the current state of the documentation and want to freeze it as the v1.0.0 docs. First you `cd` to the `website` directory and run the following command.
 
 ```sh
-npm run examples versions
+npm run examples version
 ```
 
 That command generates a `versions.json` file, which will be used to list down all the versions of docs in the project.

--- a/website-1.x/versioned_docs/version-1.13.0/tutorial-version.md
+++ b/website-1.x/versioned_docs/version-1.13.0/tutorial-version.md
@@ -13,7 +13,7 @@ With an example site deployed, we can now try out one of the killer features of 
 Assume you are happy with the current state of the documentation and want to freeze it as the v1.0.0 docs. First you `cd` to the `website` directory and run the following command.
 
 ```sh
-npm run examples versions
+npm run examples version
 ```
 
 That command generates a `versions.js` file, which will be used to list down all the versions of docs in the project.

--- a/website-1.x/versioned_docs/version-1.14.7/tutorial-version.md
+++ b/website-1.x/versioned_docs/version-1.14.7/tutorial-version.md
@@ -13,7 +13,7 @@ With an example site deployed, we can now try out one of the killer features of 
 Assume you are happy with the current state of the documentation and want to freeze it as the v1.0.0 docs. First you `cd` to the `website` directory and run the following command.
 
 ```sh
-npm run examples versions
+npm run examples version
 ```
 
 That command generates a `versions.json` file, which will be used to list down all the versions of docs in the project.


### PR DESCRIPTION
## Motivation

Fixed command in the doc. As you can see from the "scripts" section in `package.json` the command is `version` and not `versions`

https://github.com/facebook/docusaurus/blob/ac28dc70917e2746b5229b1717f21dbe0acdba6e/packages/docusaurus-1.x/lib/copy-examples.js#L59


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Docs contribution only.