### PR TITLE
docs: add info about `DefaultValue` prop in `Tabs`

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-tabs.mdx
@@ -50,6 +50,14 @@ By default, tabs are rendered eagerly, but it is possible to load them lazily by
 
 :::
 
+## Displaying a default tab
+
+Set the `defaultValue` property in the `Tabs` component to the label value of your choice to show the matching tab by default.
+
+For example, in the example above, `defaultValue="apple"` forces the `Apple` tab to be open by default.
+
+If the `defaultValue` property is not provided or refers to an non-existing value, only the tab headings appear until the user clicks on a tab.
+
 ## Syncing tab choices {#syncing-tab-choices}
 
 You may want choices of the same kind of tabs to sync with each other. For example, you might want to provide different instructions for users on Windows vs users on macOS, and you want to changing all OS-specific instructions tabs in one click. To achieve that, you can give all related tabs the same `groupId` prop. Note that doing this will persist the choice in `localStorage` and all `<Tab>` instances with the same `groupId` will update automatically when the value of one of them is changed. Note that `groupID` are globally-namespaced.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The docs do not clearly mention the `defaultValue` prop available for Tabs, but I thought that we should for SEO reasons and to raise awareness about it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Make sure the docs build. 

