### PR TITLE
refactor(v2): purify normalizeUrl

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -69,7 +69,7 @@ describe('load utils', () => {
   });
 
   test('simpleHash', () => {
-    const asserts = {
+    const asserts: Record<string, string> = {
       '': 'd41',
       '/foo-bar': '096',
       '/foo/bar': '1df',
@@ -230,7 +230,9 @@ describe('load utils', () => {
     });
     expect(idx(obj, ['translation', 'enabled'])).toEqual(true);
     expect(
-      idx(obj, ['translation', variable]).map((lang) => lang.tag),
+      idx(obj, ['translation', variable]).map(
+        (lang: {tag: string}) => lang.tag,
+      ),
     ).toEqual(['en', 'ja']);
     expect(idx(test, ['arr', 0])).toEqual(1);
     expect(idx(undefined)).toBeUndefined();
@@ -350,6 +352,7 @@ describe('load utils', () => {
     });
 
     expect(() =>
+      // @ts-expect-error undefined for test
       normalizeUrl(['http:example.com', undefined]),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Url must be a string. Received undefined"`,

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -199,7 +199,7 @@ export function getSubFolder(file: string, refDir: string): string | null {
 }
 
 export function normalizeUrl(rawUrls: string[]): string {
-  const urls = rawUrls;
+  const urls = [...rawUrls];
   const resultArray = [];
 
   let hasStartingSlash = false;


### PR DESCRIPTION
## Motivation

We use `normalizeUrl` a lot, and currently, there is no known issue. But it's always the best practice to use the pure function.

I also add some code to keep the ts compiler silent in the test file. Please tell me if it's irrelevant, and I will remove it :)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Review
