### PR TITLE
docs(v2): heading typo

### DIFF
--- a/website/docs/using-themes.md
+++ b/website/docs/using-themes.md
@@ -71,7 +71,7 @@ And if you want to use Bootstrap styling, you can swap out the theme with `theme
 }
 ```
 
-## Wrapper your site with `<Root>` {#wrapper-your-site-with-root}
+## Wrapping your site with `<Root>` {#wrapper-your-site-with-root}
 
 A `<Root>` theme component is rendered at the very top of your Docusaurus site.
 


### PR DESCRIPTION
Hi there,
It looks like there is a typo in the heading.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Reduction of the typo cardinality in the open source world.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
None

## Related PRs
None