### PR TITLE
chore(v2): Fix Crowdin 409 issues in CI

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -20,13 +20,15 @@
     "build:blogOnly": "cross-env yarn build --config=docusaurus.config-blog-only.js",
     "netlify:build:production": "yarn docusaurus write-translations && yarn netlify:crowdin:uploadSources && yarn netlify:crowdin:downloadTranslations && yarn build",
     "netlify:build:deployPreview": "yarn docusaurus write-translations --locale fr --messagePrefix '(fr) ' && yarn build",
-    "netlify:crowdin:downloadTranslations": "yarn --cwd .. crowdin:download:v2",
-    "netlify:crowdin:downloadTranslationsFailSafe": "yarn --cwd .. crowdin:download:v2 || echo 'Crowdin translation download failure (only internal PRs have access to the Crowdin env token)'",
+    "netlify:crowdin:wait": "node waitForCrowdin.js",
+    "netlify:crowdin:downloadTranslations": "yarn netlify:crowdin:wait && yarn --cwd .. crowdin:download:v2",
+    "netlify:crowdin:downloadTranslationsFailSafe": "yarn netlify:crowdin:wait && (yarn --cwd .. crowdin:download:v2 || echo 'Crowdin translation download failure (only internal PRs have access to the Crowdin env token)')",
     "netlify:crowdin:uploadSources": "yarn --cwd .. crowdin:upload:v2",
     "netlify:test": "yarn netlify:build:deployPreview && yarn netlify dev --debug"
   },
   "dependencies": {
     "@crowdin/cli": "^3.5.2",
+    "@crowdin/crowdin-api-client": "^1.10.6",
     "@docusaurus/core": "2.0.0-alpha.75",
     "@docusaurus/plugin-client-redirects": "2.0.0-alpha.75",
     "@docusaurus/plugin-ideal-image": "2.0.0-alpha.75",

--- a/website/waitForCrowdin.js
+++ b/website/waitForCrowdin.js
@@ -1,0 +1,65 @@
+const {Translations} = require('@crowdin/crowdin-api-client');
+
+/*
+Crowdin does not support concurrent "project builds" (downloads of translations).
+The Crowdin CLI fails with error 409, and it leads to failures on Netlify.
+
+On Docusaurus, when we commit on master, we have 2 Netlify deployments triggered:
+- prod
+- i18n-staging (work-in-progress locales)
+
+This script helps the 2 deployments to not download translations concurrently from Crowdin.
+ */
+
+const pollInterval = 5000;
+const timeout = 5 * 60 * 1000;
+
+const projectId = 428890;
+const token = process.env.CROWDIN_PERSONAL_TOKEN; // set on Netlify
+
+const translations = new Translations({
+  token,
+});
+
+async function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function hasBuildInProgress() {
+  const projectBuilds = await translations.listProjectBuilds(projectId);
+  return projectBuilds.data.some(
+    (build) => build.data.status === 'in-progress',
+  );
+}
+
+async function run() {
+  const timeBefore = Date.now();
+  while (true) {
+    if (Date.now() - timeBefore > timeout) {
+      console.warn(
+        '[Crowdin] Timeout of wait script reached => will try to proceed but download translations is likely to fail...',
+      );
+      break;
+    }
+
+    const inProgress = await hasBuildInProgress();
+    if (inProgress) {
+      console.log('[Crowdin] A build is still in progress => waiting...');
+      await delay(pollInterval);
+    } else {
+      console.warn('[Crowdin] No build in progress => lets continue');
+      break;
+    }
+  }
+}
+
+run().then(
+  () => {
+    process.exit(0);
+  },
+  (e) => {
+    console.error(e.message);
+    console.error(e.stack);
+    process.exit(1);
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,6 +1246,13 @@
   dependencies:
     shelljs "^0.8.4"
 
+"@crowdin/crowdin-api-client@^1.10.6":
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/@crowdin/crowdin-api-client/-/crowdin-api-client-1.10.6.tgz#d9cd6f340ced065b8020865b9ded69f86e8d5b30"
+  integrity sha512-6bT9WF1yJFgUCuP9q+7RH//vcULmMxmZhhmKaWLlPPRdkTEasQFednb6ITIPX0UnBvSd5r0CBSa6UqEXbBQPUQ==
+  dependencies:
+    axios "^0.21.1"
+
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"


### PR DESCRIPTION

## Motivation

Crowdin does not support concurrency well, and emit 409 errors in case of concurrent translation downloads

We have 2 Netlify deployments triggered on each PR merge: prod and i18n staging.

One of them often resulting in a 409 error.

And the prod website may not deploy immediately, which can be annoying after a new release (see https://github.com/facebook/docusaurus/discussions/4702)

Solution: a node script to wait for Crowdin API to report there is no build in progress (ie, it's safe to download the translations)

Note: I think concurrent uploads can also lead to 409 errors but it is less frequent (upload is generally faster)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

CI
