### PR TITLE
fix(v2): fix minor a11y issue with headings

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -71,7 +71,7 @@ function Footer(): JSX.Element | null {
             {links.map((linkItem, i) => (
               <div key={i} className="col footer__col">
                 {linkItem.title != null ? (
-                  <h4 className="footer__title">{linkItem.title}</h4>
+                  <div className="footer__title">{linkItem.title}</div>
                 ) : null}
                 {linkItem.items != null &&
                 Array.isArray(linkItem.items) &&


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Actually it should have been done with the [last Infima update](https://github.com/facebook/docusaurus/pull/4689
), but I did not have time to mention it.

![image](https://user-images.githubusercontent.com/4408379/118282349-dc7b4800-b4d6-11eb-80aa-e5cf392ce63b.png)

However we still have one a11y error (`h5`) related with headings -- I want to fix this in our fork of `remark-admonitions` (which will be placed in docusaurus organization, hopefully)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview - no visual changes.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
