### PR TITLE
chore: add some redirects to v1.docusaurus.io

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -3,6 +3,15 @@
 # v2.docusaurus.io domain redirect after we put v2 on docusaurus.io
 https://v2.docusaurus.io/*      https://docusaurus.io/:splat 301!
 
+# Redirect older Docusaurus v1 links (unfortunately there is not always a v2 equivalent, can't use :splat safely)
+https://docusaurus.io/docs/en/*       https://docusaurus.io/
+https://docusaurus.io/docs/fr/*       https://docusaurus.io/
+https://docusaurus.io/docs/ko/*       https://docusaurus.io/
+https://docusaurus.io/docs/ro/*       https://docusaurus.io/
+https://docusaurus.io/docs/ru/*       https://docusaurus.io/
+https://docusaurus.io/docs/pt-br/*    https://docusaurus.io/
+https://docusaurus.io/docs/zh-cn/*    https://docusaurus.io/
+
 
 # Redirect to fix blog post url typo on publish :'( can be cleaned up soon
 /blog/2020/01/19/docusaurus-2020-recap            /blog/2021/01/19/docusaurus-2020-recap

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -3,14 +3,15 @@
 # v2.docusaurus.io domain redirect after we put v2 on docusaurus.io
 https://v2.docusaurus.io/*      https://docusaurus.io/:splat 301!
 
-# Redirect older Docusaurus v1 links (unfortunately there is not always a v2 equivalent, can't use :splat safely)
-https://docusaurus.io/docs/en/*       https://docusaurus.io/
-https://docusaurus.io/docs/fr/*       https://docusaurus.io/
-https://docusaurus.io/docs/ko/*       https://docusaurus.io/
-https://docusaurus.io/docs/ro/*       https://docusaurus.io/
-https://docusaurus.io/docs/ru/*       https://docusaurus.io/
-https://docusaurus.io/docs/pt-br/*    https://docusaurus.io/
-https://docusaurus.io/docs/zh-cn/*    https://docusaurus.io/
+
+# Redirect older Docusaurus v1 links that do not exist anymore in v2
+https://docusaurus.io/docs/en/*         https://v1.docusaurus.io/docs/en/:splat
+https://docusaurus.io/docs/fr/*         https://v1.docusaurus.io/docs/fr/:splat
+https://docusaurus.io/docs/ko/*         https://v1.docusaurus.io/docs/ko/:splat
+https://docusaurus.io/docs/ro/*         https://v1.docusaurus.io/docs/ro/:splat
+https://docusaurus.io/docs/ru/*         https://v1.docusaurus.io/docs/ru/:splat
+https://docusaurus.io/docs/pt-br/*      https://v1.docusaurus.io/docs/pt-br/:splat
+https://docusaurus.io/docs/zh-cn/*      https://v1.docusaurus.io/docs/zh-cn/:splat
 
 
 # Redirect to fix blog post url typo on publish :'( can be cleaned up soon


### PR DESCRIPTION

## Motivation

SEO tools report we have a few external links targeting Docusaurus v1 URLs, but these links now show a v2 404 page.

We can:
- redirect those URLs to the v1.docusaurus.io subdomain (same page)
- redirect those URLs to the v2 homepage (v1 pages might not exist in v2) and try to pass the "SEO juice" to v2

I choose the first solution