### PR TITLE
fix(v2): tidy up Markdown page layout

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
@@ -6,12 +6,15 @@
  */
 
 import React from 'react';
+import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import {MDXProvider} from '@mdx-js/react';
 import MDXComponents from '@theme/MDXComponents';
 import type {Props} from '@theme/MDXPage';
 import TOC from '@theme/TOC';
 import {ThemeClassNames} from '@docusaurus/theme-common';
+
+import styles from './styles.module.css';
 
 function MDXPage(props: Props): JSX.Element {
   const {content: MDXPageContent} = props;
@@ -32,24 +35,18 @@ function MDXPage(props: Props): JSX.Element {
       permalink={permalink}
       wrapperClassName={wrapperClassName ?? ThemeClassNames.wrapper.mdxPages}
       pageClassName={ThemeClassNames.page.mdxPage}>
-      <main>
-        <div className="container container--fluid">
-          <div className="margin-vert--lg padding-vert--lg">
-            <div className="row">
-              <div className="col col--8 col--offset-2">
-                <div className="container">
-                  <MDXProvider components={MDXComponents}>
-                    <MDXPageContent />
-                  </MDXProvider>
-                </div>
-              </div>
-              {!hideTableOfContents && MDXPageContent.toc && (
-                <div className="col col--2">
-                  <TOC toc={MDXPageContent.toc} />
-                </div>
-              )}
-            </div>
+      <main className="container container--fluid margin-vert--lg">
+        <div className={clsx('row', styles.MdxPageWrapper)}>
+          <div className={clsx('col', !hideTableOfContents && 'col--8')}>
+            <MDXProvider components={MDXComponents}>
+              <MDXPageContent />
+            </MDXProvider>
           </div>
+          {!hideTableOfContents && MDXPageContent.toc && (
+            <div className="col col--2">
+              <TOC toc={MDXPageContent.toc} />
+            </div>
+          )}
         </div>
       </main>
     </Layout>

--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/styles.module.css
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.MdxPageWrapper {
+  justify-content: center;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Quite strange looking now markdown page, I suppose it should be aligned to center like on all the other pages (see screenshots below).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before <br/> (https://docusaurus.io/examples/markdownPageExample)   | After <br/> (https://deploy-preview-4917--docusaurus-2.netlify.app/examples/markdownPageExample)    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/120924527-d72baa80-c6dc-11eb-8a38-f35b7cccddb7.png) | ![image](https://user-images.githubusercontent.com/4408379/120924924-c9772480-c6de-11eb-81d9-e9856b9e7df6.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
