### PR TITLE
refactor(v2): remove sidebar_label filed from doc metadata file

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -76,7 +76,7 @@ function createTestUtils({
     docFileSource: string,
     expectedMetadata: Optional<
       DocMetadataBase,
-      'source' | 'lastUpdatedBy' | 'lastUpdatedAt' | 'sidebar_label' | 'editUrl'
+      'source' | 'lastUpdatedBy' | 'lastUpdatedAt' | 'editUrl'
     >,
   ) {
     const docFile = await readDoc(docFileSource);
@@ -89,7 +89,6 @@ function createTestUtils({
     expect(metadata).toEqual({
       lastUpdatedBy: undefined,
       lastUpdatedAt: undefined,
-      sidebar_label: undefined,
       editUrl: undefined,
       source: path.posix.join(
         '@site',

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -57,7 +57,6 @@ const defaultDocMetadata: Partial<DocMetadata> = {
   editUrl: undefined,
   lastUpdatedAt: undefined,
   lastUpdatedBy: undefined,
-  sidebar_label: undefined,
   formattedLastUpdatedAt: undefined,
 };
 

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -125,7 +125,6 @@ export function processDocMetadata({
   const frontMatter = validateDocFrontMatter(unsafeFrontMatter);
 
   const {
-    sidebar_label: sidebarLabel,
     custom_edit_url: customEditURL,
 
     // Strip number prefixes by default (01-MyFolder/01-MyDoc.md => MyFolder/MyDoc) by default,
@@ -261,7 +260,6 @@ export function processDocMetadata({
           lastUpdate.lastUpdatedAt * 1000,
         )
       : undefined,
-    sidebar_label: sidebarLabel,
     sidebarPosition,
     frontMatter,
   };

--- a/packages/docusaurus-plugin-content-docs/src/props.ts
+++ b/packages/docusaurus-plugin-content-docs/src/props.ts
@@ -33,7 +33,11 @@ Available document ids=
       );
     }
 
-    const {title, permalink, sidebar_label: sidebarLabel} = docMetadata;
+    const {
+      title,
+      permalink,
+      frontMatter: {sidebar_label: sidebarLabel},
+    } = docMetadata;
 
     return {
       type: 'link',

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -198,7 +198,6 @@ export type DocMetadataBase = LastUpdateData & {
   slug: string;
   permalink: string;
   // eslint-disable-next-line camelcase
-  sidebar_label?: string;
   sidebarPosition?: number;
   editUrl?: string | null;
   frontMatter: FrontMatter;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After merging #4495, all frontmatter fields became part of doc metadata, we have at least one redundant field -- sidebar_label. We can safely remove it from the current metadata, and get it from the `frontMatter` field instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests passed.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
