### PR TITLE
fix: DocNavbarItem error message

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -27,11 +27,12 @@ export default function DocNavbarItem({
 
   const doc = version.docs.find((versionDoc) => versionDoc.id === docId);
   if (!doc) {
+    const docIds = version.docs.map((doc) => {return doc.id}).join('\n- ')
     throw new Error(
       `DocNavbarItem: couldn't find any doc with id=${docId} in version ${
         version.name
       }.
-Available docIds=\n- ${version.docs.join('\n- ')}`,
+Available docIds=\n- ${docIds}`,
     );
   }
 

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -27,11 +27,9 @@ export default function DocNavbarItem({
 
   const doc = version.docs.find((versionDoc) => versionDoc.id === docId);
   if (!doc) {
-    const docIds = version.docs.map((versionDoc) => versionDoc.id).join('\n- ')
+    const docIds = version.docs.map((versionDoc) => versionDoc.id).join('\n- ');
     throw new Error(
-      `DocNavbarItem: couldn't find any doc with id=${docId} in version ${
-        version.name
-      }.
+      `DocNavbarItem: couldn't find any doc with id=${docId} in version ${version.name}.
 Available docIds=\n- ${docIds}`,
     );
   }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -27,7 +27,7 @@ export default function DocNavbarItem({
 
   const doc = version.docs.find((versionDoc) => versionDoc.id === docId);
   if (!doc) {
-    const docIds = version.docs.map((doc) => {return doc.id}).join('\n- ')
+    const docIds = version.docs.map((versionDoc) => versionDoc.id).join('\n- ')
     throw new Error(
       `DocNavbarItem: couldn't find any doc with id=${docId} in version ${
         version.name


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When you set an invalid `docId` inside `docusaurus.config.js`, the error message that's thrown by `DocNavbarItem` does not let you know the list of existing `docId`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?


Yes.
## Before

![Screenshot from 2021-04-02 13-35-30](https://user-images.githubusercontent.com/2767218/113412447-964fa680-93b8-11eb-9de6-0f80f522e818.png)


## After 

![Screenshot from 2021-04-02 13-35-07](https://user-images.githubusercontent.com/2767218/113412460-a1a2d200-93b8-11eb-9a3d-1eefc70be22c.png)



