### PR TITLE
chore: fail CI if yarn.lock is modified on install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Installation
         uses: bahmutov/npm-install@v1
         with:
-          install-command: yarn
+          install-command: yarn install --immutable # Fails if yarn.lock is modified
       - name: Lint
         run: yarn lint:ci
       - name: Prettier Code


### PR DESCRIPTION

## Motivation

TIL about `yarn install --immutable`, useful to fail the CI if an install requires updating yarn.lock

