### PR TITLE
docs(v2): i18n site: enable ko + zh-CN locales

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -59,9 +59,9 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
     defaultLocale: 'en',
     locales: isI18nStaging
       ? // Staging locales: https://docusaurus-i18n-staging.netlify.app/
-        ['en', 'zh-CN', 'ko', 'ja']
+        ['en', 'ja']
       : // Production locales
-        ['en', 'fr'],
+        ['en', 'fr', 'ko', 'zh-CN'],
   },
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -57,7 +57,10 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
   url: 'https://docusaurus.io',
   i18n: {
     defaultLocale: 'en',
-    locales: isI18nStaging
+    locales: isDeployPreview
+      ? // Deploy preview: keep it fast!
+        ['en']
+      : isI18nStaging
       ? // Staging locales: https://docusaurus-i18n-staging.netlify.app/
         ['en', 'ja']
       : // Production locales


### PR DESCRIPTION


## Motivation

ko and zh-CN have enough translations on Crowdin (according to threshold we defined in https://github.com/facebook/docusaurus/issues/3526)

Let's enable those locales in production!
