### PR TITLE
chore(v2): fix prod deployment due to bad image path

### DIFF
--- a/website/src/pages/examples/markdownPageExample.md
+++ b/website/src/pages/examples/markdownPageExample.md
@@ -227,18 +227,6 @@ Code tag + double pipe: <code>||</code>
 
 ![](/dogfooding/新控制器空间/图片.png)
 
-![](../../../static/dogfooding/新控制器空间/图片.png)
-
-![](./../../../static/dogfooding/新控制器空间/图片.png)
-
 ![](/dogfooding/4/图片.png)
 
-![](../../../static/dogfooding/4/图片.png)
-
-![](./../../../static/dogfooding/4/图片.png)
-
 ![](/dogfooding/4/docu.png)
-
-![](../../../static/dogfooding/4/docu.png)
-
-![](./../../../static/dogfooding/4/docu.png)


### PR DESCRIPTION

## Motivation

Relative Markdown image path used in dogfooding example page lead to prod deployment issues on localized sites.

Referencing assets in /static using a relative path is not good, as the assets are not uploaded to Crowdin and the localized doc can fail to resolve it
