### PR TITLE
fix(v2): always use UTC when dealing with blog dates

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -172,7 +172,8 @@ export async function generateBlogPosts(
 
       if (dateFilenameMatch) {
         const [, dateString, name] = dateFilenameMatch;
-        date = new Date(dateString);
+        // Always treat dates as UTC by adding the `Z`
+        date = new Date(`${dateString}Z`);
         linkName = name;
       }
 
@@ -187,6 +188,7 @@ export async function generateBlogPosts(
         day: 'numeric',
         month: 'long',
         year: 'numeric',
+        timeZone: 'UTC',
       }).format(date);
 
       const title = frontMatter.title ?? contentTitle ?? linkName;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #4881. This issue contains two bugs, the first (wrong displayed date) is related to `formattedDate`, the second (wrong generated URL) is related to `toUrl`. By always dealing with the blog date object in the UTC timezone, both bugs should be fixed. (@josh-kaplan inspired me on how to fix the first one.)

Although in the documentation, it is suggested to use `YYYY-MM-DD` for the blog date, numbers without a preceding zero will not be rejected and will be correctly parsed. However, this causes the date to be treated as a local time object instead of a UTC one when creating the date object, [as documented](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date). By forcing the date object to be created in UTC, this problem is solved.

In `formattedDate`, the default timezone is the one of the runtime instead of UTC ([documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat)). We need to force it to UTC.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep

## Test Plan

I can't demonstrate this error as a test case because this timezone is set in the local runtime environment. However, I constructed some examples:

**Previous**

```js
let d = new Date("2021-5-10") // "Mon May 10 2021 00:00:00 GMT+0800 (China Standard Time)"
// This is because the date is not in the standard "YYYY-MM-DD" format, and therefore uses the local time zone instead of UTC.
toUrl({d, "Hi"}) // "2021/05/09/Hi"; has a one-offset from the actual date
```

```js
let d = new Date("2021-02-01") // "Sun Jan 31 2021 19:00:00 GMT-0500 (Eastern Standard Time)"
new Intl.DateTimeFormat("en", {
  day: 'numeric',
  month: 'long',
  year: 'numeric',
}).format(d) // "January 31, 2021"; because the timezone is GMT-0500
```

**Now**

```js
let d = new Date("2021-5-10Z") // "Mon May 10 2021 08:00:00 GMT+0800 (China Standard Time)"
toUrl({d, "Hi"}) // "2021/05/10/Hi"
```

```js
let d = new Date("2021-02-01Z") // "Sun Jan 31 2021 19:00:00 GMT-0500 (Eastern Standard Time)"
new Intl.DateTimeFormat("en", {
  day: 'numeric',
  month: 'long',
  year: 'numeric',
  timeZone: 'UTC'
}).format(d) // "February 1, 2021"
```

Let me know how to create a test case if there's such a need...