### PR TITLE
Fix incorrect link to plugin-ideal-image

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -53,7 +53,7 @@ This results in displaying the image:
 
 :::note
 
-If you are using [@docusaurus/plugin-ideal-image](../../using-plugins.md#docusaurusplugin-ideal-image), you need to use the dedicated image component, as documented.
+If you are using [@docusaurus/plugin-ideal-image](../../api/plugins/plugin-ideal-image.md), you need to use the dedicated image component, as documented.
 
 :::
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, it links to https://docusaurus.io/docs/using-plugins#docusaurusplugin-ideal-image which have no `plugin-ideal-image` related contents available (presumably moved)

To correctly guide users to the contents the link should be at https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-ideal-image

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes