### PR TITLE
chore: fb json header commit typo

### DIFF
--- a/packages/docusaurus-theme-classic/codeTranslations/ko.json
+++ b/packages/docusaurus-theme-classic/codeTranslations/ko.json
@@ -1,9 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
 {
   "theme.AnnouncementBar.closeButtonAriaLabel": "닫기",
   "theme.CodeBlock.copied": "복사했습니다",


### PR DESCRIPTION

## Motivation

commit typo: fb header should not be added to json files