### PR TITLE
docs(v2): add mr-pdf to resources

### DIFF
--- a/website/community/2-resources.md
+++ b/website/community/2-resources.md
@@ -32,8 +32,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 ### Features {#features}
 
 - [docusaurus-theme-github-codeblock](https://github.com/saucelabs/docusaurus-theme-github-codeblock). A Docusaurus v2 plugin that supports referencing code examples from public GitHub repositories
-- [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format, up to Docusaurus v2.0.0-alpha73
-- [mr-pdf](https://github.com/kohheepeace/mr-pdf) - Generate documentation into PDF formet, suitable for Docusaurus v1 and v2 (including 2.0.0-beta0)
+- [mr-pdf](https://github.com/kohheepeace/mr-pdf) - Generate documentation into PDF format, suitable for Docusaurus v1 and v2 (including beta versions)
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
 - [docusaurus-plugin-remote-content](https://github.com/rdilweb/docusaurus-plugin-remote-content) - A Docusaurus v2 plugin that allows you to fetch content from remote sources
 - [docusaurus2-graphql-doc-generator](https://github.com/edno/docusaurus2-graphql-doc-generator) - A Docusaurus v2 plugin for generating documentation from a GraphQL schema

--- a/website/community/2-resources.md
+++ b/website/community/2-resources.md
@@ -32,7 +32,8 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 ### Features {#features}
 
 - [docusaurus-theme-github-codeblock](https://github.com/saucelabs/docusaurus-theme-github-codeblock). A Docusaurus v2 plugin that supports referencing code examples from public GitHub repositories
-- [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format
+- [docusaurus-pdf](https://github.com/KohheePeace/docusaurus-pdf) - Generate documentation into PDF format, up to Docusaurus v2.0.0-alpha73
+- [mr-pdf](https://github.com/kohheepeace/mr-pdf) - Generate documentation into PDF formet, suitable for Docusaurus v1 and v2 (including 2.0.0-beta0)
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
 - [docusaurus-plugin-remote-content](https://github.com/rdilweb/docusaurus-plugin-remote-content) - A Docusaurus v2 plugin that allows you to fetch content from remote sources
 - [docusaurus2-graphql-doc-generator](https://github.com/edno/docusaurus2-graphql-doc-generator) - A Docusaurus v2 plugin for generating documentation from a GraphQL schema


### PR DESCRIPTION
Added new option for PDF generation seeing as docusaurus-pdf doesn't work beyond 2.0.0.-alpha73, as establised in [bug #29](https://github.com/kohheepeace/docusaurus-pdf/issues/29).

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
