### PR TITLE
chore(v2): fix typo in classic init template

### DIFF
--- a/examples/classic/README.md
+++ b/examples/classic/README.md
@@ -14,7 +14,7 @@ yarn install
 yarn start
 ```
 
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 ## Build
 


### PR DESCRIPTION
A very small typo as found there https://gitlab.com/nomadic-labs/coq-tezos-of-ocaml/-/merge_requests/42#note_529524133