### PR TITLE
fix(v2): add shadow to skip link on focus only

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, {useRef} from 'react';
-import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import {useLocationChange} from '@docusaurus/theme-common';
 
@@ -40,10 +39,7 @@ function SkipToContent(): JSX.Element {
 
   return (
     <div ref={containerRef}>
-      <a
-        href="#main"
-        className={clsx(styles.skipToContent, 'shadow--md')}
-        onClick={handleSkip}>
+      <a href="#main" className={styles.skipToContent} onClick={handleSkip}>
         <Translate
           id="theme.common.skipToMainContent"
           description="The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation">

--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/styles.module.css
@@ -10,4 +10,5 @@
 
 .skipToContent:focus {
   left: 1rem;
+  box-shadow: var(--ifm-global-shadow-md);
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Apparently, it is better to apply shadow to the skip link only on focusing to avoid its visibility in light mode.

![image](https://user-images.githubusercontent.com/4408379/123238825-7d521f80-d4e7-11eb-9760-211d1020bc13.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
