### PR TITLE
fix(v2): fix i18n isLastLocale bug preventing docusaurus from building some locales

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -88,7 +88,7 @@ export default async function build(
 
     const results = await mapAsyncSequencial(orderedLocales, (locale) => {
       const isLastLocale =
-        i18n.locales.indexOf(locale) === i18n.locales.length - 1;
+        orderedLocales.indexOf(locale) === i18n.locales.length - 1;
       return tryToBuildLocale({locale, isLastLocale});
     });
     return results[0];

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -88,7 +88,7 @@ export default async function build(
 
     const results = await mapAsyncSequencial(orderedLocales, (locale) => {
       const isLastLocale =
-        orderedLocales.indexOf(locale) === i18n.locales.length - 1;
+        orderedLocales.indexOf(locale) === orderedLocales.length - 1;
       return tryToBuildLocale({locale, isLastLocale});
     });
     return results[0];


### PR DESCRIPTION

## Motivation

Typo in the build script makes Docusaurus bail-out of the build process too soon and it does not build all locales provided by the user.

Fixes #4567
