### PR TITLE
fix(v2): fix some docs container/sidebar layout issues

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -7,6 +7,7 @@
 
 :root {
   --doc-sidebar-width: 300px;
+  --doc-sidebar-hidden-width: 30px;
 }
 
 :global(.docs-wrapper) {
@@ -26,7 +27,7 @@
   }
 
   .docMainContainerEnhanced {
-    max-width: none;
+    max-width: calc(100% - var(--doc-sidebar-hidden-width));
   }
 
   .docSidebarContainer {
@@ -39,7 +40,7 @@
   }
 
   .docSidebarContainerHidden {
-    width: 30px;
+    width: var(--doc-sidebar-hidden-width);
     cursor: pointer;
   }
 
@@ -80,21 +81,6 @@
 
 @media (max-width: 996px) {
   .docSidebarContainer {
-    margin-top: 0;
-  }
-}
-
-@media (min-width: 997px) and (max-width: 1320px) {
-  .docItemWrapper {
-    max-width: calc(
-      var(--ifm-container-width) - var(--doc-sidebar-width) -
-        var(--ifm-spacing-horizontal) * 2
-    );
-  }
-
-  .docItemWrapperEnhanced {
-    max-width: calc(
-      var(--ifm-container-width) - var(--ifm-spacing-horizontal) * 2
-    );
+    display: none;
   }
 }


### PR DESCRIPTION

## Motivation

Fix some docs layout issues.

@covalentbond reported here that the TOC should take more space for medium size devices (ex: 1300px): https://github.com/facebook/docusaurus/pull/4995#issuecomment-864242680

![image](https://user-images.githubusercontent.com/749374/122934531-e1ea6e80-d36f-11eb-99c5-da11ac28048a.png)

Also fixing the collapsed sidebar icon appearing on mobile:

![image](https://user-images.githubusercontent.com/749374/122934703-0d6d5900-d370-11eb-94ec-72f2c0d2b1b6.png)


Also fixing the vertical scrollbar appearing for medium width when toc is large:

![image](https://user-images.githubusercontent.com/749374/122934880-32fa6280-d370-11eb-94b4-ea1e9241ab10.png)

@lex111 any concern with those changes?


