### PR TITLE
misc: monitor site global data with build size bot

### DIFF
--- a/.github/workflows/v2-build-size-report.yml
+++ b/.github/workflows/v2-build-size-report.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: 'build:v2:en'
-          pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html}'
+          pattern: '{website/build/assets/js/main*js,website/build/assets/css/styles*css,website/build/index.html,website/build/blog/**/introducing-docusaurus/*,website/build/docs/introduction/index.html,website/.docusaurus/globalData.json}'
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 30
           compression: 'none'


### PR DESCRIPTION
## Motivation

`globalData.json` is a file that should rather stay small over time as it's loaded for all pages of the site and can increase js processing time and delay hydration
