### PR TITLE
misc: disable google-gtag plugin in Netlify deploys

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -326,9 +326,11 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
     },
     image: 'img/docusaurus-soc.png',
     // metadatas: [{name: 'twitter:card', content: 'summary'}],
-    gtag: {
-      trackingID: 'UA-141789564-1',
-    },
+    gtag: !isDeployPreview
+      ? {
+          trackingID: 'UA-141789564-1',
+        }
+      : undefined,
     algolia: {
       apiKey: '47ecd3b21be71c5822571b9f59e52544',
       indexName: 'docusaurus-2',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

At the moment we see that the performance in new Lighthouse reports has decreased. This is because Netlify now automatically include their own widget (Netlify Drawer) into preview sites. They [promise to make it configurable](https://answers.netlify.com/t/netlify-github-app-permission-updates-with-collaborative-deploy-previews/37872/24), so for now I suggest disable the Google metrics from preview sites to slightly increase the current performance metrics.

![image](https://user-images.githubusercontent.com/4408379/121662736-5ab71400-caae-11eb-9f52-55ede9b3efe7.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Make sure that the preview is not using Google Analytics.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
