### PR TITLE
fix(v2): fix UX for docsVersionDropdown on mobile for single version

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -68,14 +68,15 @@ export default function DocsVersionDropdownNavbarItem({
     return items;
   }
 
+  const items = getItems();
+
   const dropdownVersion =
     activeDocContext.activeVersion ?? preferredVersion ?? latestVersion;
 
-  // Mobile is handled a bit differently
-  const dropdownLabel = mobile ? 'Versions' : dropdownVersion.label;
-  const dropdownTo = mobile
-    ? undefined
-    : getVersionMainDoc(dropdownVersion).path;
+  // Mobile dropdown is handled a bit differently
+  const dropdownLabel = mobile && items ? 'Versions' : dropdownVersion.label;
+  const dropdownTo =
+    mobile && items ? undefined : getVersionMainDoc(dropdownVersion).path;
 
   return (
     <DefaultNavbarItem
@@ -83,7 +84,7 @@ export default function DocsVersionDropdownNavbarItem({
       mobile={mobile}
       label={dropdownLabel}
       to={dropdownTo}
-      items={getItems()}
+      items={items}
       isActive={dropdownActiveClassDisabled ? () => false : undefined}
     />
   );


### PR DESCRIPTION

## Motivation

Fix #4932

When the version dropdown contains a single version, it should transform to a regular button/link. It does not Desktop but didn't for mobile
