### PR TITLE
docs(v2): Fix typo in doc: sidebar.md

### DIFF
--- a/website/docs/guides/docs/sidebar.md
+++ b/website/docs/guides/docs/sidebar.md
@@ -594,7 +594,7 @@ Using the enabled `themeConfig.hideableSidebar` option, you can make the entire 
 ```js title="docusaurus.config.js"
 module.exports = {
   themeConfig: {
-    // highlight-starrt
+    // highlight-start
     hideableSidebar: true,
     // highlight-end
   },


### PR DESCRIPTION
Fixed a typo on `highlight-start` in the section **Hideable sidebar**.