### PR TITLE
docs(v2): fixed broken link in sidebar documentation

### DIFF
--- a/website/docs/guides/docs/sidebar.md
+++ b/website/docs/guides/docs/sidebar.md
@@ -64,7 +64,7 @@ In this example, notice the following:
 
 - The key `docs` is the id of the sidebar. The id can be any value, not necessarily `docs`.
 - `Getting Started` is a category within the sidebar.
-- `greeting` and `doc1` are both [sidebar item](#sidebar-item).
+- `greeting` and `doc1` are both [sidebar item](#understanding-sidebar-items).
 
 Shorthand notation can also be used:
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.  Help us understand your motivation by explaining why you decided to make this change.  You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md  Happy contributing!  -->

  ## Issue  
The [Sidebar Object](https://v2.docusaurus.io/docs/sidebar#sidebar-object) Section contains a statement:  `greeting and doc1 are both sidebar item`.
Here the _sidebar item_ links to broken URL ie. https://v2.docusaurus.io/docs/sidebar#sidebar-item
![image](https://user-images.githubusercontent.com/53327173/111817841-83db6480-8904-11eb-9582-8a101db0dae8.png)

## Fix
Updated the link with https://v2.docusaurus.io/docs/sidebar#understanding-sidebar-items

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes.