### PR TITLE
refactor(v2): reduce top padding in doc content container

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -144,7 +144,7 @@ function DocPageContent({
           })}>
           <div
             className={clsx(
-              'container padding-vert--lg',
+              'container padding-top--md padding-bottom--lg',
               styles.docItemWrapper,
               {
                 [styles.docItemWrapperEnhanced]: hiddenSidebarContainer,

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -19,10 +19,6 @@
   width: 100%;
 }
 
-.docItemWrapper {
-  padding-top: 0.5rem !important;
-}
-
 @media (min-width: 997px) {
   .docMainContainer {
     flex-grow: 1;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Re-attempted to apply the changes from #4877.

Because of style minification the changes from that PR didn't apply (didn't notice it right away). So I decided to use the built-in Infima utility classes to achieve purpose of that PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
