### PR TITLE
fix(v2): never remove trailing slash from site root like '/baseUrl/'

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
@@ -17,7 +17,10 @@ import {
   createToExtensionsRedirects,
 } from './extensionRedirects';
 import {validateRedirect} from './redirectValidation';
-import {applyTrailingSlash} from '@docusaurus/utils-common';
+import {
+  applyTrailingSlash,
+  ApplyTrailingSlashParams,
+} from '@docusaurus/utils-common';
 
 import chalk from 'chalk';
 
@@ -26,7 +29,12 @@ export default function collectRedirects(
   trailingSlash: boolean | undefined,
 ): RedirectMetadata[] {
   let redirects = doCollectRedirects(pluginContext);
-  redirects = applyRedirectsTrailingSlash(redirects, trailingSlash);
+
+  redirects = applyRedirectsTrailingSlash(redirects, {
+    trailingSlash,
+    baseUrl: pluginContext.baseUrl,
+  });
+
   validateCollectedRedirects(redirects, pluginContext);
   return filterUnwantedRedirects(redirects, pluginContext);
 }
@@ -37,12 +45,12 @@ export default function collectRedirects(
 // It should be easy to toggle siteConfig.trailingSlash option without having to change other configs
 function applyRedirectsTrailingSlash(
   redirects: RedirectMetadata[],
-  trailingSlash: boolean | undefined,
+  params: ApplyTrailingSlashParams,
 ) {
   return redirects.map((redirect) => {
     return {
       ...redirect,
-      to: applyTrailingSlash(redirect.to, trailingSlash),
+      to: applyTrailingSlash(redirect.to, params),
     };
   });
 }

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -32,7 +32,10 @@ export default async function createSitemap(
     if (options.trailingSlash) {
       return addTrailingSlash(routePath);
     } else {
-      return applyTrailingSlash(routePath, siteConfig.trailingSlash);
+      return applyTrailingSlash(routePath, {
+        trailingSlash: siteConfig.trailingSlash,
+        baseUrl: siteConfig.baseUrl,
+      });
     }
   }
 

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -180,7 +180,7 @@ export interface LoadContext {
   siteConfig: DocusaurusConfig;
   siteConfigPath: string;
   outDir: string;
-  baseUrl: string;
+  baseUrl: string; // TODO to remove: useless, there's already siteConfig.baseUrl!
   i18n: I18n;
   ssrTemplate?: string;
   codeTranslations: Record<string, string>;

--- a/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
@@ -5,116 +5,174 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import applyTrailingSlash from '../applyTrailingSlash';
+import applyTrailingSlash, {
+  ApplyTrailingSlashParams,
+} from '../applyTrailingSlash';
+
+function params(
+  trailingSlash: boolean | undefined,
+  baseUrl: string = '/',
+): ApplyTrailingSlashParams {
+  return {trailingSlash, baseUrl};
+}
 
 describe('applyTrailingSlash', () => {
   test('should apply to empty', () => {
-    expect(applyTrailingSlash('', true)).toEqual('/');
-    expect(applyTrailingSlash('', false)).toEqual('');
-    expect(applyTrailingSlash('', undefined)).toEqual('');
+    expect(applyTrailingSlash('', params(true))).toEqual('/');
+    expect(applyTrailingSlash('', params(false))).toEqual('');
+    expect(applyTrailingSlash('', params(undefined))).toEqual('');
   });
 
   test('should not apply to /', () => {
-    expect(applyTrailingSlash('/', true)).toEqual('/');
-    expect(applyTrailingSlash('/', false)).toEqual('/');
-    expect(applyTrailingSlash('/', undefined)).toEqual('/');
+    expect(applyTrailingSlash('/', params(true))).toEqual('/');
+    expect(applyTrailingSlash('/', params(false))).toEqual('/');
+    expect(applyTrailingSlash('/', params(undefined))).toEqual('/');
 
-    expect(applyTrailingSlash('/?query#anchor', true)).toEqual(
+    expect(applyTrailingSlash('/?query#anchor', params(true))).toEqual(
       '/?query#anchor',
     );
-    expect(applyTrailingSlash('/?query#anchor', false)).toEqual(
+    expect(applyTrailingSlash('/?query#anchor', params(false))).toEqual(
       '/?query#anchor',
     );
-    expect(applyTrailingSlash('/?query#anchor', undefined)).toEqual(
+    expect(applyTrailingSlash('/?query#anchor', params(undefined))).toEqual(
       '/?query#anchor',
     );
+  });
+
+  test('should not apply to /baseUrl/', () => {
+    const baseUrl = '/baseUrl/';
+    expect(applyTrailingSlash('/baseUrl/', params(true, baseUrl))).toEqual(
+      '/baseUrl/',
+    );
+    expect(applyTrailingSlash('/baseUrl/', params(false, baseUrl))).toEqual(
+      '/baseUrl/',
+    );
+    expect(applyTrailingSlash('/baseUrl/', params(undefined, baseUrl))).toEqual(
+      '/baseUrl/',
+    );
+
+    expect(
+      applyTrailingSlash('/baseUrl/?query#anchor', params(true, baseUrl)),
+    ).toEqual('/baseUrl/?query#anchor');
+    expect(
+      applyTrailingSlash('/baseUrl/?query#anchor', params(false, baseUrl)),
+    ).toEqual('/baseUrl/?query#anchor');
+    expect(
+      applyTrailingSlash('/baseUrl/?query#anchor', params(undefined, baseUrl)),
+    ).toEqual('/baseUrl/?query#anchor');
   });
 
   test('should not apply to #anchor links ', () => {
-    expect(applyTrailingSlash('#', true)).toEqual('#');
-    expect(applyTrailingSlash('#', false)).toEqual('#');
-    expect(applyTrailingSlash('#', undefined)).toEqual('#');
-    expect(applyTrailingSlash('#anchor', true)).toEqual('#anchor');
-    expect(applyTrailingSlash('#anchor', false)).toEqual('#anchor');
-    expect(applyTrailingSlash('#anchor', undefined)).toEqual('#anchor');
+    expect(applyTrailingSlash('#', params(true))).toEqual('#');
+    expect(applyTrailingSlash('#', params(false))).toEqual('#');
+    expect(applyTrailingSlash('#', params(undefined))).toEqual('#');
+    expect(applyTrailingSlash('#anchor', params(true))).toEqual('#anchor');
+    expect(applyTrailingSlash('#anchor', params(false))).toEqual('#anchor');
+    expect(applyTrailingSlash('#anchor', params(undefined))).toEqual('#anchor');
   });
 
   test('should apply to simple paths', () => {
-    expect(applyTrailingSlash('abc', true)).toEqual('abc/');
-    expect(applyTrailingSlash('abc', false)).toEqual('abc');
-    expect(applyTrailingSlash('abc', undefined)).toEqual('abc');
-    expect(applyTrailingSlash('abc/', true)).toEqual('abc/');
-    expect(applyTrailingSlash('abc/', false)).toEqual('abc');
-    expect(applyTrailingSlash('abc/', undefined)).toEqual('abc/');
-    expect(applyTrailingSlash('/abc', true)).toEqual('/abc/');
-    expect(applyTrailingSlash('/abc', false)).toEqual('/abc');
-    expect(applyTrailingSlash('/abc', undefined)).toEqual('/abc');
-    expect(applyTrailingSlash('/abc/', true)).toEqual('/abc/');
-    expect(applyTrailingSlash('/abc/', false)).toEqual('/abc');
-    expect(applyTrailingSlash('/abc/', undefined)).toEqual('/abc/');
+    expect(applyTrailingSlash('abc', params(true))).toEqual('abc/');
+    expect(applyTrailingSlash('abc', params(false))).toEqual('abc');
+    expect(applyTrailingSlash('abc', params(undefined))).toEqual('abc');
+    expect(applyTrailingSlash('abc/', params(true))).toEqual('abc/');
+    expect(applyTrailingSlash('abc/', params(false))).toEqual('abc');
+    expect(applyTrailingSlash('abc/', params(undefined))).toEqual('abc/');
+    expect(applyTrailingSlash('/abc', params(true))).toEqual('/abc/');
+    expect(applyTrailingSlash('/abc', params(false))).toEqual('/abc');
+    expect(applyTrailingSlash('/abc', params(undefined))).toEqual('/abc');
+    expect(applyTrailingSlash('/abc/', params(true))).toEqual('/abc/');
+    expect(applyTrailingSlash('/abc/', params(false))).toEqual('/abc');
+    expect(applyTrailingSlash('/abc/', params(undefined))).toEqual('/abc/');
   });
 
   test('should apply to path with #anchor', () => {
-    expect(applyTrailingSlash('/abc#anchor', true)).toEqual('/abc/#anchor');
-    expect(applyTrailingSlash('/abc#anchor', false)).toEqual('/abc#anchor');
-    expect(applyTrailingSlash('/abc#anchor', undefined)).toEqual('/abc#anchor');
-    expect(applyTrailingSlash('/abc/#anchor', true)).toEqual('/abc/#anchor');
-    expect(applyTrailingSlash('/abc/#anchor', false)).toEqual('/abc#anchor');
-    expect(applyTrailingSlash('/abc/#anchor', undefined)).toEqual(
+    expect(applyTrailingSlash('/abc#anchor', params(true))).toEqual(
+      '/abc/#anchor',
+    );
+    expect(applyTrailingSlash('/abc#anchor', params(false))).toEqual(
+      '/abc#anchor',
+    );
+    expect(applyTrailingSlash('/abc#anchor', params(undefined))).toEqual(
+      '/abc#anchor',
+    );
+    expect(applyTrailingSlash('/abc/#anchor', params(true))).toEqual(
+      '/abc/#anchor',
+    );
+    expect(applyTrailingSlash('/abc/#anchor', params(false))).toEqual(
+      '/abc#anchor',
+    );
+    expect(applyTrailingSlash('/abc/#anchor', params(undefined))).toEqual(
       '/abc/#anchor',
     );
   });
 
   test('should apply to path with ?search', () => {
-    expect(applyTrailingSlash('/abc?search', true)).toEqual('/abc/?search');
-    expect(applyTrailingSlash('/abc?search', false)).toEqual('/abc?search');
-    expect(applyTrailingSlash('/abc?search', undefined)).toEqual('/abc?search');
-    expect(applyTrailingSlash('/abc/?search', true)).toEqual('/abc/?search');
-    expect(applyTrailingSlash('/abc/?search', false)).toEqual('/abc?search');
-    expect(applyTrailingSlash('/abc/?search', undefined)).toEqual(
+    expect(applyTrailingSlash('/abc?search', params(true))).toEqual(
+      '/abc/?search',
+    );
+    expect(applyTrailingSlash('/abc?search', params(false))).toEqual(
+      '/abc?search',
+    );
+    expect(applyTrailingSlash('/abc?search', params(undefined))).toEqual(
+      '/abc?search',
+    );
+    expect(applyTrailingSlash('/abc/?search', params(true))).toEqual(
+      '/abc/?search',
+    );
+    expect(applyTrailingSlash('/abc/?search', params(false))).toEqual(
+      '/abc?search',
+    );
+    expect(applyTrailingSlash('/abc/?search', params(undefined))).toEqual(
       '/abc/?search',
     );
   });
 
   test('should apply to path with ?search#anchor', () => {
-    expect(applyTrailingSlash('/abc?search#anchor', true)).toEqual(
+    expect(applyTrailingSlash('/abc?search#anchor', params(true))).toEqual(
       '/abc/?search#anchor',
     );
-    expect(applyTrailingSlash('/abc?search#anchor', false)).toEqual(
+    expect(applyTrailingSlash('/abc?search#anchor', params(false))).toEqual(
       '/abc?search#anchor',
     );
-    expect(applyTrailingSlash('/abc?search#anchor', undefined)).toEqual(
+    expect(applyTrailingSlash('/abc?search#anchor', params(undefined))).toEqual(
       '/abc?search#anchor',
     );
-    expect(applyTrailingSlash('/abc/?search#anchor', true)).toEqual(
+    expect(applyTrailingSlash('/abc/?search#anchor', params(true))).toEqual(
       '/abc/?search#anchor',
     );
-    expect(applyTrailingSlash('/abc/?search#anchor', false)).toEqual(
+    expect(applyTrailingSlash('/abc/?search#anchor', params(false))).toEqual(
       '/abc?search#anchor',
     );
-    expect(applyTrailingSlash('/abc/?search#anchor', undefined)).toEqual(
-      '/abc/?search#anchor',
-    );
+    expect(
+      applyTrailingSlash('/abc/?search#anchor', params(undefined)),
+    ).toEqual('/abc/?search#anchor');
   });
 
   test('should apply to fully qualified urls', () => {
     expect(
-      applyTrailingSlash('https://xyz.com/abc?search#anchor', true),
+      applyTrailingSlash('https://xyz.com/abc?search#anchor', params(true)),
     ).toEqual('https://xyz.com/abc/?search#anchor');
     expect(
-      applyTrailingSlash('https://xyz.com/abc?search#anchor', false),
+      applyTrailingSlash('https://xyz.com/abc?search#anchor', params(false)),
     ).toEqual('https://xyz.com/abc?search#anchor');
     expect(
-      applyTrailingSlash('https://xyz.com/abc?search#anchor', undefined),
+      applyTrailingSlash(
+        'https://xyz.com/abc?search#anchor',
+        params(undefined),
+      ),
     ).toEqual('https://xyz.com/abc?search#anchor');
     expect(
-      applyTrailingSlash('https://xyz.com/abc/?search#anchor', true),
+      applyTrailingSlash('https://xyz.com/abc/?search#anchor', params(true)),
     ).toEqual('https://xyz.com/abc/?search#anchor');
     expect(
-      applyTrailingSlash('https://xyz.com/abc/?search#anchor', false),
+      applyTrailingSlash('https://xyz.com/abc/?search#anchor', params(false)),
     ).toEqual('https://xyz.com/abc?search#anchor');
     expect(
-      applyTrailingSlash('https://xyz.com/abc/?search#anchor', undefined),
+      applyTrailingSlash(
+        'https://xyz.com/abc/?search#anchor',
+        params(undefined),
+      ),
     ).toEqual('https://xyz.com/abc/?search#anchor');
   });
 });

--- a/packages/docusaurus-utils-common/src/applyTrailingSlash.tsx
+++ b/packages/docusaurus-utils-common/src/applyTrailingSlash.tsx
@@ -5,12 +5,29 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {DocusaurusConfig} from '@docusaurus/types';
+
+export type ApplyTrailingSlashParams = Pick<
+  DocusaurusConfig,
+  'trailingSlash' | 'baseUrl'
+>;
+
+// Trailing slash handling depends in some site configuration options
 export default function applyTrailingSlash(
   path: string,
-  trailingSlash: boolean | undefined,
+  options: ApplyTrailingSlashParams,
 ): string {
+  const {trailingSlash, baseUrl} = options;
+
   if (path.startsWith('#')) {
     // Never apply trailing slash to an anchor link
+    return path;
+  }
+
+  // Never remove the baseUrl trailing slash!
+  // If baseUrl = /myBase/, we want to emit /myBase/index.html and not /myBase.html !
+  // See https://github.com/facebook/docusaurus/issues/5077
+  if (path === baseUrl) {
     return path;
   }
 
@@ -34,7 +51,14 @@ export default function applyTrailingSlash(
   const [pathname] = path.split(/[#?]/);
 
   // Never transform '/' to ''
-  const newPathname =
-    pathname === '/' ? '/' : handleTrailingSlash(pathname, trailingSlash);
+  // Never remove the baseUrl trailing slash!
+  // If baseUrl = /myBase/, we want to emit /myBase/index.html and not /myBase.html !
+  // See https://github.com/facebook/docusaurus/issues/5077
+  const shouldNotApply = pathname === '/' || pathname === baseUrl;
+
+  const newPathname = shouldNotApply
+    ? pathname
+    : handleTrailingSlash(pathname, trailingSlash);
+
   return path.replace(pathname, newPathname);
 }

--- a/packages/docusaurus-utils-common/src/index.ts
+++ b/packages/docusaurus-utils-common/src/index.ts
@@ -6,4 +6,6 @@
  */
 
 export {default as applyTrailingSlash} from './applyTrailingSlash';
+export type {ApplyTrailingSlashParams} from './applyTrailingSlash';
+
 export {default as uniq} from './uniq';

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -42,7 +42,7 @@ function Link({
   ...props
 }: LinkProps): JSX.Element {
   const {
-    siteConfig: {trailingSlash},
+    siteConfig: {trailingSlash, baseUrl},
   } = useDocusaurusContext();
   const {withBaseUrl} = useBaseUrlUtils();
   const linksCollector = useLinksCollector();
@@ -80,7 +80,7 @@ function Link({
       : undefined;
 
   if (targetLink && isInternal) {
-    targetLink = applyTrailingSlash(targetLink, trailingSlash);
+    targetLink = applyTrailingSlash(targetLink, {trailingSlash, baseUrl});
   }
 
   const preloaded = useRef(false);

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -116,7 +116,7 @@ export async function loadContext(
     siteConfig,
     siteConfigPath,
     outDir,
-    baseUrl,
+    baseUrl, // TODO to remove: useless, there's already siteConfig.baseUrl! (and yes, it's the same value, cf code above)
     i18n,
     ssrTemplate,
     codeTranslations,

--- a/packages/docusaurus/src/server/plugins/__tests__/applyRouteTrailingSlash.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/applyRouteTrailingSlash.test.ts
@@ -7,6 +7,7 @@
 
 import applyRouteTrailingSlash from '../applyRouteTrailingSlash';
 import {RouteConfig} from '@docusaurus/types';
+import {ApplyTrailingSlashParams} from '@docusaurus/utils-common';
 
 function route(path: string, subRoutes?: string[]): RouteConfig {
   const result: RouteConfig = {path, component: 'any'};
@@ -18,76 +19,126 @@ function route(path: string, subRoutes?: string[]): RouteConfig {
   return result;
 }
 
+function params(
+  trailingSlash: boolean | undefined,
+  baseUrl: string = '/',
+): ApplyTrailingSlashParams {
+  return {trailingSlash, baseUrl};
+}
+
 describe('applyRouteTrailingSlash', () => {
   test('apply to empty', () => {
-    expect(applyRouteTrailingSlash(route(''), true)).toEqual(route('/'));
-    expect(applyRouteTrailingSlash(route(''), false)).toEqual(route(''));
-    expect(applyRouteTrailingSlash(route(''), undefined)).toEqual(route(''));
+    expect(applyRouteTrailingSlash(route(''), params(true))).toEqual(
+      route('/'),
+    );
+    expect(applyRouteTrailingSlash(route(''), params(false))).toEqual(
+      route(''),
+    );
+    expect(applyRouteTrailingSlash(route(''), params(undefined))).toEqual(
+      route(''),
+    );
   });
 
   test('apply to /', () => {
-    expect(applyRouteTrailingSlash(route('/'), true)).toEqual(route('/'));
-    expect(applyRouteTrailingSlash(route('/'), false)).toEqual(route('/'));
-    expect(applyRouteTrailingSlash(route('/'), undefined)).toEqual(route('/'));
+    expect(applyRouteTrailingSlash(route('/'), params(true))).toEqual(
+      route('/'),
+    );
+    expect(applyRouteTrailingSlash(route('/'), params(false))).toEqual(
+      route('/'),
+    );
+    expect(applyRouteTrailingSlash(route('/'), params(undefined))).toEqual(
+      route('/'),
+    );
   });
 
   test('apply to /abc', () => {
-    expect(applyRouteTrailingSlash(route('/abc'), true)).toEqual(
+    expect(applyRouteTrailingSlash(route('/abc'), params(true))).toEqual(
       route('/abc/'),
     );
-    expect(applyRouteTrailingSlash(route('/abc'), false)).toEqual(
+    expect(applyRouteTrailingSlash(route('/abc'), params(false))).toEqual(
       route('/abc'),
     );
-    expect(applyRouteTrailingSlash(route('/abc'), undefined)).toEqual(
+    expect(applyRouteTrailingSlash(route('/abc'), params(undefined))).toEqual(
       route('/abc'),
     );
   });
 
   test('apply to /abc/', () => {
-    expect(applyRouteTrailingSlash(route('/abc/'), true)).toEqual(
+    expect(applyRouteTrailingSlash(route('/abc/'), params(true))).toEqual(
       route('/abc/'),
     );
-    expect(applyRouteTrailingSlash(route('/abc/'), false)).toEqual(
+    expect(applyRouteTrailingSlash(route('/abc/'), params(false))).toEqual(
       route('/abc'),
     );
-    expect(applyRouteTrailingSlash(route('/abc/'), undefined)).toEqual(
+    expect(applyRouteTrailingSlash(route('/abc/'), params(undefined))).toEqual(
       route('/abc/'),
     );
   });
 
   test('apply to /abc?search#anchor', () => {
-    expect(applyRouteTrailingSlash(route('/abc?search#anchor'), true)).toEqual(
-      route('/abc/?search#anchor'),
-    );
-    expect(applyRouteTrailingSlash(route('/abc?search#anchor'), false)).toEqual(
-      route('/abc?search#anchor'),
-    );
     expect(
-      applyRouteTrailingSlash(route('/abc?search#anchor'), undefined),
+      applyRouteTrailingSlash(route('/abc?search#anchor'), params(true)),
+    ).toEqual(route('/abc/?search#anchor'));
+    expect(
+      applyRouteTrailingSlash(route('/abc?search#anchor'), params(false)),
+    ).toEqual(route('/abc?search#anchor'));
+    expect(
+      applyRouteTrailingSlash(route('/abc?search#anchor'), params(undefined)),
     ).toEqual(route('/abc?search#anchor'));
   });
 
   test('apply to /abc/?search#anchor', () => {
-    expect(applyRouteTrailingSlash(route('/abc/?search#anchor'), true)).toEqual(
-      route('/abc/?search#anchor'),
-    );
     expect(
-      applyRouteTrailingSlash(route('/abc/?search#anchor'), false),
+      applyRouteTrailingSlash(route('/abc/?search#anchor'), params(true)),
+    ).toEqual(route('/abc/?search#anchor'));
+    expect(
+      applyRouteTrailingSlash(route('/abc/?search#anchor'), params(false)),
     ).toEqual(route('/abc?search#anchor'));
     expect(
-      applyRouteTrailingSlash(route('/abc/?search#anchor'), undefined),
+      applyRouteTrailingSlash(route('/abc/?search#anchor'), params(undefined)),
+    ).toEqual(route('/abc/?search#anchor'));
+  });
+
+  test('not apply to /abc/?search#anchor when baseUrl=/abc/', () => {
+    const baseUrl = '/abc/';
+    expect(
+      applyRouteTrailingSlash(
+        route('/abc/?search#anchor'),
+        params(true, baseUrl),
+      ),
+    ).toEqual(route('/abc/?search#anchor'));
+    expect(
+      applyRouteTrailingSlash(
+        route('/abc/?search#anchor'),
+        params(false, baseUrl),
+      ),
+    ).toEqual(route('/abc/?search#anchor'));
+    expect(
+      applyRouteTrailingSlash(
+        route('/abc/?search#anchor'),
+        params(undefined, baseUrl),
+      ),
     ).toEqual(route('/abc/?search#anchor'));
   });
 
   test('apply to subroutes', () => {
     expect(
-      applyRouteTrailingSlash(route('/abc', ['/abc/1', '/abc/2']), true),
+      applyRouteTrailingSlash(
+        route('/abc', ['/abc/1', '/abc/2']),
+        params(true),
+      ),
     ).toEqual(route('/abc/', ['/abc/1/', '/abc/2/']));
     expect(
-      applyRouteTrailingSlash(route('/abc', ['/abc/1', '/abc/2']), false),
+      applyRouteTrailingSlash(
+        route('/abc', ['/abc/1', '/abc/2']),
+        params(false),
+      ),
     ).toEqual(route('/abc', ['/abc/1', '/abc/2']));
     expect(
-      applyRouteTrailingSlash(route('/abc', ['/abc/1', '/abc/2']), undefined),
+      applyRouteTrailingSlash(
+        route('/abc', ['/abc/1', '/abc/2']),
+        params(undefined),
+      ),
     ).toEqual(route('/abc', ['/abc/1', '/abc/2']));
   });
 
@@ -95,10 +146,20 @@ describe('applyRouteTrailingSlash', () => {
     expect(
       applyRouteTrailingSlash(
         route('/abc?search#anchor', ['/abc/1?search', '/abc/2#anchor']),
-        true,
+        params(true),
       ),
     ).toEqual(
       route('/abc/?search#anchor', ['/abc/1/?search', '/abc/2/#anchor']),
     );
+  });
+
+  test('apply for complex case with baseUrl', () => {
+    const baseUrl = '/abc/';
+    expect(
+      applyRouteTrailingSlash(
+        route('/abc/?search#anchor', ['/abc/1?search', '/abc/2#anchor']),
+        params(false, baseUrl),
+      ),
+    ).toEqual(route('/abc/?search#anchor', ['/abc/1?search', '/abc/2#anchor']));
   });
 });

--- a/packages/docusaurus/src/server/plugins/applyRouteTrailingSlash.ts
+++ b/packages/docusaurus/src/server/plugins/applyRouteTrailingSlash.ts
@@ -6,18 +6,21 @@
  */
 
 import {RouteConfig} from '@docusaurus/types';
-import {applyTrailingSlash} from '@docusaurus/utils-common';
+import {
+  applyTrailingSlash,
+  ApplyTrailingSlashParams,
+} from '@docusaurus/utils-common';
 
 export default function applyRouteTrailingSlash(
   route: RouteConfig,
-  trailingSlash: boolean | undefined,
+  params: ApplyTrailingSlashParams,
 ): RouteConfig {
   return {
     ...route,
-    path: applyTrailingSlash(route.path, trailingSlash),
+    path: applyTrailingSlash(route.path, params),
     ...(route.routes && {
       routes: route.routes.map((subroute) =>
-        applyRouteTrailingSlash(subroute, trailingSlash),
+        applyRouteTrailingSlash(subroute, params),
       ),
     }),
   };

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -142,10 +142,10 @@ export async function loadPlugins({
           initialRouteConfig,
         ) => {
           // Trailing slash behavior is handled in a generic way for all plugins
-          const finalRouteConfig = applyRouteTrailingSlash(
-            initialRouteConfig,
-            context.siteConfig.trailingSlash,
-          );
+          const finalRouteConfig = applyRouteTrailingSlash(initialRouteConfig, {
+            trailingSlash: context.siteConfig.trailingSlash,
+            baseUrl: context.siteConfig.baseUrl,
+          });
           pluginsRouteConfigs.push(finalRouteConfig);
         };
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,13 +52,13 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
   tagline: 'Build optimized websites quickly, focus on your content',
   organizationName: 'facebook',
   projectName: 'docusaurus',
-  baseUrl,
+  baseUrl: '/myTest/',
   baseUrlIssueBanner: true,
   url: 'https://docusaurus.io',
   // Dogfood both settings:
   // - force trailing slashes for deploy previews
   // - avoid trailing slashes in prod
-  trailingSlash: isDeployPreview,
+  trailingSlash: false,
   stylesheets: [
     {
       href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',


### PR DESCRIPTION

## Motivation

Fixes https://github.com/facebook/docusaurus/issues/5077

With `baseUrl = /xyz/` and `trailingSlash: false`, we should never transform the root route to `/xyz` 

Otherwise the output folder will contain `website/build/xyz.html` instead of `website/build/index.html`

Trailing slash config should only apply to subroutes of the site, not the root / baseUrl / homepage of the site, or it can lead to 404 server errors

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests + dogfooding on our i18n sites (using locale baseurl)
