### PR TITLE
perf(v2): reduce amount of component updates while scrolling

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -190,12 +190,15 @@ function DocSidebar({
   isHidden,
 }: Props): JSX.Element | null {
   const [showResponsiveSidebar, setShowResponsiveSidebar] = useState(false);
+  const [showAnnouncementBar, setShowAnnouncementBar] = useState(true);
   const {
     navbar: {hideOnScroll},
     hideableSidebar,
   } = useThemeConfig();
   const {isAnnouncementBarClosed} = useUserPreferencesContext();
-  const {scrollY} = useScrollPosition();
+  useScrollPosition(({scrollY}) => {
+    setShowAnnouncementBar(scrollY === 0);
+  });
 
   useLockBodyScroll(showResponsiveSidebar);
   const windowSize = useWindowSize();
@@ -222,7 +225,7 @@ function DocSidebar({
           {
             'menu--show': showResponsiveSidebar,
             [styles.menuWithAnnouncementBar]:
-              !isAnnouncementBarClosed && scrollY === 0,
+              !isAnnouncementBarClosed && showAnnouncementBar,
           },
         )}>
         <button

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -14,7 +14,6 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   const location = useLocation();
   const [isNavbarVisible, setIsNavbarVisible] = useState(hideOnScroll);
   const isFocusedAnchor = useRef(false);
-  const [lastScrollTop, setLastScrollTop] = useState(0);
   const [navbarHeight, setNavbarHeight] = useState(0);
   const navbarRef = useCallback((node: HTMLElement | null) => {
     if (node !== null) {
@@ -23,7 +22,7 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   }, []);
 
   useScrollPosition(
-    ({scrollY: scrollTop}) => {
+    ({scrollY: scrollTop}, {scrollY: lastScrollTop}) => {
       if (!hideOnScroll) {
         return;
       }
@@ -36,7 +35,6 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
       if (isFocusedAnchor.current) {
         isFocusedAnchor.current = false;
         setIsNavbarVisible(false);
-        setLastScrollTop(scrollTop);
         return;
       }
 
@@ -53,18 +51,12 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
       } else if (scrollTop + windowHeight < documentHeight) {
         setIsNavbarVisible(true);
       }
-
-      setLastScrollTop(scrollTop);
     },
-    [lastScrollTop, navbarHeight, isFocusedAnchor],
+    [navbarHeight, isFocusedAnchor],
   );
 
   useEffect(() => {
     if (!hideOnScroll) {
-      return;
-    }
-
-    if (!lastScrollTop) {
       return;
     }
 

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {useState, useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import type {ScrollPosition} from '@theme/hooks/useScrollPosition';
 
@@ -15,19 +15,19 @@ const getScrollPosition = (): ScrollPosition => ({
 });
 
 const useScrollPosition = (
-  effect?: (position: ScrollPosition) => void,
+  effect?: (position: ScrollPosition, lastPosition: ScrollPosition) => void,
   deps = [],
-): ScrollPosition => {
-  const [scrollPosition, setScrollPosition] = useState(getScrollPosition());
+): void => {
+  const scrollPosition = useRef(getScrollPosition());
 
   const handleScroll = () => {
     const currentScrollPosition = getScrollPosition();
 
-    setScrollPosition(currentScrollPosition);
-
     if (effect) {
-      effect(currentScrollPosition);
+      effect(currentScrollPosition, scrollPosition.current);
     }
+
+    scrollPosition.current = currentScrollPosition;
   };
 
   useEffect(() => {
@@ -35,12 +35,11 @@ const useScrollPosition = (
       passive: true,
     };
 
+    handleScroll();
     window.addEventListener('scroll', handleScroll, opts);
 
     return () => window.removeEventListener('scroll', handleScroll, opts);
   }, deps);
-
-  return scrollPosition;
 };
 
 export default useScrollPosition;

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -163,9 +163,9 @@ declare module '@theme/hooks/useScrollPosition' {
   export type ScrollPosition = {scrollX: number; scrollY: number};
 
   const useScrollPosition: (
-    effect?: (position: ScrollPosition) => void,
+    effect?: (position: ScrollPosition, lastPosition: ScrollPosition) => void,
     deps?: unknown[],
-  ) => ScrollPosition;
+  ) => void;
   export default useScrollPosition;
 }
 


### PR DESCRIPTION
## Motivation

This change limits amount of NavBar component updates by not updating it on every keyframe while user scroll through website

fixes #4454

<details>
  <summary>Chrome</summary>

**New "performance"**

![image](https://user-images.githubusercontent.com/625469/111827586-58e41700-88ea-11eb-8501-3bf0ec11a781.png)


**Old "performance"**

![image](https://user-images.githubusercontent.com/625469/111827629-66999c80-88ea-11eb-8253-a28a0e3e7835.png)

</details>

<details>
  <summary>Firefox</summary>

**New flame chart**

![image](https://user-images.githubusercontent.com/625469/111823260-05bb9580-88e5-11eb-8564-ff6e629df011.png)

**Old flame chart**

![image](https://user-images.githubusercontent.com/625469/111823311-18ce6580-88e5-11eb-80c0-0a36f8733686.png)

</details>

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

open website in browser and start scrolling
