### PR TITLE
fix(v2): allow negative sidebar positions

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
@@ -196,16 +196,16 @@ describe('validateDocFrontMatter sidebar_position', () => {
   testField({
     fieldName: 'sidebar_position',
     validFrontMatters: [
+      {sidebar_position: -5},
+      {sidebar_position: -3.5},
       {sidebar_position: 0},
       {sidebar_position: 5},
       {sidebar_position: 3.5},
     ],
     convertibleFrontMatter: [
+      [{sidebar_position: '-1.5'}, {sidebar_position: -1.5}],
       [{sidebar_position: '1'}, {sidebar_position: 1}],
       [{sidebar_position: '1.5'}, {sidebar_position: 1.5}],
-    ],
-    invalidFrontMatters: [
-      [{sidebar_position: -1}, 'must be greater than or equal to 0'],
     ],
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
@@ -28,7 +28,7 @@ const DocFrontMatterSchema = Joi.object<DocFrontMatter>({
   description: Joi.string().allow(''), // see  https://github.com/facebook/docusaurus/issues/4591#issuecomment-822372398
   slug: Joi.string(),
   sidebar_label: Joi.string(),
-  sidebar_position: Joi.number().min(0),
+  sidebar_position: Joi.number(),
   pagination_label: Joi.string(),
   custom_edit_url: URISchema.allow('', null),
   parse_number_prefixes: Joi.boolean(),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In some cases, negative sidebar positions can be useful for reversing the sorting order with minimal maintenance overhead. For example, a docs folder with changelogs for historical versions should be sorted in reverse chronological order. This is easy to do for semantic version numbers by converting them into a negative numerical representation, e.g. 11.5.1 -> -110501.

The alternative is to make the first version start with a large position number (e.g. 9999) and decrement it for each version. However, this requires referring to older versions to get the current sequence number, thus increasing maintenance overhead. It also makes the number less intuitive and more prone to error.

Negative sidebar positions work great for this purpose, so make the front matter validator allow them again as #4796 broke this use case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Negative sidebar positions worked on 2.0.0-beta.0, so I simply reverted #4796 by removing `.min(0)`. I also added tests that follow the existing format in order to prevent regressions.
