### PR TITLE
docs(v2): remind running `clear` after swizzling

### DIFF
--- a/website/docs/using-themes.md
+++ b/website/docs/using-themes.md
@@ -126,7 +126,7 @@ Although we highly discourage swizzling of all components, if you wish to do tha
 npm run swizzle @docusaurus/theme-classic
 ```
 
-**Note**: You need to restart your webpack dev server in order for Docusaurus to know about the new component.
+**Note**: You need to restart your webpack dev server in order for Docusaurus to know about the new component. You may also need to clear the cache by running `npm run clear` or `yarn clear` after terminating the current process.
 
 ## Wrapping theme components {#wrapping-theme-components}
 

--- a/website/docs/using-themes.md
+++ b/website/docs/using-themes.md
@@ -120,13 +120,13 @@ npm run swizzle @docusaurus/theme-classic Footer
 
 This will copy the current `<Footer />` component used by the theme to a `src/theme/Footer` directory under the root of your site, which is where Docusaurus will look for swizzled components. Docusaurus will then use swizzled component in place of the original one from the theme.
 
+**Note**: You need to restart your webpack dev server in order for Docusaurus to know about the new component. You may also need to clear the cache by running `npm run clear` or `yarn clear` after terminating the current process.
+
 Although we highly discourage swizzling of all components, if you wish to do that, run:
 
 ```bash npm2yarn
 npm run swizzle @docusaurus/theme-classic
 ```
-
-**Note**: You need to restart your webpack dev server in order for Docusaurus to know about the new component. You may also need to clear the cache by running `npm run clear` or `yarn clear` after terminating the current process.
 
 ## Wrapping theme components {#wrapping-theme-components}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

A common pitfall leading to many people asking "why doesn't docusaurus pick up my new component even after restarting dev server".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
