### PR TITLE
refactor(v2): align external icon on right

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -131,7 +131,7 @@
   height: 1.15rem;
   width: 1.15rem;
   min-width: 1.15rem;
-  margin: 0 auto 0 3%;
+  margin: 0 0 0 3%;
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24'%3E%3Cpath fill='rgba(0,0,0,0.5)' d='M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z'/%3E%3C/svg%3E")
     no-repeat;
   filter: var(--ifm-menu-link-sublist-icon-filter);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

For design consistency, it is better to have the same external icon positioning in external doc links. Subjectively, it looks cleaner and neater.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Demo on https://mikro-orm.io/docs/installation/ site as example:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/116004260-92efb980-a60a-11eb-9b7d-c26689813ed1.png) |  ![image](https://user-images.githubusercontent.com/4408379/116004272-9edb7b80-a60a-11eb-84ea-033ba51302fb.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
