### PR TITLE
ci: change default actions timeout from 6h to 30m

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   lint:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/migration-cli.yml
+++ b/.github/workflows/migration-cli.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/v1-tests-windows.yml
+++ b/.github/workflows/v1-tests-windows.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/v1-tests.yml
+++ b/.github/workflows/v1-tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/v2-build-blog-only.yml
+++ b/.github/workflows/v2-build-blog-only.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   lint:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/v2-build-size-report.yml
+++ b/.github/workflows/v2-build-size-report.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   yarn-v1:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,6 +40,7 @@ jobs:
         env:
           CI: true
   yarn-v2:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/v2-tests-windows.yml
+++ b/.github/workflows/v2-tests-windows.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Motivation

while working on #4404 i noticed that default timeout for github actions is set to 6h, in case of issues in webpack like here: https://github.com/facebook/docusaurus/runs/2181853194?check_suite_focus=true we can run into cases when job is never going to be finished.

default value is set to 360min (6h) and this change reduces it to 30min (no job for now is executed for longer than 12min on linux and 20min on windows)

ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes
