### PR TITLE
fix(v2): add missing peer dep on @babel/core

### DIFF
--- a/packages/docusaurus-plugin-pwa/package.json
+++ b/packages/docusaurus-plugin-pwa/package.json
@@ -29,6 +29,7 @@
     "workbox-window": "^6.1.1"
   },
   "peerDependencies": {
+    "@babel/core": "^7.0.0",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

![image](https://user-images.githubusercontent.com/1404810/111030861-d6001f80-8404-11eb-809b-08035e8ff113.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yup!

## Test Plan

Adding

```yaml
packageExtensions:
  "@docusaurus/plugin-pwa@*":
    peerDependencies:
      "@babel/core": "^7.0.0"
```

removes the warning

## Related PRs

N/A