### PR TITLE
docs(v2): GH pages: recommend using trailingSlash

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -47,6 +47,17 @@ export default async function deploy(
     customOutDir: cliOptions.outDir,
   });
 
+  if (typeof siteConfig.trailingSlash === 'undefined') {
+    console.warn(
+      chalk.yellow(`
+Docusaurus recommendation:
+When deploying to GitHub Pages, it is better to use an explicit "trailingSlash" site config.
+Otherwise, GitHub Pages will add an extra trailing slash to your site urls only on direct-access (not when navigation) with a server redirect.
+This behavior can have SEO impacts and create relative link issues.
+`),
+    );
+  }
+
   console.log('Deploy command invoked...');
   if (!shell.which('git')) {
     throw new Error('Git not installed or on the PATH!');

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -90,7 +90,7 @@ You may refer to GitHub Pages' documentation [User, Organization, and Project Pa
 
 :::caution
 
-GitHub Pages adds a trailing slash to Docusaurus URLs by default. Adjusting the `trailingSlash` setting can be useful.
+GitHub Pages adds a trailing slash to Docusaurus URLs by default. It is recommended to set a `trailingSlash` config (`true` or `false`, not `undefined`).
 
 :::
 


### PR DESCRIPTION


## Motivation

Using the legacy `trailingSlash: undefined` behavior is not recommended with GH pages due to the reconfigurable behavior of GH pages to add a trailing slash with a server redirect. This is better to use set explicit value (either true or false) instead of using the legacy retrocompatible behavior.

Also adding a warning to the deploy script.

Note: later we may remove this because we could use `trailingSlash: false` as a default (after explicitly deprecating "undefined" legacy behavior). (but it might be a problem for deploying on Vercel without the cleanUrl option: see https://github.com/slorber/trailing-slash-guide/issues/1)