### PR TITLE
fix(v2): improve BlogPostFrontMatter schema validation

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
@@ -10,58 +10,255 @@ import {
   validateBlogPostFrontMatter,
 } from '../blogFrontMatter';
 
+function testField(params: {
+  fieldName: keyof BlogPostFrontMatter;
+  validFrontMatters: BlogPostFrontMatter[];
+  convertibleFrontMatter?: [
+    ConvertableFrontMatter: Record<string, unknown>,
+    ConvertedFrontMatter: BlogPostFrontMatter,
+  ][];
+  invalidFrontMatters?: [
+    InvalidFrontMatter: Record<string, unknown>,
+    ErrorMessage: string,
+  ][];
+}) {
+  describe(`"${params.fieldName}" field`, () => {
+    test('accept valid values', () => {
+      params.validFrontMatters.forEach((frontMatter) => {
+        expect(validateBlogPostFrontMatter(frontMatter)).toEqual(frontMatter);
+      });
+    });
+
+    test('convert valid values', () => {
+      params.convertibleFrontMatter?.forEach(
+        ([convertibleFrontMatter, convertedFrontMatter]) => {
+          expect(validateBlogPostFrontMatter(convertibleFrontMatter)).toEqual(
+            convertedFrontMatter,
+          );
+        },
+      );
+    });
+
+    test('throw error for values', () => {
+      params.invalidFrontMatters?.forEach(([frontMatter, message]) => {
+        expect(() => validateBlogPostFrontMatter(frontMatter)).toThrow(message);
+      });
+    });
+  });
+}
+
 describe('validateBlogPostFrontMatter', () => {
   test('accept empty object', () => {
     const frontMatter = {};
     expect(validateBlogPostFrontMatter(frontMatter)).toEqual(frontMatter);
   });
 
-  test('accept valid values', () => {
-    const frontMatter: BlogPostFrontMatter = {
-      id: 'blog',
-      title: 'title',
-      description: 'description',
-      date: 'date',
-      slug: 'slug',
-      draft: true,
-      tags: ['hello', {label: 'tagLabel', permalink: '/tagPermalink'}],
-    };
+  test('accept unknown field', () => {
+    const frontMatter = {abc: '1'};
     expect(validateBlogPostFrontMatter(frontMatter)).toEqual(frontMatter);
   });
 
-  // See https://github.com/facebook/docusaurus/issues/4591#issuecomment-822372398
-  test('accept empty title', () => {
-    const frontMatter: BlogPostFrontMatter = {title: ''};
-    expect(validateBlogPostFrontMatter(frontMatter)).toEqual(frontMatter);
+  testField({
+    fieldName: 'description',
+    validFrontMatters: [
+      // See https://github.com/facebook/docusaurus/issues/4591#issuecomment-822372398
+      {description: ''},
+      {description: 'description'},
+    ],
   });
 
-  // See https://github.com/facebook/docusaurus/issues/4591#issuecomment-822372398
-  test('accept empty description', () => {
-    const frontMatter: BlogPostFrontMatter = {description: ''};
-    expect(validateBlogPostFrontMatter(frontMatter)).toEqual(frontMatter);
+  testField({
+    fieldName: 'title',
+    validFrontMatters: [
+      // See https://github.com/facebook/docusaurus/issues/4591#issuecomment-822372398
+      {title: ''},
+      {title: 'title'},
+    ],
   });
 
-  // See https://github.com/facebook/docusaurus/issues/4642
-  test('convert tags as numbers', () => {
-    const frontMatter: BlogPostFrontMatter = {
-      tags: [
-        // @ts-expect-error: number for test
-        42,
-        {
-          // @ts-expect-error: number for test
-          label: 84,
-          permalink: '/tagPermalink',
-        },
+  testField({
+    fieldName: 'id',
+    validFrontMatters: [{id: '123'}, {id: 'id'}],
+    invalidFrontMatters: [[{id: ''}, 'is not allowed to be empty']],
+  });
+
+  testField({
+    fieldName: 'author',
+    validFrontMatters: [{author: '123'}, {author: 'author'}],
+    invalidFrontMatters: [[{author: ''}, 'is not allowed to be empty']],
+  });
+
+  testField({
+    fieldName: 'authorTitle',
+    validFrontMatters: [{authorTitle: '123'}, {authorTitle: 'authorTitle'}],
+    invalidFrontMatters: [[{authorTitle: ''}, 'is not allowed to be empty']],
+  });
+
+  testField({
+    fieldName: 'author_title',
+    validFrontMatters: [{author_title: '123'}, {author_title: 'author_title'}],
+    invalidFrontMatters: [[{author_title: ''}, 'is not allowed to be empty']],
+  });
+
+  testField({
+    fieldName: 'authorURL',
+    validFrontMatters: [{authorURL: 'https://docusaurus.io'}],
+    invalidFrontMatters: [
+      [{authorURL: ''}, 'is not allowed to be empty'],
+      [{authorURL: '@site/api/author'}, 'must be a valid uri'],
+      [{authorURL: '../../api/author'}, 'must be a valid uri'],
+    ],
+  });
+
+  testField({
+    fieldName: 'author_url',
+    validFrontMatters: [{author_url: 'https://docusaurus.io'}],
+    invalidFrontMatters: [
+      [{author_url: ''}, 'is not allowed to be empty'],
+      [{author_url: '@site/api/author'}, 'must be a valid uri'],
+      [{author_url: '../../api/author'}, 'must be a valid uri'],
+    ],
+  });
+
+  testField({
+    fieldName: 'authorImageURL',
+    validFrontMatters: [
+      {authorImageURL: 'https://docusaurus.io/asset/image.png'},
+    ],
+    invalidFrontMatters: [
+      [{authorImageURL: ''}, 'is not allowed to be empty'],
+      [{authorImageURL: '@site/api/asset/image.png'}, 'must be a valid uri'],
+      [{authorImageURL: '../../api/asset/image.png'}, 'must be a valid uri'],
+    ],
+  });
+
+  testField({
+    fieldName: 'author_image_url',
+    validFrontMatters: [
+      {author_image_url: 'https://docusaurus.io/asset/image.png'},
+    ],
+    invalidFrontMatters: [
+      [{author_image_url: ''}, 'is not allowed to be empty'],
+      [{author_image_url: '@site/api/asset/image.png'}, 'must be a valid uri'],
+      [{author_image_url: '../../api/asset/image.png'}, 'must be a valid uri'],
+    ],
+  });
+
+  testField({
+    fieldName: 'slug',
+    validFrontMatters: [
+      {slug: 'blog/'},
+      {slug: '/blog'},
+      {slug: '/blog/'},
+      {slug: './blog'},
+      {slug: '../blog'},
+      {slug: '../../blog'},
+      {slug: '/api/plugins/@docusaurus/plugin-debug'},
+      {slug: '@site/api/asset/image.png'},
+    ],
+    invalidFrontMatters: [[{slug: ''}, 'is not allowed to be empty']],
+  });
+
+  testField({
+    fieldName: 'image',
+    validFrontMatters: [
+      {image: 'blog/'},
+      {image: '/blog'},
+      {image: '/blog/'},
+      {image: './blog'},
+      {image: '../blog'},
+      {image: '../../blog'},
+      {image: '/api/plugins/@docusaurus/plugin-debug'},
+      {image: '@site/api/asset/image.png'},
+    ],
+    invalidFrontMatters: [
+      [{image: ''}, 'is not allowed to be empty'],
+      [{image: 'https://docusaurus.io'}, 'must be a valid relative uri'],
+      [
+        {image: 'https://docusaurus.io/blog/image.png'},
+        'must be a valid relative uri',
       ],
-    };
-    expect(validateBlogPostFrontMatter(frontMatter)).toEqual({
-      tags: [
-        '42',
-        {
-          label: '84',
-          permalink: '/tagPermalink',
-        },
+    ],
+  });
+
+  testField({
+    fieldName: 'tags',
+    validFrontMatters: [
+      {tags: []},
+      {tags: ['hello']},
+      {tags: ['hello', 'world']},
+      {tags: ['hello', 'world']},
+      {tags: ['hello', {label: 'tagLabel', permalink: '/tagPermalink'}]},
+    ],
+    invalidFrontMatters: [
+      [{tags: ''}, 'must be an array'],
+      [{tags: ['']}, 'is not allowed to be empty'],
+    ],
+    // See https://github.com/facebook/docusaurus/issues/4642
+    convertibleFrontMatter: [
+      [{tags: [42]}, {tags: ['42']}],
+      [
+        {tags: [{label: 84, permalink: '/tagPermalink'}]},
+        {tags: [{label: '84', permalink: '/tagPermalink'}]},
       ],
-    });
+    ],
+  });
+
+  testField({
+    fieldName: 'keywords',
+    validFrontMatters: [
+      {keywords: ['hello']},
+      {keywords: ['hello', 'world']},
+      {keywords: ['hello', 'world']},
+      {keywords: ['hello']},
+    ],
+    invalidFrontMatters: [
+      [{keywords: ''}, 'must be an array'],
+      [{keywords: ['']}, 'is not allowed to be empty'],
+      [{keywords: []}, 'does not contain 1 required value(s)'],
+    ],
+  });
+
+  testField({
+    fieldName: 'draft',
+    validFrontMatters: [{draft: true}, {draft: false}],
+    convertibleFrontMatter: [
+      [{draft: 'true'}, {draft: true}],
+      [{draft: 'false'}, {draft: false}],
+    ],
+    invalidFrontMatters: [
+      [{draft: 'yes'}, 'must be a boolean'],
+      [{draft: 'no'}, 'must be a boolean'],
+    ],
+  });
+
+  testField({
+    fieldName: 'hide_table_of_contents',
+    validFrontMatters: [
+      {hide_table_of_contents: true},
+      {hide_table_of_contents: false},
+    ],
+    convertibleFrontMatter: [
+      [{hide_table_of_contents: 'true'}, {hide_table_of_contents: true}],
+      [{hide_table_of_contents: 'false'}, {hide_table_of_contents: false}],
+    ],
+    invalidFrontMatters: [
+      [{hide_table_of_contents: 'yes'}, 'must be a boolean'],
+      [{hide_table_of_contents: 'no'}, 'must be a boolean'],
+    ],
+  });
+
+  testField({
+    fieldName: 'date',
+    validFrontMatters: [
+      // @ts-expect-error: number for test
+      {date: new Date('2020-01-01')},
+      {date: '2020-01-01'},
+      {date: '2020'},
+    ],
+    invalidFrontMatters: [
+      [{date: 'abc'}, 'must be a valid date'],
+      [{date: ''}, 'must be a valid date'],
+    ],
   });
 });

--- a/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
@@ -23,16 +23,18 @@ export type BlogPostFrontMatter = {
   date?: string;
 
   author?: string;
-  authorTitle?: string;
   author_title?: string;
-  authorURL?: string;
   author_url?: string;
-  authorImageURL?: string;
   author_image_url?: string;
 
   image?: string;
   keywords?: string[];
   hide_table_of_contents?: boolean;
+
+  /** @deprecated */
+  authorTitle?: string;
+  authorURL?: string;
+  authorImageURL?: string;
 };
 
 // NOTE: we don't add any default value on purpose here
@@ -56,19 +58,29 @@ const BlogFrontMatterSchema = Joi.object<BlogPostFrontMatter>({
   date: Joi.date().raw(),
 
   author: Joi.string(),
-  authorTitle: Joi.string(),
   author_title: Joi.string(),
-
-  authorURL: Joi.string().uri(),
   author_url: Joi.string().uri(),
-  authorImageURL: Joi.string().uri(),
   author_image_url: Joi.string().uri(),
   slug: Joi.string(),
   image: Joi.string().uri({relativeOnly: true}),
-
   keywords: Joi.array().items(Joi.string().required()),
   hide_table_of_contents: Joi.boolean(),
-}).unknown();
+
+  authorURL: Joi.string().uri().warning('deprecate.error', {
+    alternative: '"author_url"',
+  }),
+  authorTitle: Joi.string().warning('deprecate.error', {
+    alternative: '"author_title"',
+  }),
+  authorImageURL: Joi.string().uri().warning('deprecate.error', {
+    alternative: '"author_image_url"',
+  }),
+})
+  .unknown()
+  .messages({
+    'deprecate.error':
+      '{#label} field is deprecated. Please use {#alternative} one instead.',
+  });
 
 export function validateBlogPostFrontMatter(
   frontMatter: Record<string, unknown>,

--- a/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
@@ -5,13 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable camelcase */
+
 import {
   JoiFrontMatter as Joi, // Custom instance for frontmatter
   validateFrontMatter,
 } from '@docusaurus/utils-validation';
 import {Tag} from './types';
 
-// TODO complete this frontmatter + add unit tests
 export type BlogPostFrontMatter = {
   id?: string;
   title?: string;
@@ -20,6 +21,18 @@ export type BlogPostFrontMatter = {
   slug?: string;
   draft?: boolean;
   date?: string;
+
+  author?: string;
+  authorTitle?: string;
+  author_title?: string;
+  authorURL?: string;
+  author_url?: string;
+  authorImageURL?: string;
+  author_image_url?: string;
+
+  image?: string;
+  keywords?: string[];
+  hide_table_of_contents?: boolean;
 };
 
 // NOTE: we don't add any default value on purpose here
@@ -39,9 +52,22 @@ const BlogFrontMatterSchema = Joi.object<BlogPostFrontMatter>({
   title: Joi.string().allow(''),
   description: Joi.string().allow(''),
   tags: Joi.array().items(BlogTagSchema),
-  slug: Joi.string(),
   draft: Joi.boolean(),
-  date: Joi.string().allow(''), // TODO validate the date better!
+  date: Joi.date().raw(),
+
+  author: Joi.string(),
+  authorTitle: Joi.string(),
+  author_title: Joi.string(),
+
+  authorURL: Joi.string().uri(),
+  author_url: Joi.string().uri(),
+  authorImageURL: Joi.string().uri(),
+  author_image_url: Joi.string().uri(),
+  slug: Joi.string(),
+  image: Joi.string().uri({relativeOnly: true}),
+
+  keywords: Joi.array().items(Joi.string().required()),
+  hide_table_of_contents: Joi.boolean(),
 }).unknown();
 
 export function validateBlogPostFrontMatter(

--- a/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
@@ -66,6 +66,8 @@ const BlogFrontMatterSchema = Joi.object<BlogPostFrontMatter>({
   keywords: Joi.array().items(Joi.string().required()),
   hide_table_of_contents: Joi.boolean(),
 
+  /*
+  TODO re-enable later, our v1 blog posts use those frontmatter fields
   authorURL: Joi.string().uri().warning('deprecate.error', {
     alternative: '"author_url"',
   }),
@@ -75,11 +77,12 @@ const BlogFrontMatterSchema = Joi.object<BlogPostFrontMatter>({
   authorImageURL: Joi.string().uri().warning('deprecate.error', {
     alternative: '"author_image_url"',
   }),
+   */
 })
   .unknown()
   .messages({
     'deprecate.error':
-      '{#label} field is deprecated. Please use {#alternative} one instead.',
+      '{#label} blog frontMatter field is deprecated. Please use {#alternative} instead.',
   });
 
 export function validateBlogPostFrontMatter(

--- a/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
@@ -20,7 +20,7 @@ export type BlogPostFrontMatter = {
   tags?: (string | Tag)[];
   slug?: string;
   draft?: boolean;
-  date?: string;
+  date?: Date;
 
   author?: string;
   author_title?: string;
@@ -66,18 +66,13 @@ const BlogFrontMatterSchema = Joi.object<BlogPostFrontMatter>({
   keywords: Joi.array().items(Joi.string().required()),
   hide_table_of_contents: Joi.boolean(),
 
-  /*
-  TODO re-enable later, our v1 blog posts use those frontmatter fields
-  authorURL: Joi.string().uri().warning('deprecate.error', {
-    alternative: '"author_url"',
-  }),
-  authorTitle: Joi.string().warning('deprecate.error', {
-    alternative: '"author_title"',
-  }),
-  authorImageURL: Joi.string().uri().warning('deprecate.error', {
-    alternative: '"author_image_url"',
-  }),
-   */
+  // TODO re-enable warnings later, our v1 blog posts use those older frontmatter fields
+  authorURL: Joi.string().uri(),
+  // .warning('deprecate.error', { alternative: '"author_url"'}),
+  authorTitle: Joi.string(),
+  // .warning('deprecate.error', { alternative: '"author_title"'}),
+  authorImageURL: Joi.string().uri(),
+  // .warning('deprecate.error', { alternative: '"author_image_url"'}),
 })
   .unknown()
   .messages({

--- a/packages/docusaurus-utils-validation/src/__tests__/validationUtils.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationUtils.test.ts
@@ -31,7 +31,7 @@ describe('validateFrontMatter', () => {
       validateFrontMatter(frontMatter, schema),
     ).toThrowErrorMatchingInlineSnapshot(`"\\"test\\" must be a string"`);
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('FrontMatter contains invalid values: '),
+      expect.stringContaining('The following FrontMatter'),
     );
   });
 

--- a/packages/docusaurus-utils-validation/src/validationUtils.ts
+++ b/packages/docusaurus-utils-validation/src/validationUtils.ts
@@ -114,7 +114,7 @@ export function validateFrontMatter<T>(
 
   if (error) {
     const frontMatterString = JSON.stringify(frontMatter, null, 2);
-    const errorDetails = (error as Joi.ValidationError).details;
+    const errorDetails = error.details;
     const invalidFields = errorDetails.map(({path}) => path).join(', ');
     const errorMessages = errorDetails
       .map(({message}) => ` - ${message}`)

--- a/packages/docusaurus-utils-validation/src/validationUtils.ts
+++ b/packages/docusaurus-utils-validation/src/validationUtils.ts
@@ -110,15 +110,23 @@ export function validateFrontMatter<T>(
     return JoiFrontMatter.attempt(frontMatter, schema, {
       convert: true,
       allowUnknown: true,
+      abortEarly: false,
     });
   } catch (e) {
+    const frontMatterString = JSON.stringify(frontMatter, null, 2);
+    const errorDetails = (e as Joi.ValidationError).details;
+    const invalidFields = errorDetails.map(({path}) => path).join(', ');
+    const errorMessages = errorDetails
+      .map(({message}) => ` - ${message}`)
+      .join('\n');
+
+    logValidationBugReportHint();
+
     console.error(
       chalk.red(
-        `FrontMatter contains invalid values: ${JSON.stringify(
-          frontMatter,
-          null,
-          2,
-        )}`,
+        `The following FrontMatter:\n${chalk.yellow(
+          frontMatterString,
+        )}\ncontains invalid values for field(s): ${invalidFields}.\n${errorMessages}\n`,
       ),
     );
     throw e;

--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -56,9 +56,9 @@ A whole bunch of exploration to follow.
 The only required field is `title`; however, we provide options to add author information to your blog post as well along with other options.
 
 - `author`: The author name to be displayed.
-- `author_url`/`authorURL`: The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc.
-- `author_image_url`/`authorImageURL`: The URL to the author's thumbnail image.
-- `author_title`/`authorTitle`: A description of the author.
+- `author_url`: The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc.
+- `author_image_url`: The URL to the author's thumbnail image.
+- `author_title`: A description of the author.
 - `title`: The blog post title.
 - `slug`: Allows to customize the blog post url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-blog-post`, `slug: /my/path/to/blog/post`, slug: `/`.
 - `date`: The blog post creation date. If not specified, this could be extracted from the file name, e.g, `2021-04-15-blog-post.mdx`. By default, it is the markdown file creation time.

--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -55,19 +55,19 @@ A whole bunch of exploration to follow.
 
 The only required field is `title`; however, we provide options to add author information to your blog post as well along with other options.
 
-- `author` - The author name to be displayed.
-- `author_url`/`authorURL` - The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc.
-- `author_image_url`/`authorImageURL` - The URL to the author's thumbnail image.
-- `author_title`/`authorTitle` - A description of the author.
-- `title` - The blog post title.
-- `slug` - The custom blog post slug.
-- `date` - The blog post creation date. If not specified, this could be extracted from the file name, e.g, `2021-04-15-blog-post.mdx`. By default, it is the markdown file creation time.
-- `tags` - A list of strings or objects of two string fields `label` and `permalink` to tag to your post.
-- `draft` - A boolean flag to indicate that the blog post is work-in-progress and therefore should not be published yet. However, draft blog posts will be displayed during development.
-- `description` - The description of your post, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. If this field is not present, it will default to the first line of the contents.
-- `keywords` - The list of your post's keywords, which will become the `<meta name="keywords" content="keyword1,keyword2,..."/>` in `<head>`, used by search engines.
-- `image` - Cover or thumbnail image that will be used when displaying the link to your post.
-- `hide_table_of_contents` - Whether to hide the table of contents to the right. By default, it is `false`.
+- `author`: The author name to be displayed.
+- `author_url`/`authorURL`: The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc.
+- `author_image_url`/`authorImageURL`: The URL to the author's thumbnail image.
+- `author_title`/`authorTitle`: A description of the author.
+- `title`: The blog post title.
+- `slug`: Allows to customize the blog post url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-blog-post`, `slug: /my/path/to/blog/post`, slug: `/`.
+- `date`: The blog post creation date. If not specified, this could be extracted from the file name, e.g, `2021-04-15-blog-post.mdx`. By default, it is the markdown file creation time.
+- `tags`: A list of strings or objects of two string fields `label` and `permalink` to tag to your post.
+- `draft`: A boolean flag to indicate that the blog post is work-in-progress and therefore should not be published yet. However, draft blog posts will be displayed during development.
+- `description`: The description of your post, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. If this field is not present, it will default to the first line of the contents.
+- `keywords`: Keywords meta tag, which will become the `<meta name="keywords" content="keyword1,keyword2,..."/>` in `<head>`, used by search engines.
+- `image`: Cover or thumbnail image that will be used when displaying the link to your post.
+- `hide_table_of_contents`: Whether to hide the table of contents to the right. By default, it is `false`.
 
 ## Summary truncation {#summary-truncation}
 

--- a/website/docs/blog.md
+++ b/website/docs/blog.md
@@ -56,15 +56,18 @@ A whole bunch of exploration to follow.
 The only required field is `title`; however, we provide options to add author information to your blog post as well along with other options.
 
 - `author` - The author name to be displayed.
-- `author_url` - The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc.
-- `author_image_url` - The URL to the author's thumbnail image.
-- `author_title` - A description of the author.
+- `author_url`/`authorURL` - The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc.
+- `author_image_url`/`authorImageURL` - The URL to the author's thumbnail image.
+- `author_title`/`authorTitle` - A description of the author.
 - `title` - The blog post title.
-- `tags` - A list of strings to tag to your post.
+- `slug` - The custom blog post slug.
+- `date` - The blog post creation date. If not specified, this could be extracted from the file name, e.g, `2021-04-15-blog-post.mdx`. By default, it is the markdown file creation time.
+- `tags` - A list of strings or objects of two string fields `label` and `permalink` to tag to your post.
 - `draft` - A boolean flag to indicate that the blog post is work-in-progress and therefore should not be published yet. However, draft blog posts will be displayed during development.
-- `description`: The description of your post, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. If this field is not present, it will default to the first line of the contents.
-- `image`: Cover or thumbnail image that will be used when displaying the link to your post.
-- `hide_table_of_contents`: Whether to hide the table of contents to the right. By default it is `false`.
+- `description` - The description of your post, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. If this field is not present, it will default to the first line of the contents.
+- `keywords` - The list of your post's keywords, which will become the `<meta name="keywords" content="keyword1,keyword2,..."/>` in `<head>`, used by search engines.
+- `image` - Cover or thumbnail image that will be used when displaying the link to your post.
+- `hide_table_of_contents` - Whether to hide the table of contents to the right. By default, it is `false`.
 
 ## Summary truncation {#summary-truncation}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

From #4591.

## What the PR does

* Complete the BlogPostFrontMatter typing and the corresponding Joi schema validator in _packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts_
* Add unit tests
* Display friendly messages for wrong schemas:
<img width="860" alt="image" src="https://user-images.githubusercontent.com/28835226/117566822-11585b00-b0e3-11eb-8718-de109e499fad.png">


* @slorber: Can you explain the sentence: _"try to use the frontmatter TS types in the theme?"_ ?

I found the after parsing the frontmatter use `gray-matter` package, the `date` field will be converted to a `Date object`, not a raw string. But we are treating it as a string. Currently there is no problem about it, but maybe furture.
 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit test.
