### PR TITLE
refactor(v2): do not generate RSS files for empty feed

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/generateBlogFeed.test.ts.snap
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/generateBlogFeed.test.ts.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`blogFeed atom can show feed without posts 1`] = `
-"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<feed xmlns=\\"http://www.w3.org/2005/Atom\\">
-    <id>https://docusaurus.io/blog</id>
-    <title>Hello Blog</title>
-    <updated>2015-10-25T23:29:00.000Z</updated>
-    <generator>https://github.com/jpmonette/feed</generator>
-    <link rel=\\"alternate\\" href=\\"https://docusaurus.io/blog\\"/>
-    <subtitle>Hello Blog</subtitle>
-    <icon>https://docusaurus.io/image/favicon.ico</icon>
-    <rights>Copyright</rights>
-</feed>"
-`;
+exports[`blogFeed atom should not show feed without posts 1`] = `null`;
 
 exports[`blogFeed atom shows feed item for each post 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -49,20 +37,7 @@ exports[`blogFeed atom shows feed item for each post 1`] = `
 </feed>"
 `;
 
-exports[`blogFeed rss can show feed without posts 1`] = `
-"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\">
-    <channel>
-        <title>Hello Blog</title>
-        <link>https://docusaurus.io/blog</link>
-        <description>Hello Blog</description>
-        <lastBuildDate>Sun, 25 Oct 2015 23:29:00 GMT</lastBuildDate>
-        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
-        <generator>https://github.com/jpmonette/feed</generator>
-        <copyright>Copyright</copyright>
-    </channel>
-</rss>"
-`;
+exports[`blogFeed rss should not show feed without posts 1`] = `null`;
 
 exports[`blogFeed rss shows feed item for each post 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/generateBlogFeed.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/generateBlogFeed.test.ts
@@ -32,7 +32,7 @@ function getBlogContentPaths(siteDir: string): BlogContentPaths {
 describe('blogFeed', () => {
   (['atom', 'rss'] as const).forEach((feedType) => {
     describe(`${feedType}`, () => {
-      test('can show feed without posts', async () => {
+      test('should not show feed without posts', async () => {
         const siteDir = __dirname;
         const siteConfig = {
           title: 'Hello',

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -67,7 +67,7 @@ export async function generateBlogFeed(
   }
   const {siteConfig} = context;
   const blogPosts = await generateBlogPosts(contentPaths, context, options);
-  if (blogPosts == null) {
+  if (!blogPosts.length) {
     return null;
   }
 

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -117,6 +117,7 @@ export default function pluginContentBlog(
       const {postsPerPage, routeBasePath} = options;
 
       blogPosts = await generateBlogPosts(contentPaths, context, options);
+
       if (!blogPosts.length) {
         return null;
       }
@@ -506,9 +507,14 @@ export default function pluginContentBlog(
     },
 
     injectHtmlTags() {
+      if (!blogPosts.length) {
+        return {};
+      }
+
       if (!options.feedOptions?.type) {
         return {};
       }
+
       const feedTypes = options.feedOptions.type;
       const {
         siteConfig: {title},


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, for sites that do not use a blog, RSS files are generated with an empty feed (e.g. https://www.graphql-code-generator.com/blog/rss.xml)

Most likely, we should avoid such behavior, it does not make sense at all.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Not sure if need to create another blog to test this?

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
