### PR TITLE
fix(v2): fix Java syntax highlight in website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -302,6 +302,7 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
     prism: {
       theme: require('prism-react-renderer/themes/github'),
       darkTheme: require('prism-react-renderer/themes/dracula'),
+      additionalLanguages: ['java'],
     },
     image: 'img/docusaurus-soc.png',
     // metadatas: [{name: 'twitter:card', content: 'summary'}],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The Java syntax highlight is finally broken in [docusaurus.io](docusaurus.io). (Weird I say finally here, but [no-one had any idea why it worked before](https://github.com/facebook/docusaurus/issues/4720#issuecomment-831950301).) Now is good time to add `java` to `additionalLanguages` and make the site consistent with our documentation.

![Broken highlight](https://user-images.githubusercontent.com/55398995/119503782-eb4ae000-bd9d-11eb-8b16-fb04d674eabb.png)

Fix #4845.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yea
