### PR TITLE
chore(v2): migrate webpack file-loader to asset modules

### DIFF
--- a/packages/docusaurus-init/templates/bootstrap/package.json
+++ b/packages/docusaurus-init/templates/bootstrap/package.json
@@ -19,10 +19,8 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "file-loader": "^6.2.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "url-loader": "^4.1.1"
+    "react-dom": "^17.0.1"
   },
   "browserslist": {
     "production": [

--- a/packages/docusaurus-init/templates/classic/package.json
+++ b/packages/docusaurus-init/templates/classic/package.json
@@ -19,10 +19,8 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "file-loader": "^6.2.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "url-loader": "^4.1.1"
+    "react-dom": "^17.0.1"
   },
   "browserslist": {
     "production": [

--- a/packages/docusaurus-init/templates/facebook/package.json
+++ b/packages/docusaurus-init/templates/facebook/package.json
@@ -23,10 +23,8 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "file-loader": "^6.2.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "url-loader": "^4.1.1"
+    "react-dom": "^17.0.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.13.10",

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/index.js
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/index.js
@@ -19,7 +19,7 @@ const createJSX = (node, pathUrl) => {
   const jsxNode = node;
   jsxNode.type = 'jsx';
   jsxNode.value = `<img ${node.alt ? `alt={"${escapeHtml(node.alt)}"} ` : ''}${
-    node.url ? `src={require("${pathUrl}?${assetQuery}").default}` : ''
+    node.url ? `src={require("${pathUrl}?${assetQuery}")}` : ''
   }${node.title ? ` title="${escapeHtml(node.title)}"` : ''} />`;
 
   if (jsxNode.url) {

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/index.js
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/index.js
@@ -13,17 +13,13 @@ const escapeHtml = require('escape-html');
 const {getFileLoaderUtils} = require('@docusaurus/core/lib/webpack/utils');
 const {posixPath, toMessageRelativeFilePath} = require('@docusaurus/utils');
 
-const {
-  loaders: {inlineMarkdownImageFileLoader},
-} = getFileLoaderUtils();
+const {assetQuery} = getFileLoaderUtils();
 
 const createJSX = (node, pathUrl) => {
   const jsxNode = node;
   jsxNode.type = 'jsx';
   jsxNode.value = `<img ${node.alt ? `alt={"${escapeHtml(node.alt)}"} ` : ''}${
-    node.url
-      ? `src={require("${inlineMarkdownImageFileLoader}${pathUrl}").default}`
-      : ''
+    node.url ? `src={require("${pathUrl}?${assetQuery}").default}` : ''
   }${node.title ? ` title="${escapeHtml(node.title)}"` : ''} />`;
 
   if (jsxNode.url) {

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.js
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.js
@@ -41,7 +41,7 @@ function toAssetRequireNode({node, filePath, requireAssetPath}) {
     ? relativeRequireAssetPath
     : `./${relativeRequireAssetPath}`;
 
-  const href = `require('${relativeRequireAssetPath}?${assetQuery}').default`;
+  const href = `require('${relativeRequireAssetPath}?${assetQuery}')`;
   const children = (node.children || []).map((n) => toValue(n)).join('');
   const title = node.title ? `title="${escapeHtml(node.title)}"` : '';
 

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.js
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.js
@@ -15,9 +15,7 @@ const escapeHtml = require('escape-html');
 const {toValue} = require('../utils');
 const {getFileLoaderUtils} = require('@docusaurus/core/lib/webpack/utils');
 
-const {
-  loaders: {inlineMarkdownLinkFileLoader},
-} = getFileLoaderUtils();
+const {assetQuery} = getFileLoaderUtils();
 
 async function ensureAssetFileExist(fileSystemAssetPath, sourceFilePath) {
   const assetExists = await fs.pathExists(fileSystemAssetPath);
@@ -43,7 +41,7 @@ function toAssetRequireNode({node, filePath, requireAssetPath}) {
     ? relativeRequireAssetPath
     : `./${relativeRequireAssetPath}`;
 
-  const href = `require('${inlineMarkdownLinkFileLoader}${relativeRequireAssetPath}').default`;
+  const href = `require('${relativeRequireAssetPath}?${assetQuery}').default`;
   const children = (node.children || []).map((n) => toValue(n)).join('');
   const title = node.title ? `title="${escapeHtml(node.title)}"` : '';
 

--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -32,10 +32,6 @@ export default function (
           rules: [
             {
               test: /\.(png|jpe?g)$/i,
-              type: 'javascript/auto',
-              generator: {
-                emit: !isServer,
-              },
               use: [
                 require.resolve('@docusaurus/lqip-loader'),
                 {
@@ -44,9 +40,8 @@ export default function (
                     emitFile: !isServer, // don't emit for server-side rendering
                     disable: !isProd,
                     adapter: require('@docusaurus/responsive-loader/sharp'),
-                    name: isProd
-                      ? 'assets/ideal-img/[name].[hash:hex:7].[width].[ext]'
-                      : 'assets/ideal-img/[name].[width].[ext]',
+                    name:
+                      'assets/ideal-img/[name].[contenthash:8].[width].[ext]',
                     ...options,
                   },
                 },

--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -31,7 +31,11 @@ export default function (
         module: {
           rules: [
             {
-              test: /\.(png|jpe?g|gif)$/i,
+              test: /\.(png|jpe?g)$/i,
+              type: 'javascript/auto',
+              generator: {
+                emit: !isServer,
+              },
               use: [
                 require.resolve('@docusaurus/lqip-loader'),
                 {

--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -32,6 +32,13 @@ export default function (
           rules: [
             {
               test: /\.(png|jpe?g)$/i,
+              resourceQuery: {
+                not: [/asset/],
+              },
+              type: 'javascript/auto',
+              generator: {
+                emit: !isServer,
+              },
               use: [
                 require.resolve('@docusaurus/lqip-loader'),
                 {
@@ -41,7 +48,7 @@ export default function (
                     disable: !isProd,
                     adapter: require('@docusaurus/responsive-loader/sharp'),
                     name:
-                      'assets/ideal-img/[name].[contenthash:8].[width].[ext]',
+                      'assets/ideal-img/[name]-[contenthash:8].[width].[ext]',
                     ...options,
                   },
                 },

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -24,6 +24,7 @@ import {
   applyConfigurePostCss,
   applyConfigureWebpack,
   compile,
+  getFileLoaderUtils,
 } from '../webpack/utils';
 import CleanWebpackPlugin from '../webpack/plugins/CleanWebpackPlugin';
 import {loadI18n} from '../server/i18n';
@@ -196,6 +197,11 @@ async function buildLocale({
       );
     }
   });
+
+  // Add the very high-priority rules triggered by using a resourceQuery like ?asset
+  const {prependAssetQueryRules} = getFileLoaderUtils();
+  clientConfig = prependAssetQueryRules(clientConfig);
+  serverConfig = prependAssetQueryRules(serverConfig);
 
   // Make sure generated client-manifest is cleaned first so we don't reuse
   // the one from previous builds.

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -29,6 +29,7 @@ import {
   applyConfigureWebpack,
   applyConfigurePostCss,
   getHttpsConfig,
+  getFileLoaderUtils,
 } from '../webpack/utils';
 import {getCLIOptionHost, getCLIOptionPort} from './commandUtils';
 import {getTranslationsLocaleDirPath} from '../server/translations/translations';
@@ -156,6 +157,10 @@ export default async function start(
       );
     }
   });
+
+  // Add the very high-priority rules triggered by using a resourceQuery like ?asset
+  const {prependAssetQueryRules} = getFileLoaderUtils();
+  config = prependAssetQueryRules(config);
 
   // https://webpack.js.org/configuration/dev-server
   const devServerConfig: WebpackDevServer.Configuration = {

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -108,7 +108,7 @@ export function createBaseConfig(
       chunkFilename: isProd
         ? 'assets/js/[name].[contenthash:8].js'
         : '[name].js',
-      assetModuleFilename: 'assets/[hash][ext][query]',
+      assetModuleFilename: 'assets/[name]-[hash][ext]',
       publicPath: baseUrl,
     },
     // Don't throw warning when asset created is over 250kb

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -108,6 +108,7 @@ export function createBaseConfig(
       chunkFilename: isProd
         ? 'assets/js/[name].[contenthash:8].js'
         : '[name].js',
+      assetModuleFilename: 'assets/[hash][ext][query]',
       publicPath: baseUrl,
     },
     // Don't throw warning when asset created is over 250kb
@@ -191,7 +192,7 @@ export function createBaseConfig(
         fileLoaderUtils.rules.fonts(),
         fileLoaderUtils.rules.media(),
         fileLoaderUtils.rules.svg(),
-        fileLoaderUtils.rules.otherAssets(),
+        fileLoaderUtils.rules.files(),
         {
           test: /\.(j|t)sx?$/,
           exclude: excludeJS,

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -284,7 +284,7 @@ export function compile(config: Configuration[]): Promise<void> {
   });
 }
 
-type AssetFolder = 'images' | 'files' | 'fonts' | 'medias' | 'svgs' | 'other';
+type AssetFolder = 'images' | 'files' | 'fonts' | 'medias' | 'svgs';
 
 type FileLoaderUtils = {
   assetQuery: string;
@@ -312,7 +312,9 @@ export function getFileLoaderUtils(): FileLoaderUtils {
   // - converting an SVG to a React component
   // - other cases
   const assetQuery = 'asset';
-  const assetQueryRegex = /asset/;
+  const assetResourceQuery = /asset/;
+  // Can this be removed? see https://github.com/facebook/docusaurus/commit/2f21d306bdd4d286cc5d25c81adaea2fc77f0474#commitcomment-50223144)
+  const notAssetResourceQuery: RuleSetRule['resourceQuery'] = {not: [/asset/]};
 
   // Threshold for datauri/file (previously set on url-loader)
   // files/images < 10kb will be inlined as base64 strings directly in the JS bundle
@@ -321,7 +323,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
 
   // defines the path/pattern of the assets handled by webpack
   const generatedFileName = (folder: AssetFolder) =>
-    `${OUTPUT_STATIC_ASSETS_DIR_NAME}/${folder}/[name]-[hash].[ext]`;
+    `${OUTPUT_STATIC_ASSETS_DIR_NAME}/${folder}/[name]-[hash][ext]`;
 
   function fileNameGenerator(folder: AssetFolder) {
     return {
@@ -340,6 +342,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
         },
       },
       generator: fileNameGenerator(folder),
+      resourceQuery: notAssetResourceQuery,
     };
   }
 
@@ -419,6 +422,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
   function svgComponentOrAssetRule(): RuleSetRule {
     return {
       test: /\.svg?$/,
+      resourceQuery: notAssetResourceQuery,
       oneOf: [
         {
           // only convert for those extensions
@@ -463,14 +467,14 @@ export function getFileLoaderUtils(): FileLoaderUtils {
     })(configuration, {
       module: {
         rules: [
-          {...imageAssetRule(), resourceQuery: assetQueryRegex},
-          {...fontAssetRule(), resourceQuery: assetQueryRegex},
-          {...mediaAssetRule(), resourceQuery: assetQueryRegex},
-          {...svgAssetRule(), resourceQuery: assetQueryRegex},
+          {...imageAssetRule(), resourceQuery: assetResourceQuery},
+          {...fontAssetRule(), resourceQuery: assetResourceQuery},
+          {...mediaAssetRule(), resourceQuery: assetResourceQuery},
+          {...svgAssetRule(), resourceQuery: assetResourceQuery},
           // Fallback when ?asset is used but the file is unknown
           {
             type: 'asset/resource',
-            resourceQuery: assetQueryRegex,
+            resourceQuery: assetResourceQuery,
             generator: fileNameGenerator('files'),
           },
         ],

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -333,6 +333,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
 
   function baseAssetRule(folder: AssetFolder): RuleSetRule {
     return {
+      type: 'asset',
       parser: {
         dataUrlCondition: {
           // Threshold for datauri/file (previously set on url-loader)

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -303,7 +303,7 @@ In most cases, you don't need `useBaseUrl`.
 Prefer a `require()` call for [assets](./guides/markdown-features/markdown-features-assets.mdx):
 
 ```jsx
-<img src={require('@site/static/img/myImage.png').default} />
+<img src={require('@site/static/img/myImage.png')} />
 ```
 
 :::

--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -28,7 +28,7 @@ You can use images in Markdown, or by requiring them and using a JSX image tag:
 # My Markdown page
 
 <img
-  src={require('./assets/docusaurus-asset-example-banner.png').default}
+  src={require('./assets/docusaurus-asset-example-banner.png')}
   alt="Example banner"
 />
 
@@ -64,9 +64,7 @@ In the same way, you can link to existing assets by requiring them and using the
 ```mdx
 # My Markdown page
 
-<a
-  target="_blank"
-  href={require('./assets/docusaurus-asset-example-pdf.pdf').default}>
+<a target="_blank" href={require('./assets/docusaurus-asset-example-pdf.pdf')}>
   Download this PDF
 </a>
 
@@ -77,7 +75,7 @@ or
 
 <a
   target="_blank"
-  href={require('../../assets/docusaurus-asset-example-pdf.pdf').default}>
+  href={require('../../assets/docusaurus-asset-example-pdf.pdf')}>
   Download this PDF
 </a>
 

--- a/website/docs/static-assets.md
+++ b/website/docs/static-assets.md
@@ -27,7 +27,7 @@ import DocusaurusImageUrl from '@site/static/img/docusaurus.png';
 ```
 
 ```jsx title="MyComponent.js"
-<img src={require('@site/static/img/docusaurus.png').default} />
+<img src={require('@site/static/img/docusaurus.png')} />
 ```
 
 ```jsx title="MyComponent.js"


### PR DESCRIPTION


## Breaking changes

- `require("./img/image.png").default` becomes `require("./img/image.png")`

## Motivation

url-loader and file-loader are going to be deprecated in favor of asset modules

This is an attempt to migrate to asset modules.

Some initial problems encountered:
- https://github.com/facebook/docusaurus/commit/2f21d306bdd4d286cc5d25c81adaea2fc77f0474
- https://github.com/webpack/webpack/issues/12900

cc @alexander-akait 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

## Related PRs

Follow-up of https://github.com/facebook/docusaurus/pull/4089




