### PR TITLE
refactor(v2): reduce vertical space in doc content container

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -123,13 +123,9 @@ function DocPageContent({
               hiddenSidebarContainer || !sidebar,
           })}>
           <div
-            className={clsx(
-              'container padding-vert--lg',
-              styles.docItemWrapper,
-              {
-                [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
-              },
-            )}>
+            className={clsx('container', styles.docItemWrapper, {
+              [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
+            })}>
             <MDXProvider components={MDXComponents}>{children}</MDXProvider>
           </div>
         </main>

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -123,9 +123,13 @@ function DocPageContent({
               hiddenSidebarContainer || !sidebar,
           })}>
           <div
-            className={clsx('container', styles.docItemWrapper, {
-              [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
-            })}>
+            className={clsx(
+              'container padding-vert--lg',
+              styles.docItemWrapper,
+              {
+                [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,
+              },
+            )}>
             <MDXProvider components={MDXComponents}>{children}</MDXProvider>
           </div>
         </main>

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -19,6 +19,10 @@
   width: 100%;
 }
 
+.docItemWrapper {
+  padding-top: 0.5rem !important;
+}
+
 @media (min-width: 997px) {
   .docMainContainer {
     flex-grow: 1;
@@ -72,7 +76,9 @@
   }
 
   .docItemWrapperEnhanced {
-    max-width: calc(var(--ifm-container-width) + var(--doc-sidebar-width)) !important;
+    max-width: calc(
+      var(--ifm-container-width) + var(--doc-sidebar-width)
+    ) !important;
   }
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -20,7 +20,7 @@
 }
 
 .docItemWrapper {
-  padding-top: 0.5rem !important;
+  padding: 0.5rem 0 2rem 0;
 }
 
 @media (min-width: 997px) {

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -20,7 +20,7 @@
 }
 
 .docItemWrapper {
-  padding: 0.5rem 0 2rem 0;
+  padding-top: 0.5rem !important;
 }
 
 @media (min-width: 997px) {

--- a/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
@@ -9,7 +9,7 @@
   max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
   overflow-y: auto;
   position: sticky;
-  top: calc(var(--ifm-navbar-height) + 2rem);
+  top: calc(var(--ifm-navbar-height) + 1rem);
 }
 
 @media only screen and (max-width: 996px) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

At the moment, doc content is positioned bit lower compared to doc sidebar content, this inconsistency in these two columns is a bit disturbing to the eye. If you look at the blog layout, there is no such issue, so I suggest eliminating this visual discrepancy.

![2021-05-30_15-01](https://user-images.githubusercontent.com/4408379/120246542-2dca5c00-c279-11eb-9710-2dad3213cf60.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before:

![2021-06-01_01-26](https://user-images.githubusercontent.com/4408379/120246569-463a7680-c279-11eb-82fc-e30de3edc4b0.png)


After:

![2021-06-01_01-36](https://user-images.githubusercontent.com/4408379/120246766-e7293180-c279-11eb-8580-2e2258066ce5.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
