### PR TITLE
docs(v2): add documentation about importing markdown

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -90,4 +90,12 @@ import Intro from './markdown-features-intro.mdx';
 
 </BrowserWindow>
 
+<br />
+
 This way, you can reuse contents among multiple pages and avoid duplicating materials.
+
+:::caution
+
+The table-of-contents does not currently contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
+
+::: 

--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -98,4 +98,4 @@ This way, you can reuse contents among multiple pages and avoid duplicating mate
 
 The table-of-contents does not currently contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
 
-::: 
+:::

--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -7,6 +7,8 @@ slug: /markdown-features/react
 
 import BrowserWindow from '@site/src/components/BrowserWindow';
 
+## Using JSX in Markdown {#using-jsx-in-markdown}
+
 Docusaurus has built-in support for [MDX](https://mdxjs.com/), which allows you to write JSX within your Markdown files and render them as React components.
 
 :::note
@@ -69,3 +71,23 @@ You can also import your own components defined in other files or third-party co
 Since all doc files are parsed using MDX, any HTML is treated as JSX. Therefore, if you need to inline-style a component, follow JSX flavor and provide style objects. This behavior is different from Docusaurus 1. See also [Migrating from v1 to v2](../../migration/migration-manual.md#convert-style-attributes-to-style-objects-in-mdx).
 
 :::
+
+## Importing Markdown {#importing-markdown}
+
+You can use Markdown files as components and import them elsewhere, either in Markdown files or in React pages. Below we are importing from [another file](./markdown-features-intro.mdx) and inserting it as a component.
+
+```jsx
+import Intro from './markdown-features-intro.mdx';
+
+<Intro />;
+```
+
+<BrowserWindow url="http://localhost:3000">
+
+import Intro from './markdown-features-intro.mdx';
+
+<Intro />
+
+</BrowserWindow>
+
+This way, you can reuse contents among multiple pages and avoid duplicating materials.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The website has [a hidden Markdown page example](https://docusaurus.io/examples/markdownpageexample). It includes [an example of importing markdown](https://docusaurus.io/examples/markdownpageexample#import-mdx-and-md-files), which is not documented anywhere else on the website.

On Discord people often ask about reusing Markdown files, and I have to give them links to this hidden file. It would be great if it can be documented in the actual documentation.

I'm not sure if I'm putting this section in the right place...

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep

