### PR TITLE
chore: fix GH actions lint problem matchers issue in PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Installation
         run: yarn
       - name: Lint
-        run: yarn lint
+        run: yarn lint:ci
       - name: Prettier Code
         run: yarn prettier:diff
       - name: Prettier Docs

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prettier-docs": "prettier --config .prettierrc --write \"**/*.{md,mdx}\"",
     "prettier-docs:diff": "prettier --config .prettierrc --list-different \"**/*.{md,mdx}\"",
     "lint": "yarn lint:js && yarn lint:style",
+    "lint:ci": "yarn lint:js --quiet && yarn lint:style",
     "lint:js": "eslint --cache \"**/*.{js,jsx,ts,tsx}\"",
     "lint:style": "stylelint \"**/*.css\"",
     "lerna": "lerna",


### PR DESCRIPTION

## Motivation

With #4447 we now lint on Github Actions and also use setup-node actions, enabling GH actions "problem matchers".

The problem is that now each PR has a list of reported lint errors in the files tab, like here: https://github.com/facebook/docusaurus/pull/4468/files

This is distracting PR reviews, so I'm using eslint `--quiet` option to ensure we don't care about warnings in CI and they don't end up in the PR.

cc @SamChou19815 , any alternative to suggest?

![image](https://user-images.githubusercontent.com/749374/111818538-942d1880-88df-11eb-9999-0972bfe2532e.png)

