### PR TITLE
fix(v2): escape HTML entities in user tags attributes

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -69,6 +69,7 @@
     "cssnano": "^5.0.4",
     "del": "^6.0.0",
     "detect-port": "^1.3.0",
+    "escape-html": "^1.0.3",
     "eta": "^1.12.1",
     "express": "^4.17.1",
     "file-loader": "^6.2.0",

--- a/packages/docusaurus/src/server/html-tags/__tests__/htmlTags.test.ts
+++ b/packages/docusaurus/src/server/html-tags/__tests__/htmlTags.test.ts
@@ -8,7 +8,7 @@
 import htmlTagObjectToString from '../htmlTags';
 
 describe('htmlTagObjectToString', () => {
-  test('simple html tag', () => {
+  test('valid html tag', () => {
     expect(
       htmlTagObjectToString({
         tagName: 'script',
@@ -17,10 +17,11 @@ describe('htmlTagObjectToString', () => {
           src:
             'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
           async: true,
+          'data-options': '{"prop":true}',
         },
       }),
     ).toMatchInlineSnapshot(
-      `"<script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js\\" async></script>"`,
+      `"<script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js\\" async data-options=\\"{&quot;prop&quot;:true}\\"></script>"`,
     );
 
     expect(

--- a/packages/docusaurus/src/server/html-tags/htmlTags.ts
+++ b/packages/docusaurus/src/server/html-tags/htmlTags.ts
@@ -9,6 +9,7 @@ import {isPlainObject} from 'lodash';
 import {HtmlTagObject} from '@docusaurus/types';
 import htmlTags from 'html-tags';
 import voidHtmlTags from 'html-tags/void';
+import escapeHTML from 'escape-html';
 
 function assertIsHtmlTagObject(val: unknown): asserts val is HtmlTagObject {
   if (!isPlainObject(val)) {
@@ -41,7 +42,7 @@ export default function htmlTagObjectToString(tagDefinition: unknown): string {
       if (tagAttributes[attributeName] === true) {
         return attributeName;
       }
-      return `${attributeName}="${tagAttributes[attributeName]}"`;
+      return `${attributeName}="${escapeHTML(tagAttributes[attributeName])}"`;
     });
   return `<${[tagDefinition.tagName].concat(attributes).join(' ')}>${
     (!isVoidTag && tagDefinition.innerHTML) || ''


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves #4892

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See To Reproduce section in #4892

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
