### PR TITLE
docs(v2): replace `diff` codeblocks with line highlight

### DIFF
--- a/packages/docusaurus-init/templates/classic/docs/tutorial-basics/create-a-document.md
+++ b/packages/docusaurus-init/templates/classic/docs/tutorial-basics/create-a-document.md
@@ -28,12 +28,11 @@ Docusaurus automatically **creates a sidebar** from the `docs` folder.
 
 Add metadatas to customize the sidebar label and position:
 
-```diff title="docs/hello.md"
-+ ---
-+ sidebar_label: "Hi!"
-+ sidebar_position: 3
-+ ---
-
+```md title="docs/hello.md"
+---
+sidebar_label: 'Hi!'
+sidebar_position: 3
+---
 
 # Hello
 

--- a/packages/docusaurus-init/templates/classic/docs/tutorial-basics/create-a-document.md
+++ b/packages/docusaurus-init/templates/classic/docs/tutorial-basics/create-a-document.md
@@ -28,7 +28,7 @@ Docusaurus automatically **creates a sidebar** from the `docs` folder.
 
 Add metadatas to customize the sidebar label and position:
 
-```md title="docs/hello.md"
+```md title="docs/hello.md" {1-4}
 ---
 sidebar_label: 'Hi!'
 sidebar_position: 3

--- a/website/docs/api/plugins/plugin-ideal-image.md
+++ b/website/docs/api/plugins/plugin-ideal-image.md
@@ -16,10 +16,10 @@ npm install --save @docusaurus/plugin-ideal-image
 
 Modify your `docusaurus.config.js`
 
-```diff
+```js {3}
 module.exports = {
   ...
-+ plugins: ['@docusaurus/plugin-ideal-image'],
+  plugins: ['@docusaurus/plugin-ideal-image'],
   ...
 }
 ```

--- a/website/docs/guides/docs/sidebar.md
+++ b/website/docs/guides/docs/sidebar.md
@@ -442,12 +442,11 @@ If the generated sidebar does not look good, you can assign additional metadatas
 
 **For docs**: use additional frontmatter:
 
-```diff title="docs/tutorials/tutorial-easy.md"
-+ ---
-+ sidebar_label: Easy
-+ sidebar_position: 2
-+ ---
-
+```md title="docs/tutorials/tutorial-easy.md" {1-4}
+---
+sidebar_label: Easy
+sidebar_position: 2
+---
 
 # Easy Tutorial
 

--- a/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
@@ -79,12 +79,11 @@ stylesheets: [
 
 Overall the changes look like:
 
-```diff title="docusaurus.config.js"
+```js title="docusaurus.config.js"
 // highlight-start
-+ const math = require('remark-math');
-+ const katex = require('rehype-katex');
+const math = require('remark-math');
+const katex = require('rehype-katex');
 // highlight-end
-
 
 module.exports = {
   title: 'Docusaurus',
@@ -96,22 +95,22 @@ module.exports = {
         docs: {
           path: 'docs',
           // highlight-start
-+         remarkPlugins: [math],
-+         rehypePlugins: [katex],
+          remarkPlugins: [math],
+          rehypePlugins: [katex],
           // highlight-end
         },
       },
     ],
   ],
   // highlight-start
-+ stylesheets: [
-+   {
-+     href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',
-+     integrity:
-+       'sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc',
-+     crossorigin: 'anonymous',
-+   },
-+ ],
+  stylesheets: [
+    {
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',
+      integrity:
+        'sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc',
+      crossorigin: 'anonymous',
+    },
+  ],
   // highlight-end
 };
 ```


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #4698. There are some `diff` code blocks with only `+` and no `-`. In this case using line highlight equally makes sense, with the additional merits of:

1. Not generating "confusing code" when using copy button;
2. Leverages syntax highlight to make the code block more visually appealing.

For the rest of the code blocks that have `-` as well, I kept them as-is.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep
