### PR TITLE
fix(v2): sitemap should respect the global trailingSlash config option.

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -7,6 +7,7 @@
 
 import createSitemap from '../createSitemap';
 import {DocusaurusConfig} from '@docusaurus/types';
+import {EnumChangefreq} from 'sitemap';
 
 describe('createSitemap', () => {
   test('simple site', async () => {
@@ -16,7 +17,7 @@ describe('createSitemap', () => {
       } as DocusaurusConfig,
       ['/', '/test'],
       {
-        changefreq: 'daily',
+        changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
         trailingSlash: false,
       },
@@ -41,7 +42,7 @@ describe('createSitemap', () => {
       } as DocusaurusConfig,
       ['/', '/404.html', '/mypage'],
       {
-        changefreq: 'daily',
+        changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
         trailingSlash: false,
       },
@@ -49,20 +50,79 @@ describe('createSitemap', () => {
     expect(sitemap).not.toContain('404');
   });
 
+  test('keep trailing slash unchanged', async () => {
+    const sitemap = await createSitemap(
+      {
+        url: 'https://example.com',
+        trailingSlash: undefined,
+      } as DocusaurusConfig,
+      ['/', '/test', '/nested/test', '/nested/test2/'],
+      {
+        changefreq: EnumChangefreq.DAILY,
+        priority: 0.7,
+      },
+    );
+
+    expect(sitemap).toContain('<loc>https://example.com/</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/test</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test2/</loc>');
+  });
+
   test('add trailing slash', async () => {
     const sitemap = await createSitemap(
       {
         url: 'https://example.com',
+        trailingSlash: true,
       } as DocusaurusConfig,
-      ['/', '/test'],
+      ['/', '/test', '/nested/test', '/nested/test2/'],
       {
-        changefreq: 'daily',
+        changefreq: EnumChangefreq.DAILY,
+        priority: 0.7,
+      },
+    );
+
+    expect(sitemap).toContain('<loc>https://example.com/</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/test/</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test/</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test2/</loc>');
+  });
+
+  test('remove trailing slash', async () => {
+    const sitemap = await createSitemap(
+      {
+        url: 'https://example.com',
+        trailingSlash: false,
+      } as DocusaurusConfig,
+      ['/', '/test', '/nested/test', '/nested/test2/'],
+      {
+        changefreq: EnumChangefreq.DAILY,
+        priority: 0.7,
+      },
+    );
+
+    expect(sitemap).toContain('<loc>https://example.com/</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/test</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test2</loc>');
+  });
+
+  test('add trailing slash (deprecated plugin option)', async () => {
+    const sitemap = await createSitemap(
+      {
+        url: 'https://example.com',
+      } as DocusaurusConfig,
+      ['/', '/test', '/nested/test', '/nested/test2/'],
+      {
+        changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
         trailingSlash: true,
       },
     );
 
+    expect(sitemap).toContain('<loc>https://example.com/</loc>');
     expect(sitemap).toContain('<loc>https://example.com/test/</loc>');
-    expect(sitemap).not.toContain('<loc>https://example.com/test</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test/</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/nested/test2/</loc>');
   });
 });

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -20,7 +20,8 @@ export default async function createSitemap(
   if (!hostname) {
     throw new Error('URL in docusaurus.config.js cannot be empty/undefined.');
   }
-  const {changefreq, priority, trailingSlash} = options;
+  const {changefreq, priority} = options;
+  const trailingSlash = options.trailingSlash || siteConfig.trailingSlash;
 
   const sitemapStream = new SitemapStream({
     hostname,
@@ -29,7 +30,7 @@ export default async function createSitemap(
   function applySitemapTrailingSlash(routePath: string): string {
     // kept for retrocompatibility
     // TODO remove deprecated trailingSlash option before 2022
-    if (options.trailingSlash) {
+    if (trailingSlash) {
       return addTrailingSlash(routePath);
     } else {
       return applyTrailingSlash(routePath, trailingSlash);

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -21,7 +21,6 @@ export default async function createSitemap(
     throw new Error('URL in docusaurus.config.js cannot be empty/undefined.');
   }
   const {changefreq, priority} = options;
-  const trailingSlash = options.trailingSlash || siteConfig.trailingSlash;
 
   const sitemapStream = new SitemapStream({
     hostname,
@@ -30,10 +29,10 @@ export default async function createSitemap(
   function applySitemapTrailingSlash(routePath: string): string {
     // kept for retrocompatibility
     // TODO remove deprecated trailingSlash option before 2022
-    if (trailingSlash) {
+    if (options.trailingSlash) {
       return addTrailingSlash(routePath);
     } else {
-      return applyTrailingSlash(routePath, trailingSlash);
+      return applyTrailingSlash(routePath, siteConfig.trailingSlash);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Sitemap has a depricated option, `trailingSlash`. When used, URLs in the sitemap have trailing slashes, but you see a warning: 
> Option "trailingSlash" of the sitemap plugin is deprecated: Please use the new Docusaurus global trailingSlash config instead, and the sitemaps plugin will use it.

If you remove the `trailingSlash` option from the sitemap plugin, and instead have a global `trailingSlash` option set to `true`, the generated sitemap lacks trailing slashes.

This PR causes the sitemap plugin to respect the global `trailingSlash` option.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Within `website` I explicitly set the global `trailingSlash` option to true, and then false, to verify that trailing slashes are generated (or not) respectively.
