### PR TITLE
perf(v2): avoid rerender of sidebar items while scrolling

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState, useCallback, useEffect, useRef} from 'react';
+import React, {useState, useCallback, useEffect, useRef, useMemo} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig, isSamePath} from '@docusaurus/theme-common';
 import useUserPreferencesContext from '@theme/hooks/useUserPreferencesContext';
@@ -209,6 +209,27 @@ function DocSidebar({
     }
   }, [windowSize]);
 
+  const closeResponsiveSidebar = useCallback(
+    (e) => {
+      e.target.blur();
+      setShowResponsiveSidebar(false);
+    },
+    [setShowResponsiveSidebar],
+  );
+  const sidebarItems = useMemo(
+    () =>
+      sidebar.map((item) => (
+        <DocSidebarItem
+          key={item.label}
+          item={item}
+          onItemClick={closeResponsiveSidebar}
+          collapsible={sidebarCollapsible}
+          activePath={path}
+        />
+      )),
+    [sidebar, sidebarCollapsible, path, closeResponsiveSidebar],
+  );
+
   return (
     <div
       className={clsx(styles.sidebar, {
@@ -266,20 +287,7 @@ function DocSidebar({
             />
           )}
         </button>
-        <ul className="menu__list">
-          {sidebar.map((item) => (
-            <DocSidebarItem
-              key={item.label}
-              item={item}
-              onItemClick={(e) => {
-                e.target.blur();
-                setShowResponsiveSidebar(false);
-              }}
-              collapsible={sidebarCollapsible}
-              activePath={path}
-            />
-          ))}
-        </ul>
+        <ul className="menu__list">{sidebarItems}</ul>
       </div>
       {hideableSidebar && (
         <button


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Should fix #4589 

Currently we use the scroll event to adjust the correct height of the doc sidebar when displaying the announcement bar. To do this we toggle the class if the user scrolls to the top of a page, which in turn causes the while DocSidebar component to be re-rendered at this moment. Since only items in this component are the most memory-consuming elements, I propose to memoize them to mitigate that issue. 

https://github.com/facebook/docusaurus/blob/f12e8b596d7af688e1800bdcdcc8aa7ec30f9d4c/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx#L199-L201

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See To Reproduce section in #4589

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
