### PR TITLE
fix(v2): Fix writeHeadingIds on Windows due to non-posix paths

### DIFF
--- a/packages/docusaurus/src/commands/writeHeadingIds.ts
+++ b/packages/docusaurus/src/commands/writeHeadingIds.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import globby from 'globby';
 import fs from 'fs-extra';
 import GithubSlugger from 'github-slugger';
 import chalk from 'chalk';
@@ -14,6 +13,7 @@ import initPlugins from '../server/plugins/init';
 
 import {flatten} from 'lodash';
 import {parseMarkdownHeadingId} from '@docusaurus/utils';
+import {safeGlobby} from '../server/utils';
 
 export function unwrapMarkdownLinks(line: string): string {
   return line.replace(/\[([^\]]+)\]\([^)]+\)/g, (match, p1) => p1);
@@ -107,7 +107,7 @@ async function getPathsToWatch(siteDir: string): Promise<string[]> {
 }
 
 export default async function writeHeadingIds(siteDir: string): Promise<void> {
-  const markdownFiles = await globby(await getPathsToWatch(siteDir), {
+  const markdownFiles = await safeGlobby(await getPathsToWatch(siteDir), {
     expandDirectories: ['**/*.{md,mdx}'],
   });
 

--- a/packages/docusaurus/src/server/translations/translationsExtractor.ts
+++ b/packages/docusaurus/src/server/translations/translationsExtractor.ts
@@ -11,11 +11,10 @@ import chalk from 'chalk';
 import {parse, types as t, NodePath, TransformOptions} from '@babel/core';
 import {flatten} from 'lodash';
 import {TranslationFileContent, TranslationMessage} from '@docusaurus/types';
-import globby from 'globby';
 import nodePath from 'path';
 import {InitPlugin} from '../plugins/init';
-import {posixPath} from '@docusaurus/utils';
 import {SRC_DIR_NAME} from '../../constants';
+import {safeGlobby} from '../utils';
 
 // We only support extracting source code translations from these kind of files
 const TranslatableSourceCodeExtension = new Set([
@@ -54,13 +53,7 @@ function getPluginSourceCodeFilePaths(plugin: InitPlugin): string[] {
 export async function globSourceCodeFilePaths(
   dirPaths: string[],
 ): Promise<string[]> {
-  // Required for Windows support, as paths using \ should not be used by globby
-  // (also using the windows hard drive prefix like c: is not a good idea)
-  const globPaths = dirPaths.map((dirPath) =>
-    posixPath(nodePath.relative(process.cwd(), dirPath)),
-  );
-
-  const filePaths = await globby(globPaths);
+  const filePaths = await safeGlobby(dirPaths);
   return filePaths.filter(isTranslatableSourceCodePath);
 }
 

--- a/packages/docusaurus/src/server/utils.ts
+++ b/packages/docusaurus/src/server/utils.ts
@@ -6,6 +6,9 @@
  */
 import {flatMap} from 'lodash';
 import {RouteConfig} from '@docusaurus/types';
+import globby from 'globby';
+import nodePath from 'path';
+import {posixPath} from '@docusaurus/utils';
 
 // Recursively get the final routes (routes with no subroutes)
 export function getAllFinalRoutes(routeConfig: RouteConfig[]): RouteConfig[] {
@@ -13,4 +16,19 @@ export function getAllFinalRoutes(routeConfig: RouteConfig[]): RouteConfig[] {
     return route.routes ? flatMap(route.routes, getFinalRoutes) : [route];
   }
   return flatMap(routeConfig, getFinalRoutes);
+}
+
+// Globby that fix Windows path patterns
+// See https://github.com/facebook/docusaurus/pull/4222#issuecomment-795517329
+export async function safeGlobby(
+  patterns: string[],
+  options?: globby.GlobbyOptions,
+) {
+  // Required for Windows support, as paths using \ should not be used by globby
+  // (also using the windows hard drive prefix like c: is not a good idea)
+  const globPaths = patterns.map((dirPath) =>
+    posixPath(nodePath.relative(process.cwd(), dirPath)),
+  );
+
+  return globby(globPaths, options);
 }


### PR DESCRIPTION

## Motivation

the write-heading-ids cli did not work on Windows

Reported here: https://github.com/facebook/docusaurus/pull/4222#issuecomment-795517329
