### PR TITLE
chore(v2): Joi cyclic dep warning

### DIFF
--- a/packages/docusaurus-utils-validation/package.json
+++ b/packages/docusaurus-utils-validation/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "@docusaurus/utils": "2.0.0-alpha.72",
-    "@docusaurus/utils-validation": "2.0.0-alpha.72",
     "chalk": "^4.1.0",
     "joi": "^17.4.0",
     "tslib": "^2.1.0"

--- a/packages/docusaurus-utils-validation/src/Joi.ts
+++ b/packages/docusaurus-utils-validation/src/Joi.ts
@@ -5,8 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// /!\ don't remove this export, as we recommend plugin authors to use it
-export {default as Joi} from './Joi';
-
-export * from './validationUtils';
-export * from './validationSchemas';
+export {default} from 'joi';

--- a/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Joi} from '@docusaurus/utils-validation';
+import Joi from '../Joi';
 
 import {
   AdmonitionsSchema,

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import * as Joi from 'joi';
+import Joi from './Joi';
 import {isValidPathname} from '@docusaurus/utils';
 
 export const PluginIdSchema = Joi.string()

--- a/packages/docusaurus-utils-validation/src/validationUtils.ts
+++ b/packages/docusaurus-utils-validation/src/validationUtils.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import * as Joi from 'joi';
+import Joi from './Joi';
 import chalk from 'chalk';
 import {PluginIdSchema} from './validationSchemas';
 


### PR DESCRIPTION
`@docusaurus/utils-validation` depends on itself by mistake.

This removes the cyclic dependency warning:

![image](https://user-images.githubusercontent.com/749374/111682119-499a9600-8824-11eb-98aa-ff612cead35d.png)
