### PR TITLE
fix(v2): render children in BrowserOnly after client is ready

### DIFF
--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import ExecutionEnvironment from './ExecutionEnvironment';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 function BrowserOnly({
   children,
@@ -15,11 +16,13 @@ function BrowserOnly({
   children?: () => JSX.Element;
   fallback?: JSX.Element;
 }): JSX.Element | null {
+  const {isClient} = useDocusaurusContext();
+
   if (!ExecutionEnvironment.canUseDOM || children == null) {
     return fallback || null;
   }
 
-  return <>{children()}</>;
+  return isClient ? <>{children()}</> : null;
 }
 
 export default BrowserOnly;

--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import ExecutionEnvironment from './ExecutionEnvironment';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 function BrowserOnly({
@@ -18,11 +17,11 @@ function BrowserOnly({
 }): JSX.Element | null {
   const {isClient} = useDocusaurusContext();
 
-  if (!ExecutionEnvironment.canUseDOM || children == null) {
-    return fallback || null;
+  if (isClient && children != null) {
+    return <>{children()}</>;
   }
 
-  return isClient ? <>{children()}</> : null;
+  return fallback || null;
 }
 
 export default BrowserOnly;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #4934

Currently child elements inside `BrowserOnly` are rendered too early, before the client side is ready, because in some cases the final markup may break.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See To reproduce section in #4934 (eg. insert code below on index page).

```js
<BrowserOnly
  fallback={
    <div className="a">
      <div className="b">Will be render during SSR</div>
    </div>
  }>
  {() => (
    <div className="a">
      <div className="b">Will be render on client (i.e. replace SSR content above)</div>
    </div>
  )}
</BrowserOnly>
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
