### PR TITLE
feat(v2): plugins injectHtmlTags + configureWebpack should receive content loaded

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -319,6 +319,8 @@ describe('simple website', () => {
         },
       },
       false,
+      undefined,
+      {content: 42},
     );
     const errors = validate(config);
     expect(errors).toBeUndefined();

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -309,6 +309,8 @@ describe('simple website', () => {
   test('configureWebpack', async () => {
     const {plugin} = await loadSite();
 
+    const content = await plugin.loadContent?.();
+
     const config = applyConfigureWebpack(
       plugin.configureWebpack,
       {
@@ -320,7 +322,7 @@ describe('simple website', () => {
       },
       false,
       undefined,
-      {content: 42},
+      content,
     );
     const errors = validate(config);
     expect(errors).toBeUndefined();

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -372,9 +372,7 @@ export default function pluginContentDocs(
       } = options;
 
       function getSourceToPermalink(): SourceToPermalink {
-        const allDocs = content.loadedVersions.flatMap(
-          (version) => version.docs,
-        );
+        const allDocs = flatten(content.loadedVersions.map((v) => v.docs));
         return mapValues(
           keyBy(allDocs, (d) => d.source),
           (d) => d.permalink,

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -41,7 +41,7 @@ import {PermalinkToSidebar} from '@docusaurus/plugin-content-docs-types';
 import {RuleSetRule} from 'webpack';
 import {cliDocsVersionCommand} from './cli';
 import {VERSIONS_JSON_FILE} from './constants';
-import {flatten, keyBy, compact} from 'lodash';
+import {flatten, keyBy, compact, mapValues} from 'lodash';
 import {toGlobalDataVersion} from './globalData';
 import {toVersionMetadataProp} from './props';
 import {
@@ -59,7 +59,6 @@ export default function pluginContentDocs(
 
   const versionsMetadata = readVersionsMetadata({context, options});
 
-  const sourceToPermalink: SourceToPermalink = {};
   const pluginId = options.id ?? DEFAULT_PLUGIN_ID;
 
   const pluginDataDirRoot = path.join(
@@ -225,12 +224,6 @@ export default function pluginContentDocs(
         // sort to ensure consistent output for tests
         docs.sort((a, b) => a.id.localeCompare(b.id));
 
-        // TODO annoying side effect!
-        Object.values(docs).forEach((loadedDoc) => {
-          const {source, permalink} = loadedDoc;
-          sourceToPermalink[source] = permalink;
-        });
-
         // TODO really useful? replace with global state logic?
         const permalinkToSidebar: PermalinkToSidebar = {};
         Object.values(docs).forEach((doc) => {
@@ -369,7 +362,7 @@ export default function pluginContentDocs(
       });
     },
 
-    configureWebpack(_config, isServer, utils) {
+    configureWebpack(_config, isServer, utils, content) {
       const {getJSLoader} = utils;
       const {
         rehypePlugins,
@@ -378,9 +371,19 @@ export default function pluginContentDocs(
         beforeDefaultRemarkPlugins,
       } = options;
 
+      function getSourceToPermalink(): SourceToPermalink {
+        const allDocs = content.loadedVersions.flatMap(
+          (version) => version.docs,
+        );
+        return mapValues(
+          keyBy(allDocs, (d) => d.source),
+          (d) => d.permalink,
+        );
+      }
+
       const docsMarkdownOptions: DocsMarkdownOption = {
         siteDir,
-        sourceToPermalink,
+        sourceToPermalink: getSourceToPermalink(),
         versionsMetadata,
         onBrokenMarkdownLink: (brokenMarkdownLink) => {
           if (siteConfig.onBrokenMarkdownLinks === 'ignore') {

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -198,7 +198,7 @@ export interface Props extends LoadContext, InjectedHtmlTags {
   siteMetadata: DocusaurusSiteMetadata;
   routes: RouteConfig[];
   routesPaths: string[];
-  plugins: Plugin<unknown>[];
+  plugins: LoadedPlugin<unknown>[];
 }
 
 export interface PluginContentLoadedActions {
@@ -233,10 +233,12 @@ export interface Plugin<Content> {
   routesLoaded?(routes: RouteConfig[]): void; // TODO remove soon, deprecated (alpha-60)
   postBuild?(props: Props): void;
   postStart?(props: Props): void;
+  // TODO refactor the configureWebpack API surface: use an object instead of multiple params (requires breaking change)
   configureWebpack?(
     config: Configuration,
     isServer: boolean,
     utils: ConfigureWebpackUtils,
+    content: Content,
   ): Configuration & {mergeStrategy?: ConfigureWebpackFnMergeStrategy};
   configurePostCss?(options: PostCssOptions): PostCssOptions;
   getThemePath?(): string;
@@ -244,7 +246,9 @@ export interface Plugin<Content> {
   getPathsToWatch?(): string[];
   getClientModules?(): string[];
   extendCli?(cli: Command): void;
-  injectHtmlTags?(): {
+  injectHtmlTags?({
+    content: Content,
+  }): {
     headTags?: HtmlTags;
     preBodyTags?: HtmlTags;
     postBodyTags?: HtmlTags;

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -184,7 +184,7 @@ async function buildLocale({
 
     if (configureWebpack) {
       clientConfig = applyConfigureWebpack(
-        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`.
+        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`. // TODO remove this implicit api: inject in callback instead
         clientConfig,
         false,
         props.siteConfig.webpack?.jsLoader,
@@ -192,7 +192,7 @@ async function buildLocale({
       );
 
       serverConfig = applyConfigureWebpack(
-        configureWebpack,
+        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`. // TODO remove this implicit api: inject in callback instead
         serverConfig,
         true,
         props.siteConfig.webpack?.jsLoader,

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -188,13 +188,15 @@ async function buildLocale({
         clientConfig,
         false,
         props.siteConfig.webpack?.jsLoader,
+        plugin.content,
       );
 
       serverConfig = applyConfigureWebpack(
-        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`.
+        configureWebpack,
         serverConfig,
         true,
         props.siteConfig.webpack?.jsLoader,
+        plugin.content,
       );
     }
   });

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -156,7 +156,7 @@ export default async function start(
 
     if (configureWebpack) {
       config = applyConfigureWebpack(
-        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`.
+        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`. // TODO remove this implicit api: inject in callback instead
         config,
         false,
         props.siteConfig.webpack?.jsLoader,

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -160,6 +160,7 @@ export default async function start(
         config,
         false,
         props.siteConfig.webpack?.jsLoader,
+        plugin.content,
       );
     }
   });

--- a/packages/docusaurus/src/server/html-tags/index.ts
+++ b/packages/docusaurus/src/server/html-tags/index.ts
@@ -6,12 +6,8 @@
  */
 
 import htmlTagObjectToString from './htmlTags';
-import {
-  Plugin,
-  InjectedHtmlTags,
-  HtmlTagObject,
-  HtmlTags,
-} from '@docusaurus/types';
+import {InjectedHtmlTags, HtmlTagObject, HtmlTags} from '@docusaurus/types';
+import {LoadedPlugin} from '../plugins';
 
 function toString(val: string | HtmlTagObject): string {
   return typeof val === 'string' ? val : htmlTagObjectToString(val);
@@ -21,14 +17,14 @@ export function createHtmlTagsString(tags: HtmlTags): string {
   return Array.isArray(tags) ? tags.map(toString).join('\n') : toString(tags);
 }
 
-export function loadHtmlTags(plugins: Plugin<unknown>[]): InjectedHtmlTags {
+export function loadHtmlTags(plugins: LoadedPlugin[]): InjectedHtmlTags {
   const htmlTags = plugins.reduce(
     (acc, plugin) => {
       if (!plugin.injectHtmlTags) {
         return acc;
       }
       const {headTags, preBodyTags, postBodyTags} =
-        plugin.injectHtmlTags() || {};
+        plugin.injectHtmlTags({content: plugin.content}) || {};
       return {
         headTags: headTags
           ? `${acc.headTags}\n${createHtmlTagsString(headTags)}`

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -196,6 +196,7 @@ export async function load(
   } = siteConfig;
   plugins.push({
     name: 'docusaurus-bootstrap-plugin',
+    content: null,
     options: {},
     version: {type: 'synthetic'},
     getClientModules() {

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -53,6 +53,8 @@ export function sortConfig(routeConfigs: RouteConfig[]): void {
   });
 }
 
+export type LoadedPlugin = InitPlugin & {content: unknown};
+
 export async function loadPlugins({
   pluginConfigs,
   context,
@@ -60,7 +62,7 @@ export async function loadPlugins({
   pluginConfigs: PluginConfig[];
   context: LoadContext;
 }): Promise<{
-  plugins: InitPlugin[];
+  plugins: LoadedPlugin[];
   pluginsRouteConfigs: RouteConfig[];
   globalData: unknown;
   themeConfigTranslated: ThemeConfig;
@@ -75,21 +77,20 @@ export async function loadPlugins({
   // Currently plugins run lifecycle methods in parallel and are not order-dependent.
   // We could change this in future if there are plugins which need to
   // run in certain order or depend on others for data.
-  type ContentLoadedPlugin = {plugin: InitPlugin; content: unknown};
-  const contentLoadedPlugins: ContentLoadedPlugin[] = await Promise.all(
+  const loadedPlugins: LoadedPlugin[] = await Promise.all(
     plugins.map(async (plugin) => {
       const content = plugin.loadContent ? await plugin.loadContent() : null;
-      return {plugin, content};
+      return {...plugin, content};
     }),
   );
 
-  type ContentLoadedTranslatedPlugin = ContentLoadedPlugin & {
+  type ContentLoadedTranslatedPlugin = LoadedPlugin & {
     translationFiles: TranslationFiles;
   };
   const contentLoadedTranslatedPlugins: ContentLoadedTranslatedPlugin[] = await Promise.all(
-    contentLoadedPlugins.map(async (contentLoadedPlugin) => {
+    loadedPlugins.map(async (contentLoadedPlugin) => {
       const translationFiles =
-        (await contentLoadedPlugin.plugin?.getTranslationFiles?.({
+        (await contentLoadedPlugin?.getTranslationFiles?.({
           content: contentLoadedPlugin.content,
         })) ?? [];
       const localizedTranslationFiles = await Promise.all(
@@ -98,7 +99,7 @@ export async function loadPlugins({
             locale: context.i18n.currentLocale,
             siteDir: context.siteDir,
             translationFile,
-            plugin: contentLoadedPlugin.plugin,
+            plugin: contentLoadedPlugin,
           }),
         ),
       );
@@ -109,11 +110,11 @@ export async function loadPlugins({
     }),
   );
 
-  const allContent: AllContent = chain(contentLoadedPlugins)
-    .groupBy((item) => item.plugin.name)
+  const allContent: AllContent = chain(loadedPlugins)
+    .groupBy((item) => item.name)
     .mapValues((nameItems) => {
       return chain(nameItems)
-        .groupBy((item) => item.plugin.options.id ?? DEFAULT_PLUGIN_ID)
+        .groupBy((item) => item.options.id ?? DEFAULT_PLUGIN_ID)
         .mapValues((idItems) => idItems[0].content)
         .value();
     })
@@ -126,7 +127,7 @@ export async function loadPlugins({
 
   await Promise.all(
     contentLoadedTranslatedPlugins.map(
-      async ({plugin, content, translationFiles}) => {
+      async ({content, translationFiles, ...plugin}) => {
         if (!plugin.contentLoaded) {
           return;
         }
@@ -191,7 +192,7 @@ export async function loadPlugins({
   // We could change this in future if there are plugins which need to
   // run in certain order or depend on others for data.
   await Promise.all(
-    contentLoadedTranslatedPlugins.map(async ({plugin}) => {
+    contentLoadedTranslatedPlugins.map(async (plugin) => {
       if (!plugin.routesLoaded) {
         return null;
       }
@@ -218,10 +219,10 @@ export async function loadPlugins({
     untranslatedThemeConfig: ThemeConfig,
   ): ThemeConfig {
     return contentLoadedTranslatedPlugins.reduce(
-      (currentThemeConfig, {plugin, translationFiles}) => {
+      (currentThemeConfig, plugin) => {
         const translatedThemeConfigSlice = plugin.translateThemeConfig?.({
           themeConfig: currentThemeConfig,
-          translationFiles,
+          translationFiles: plugin.translationFiles,
         });
         return {
           ...currentThemeConfig,
@@ -233,7 +234,7 @@ export async function loadPlugins({
   }
 
   return {
-    plugins,
+    plugins: loadedPlugins,
     pluginsRouteConfigs,
     globalData,
     themeConfigTranslated: translateThemeConfig(context.siteConfig.themeConfig),

--- a/packages/docusaurus/src/webpack/__tests__/utils.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/utils.test.ts
@@ -77,7 +77,9 @@ describe('extending generated webpack config', () => {
       return {};
     };
 
-    config = applyConfigureWebpack(configureWebpack, config, false);
+    config = applyConfigureWebpack(configureWebpack, config, false, undefined, {
+      content: 42,
+    });
     expect(config).toEqual({
       entry: 'entry.js',
       output: {
@@ -105,7 +107,9 @@ describe('extending generated webpack config', () => {
       },
     });
 
-    config = applyConfigureWebpack(configureWebpack, config, false);
+    config = applyConfigureWebpack(configureWebpack, config, false, undefined, {
+      content: 42,
+    });
     expect(config).toEqual({
       entry: 'entry.js',
       output: {
@@ -137,6 +141,8 @@ describe('extending generated webpack config', () => {
       createConfigureWebpack(),
       config,
       false,
+      undefined,
+      {content: 42},
     );
     expect(defaultStrategyMergeConfig).toEqual({
       module: {
@@ -148,6 +154,8 @@ describe('extending generated webpack config', () => {
       createConfigureWebpack({'module.rules': 'prepend'}),
       config,
       false,
+      undefined,
+      {content: 42},
     );
     expect(prependRulesStrategyConfig).toEqual({
       module: {
@@ -159,6 +167,8 @@ describe('extending generated webpack config', () => {
       createConfigureWebpack({uselessAttributeName: 'append'}),
       config,
       false,
+      undefined,
+      {content: 42},
     );
     expect(uselessMergeStrategyConfig).toEqual({
       module: {

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -198,13 +198,15 @@ function getCacheLoaderDeprecated() {
  * @param config initial webpack config
  * @param isServer indicates if this is a server webpack configuration
  * @param jsLoader custom js loader config
+ * @param content content loaded by the plugin
  * @returns final/ modified webpack config
  */
 export function applyConfigureWebpack(
   configureWebpack: ConfigureWebpackFn,
   config: Configuration,
   isServer: boolean,
-  jsLoader?: 'babel' | ((isServer: boolean) => RuleSetRule),
+  jsLoader: 'babel' | ((isServer: boolean) => RuleSetRule) | undefined,
+  content: unknown,
 ): Configuration {
   // Export some utility functions
   const utils: ConfigureWebpackUtils = {
@@ -214,7 +216,12 @@ export function applyConfigureWebpack(
     getCacheLoader: getCacheLoaderDeprecated,
   };
   if (typeof configureWebpack === 'function') {
-    const {mergeStrategy, ...res} = configureWebpack(config, isServer, utils);
+    const {mergeStrategy, ...res} = configureWebpack(
+      config,
+      isServer,
+      utils,
+      content,
+    );
     if (res && typeof res === 'object') {
       // @ts-expect-error: annoying error due to enums: https://github.com/survivejs/webpack-merge/issues/179
       const customizeRules: Record<string, CustomizeRule> = mergeStrategy ?? {};

--- a/website/docs/lifecycle-apis.md
+++ b/website/docs/lifecycle-apis.md
@@ -283,6 +283,12 @@ export default function friendsPlugin(context, options) {
 
 Modifies the internal webpack config. If the return value is a JavaScript object, it will be merged into the final config using [`webpack-merge`](https://github.com/survivejs/webpack-merge). If it is a function, it will be called and receive `config` as the first argument and an `isServer` flag as the argument argument.
 
+:::caution
+
+The API of `configureWebpack` will be modified in the future to accept an object (`configureWebpack({config, isServer, utils, content})`)
+
+:::
+
 ### `config` {#config}
 
 `configureWebpack` is called with `config` generated according to client/server build. You may treat this as the base config to be merged with.

--- a/website/docs/lifecycle-apis.md
+++ b/website/docs/lifecycle-apis.md
@@ -279,7 +279,7 @@ export default function friendsPlugin(context, options) {
 }
 ```
 
-## `configureWebpack(config, isServer, utils)` {#configurewebpackconfig-isserver-utils}
+## `configureWebpack(config, isServer, utils, content)` {#configurewebpackconfig-isserver-utils}
 
 Modifies the internal webpack config. If the return value is a JavaScript object, it will be merged into the final config using [`webpack-merge`](https://github.com/survivejs/webpack-merge). If it is a function, it will be called and receive `config` as the first argument and an `isServer` flag as the argument argument.
 
@@ -293,11 +293,10 @@ Modifies the internal webpack config. If the return value is a JavaScript object
 
 ### `utils` {#utils}
 
-The initial call to `configureWebpack` also receives a util object consists of three functions:
+`configureWebpack` also receives an util object:
 
 - `getStyleLoaders(isServer: boolean, cssOptions: {[key: string]: any}): Loader[]`
-- `getCacheLoader(isServer: boolean, cacheOptions?: {}): Loader | null`
-- `getBabelLoader(isServer: boolean, babelOptions?: {}): Loader`
+- `getJSLoader(isServer: boolean, cacheOptions?: {}): Loader | null`
 
 You may use them to return your webpack configures conditionally.
 
@@ -325,6 +324,10 @@ module.exports = function (context, options) {
   };
 };
 ```
+
+### `content` {#content}
+
+`configureWebpack` will be called both with the content loaded by the plugin.
 
 ### Merge strategy {#merge-strategy}
 
@@ -439,9 +442,11 @@ module.exports = function (context, options) {
 };
 ```
 
-## `injectHtmlTags()` {#injecthtmltags}
+## `injectHtmlTags({content})` {#injecthtmltags}
 
 Inject head and/or body HTML tags to Docusaurus generated HTML.
+
+`injectHtmlTags` will be called both with the content loaded by the plugin.
 
 ```typescript
 function injectHtmlTags(): {
@@ -477,8 +482,11 @@ Example:
 module.exports = function (context, options) {
   return {
     name: 'docusaurus-plugin',
+    loadContent: async () => {
+      return {remoteHeadTags: await fetchHeadTagsFromAPI()};
+    },
     // highlight-start
-    injectHtmlTags() {
+    injectHtmlTags({content}) {
       return {
         headTags: [
           {
@@ -488,6 +496,7 @@ module.exports = function (context, options) {
               href: 'https://www.github.com',
             },
           },
+          ...content.remoteHeadTags,
         ],
         preBodyTags: [
           {
@@ -765,7 +774,7 @@ module.exports = function (context, opts) {
       // https://webpack.js.org/configuration/dev-server/#devserverafter
     },
 
-    configureWebpack(config, isServer) {
+    configureWebpack(config, isServer, utils, content) {
       // Modify internal webpack config. If returned value is an Object, it
       // will be merged into the final config using webpack-merge;
       // If the returned value is a function, it will receive the config as the 1st argument and an isServer flag as the 2nd argument.
@@ -790,11 +799,11 @@ module.exports = function (context, opts) {
       // Register an extra command to enhance the CLI of Docusaurus
     },
 
-    injectHtmlTags() {
+    injectHtmlTags({content}) {
       // Inject head and/or body HTML tags.
     },
 
-    async getTranslationFiles() {
+    async getTranslationFiles({content}) {
       // Return translation files
     },
 


### PR DESCRIPTION

## Motivation

Plugin lifecycles that are triggered after we loaded the plugin content should permit to access that plugin content.

The following should work:

```js
module.exports = function (context, options) {
  return {
    name: 'docusaurus-plugin',
    loadContent: async () => {
      return {remoteHeadTags: await fetchHeadTagsFromAPI()};
    },
    injectHtmlTags({content}) {
      return {
        headTags: content.remoteHeadTags,       
      };
    },
  };
};
```

Also injecting the content in the `configureWebpack` lifecycle, as we compute the mdx/remark config by using the loaded content for resolving relative file path links to URLs. This permits to avoid an unelegant side-effect we previously had in `loadContent`:

```js
        // TODO annoying side effect!
        Object.values(docs).forEach((loadedDoc) => {
          const {source, permalink} = loadedDoc;
          sourceToPermalink[source] = permalink;
        });
```

Mentioned in https://github.com/facebook/docusaurus/issues/4923#issuecomment-863115893

## Test Plan

test + dogfood in internal plugins


