### PR TITLE
fix(v2): do not warn about duplicated title for pages

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/__snapshots__/parseMarkdown.test.ts.snap
+++ b/packages/docusaurus-utils/src/__tests__/__snapshots__/parseMarkdown.test.ts.snap
@@ -81,6 +81,17 @@ Object {
 }
 `;
 
+exports[`load utils: parseMarkdown readFrontMatter should not warn about duplicated title 1`] = `
+Object {
+  "content": "# test",
+  "excerpt": "",
+  "frontMatter": Object {
+    "title": "title",
+  },
+  "hasFrontMatter": true,
+}
+`;
+
 exports[`load utils: parseMarkdown readFrontMatter should parse first heading as title 1`] = `
 Object {
   "content": "",

--- a/packages/docusaurus-utils/src/__tests__/parseMarkdown.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/parseMarkdown.test.ts
@@ -96,6 +96,23 @@ describe('load utils: parseMarkdown', () => {
       ).toMatchSnapshot();
       expect(warn).not.toBeCalled();
     });
+    test('should not warn about duplicated title', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(
+        readFrontMatter(
+          dedent`
+          ---
+          title: title
+          ---
+          # test
+          `,
+          undefined,
+          {},
+          false,
+        ),
+      ).toMatchSnapshot();
+      expect(warn).not.toBeCalled();
+    });
   });
 
   describe('parseMarkdownString', () => {

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -276,9 +276,11 @@ export function readFrontMatter(
     const heading = /^# (.*)[\n\r]?/gi.exec(result.content);
     if (heading) {
       if (result.data.title) {
-        console.warn(
-          `Duplicate title detected in \`${source || 'this'}\` file`,
-        );
+        if (removeTitleHeading) {
+          console.warn(
+            `Duplicate title detected in \`${source || 'this'}\` file`,
+          );
+        }
       } else {
         result.data.title = heading[1].trim();
         if (removeTitleHeading) {


### PR DESCRIPTION
## Motivation

remove invalid warning about duplicated title in pages

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

unit tests should pass and warning for pages should disappear for src/pages/examples/markdownPageExample.md

## Related PRs

#4485
