### PR TITLE
chore(v2): delay i18n-staging deployment to avoid Crowdin 409 errors

### DIFF
--- a/website/waitForCrowdin.js
+++ b/website/waitForCrowdin.js
@@ -33,6 +33,20 @@ async function hasBuildInProgress() {
 }
 
 async function run() {
+  // We delay a bit the i18n staging deployment
+  // Because sometimes, prod + i18n-staging call this script at the exact same time
+  // And then both try to dl the translations at the same time, and then we have a 409 error
+  // This delay makes sure prod starts to dl the translations in priority
+  if (
+    process.env.NETLIFY === 'true' &&
+    process.env.SITE_NAME === 'docusaurus-i18n-staging'
+  ) {
+    console.log(
+      '[Crowdin] Delaying the docusaurus-i18n-staging deployment to avoid 409 errors',
+    );
+    await delay(30000);
+  }
+
   const timeBefore = Date.now();
   while (true) {
     if (Date.now() - timeBefore > timeout) {


### PR DESCRIPTION

## Motivation

Follow-up of https://github.com/facebook/docusaurus/pull/4739

Unfortunately, it did not work as the 2 deployments call the wait script at the exact same time.

Let's make prod deployment download Crowdin translations first, and then make i18n-staging wait until Crowdin can accept a new translation download