### PR TITLE
fix(v2): fix theme array deduplication bug

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -30,6 +30,7 @@
     "@docusaurus/theme-common": "2.0.0-beta.0",
     "@docusaurus/types": "2.0.0-beta.0",
     "@docusaurus/utils": "2.0.0-beta.0",
+    "@docusaurus/utils-common": "2.0.0-beta.0",
     "@docusaurus/utils-validation": "2.0.0-beta.0",
     "@mdx-js/mdx": "^1.6.21",
     "@mdx-js/react": "^1.6.21",

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -11,6 +11,7 @@ import {useLatestVersion, useActiveDocContext} from '@theme/hooks/useDocs';
 import clsx from 'clsx';
 import type {Props} from '@theme/NavbarItem/DocNavbarItem';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
+import {uniq} from '@docusaurus/utils-common';
 import type {
   GlobalDataVersion,
   GlobalDataDoc,
@@ -47,11 +48,9 @@ export default function DocNavbarItem({
   const latestVersion = useLatestVersion(docsPluginId);
 
   // Versions used to look for the doc to link to, ordered + no duplicate
-  const versions: GlobalDataVersion[] = [
-    ...new Set(
-      [activeVersion, preferredVersion, latestVersion].filter(Boolean),
-    ),
-  ];
+  const versions: GlobalDataVersion[] = uniq(
+    [activeVersion, preferredVersion, latestVersion].filter(Boolean),
+  );
   const doc = getDocInVersions(versions, docId);
 
   return (

--- a/packages/docusaurus-utils-common/src/__tests__/uniq.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/uniq.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import uniq from '../uniq';
+
+describe('uniq', () => {
+  test('remove duplicate primitives', () => {
+    expect(uniq(['A', 'B', 'C', 'B', 'A', 'D'])).toEqual(['A', 'B', 'C', 'D']);
+    expect(uniq([3, 3, 5, 1, 6, 3, 5])).toEqual([3, 5, 1, 6]);
+    expect(uniq([null, undefined, 3, null, 4, 3])).toEqual([
+      null,
+      undefined,
+      3,
+      4,
+    ]);
+  });
+
+  test('remove duplicate objects/arrays by identity', () => {
+    const obj1 = {};
+    const obj2 = {};
+    const obj3 = {};
+    const array1: unknown[] = [];
+    const array2: unknown[] = [];
+    const array3: unknown[] = [];
+    expect(
+      uniq([obj1, obj1, obj2, array1, obj2, array3, array2, array1, obj3]),
+    ).toEqual([obj1, obj2, array1, array3, array2, obj3]);
+  });
+});

--- a/packages/docusaurus-utils-common/src/index.ts
+++ b/packages/docusaurus-utils-common/src/index.ts
@@ -6,3 +6,4 @@
  */
 
 export {default as applyTrailingSlash} from './applyTrailingSlash';
+export {default as uniq} from './uniq';

--- a/packages/docusaurus-utils-common/src/uniq.ts
+++ b/packages/docusaurus-utils-common/src/uniq.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Remove duplicate array items (similar to _.uniq)
+export default function uniq<T>(array: T[]): T[] {
+  // Note: had problems with [...new Set()]: https://github.com/facebook/docusaurus/issues/4972#issuecomment-863895061
+  return Array.from(new Set(array));
+}


### PR DESCRIPTION

## Motivation

Due to some weird reason, the array dedupication logic using `[...new Set()]` is badly processed and buggy in the production build. Switching to `Array.from(new Set())` fixes the problem.

https://github.com/facebook/docusaurus/issues/4972#issuecomment-863895061

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests

