### PR TITLE
fix(v2): fix SkipToContent programmatic focus when updating querystring

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -34,7 +34,7 @@ function SkipToContent(): JSX.Element {
   };
 
   useLocationChange(({location}) => {
-    if (containerRef.current && !location.hash && action !== 'POP') {
+    if (containerRef.current && !location.hash && action === 'PUSH') {
       programmaticFocus(containerRef.current);
     }
   });


### PR DESCRIPTION
## Motivation

SkipToContent programmatic focus should only happen when we navigate with a push action, and ignored for back/next (pop) or querystring updates (replace)

Fix https://github.com/facebook/docusaurus/issues/5100

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview
