### PR TITLE
docs(v2): fixed broken link in i18n-tutorial.md

### DIFF
--- a/website/docs/i18n/i18n-tutorial.md
+++ b/website/docs/i18n/i18n-tutorial.md
@@ -153,7 +153,7 @@ JSON translation files are used for everything that is not contained in a Markdo
 - Docs sidebar category labels
 - ...
 
-Run the [write-translations](../cli.md#docusaurus-write-translations) command:
+Run the [write-translations](../cli.md#docusaurus-write-translations-sitedir) command:
 
 ```bash npm2yarn
 npm run write-translations -- --locale fr


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixed broken link in `i18n-tutorial.md`
In [Translate JSON Files](https://docusaurus.io/docs/i18n/tutorial#translate-json-files) section.

Run the write-translations redirects to https://docusaurus.io/docs/cli#docusaurus-write-translations, which is broken
Instead it should redirect to https://docusaurus.io/docs/cli#docusaurus-write-translations-sitedir

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

