### PR TITLE
fix(v2): accept empty/null custom_edit_url docs frontmatter for retrocompat

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
@@ -34,4 +34,15 @@ describe('validateDocFrontMatter', () => {
     const frontMatter: DocFrontMatter = {description: ''};
     expect(validateDocFrontMatter(frontMatter)).toEqual(frontMatter);
   });
+
+  test('accept null custom_edit_url', () => {
+    const frontMatter: DocFrontMatter = {custom_edit_url: null};
+    expect(validateDocFrontMatter(frontMatter)).toEqual(frontMatter);
+  });
+
+  // See https://github.com/demisto/content-docs/pull/616#issuecomment-827087566
+  test('accept empty custom_edit_url', () => {
+    const frontMatter: DocFrontMatter = {custom_edit_url: ''};
+    expect(validateDocFrontMatter(frontMatter)).toEqual(frontMatter);
+  });
 });

--- a/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
@@ -33,7 +33,7 @@ const DocFrontMatterSchema = Joi.object<DocFrontMatter>({
   slug: Joi.string(),
   sidebar_label: Joi.string(),
   sidebar_position: Joi.number(),
-  custom_edit_url: Joi.string().allow(null),
+  custom_edit_url: Joi.string().allow('', null),
   parse_number_prefixes: Joi.boolean(),
 });
 


### PR DESCRIPTION

## Motivation

We used to accept "" as valid custom_edit_url value before adding the frontmatter validation system.

Let's keep it this way to avoid annoying existing users (see https://github.com/demisto/content-docs/pull/616#issuecomment-827087566)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

test

