### PR TITLE
fix(v2): normalizeLocation should allow to remove trailing slash (fix #2394)

### DIFF
--- a/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
+++ b/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
@@ -67,4 +67,26 @@ describe('normalizeLocation', () => {
       pathname: '/',
     });
   });
+
+  test('remove trailing /, unless only a /', () => {
+    expect(
+      normalizeLocation({
+        pathname: '/docs/introduction/',
+        search: '',
+        hash: '#features',
+      }),
+    ).toEqual({
+      pathname: '/docs/introduction',
+      search: '',
+      hash: '#features',
+    });
+
+    expect(
+      normalizeLocation({
+        pathname: '/',
+      }),
+    ).toEqual({
+      pathname: '/',
+    });
+  });
 });

--- a/packages/docusaurus/src/client/normalizeLocation.ts
+++ b/packages/docusaurus/src/client/normalizeLocation.ts
@@ -20,7 +20,7 @@ function normalizeLocation<T extends Location>(location: T): T {
 
   let pathname = location.pathname || '/';
   pathname = pathname.trim().replace(/\/index\.html$/, '');
-
+  pathname = pathname.replace(/\/$/, '');
   if (pathname === '') {
     pathname = '/';
   }


### PR DESCRIPTION
## Motivation

We are having the trailing-slash problem on a website I use, so I wanted it fixed.
I traced it back to the one code file and found an inconsistency in how paths are 'normailzed'.
So added an extra line to make /foo and /foo/ normalize to the same /foo path.
This fixed the problem, passes your tests and I don't think this should break anything.
First ever pull request, btw. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test to verify my change does what I wanted it to.
Verified the change did not cause any other tests to fail.

## Related PRs

This should normalize the treatment of paths whether they have a trailing slash or not.
