### PR TITLE
fix(v2): optimize markdown parser regex (fix #4726)

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
@@ -359,7 +359,7 @@ describe('parseMarkdownContentTitle', () => {
     });
   });
 
-  test('Test', () => {
+  test('Should parse markdown h1 title placed after multiple import declarations', () => {
     const markdown = dedent`
           import Component1 from '@site/src/components/Component1';
           import Component2 from '@site/src/components/Component2';
@@ -383,7 +383,6 @@ describe('parseMarkdownContentTitle', () => {
 
         `;
 
-    // remove the useless line breaks? Does not matter too much
     expect(parseMarkdownContentTitle(markdown)).toEqual({
       content: dedent`
           import Component1 from '@site/src/components/Component1';

--- a/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
@@ -358,6 +358,58 @@ describe('parseMarkdownContentTitle', () => {
       contentTitle: undefined,
     });
   });
+
+  test('Test', () => {
+    const markdown = dedent`
+          import Component1 from '@site/src/components/Component1';
+          import Component2 from '@site/src/components/Component2';
+          import Component3 from '@site/src/components/Component3';
+          import Component4 from '@site/src/components/Component4';
+          import Component5 from '@site/src/components/Component5';
+          import Component6 from '@site/src/components/Component6';
+          import Component7 from '@site/src/components/Component7';
+          import Component8 from '@site/src/components/Component8';
+          import Component9 from '@site/src/components/Component9';
+          import Component10 from '@site/src/components/Component10';
+          import Component11 from '@site/src/components/Component11';
+          import Component12 from '@site/src/components/Component12';
+          import Component13 from '@site/src/components/Component13';
+          import Component14 from '@site/src/components/Component14';
+          import Component15 from '@site/src/components/Component15';
+
+          # Markdown Title
+
+          Lorem Ipsum
+
+        `;
+
+    // remove the useless line breaks? Does not matter too much
+    expect(parseMarkdownContentTitle(markdown)).toEqual({
+      content: dedent`
+          import Component1 from '@site/src/components/Component1';
+          import Component2 from '@site/src/components/Component2';
+          import Component3 from '@site/src/components/Component3';
+          import Component4 from '@site/src/components/Component4';
+          import Component5 from '@site/src/components/Component5';
+          import Component6 from '@site/src/components/Component6';
+          import Component7 from '@site/src/components/Component7';
+          import Component8 from '@site/src/components/Component8';
+          import Component9 from '@site/src/components/Component9';
+          import Component10 from '@site/src/components/Component10';
+          import Component11 from '@site/src/components/Component11';
+          import Component12 from '@site/src/components/Component12';
+          import Component13 from '@site/src/components/Component13';
+          import Component14 from '@site/src/components/Component14';
+          import Component15 from '@site/src/components/Component15';
+
+
+
+          Lorem Ipsum
+
+        `,
+      contentTitle: 'Markdown Title',
+    });
+  });
 });
 
 describe('parseMarkdownString', () => {

--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -86,10 +86,10 @@ export function parseMarkdownContentTitle(
 
   const content = contentUntrimmed.trim();
 
-  const regularTitleMatch = /^(?:import\s.*(from.*)?;?|\n)*?(?<pattern>#\s*(?<title>[^#\n{]*)+[ \t]*(?<suffix>({#*[\w-]+})|#)?\n*?)/g.exec(
+  const regularTitleMatch = /^(?:import\s+\S+(\s+from\s+\S+)?;?|\n)*?(?<pattern>#\s*(?<title>[^#\n{]*)+[ \t]*(?<suffix>({#*[\w-]+})|#)?\n*?)/g.exec(
     content,
   );
-  const alternateTitleMatch = /^(?:import\s.*(from.*)?;?|\n)*?(?<pattern>\s*(?<title>[^\n]*)\s*\n[=]+)/g.exec(
+  const alternateTitleMatch = /^(?:import\s+\S+(\s+from\s+\S+)?;?|\n)*?(?<pattern>\s*(?<title>[^\n]*)\s*\n[=]+)/g.exec(
     content,
   );
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #4726 (origin: #4713)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1. Clone my prepared [repo](https://github.com/nam-hle/client-docusaurus) and install
2. Start. Everything should work well
3. Incremental uncomment import statements in docs/intro.md, the compilation time will increase exponentially from around 15 imported components.
4. Apply the changes in `packages/docusaurus-utils/src/markdownParser.ts` of this PR into the corresponding compiled file (at `client-docusaurus/node_modules/@docusaurus/utils/lib/markdownParser.js`) of my repo. 
5. Do the step 2-3 again to see the compile time improvement.

Please feel free to suggest any concrete performat tests that need to do.

## Related PRs

N/A.
