### PR TITLE
fix(v2): allow using pre tag in Markdown directly

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {isValidElement} from 'react';
 import Link from '@docusaurus/Link';
-import CodeBlock from '@theme/CodeBlock';
+import CodeBlock, {Props} from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 
@@ -25,7 +25,13 @@ const MDXComponents: MDXComponentsObject = {
   a: (props) => <Link {...props} />,
   pre: (props: any) => {
     const {children} = props;
-    return <CodeBlock {...children?.props} />;
+    return (
+      <CodeBlock
+        {...((isValidElement(children)
+          ? children?.props
+          : {children}) as Props)}
+      />
+    );
   },
   h1: Heading('h1'),
   h2: Heading('h2'),

--- a/website/src/pages/examples/markdownPageExample.md
+++ b/website/src/pages/examples/markdownPageExample.md
@@ -188,4 +188,15 @@ function Clock(props) {
 
 <code>test</code>
 
+## direct using of `pre`
+
+<pre>test</pre>
+
+<!-- Multi-line text inside `pre` will turn into one-liner, but it's okay (https://github.com/mdx-js/mdx/issues/1095) -->
+<pre>
+1
+2
+3
+</pre>
+
 ## Custom heading id {#custom}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In #4315 a small regression was made related with using of `<pre>` tag in Markdown markup. Usually it is not necessary to use this tag, but legacy content pages (e.g., when migrating from other platforms) can contains it.

However, when using pre in the MDX will be removed all line breaks (see https://github.com/mdx-js/mdx/issues/1095). So it shouldn't be used anyway and users will have to use triple backtick or CodeBlock component to proper formatting of code blocks.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
