### PR TITLE
refactor(v2): replace react-toggle with own implementation

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -33,7 +33,6 @@
     "@docusaurus/utils-validation": "2.0.0-alpha.72",
     "@mdx-js/mdx": "^1.6.21",
     "@mdx-js/react": "^1.6.21",
-    "@types/react-toggle": "^4.0.2",
     "chalk": "^4.1.0",
     "clsx": "^1.1.1",
     "copy-text-to-clipboard": "^3.0.0",
@@ -47,7 +46,6 @@
     "prismjs": "^1.23.0",
     "prop-types": "^15.7.2",
     "react-router-dom": "^5.2.0",
-    "react-toggle": "^4.1.2",
     "rtlcss": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -112,7 +112,6 @@ function Navbar(): JSX.Element {
           {!disableColorModeSwitch && (
             <Toggle
               className={styles.displayOnlyInLargeViewport}
-              aria-label="Dark mode toggle"
               checked={isDarkTheme}
               onChange={onToggleChange}
             />
@@ -134,11 +133,7 @@ function Navbar(): JSX.Element {
             onClick={hideSidebar}
           />
           {!disableColorModeSwitch && sidebarShown && (
-            <Toggle
-              aria-label="Dark mode toggle in sidebar"
-              checked={isDarkTheme}
-              onChange={onToggleChange}
-            />
+            <Toggle checked={isDarkTheme} onChange={onToggleChange} />
           )}
         </div>
         <div className="navbar-sidebar__items">

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {CSSProperties} from 'react';
-import Toggle from 'react-toggle';
+import React, {useState, useRef, CSSProperties} from 'react';
 import type {Props} from '@theme/Toggle';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -31,21 +30,63 @@ const Light = ({icon, style}: IconProps): JSX.Element => (
 );
 
 export default function (props: Props): JSX.Element {
+  const {className, checked: defaultChecked, onChange} = props;
   const {
     colorMode: {
       switchConfig: {darkIcon, darkIconStyle, lightIcon, lightIconStyle},
     },
   } = useThemeConfig();
   const {isClient} = useDocusaurusContext();
+  const [checked, setChecked] = useState(defaultChecked);
+  const [focused, setFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleToggle = (e) => {
+    const checkbox = inputRef.current;
+
+    if (!checkbox) {
+      return;
+    }
+
+    if (e.target !== checkbox) {
+      e.preventDefault();
+      checkbox.focus();
+      checkbox.click();
+      return;
+    }
+
+    setChecked(checkbox?.checked);
+  };
 
   return (
-    <Toggle
-      disabled={!isClient}
-      icons={{
-        checked: <Dark icon={darkIcon} style={darkIconStyle} />,
-        unchecked: <Light icon={lightIcon} style={lightIconStyle} />,
-      }}
-      {...props}
-    />
+    <div
+      className={clsx('react-toggle', className, {
+        'react-toggle--checked': checked,
+        'react-toggle--focus': focused,
+        'react-toggle--disabled': !isClient,
+      })}
+      role="button"
+      tabIndex={-1}
+      onClick={handleToggle}>
+      <div className="react-toggle-track">
+        <div className="react-toggle-track-check">
+          <Dark icon={darkIcon} style={darkIconStyle} />
+        </div>
+        <div className="react-toggle-track-x">
+          <Light icon={lightIcon} style={lightIconStyle} />
+        </div>
+      </div>
+      <div className="react-toggle-thumb" />
+
+      <input
+        ref={inputRef}
+        checked={checked}
+        type="checkbox"
+        className="react-toggle-screenreader-only"
+        aria-label="Switch between dark and light mode"
+        onChange={onChange}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+      />
+    </div>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState, useRef, CSSProperties} from 'react';
+import React, {useState, useRef, memo, CSSProperties} from 'react';
 import type {Props} from '@theme/Toggle';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -29,64 +29,85 @@ const Light = ({icon, style}: IconProps): JSX.Element => (
   </span>
 );
 
+// Based on react-toggle (https://github.com/aaronshaf/react-toggle/).
+const Toggle = memo(
+  ({
+    className,
+    icons,
+    checked: defaultChecked,
+    disabled,
+    onChange,
+  }: Props & {
+    icons: {checked: JSX.Element; unchecked: JSX.Element};
+    disabled: boolean;
+  }): JSX.Element => {
+    const [checked, setChecked] = useState(defaultChecked);
+    const [focused, setFocused] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const handleToggle = (e) => {
+      const checkbox = inputRef.current;
+
+      if (!checkbox) {
+        return;
+      }
+
+      if (e.target !== checkbox) {
+        e.preventDefault();
+        checkbox.focus();
+        checkbox.click();
+        return;
+      }
+
+      setChecked(checkbox?.checked);
+    };
+
+    return (
+      <div
+        className={clsx('react-toggle', className, {
+          'react-toggle--checked': checked,
+          'react-toggle--focus': focused,
+          'react-toggle--disabled': disabled,
+        })}
+        role="button"
+        tabIndex={-1}
+        onClick={handleToggle}>
+        <div className="react-toggle-track">
+          <div className="react-toggle-track-check">{icons.checked}</div>
+          <div className="react-toggle-track-x">{icons.unchecked}</div>
+        </div>
+        <div className="react-toggle-thumb" />
+
+        <input
+          ref={inputRef}
+          checked={checked}
+          type="checkbox"
+          className="react-toggle-screenreader-only"
+          aria-label="Switch between dark and light mode"
+          onChange={onChange}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+        />
+      </div>
+    );
+  },
+);
+
 export default function (props: Props): JSX.Element {
-  const {className, checked: defaultChecked, onChange} = props;
   const {
     colorMode: {
       switchConfig: {darkIcon, darkIconStyle, lightIcon, lightIconStyle},
     },
   } = useThemeConfig();
   const {isClient} = useDocusaurusContext();
-  const [checked, setChecked] = useState(defaultChecked);
-  const [focused, setFocused] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const handleToggle = (e) => {
-    const checkbox = inputRef.current;
-
-    if (!checkbox) {
-      return;
-    }
-
-    if (e.target !== checkbox) {
-      e.preventDefault();
-      checkbox.focus();
-      checkbox.click();
-      return;
-    }
-
-    setChecked(checkbox?.checked);
-  };
 
   return (
-    <div
-      className={clsx('react-toggle', className, {
-        'react-toggle--checked': checked,
-        'react-toggle--focus': focused,
-        'react-toggle--disabled': !isClient,
-      })}
-      role="button"
-      tabIndex={-1}
-      onClick={handleToggle}>
-      <div className="react-toggle-track">
-        <div className="react-toggle-track-check">
-          <Dark icon={darkIcon} style={darkIconStyle} />
-        </div>
-        <div className="react-toggle-track-x">
-          <Light icon={lightIcon} style={lightIconStyle} />
-        </div>
-      </div>
-      <div className="react-toggle-thumb" />
-
-      <input
-        ref={inputRef}
-        checked={checked}
-        type="checkbox"
-        className="react-toggle-screenreader-only"
-        aria-label="Switch between dark and light mode"
-        onChange={onChange}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-      />
-    </div>
+    <Toggle
+      disabled={!isClient}
+      icons={{
+        checked: <Dark icon={darkIcon} style={darkIconStyle} />,
+        unchecked: <Light icon={lightIcon} style={lightIconStyle} />,
+      }}
+      {...props}
+    />
   );
 }

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -501,10 +501,13 @@ declare module '@theme/TOCInline' {
 }
 
 declare module '@theme/Toggle' {
-  import type {ComponentProps} from 'react';
-  import type ReactToggle from 'react-toggle';
+  import type {SyntheticEvent} from 'react';
 
-  export type Props = ComponentProps<typeof ReactToggle>;
+  export type Props = {
+    readonly className?: string;
+    readonly checked: boolean;
+    readonly onChange: (e: SyntheticEvent) => void;
+  };
 
   const Toggle: (props: Props) => JSX.Element;
   export default Toggle;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3672,13 +3672,6 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-toggle@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react-toggle/-/react-toggle-4.0.2.tgz#46ffa5af1a55de5f25d0aa78ef0b557b5c8bf276"
-  integrity sha512-sHqfoKFnL0YU2+OC4meNEC8Ptx9FE8/+nFeFvNcdBa6ANA8KpAzj3R9JN8GtrvlLgjKDoYgI7iILgXYcTPo2IA==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*", "@types/react@^17.0.2":
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
@@ -5949,7 +5942,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.2.3, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -16461,13 +16454,6 @@ react-textarea-autosize@^6.1.0:
   integrity sha512-F6bI1dgib6fSvG8so1HuArPUv+iVEfPliuLWusLF+gAKz0FbB4jLrWUrTAeq1afnPT2c9toEZYUdz/y1uKMy4A==
   dependencies:
     prop-types "^15.6.0"
-
-react-toggle@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.1.2.tgz#b00500832f925ad524356d909821821ae39f6c52"
-  integrity sha512-4Ohw31TuYQdhWfA6qlKafeXx3IOH7t4ZHhmRdwsm1fQREwOBGxJT+I22sgHqR/w8JRdk+AeMCJXPImEFSrNXow==
-  dependencies:
-    classnames "^2.2.5"
 
 react-transition-group@^2.3.1:
   version "2.9.0"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

A lightweight and simplified alternative to react-toggle built on functional component/hooks instead on class as in original component. Also I deliberately not using [touch events](https://github.com/aaronshaf/react-toggle/blob/master/src/component/index.js#L146-L148), because I think a mobile user can just tap on toggle to switch mode ( not sure if someone used gestures for this).
As another advantage, we get rid of another external dependency and have more control over this component.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No breaking changes, CSS class names are same.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
