### PR TITLE
chore(v2): TypeScript, use isolatedModules

### DIFF
--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -30,3 +30,6 @@ packages:
 # Log settings
 logs:
   - {type: stdout, format: pretty, level: http}
+
+# Fix 413 errors in e2e CI
+max_body_size: 1000mb

--- a/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
@@ -6,8 +6,8 @@
  */
 
 import {useLocation} from '@docusaurus/router';
-import {
-  useAllPluginInstancesData,
+import useGlobalData, {
+  // useAllPluginInstancesData,
   usePluginData,
 } from '@docusaurus/useGlobalData';
 
@@ -24,8 +24,11 @@ import {
   GetActivePluginOptions,
 } from '../../client/docsClientUtils';
 
+// Not using useAllPluginInstancesData() because in blog-only mode, docs hooks are still used by the theme
+// We need a fail-safe fallback when the docs plugin is not in use
 export const useAllDocsData = (): Record<string, GlobalPluginData> =>
-  useAllPluginInstancesData('docusaurus-plugin-content-docs');
+  // useAllPluginInstancesData('docusaurus-plugin-content-docs');
+  useGlobalData()['docusaurus-plugin-content-docs'] ?? {};
 
 export const useDocsData = (pluginId: string | undefined): GlobalPluginData =>
   usePluginData('docusaurus-plugin-content-docs', pluginId) as GlobalPluginData;

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
@@ -8,4 +8,4 @@
 // Re-expose useDocs
 // Ensure it's always statically available even if user is not using the docs plugin
 // Problem reported for the blog-only mode: https://github.com/facebook/docusaurus/issues/3360
-export * from '@docusaurus/plugin-content-docs/src/theme/hooks/useDocs';
+export * from '@docusaurus/plugin-content-docs/lib/theme/hooks/useDocs';

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
@@ -11,18 +11,22 @@
 // TODO this is not ideal and produce a warning!
 // see https://github.com/webpack/webpack/issues/7713#issuecomment-467888437
 // note: warning can be filtered: https://github.com/facebook/docusaurus/pull/3382#issuecomment-684966924
-try {
-  // eslint-disable-next-line global-require
-  module.exports = require('@theme-init/hooks/useDocs');
-} catch (e) {
-  // In case the docs plugin is not available, might be useful to stub some methods here
-  // https://github.com/facebook/docusaurus/issues/3947
-  const Empty = {};
-  module.exports = {
-    useAllDocsData: () => Empty,
-    useActivePluginAndVersion: () => undefined,
-  };
+function getExport() {
+  try {
+    // eslint-disable-next-line global-require
+    return require('@theme-init/hooks/useDocs');
+  } catch (e) {
+    // In case the docs plugin is not available, might be useful to stub some methods here
+    // https://github.com/facebook/docusaurus/issues/3947
+    const Empty = {};
+    return {
+      useAllDocsData: () => Empty,
+      useActivePluginAndVersion: () => undefined,
+    };
+  }
 }
+
+export default getExport();
 
 /*
 throw new Error(

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
@@ -5,31 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// See https://github.com/facebook/docusaurus/issues/3360
-// TODO find a better solution, this shouldn't be needed
-
-// TODO this is not ideal and produce a warning!
-// see https://github.com/webpack/webpack/issues/7713#issuecomment-467888437
-// note: warning can be filtered: https://github.com/facebook/docusaurus/pull/3382#issuecomment-684966924
-function getExport() {
-  try {
-    // eslint-disable-next-line global-require
-    return require('@theme-init/hooks/useDocs');
-  } catch (e) {
-    // In case the docs plugin is not available, might be useful to stub some methods here
-    // https://github.com/facebook/docusaurus/issues/3947
-    const Empty = {};
-    return {
-      useAllDocsData: () => Empty,
-      useActivePluginAndVersion: () => undefined,
-    };
-  }
-}
-
-export default getExport();
-
-/*
-throw new Error(
-  "The docs plugin is not used, so you can't require the useDocs hooks. ",
-);
- */
+// Re-expose useDocs
+// Ensure it's always statically available even if user is not using the docs plugin
+// Problem reported for the blog-only mode: https://github.com/facebook/docusaurus/issues/3360
+export * from '@docusaurus/plugin-content-docs/src/theme/hooks/useDocs';

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export {
-  useThemeConfig,
+export {useThemeConfig} from './utils/useThemeConfig';
+
+export type {
   ThemeConfig,
   Navbar,
   NavbarItem,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
 
     /* Advanced Options */
     "resolveJsonModule": true,


### PR DESCRIPTION

## Motivation

It's safer to ensure that TS files can be transpiled independently.

Ie, transpiled by other tools like Babel or esbuild. 


We use esbuild-loader in https://github.com/facebook/docusaurus/issues/4765 on the Docusaurus website now, and it is a recommended option

