### PR TITLE
fix(v2): remove Markdown heading id from excerpt

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
@@ -121,6 +121,14 @@ describe('createExcerpt', () => {
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ex urna, molestie et sagittis ut, varius ac justo.',
     );
   });
+
+  test('should create excerpt for heading specified with anchor-id syntax', () => {
+    expect(
+      createExcerpt(dedent`
+          ## Markdown title {#my-anchor-id}
+        `),
+    ).toEqual('Markdown title');
+  });
 });
 
 describe('parseMarkdownContentTitle', () => {

--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -55,6 +55,8 @@ export function createExcerpt(fileString: string): string | undefined {
       .replace(/(:{3}.*)/, '')
       // Remove Emoji names within colons include preceding whitespace.
       .replace(/\s?(:(::|[^:\n])+:)/g, '')
+      // Remove custom Markdown heading id.
+      .replace(/{#*[\w-]+}/, '')
       .trim();
 
     if (cleanedLine) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

There are doc pages in which after main heading appears second level header, that would be used as excerpt. In this case excerpt will contain Markdown heading second-level id (if present), that shouldn't be there.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
