### PR TITLE
fix(v2): Fix update-notifier not run at first and not notifying consistently

### DIFF
--- a/packages/docusaurus/bin/beforeCli.js
+++ b/packages/docusaurus/bin/beforeCli.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const chalk = require('chalk');
+const fs = require('fs-extra');
+const semver = require('semver');
+const path = require('path');
+const updateNotifier = require('update-notifier');
+const boxen = require('boxen');
+
+const {
+  name,
+  version,
+  engines: {node: requiredVersion},
+} = require('../package.json');
+
+// Notify user if @docusaurus packages is outdated
+//
+// Note: this is a 2-step process to avoid delaying cli usage by awaiting a response:
+// - 1st run: trigger background job to check releases + store result
+// - 2nd run: display potential update to users
+//
+// Note: even if the
+//
+// cache data is stored in ~/.config/configstore/update-notifier-@docusaurus
+//
+const notifier = updateNotifier({
+  pkg: {
+    name,
+    version,
+  },
+  // Check is in background so it's fine to use a small value like 1h
+  // Use 0 for debugging
+  updateCheckInterval: 1000 * 60 * 60,
+  // updateCheckInterval: 0
+});
+
+// Hacky way to ensure we check for updates on first run
+// Note: the notification will only happen in the 2nd run
+// See https://github.com/yeoman/update-notifier/issues/209
+if (Date.now() - notifier.config.get('lastUpdateCheck') < 50) {
+  notifier.config.set('lastUpdateCheck', 0);
+  notifier.check();
+}
+
+if (notifier.update && notifier.update.current !== notifier.update.latest) {
+  // Because notifier clears cached data after reading it, leading to notifier not consistently displaying the update
+  // See https://github.com/yeoman/update-notifier/issues/209
+  notifier.config.set('update', notifier.update);
+
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  const sitePkg = require(path.resolve(process.cwd(), 'package.json'));
+  const siteDocusaurusPackagesForUpdate = Object.keys(sitePkg.dependencies)
+    .filter((p) => p.startsWith('@docusaurus'))
+    .map((p) => p.concat('@latest'))
+    .join(' ');
+  const isYarnUsed = fs.existsSync(path.resolve(process.cwd(), 'yarn.lock'));
+  const upgradeCommand = isYarnUsed
+    ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
+    : `npm i ${siteDocusaurusPackagesForUpdate}`;
+
+  const boxenOptions = {
+    padding: 1,
+    margin: 1,
+    align: 'center',
+    borderColor: 'yellow',
+    borderStyle: 'round',
+  };
+
+  const docusaurusUpdateMessage = boxen(
+    `Update available ${chalk.dim(`${notifier.update.current}`)}${chalk.reset(
+      ' → ',
+    )}${chalk.green(
+      `${notifier.update.latest}`,
+    )}\n\nTo upgrade Docusaurus packages with the latest version, run the following command:\n${chalk.cyan(
+      `${upgradeCommand}`,
+    )}`,
+    boxenOptions,
+  );
+
+  console.log(docusaurusUpdateMessage);
+}
+
+// notify user if node version needs to be updated
+if (!semver.satisfies(process.version, requiredVersion)) {
+  console.log(
+    chalk.red(`\nMinimum Node version not met :(`) +
+      chalk.yellow(
+        `\n\nYou are using Node ${process.version}. We require Node ${requiredVersion} or up!\n`,
+      ),
+  );
+  process.exit(1);
+}

--- a/packages/docusaurus/bin/beforeCli.js
+++ b/packages/docusaurus/bin/beforeCli.js
@@ -42,7 +42,10 @@ const notifier = updateNotifier({
 // Hacky way to ensure we check for updates on first run
 // Note: the notification will only happen in the 2nd run
 // See https://github.com/yeoman/update-notifier/issues/209
-if (Date.now() - notifier.config.get('lastUpdateCheck') < 50) {
+if (
+  !notifier.disabled &&
+  Date.now() - notifier.config.get('lastUpdateCheck') < 50
+) {
   notifier.config.set('lastUpdateCheck', 0);
   notifier.check();
 }

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -10,12 +10,8 @@
  */
 
 const chalk = require('chalk');
-const fs = require('fs-extra');
-const semver = require('semver');
 const path = require('path');
 const cli = require('commander');
-const updateNotifier = require('update-notifier');
-const boxen = require('boxen');
 const {
   build,
   swizzle,
@@ -27,69 +23,8 @@ const {
   writeTranslations,
   writeHeadingIds,
 } = require('../lib');
-const {
-  name,
-  version,
-  engines: {node: requiredVersion},
-} = require('../package.json');
 
-// notify user if @docusaurus packages is outdated
-const notifier = updateNotifier({
-  pkg: {
-    name,
-    version,
-  },
-});
-
-// allow the user to be notified for updates on the first run
-if (notifier.lastUpdateCheck === Date.now()) {
-  notifier.lastUpdateCheck = 0;
-}
-
-if (notifier.update && semver.gt(this.update.latest, this.update.current)) {
-  // eslint-disable-next-line import/no-dynamic-require, global-require
-  const sitePkg = require(path.resolve(process.cwd(), 'package.json'));
-  const siteDocusaurusPackagesForUpdate = Object.keys(sitePkg.dependencies)
-    .filter((p) => p.startsWith('@docusaurus'))
-    .map((p) => p.concat('@latest'))
-    .join(' ');
-  const isYarnUsed = fs.existsSync(path.resolve(process.cwd(), 'yarn.lock'));
-  const upgradeCommand = isYarnUsed
-    ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
-    : `npm i ${siteDocusaurusPackagesForUpdate}`;
-
-  const boxenOptions = {
-    padding: 1,
-    margin: 1,
-    align: 'center',
-    borderColor: 'yellow',
-    borderStyle: 'round',
-  };
-
-  const docusaurusUpdateMessage = boxen(
-    `Update available ${chalk.dim(`${notifier.update.current}`)}${chalk.reset(
-      ' → ',
-    )}${chalk.green(
-      `${notifier.update.latest}`,
-    )}\n\nTo upgrade Docusaurus packages with the latest version, run the following command:\n${chalk.cyan(
-      `${upgradeCommand}`,
-    )}`,
-    boxenOptions,
-  );
-
-  console.log(docusaurusUpdateMessage);
-}
-
-// notify user if node version needs to be updated
-if (!semver.satisfies(process.version, requiredVersion)) {
-  console.log(
-    chalk.red(`\nMinimum Node.js version not met :(`) +
-      chalk.yellow(
-        `\n\nYou are using Node.js ${process.version}. We require Node.js ${requiredVersion} or up!\n`,
-      ),
-  );
-  process.exit(1);
-}
+require('./beforeCli');
 
 cli.version(require('../package.json').version).usage('<command> [options]');
 


### PR DESCRIPTION

## Motivation

- Move notifier logic to separate file
- Fix code to make it check new version on first run
- Make it display notification consistently (not at most once per interval): https://github.com/yeoman/update-notifier/issues/209
- Reduce interval to 1h: it is a background check and does not slow-down the cli anyway so let's do it more
- Useful comments for later usage

Motived by this comment: https://github.com/facebook/docusaurus/issues/5105#issuecomment-871890235

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

local tests


