### PR TITLE
fix(v2): fix bad @docusaurus/types Plugin type generics

### DIFF
--- a/packages/docusaurus-types/package.json
+++ b/packages/docusaurus-types/package.json
@@ -13,11 +13,17 @@
     "directory": "packages/docusaurus-types"
   },
   "license": "MIT",
+  "scripts": {
+    "test": "tsc -p ."
+  },
   "dependencies": {
     "commander": "^5.1.0",
     "joi": "^17.4.0",
     "querystring": "0.2.0",
     "webpack": "^5.40.0",
     "webpack-merge": "^5.8.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.3.4"
   }
 }

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -219,7 +219,7 @@ export type AllContent = Record<
 // TODO improve type (not exposed by postcss-loader)
 export type PostCssOptions = Record<string, unknown> & {plugins: unknown[]};
 
-export interface Plugin<Content> {
+export interface Plugin<Content = unknown> {
   name: string;
   loadContent?(): Promise<Content>;
   contentLoaded?({
@@ -283,12 +283,14 @@ export interface Plugin<Content> {
   }): ThemeConfig;
 }
 
-export type InitializedPlugin = Plugin<unknown> & {
+export type InitializedPlugin<Content = unknown> = Plugin<Content> & {
   readonly options: PluginOptions;
   readonly version: DocusaurusPluginVersionInformation;
 };
 
-export type LoadedPlugin = InitializedPlugin & {readonly content: unknown};
+export type LoadedPlugin<Content = unknown> = InitializedPlugin<Content> & {
+  readonly content: Content;
+};
 
 export type PluginModule = {
   <T, X>(context: LoadContext, options: T): Plugin<X>;

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -198,7 +198,7 @@ export interface Props extends LoadContext, InjectedHtmlTags {
   siteMetadata: DocusaurusSiteMetadata;
   routes: RouteConfig[];
   routesPaths: string[];
-  plugins: LoadedPlugin<unknown>[];
+  plugins: LoadedPlugin[];
 }
 
 export interface PluginContentLoadedActions {

--- a/packages/docusaurus-types/tsconfig.json
+++ b/packages/docusaurus-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18490,6 +18490,11 @@ typescript@^4.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
   integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
+typescript@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+
 ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When building a Typescript project depending on `@docusaurus/types`, this error is raised:

![type-no-generic](https://user-images.githubusercontent.com/3646758/123317588-90bfb380-d504-11eb-884a-b3df177dabc6.png)

![type-no-generic](https://user-images.githubusercontent.com/3646758/123317467-6ec63100-d504-11eb-88c6-5d67ded1603f.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I have added a `tsconfig.json` file to `@docusaurus/types` and typescript as a dev dep. One can check those types now with

```bash
yarn workspace @docusaurus/types test
```
The test **now** passes:

![test-passes](https://user-images.githubusercontent.com/3646758/123317865-e6945b80-d504-11eb-9aaf-6dc5c929e048.png)

