### PR TITLE
fix(v2): allow undefined favicon

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -99,7 +99,7 @@ export async function generateBlogFeed(
     language: feedOptions.language,
     link: blogBaseUrl,
     description: feedOptions.description || `${siteConfig.title} Blog`,
-    favicon: normalizeUrl([siteUrl, baseUrl, favicon]),
+    favicon: favicon ? normalizeUrl([siteUrl, baseUrl, favicon]) : undefined,
     copyright: feedOptions.copyright,
   });
 

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -26,7 +26,7 @@ export type ThemeConfig = {
 export interface DocusaurusConfig {
   baseUrl: string;
   baseUrlIssueBanner: boolean;
-  favicon: string;
+  favicon?: string;
   tagline?: string;
   title: string;
   url: string;

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -1,14 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`loadConfig website with incomplete siteConfig 1`] = `
-"\\"favicon\\" is required
-\\"url\\" is required
+"\\"url\\" is required
 "
 `;
 
 exports[`loadConfig website with useless field (wrong field) in siteConfig 1`] = `
-"\\"favicon\\" is required
-These field(s) (\\"useLessField\\",) are not recognized in docusaurus.config.js.
+"These field(s) (\\"useLessField\\",) are not recognized in docusaurus.config.js.
 If you still want these fields to be in your configuration, put them in the \\"customFields\\" field.
 See https://docusaurus.io/docs/docusaurus.config.js/#customfields"
 `;

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/configValidation.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/configValidation.test.ts.snap
@@ -7,7 +7,6 @@ exports[`normalizeConfig should throw error for baseUrl without trailing \`/\` 1
 
 exports[`normalizeConfig should throw error for required fields 1`] = `
 "\\"baseUrl\\" is required
-\\"favicon\\" is required
 \\"title\\" is required
 \\"url\\" is required
 \\"themes\\" must be an array

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -12,9 +12,8 @@ import {
 } from '../configValidation';
 import {DocusaurusConfig} from '@docusaurus/types';
 
-const baseConfig = {
+const baseConfig: DocusaurusConfig = {
   baseUrl: '/',
-  favicon: 'some.ico',
   title: 'my site',
   url: 'https://mysite.com',
 };

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -127,7 +127,7 @@ export const ConfigSchema = Joi.object({
     .regex(new RegExp('/$', 'm'))
     .message('{{#label}} must be a string with a trailing slash.'),
   baseUrlIssueBanner: Joi.boolean().default(DEFAULT_CONFIG.baseUrlIssueBanner),
-  favicon: Joi.string().required(),
+  favicon: Joi.string().optional(),
   title: Joi.string().required(),
   url: SiteUrlSchema,
   trailingSlash: Joi.boolean(), // No default value! undefined = retrocompatible legacy behavior!

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -24,37 +24,6 @@ module.exports = {
 };
 ```
 
-### `favicon` {#favicon}
-
-- Type: `string`
-
-URL for site favicon. Example:
-
-```js title="docusaurus.config.js"
-module.exports = {
-  favicon: 'https://docusaurus.io/favicon.ico',
-};
-```
-
-You can also use the favicon URL relative to the `static` directory of your site. For example, your site has the following directory structure:
-
-```bash
-.
-├── README.md
-├ # ... other files in root directory
-└─ static
-    └── img
-        └── favicon.ico
-```
-
-So you can refer it like below:
-
-```js title="docusaurus.config.js"
-module.exports = {
-  favicon: 'img/favicon.ico',
-};
-```
-
 ### `url` {#url}
 
 - Type: `string`
@@ -80,6 +49,20 @@ module.exports = {
 ```
 
 ## Optional fields {#optional-fields}
+
+### `favicon` {#favicon}
+
+- Type: `string | undefined`
+
+Path to your site favicon
+
+Example, if your favicon is in `static/img/favicon.ico`:
+
+```js title="docusaurus.config.js"
+module.exports = {
+  favicon: '/img/favicon.ico',
+};
+```
 
 ### `trailingSlash` {#trailing-slash}
 


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/4923

We should allow undefined as favicon so that users can add favicon themself

Also updated the favicon config doc: using a fully-qualified URL is not really recommended and would actually lead to a bad URL in the blog feed (as we add the site URL to it)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests
