### PR TITLE
fix(v2): fix swizzle readComponent

### DIFF
--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -48,27 +48,27 @@ export function getPluginNames(plugins: PluginConfig[]): string[] {
     .filter((plugin) => plugin !== '');
 }
 
-function walk(dir: string): Array<string> {
-  let results: Array<string> = [];
-  const list = fs.readdirSync(dir);
-  list.forEach((file: string) => {
-    const fullPath = path.join(dir, file);
-    const stat = fs.statSync(fullPath);
-    if (stat && stat.isDirectory()) {
-      results = results.concat(walk(fullPath));
-    } else if (!/node_modules|.css|.d.ts|.d.map/.test(fullPath)) {
-      results.push(fullPath);
-    }
-  });
-  return results;
-}
-
 const formatComponentName = (componentName: string): string =>
   componentName
     .replace(/(\/|\\)index.(js|tsx|ts|jsx)/, '')
     .replace(/.(js|tsx|ts|jsx)/, '');
 
 function readComponent(themePath: string) {
+  function walk(dir: string): Array<string> {
+    let results: Array<string> = [];
+    const list = fs.readdirSync(dir);
+    list.forEach((file: string) => {
+      const fullPath = path.join(dir, file);
+      const stat = fs.statSync(fullPath);
+      if (stat && stat.isDirectory()) {
+        results = results.concat(walk(fullPath));
+      } else if (!/\.css|\.d\.ts|\.d\.map/.test(fullPath)) {
+        results.push(fullPath);
+      }
+    });
+    return results;
+  }
+
   return walk(themePath).map((filePath) =>
     formatComponentName(path.relative(themePath, filePath)),
   );


### PR DESCRIPTION

## Motivation

Bad regex prevent usage of `npm run swizzle @docusaurus/theme-classic ` when running outside our Docusaurus monorepo (when using `node_modules`)

Quick fix https://github.com/facebook/docusaurus/issues/5083

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

none: the swizzle code is not testable and hard to maintain, all this should be rewritten someday

