### PR TITLE
fix(v2): dev css modules classnames should include filename

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -228,7 +228,7 @@ export function createBaseConfig(
             modules: {
               localIdentName: isProd
                 ? `[local]_[contenthash:base64:4]`
-                : `[local]_[path]`,
+                : `[local]_[path][name]`,
               exportOnlyLocals: isServer,
             },
             importLoaders: 1,


### PR DESCRIPTION

## Motivation

Add the css module filename to avoid potential dev classname collisions.

Fix https://github.com/facebook/docusaurus/issues/5018

If it's not enough we can also add the hash in dev

See doc: https://webpack.js.org/loaders/css-loader/#localidentname

