### PR TITLE
docs(v2): config for self-hosted docsearch crawler

### DIFF
--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -33,6 +33,9 @@ module.exports = {
       // Optional: see doc section below
       contextualSearch: true,
 
+      // Optional: see doc section below
+      appId: 'YOUR_APP_ID',
+
       // Optional: Algolia search parameters
       searchParameters: {},
 
@@ -79,6 +82,24 @@ module.exports = {
 When using `contextualSearch: true`, the contextual facet filters will be merged with the ones provided with `algolia.searchParameters.facetFilters`.
 
 :::
+
+### Custom Application ID {#custom-application-id}
+
+When [running your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler, it is [required to set the `appId` configuration key](https://docsearch.algolia.com/docs/behavior/#appid) to your own Application ID. If left unset, the `appId` will fallback to the one used with the free, hosted version of Algolia DocSearch.
+
+```jsx title="docusaurus.config.js"
+module.exports = {
+  // ...
+  themeConfig: {
+    // ...
+    // highlight-start
+    algolia: {
+      appId: 'YOUR_APP_ID',
+    },
+    // highlight-end
+  },
+};
+```
 
 ### Styling your Algolia search {#styling-your-algolia-search}
 


### PR DESCRIPTION
## Motivation

This PR adds a section in the search docs on the additional configuration required when running your own DocSearch crawler.

Related: #454

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

N/A

