### PR TITLE
docs(v2): fix incorrect anchor links in website

### DIFF
--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -241,7 +241,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-plugin-content-docs`
 - **Multi-instance path**: `website/i18n/<locale>/docusaurus-plugin-content-docs-<pluginId>`
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `website/i18n/<locale>/docusaurus-plugin-content-docs/<version>`
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/docs/api/plugins/plugin-content-pages.md
+++ b/website/docs/api/plugins/plugin-content-pages.md
@@ -75,7 +75,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-plugin-content-pages`
 - **Multi-instance path**: `website/i18n/<locale>/docusaurus-plugin-content-pages-<pluginId>`
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `website/i18n/<locale>/docusaurus-plugin-content-pages`
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/docs/api/themes/theme-configuration.md
+++ b/website/docs/api/themes/theme-configuration.md
@@ -125,7 +125,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-theme-<themeName>`
 - **Multi-instance path**: N/A
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `N/A
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -27,7 +27,7 @@ A Docusaurus site is statically rendered, and it can generally work without Java
 
 It is important to test your build locally before deploying to production.
 
-Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command for that:
+Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve-sitedir) command for that:
 
 ```bash npm2yarn
 npm run serve
@@ -51,7 +51,7 @@ Use [slorber/trailing-slash-guide](https://github.com/slorber/trailing-slash-gui
 
 ## Self-Hosting {#self-hosting}
 
-Docusaurus can be self-hosted using [`docusaurus serve`](cli.md#docusaurus-serve). Change port using `--port` and `--host` to change host.
+Docusaurus can be self-hosted using [`docusaurus serve`](cli.md#docusaurus-serve-sitedir). Change port using `--port` and `--host` to change host.
 
 ```bash npm2yarn
 npm run serve -- --build --port 80 --host 0.0.0.0

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -164,7 +164,7 @@ export default function VisitMyWebsiteMessage() {
 
 When [localizing your site](./i18n/i18n-introduction.md), the `<Translate/>` component will allow providing **translation support to React components**, such as your homepage. The `<Translate>` component supports [interpolation](#interpolate).
 
-The translation strings will be extracted from your code with the [`docusaurus write-translations`](./cli.md#docusaurus-write-translations) CLI and create a `code.json` translation file in `website/i18n/<locale>`.
+The translation strings will be extracted from your code with the [`docusaurus write-translations`](./cli.md#docusaurus-write-translations-sitedir) CLI and create a `code.json` translation file in `website/i18n/<locale>`.
 
 :::note
 

--- a/website/docs/i18n/i18n-git.md
+++ b/website/docs/i18n/i18n-git.md
@@ -88,7 +88,7 @@ export default function Home() {
 
 ### Initialize the `i18n` folder {#initialize-the-i18n-folder}
 
-Use the [write-translations](../cli.md#docusaurus-write-translations) CLI command to initialize the JSON translation files for the French locale:
+Use the [write-translations](../cli.md#docusaurus-write-translations-sitedir) CLI command to initialize the JSON translation files for the French locale:
 
 ```bash npm2yarn
 npm run write-translations -- --locale fr
@@ -157,7 +157,7 @@ To keep your translated sites consistent, when the `website/docs/doc1.md` doc is
 
 ### JSON translations {#json-translations}
 
-To help you maintain the JSON translation files, it is possible to run again the [write-translations](../cli.md#docusaurus-write-translations) CLI command:
+To help you maintain the JSON translation files, it is possible to run again the [write-translations](../cli.md#docusaurus-write-translations-sitedir) CLI command:
 
 ```bash npm2yarn
 npm run write-translations -- --locale fr

--- a/website/docs/i18n/i18n-introduction.md
+++ b/website/docs/i18n/i18n-introduction.md
@@ -122,7 +122,7 @@ website/i18n
         └── navbar.json
 ```
 
-The JSON files are initialized with the [`docusaurus write-translations`](../cli.md#docusaurus-write-translations) CLI command.
+The JSON files are initialized with the [`docusaurus write-translations`](../cli.md#docusaurus-write-translations-sitedir) CLI command.
 
 The `code.json` file is extracted from React components using the `<Translate>` API.
 

--- a/website/versioned_docs/version-2.0.0-beta.0/api/plugins/plugin-content-docs.md
+++ b/website/versioned_docs/version-2.0.0-beta.0/api/plugins/plugin-content-docs.md
@@ -236,7 +236,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-plugin-content-docs`
 - **Multi-instance path**: `website/i18n/<locale>/docusaurus-plugin-content-docs-<pluginId>`
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `website/i18n/<locale>/docusaurus-plugin-content-docs/<version>`
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/versioned_docs/version-2.0.0-beta.0/api/plugins/plugin-content-pages.md
+++ b/website/versioned_docs/version-2.0.0-beta.0/api/plugins/plugin-content-pages.md
@@ -75,7 +75,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-plugin-content-pages`
 - **Multi-instance path**: `website/i18n/<locale>/docusaurus-plugin-content-pages-<pluginId>`
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `website/i18n/<locale>/docusaurus-plugin-content-pages`
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/versioned_docs/version-2.0.0-beta.0/api/themes/theme-configuration.md
+++ b/website/versioned_docs/version-2.0.0-beta.0/api/themes/theme-configuration.md
@@ -125,7 +125,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-theme-<themeName>`
 - **Multi-instance path**: N/A
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `N/A
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/versioned_docs/version-2.0.0-beta.0/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.0/deployment.mdx
@@ -15,7 +15,7 @@ You can deploy your site to static site hosting services such as [Vercel](https:
 
 ## Testing Build Local {#testing-build-local}
 
-It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command to test build locally.
+It is important to test build before deploying to a production. Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve-sitedir) command to test build locally.
 
 ```bash npm2yarn
 npm run serve
@@ -29,7 +29,7 @@ It is not the most performant solution
 
 :::
 
-Docusaurus can be self hosted using [`docusaurus serve`](cli.md#docusaurus-serve). Change port using `--port` and `--host` to change host.
+Docusaurus can be self hosted using [`docusaurus serve`](cli.md#docusaurus-serve-sitedir). Change port using `--port` and `--host` to change host.
 
 ```bash npm2yarn
 npm run serve -- --build --port 80 --host 0.0.0.0

--- a/website/versioned_docs/version-2.0.0-beta.0/docusaurus-core.md
+++ b/website/versioned_docs/version-2.0.0-beta.0/docusaurus-core.md
@@ -164,7 +164,7 @@ export default function VisitMyWebsiteMessage() {
 
 When [localizing your site](./i18n/i18n-introduction.md), the `<Translate/>` component will allow providing **translation support to React components**, such as your homepage. The `<Translate>` component supports [interpolation](#interpolate).
 
-The translation strings will be extracted from your code with the [`docusaurus write-translations`](./cli.md#docusaurus-write-translations) CLI and create a `code.json` translation file in `website/i18n/<locale>`.
+The translation strings will be extracted from your code with the [`docusaurus write-translations`](./cli.md#docusaurus-write-translations-sitedir) CLI and create a `code.json` translation file in `website/i18n/<locale>`.
 
 :::note
 

--- a/website/versioned_docs/version-2.0.0-beta.0/i18n/i18n-git.md
+++ b/website/versioned_docs/version-2.0.0-beta.0/i18n/i18n-git.md
@@ -88,7 +88,7 @@ export default function Home() {
 
 ### Initialize the `i18n` folder {#initialize-the-i18n-folder}
 
-Use the [write-translations](../cli.md#docusaurus-write-translations) CLI command to initialize the JSON translation files for the French locale:
+Use the [write-translations](../cli.md#docusaurus-write-translations-sitedir) CLI command to initialize the JSON translation files for the French locale:
 
 ```bash npm2yarn
 npm run write-translations -- --locale fr
@@ -157,7 +157,7 @@ To keep your translated sites consistent, when the `website/docs/doc1.md` doc is
 
 ### JSON translations {#json-translations}
 
-To help you maintain the JSON translation files, it is possible to run again the [write-translations](../cli.md#docusaurus-write-translations) CLI command:
+To help you maintain the JSON translation files, it is possible to run again the [write-translations](../cli.md#docusaurus-write-translations-sitedir) CLI command:
 
 ```bash npm2yarn
 npm run write-translations -- --locale fr

--- a/website/versioned_docs/version-2.0.0-beta.0/i18n/i18n-introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.0/i18n/i18n-introduction.md
@@ -122,7 +122,7 @@ website/i18n
         └── navbar.json
 ```
 
-The JSON files are initialized with the [`docusaurus write-translations`](../cli.md#docusaurus-write-translations) CLI command.
+The JSON files are initialized with the [`docusaurus write-translations`](../cli.md#docusaurus-write-translations-sitedir) CLI command.
 
 The `code.json` file is extracted from React components using the `<Translate>` API.
 

--- a/website/versioned_docs/version-2.0.0-beta.1/api/plugins/plugin-content-docs.md
+++ b/website/versioned_docs/version-2.0.0-beta.1/api/plugins/plugin-content-docs.md
@@ -241,7 +241,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-plugin-content-docs`
 - **Multi-instance path**: `website/i18n/<locale>/docusaurus-plugin-content-docs-<pluginId>`
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `website/i18n/<locale>/docusaurus-plugin-content-docs/<version>`
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/versioned_docs/version-2.0.0-beta.1/api/plugins/plugin-content-pages.md
+++ b/website/versioned_docs/version-2.0.0-beta.1/api/plugins/plugin-content-pages.md
@@ -75,7 +75,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-plugin-content-pages`
 - **Multi-instance path**: `website/i18n/<locale>/docusaurus-plugin-content-pages-<pluginId>`
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `website/i18n/<locale>/docusaurus-plugin-content-pages`
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/versioned_docs/version-2.0.0-beta.1/api/themes/theme-configuration.md
+++ b/website/versioned_docs/version-2.0.0-beta.1/api/themes/theme-configuration.md
@@ -125,7 +125,7 @@ Read the [i18n introduction](../../i18n/i18n-introduction.md) first.
 
 - **Base path**: `website/i18n/<locale>/docusaurus-theme-<themeName>`
 - **Multi-instance path**: N/A
-- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations)
+- **JSON files**: extracted with [`docusaurus write-translations`](../../cli.md#docusaurus-write-translations-sitedir)
 - **Markdown files**: `N/A
 
 ### Example file-system structure {#example-file-system-structure}

--- a/website/versioned_docs/version-2.0.0-beta.1/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.1/deployment.mdx
@@ -27,7 +27,7 @@ A Docusaurus site is statically rendered, and it can generally work without Java
 
 It is important to test your build locally before deploying to production.
 
-Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve) command for that:
+Docusaurus includes a [`docusaurus serve`](cli.md#docusaurus-serve-sitedir) command for that:
 
 ```bash npm2yarn
 npm run serve
@@ -51,7 +51,7 @@ Use [slorber/trailing-slash-guide](https://github.com/slorber/trailing-slash-gui
 
 ## Self-Hosting {#self-hosting}
 
-Docusaurus can be self-hosted using [`docusaurus serve`](cli.md#docusaurus-serve). Change port using `--port` and `--host` to change host.
+Docusaurus can be self-hosted using [`docusaurus serve`](cli.md#docusaurus-serve-sitedir). Change port using `--port` and `--host` to change host.
 
 ```bash npm2yarn
 npm run serve -- --build --port 80 --host 0.0.0.0

--- a/website/versioned_docs/version-2.0.0-beta.1/docusaurus-core.md
+++ b/website/versioned_docs/version-2.0.0-beta.1/docusaurus-core.md
@@ -164,7 +164,7 @@ export default function VisitMyWebsiteMessage() {
 
 When [localizing your site](./i18n/i18n-introduction.md), the `<Translate/>` component will allow providing **translation support to React components**, such as your homepage. The `<Translate>` component supports [interpolation](#interpolate).
 
-The translation strings will be extracted from your code with the [`docusaurus write-translations`](./cli.md#docusaurus-write-translations) CLI and create a `code.json` translation file in `website/i18n/<locale>`.
+The translation strings will be extracted from your code with the [`docusaurus write-translations`](./cli.md#docusaurus-write-translations-sitedir) CLI and create a `code.json` translation file in `website/i18n/<locale>`.
 
 :::note
 

--- a/website/versioned_docs/version-2.0.0-beta.1/i18n/i18n-git.md
+++ b/website/versioned_docs/version-2.0.0-beta.1/i18n/i18n-git.md
@@ -88,7 +88,7 @@ export default function Home() {
 
 ### Initialize the `i18n` folder {#initialize-the-i18n-folder}
 
-Use the [write-translations](../cli.md#docusaurus-write-translations) CLI command to initialize the JSON translation files for the French locale:
+Use the [write-translations](../cli.md#docusaurus-write-translations-sitedir) CLI command to initialize the JSON translation files for the French locale:
 
 ```bash npm2yarn
 npm run write-translations -- --locale fr
@@ -157,7 +157,7 @@ To keep your translated sites consistent, when the `website/docs/doc1.md` doc is
 
 ### JSON translations {#json-translations}
 
-To help you maintain the JSON translation files, it is possible to run again the [write-translations](../cli.md#docusaurus-write-translations) CLI command:
+To help you maintain the JSON translation files, it is possible to run again the [write-translations](../cli.md#docusaurus-write-translations-sitedir) CLI command:
 
 ```bash npm2yarn
 npm run write-translations -- --locale fr

--- a/website/versioned_docs/version-2.0.0-beta.1/i18n/i18n-introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.1/i18n/i18n-introduction.md
@@ -122,7 +122,7 @@ website/i18n
         └── navbar.json
 ```
 
-The JSON files are initialized with the [`docusaurus write-translations`](../cli.md#docusaurus-write-translations) CLI command.
+The JSON files are initialized with the [`docusaurus write-translations`](../cli.md#docusaurus-write-translations-sitedir) CLI command.
 
 The `code.json` file is extracted from React components using the `<Translate>` API.
 


### PR DESCRIPTION
## Motivation

This PR fixes one of the root causes of https://github.com/facebook/docusaurus/issues/5020 (See Demo 2)

Some anchor links are specified with the incorrect target, so this PR fixes these incorrect links

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manual testing using local dev server. We won't be able to use the netlify preview to test this because all cross-page anchor links are failing due to another root cause (see https://github.com/facebook/docusaurus/issues/5020). 

1. Temporarily change `useChangeRoute.ts` hook in `packages/docusaurus-theme-common/src/utils/useChangeRoute.ts` as follows:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/46853051/122682753-e3138280-d22d-11eb-958c-2e203e103688.png">

2. Start the development server and go to localhost:3000/docs/deployment#self-hosting

3. Click on the `docusaurus serve` link
4. Should be redirected to the correct target header
<img width="792" alt="image" src="https://user-images.githubusercontent.com/46853051/122682865-7482f480-d22e-11eb-9690-293d3eacbf53.png">
