### PR TITLE
fix(v2): fix webpack SSG plugin error thrown due to new URL() / __filename

### DIFF
--- a/packages/docusaurus/src/webpack/server.ts
+++ b/packages/docusaurus/src/webpack/server.ts
@@ -78,6 +78,11 @@ export default function createServerConfig({
         },
         paths: ssgPaths,
         preferFoldersOutput: trailingSlash,
+
+        // When using "new URL('file.js', import.meta.url)", Webpack will emit __filename, and this plugin will throw
+        // not sure the __filename value has any importance for this plugin, just using an empty string to avoid the error
+        // See https://github.com/facebook/docusaurus/issues/4922
+        globals: {__filename: ''},
       }),
 
       // Show compilation progress bar.


### PR DESCRIPTION
## Motivation

Quite complicated to explain, fixes https://github.com/facebook/docusaurus/issues/4922 (including all the relevant details)

Not sure it's the perfect fix, but it looks to me we can pass any `__filename` value to unlock the situation, and it has no particular effect in practice apart preventing the eval error

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

local test + feedback from Relay Compiler playground integration, using Rust/WASM compiler

