### PR TITLE
refactor(v2): remove deprecated docs option excludeNextVersionDocs

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
@@ -42,7 +42,6 @@ describe('normalizeDocsPluginOptions', () => {
       showLastUpdateTime: true,
       showLastUpdateAuthor: true,
       admonitions: {},
-      excludeNextVersionDocs: true,
       includeCurrentVersion: false,
       disableVersioning: true,
       editCurrentVersion: true,

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -37,7 +37,6 @@ export const DEFAULT_OPTIONS: Omit<PluginOptions, 'id' | 'sidebarPath'> = {
   showLastUpdateTime: false,
   showLastUpdateAuthor: false,
   admonitions: {},
-  excludeNextVersionDocs: false,
   includeCurrentVersion: true,
   disableVersioning: false,
   lastVersion: undefined,
@@ -102,10 +101,6 @@ export const OptionsSchema = Joi.object({
   showLastUpdateAuthor: Joi.bool().default(
     DEFAULT_OPTIONS.showLastUpdateAuthor,
   ),
-  // TODO deprecated, excludeNextVersionDocs replaced by includeCurrentVersion
-  excludeNextVersionDocs: Joi.bool().default(
-    DEFAULT_OPTIONS.excludeNextVersionDocs,
-  ),
   includeCurrentVersion: Joi.bool().default(
     DEFAULT_OPTIONS.includeCurrentVersion,
   ),
@@ -127,17 +122,6 @@ export function validateOptions({
         `The docs plugin option homePageId=${options.homePageId} is deprecated. To make a doc the "home", prefer frontmatter: "slug: /"`,
       ),
     );
-  }
-
-  if (typeof options.excludeNextVersionDocs !== 'undefined') {
-    console.log(
-      chalk.red(
-        `The docs plugin option "excludeNextVersionDocs=${
-          options.excludeNextVersionDocs
-        }" is deprecated. Use the "includeCurrentVersion=${!options.excludeNextVersionDocs}" option instead!"`,
-      ),
-    );
-    options.includeCurrentVersion = !options.excludeNextVersionDocs;
   }
 
   const normalizedOptions = validate(OptionsSchema, options);

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -85,7 +85,6 @@ export type PluginOptions = MetadataOptions &
     docItemComponent: string;
     admonitions: Record<string, unknown>;
     disableVersioning: boolean;
-    excludeNextVersionDocs?: boolean;
     includeCurrentVersion: boolean;
     sidebarItemsGenerator: SidebarItemsGeneratorOption;
   };


### PR DESCRIPTION
**Breaking changes**:
- The `excludeNextVersionDocs` deprecated docs option will now be rejected with a validation error

## Motivation

The docs plugin option `excludeNextVersionDocs: true` has been deprecated with a warning for more than 6 months now, and replaced by `includeCurrentVersion: false`.

Let's do the cleanup and remove this useless code.

