### PR TITLE
docs(v2): fix css snipped with missing color

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -137,7 +137,7 @@ To accomplish this, Docusaurus adds the `docusaurus-highlight-code-line` class t
 
 /* If you have a different syntax highlighting theme for dark mode. */
 html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: ; /* Color which works with dark mode syntax highlighting theme */
+  background-color: rgb(100, 100, 100); /* Color which works with dark mode syntax highlighting theme */
 }
 ```
 

--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -137,7 +137,8 @@ To accomplish this, Docusaurus adds the `docusaurus-highlight-code-line` class t
 
 /* If you have a different syntax highlighting theme for dark mode. */
 html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgb(100, 100, 100); /* Color which works with dark mode syntax highlighting theme */
+  /* Color which works with dark mode syntax highlighting theme */
+  background-color: rgb(100, 100, 100);
 }
 ```
 


### PR DESCRIPTION

## Motivation

dark mode color seems to be missing in this css code sample:

![image](https://user-images.githubusercontent.com/749374/118668612-53755100-b7f5-11eb-9b6d-bb961561614f.png)
