### PR TITLE
docs(v2): plugins: fix typo in code block

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -134,7 +134,7 @@ module.exports = {
   // ...
   plugins: [
     // highligh-start
-    function myPlugin(contex, options) {
+    function myPlugin(context, options) {
       // ...
       return {
         name: 'my-plugin',


### PR DESCRIPTION
## Motivation

Fix "context" typo in Advanced Guides/plugins codeblock.
