### PR TITLE
fix(v2): classic theme - semantic correct anchors links

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -128,6 +128,7 @@ function DocSidebarItemCategory({
       className={clsx('menu__list-item', {
         'menu__list-item--collapsed': collapsed,
       })}>
+      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a
         className={clsx('menu__link', {
           'menu__link--sublist': collapsible,

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -135,7 +135,7 @@ function DocSidebarItemCategory({
           [styles.menuLinkText]: !collapsible,
         })}
         onClick={collapsible ? handleItemClick : undefined}
-        href={collapsible ? '#!' : undefined}
+        href={collapsible ? '#' : undefined}
         {...props}>
         {label}
       </a>

--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -39,7 +39,7 @@ function SkipToContent(): JSX.Element {
 
   return (
     <div ref={containerRef}>
-      <a href="#main" className={styles.skipToContent} onClick={handleSkip}>
+      <a href="#" className={styles.skipToContent} onClick={handleSkip}>
         <Translate
           id="theme.common.skipToMainContent"
           description="The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation">

--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -39,6 +39,7 @@ function SkipToContent(): JSX.Element {
 
   return (
     <div ref={containerRef}>
+      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a href="#" className={styles.skipToContent} onClick={handleSkip}>
         <Translate
           id="theme.common.skipToMainContent"


### PR DESCRIPTION
## Motivation

Across the Classic Theme, there are two places where a link points to an anchor that does not exist on the page. This is for example problem for tools that try to verify the validity of links and if applicable their anchors. These tools are crucial in maintaining coherent documentations.

This PR fixes these links to be semantic correct and uses simple `#` instead.

Alternative to this change is to introduce `#main` anchor for the "Skip to main content" on the `main-wrapper` element. But not sure what would then be introduced for the Doc Sidebar.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

None