### PR TITLE
fix(v2): use page title from config if not set

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
@@ -82,15 +82,13 @@ function CanonicalUrlHeaders({permalink}: {permalink?: string}) {
 
 export default function LayoutHead(props: Props): JSX.Element {
   const {
-    siteConfig,
+    siteConfig: {
+      favicon,
+      themeConfig: {metadatas},
+    },
     i18n: {currentLocale, localeConfigs},
   } = useDocusaurusContext();
-  const {
-    favicon,
-    themeConfig: {image: defaultImage, metadatas},
-  } = siteConfig;
   const {title, description, image, keywords, searchMetadatas} = props;
-
   const faviconUrl = useBaseUrl(favicon);
 
   // See https://github.com/facebook/docusaurus/issues/3317#issuecomment-754661855
@@ -105,7 +103,7 @@ export default function LayoutHead(props: Props): JSX.Element {
         {favicon && <link rel="shortcut icon" href={faviconUrl} />}
       </Head>
 
-      <Seo {...{title, description, keywords, image: image || defaultImage}} />
+      <Seo {...{title, description, keywords, image}} />
 
       <CanonicalUrlHeaders />
 

--- a/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
@@ -7,8 +7,9 @@
 
 import React from 'react';
 import Head from '@docusaurus/Head';
+import {useThemeConfig, useTitleFormatter} from '@docusaurus/theme-common';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import {useTitleFormatter} from '@docusaurus/theme-common';
+
 import type {Props} from '@theme/Seo';
 
 export default function Seo({
@@ -17,13 +18,14 @@ export default function Seo({
   keywords,
   image,
 }: Props): JSX.Element {
-  const metaTitle = useTitleFormatter(title);
-  const metaImageUrl = useBaseUrl(image, {absolute: true});
+  const {image: defaultImage} = useThemeConfig();
+  const pageTitle = useTitleFormatter(title);
+  const pageImage = useBaseUrl(image || defaultImage, {absolute: true});
 
   return (
     <Head>
-      {title && <title>{metaTitle}</title>}
-      {title && <meta property="og:title" content={metaTitle} />}
+      <title>{pageTitle}</title>
+      <meta property="og:title" content={pageTitle} />
 
       {description && <meta name="description" content={description} />}
       {description && <meta property="og:description" content={description} />}
@@ -37,9 +39,9 @@ export default function Seo({
         />
       )}
 
-      {image && <meta property="og:image" content={metaImageUrl} />}
-      {image && <meta name="twitter:image" content={metaImageUrl} />}
-      {image && <meta name="twitter:card" content="summary_large_image" />}
+      {pageImage && <meta property="og:image" content={pageImage} />}
+      {pageImage && <meta name="twitter:image" content={pageImage} />}
+      {pageImage && <meta name="twitter:card" content="summary_large_image" />}
     </Head>
   );
 }

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -100,6 +100,7 @@ export type ThemeConfig = {
   prism: PrismConfig;
   footer?: Footer;
   hideableSidebar: boolean;
+  image: string;
 };
 
 export function useThemeConfig(): ThemeConfig {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #4549

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try remove `title` prop from `Layout` component of any page and make sure that title from config has been used.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
