### PR TITLE
fix(v2): allow relative sidebar path resolution in docs:version command

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/cli.ts
+++ b/packages/docusaurus-plugin-content-docs/src/cli.ts
@@ -17,7 +17,7 @@ import {
   UnprocessedSidebarItem,
   UnprocessedSidebars,
 } from './types';
-import {loadSidebars} from './sidebars';
+import {loadSidebars, resolveSidebarPathOption} from './sidebars';
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
 
 function createVersionedSidebarFile({
@@ -154,17 +154,11 @@ export function cliDocsVersionCommand(
     throw new Error(`${pluginIdLogPrefix}There is no docs to version !`);
   }
 
-  // Create sidebar file.
-  const normalizedSidebarPath =
-    sidebarPath && !path.isAbsolute(sidebarPath)
-      ? path.join(siteDir, sidebarPath)
-      : sidebarPath;
-
   createVersionedSidebarFile({
     siteDir,
     pluginId,
     version,
-    sidebarPath: normalizedSidebarPath,
+    sidebarPath: resolveSidebarPathOption(siteDir, sidebarPath),
   });
 
   // Update versions.json file.

--- a/packages/docusaurus-plugin-content-docs/src/cli.ts
+++ b/packages/docusaurus-plugin-content-docs/src/cli.ts
@@ -145,6 +145,7 @@ export function cliDocsVersionCommand(
 
   // Copy docs files.
   const docsDir = path.join(siteDir, docsPath);
+
   if (fs.existsSync(docsDir) && fs.readdirSync(docsDir).length > 0) {
     const versionedDir = getVersionedDocsDirPath(siteDir, pluginId);
     const newVersionDir = path.join(versionedDir, `version-${version}`);
@@ -153,7 +154,18 @@ export function cliDocsVersionCommand(
     throw new Error(`${pluginIdLogPrefix}There is no docs to version !`);
   }
 
-  createVersionedSidebarFile({siteDir, pluginId, version, sidebarPath});
+  // Create sidebar file.
+  const normalizedSidebarPath =
+    sidebarPath && !path.isAbsolute(sidebarPath)
+      ? path.join(siteDir, sidebarPath)
+      : sidebarPath;
+
+  createVersionedSidebarFile({
+    siteDir,
+    pluginId,
+    version,
+    sidebarPath: normalizedSidebarPath,
+  });
 
   // Update versions.json file.
   versions.unshift(version);

--- a/packages/docusaurus-plugin-content-docs/src/sidebars.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars.ts
@@ -25,11 +25,13 @@ import {
   SidebarItemsGeneratorVersion,
   NumberPrefixParser,
   SidebarItemsGeneratorOption,
+  PluginOptions,
 } from './types';
 import {mapValues, flatten, flatMap, difference, pick, memoize} from 'lodash';
 import {getElementsAround} from '@docusaurus/utils';
 import combinePromises from 'combine-promises';
 import {DefaultSidebarItemsGenerator} from './sidebarItemsGenerator';
+import path from 'path';
 
 type SidebarItemCategoryJSON = SidebarItemBase & {
   type: 'category';
@@ -256,7 +258,19 @@ export const DefaultSidebars: UnprocessedSidebars = {
 
 export const DisabledSidebars: UnprocessedSidebars = {};
 
+// If a path is provided, make it absolute
+// use this before loadSidebars()
+export function resolveSidebarPathOption(
+  siteDir: string,
+  sidebarPathOption: PluginOptions['sidebarPath'],
+): PluginOptions['sidebarPath'] {
+  return sidebarPathOption
+    ? path.resolve(siteDir, sidebarPathOption)
+    : sidebarPathOption;
+}
+
 // TODO refactor: make async
+// Note: sidebarFilePath must be absolute, use resolveSidebarPathOption
 export function loadSidebars(
   sidebarFilePath: string | false | undefined,
 ): UnprocessedSidebars {
@@ -279,6 +293,7 @@ export function loadSidebars(
 
   // We don't want sidebars to be cached because of hot reloading.
   const sidebarJson = importFresh(sidebarFilePath) as SidebarsJSON;
+
   return normalizeSidebars(sidebarJson);
 }
 

--- a/packages/docusaurus-plugin-content-docs/src/versions.ts
+++ b/packages/docusaurus-plugin-content-docs/src/versions.ts
@@ -24,6 +24,7 @@ import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
 import {LoadContext} from '@docusaurus/types';
 import {getPluginI18nPath, normalizeUrl, posixPath} from '@docusaurus/utils';
 import {difference} from 'lodash';
+import {resolveSidebarPathOption} from './sidebars';
 
 // retro-compatibility: no prefix for the default plugin id
 function addPluginIdPrefix(fileOrDir: string, pluginId: string): string {
@@ -184,9 +185,7 @@ function getVersionMetadataPaths({
 
   function getSidebarFilePath() {
     if (isCurrentVersion) {
-      return options.sidebarPath
-        ? path.resolve(context.siteDir, options.sidebarPath)
-        : options.sidebarPath;
+      return resolveSidebarPathOption(context.siteDir, options.sidebarPath);
     } else {
       return path.join(
         getVersionedSidebarsDirPath(context.siteDir, options.id),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -224,7 +224,7 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
         docs: {
           // routeBasePath: '/',
           path: 'docs',
-          sidebarPath: require.resolve('./sidebars.js'),
+          sidebarPath: 'sidebars.js',
           editUrl: ({locale, docPath}) => {
             if (locale !== 'en') {
               return `https://crowdin.com/project/docusaurus-v2/${locale}`;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves #4844

Because we do not seem to have a strict requirement that the sidebar file path be absolute, currently users who use relative path in the `sidebarPath` field will get an error when creating new docs version.

Although after merging of #4775 `docs:versions` command will no longer fails, and just silently create empty sidebar file. However, this is not what the user expects - copy of current sidebar file in new docs folder.  So I think instead of forcing users to specify _only_ absolute path to the sidebar file, we can automatically resolve relative path to it when cutting new docs version.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Not sure if tests are needed here?

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
