### PR TITLE
fix(v2): navbar doc item fallback: search doc in lastVersion

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -43,6 +43,11 @@ declare module '@docusaurus/plugin-content-docs-types' {
   export type PropSidebars = {
     [sidebarId: string]: PropSidebarItem[];
   };
+
+  export type {
+    GlobalVersion as GlobalDataVersion,
+    GlobalDoc as GlobalDataDoc,
+  } from './types';
 }
 
 declare module '@theme/DocItem' {


### PR DESCRIPTION


## Motivation


When using a navbar doc item like:

```
        {
          type: 'doc',
          docId: 'myDocId',
        },
```

It was previously required that myDocId exist in ALL docs versions of the sites, so that we can always link to the currently active version.

This PR makes it more fail-safe, and falls-back to looking for the doc in lastVersion, so that older versions are not forced to contain a doc with `id: myDocId` (ie we can more easily introduce a navbar link to an existing versioned site)

Fix https://github.com/facebook/docusaurus/issues/4972

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

local :'( we don't have much test infra on the theme code and no dogfooding possible

