### PR TITLE
fix(v2): Unbreak blog post title by handling title fallback in `LayoutHead`

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -98,7 +98,7 @@ function BlogPostItem(props: Props): JSX.Element {
 
   return (
     <>
-      <Seo {...{keywords, image}} />
+      <Seo {...{title, keywords, image}} />
 
       <article className={!isBlogPostPage ? 'margin-bottom--xl' : undefined}>
         {renderPostHeader()}

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -98,7 +98,7 @@ function BlogPostItem(props: Props): JSX.Element {
 
   return (
     <>
-      <Seo {...{title, keywords, image}} />
+      <Seo {...{keywords, image}} />
 
       <article className={!isBlogPostPage ? 'margin-bottom--xl' : undefined}>
         {renderPostHeader()}

--- a/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
@@ -14,6 +14,7 @@ import SearchMetadatas from '@theme/SearchMetadatas';
 import Seo from '@theme/Seo';
 import {
   DEFAULT_SEARCH_TAG,
+  useTitleFormatter,
   useAlternatePageUtils,
 } from '@docusaurus/theme-common';
 import {useLocation} from '@docusaurus/router';
@@ -90,6 +91,7 @@ export default function LayoutHead(props: Props): JSX.Element {
   } = useDocusaurusContext();
   const {title, description, image, keywords, searchMetadatas} = props;
   const faviconUrl = useBaseUrl(favicon);
+  const pageTitle = useTitleFormatter(title);
 
   // See https://github.com/facebook/docusaurus/issues/3317#issuecomment-754661855
   // const htmlLang = currentLocale.split('-')[0];
@@ -101,9 +103,11 @@ export default function LayoutHead(props: Props): JSX.Element {
       <Head>
         <html lang={htmlLang} dir={htmlDir} />
         {favicon && <link rel="shortcut icon" href={faviconUrl} />}
+        <title>{pageTitle}</title>
+        <meta property="og:title" content={pageTitle} />
       </Head>
 
-      <Seo {...{title, description, keywords, image}} />
+      <Seo {...{description, keywords, image}} />
 
       <CanonicalUrlHeaders />
 

--- a/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
@@ -24,8 +24,8 @@ export default function Seo({
 
   return (
     <Head>
-      <title>{pageTitle}</title>
-      <meta property="og:title" content={pageTitle} />
+      {title && <title>{pageTitle}</title>}
+      {title && <meta property="og:title" content={pageTitle} />}
 
       {description && <meta name="description" content={description} />}
       {description && <meta property="og:description" content={description} />}


### PR DESCRIPTION
## Motivation

Fix #4666.

### What caused the problem

The `Head` component of docusaurus is re-export of `Helmet`. According to Helmet docs, items rendered later in Head will override the ones rendered earlier. Currently, there are two places where title is changed when blog post is rendered: `<Layout>` and `<Seo>`, and `<Seo>` happens later than `<Layout>`.

When rendering a blog post page, it starts in `BlogPostPage`, which has the correct title:

https://github.com/SamChou19815/docusaurus/blob/d21444b6fb03db87796068fd476f1d10af986182/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx#L24-L29

Then it starts render `BlogPostItem`, which has a SEO component that will rerender header: https://github.com/SamChou19815/docusaurus/blob/792f4ac6fb8d7e1124f4b9f5151a827929e6dc50/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx#L99-L102

Here you can see that the title prop is not passed in. Finally, since `title` prop is not passed, it causes the blog post title to be overridden to only site title according to

https://github.com/SamChou19815/docusaurus/blob/792f4ac6fb8d7e1124f4b9f5151a827929e6dc50/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx#L15-L22

https://github.com/SamChou19815/docusaurus/blob/d21444b6fb03db87796068fd476f1d10af986182/packages/docusaurus-theme-common/src/utils/generalUtils.ts#L10-L14

~My fix is simple: adding the title prop. The practice seems to be consistently with the rest of the codebase, since every other occurrences of `Seo` will pass in the title prop~

Using the advice from @slorber, I reverted the change in #4600 that makes the SEO component handle title fallback. Instead, the fallback is moved to `LayoutHead` and the SEO fallback will only change title if the passed in `title` prop is not null.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Goto `/blog/2021/03/09/releasing-docusaurus-i18n` on preview site, and the title is correct again.

## Related PRs

N/A
