### PR TITLE
fix(v2): redirect from should work with trailingSlash: true

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/extensionRedirects.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/extensionRedirects.test.ts
@@ -111,7 +111,7 @@ describe('createFromExtensionsRedirects', () => {
     `);
   });
 
-  test('should create redirects to html/htm extensions', () => {
+  test('should create redirects from html/htm extensions', () => {
     const ext = ['html', 'htm'];
     expect(createFromExtensionsRedirects([''], ext)).toEqual([]);
     expect(createFromExtensionsRedirects(['/'], ext)).toEqual([]);
@@ -120,7 +120,10 @@ describe('createFromExtensionsRedirects', () => {
       {from: '/abc.htm', to: '/abc'},
     ]);
     expect(createFromExtensionsRedirects(['/def.html'], ext)).toEqual([]);
-    expect(createFromExtensionsRedirects(['/def/'], ext)).toEqual([]);
+    expect(createFromExtensionsRedirects(['/def/'], ext)).toEqual([
+      {from: '/def.html/', to: '/def/'},
+      {from: '/def.htm/', to: '/def/'},
+    ]);
   });
 
   test('should create "from" redirects when relativeRoutesPath contains a prefix', () => {

--- a/packages/docusaurus-plugin-client-redirects/src/index.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/index.ts
@@ -15,7 +15,6 @@ import writeRedirectFiles, {
   RedirectFileMetadata,
 } from './writeRedirectFiles';
 import {removePrefix, addLeadingSlash} from '@docusaurus/utils';
-import chalk from 'chalk';
 
 export default function pluginClientRedirectsPages(
   context: LoadContext,
@@ -24,18 +23,6 @@ export default function pluginClientRedirectsPages(
   const {trailingSlash} = context.siteConfig;
 
   const options = normalizePluginOptions(opts);
-
-  // Special case, when using trailingSlash=false we output /xyz.html files instead of /xyz/index.html
-  // It makes no sense to use option fromExtensions=["html"]: the redirect files would be the same as the original files
-  if (options.fromExtensions.includes('html') && trailingSlash === false) {
-    console.warn(
-      chalk.yellow(`Using the Docusaurus redirect plugin with fromExtensions=['html'] and siteConfig.trailingSlash=false is prevented.
-It would lead the redirect plugin to override all the page.html files created by Docusaurus.`),
-    );
-    options.fromExtensions = options.fromExtensions.filter(
-      (ext) => ext !== 'html',
-    );
-  }
 
   return {
     name: 'docusaurus-plugin-client-redirects',


### PR DESCRIPTION
## Motivation

Follow-up of https://github.com/facebook/docusaurus/issues/5055#issuecomment-870951538

When using `trailingSlash: true`, the redirect plugin does not emit files for `fromExtensions: ['html']` because it ignorers all paths ending with `/`

If there's a path such as `/xyz/`, we should emit `/xyz.html/index.html`, otherwise deployments like Netlify wouldn't redirect when browsing `/xyz.html`, they would just serve the HTML file and it would lead to a 404 error due to the route not existing on the frontend router.

Also cleanup now useless warning since we reverted to emit `/xyz.html/index.html`, as the warning does not make sense anymore

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

test + preview

This URL now works fine, while it used to display a frontend 404 error: https://deploy-preview-5093--docusaurus-2.netlify.app/docs/typescript-support.html

## Related PRs

https://github.com/facebook/docusaurus/pull/5085
