### PR TITLE
fix(v2): transpile libs with too recent syntax with babel

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -24,6 +24,14 @@ const CSS_REGEX = /\.css$/;
 const CSS_MODULE_REGEX = /\.module\.css$/;
 export const clientDir = path.join(__dirname, '..', 'client');
 
+const LibrariesToTranspile = [
+  'copy-text-to-clipboard', // contains optional catch binding, incompatible with recent versions of Edge
+];
+
+const LibrariesToTranspileRegex = new RegExp(
+  LibrariesToTranspile.map((libName) => `(node_modules/${libName})`).join('|'),
+);
+
 export function excludeJS(modulePath: string): boolean {
   // always transpile client dir
   if (modulePath.startsWith(clientDir)) {
@@ -32,7 +40,8 @@ export function excludeJS(modulePath: string): boolean {
   // Don't transpile node_modules except any docusaurus npm package
   return (
     /node_modules/.test(modulePath) &&
-    !/(docusaurus)((?!node_modules).)*\.jsx?$/.test(modulePath)
+    !/(docusaurus)((?!node_modules).)*\.jsx?$/.test(modulePath) &&
+    !LibrariesToTranspileRegex.test(modulePath)
   );
 }
 


### PR DESCRIPTION

## Motivation

Some libs (many from Sindre Sorhus) use too recent ES syntax and should be transpiled with Babel

copy-text-to-clipboard contains `try {} catch {}` for example

Not doing this means we have some older browsers (like Edge 18 released in nov 2018) not supported while it could easily.

Noticed this while testing browser support of Docusaurus in https://github.com/facebook/docusaurus/pull/4766


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview + inspecting JS output + testing on Edge 18
