### PR TITLE
chore(v2): remove badge for v1 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <a href="#backers" alt="sponsors on Open Collective"><img src="https://opencollective.com/Docusaurus/backers/badge.svg" /></a>
   <a href="#sponsors" alt="Sponsors on Open Collective"><img src="https://opencollective.com/Docusaurus/sponsors/badge.svg" /></a>
   <a href="https://www.npmjs.com/package/@docusaurus/core"><img src="https://img.shields.io/npm/v/@docusaurus/core.svg?style=flat" alt="npm version"></a>
-  <a href="https://github.com/facebook/docusaurus/actions/workflows/v1-tests.yml"><img src="https://github.com/facebook/docusaurus/actions/workflows/v1-tests.yml/badge.svg" alt="Github Actions status"></a>
   <a href="https://github.com/facebook/docusaurus/actions/workflows/v2-tests.yml"><img src="https://github.com/facebook/docusaurus/actions/workflows/v2-tests.yml/badge.svg" alt="Github Actions status"></a>
   <a href="CONTRIBUTING.md#pull-requests"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a href="https://discord.gg/docusaurus"><img src="https://img.shields.io/discord/102860784329052160.svg" align="right" alt="Discord Chat" /></a>


### PR DESCRIPTION
Following #4902, this PR removes the broken badge for V1 tests, which has already been removed.