### PR TITLE
fix(v2): select correct tab when items are incorrectly ordered

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -46,10 +46,12 @@ function Tabs(props: Props): JSX.Element {
     }
   }
 
-  const handleTabChange = (event) => {
-    const selectedTab = event.target;
+  const handleTabChange = (
+    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement>,
+  ) => {
+    const selectedTab = event.currentTarget;
     const selectedTabIndex = tabRefs.indexOf(selectedTab);
-    const selectedTabValue = children[selectedTabIndex].props.value;
+    const selectedTabValue = values[selectedTabIndex].value;
 
     setSelectedValue(selectedTabValue);
 

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -429,8 +429,8 @@ declare module '@theme/TabItem' {
   export type Props = {
     readonly children: ReactNode;
     readonly value: string;
-    readonly hidden: boolean;
-    readonly className: string;
+    readonly hidden?: boolean;
+    readonly className?: string;
   };
 
   const TabItem: (props: Props) => JSX.Element;


### PR DESCRIPTION
## Motivation

fixes #4465

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

create md(x) file in project with

```jsx
import Tabs from '@theme/Tabs';
import TabItem from '@theme/TabItem';

<Tabs values={[ {label: 'Android', value: 'android'}, {label: 'iOS', value: 'ios'}, {label: 'Web', value: 'web'}, ]}>
  <TabItem value="web">Web</TabItem>
  <TabItem value="android">Android</TabItem>
  <TabItem value="ios">iOS</TabItem>
</Tabs>
```

currently there is no component gallery or place where specific test can be added

simple regression test can be done by checking: https://deploy-preview-4468--docusaurus-2.netlify.app/docs/typescript-support
