### PR TITLE
docs(v2): add missing version link to legacy (v1) version of website

### DIFF
--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -99,6 +99,24 @@ function Version() {
             </table>
           </div>
         )}
+        <div className="margin-bottom--lg">
+          <h3 id="legacy">Docusaurus v1 (Legacy)</h3>
+          <p>
+            Here you can find documentation for legacy version of Docusaurus.
+          </p>
+          <table>
+            <tbody>
+              <tr>
+                <th>1.x</th>
+                <td>
+                  <a href={`https://v1.docusaurus.io/docs/en/installation`}>
+                    Documentation
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </main>
     </Layout>
   );


### PR DESCRIPTION
## Motivation

Add missing link to previous - legacy - v1 version of page in v2 docs

![image](https://user-images.githubusercontent.com/625469/112192410-35c9a800-8c07-11eb-971a-a7309f92a91c.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes
