### PR TITLE
refactor(v2): rename class main-docs-wrapper to docs-wrapper

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -9,7 +9,7 @@
   --doc-sidebar-width: 300px;
 }
 
-:global(.main-docs-wrapper) {
+:global(.docs-wrapper) {
   display: flex;
 }
 

--- a/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
+++ b/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
@@ -18,7 +18,7 @@ export const ThemeClassNames = {
   wrapper: {
     main: 'main-wrapper',
     blogPages: 'blog-wrapper',
-    docPages: 'main-docs-wrapper',
+    docPages: 'docs-wrapper',
     mdxPages: 'mdx-wrapper',
   },
 };

--- a/website/docs/styling-layout.md
+++ b/website/docs/styling-layout.md
@@ -105,13 +105,18 @@ function MyComponent() {
 
 We provide some predefined CSS class names to provide access for developers to style layout of a page globally in Docusaurus. The purpose is to have stable classnames shared by all themes that are meant to be targeted by custom CSS.
 
-import ThemeClassNamesCode from '!!raw-loader!@site/../packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts'; import CodeBlock from '@theme/CodeBlock';
+```mdx-code-block
+import ThemeClassNamesCode from '!!raw-loader!@site/../packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts';
+
+import CodeBlock from '@theme/CodeBlock';
 
 <CodeBlock className="language-ts">
   {ThemeClassNamesCode
+    // remove source comments
     .replace(/\/\*[\s\S]*?\*\/|\/\/.*/g,'')
     .trim()}
 </CodeBlock>
+```
 
 ### CSS modules {#css-modules}
 


### PR DESCRIPTION

## Motivation


Make the docsc-wrapper global class name consistent with other wrapper classnames 

Follow up of https://github.com/facebook/docusaurus/pull/4511#discussion_r611264310)

