### PR TITLE
fix(v2): fix validation rejecting admonitions false

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
@@ -74,6 +74,27 @@ describe('normalizeDocsPluginOptions', () => {
     expect(error).toBe(undefined);
   });
 
+  test('should accept admonitions false', async () => {
+    const admonitionsFalse = {
+      ...DEFAULT_OPTIONS,
+      admonitions: false,
+    };
+    const {value, error} = OptionsSchema.validate(admonitionsFalse);
+    expect(value).toEqual(admonitionsFalse);
+    expect(error).toBe(undefined);
+  });
+
+  test('should reject admonitions true', async () => {
+    const admonitionsTrue = {
+      ...DEFAULT_OPTIONS,
+      admonitions: true,
+    };
+    const {error} = OptionsSchema.validate(admonitionsTrue);
+    expect(error).toMatchInlineSnapshot(
+      `[ValidationError: "admonitions" contains an invalid value]`,
+    );
+  });
+
   test('should reject invalid remark plugin options', () => {
     expect(() => {
       normalizePluginOptions(OptionsSchema, {

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -76,7 +76,9 @@ export const OptionsSchema = Joi.object({
   beforeDefaultRehypePlugins: RehypePluginsSchema.default(
     DEFAULT_OPTIONS.beforeDefaultRehypePlugins,
   ),
-  admonitions: AdmonitionsSchema.default(DEFAULT_OPTIONS.admonitions),
+  admonitions: Joi.alternatives()
+    .try(AdmonitionsSchema, Joi.boolean().invalid(true))
+    .default(DEFAULT_OPTIONS.admonitions),
   showLastUpdateTime: Joi.bool().default(DEFAULT_OPTIONS.showLastUpdateTime),
   showLastUpdateAuthor: Joi.bool().default(
     DEFAULT_OPTIONS.showLastUpdateAuthor,


### PR DESCRIPTION
## Motivation

Validation error prevents disabling default admonitions as documented under <https://docusaurus.io/docs/presets#official-presets>.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Automated tests were added to check `false` is accepted, and `true` is rejected.