### PR TITLE
fix(v2): RTL languages: codeblock fixes

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -7,12 +7,12 @@
 
 .codeBlockContainer {
   margin-bottom: var(--ifm-leading);
+  /*rtl:ignore*/
+  direction: ltr;
 }
 
 .codeBlockContent {
   position: relative;
-  /*rtl:ignore*/
-  direction: ltr;
 }
 
 .codeBlockTitle {
@@ -41,6 +41,7 @@
   user-select: none;
   padding: 0.4rem 0.5rem;
   position: absolute;
+  /*rtl:ignore*/
   right: calc(var(--ifm-pre-padding) / 2);
   top: calc(var(--ifm-pre-padding) / 2);
   transition: opacity 200ms ease-in-out;

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
@@ -7,6 +7,8 @@
 
 .playgroundContainer {
   margin-bottom: var(--ifm-leading);
+  /*rtl:ignore*/
+  direction: ltr;
 }
 
 .playgroundHeader {
@@ -29,8 +31,6 @@
 .playgroundEditor {
   font: var(--ifm-code-font-size) / var(--ifm-pre-line-height)
     var(--ifm-font-family-monospace) !important;
-  /*rtl:ignore*/
-  direction: ltr;
 }
 
 .playgroundPreview {


### PR DESCRIPTION

## Motivation

Code blocks should be forced to be LTR. It's already the case but it should also be applied to code block title, playground result, copy button etc...

cc @massoudmaboudi 

![image](https://user-images.githubusercontent.com/749374/122963966-13226900-d387-11eb-9fcb-1bbae56130ff.png)

![image](https://user-images.githubusercontent.com/749374/122964032-26cdcf80-d387-11eb-86b1-0b98f9dd1676.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview + screenshots

