### PR TITLE
types(v2): add simple script to generate type aliases

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -75,7 +75,7 @@ declare module '@docusaurus/Head' {
 
 declare module '@docusaurus/Link' {
   type RRLinkProps = Partial<import('react-router-dom').LinkProps>;
-  type LinkProps = RRLinkProps & {
+  export type LinkProps = RRLinkProps & {
     to?: string;
     activeClassName?: string;
     isNavLink?: boolean;

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc --noEmit && yarn babel:lib && yarn babel:lib-next && yarn prettier:lib-next",
     "watch": "concurrently -n \"lib,lib-next\" --kill-others \"yarn babel:lib --watch\" \"yarn babel:lib-next --watch\"",
+    "update:types": "tsc -p tsconfig.types.json && node update-types.js && prettier --write \"src/types.d.ts\"",
     "babel:lib": "cross-env BABEL_ENV=lib babel src -d lib --extensions \".tsx,.ts\" --ignore \"**/*.d.ts\" --copy-files",
     "babel:lib-next": "cross-env BABEL_ENV=lib-next babel src -d lib-next --extensions \".tsx,.ts\" --ignore \"**/*.d.ts\" --copy-files",
     "prettier": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --write \"**/*.{js,ts,jsx,tsc}\"",

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
@@ -8,7 +8,9 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import Translate, {translate} from '@docusaurus/Translate';
-import type {Props} from '@theme/BlogListPaginator';
+import type {Metadata} from '@theme/BlogListPage';
+
+export type Props = {readonly metadata: Metadata};
 
 function BlogListPaginator(props: Props): JSX.Element {
   const {metadata} = props;

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -12,11 +12,19 @@ import Translate, {translate} from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
 import MDXComponents from '@theme/MDXComponents';
 import Seo from '@theme/Seo';
-import type {Props} from '@theme/BlogPostItem';
 
 import styles from './styles.module.css';
 
 import {usePluralForm} from '@docusaurus/theme-common';
+import {FrontMatter, Metadata} from '@theme/BlogPostPage';
+
+export type Props = {
+  readonly frontMatter: FrontMatter;
+  readonly metadata: Metadata;
+  readonly truncated?: string | boolean;
+  readonly isBlogPostPage?: boolean;
+  readonly children: JSX.Element;
+};
 
 // Very simple pluralization: probably good enough for now
 function useReadingTimePlural() {

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
@@ -8,7 +8,10 @@
 import React from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
-import type {Props} from '@theme/BlogPostPaginator';
+
+type Item = {readonly title: string; readonly permalink: string};
+
+export type Props = {readonly nextItem?: Item; readonly prevItem?: Item};
 
 function BlogPostPaginator(props: Props): JSX.Element {
   const {nextItem, prevItem} = props;

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -11,11 +11,16 @@ import Highlight, {defaultProps, Language} from 'prism-react-renderer';
 import copy from 'copy-text-to-clipboard';
 import rangeParser from 'parse-numeric-range';
 import usePrismTheme from '@theme/hooks/usePrismTheme';
-import type {Props} from '@theme/CodeBlock';
 import Translate, {translate} from '@docusaurus/Translate';
 
 import styles from './styles.module.css';
 import {useThemeConfig} from '@docusaurus/theme-common';
+
+export type Props = {
+  readonly children: string;
+  readonly className?: string;
+  readonly metastring?: string;
+};
 
 const highlightLinesRangeRegex = /{([\d,-]+)}/;
 const getHighlightDirectiveRegex = (

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -8,7 +8,12 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import Translate, {translate} from '@docusaurus/Translate';
-import type {Props} from '@theme/DocPaginator';
+
+type PageInfo = {readonly permalink: string; readonly title: string};
+
+export type Props = {
+  readonly metadata: {readonly previous?: PageInfo; readonly next?: PageInfo};
+};
 
 function DocPaginator(props: Props): JSX.Element {
   const {metadata} = props;

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -14,11 +14,11 @@ import useWindowSize, {windowSizes} from '@theme/hooks/useWindowSize';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
 import Link from '@docusaurus/Link';
 import isInternalUrl from '@docusaurus/isInternalUrl';
-import type {Props} from '@theme/DocSidebar';
 import Logo from '@theme/Logo';
 import IconArrow from '@theme/IconArrow';
 import IconMenu from '@theme/IconMenu';
 import {translate} from '@docusaurus/Translate';
+import type {PropSidebarItem} from '@docusaurus/plugin-content-docs-types';
 
 import styles from './styles.module.css';
 
@@ -181,6 +181,14 @@ function DocSidebarItem(props): JSX.Element {
       return <DocSidebarItemLink {...props} />;
   }
 }
+
+export type Props = {
+  readonly path: string;
+  readonly sidebar: readonly PropSidebarItem[];
+  readonly sidebarCollapsible?: boolean;
+  readonly onCollapse: () => void;
+  readonly isHidden: boolean;
+};
 
 function DocSidebar({
   path,

--- a/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
@@ -8,8 +8,11 @@
 import React from 'react';
 import Translate from '@docusaurus/Translate';
 
-import type {Props} from '@theme/EditThisPage';
 import IconEdit from '@theme/IconEdit';
+
+export type Props = {
+  readonly editUrl: string;
+};
 
 export default function EditThisPage({editUrl}: Props): JSX.Element {
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -7,14 +7,16 @@
 
 /* eslint-disable jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid */
 
-import React from 'react';
+import React, {ComponentProps} from 'react';
 import clsx from 'clsx';
-import type {HeadingType, Props} from '@theme/Heading';
 import {translate} from '@docusaurus/Translate';
 import {useThemeConfig} from '@docusaurus/theme-common';
 
 import './styles.css';
 import styles from './styles.module.css';
+
+export type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export type Props = ComponentProps<HeadingType>;
 
 const Heading = (Tag: HeadingType): ((props: Props) => JSX.Element) =>
   function TargetComponent({id, ...props}) {

--- a/packages/docusaurus-theme-classic/src/theme/IconArrow/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconArrow/index.tsx
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import type {Props} from '@theme/IconArrow';
+import React, {ComponentProps} from 'react';
+
+export type Props = ComponentProps<'svg'>;
 
 const IconArrow = (props: Props): JSX.Element => {
   return (

--- a/packages/docusaurus-theme-classic/src/theme/IconEdit/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconEdit/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ComponentProps} from 'react';
 import clsx from 'clsx';
 
-import type {Props} from '@theme/IconEdit';
-
 import styles from './styles.module.css';
+
+export type Props = ComponentProps<'svg'>;
 
 const IconEdit = ({className, ...restProps}: Props): JSX.Element => {
   return (

--- a/packages/docusaurus-theme-classic/src/theme/IconLanguage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconLanguage/index.tsx
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import type {Props} from '@theme/IconLanguage';
+import React, {ComponentProps} from 'react';
+
+export type Props = ComponentProps<'svg'>;
 
 const IconLanguage = ({
   width = 20,

--- a/packages/docusaurus-theme-classic/src/theme/IconMenu/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconMenu/index.tsx
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import type {Props} from '@theme/IconMenu';
+import React, {ComponentProps} from 'react';
+
+export type Props = ComponentProps<'svg'>;
 
 const IconMenu = ({
   width = 30,

--- a/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import styles from './styles.module.css';
 import Translate from '@docusaurus/Translate';
-import type {Props} from '@theme/LastUpdated';
 
 function LastUpdatedAtDate({
   lastUpdatedAt,
@@ -51,6 +50,12 @@ function LastUpdatedByUser({
     </Translate>
   );
 }
+
+export type Props = {
+  lastUpdatedAt?: number;
+  formattedLastUpdatedAt?: string;
+  lastUpdatedBy?: string;
+};
 
 export default function LastUpdated({
   lastUpdatedAt,

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ReactNode} from 'react';
 import clsx from 'clsx';
 import SkipToContent from '@theme/SkipToContent';
 import AnnouncementBar from '@theme/AnnouncementBar';
@@ -13,9 +13,23 @@ import Navbar from '@theme/Navbar';
 import Footer from '@theme/Footer';
 import LayoutProviders from '@theme/LayoutProviders';
 import LayoutHead from '@theme/LayoutHead';
-import type {Props} from '@theme/Layout';
 import useKeyboardNavigation from '@theme/hooks/useKeyboardNavigation';
 import './styles.css';
+
+export type Props = {
+  children: ReactNode;
+  title?: string;
+  noFooter?: boolean;
+  description?: string;
+  image?: string;
+  keywords?: string | string[];
+  permalink?: string;
+  wrapperClassName?: string;
+  searchMetadatas?: {
+    version?: string;
+    tag?: string;
+  };
+};
 
 function Layout(props: Props): JSX.Element {
   const {children, noFooter, wrapperClassName} = props;

--- a/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ReactNode} from 'react';
 import ThemeProvider from '@theme/ThemeProvider';
 import UserPreferencesProvider from '@theme/UserPreferencesProvider';
 import {DocsPreferredVersionContextProvider} from '@docusaurus/theme-common';
-import type {Props} from '@theme/LayoutProviders';
+
+export type Props = {readonly children: ReactNode};
 
 export default function LayoutProviders({children}: Props): JSX.Element {
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -5,14 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import type {Props} from '@theme/Logo';
+import React, {ComponentProps} from 'react';
 
 import Link from '@docusaurus/Link';
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useThemeConfig} from '@docusaurus/theme-common';
+
+export type Props = {
+  imageClassName?: string;
+  titleClassName?: string;
+} & ComponentProps<'a'>;
 
 const Logo = (props: Props): JSX.Element => {
   const {isClient} = useDocusaurusContext();

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -5,11 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ComponentProps} from 'react';
 import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
-import type {MDXComponentsObject} from '@theme/MDXComponents';
+
+export type MDXComponentsObject = {
+  readonly code: typeof CodeBlock;
+  readonly a: (props: ComponentProps<'a'>) => JSX.Element;
+  readonly pre: typeof CodeBlock;
+  readonly h1: (props: ComponentProps<'h1'>) => JSX.Element;
+  readonly h2: (props: ComponentProps<'h2'>) => JSX.Element;
+  readonly h3: (props: ComponentProps<'h3'>) => JSX.Element;
+  readonly h4: (props: ComponentProps<'h4'>) => JSX.Element;
+  readonly h5: (props: ComponentProps<'h5'>) => JSX.Element;
+  readonly h6: (props: ComponentProps<'h6'>) => JSX.Element;
+};
 
 const MDXComponents: MDXComponentsObject = {
   code: (props) => {

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -5,17 +5,36 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState, useRef, useEffect} from 'react';
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  ReactNode,
+  ComponentProps,
+} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import {useLocation} from '@docusaurus/router';
 import {isSamePath} from '@docusaurus/theme-common';
-import type {
-  NavLinkProps,
-  DesktopOrMobileNavBarItemProps,
-  Props,
-} from '@theme/NavbarItem/DefaultNavbarItem';
+
+export type NavLinkProps = {
+  activeBasePath?: string;
+  activeBaseRegex?: string;
+  to?: string;
+  exact?: boolean;
+  href?: string;
+  label?: ReactNode;
+  activeClassName?: string;
+  prependBaseUrlToHref?: string;
+  isActive?: () => boolean;
+} & ComponentProps<'a'>;
+
+export type DesktopOrMobileNavBarItemProps = NavLinkProps & {
+  readonly items?: readonly NavLinkProps[];
+  readonly position?: 'left' | 'right';
+  readonly className?: string;
+};
 
 function NavLink({
   activeBasePath,
@@ -216,6 +235,10 @@ function NavItemMobile({
     </li>
   );
 }
+
+export type Props = DesktopOrMobileNavBarItemProps & {
+  readonly mobile?: boolean;
+};
 
 function DefaultNavbarItem({mobile = false, ...props}: Props): JSX.Element {
   const Comp = mobile ? NavItemMobile : NavItemDesktop;

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -6,11 +6,18 @@
  */
 
 import React from 'react';
-import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DefaultNavbarItem, {
+  Props as DefaultNavbarItemProps,
+} from '@theme/NavbarItem/DefaultNavbarItem';
 import {useLatestVersion, useActiveDocContext} from '@theme/hooks/useDocs';
 import clsx from 'clsx';
-import type {Props} from '@theme/NavbarItem/DocNavbarItem';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
+
+export type Props = DefaultNavbarItemProps & {
+  readonly docId: string;
+  readonly activeSidebarClassName: string;
+  readonly docsPluginId?: string;
+};
 
 export default function DocNavbarItem({
   docId,

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -6,17 +6,26 @@
  */
 
 import React from 'react';
-import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DefaultNavbarItem, {
+  NavLinkProps,
+  Props as DefaultNavbarItemProps,
+} from '@theme/NavbarItem/DefaultNavbarItem';
 import {
   useVersions,
   useLatestVersion,
   useActiveDocContext,
 } from '@theme/hooks/useDocs';
-import type {Props} from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 
 const getVersionMainDoc = (version) =>
   version.docs.find((doc) => doc.id === version.mainDocId);
+
+export type Props = DefaultNavbarItemProps & {
+  readonly docsPluginId?: string;
+  readonly dropdownActiveClassDisabled?: boolean;
+  readonly dropdownItemsBefore: NavLinkProps[];
+  readonly dropdownItemsAfter: NavLinkProps[];
+};
 
 export default function DocsVersionDropdownNavbarItem({
   mobile,

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
@@ -6,13 +6,16 @@
  */
 
 import React from 'react';
-import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DefaultNavbarItem, {
+  Props as DefaultNavbarItemProps,
+} from '@theme/NavbarItem/DefaultNavbarItem';
 import {useActiveVersion, useLatestVersion} from '@theme/hooks/useDocs';
-import type {Props} from '@theme/NavbarItem/DocsVersionNavbarItem';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 
 const getVersionMainDoc = (version) =>
   version.docs.find((doc) => doc.id === version.mainDocId);
+
+export type Props = DefaultNavbarItemProps & {readonly docsPluginId?: string};
 
 export default function DocsVersionNavbarItem({
   label: staticLabel,

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem.tsx
@@ -6,11 +6,18 @@
  */
 
 import React from 'react';
-import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DefaultNavbarItem, {
+  NavLinkProps,
+  Props as DefaultNavbarItemProps,
+} from '@theme/NavbarItem/DefaultNavbarItem';
 import IconLanguage from '@theme/IconLanguage';
-import type {Props} from '@theme/NavbarItem/LocaleDropdownNavbarItem';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useAlternatePageUtils} from '@docusaurus/theme-common';
+
+export type Props = DefaultNavbarItemProps & {
+  readonly dropdownItemsBefore: NavLinkProps[];
+  readonly dropdownItemsAfter: NavLinkProps[];
+};
 
 export default function LocaleDropdownNavbarItem({
   mobile,

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import type {Props} from '@theme/NavbarItem/SearchNavbarItem';
 import SearchBar from '@theme/SearchBar';
 import styles from './styles.module.css';
+
+export type Props = {readonly mobile?: boolean};
 
 export default function SearchNavbarItem({mobile}: Props): JSX.Element | null {
   if (mobile) {

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -6,10 +6,15 @@
  */
 
 import React from 'react';
-import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DefaultNavbarItem, {
+  Props as DefaultNavbarItemProps,
+} from '@theme/NavbarItem/DefaultNavbarItem';
 import LocaleDropdownNavbarItem from '@theme/NavbarItem/LocaleDropdownNavbarItem';
-import SearchNavbarItem from '@theme/NavbarItem/SearchNavbarItem';
-import type {Props} from '@theme/NavbarItem';
+import SearchNavbarItem, {
+  Props as SearchNavbarItemProps,
+} from '@theme/NavbarItem/SearchNavbarItem';
+import {Props as DocsVersionDropdownNavbarItemProps} from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
+import {Props as DocsVersionNavbarItemProps} from '@theme/NavbarItem/DocsVersionNavbarItem';
 
 const NavbarItemComponents = {
   default: () => DefaultNavbarItem,
@@ -38,6 +43,14 @@ const getNavbarItemComponent = (
   }
   return navbarItemComponent();
 };
+
+export type Props =
+  | ({readonly type?: 'default' | undefined} & DefaultNavbarItemProps)
+  | ({
+      readonly type: 'docsVersionDropdown';
+    } & DocsVersionDropdownNavbarItemProps)
+  | ({readonly type: 'docsVersion'} & DocsVersionNavbarItemProps)
+  | ({readonly type: 'search'} & SearchNavbarItemProps);
 
 export default function NavbarItem({type, ...props}: Props): JSX.Element {
   const NavbarItemComponent = getNavbarItemComponent(type);

--- a/packages/docusaurus-theme-classic/src/theme/NotFound.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NotFound.tsx
@@ -8,8 +8,9 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 import Translate from '@docusaurus/Translate';
+import type {Props} from '@theme/DocPage';
 
-function NotFound(): JSX.Element {
+function NotFound(_props: Props): JSX.Element {
   return (
     <Layout title="Page Not Found">
       <main className="container margin-vert--xl">

--- a/packages/docusaurus-theme-classic/src/theme/SearchMetadatas/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SearchMetadatas/index.tsx
@@ -6,9 +6,13 @@
  */
 
 import React from 'react';
-
 import Head from '@docusaurus/Head';
-import type {Props} from '@theme/SearchMetadatas';
+
+export type Props = {
+  locale?: string;
+  version?: string;
+  tag?: string;
+};
 
 // Note: we don't couple this to Algolia/DocSearch on purpose
 // We may want to support other search engine plugins too

--- a/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import clsx from 'clsx';
 import useTOCHighlight from '@theme/hooks/useTOCHighlight';
-import type {TOCProps} from '@theme/TOC';
 import styles from './styles.module.css';
 import {TOCItem} from '@docusaurus/types';
 
@@ -47,6 +46,10 @@ function Headings({
     </ul>
   );
 }
+
+export type TOCProps = {
+  readonly toc: readonly TOCItem[];
+};
 
 function TOC({toc}: TOCProps): JSX.Element {
   useTOCHighlight(LINK_CLASS_NAME, ACTIVE_LINK_CLASS_NAME, TOP_OFFSET);

--- a/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import type {TOCInlineProps} from '@theme/TOCInline';
 import styles from './styles.module.css';
 import {TOCItem} from '@docusaurus/types';
 
@@ -38,6 +37,10 @@ function HeadingsInline({
     </ul>
   );
 }
+
+export type TOCInlineProps = {
+  readonly toc: readonly TOCItem[];
+};
 
 function TOCInline({toc}: TOCInlineProps): JSX.Element {
   return (

--- a/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
@@ -5,8 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import type {Props} from '@theme/TabItem';
+import React, {ReactNode} from 'react';
+
+export type Props = {
+  readonly children: ReactNode;
+  readonly value: string;
+  readonly hidden: boolean;
+  readonly className: string;
+};
 
 function TabItem({children, hidden, className}: Props): JSX.Element {
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -7,7 +7,6 @@
 
 import React, {useState, cloneElement, Children, ReactElement} from 'react';
 import useUserPreferencesContext from '@theme/hooks/useUserPreferencesContext';
-import type {Props} from '@theme/Tabs';
 import type {Props as TabItemProps} from '@theme/TabItem';
 
 import clsx from 'clsx';
@@ -25,6 +24,16 @@ const keys = {
   left: 37,
   right: 39,
 } as const;
+
+export type Props = {
+  readonly lazy?: boolean;
+  readonly block?: boolean;
+  readonly children: readonly ReactElement<TabItemProps>[];
+  readonly defaultValue?: string;
+  readonly values: readonly {value: string; label: string}[];
+  readonly groupId?: string;
+  readonly className?: string;
+};
 
 function Tabs(props: Props): JSX.Element {
   const {lazy, block, defaultValue, values, groupId, className} = props;

--- a/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.tsx
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ReactNode} from 'react';
 
 import useTheme from '@theme/hooks/useTheme';
 import ThemeContext from '@theme/ThemeContext';
-import type {Props} from '@theme/ThemeProvider';
+
+export type Props = {readonly children: ReactNode};
 
 function ThemeProvider(props: Props): JSX.Element {
   const {isDarkTheme, setLightTheme, setDarkTheme} = useTheme();

--- a/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
@@ -5,12 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ComponentProps} from 'react';
 import clsx from 'clsx';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useThemeContext from '@theme/hooks/useThemeContext';
-import type {Props} from '@theme/ThemedImage';
+
+export type Props = {
+  readonly sources: {
+    readonly light: string;
+    readonly dark: string;
+  };
+} & Omit<ComponentProps<'img'>, 'src'>;
 
 import styles from './styles.module.css';
 

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {CSSProperties} from 'react';
+import React, {ComponentProps, CSSProperties} from 'react';
 import Toggle from 'react-toggle';
-import type {Props} from '@theme/Toggle';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
@@ -29,6 +28,8 @@ const Light = ({icon, style}: IconProps): JSX.Element => (
     {icon}
   </span>
 );
+
+export type Props = ComponentProps<typeof Toggle>;
 
 export default function (props: Props): JSX.Element {
   const {

--- a/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.ts
@@ -6,7 +6,10 @@
  */
 
 import {createContext} from 'react';
+import {UserPreferencesContextProps} from '@theme/hooks/useUserPreferencesContext';
 
-const UserPreferencesContext = createContext(undefined);
+const UserPreferencesContext = createContext<
+  UserPreferencesContextProps | undefined
+>(undefined);
 
 export default UserPreferencesContext;

--- a/packages/docusaurus-theme-classic/src/theme/UserPreferencesProvider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/UserPreferencesProvider/index.tsx
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {ReactNode} from 'react';
 
 import useTabGroupChoice from '@theme/hooks/useTabGroupChoice';
 import useAnnouncementBar from '@theme/hooks/useAnnouncementBar';
 import UserPreferencesContext from '@theme/UserPreferencesContext';
-import type {Props} from '@theme/UserPreferencesProvider';
+
+export type Props = {readonly children: ReactNode};
 
 function UserPreferencesProvider(props: Props): JSX.Element {
   const {tabGroupChoices, setTabGroupChoices} = useTabGroupChoice();

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useAnnouncementBar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useAnnouncementBar.ts
@@ -7,7 +7,11 @@
 
 import {useState, useEffect, useCallback} from 'react';
 import {useThemeConfig} from '@docusaurus/theme-common';
-import type {useAnnouncementBarReturns} from '@theme/hooks/useAnnouncementBar';
+
+export type useAnnouncementBarReturns = {
+  readonly isAnnouncementBarClosed: boolean;
+  readonly closeAnnouncementBar: () => void;
+};
 
 const STORAGE_DISMISS_KEY = 'docusaurus.announcement.dismiss';
 const STORAGE_ID_KEY = 'docusaurus.announcement.id';

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -8,7 +8,11 @@
 import {useState, useCallback, useEffect, useRef} from 'react';
 import {useLocation} from '@docusaurus/router';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
-import type {useHideableNavbarReturns} from '@theme/hooks/useHideableNavbar';
+
+export type useHideableNavbarReturns = {
+  readonly navbarRef: (node: HTMLElement | null) => void;
+  readonly isNavbarVisible: boolean;
+};
 
 const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   const location = useLocation();

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.ts
@@ -5,8 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {useState, useEffect} from 'react';
-import type {useLocationHashReturns} from '@theme/hooks/useLocationHash';
+import {useState, useEffect, Dispatch, SetStateAction} from 'react';
+
+export type useLocationHashReturns = readonly [
+  string,
+  Dispatch<SetStateAction<string>>,
+];
 
 function useLocationHash(initialHash: string): useLocationHashReturns {
   const [hash, setHash] = useState(initialHash);

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
@@ -7,7 +7,8 @@
 
 import {useState, useEffect} from 'react';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
-import type {ScrollPosition} from '@theme/hooks/useScrollPosition';
+
+export type ScrollPosition = {scrollX: number; scrollY: number};
 
 const getScrollPosition = (): ScrollPosition => ({
   scrollX: ExecutionEnvironment.canUseDOM ? window.pageXOffset : 0,
@@ -16,7 +17,7 @@ const getScrollPosition = (): ScrollPosition => ({
 
 const useScrollPosition = (
   effect?: (position: ScrollPosition) => void,
-  deps = [],
+  deps: unknown[] = [],
 ): ScrollPosition => {
   const [scrollPosition, setScrollPosition] = useState(getScrollPosition());
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTabGroupChoice.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTabGroupChoice.ts
@@ -6,7 +6,11 @@
  */
 
 import {useState, useCallback, useEffect} from 'react';
-import type {useTabGroupChoiceReturns} from '@theme/hooks/useTabGroupChoice';
+
+export type useTabGroupChoiceReturns = {
+  readonly tabGroupChoices: {readonly [groupId: string]: string};
+  readonly setTabGroupChoices: (groupId: string, newChoice: string) => void;
+};
 
 const TAB_CHOICE_PREFIX = 'docusaurus.tab.';
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
@@ -8,16 +8,21 @@
 import {useState, useCallback, useEffect} from 'react';
 
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
-import type {useThemeReturns} from '@theme/hooks/useTheme';
 import {useThemeConfig} from '@docusaurus/theme-common';
+
+export type useThemeReturns = {
+  readonly isDarkTheme: boolean;
+  readonly setLightTheme: () => void;
+  readonly setDarkTheme: () => void;
+};
 
 const themes = {
   light: 'light',
   dark: 'dark',
-};
+} as const;
 
 // Ensure to always return a valid theme even if input is invalid
-const coerceToTheme = (theme) => {
+const coerceToTheme = (theme: string | null) => {
   return theme === themes.dark ? themes.dark : themes.light;
 };
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.ts
@@ -8,7 +8,12 @@
 import {useContext} from 'react';
 
 import ThemeContext from '@theme/ThemeContext';
-import type {ThemeContextProps} from '@theme/hooks/useThemeContext';
+
+export type ThemeContextProps = {
+  isDarkTheme: boolean;
+  setLightTheme: () => void;
+  setDarkTheme: () => void;
+};
 
 function useThemeContext(): ThemeContextProps {
   const context = useContext<ThemeContextProps | undefined>(ThemeContext);

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.ts
@@ -8,7 +8,13 @@
 import {useContext} from 'react';
 
 import UserPreferencesContext from '@theme/UserPreferencesContext';
-import type {UserPreferencesContextProps} from '@theme/hooks/useUserPreferencesContext';
+
+export type UserPreferencesContextProps = {
+  tabGroupChoices: {readonly [groupId: string]: string};
+  setTabGroupChoices: (groupId: string, newChoice: string) => void;
+  isAnnouncementBarClosed: boolean;
+  closeAnnouncementBar: () => void;
+};
 
 function useUserPreferencesContext(): UserPreferencesContextProps {
   const context = useContext<UserPreferencesContextProps | undefined>(

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.ts
@@ -8,7 +8,6 @@
 import {useEffect, useState} from 'react';
 
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
-import type {WindowSize} from '@theme/hooks/useWindowSize';
 
 const desktopThresholdWidth = 996;
 
@@ -16,6 +15,8 @@ const windowSizes = {
   desktop: 'desktop',
   mobile: 'mobile',
 } as const;
+
+export type WindowSize = keyof typeof windowSizes;
 
 function useWindowSize(): WindowSize | undefined {
   const isClient = ExecutionEnvironment.canUseDOM;

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -7,28 +7,55 @@
 
 /* eslint-disable import/no-duplicates */
 /* eslint-disable spaced-comment */
+/* eslint-disable import/newline-after-import */
 /// <reference types="@docusaurus/module-type-aliases" />
 /// <reference types="@docusaurus/plugin-content-blog" />
 /// <reference types="@docusaurus/plugin-content-docs" />
 /// <reference types="@docusaurus/plugin-content-pages" />
 
+declare module '@theme/NotFound' {
+  import type {Props} from '@theme/DocPage';
+  function NotFound(_props: Props): JSX.Element;
+  export default NotFound;
+}
+
+declare module '@theme/ThemeContext' {
+  import React from 'react';
+  import type {ThemeContextProps} from '@theme/hooks/useThemeContext';
+  const ThemeContext: React.Context<ThemeContextProps | undefined>;
+  export default ThemeContext;
+}
+
+declare module '@theme/UserPreferencesContext' {
+  import type {UserPreferencesContextProps} from '@theme/hooks/useUserPreferencesContext';
+  const UserPreferencesContext: import('react').Context<
+    UserPreferencesContextProps | undefined
+  >;
+  export default UserPreferencesContext;
+}
+
+declare module '@theme/prism-include-languages' {
+  import type * as PrismNamespace from 'prismjs';
+  const prismIncludeLanguages: (PrismObject: typeof PrismNamespace) => void;
+  export default prismIncludeLanguages;
+}
+
 declare module '@theme/AnnouncementBar' {
-  const AnnouncementBar: () => JSX.Element | null;
+  function AnnouncementBar(): JSX.Element | null;
   export default AnnouncementBar;
 }
 
 declare module '@theme/BlogListPaginator' {
   import type {Metadata} from '@theme/BlogListPage';
-
-  export type Props = {readonly metadata: Metadata};
-
-  const BlogListPaginator: (props: Props) => JSX.Element;
+  export type Props = {
+    readonly metadata: Metadata;
+  };
+  function BlogListPaginator(props: Props): JSX.Element;
   export default BlogListPaginator;
 }
 
 declare module '@theme/BlogPostItem' {
   import type {FrontMatter, Metadata} from '@theme/BlogPostPage';
-
   export type Props = {
     readonly frontMatter: FrontMatter;
     readonly metadata: Metadata;
@@ -36,17 +63,20 @@ declare module '@theme/BlogPostItem' {
     readonly isBlogPostPage?: boolean;
     readonly children: JSX.Element;
   };
-
-  const BlogPostItem: (props: Props) => JSX.Element;
+  function BlogPostItem(props: Props): JSX.Element;
   export default BlogPostItem;
 }
 
 declare module '@theme/BlogPostPaginator' {
-  type Item = {readonly title: string; readonly permalink: string};
-
-  export type Props = {readonly nextItem?: Item; readonly prevItem?: Item};
-
-  const BlogPostPaginator: (props: Props) => JSX.Element;
+  type Item = {
+    readonly title: string;
+    readonly permalink: string;
+  };
+  export type Props = {
+    readonly nextItem?: Item;
+    readonly prevItem?: Item;
+  };
+  function BlogPostPaginator(props: Props): JSX.Element;
   export default BlogPostPaginator;
 }
 
@@ -56,25 +86,30 @@ declare module '@theme/CodeBlock' {
     readonly className?: string;
     readonly metastring?: string;
   };
-
-  const CodeBlock: (props: Props) => JSX.Element;
-  export default CodeBlock;
+  export default function CodeBlock({
+    children,
+    className: languageClassName,
+    metastring,
+  }: Props): JSX.Element;
 }
 
 declare module '@theme/DocPaginator' {
-  type PageInfo = {readonly permalink: string; readonly title: string};
-
-  export type Props = {
-    readonly metadata: {readonly previous?: PageInfo; readonly next?: PageInfo};
+  type PageInfo = {
+    readonly permalink: string;
+    readonly title: string;
   };
-
-  const DocPaginator: (props: Props) => JSX.Element;
+  export type Props = {
+    readonly metadata: {
+      readonly previous?: PageInfo;
+      readonly next?: PageInfo;
+    };
+  };
+  function DocPaginator(props: Props): JSX.Element;
   export default DocPaginator;
 }
 
 declare module '@theme/DocSidebar' {
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs-types';
-
   export type Props = {
     readonly path: string;
     readonly sidebar: readonly PropSidebarItem[];
@@ -82,13 +117,18 @@ declare module '@theme/DocSidebar' {
     readonly onCollapse: () => void;
     readonly isHidden: boolean;
   };
-
-  const DocSidebar: (props: Props) => JSX.Element;
+  function DocSidebar({
+    path,
+    sidebar,
+    sidebarCollapsible,
+    onCollapse,
+    isHidden,
+  }: Props): JSX.Element | null;
   export default DocSidebar;
 }
 
 declare module '@theme/DocVersionSuggestions' {
-  const DocVersionSuggestions: () => JSX.Element;
+  function DocVersionSuggestions(): JSX.Element;
   export default DocVersionSuggestions;
 }
 
@@ -96,149 +136,77 @@ declare module '@theme/EditThisPage' {
   export type Props = {
     readonly editUrl: string;
   };
-  const EditThisPage: (props: Props) => JSX.Element;
-  export default EditThisPage;
+  export default function EditThisPage({editUrl}: Props): JSX.Element;
 }
 
 declare module '@theme/Footer' {
-  const Footer: () => JSX.Element | null;
+  function Footer(): JSX.Element | null;
   export default Footer;
 }
 
 declare module '@theme/Heading' {
   import type {ComponentProps} from 'react';
-
   export type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   export type Props = ComponentProps<HeadingType>;
-
   const Heading: (Tag: HeadingType) => (props: Props) => JSX.Element;
   export default Heading;
 }
 
-declare module '@theme/hooks/useAnnouncementBar' {
-  export type useAnnouncementBarReturns = {
-    readonly isAnnouncementBarClosed: boolean;
-    readonly closeAnnouncementBar: () => void;
+declare module '@theme/IconArrow' {
+  import React, {ComponentProps} from 'react';
+  export type Props = ComponentProps<'svg'>;
+  const IconArrow: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
+  export default IconArrow;
+}
+
+declare module '@theme/IconEdit' {
+  import React, {ComponentProps} from 'react';
+  export type Props = ComponentProps<'svg'>;
+  const IconEdit: ({
+    className,
+    ...restProps
+  }: React.SVGProps<SVGSVGElement>) => JSX.Element;
+  export default IconEdit;
+}
+
+declare module '@theme/IconLanguage' {
+  import React, {ComponentProps} from 'react';
+  export type Props = ComponentProps<'svg'>;
+  const IconLanguage: ({
+    width,
+    height,
+    ...props
+  }: React.SVGProps<SVGSVGElement>) => JSX.Element;
+  export default IconLanguage;
+}
+
+declare module '@theme/IconMenu' {
+  import React, {ComponentProps} from 'react';
+  export type Props = ComponentProps<'svg'>;
+  const IconMenu: ({
+    width,
+    height,
+    className,
+    ...restProps
+  }: React.SVGProps<SVGSVGElement>) => JSX.Element;
+  export default IconMenu;
+}
+
+declare module '@theme/LastUpdated' {
+  export type Props = {
+    lastUpdatedAt?: number;
+    formattedLastUpdatedAt?: string;
+    lastUpdatedBy?: string;
   };
-
-  const useAnnouncementBar: () => useAnnouncementBarReturns;
-  export default useAnnouncementBar;
-}
-
-declare module '@theme/hooks/useHideableNavbar' {
-  export type useHideableNavbarReturns = {
-    readonly navbarRef: (node: HTMLElement | null) => void;
-    readonly isNavbarVisible: boolean;
-  };
-
-  const useHideableNavbar: (hideOnScroll: boolean) => useHideableNavbarReturns;
-  export default useHideableNavbar;
-}
-
-declare module '@theme/hooks/useLocationHash' {
-  import type {Dispatch, SetStateAction} from 'react';
-
-  export type useLocationHashReturns = readonly [
-    string,
-    Dispatch<SetStateAction<string>>,
-  ];
-
-  const useLocationHash: (initialHash: string) => useLocationHashReturns;
-  export default useLocationHash;
-}
-
-declare module '@theme/hooks/useLockBodyScroll' {
-  const useLockBodyScroll: (lock?: boolean) => void;
-  export default useLockBodyScroll;
-}
-
-declare module '@theme/hooks/usePrismTheme' {
-  import defaultTheme from 'prism-react-renderer/themes/palenight';
-
-  const usePrismTheme: () => typeof defaultTheme;
-  export default usePrismTheme;
-}
-
-declare module '@theme/hooks/useScrollPosition' {
-  export type ScrollPosition = {scrollX: number; scrollY: number};
-
-  const useScrollPosition: (
-    effect?: (position: ScrollPosition) => void,
-    deps?: unknown[],
-  ) => ScrollPosition;
-  export default useScrollPosition;
-}
-
-declare module '@theme/hooks/useTabGroupChoice' {
-  export type useTabGroupChoiceReturns = {
-    readonly tabGroupChoices: {readonly [groupId: string]: string};
-    readonly setTabGroupChoices: (groupId: string, newChoice: string) => void;
-  };
-
-  const useTabGroupChoice: () => useTabGroupChoiceReturns;
-  export default useTabGroupChoice;
-}
-
-declare module '@theme/hooks/useTheme' {
-  export type useThemeReturns = {
-    readonly isDarkTheme: boolean;
-    readonly setLightTheme: () => void;
-    readonly setDarkTheme: () => void;
-  };
-
-  const useTheme: () => useThemeReturns;
-  export default useTheme;
-}
-
-declare module '@theme/hooks/useThemeContext' {
-  export type ThemeContextProps = {
-    isDarkTheme: boolean;
-    setLightTheme: () => void;
-    setDarkTheme: () => void;
-  };
-
-  export default function useThemeContext(): ThemeContextProps;
-}
-
-declare module '@theme/hooks/useTOCHighlight' {
-  export default function useTOCHighlight(
-    linkClassName: string,
-    linkActiveClassName: string,
-    topOffset: number,
-  ): void;
-}
-
-declare module '@theme/hooks/useUserPreferencesContext' {
-  export type UserPreferencesContextProps = {
-    tabGroupChoices: {readonly [groupId: string]: string};
-    setTabGroupChoices: (groupId: string, newChoice: string) => void;
-    isAnnouncementBarClosed: boolean;
-    closeAnnouncementBar: () => void;
-  };
-
-  export default function useUserPreferencesContext(): UserPreferencesContextProps;
-}
-
-declare module '@theme/hooks/useWindowSize' {
-  export const windowSizes: {
-    desktop: 'desktop';
-    mobile: 'mobile';
-  };
-
-  export type WindowSize = keyof typeof windowSizes;
-
-  export default function useWindowSize(): WindowSize | undefined;
-}
-
-declare module '@theme/hooks/useKeyboardNavigation' {
-  const useKeyboardNavigation: () => void;
-
-  export default useKeyboardNavigation;
+  export default function LastUpdated({
+    lastUpdatedAt,
+    formattedLastUpdatedAt,
+    lastUpdatedBy,
+  }: Props): JSX.Element;
 }
 
 declare module '@theme/Layout' {
   import type {ReactNode} from 'react';
-
   export type Props = {
     children: ReactNode;
     title?: string;
@@ -253,49 +221,36 @@ declare module '@theme/Layout' {
       tag?: string;
     };
   };
-
-  const Layout: (props: Props) => JSX.Element;
+  function Layout(props: Props): JSX.Element;
   export default Layout;
 }
 
 declare module '@theme/LayoutHead' {
   import type {Props} from '@theme/Layout';
-
-  const LayoutHead: (props: Props) => JSX.Element;
-  export default LayoutHead;
+  export default function LayoutHead(props: Props): JSX.Element;
 }
 
-declare module '@theme/SearchMetadatas' {
+declare module '@theme/LayoutProviders' {
+  import type {ReactNode} from 'react';
   export type Props = {
-    locale?: string;
-    version?: string;
-    tag?: string;
+    readonly children: ReactNode;
   };
-
-  const SearchMetadatas: (props: Props) => JSX.Element;
-  export default SearchMetadatas;
+  export default function LayoutProviders({children}: Props): JSX.Element;
 }
 
-declare module '@theme/LastUpdated' {
+declare module '@theme/Logo' {
+  import type {ComponentProps} from 'react';
   export type Props = {
-    lastUpdatedAt?: number;
-    formattedLastUpdatedAt?: string;
-    lastUpdatedBy?: string;
-  };
-
-  const LastUpdated: (props: Props) => JSX.Element;
-  export default LastUpdated;
-}
-
-declare module '@theme/SkipToContent' {
-  const SkipToContent: () => JSX.Element;
-  export default SkipToContent;
+    imageClassName?: string;
+    titleClassName?: string;
+  } & ComponentProps<'a'>;
+  const Logo: (props: Props) => JSX.Element;
+  export default Logo;
 }
 
 declare module '@theme/MDXComponents' {
   import type {ComponentProps} from 'react';
-  import type CodeBlock from '@theme/CodeBlock';
-
+  import CodeBlock from '@theme/CodeBlock';
   export type MDXComponentsObject = {
     readonly code: typeof CodeBlock;
     readonly a: (props: ComponentProps<'a'>) => JSX.Element;
@@ -307,19 +262,17 @@ declare module '@theme/MDXComponents' {
     readonly h5: (props: ComponentProps<'h5'>) => JSX.Element;
     readonly h6: (props: ComponentProps<'h6'>) => JSX.Element;
   };
-
   const MDXComponents: MDXComponentsObject;
   export default MDXComponents;
 }
 
 declare module '@theme/Navbar' {
-  const Navbar: () => JSX.Element;
+  function Navbar(): JSX.Element;
   export default Navbar;
 }
 
 declare module '@theme/NavbarItem/DefaultNavbarItem' {
-  import type {ComponentProps, ReactNode} from 'react';
-
+  import type {ReactNode, ComponentProps} from 'react';
   export type NavLinkProps = {
     activeBasePath?: string;
     activeBaseRegex?: string;
@@ -331,263 +284,351 @@ declare module '@theme/NavbarItem/DefaultNavbarItem' {
     prependBaseUrlToHref?: string;
     isActive?: () => boolean;
   } & ComponentProps<'a'>;
-
   export type DesktopOrMobileNavBarItemProps = NavLinkProps & {
     readonly items?: readonly NavLinkProps[];
     readonly position?: 'left' | 'right';
     readonly className?: string;
   };
-
   export type Props = DesktopOrMobileNavBarItemProps & {
     readonly mobile?: boolean;
   };
-
-  const DefaultNavbarItem: (props: Props) => JSX.Element;
+  function DefaultNavbarItem({mobile, ...props}: Props): JSX.Element;
   export default DefaultNavbarItem;
 }
 
-declare module '@theme/NavbarItem/SearchNavbarItem' {
-  export type Props = {readonly mobile?: boolean};
-
-  const SearchNavbarItem: (props: Props) => JSX.Element;
-  export default SearchNavbarItem;
-}
-
-declare module '@theme/NavbarItem/LocaleDropdownNavbarItem' {
+declare module '@theme/NavbarItem/DocNavbarItem' {
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
-  import type {NavLinkProps} from '@theme/NavbarItem/DefaultNavbarItem';
-
   export type Props = DefaultNavbarItemProps & {
-    readonly dropdownItemsBefore: NavLinkProps[];
-    readonly dropdownItemsAfter: NavLinkProps[];
+    readonly docId: string;
+    readonly activeSidebarClassName: string;
+    readonly docsPluginId?: string;
   };
-
-  const LocaleDropdownNavbarItem: (props: Props) => JSX.Element;
-  export default LocaleDropdownNavbarItem;
+  export default function DocNavbarItem({
+    docId,
+    activeSidebarClassName,
+    label: staticLabel,
+    docsPluginId,
+    ...props
+  }: Props): JSX.Element;
 }
 
 declare module '@theme/NavbarItem/DocsVersionDropdownNavbarItem' {
-  import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
-  import type {NavLinkProps} from '@theme/NavbarItem/DefaultNavbarItem';
-
+  import type {
+    NavLinkProps,
+    Props as DefaultNavbarItemProps,
+  } from '@theme/NavbarItem/DefaultNavbarItem';
   export type Props = DefaultNavbarItemProps & {
     readonly docsPluginId?: string;
     readonly dropdownActiveClassDisabled?: boolean;
     readonly dropdownItemsBefore: NavLinkProps[];
     readonly dropdownItemsAfter: NavLinkProps[];
   };
-
-  const DocsVersionDropdownNavbarItem: (props: Props) => JSX.Element;
-  export default DocsVersionDropdownNavbarItem;
+  export default function DocsVersionDropdownNavbarItem({
+    mobile,
+    docsPluginId,
+    dropdownActiveClassDisabled,
+    dropdownItemsBefore,
+    dropdownItemsAfter,
+    ...props
+  }: Props): JSX.Element;
 }
 
 declare module '@theme/NavbarItem/DocsVersionNavbarItem' {
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
-
-  export type Props = DefaultNavbarItemProps & {readonly docsPluginId?: string};
-
-  const DocsVersionNavbarItem: (props: Props) => JSX.Element;
-  export default DocsVersionNavbarItem;
-}
-
-declare module '@theme/NavbarItem/DocNavbarItem' {
-  import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
-
   export type Props = DefaultNavbarItemProps & {
-    readonly docId: string;
-    readonly activeSidebarClassName: string;
     readonly docsPluginId?: string;
   };
+  export default function DocsVersionNavbarItem({
+    label: staticLabel,
+    to: staticTo,
+    docsPluginId,
+    ...props
+  }: Props): JSX.Element;
+}
 
-  const DocsSidebarNavbarItem: (props: Props) => JSX.Element;
-  export default DocsSidebarNavbarItem;
+declare module '@theme/NavbarItem/LocaleDropdownNavbarItem' {
+  import type {
+    NavLinkProps,
+    Props as DefaultNavbarItemProps,
+  } from '@theme/NavbarItem/DefaultNavbarItem';
+  export type Props = DefaultNavbarItemProps & {
+    readonly dropdownItemsBefore: NavLinkProps[];
+    readonly dropdownItemsAfter: NavLinkProps[];
+  };
+  export default function LocaleDropdownNavbarItem({
+    mobile,
+    dropdownItemsBefore,
+    dropdownItemsAfter,
+    ...props
+  }: Props): JSX.Element;
+}
+
+declare module '@theme/NavbarItem/SearchNavbarItem' {
+  export type Props = {
+    readonly mobile?: boolean;
+  };
+  export default function SearchNavbarItem({mobile}: Props): JSX.Element | null;
 }
 
 declare module '@theme/NavbarItem' {
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
+  import type {Props as SearchNavbarItemProps} from '@theme/NavbarItem/SearchNavbarItem';
   import type {Props as DocsVersionDropdownNavbarItemProps} from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
   import type {Props as DocsVersionNavbarItemProps} from '@theme/NavbarItem/DocsVersionNavbarItem';
-  import type {Props as SearchNavbarItemProps} from '@theme/NavbarItem/SearchNavbarItem';
-
   export type Props =
-    | ({readonly type?: 'default' | undefined} & DefaultNavbarItemProps)
+    | ({
+        readonly type?: 'default' | undefined;
+      } & DefaultNavbarItemProps)
     | ({
         readonly type: 'docsVersionDropdown';
       } & DocsVersionDropdownNavbarItemProps)
-    | ({readonly type: 'docsVersion'} & DocsVersionNavbarItemProps)
-    | ({readonly type: 'search'} & SearchNavbarItemProps);
+    | ({
+        readonly type: 'docsVersion';
+      } & DocsVersionNavbarItemProps)
+    | ({
+        readonly type: 'search';
+      } & SearchNavbarItemProps);
+  export default function NavbarItem({type, ...props}: Props): JSX.Element;
+}
 
-  const NavbarItem: (props: Props) => JSX.Element;
-  export default NavbarItem;
+declare module '@theme/SearchMetadatas' {
+  export type Props = {
+    locale?: string;
+    version?: string;
+    tag?: string;
+  };
+  export default function SearchMetadatas({
+    locale,
+    version,
+    tag,
+  }: Props): JSX.Element;
+}
+
+declare module '@theme/Seo' {
+  import type {Props} from '@theme/Seo';
+  export default function Seo({
+    title,
+    description,
+    keywords,
+    image,
+  }: Props): JSX.Element;
+}
+
+declare module '@theme/SkipToContent' {
+  function SkipToContent(): JSX.Element;
+  export default SkipToContent;
+}
+
+declare module '@theme/TOC' {
+  import type {TOCItem} from '@docusaurus/types';
+  export type TOCProps = {
+    readonly toc: readonly TOCItem[];
+  };
+  function TOC({toc}: TOCProps): JSX.Element;
+  export default TOC;
+}
+
+declare module '@theme/TOCInline' {
+  import type {TOCItem} from '@docusaurus/types';
+  export type TOCInlineProps = {
+    readonly toc: readonly TOCItem[];
+  };
+  function TOCInline({toc}: TOCInlineProps): JSX.Element;
+  export default TOCInline;
 }
 
 declare module '@theme/TabItem' {
   import type {ReactNode} from 'react';
-
   export type Props = {
     readonly children: ReactNode;
     readonly value: string;
     readonly hidden: boolean;
     readonly className: string;
   };
-
-  const TabItem: (props: Props) => JSX.Element;
+  function TabItem({children, hidden, className}: Props): JSX.Element;
   export default TabItem;
 }
 
 declare module '@theme/Tabs' {
   import type {ReactElement} from 'react';
   import type {Props as TabItemProps} from '@theme/TabItem';
-
   export type Props = {
     readonly lazy?: boolean;
     readonly block?: boolean;
     readonly children: readonly ReactElement<TabItemProps>[];
     readonly defaultValue?: string;
-    readonly values: readonly {value: string; label: string}[];
+    readonly values: readonly {
+      value: string;
+      label: string;
+    }[];
     readonly groupId?: string;
     readonly className?: string;
   };
-
-  const Tabs: (props: Props) => JSX.Element;
+  function Tabs(props: Props): JSX.Element;
   export default Tabs;
+}
+
+declare module '@theme/ThemeProvider' {
+  import type {ReactNode} from 'react';
+  export type Props = {
+    readonly children: ReactNode;
+  };
+  function ThemeProvider(props: Props): JSX.Element;
+  export default ThemeProvider;
 }
 
 declare module '@theme/ThemedImage' {
   import type {ComponentProps} from 'react';
-
   export type Props = {
     readonly sources: {
       readonly light: string;
       readonly dark: string;
     };
   } & Omit<ComponentProps<'img'>, 'src'>;
-
   const ThemedImage: (props: Props) => JSX.Element;
   export default ThemedImage;
 }
 
-declare module '@theme/ThemeProvider' {
-  import type {ReactNode} from 'react';
-
-  export type Props = {readonly children: ReactNode};
-
-  const ThemeProvider: (props: Props) => JSX.Element;
-  export default ThemeProvider;
-}
-
-declare module '@theme/TOC' {
-  import type {TOCItem} from '@docusaurus/types';
-
-  export type TOCProps = {
-    readonly toc: readonly TOCItem[];
-  };
-
-  const TOC: (props: TOCProps) => JSX.Element;
-  export default TOC;
-}
-
-declare module '@theme/TOCInline' {
-  import type {TOCItem} from '@docusaurus/types';
-
-  export type TOCInlineProps = {
-    readonly toc: readonly TOCItem[];
-  };
-
-  const TOCInline: (props: TOCInlineProps) => JSX.Element;
-  export default TOCInline;
-}
-
 declare module '@theme/Toggle' {
   import type {ComponentProps} from 'react';
-  import type ReactToggle from 'react-toggle';
-
-  export type Props = ComponentProps<typeof ReactToggle>;
-
-  const Toggle: (props: Props) => JSX.Element;
-  export default Toggle;
+  import Toggle from 'react-toggle';
+  export type Props = ComponentProps<typeof Toggle>;
+  export default function (props: Props): JSX.Element;
 }
 
 declare module '@theme/UserPreferencesProvider' {
   import type {ReactNode} from 'react';
-
-  export type Props = {readonly children: ReactNode};
-
-  const UserPreferencesProvider: (props: Props) => JSX.Element;
+  export type Props = {
+    readonly children: ReactNode;
+  };
+  function UserPreferencesProvider(props: Props): JSX.Element;
   export default UserPreferencesProvider;
 }
 
-declare module '@theme/LayoutProviders' {
-  import type {ReactNode} from 'react';
-
-  export type Props = {readonly children: ReactNode};
-
-  const LayoutProviders: (props: Props) => JSX.Element;
-  export default LayoutProviders;
+declare module '@theme/hooks/useAnnouncementBar' {
+  export type useAnnouncementBarReturns = {
+    readonly isAnnouncementBarClosed: boolean;
+    readonly closeAnnouncementBar: () => void;
+  };
+  const useAnnouncementBar: () => useAnnouncementBarReturns;
+  export default useAnnouncementBar;
 }
 
-declare module '@theme/ThemeContext' {
-  import type {Context} from 'react';
-  import type {ThemeContextProps} from '@theme/hooks/useThemeContext';
-
-  const ThemeContext: Context<ThemeContextProps | undefined>;
-  export default ThemeContext;
+declare module '@theme/hooks/useContextualSearchFilters' {
+  type ContextualSearchFilters = {
+    locale: string;
+    tags: string[];
+  };
+  export default function useContextualSearchFilters(): ContextualSearchFilters;
 }
 
-declare module '@theme/UserPreferencesContext' {
-  import type {Context} from 'react';
-  import type {UserPreferencesContextProps} from '@theme/hooks/useUserPreferencesContext';
-
-  const UserPreferencesContext: Context<
-    UserPreferencesContextProps | undefined
-  >;
-  export default UserPreferencesContext;
+declare module '@theme/hooks/useHideableNavbar' {
+  export type useHideableNavbarReturns = {
+    readonly navbarRef: (node: HTMLElement | null) => void;
+    readonly isNavbarVisible: boolean;
+  };
+  const useHideableNavbar: (hideOnScroll: boolean) => useHideableNavbarReturns;
+  export default useHideableNavbar;
 }
 
-declare module '@theme/Logo' {
-  import type {ComponentProps} from 'react';
-
-  export type Props = {
-    imageClassName?: string;
-    titleClassName?: string;
-  } & ComponentProps<'a'>;
-
-  const Logo: (props: Props) => JSX.Element;
-  export default Logo;
+declare module '@theme/hooks/useKeyboardNavigation' {
+  function useKeyboardNavigation(): void;
+  export default useKeyboardNavigation;
 }
 
-declare module '@theme/IconArrow' {
-  import type {ComponentProps} from 'react';
-
-  export type Props = ComponentProps<'svg'>;
-
-  const IconArrow: (props: Props) => JSX.Element;
-  export default IconArrow;
+declare module '@theme/hooks/useLocationHash' {
+  import type {Dispatch, SetStateAction} from 'react';
+  export type useLocationHashReturns = readonly [
+    string,
+    Dispatch<SetStateAction<string>>,
+  ];
+  function useLocationHash(initialHash: string): useLocationHashReturns;
+  export default useLocationHash;
 }
 
-declare module '@theme/IconEdit' {
-  import type {ComponentProps} from 'react';
-
-  export type Props = ComponentProps<'svg'>;
-
-  const IconEdit: (props: Props) => JSX.Element;
-  export default IconEdit;
+declare module '@theme/hooks/useLockBodyScroll' {
+  function useLockBodyScroll(lock?: boolean): void;
+  export default useLockBodyScroll;
 }
 
-declare module '@theme/IconMenu' {
-  import type {ComponentProps} from 'react';
-
-  export type Props = ComponentProps<'svg'>;
-
-  const IconMenu: (props: Props) => JSX.Element;
-  export default IconMenu;
+declare module '@theme/hooks/usePrismTheme' {
+  import defaultTheme from 'prism-react-renderer/themes/palenight';
+  const usePrismTheme: () => typeof defaultTheme;
+  export default usePrismTheme;
 }
 
-declare module '@theme/IconLanguage' {
-  import type {ComponentProps} from 'react';
+declare module '@theme/hooks/useScrollPosition' {
+  export type ScrollPosition = {
+    scrollX: number;
+    scrollY: number;
+  };
+  const useScrollPosition: (
+    effect?: ((position: ScrollPosition) => void) | undefined,
+    deps?: unknown[],
+  ) => ScrollPosition;
+  export default useScrollPosition;
+}
 
-  export type Props = ComponentProps<'svg'>;
+declare module '@theme/hooks/useTOCHighlight' {
+  function useTOCHighlight(
+    linkClassName: string,
+    linkActiveClassName: string,
+    topOffset: number,
+  ): void;
+  export default useTOCHighlight;
+}
 
-  const IconLanguage: (props: Props) => JSX.Element;
-  export default IconLanguage;
+declare module '@theme/hooks/useTabGroupChoice' {
+  export type useTabGroupChoiceReturns = {
+    readonly tabGroupChoices: {
+      readonly [groupId: string]: string;
+    };
+    readonly setTabGroupChoices: (groupId: string, newChoice: string) => void;
+  };
+  const useTabGroupChoice: () => useTabGroupChoiceReturns;
+  export default useTabGroupChoice;
+}
+
+declare module '@theme/hooks/useTheme' {
+  export type useThemeReturns = {
+    readonly isDarkTheme: boolean;
+    readonly setLightTheme: () => void;
+    readonly setDarkTheme: () => void;
+  };
+  const useTheme: () => useThemeReturns;
+  export default useTheme;
+}
+
+declare module '@theme/hooks/useThemeContext' {
+  export type ThemeContextProps = {
+    isDarkTheme: boolean;
+    setLightTheme: () => void;
+    setDarkTheme: () => void;
+  };
+  function useThemeContext(): ThemeContextProps;
+  export default useThemeContext;
+}
+
+declare module '@theme/hooks/useUserPreferencesContext' {
+  export type UserPreferencesContextProps = {
+    tabGroupChoices: {
+      readonly [groupId: string]: string;
+    };
+    setTabGroupChoices: (groupId: string, newChoice: string) => void;
+    isAnnouncementBarClosed: boolean;
+    closeAnnouncementBar: () => void;
+  };
+  function useUserPreferencesContext(): UserPreferencesContextProps;
+  export default useUserPreferencesContext;
+}
+
+declare module '@theme/hooks/useWindowSize' {
+  const windowSizes: {
+    readonly desktop: 'desktop';
+    readonly mobile: 'mobile';
+  };
+  export type WindowSize = keyof typeof windowSizes;
+  function useWindowSize(): WindowSize | undefined;
+  export {windowSizes};
+  export default useWindowSize;
 }

--- a/packages/docusaurus-theme-classic/tsconfig.types.json
+++ b/packages/docusaurus-theme-classic/tsconfig.types.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "amd",
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "noImplicitAny": false,
+    "jsx": "react",
+    "baseUrl": "src",
+    "outFile": "./.tmp.d.ts"
+  },
+  "include": ["src/"]
+}

--- a/packages/docusaurus-theme-classic/update-types.js
+++ b/packages/docusaurus-theme-classic/update-types.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const fs = require('fs');
+
+const inPath = './.tmp.d.ts';
+const outPath = './src/types.d.ts';
+
+let content = fs.readFileSync(inPath, 'utf-8');
+
+const header = `/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable import/no-duplicates */
+/* eslint-disable spaced-comment */
+/* eslint-disable import/newline-after-import */
+/// <reference types="@docusaurus/module-type-aliases" />
+/// <reference types="@docusaurus/plugin-content-blog" />
+/// <reference types="@docusaurus/plugin-content-docs" />
+/// <reference types="@docusaurus/plugin-content-pages" />
+`;
+
+const toIgnore = [
+  'translations',
+  'index',
+  '@theme/SearchBar',
+  '@theme/MDXPage',
+  '@theme/DocPage',
+  '@theme/DocItem',
+  '@theme/BlogListPage',
+  '@theme/BlogPostPage',
+  '@theme/BlogSidebar',
+  '@theme/BlogTagsPostsPage',
+  '@theme/BlogTagsListPage',
+];
+
+content = content
+  // replace theme/*/index with @theme/*
+  .replace(/theme\/([a-zA-Z0-9-]+)\/index/g, '@theme/$1')
+  // replace theme/* with @theme/*
+  .replace(/(?<!@)theme\/([a-zA-Z0-9-]+)/g, '@theme/$1')
+  // remove css imports
+  .replace(/\s+import .*'.+.css';/g, '')
+  // remove multi-line comments - Copyright (c) Facebook
+  .replace(/(\/\*[\s\S]*?\*\/[\n\r\s]+|\/\/\/.+)/gm, '')
+  // update imports to type imports
+  .replace(/import {/gm, 'import type {')
+  .replace('/// <reference types="react" />\n', '')
+  // ignore modules that are created by different packages
+  .split('declare ')
+  .filter((item) => {
+    const match = item.match(/module "([^"]+)"/);
+    return !match || !match[1] || !toIgnore.includes(match[1]);
+  })
+  .join('\ndeclare ');
+
+fs.rmSync(inPath);
+fs.writeFileSync(outPath, header + content, 'utf-8');


### PR DESCRIPTION
## Motivation

improve type maintenance, I'm unsure if this is actually good idea as this is still manual task that has to be executed by user during development 
we should think about better way to do this.

this PR adds script to generate `types.d.ts`
https://github.com/facebook/docusaurus/blob/6979d9a99e8581e93f3d03a7d79ea7adcec91c4f/packages/docusaurus-theme-classic/src/types.d.ts 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
