### PR TITLE
refactor(v2): do not use FOUC script if color mode disabled

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -174,6 +174,10 @@ export default function docusaurusThemeClassic(
     },
 
     injectHtmlTags() {
+      if (colorMode.disableSwitch) {
+        return {};
+      }
+
       return {
         preBodyTags: [
           {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In fact, similar condition was from the very beginning, but apparently by mistake (?) It was removed. Any way, the script to avoid FOUC does not need to be included if color mode is disabled.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Set ` disableSwitch: true` and make sure there is no script for color mode in the `body` element.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
