### PR TITLE
chore: fix canary version name

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "crowdin:upload:v2": "crowdin upload sources --config ./crowdin-v2.yaml",
     "crowdin:download:v2": "crowdin download --config ./crowdin-v2.yaml",
     "canary": "yarn canary:bumpVersion && yarn canary:publish",
-    "canary:bumpVersion": "yarn lerna version 2.0.0-alpha.`git rev-parse --short HEAD` --exact --no-push --yes",
+    "canary:bumpVersion": "yarn lerna version 2.0.0-beta.`git rev-parse --short HEAD` --exact --no-push --yes",
     "canary:publish": "yarn lerna publish from-package --dist-tag canary --yes --no-verify-access",
     "changelog": "lerna-changelog",
     "postinstall": "run-p postinstall:**",


### PR DESCRIPTION

## Motivation

Canary versions are still named alpha