### PR TITLE
refactor(v2): output URL to console only if it has changed

### DIFF
--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -72,9 +72,11 @@ export default async function start(
     loadSite()
       .then(({baseUrl: newBaseUrl}) => {
         const newOpenUrl = normalizeUrl([urls.localUrlForBrowser, newBaseUrl]);
-        console.log(
-          chalk.cyanBright(`Docusaurus website is running at: ${newOpenUrl}`),
-        );
+        if (newOpenUrl !== openUrl) {
+          console.log(
+            chalk.cyanBright(`Docusaurus website is running at: ${newOpenUrl}`),
+          );
+        }
       })
       .catch((err) => {
         console.error(chalk.red(err.stack));


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

At the moment, with each new incremental build, two messages are duplicated in console:

```
To use Docusaurus i18n, it is strongly advised to use NodeJS >= 14 (instead of 12)
Docusaurus website is running at: http://localhost:3000/
```

If output of the first message can be eliminated by using Node.js v14, then on the second one user can not affect. I propose displaying the URL where Docusaurus is running only if it is necessary, i.e. when the initial URL has changed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try to build site locally.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
