### PR TITLE
feat(v2): docusaurus deploy: ability to configure port in git url

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -34,6 +34,7 @@ export interface DocusaurusConfig {
   organizationName?: string;
   projectName?: string;
   githubHost?: string;
+  githubPort?: string;
   plugins?: PluginConfig[];
   themes?: PluginConfig[];
   presets?: PresetConfig[];

--- a/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
@@ -5,23 +5,53 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { buildUrl } from '../buildRemoteBranchUrl'
+import {buildUrl} from '../buildRemoteBranchUrl';
 
 describe('remoteeBranchUrl', () => {
   test('should build a normal ssh url', async () => {
-    const url = buildUrl("github.com", undefined, undefined, "facebook", "docusaurus", true)
-    expect(url).toEqual("git@github.com:facebook/docusaurus.git");
+    const url = buildUrl(
+      'github.com',
+      undefined,
+      undefined,
+      'facebook',
+      'docusaurus',
+      true,
+    );
+    expect(url).toEqual('git@github.com:facebook/docusaurus.git');
   });
   test('should build a ssh url with port', async () => {
-    const url = buildUrl("github.com", "422", undefined, "facebook", "docusaurus", true)
-    expect(url).toEqual("ssh://git@github.com:422/facebook/docusaurus.git");
+    const url = buildUrl(
+      'github.com',
+      '422',
+      undefined,
+      'facebook',
+      'docusaurus',
+      true,
+    );
+    expect(url).toEqual('ssh://git@github.com:422/facebook/docusaurus.git');
   });
   test('should build a normal http url', async () => {
-    const url = buildUrl("github.com", undefined, "user:pass", "facebook", "docusaurus", false);
-    expect(url).toEqual("https://user:pass@github.com/facebook/docusaurus.git");
+    const url = buildUrl(
+      'github.com',
+      undefined,
+      'user:pass',
+      'facebook',
+      'docusaurus',
+      false,
+    );
+    expect(url).toEqual('https://user:pass@github.com/facebook/docusaurus.git');
   });
   test('should build a normal http url', async () => {
-    const url = buildUrl("github.com", "5433", "user:pass", "facebook", "docusaurus", false);
-    expect(url).toEqual("https://user:pass@github.com:5433/facebook/docusaurus.git");
+    const url = buildUrl(
+      'github.com',
+      '5433',
+      'user:pass',
+      'facebook',
+      'docusaurus',
+      false,
+    );
+    expect(url).toEqual(
+      'https://user:pass@github.com:5433/facebook/docusaurus.git',
+    );
   });
 });

--- a/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
@@ -9,19 +9,19 @@ import { buildUrl } from '../buildRemoteBranchUrl'
 
 describe('remoteeBranchUrl', () => {
   test('should build a normal ssh url', async () => {
-    const url = buildUrl("github.com", undefined, undefined, "org", "prj", true)
-    expect(url).toEqual("git@github.com:org/prj.git");
+    const url = buildUrl("github.com", undefined, undefined, "facebook", "docusaurus", true)
+    expect(url).toEqual("git@github.com:facebook/docusaurus.git");
   });
   test('should build a ssh url with port', async () => {
-    const url = buildUrl("github.com", "422", undefined, "org", "prj", true)
-    expect(url).toEqual("ssh://git@github.com:422/org/prj.git");
+    const url = buildUrl("github.com", "422", undefined, "facebook", "docusaurus", true)
+    expect(url).toEqual("ssh://git@github.com:422/facebook/docusaurus.git");
   });
   test('should build a normal http url', async () => {
-    const url = buildUrl("github.com", undefined, "user:pass", "org", "prj", false);
-    expect(url).toEqual("https://user:pass@github.com/org/prj.git");
+    const url = buildUrl("github.com", undefined, "user:pass", "facebook", "docusaurus", false);
+    expect(url).toEqual("https://user:pass@github.com/facebook/docusaurus.git");
   });
   test('should build a normal http url', async () => {
-    const url = buildUrl("github.com", "5433", "user:pass", "org", "prj", false);
-    expect(url).toEqual("https://user:pass@github.com:5433/org/prj.git");
+    const url = buildUrl("github.com", "5433", "user:pass", "facebook", "docusaurus", false);
+    expect(url).toEqual("https://user:pass@github.com:5433/facebook/docusaurus.git");
   });
 });

--- a/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { buildUrl } from '../buildRemoteBranchUrl'
+
+describe('remoteeBranchUrl', () => {
+  test('should build a normal ssh url', async () => {
+    const url = buildUrl("github.com", undefined, undefined, "org", "prj", true)
+    expect(url).toEqual("git@github.com:org/prj.git");
+  });
+  test('should build a ssh url with port', async () => {
+    const url = buildUrl("github.com", "422", undefined, "org", "prj", true)
+    expect(url).toEqual("ssh://git@github.com:422/org/prj.git");
+  });
+  test('should build a normal http url', async () => {
+    const url = buildUrl("github.com", undefined, "user:pass", "org", "prj", false);
+    expect(url).toEqual("https://user:pass@github.com/org/prj.git");
+  });
+  test('should build a normal http url', async () => {
+    const url = buildUrl("github.com", "5433", "user:pass", "org", "prj", false);
+    expect(url).toEqual("https://user:pass@github.com:5433/org/prj.git");
+  });
+});

--- a/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
+++ b/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function buildUrl(githubHost: string, githubPort: string | undefined, gitCredentials: string | undefined, organizationName: string, projectName: string, useSSH: boolean | undefined) {
+  return useSSH
+      ? buildSshUrl(githubHost, organizationName, projectName, githubPort)
+      : buildHttpsUrl(gitCredentials, githubHost, organizationName, projectName, githubPort);
+}
+
+function buildSshUrl(githubHost: string, organizationName: string, projectName: string, githubPort: string | undefined) {
+  if (githubPort) {
+    return `ssh://git@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
+  }
+  return `git@${githubHost}:${organizationName}/${projectName}.git`;
+}
+
+function buildHttpsUrl(gitCredentials: string | undefined, githubHost: string, organizationName: string, projectName: string, githubPort: string | undefined) {
+  if (githubPort) {
+    return `https://${gitCredentials}@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
+  }
+  return `https://${gitCredentials}@${githubHost}/${organizationName}/${projectName}.git`;
+}

--- a/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
+++ b/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
@@ -5,20 +5,44 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export function buildUrl(githubHost: string, githubPort: string | undefined, gitCredentials: string | undefined, organizationName: string, projectName: string, useSSH: boolean | undefined) {
+export function buildUrl(
+  githubHost: string,
+  githubPort: string | undefined,
+  gitCredentials: string | undefined,
+  organizationName: string,
+  projectName: string,
+  useSSH: boolean | undefined,
+) {
   return useSSH
-      ? buildSshUrl(githubHost, organizationName, projectName, githubPort)
-      : buildHttpsUrl(gitCredentials, githubHost, organizationName, projectName, githubPort);
+    ? buildSshUrl(githubHost, organizationName, projectName, githubPort)
+    : buildHttpsUrl(
+        gitCredentials,
+        githubHost,
+        organizationName,
+        projectName,
+        githubPort,
+      );
 }
 
-function buildSshUrl(githubHost: string, organizationName: string, projectName: string, githubPort: string | undefined) {
+function buildSshUrl(
+  githubHost: string,
+  organizationName: string,
+  projectName: string,
+  githubPort: string | undefined,
+) {
   if (githubPort) {
     return `ssh://git@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
   }
   return `git@${githubHost}:${organizationName}/${projectName}.git`;
 }
 
-function buildHttpsUrl(gitCredentials: string | undefined, githubHost: string, organizationName: string, projectName: string, githubPort: string | undefined) {
+function buildHttpsUrl(
+  gitCredentials: string | undefined,
+  githubHost: string,
+  organizationName: string,
+  projectName: string,
+  githubPort: string | undefined,
+) {
   if (githubPort) {
     return `https://${gitCredentials}@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
   }

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -99,7 +99,11 @@ export default async function deploy(
 
   const githubHost =
     process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
-
+  const githubPort =
+    process.env.GITHUB_PORT || siteConfig.githubPort || (useSSH && useSSH.toLowerCase() === 'true'
+      ? '22'
+      : '433');
+  
   const useSSH = process.env.USE_SSH;
   const gitPass: string | undefined = process.env.GIT_PASS;
   let gitCredentials = `${gitUser}`;
@@ -107,8 +111,8 @@ export default async function deploy(
     gitCredentials = `${gitCredentials}:${gitPass}`;
   }
 
-  const sshRemoteBranch: string = `git@${githubHost}:${organizationName}/${projectName}.git`;
-  const nonSshRemoteBranch: string = `https://${gitCredentials}@${githubHost}/${organizationName}/${projectName}.git`;
+  const sshRemoteBranch: string = `git@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
+  const nonSshRemoteBranch: string = `https://${gitCredentials}@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
 
   const remoteBranch =
     useSSH && useSSH.toLowerCase() === 'true'

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -13,6 +13,7 @@ import build from './build';
 import {BuildCLIOptions} from '@docusaurus/types';
 import path from 'path';
 import os from 'os';
+import { buildUrl } from './buildRemoteBranchUrl';
 
 // GIT_PASS env variable should not appear in logs
 function obfuscateGitPass(str) {
@@ -36,6 +37,7 @@ function shellExecLog(cmd) {
     throw e;
   }
 }
+
 
 export default async function deploy(
   siteDir: string,
@@ -97,7 +99,6 @@ export default async function deploy(
     (projectName.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages');
   console.log(`${chalk.cyan('deploymentBranch:')} ${deploymentBranch}`);
 
-  const useSSH = process.env.USE_SSH;
 
   const githubHost =
     process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
@@ -109,16 +110,14 @@ export default async function deploy(
     gitCredentials = `${gitCredentials}:${gitPass}`;
   }
 
-  const githubAddress = `${githubHost}${githubPort ? ':' + githubPort : ''}`;
-  const githubPath = `${organizationName}/${projectName}`;
-
-  const sshRemoteBranch: string = `ssh://git@${githubAddress}/${githubPath}.git`;
-  const nonSshRemoteBranch: string = `https://${gitCredentials}@${githubAddress}/${githubPath}.git`;
-
-  const remoteBranch =
-    useSSH && useSSH.toLowerCase() === 'true'
-      ? sshRemoteBranch
-      : nonSshRemoteBranch;
+  const useSSH = process.env.USE_SSH;
+  const remoteBranch = buildUrl(
+    githubHost,
+    githubPort,
+    gitCredentials,
+    organizationName,
+    projectName,
+    (useSSH !== undefined && useSSH.toLowerCase() === 'true'));
 
   console.log(
     `${chalk.cyan('Remote branch:')} ${obfuscateGitPass(remoteBranch)}`,

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -13,7 +13,7 @@ import build from './build';
 import {BuildCLIOptions} from '@docusaurus/types';
 import path from 'path';
 import os from 'os';
-import { buildUrl } from './buildRemoteBranchUrl';
+import {buildUrl} from './buildRemoteBranchUrl';
 
 // GIT_PASS env variable should not appear in logs
 function obfuscateGitPass(str) {
@@ -37,7 +37,6 @@ function shellExecLog(cmd) {
     throw e;
   }
 }
-
 
 export default async function deploy(
   siteDir: string,
@@ -99,7 +98,6 @@ export default async function deploy(
     (projectName.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages');
   console.log(`${chalk.cyan('deploymentBranch:')} ${deploymentBranch}`);
 
-
   const githubHost =
     process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
   const githubPort = process.env.GITHUB_PORT || siteConfig.githubPort;
@@ -117,7 +115,8 @@ export default async function deploy(
     gitCredentials,
     organizationName,
     projectName,
-    (useSSH !== undefined && useSSH.toLowerCase() === 'true'));
+    useSSH !== undefined && useSSH.toLowerCase() === 'true',
+  );
 
   console.log(
     `${chalk.cyan('Remote branch:')} ${obfuscateGitPass(remoteBranch)}`,

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -97,22 +97,23 @@ export default async function deploy(
     (projectName.indexOf('.github.io') !== -1 ? 'master' : 'gh-pages');
   console.log(`${chalk.cyan('deploymentBranch:')} ${deploymentBranch}`);
 
+  const useSSH = process.env.USE_SSH;
+
   const githubHost =
     process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
-  const githubPort =
-    process.env.GITHUB_PORT || siteConfig.githubPort || (useSSH && useSSH.toLowerCase() === 'true'
-      ? '22'
-      : '433');
-  
-  const useSSH = process.env.USE_SSH;
+  const githubPort = process.env.GITHUB_PORT || siteConfig.githubPort;
+
   const gitPass: string | undefined = process.env.GIT_PASS;
   let gitCredentials = `${gitUser}`;
   if (gitPass) {
     gitCredentials = `${gitCredentials}:${gitPass}`;
   }
 
-  const sshRemoteBranch: string = `git@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
-  const nonSshRemoteBranch: string = `https://${gitCredentials}@${githubHost}:${githubPort}/${organizationName}/${projectName}.git`;
+  const githubAddress = `${githubHost}${githubPort ? ':' + githubPort : ''}`;
+  const githubPath = `${organizationName}/${projectName}`;
+
+  const sshRemoteBranch: string = `ssh://git@${githubAddress}/${githubPath}.git`;
+  const nonSshRemoteBranch: string = `https://${gitCredentials}@${githubAddress}/${githubPath}.git`;
 
   const remoteBranch =
     useSSH && useSSH.toLowerCase() === 'true'

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -204,6 +204,18 @@ module.exports = {
 };
 ```
 
+### `githubPort` {#githubPort}
+
+- Type: `string`
+
+The port of your server. Useful if you are using GitHub Enterprise.
+
+```js title="docusaurus.config.js"
+module.exports = {
+  githubPort: '22',
+};
+```
+
 ### `themeConfig` {#themeconfig}
 
 - Type: `Object`

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -99,6 +99,7 @@ GitHub enterprise installations should work in the same manner as github.com; yo
 | Name          | Description                                     |
 | ------------- | ----------------------------------------------- |
 | `GITHUB_HOST` | The domain name of your GitHub enterprise site. |
+| `GITHUB_PORT` | The port of your GitHub enterprise site.        |
 
 ### Deploy {#deploy}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

To have a way to deploy it to a github which is not running under the port 22.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
