### PR TITLE
chore: unstable yarn.lock

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,10 @@ jobs:
       - name: Installation
         uses: bahmutov/npm-install@v1
         with:
-          install-command: yarn install --frozen-lockfile # Fails if yarn.lock is modified
+         install-command: yarn install
+         # install-command: yarn install --immutable # Fails if yarn.lock is modified  (unfortunately only works for Yarn 2, and --frozen-lockfile is not the same!)
+      - name: Check immutable yarn.lock
+        run: git diff --exit-code
       - name: Lint
         run: yarn lint:ci
       - name: Prettier Code

--- a/packages/docusaurus-types/package.json
+++ b/packages/docusaurus-types/package.json
@@ -22,8 +22,5 @@
     "querystring": "0.2.0",
     "webpack": "^5.40.0",
     "webpack-merge": "^5.8.0"
-  },
-  "devDependencies": {
-    "typescript": "^4.3.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18490,11 +18490,6 @@ typescript@^4.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
   integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
-typescript@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
-  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
-
 ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"


### PR DESCRIPTION
CI does not catch unstable lockfile errors

Yarn v1 --frozen-lockfile is not strictly equivalent to Yarn v2 --immutable (it does not throw)

So move back to `git diff --exit-code` to detect a modified lockfile in CI