### PR TITLE
docs(v2): fix i18n doc: bad i18n page plugin path in code sample

### DIFF
--- a/website/docs/i18n/i18n-git.md
+++ b/website/docs/i18n/i18n-git.md
@@ -117,8 +117,8 @@ mkdir -p i18n/fr/docusaurus-plugin-content-blog
 cp -r blog/** i18n/fr/docusaurus-plugin-content-blog
 
 mkdir -p i18n/fr/docusaurus-plugin-content-pages
-cp -r pages/**.md i18n/fr/docusaurus-plugin-content-pages
-cp -r pages/**.mdx i18n/fr/docusaurus-plugin-content-pages
+cp -r src/pages/**.md i18n/fr/docusaurus-plugin-content-pages
+cp -r src/pages/**.mdx i18n/fr/docusaurus-plugin-content-pages
 ```
 
 Add all these files to Git.

--- a/website/docs/i18n/i18n-tutorial.md
+++ b/website/docs/i18n/i18n-tutorial.md
@@ -231,7 +231,7 @@ cp -r blog/** i18n/fr/docusaurus-plugin-content-blog
 
 #### Translate the pages {#translate-the-pages}
 
-Copy your pages Markdown files to `i18n/fr/docusaurus-plugin-content-pages/current`, and translate them:
+Copy your pages Markdown files to `i18n/fr/docusaurus-plugin-content-pages`, and translate them:
 
 ```bash
 mkdir -p i18n/fr/docusaurus-plugin-content-pages

--- a/website/docs/i18n/i18n-tutorial.md
+++ b/website/docs/i18n/i18n-tutorial.md
@@ -231,12 +231,12 @@ cp -r blog/** i18n/fr/docusaurus-plugin-content-blog
 
 #### Translate the pages {#translate-the-pages}
 
-Copy your pages Markdown files to `i18n/fr/docusaurus-plugin-content-pages`, and translate them:
+Copy your pages Markdown files to `i18n/fr/docusaurus-plugin-content-pages/current`, and translate them:
 
 ```bash
 mkdir -p i18n/fr/docusaurus-plugin-content-pages
-cp -r pages/**.md i18n/fr/docusaurus-plugin-content-pages
-cp -r pages/**.mdx i18n/fr/docusaurus-plugin-content-pages
+cp -r src/pages/**.md i18n/fr/docusaurus-plugin-content-pages
+cp -r src/pages/**.mdx i18n/fr/docusaurus-plugin-content-pages
 ```
 
 :::caution


### PR DESCRIPTION
## Motivation

Looks like legacy code from previous versions remains to be fixed

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
