### PR TITLE
chore(v2): fix yarn2 end2end test by using lerna publish --exact

### DIFF
--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -23,7 +23,7 @@ docker run -d --rm --name "$CONTAINER_NAME" -p 4873:4873 -v "$PWD/admin/verdacci
 yarn build:packages
 
 # Publish the monorepo
-npx --no-install lerna publish --yes --no-verify-access --no-git-reset --no-git-tag-version --no-push --registry "$CUSTOM_REGISTRY_URL" "$NEW_VERSION"
+npx --no-install lerna publish --exact --yes --no-verify-access --no-git-reset --no-git-tag-version --no-push --registry "$CUSTOM_REGISTRY_URL" "$NEW_VERSION"
 
 # Revert version changes
 git diff --name-only -- '*.json' | sed 's, ,\\&,g' | xargs git checkout --


### PR DESCRIPTION

## Motivation

While working on https://github.com/facebook/docusaurus/pull/4582
I noticed a weird failure in the Yarn2 e2e test after I updated init template to use a newly created sidebar item:
https://github.com/facebook/docusaurus/runs/2334693775?check_suite_focus=true

The e2e workflow:
- build packages
- publish packages to verdaccio (self-hosted npm repo)
- init new site with published packages
- try to start/build the newly initialized site


When using Yarn2, it seems like for some weird reasons, it did not download the packages that were just published to Verdaccio, but another canary version from npm instead. Not sure what happens exactly but it seems to be the case for a while, and the CI is probably responsible for a lot of downloads on this particular canary release:

https://www.npmjs.com/package/@docusaurus/core

![image](https://user-images.githubusercontent.com/749374/114734918-fa715380-9d44-11eb-97bd-c935245f40d8.png)

Using `lerna publish --exact` permits to not use the `^` package version prefix and ensure that we always use the package that we just published to Verdaccio, instead of having some kind of fallback to another package from Yarn2.
