### PR TITLE
fix(v2): adjust margin after content title

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -10,6 +10,10 @@
   padding: 0 0.5rem;
 }
 
+.docItemContainer header + * {
+  margin-top: 0;
+}
+
 .docUpdateDetails,
 .docPaginator {
   margin-top: 3rem;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Small fix to #4882: after putting content title under `div.markdown` element, subsequent headings will add unwanted margin, which is best reset as was before.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/120683296-23d97080-c4a6-11eb-9310-a55170d6bbc4.png) | ![image](https://user-images.githubusercontent.com/4408379/120683350-32278c80-c4a6-11eb-8532-6c0ceada9e70.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
