### PR TITLE
fix(v2): read last update from inner git repositories

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -31,15 +31,16 @@ describe('lastUpdate', () => {
   test('non-existing file', async () => {
     const consoleMock = jest.spyOn(console, 'error');
     consoleMock.mockImplementation();
+    const nonExistingFileName = '.nonExisting';
     const nonExistingFilePath = path.join(
       __dirname,
       '__fixtures__',
-      '.nonExisting',
+      nonExistingFileName,
     );
     expect(await getFileLastUpdate(nonExistingFilePath)).toBeNull();
     expect(consoleMock).toHaveBeenCalledTimes(1);
     expect(consoleMock.mock.calls[0][0].message).toContain(
-      `Command failed with exit code 128: git log -1 --format=%ct, %an ${nonExistingFilePath}`,
+      `Command failed with exit code 128: git log -1 --format=%ct, %an ${nonExistingFileName}`,
     );
     expect(await getFileLastUpdate(null)).toBeNull();
     expect(await getFileLastUpdate(undefined)).toBeNull();

--- a/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
+++ b/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
@@ -7,6 +7,7 @@
 
 import shell from 'shelljs';
 import execa from 'execa';
+import path from 'path';
 
 type FileLastUpdateData = {timestamp?: number; author?: string};
 
@@ -43,12 +44,15 @@ export async function getFileLastUpdate(
       return null;
     }
 
-    const {stdout} = await execa('git', [
-      'log',
-      '-1',
-      '--format=%ct, %an',
-      filePath,
-    ]);
+    const fileBasename = path.basename(filePath);
+    const fileDirname = path.dirname(filePath);
+    const {stdout} = await execa(
+      'git',
+      ['log', '-1', '--format=%ct, %an', fileBasename],
+      {
+        cwd: fileDirname,
+      },
+    );
     return getTimestampAndAuthor(stdout);
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

My use case:

```
website/ # a repo
|   external/
|   |  repo-a/ # another repo, ignored by git at website/
|   |  repo-b/ # another repo, also ignored by git
```

With the current implementation, the `lastUpdate` won't return any data, as the files are unknown by Git when using `website` as the `cwd`. But if we call git in their own folders, git will be able to properly read the metadata.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I verified by replacing the content of `lastUpdate.js` in my `node_modules` folder, which worked. But if needed, I can find a way to record a video. I just didn't record yet because in my tests there are private data from my company.

The good news is that this change won't break any existing use case, it will just fix mine.

## Related PRs

None