### PR TITLE
docs(v2): Rewrite markdown images section

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -22,7 +22,7 @@ Let's imagine the following file structure:
 
 ## Images {#images}
 
-You can display images in three diffirent ways: Markdown syntax, JSX require or ES imports syntax.
+You can display images in three different ways: Markdown syntax, JSX require or ES imports syntax.
 
 Display images using simple Markdown syntax:
 

--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -39,7 +39,7 @@ Display images using inline CommonJS `require` in JSX image tag:
 />
 ```
 
-Show images using ES imports syntax:
+Display images using ES `import` syntax and JSX image tag:
 
 ```mdx
 import myImageUrl from './assets/docusaurus-asset-example-banner.png';

--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -44,10 +44,7 @@ Display images using ES `import` syntax and JSX image tag:
 ```mdx
 import myImageUrl from './assets/docusaurus-asset-example-banner.png';
 
-<img
-  src={myImageUrl}
-  alt="Example banner"
-/>
+<img src={myImageUrl} alt="Example banner" />
 ```
 
 This results in displaying the image:

--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -30,7 +30,7 @@ Display images using simple Markdown syntax:
 ![Example banner](./assets/docusaurus-asset-example-banner.png)
 ```
 
-Require images using JSX image tag:
+Display images using inline CommonJS `require` in JSX image tag:
 
 ```mdx
 <img

--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -22,29 +22,32 @@ Let's imagine the following file structure:
 
 ## Images {#images}
 
-You can use images in Markdown, or by requiring them and using a JSX image tag:
+You can display images in three diffirent ways: Markdown syntax, JSX require or ES imports syntax.
+
+Display images using simple Markdown syntax:
 
 ```mdx
-# My Markdown page
+![Example banner](./assets/docusaurus-asset-example-banner.png)
+```
 
+Require images using JSX image tag:
+
+```mdx
 <img
   src={require('./assets/docusaurus-asset-example-banner.png').default}
   alt="Example banner"
 />
-
-or
-
-![Example banner](./assets/docusaurus-asset-example-banner.png)
 ```
 
-The ES imports syntax also works:
+Show images using ES imports syntax:
 
 ```mdx
-# My Markdown page
-
 import myImageUrl from './assets/docusaurus-asset-example-banner.png';
 
-<img src={myImageUrl} alt="My image alternative text" />
+<img
+  src={myImageUrl}
+  alt="Example banner"
+/>
 ```
 
 This results in displaying the image:


### PR DESCRIPTION
Before it looked like we have two ways to display images, now it's three ways. Each syntax has a separate example.

This way it's clear, I see each method and the code example.

Before there were 2 methods in a single code block.
