### PR TITLE
chore(v2): CI: do not build all locales when monitoring build time perf

### DIFF
--- a/.github/workflows/v2-build-time-perf.yml
+++ b/.github/workflows/v2-build-time-perf.yml
@@ -24,12 +24,12 @@ jobs:
 
       # Ensure build with a cold cache does not increase too much
       - name: Build (cold cache)
-        run: yarn workspace docusaurus-2-website build
+        run: yarn workspace docusaurus-2-website build --locale en
         timeout-minutes: 10
 
       # Ensure build with a warm cache does not increase too much
       - name: Build (warm cache)
-        run: yarn workspace docusaurus-2-website build
+        run: yarn workspace docusaurus-2-website build --locale en
         timeout-minutes: 10
 
     # TODO post a Github comment with build with perf warnings?


### PR DESCRIPTION

## Motivation

Since adding new ko + zh-CN locales, the GH workflow that monitors build times are under 10min is now above 10min and the CI fails constantly.

Let's only build English site in this workflow. 

We'll probably enable for all locales again once we have webpack5 caching system that works across multiple locales