### PR TITLE
refactor(v2): remove type attribute from link and script tags

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -178,9 +178,6 @@ export default function docusaurusThemeClassic(
         preBodyTags: [
           {
             tagName: 'script',
-            attributes: {
-              type: 'text/javascript',
-            },
             innerHTML: noFlashColorMode(colorMode),
           },
         ],

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -20,7 +20,7 @@ module.exports = `
       <%~ metaAttribute %>
     <% }); %>
     <% it.stylesheets.forEach((stylesheet) => { %>
-      <link rel="stylesheet" type="text/css" href="<%= it.baseUrl %><%= stylesheet %>" />
+      <link rel="stylesheet" href="<%= it.baseUrl %><%= stylesheet %>" />
     <% }); %>
     <% it.scripts.forEach((script) => { %>
       <link rel="preload" href="<%= it.baseUrl %><%= script %>" as="script">
@@ -32,7 +32,7 @@ module.exports = `
       <%~ it.appHtml %>
     </div>
     <% it.scripts.forEach((script) => { %>
-      <script type="text/javascript" src="<%= it.baseUrl %><%= script %>"></script>
+      <script src="<%= it.baseUrl %><%= script %>"></script>
     <% }); %>
     <%~ it.postBodyTags %>
   </body>

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -150,7 +150,7 @@ const ConfigSchema = Joi.object({
     Joi.string(),
     Joi.object({
       href: Joi.string().required(),
-      type: Joi.string().required(),
+      type: Joi.string(),
     }).unknown(),
   ),
   clientModules: Joi.array().items(Joi.string()),

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -24,6 +24,7 @@ import loadThemeAlias from './themes';
 import {
   DocusaurusConfig,
   DocusaurusSiteMetadata,
+  HtmlTagObject,
   LoadContext,
   PluginConfig,
   Props,
@@ -194,23 +195,23 @@ export async function load(
       const stylesheetsTags = stylesheets.map((source) =>
         typeof source === 'string'
           ? `<link rel="stylesheet" href="${source}">`
-          : {
+          : ({
               tagName: 'link',
               attributes: {
                 rel: 'stylesheet',
                 ...source,
               },
-            },
+            } as HtmlTagObject),
       );
       const scriptsTags = scripts.map((source) =>
         typeof source === 'string'
           ? `<script src="${source}"></script>`
-          : {
+          : ({
               tagName: 'script',
               attributes: {
                 ...source,
               },
-            },
+            } as HtmlTagObject),
       );
       return {
         headTags: [...stylesheetsTags, ...scriptsTags],

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -204,11 +204,10 @@ export async function load(
       );
       const scriptsTags = scripts.map((source) =>
         typeof source === 'string'
-          ? `<script type="text/javascript" src="${source}"></script>`
+          ? `<script src="${source}"></script>`
           : {
               tagName: 'script',
               attributes: {
-                type: 'text/javascript',
                 ...source,
               },
             },

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -406,7 +406,7 @@ module.exports = {
       <%~ metaAttribute %>
     <% }); %>
     <% it.stylesheets.forEach((stylesheet) => { %>
-      <link rel="stylesheet" type="text/css" href="<%= it.baseUrl %><%= stylesheet %>" />
+      <link rel="stylesheet" href="<%= it.baseUrl %><%= stylesheet %>" />
     <% }); %>
     <% it.scripts.forEach((script) => { %>
       <link rel="preload" href="<%= it.baseUrl %><%= script %>" as="script">
@@ -421,7 +421,7 @@ module.exports = {
       <span>Custom markup</span>
     </div>
     <% it.scripts.forEach((script) => { %>
-      <script type="text/javascript" src="<%= it.baseUrl %><%= script %>"></script>
+      <script src="<%= it.baseUrl %><%= script %>"></script>
     <% }); %>
     <%~ it.postBodyTags %>
   </body>
@@ -445,7 +445,6 @@ module.exports = {
     // Object format.
     {
       href: 'http://mydomain.com/style.css',
-      type: 'text/css',
     },
   ],
 };

--- a/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
@@ -71,7 +71,6 @@ Include the KaTeX CSS in your config under `stylesheets`:
 stylesheets: [
     {
         href: "https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css",
-        type: "text/css",
         integrity: "sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc",
         crossorigin: "anonymous",
     },
@@ -108,7 +107,6 @@ module.exports = {
 + stylesheets: [
 +   {
 +     href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',
-+     type: 'text/css',
 +     integrity:
 +       'sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc',
 +     crossorigin: 'anonymous',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -57,7 +57,6 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
   stylesheets: [
     {
       href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',
-      type: 'text/css',
       integrity:
         'sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc',
       crossorigin: 'anonymous',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

These are completely unnecessary attributes that are actually already being removed by the minifier (terser), so we can remove them from the codebase itself.

> The default type for resources given by the stylesheet keyword is "text/css" (see w3.org/TR/html5/links.html#link-type-stylesheet)
> For scripts, default type is "text/javascript" (see http://www.w3.org/TR/html5/scripting-1.html#attr-script-type)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
