### PR TITLE
docs(v2): specify google-analytics and gtag plugins

### DIFF
--- a/website/docs/api/plugins/plugin-google-analytics.md
+++ b/website/docs/api/plugins/plugin-google-analytics.md
@@ -4,7 +4,7 @@ title: '📦 plugin-google-analytics'
 slug: '/api/plugins/@docusaurus/plugin-google-analytics'
 ---
 
-The default [Google Analytics](https://developers.google.com/analytics/devguides/collection/analyticsjs/) plugin. It is a JavaScript library for measuring how users interact with your website.
+The default [Google Analytics](https://developers.google.com/analytics/devguides/collection/analyticsjs/) plugin. It is a JavaScript library for measuring how users interact with your website **in the production build**. If you are using Google Analytics 4 you might need to consider using [plugin-google-gtag](./plugin-google-gtag) instead.
 
 ## Installation {#installation}
 

--- a/website/docs/api/plugins/plugin-google-gtag.md
+++ b/website/docs/api/plugins/plugin-google-gtag.md
@@ -4,7 +4,13 @@ title: '📦 plugin-google-gtag'
 slug: '/api/plugins/@docusaurus/plugin-google-gtag'
 ---
 
-The default [Global Site Tag (gtag.js)](https://developers.google.com/analytics/devguides/collection/gtagjs/) plugin. It is a JavaScript tagging framework and API that allows you to send event data to Google Analytics, Google Ads, and Google Marketing Platform. This section describes how to configure a Docusaurus site to enable global site tag for Google Analytics.
+The default [Global Site Tag (gtag.js)](https://developers.google.com/analytics/devguides/collection/gtagjs/) plugin. It is a JavaScript tagging framework and API that allows you to send event data to Google Analytics, Google Ads, and Google Marketing Platform, **in the production build**. This section describes how to configure a Docusaurus site to enable global site tag for Google Analytics.
+
+:::tip
+
+You can use [Google's Tag Assistant](https://tagassistant.google.com/) tool to check if your gtag is set up correctly!
+
+:::
 
 ## Installation {#installation}
 
@@ -25,6 +31,7 @@ module.exports = {
   plugins: ['@docusaurus/plugin-google-gtag'],
   themeConfig: {
     gtag: {
+      // You can also use your "G-" Measurement ID here.
       trackingID: 'UA-141789564-1',
       // Optional fields.
       anonymizeIP: true, // Should IPs be anonymized?


### PR DESCRIPTION
## Motivation

As noted in #4678 it was hard to notice that the google-analytics-related plugins were only able in production builds. Notes that clarify this have been added, following the style of the _ideal-image_ plugin. Additionally, a common misconception between Tracking IDs (UA-) and Measurement IDs (G-) has been explained, and [Google's Tag Assistant](https://tagassistant.google.com/) has been linked to aid developers in debugging.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.