### PR TITLE
fix(v2): restore previous scroll position on back button click

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, {useRef} from 'react';
+import {useHistory} from '@docusaurus/router';
 import Translate from '@docusaurus/Translate';
 import {useLocationChange} from '@docusaurus/theme-common';
 
@@ -19,6 +20,7 @@ function programmaticFocus(el: HTMLElement) {
 
 function SkipToContent(): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
+  const {action} = useHistory();
   const handleSkip = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
 
@@ -32,7 +34,7 @@ function SkipToContent(): JSX.Element {
   };
 
   useLocationChange(({location}) => {
-    if (containerRef.current && !location.hash) {
+    if (containerRef.current && !location.hash && action !== 'POP') {
       programmaticFocus(containerRef.current);
     }
   });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Quick attempt to fix #5076

Currently, after changing the location, we focus on the skip link to focus on that link at first. However, this has the side effect that when the user clicks on the browser's back button, then the previous scroll position is lost. To avoid this we can focus on the skip link only when moving forward in browser history.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Scroll a bit on any doc page, then go to another page, then press on back button in the browser, as result is the previous scroll position should be preserved.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
