### PR TITLE
docs(v2): Include docusaurus-protobuffet to community plugins

### DIFF
--- a/website/community/resources.md
+++ b/website/community/resources.md
@@ -40,6 +40,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
 - [docusaurus-plugin-remote-content](https://github.com/rdilweb/docusaurus-plugin-remote-content) - A Docusaurus v2 plugin that allows you to fetch content from remote sources
 - [docusaurus2-graphql-doc-generator](https://github.com/edno/docusaurus2-graphql-doc-generator) - A Docusaurus v2 plugin for generating documentation from a GraphQL schema
+- [docusaurus-protobuffet](https://github.com/protobuffet/docusaurus-protobuffet) - Docusaurus toolset for Protobuf contract documentation
 
 ## Enterprise usage {#enterprise-usage}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

As a member of a team that works with Protobuf contracts, we have a need for developer-driven documentation that satisfies both the consumers and builders of APIs driven by these contracts. This documentation should be driven by the Protobuf contracts they document, while being extensible with human-provided context.

We already use Docusaurus at my organization for JSON APIs, but we lack the tooling required to document RPC services backed by Protobuf contracts. I've decided to leverage the Docusaurus plugin framework to provide this tooling.

[Protobuffet](https://protobuffet.com/) is a Docusaurus preset that generates doc files using Protobuf contracts. In this PR, I'm including this preset in the Community Plugins section of the docs. Check out the [Protobuffet docs](https://protobuffet.com/docs/what/overview) for more info on this toolset.

![Example Screenshot](https://github.com/protobuffet/docusaurus-protobuffet/blob/master/screenshots/overview.png?raw=true)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
