### PR TITLE
fix(v2): fix useEffect infinite loop in blogOnly mode

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
@@ -24,11 +24,15 @@ import {
   GetActivePluginOptions,
 } from '../../client/docsClientUtils';
 
+// Important to use a constant object to avoid React useEffect executions etc...,
+// see https://github.com/facebook/docusaurus/issues/5089
+const StableEmptyObject = {};
+
 // Not using useAllPluginInstancesData() because in blog-only mode, docs hooks are still used by the theme
 // We need a fail-safe fallback when the docs plugin is not in use
 export const useAllDocsData = (): Record<string, GlobalPluginData> =>
   // useAllPluginInstancesData('docusaurus-plugin-content-docs');
-  useGlobalData()['docusaurus-plugin-content-docs'] ?? {};
+  useGlobalData()['docusaurus-plugin-content-docs'] ?? StableEmptyObject;
 
 export const useDocsData = (pluginId: string | undefined): GlobalPluginData =>
   usePluginData('docusaurus-plugin-content-docs', pluginId) as GlobalPluginData;


### PR DESCRIPTION

## Motivation

Infinite loop produced because we use an "unstable" empty object fallback when there is no docs global data available => triggers downstream useEffect re-executions because the unstable object is used in dependency array

Issue can be reproduced in blogOnly mode `yarn workspace docusaurus-2-website start:blogOnly`

Fix https://github.com/facebook/docusaurus/issues/5089

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

none :( unfortunately this only happens on the client and the blogOnly CI action we have fails to catch this at build time

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
