### PR TITLE
docs(v2:) Divide `markdown-features/code-blocks` to smaller sections

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -146,7 +146,7 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 }
 ```
 
-## Multiple line highlighting {#multiple-line-highlighting}
+### Multiple line highlighting {#multiple-line-highlighting}
 
 To highlight multiple lines, separate the line numbers by commas or use the range syntax to select a chunk of lines. This feature uses the `parse-number-range` library and you can find [more syntax](https://www.npmjs.com/package/parse-numeric-range) on their project details.
 
@@ -178,7 +178,7 @@ function MyComponent(props) {
 export default MyComponent;
 ```
 
-## highlighting with comments {#highlighting-with-comments}
+### Highlighting with comments {#highlighting-with-comments}
 
 You can also use comments with `highlight-next-line`, `highlight-start`, and `highlight-end` to select which lines are highlighted.
 

--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -39,6 +39,8 @@ Use the matching language meta string for your code block, and Docusaurus will p
 console.log('Every repo must come with a mascot.');
 ```
 
+### Theming {#theming}
+
 By default, the Prism [syntax highlighting theme](https://github.com/FormidableLabs/prism-react-renderer#theming) we use is [Palenight](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/themes/palenight.js). You can change this to another theme by passing `theme` field in `prism` as `themeConfig` in your docusaurus.config.js.
 
 For example, if you prefer to use the `dracula` highlighting theme:
@@ -52,6 +54,8 @@ module.exports = {
   },
 };
 ```
+
+### Supported Languages {#supported-languages}
 
 By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js).
 
@@ -142,6 +146,8 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 }
 ```
 
+## Multiple line highlighting {#multiple-line-highlighting}
+
 To highlight multiple lines, separate the line numbers by commas or use the range syntax to select a chunk of lines. This feature uses the `parse-number-range` library and you can find [more syntax](https://www.npmjs.com/package/parse-numeric-range) on their project details.
 
     ```jsx {1,4-6,11}
@@ -171,6 +177,8 @@ function MyComponent(props) {
 
 export default MyComponent;
 ```
+
+## highlighting with comments {#highlighting-with-comments}
 
 You can also use comments with `highlight-next-line`, `highlight-start`, and `highlight-end` to select which lines are highlighted.
 


### PR DESCRIPTION
This PR adds few more heading to split the content to small topics.

This way users like me will be able to scroll directly to the specific section, instead of reading all the documentation.

I add to read the entire section because It was not divided into sections. Not a great user experience.
