### PR TITLE
refactor(v2): blog/docs: add more context in error messages

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -32,6 +32,7 @@ import globby from 'globby';
 import {getDocsDirPaths} from './versions';
 import {stripPathNumberPrefixes} from './numberPrefix';
 import {validateDocFrontMatter} from './docFrontMatter';
+import chalk from 'chalk';
 
 type LastUpdateOptions = Pick<
   PluginOptions,
@@ -102,7 +103,7 @@ export async function readVersionDocs(
   );
 }
 
-export function processDocMetadata({
+function doProcessDocMetadata({
   docFile,
   versionMetadata,
   context,
@@ -261,4 +262,22 @@ export function processDocMetadata({
     sidebarPosition,
     frontMatter,
   };
+}
+
+export function processDocMetadata(args: {
+  docFile: DocFile;
+  versionMetadata: VersionMetadata;
+  context: LoadContext;
+  options: MetadataOptions;
+}): DocMetadataBase {
+  try {
+    return doProcessDocMetadata(args);
+  } catch (e) {
+    console.error(
+      chalk.red(
+        `Can't process doc metadatas for doc at path "${args.docFile.filePath}" in version "${args.versionMetadata.versionName}"`,
+      ),
+    );
+    throw e;
+  }
 }


### PR DESCRIPTION
## Motivation

When looping over docs/versions/blog, if one item triggers an error, the user should be able to figure out which one with a relevant log.

Unfortunately, JS does not have a good way to add context to an existing error (until this proposal is implemented: https://github.com/tc39/proposal-error-cause) so I just add a log for now.

Helpful to debug some problems reported by users for which the logs are not meaningful enough

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests,  no behavior changed


