### PR TITLE
docs(v2): add a missing slug from the initial template

### DIFF
--- a/packages/docusaurus-init/templates/classic/docs/create-a-blog-post.md
+++ b/packages/docusaurus-init/templates/classic/docs/create-a-blog-post.md
@@ -10,6 +10,7 @@ Create a file at `blog/2021-02-28-greetings.md`:
 
 ```md title="blog/2021-02-28-greetings.md"
 ---
+slug: greetings
 title: Greetings!
 author: Steven Hansel
 author_title: Docusaurus Contributor


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Improve the initial template. (`classic` template)

After creating the initial template, the guide shows on the http://localhost:3000/docs/create-a-blog-post
says the created blog will be available at http://localhost:3000/blog/greetings, but it's not, because of lacking of a `slug` config on the metadata of the md file.

This commit adds the missing slug config


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

#4320 
