### PR TITLE
docs(v2): add a missing "export" from the initial template

### DIFF
--- a/packages/docusaurus-init/templates/classic/docs/create-a-page.md
+++ b/packages/docusaurus-init/templates/classic/docs/create-a-page.md
@@ -16,7 +16,7 @@ Create a file at `src/pages/my-react-page.js`:
 import React from 'react';
 import Layout from '@theme/Layout';
 
-function HelloWorld() {
+export default function MyReactPage() {
   return (
     <Layout>
       <h1>My React page</h1>
@@ -24,8 +24,6 @@ function HelloWorld() {
     </Layout>
   );
 }
-
-export default HelloWorld;
 ```
 
 A new page is now available at `http://localhost:3000/my-react-page`.

--- a/packages/docusaurus-init/templates/classic/docs/create-a-page.md
+++ b/packages/docusaurus-init/templates/classic/docs/create-a-page.md
@@ -24,6 +24,8 @@ function HelloWorld() {
     </Layout>
   );
 }
+
+export default HelloWorld;
 ```
 
 A new page is now available at `http://localhost:3000/my-react-page`.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Improve the initial template
For now, if a new user creates the project using the CLI, it opens at http://localhost:3000.
It is convenience for the user to continue reading at the guide that already shows on http://localhost:3000.
But it's missing an" export" command on the guide and it makes the guide doesn't work.
This commit is consistent with the official guide at https://docusaurus.io/docs/creating-pages (current version: 2.0.0-alpha.72)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No

## Related PRs

#4320 