### PR TITLE
docs(v2): clarify how to disable edit links entirely

### DIFF
--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -33,7 +33,7 @@ module.exports = {
         /**
          * Base url to edit your site.
          * Docusaurus will compute the final editUrl with "editUrl + relativeDocPath"
-         * Omitting this variable entirely will disable edit liks.
+         * Omitting this variable entirely will disable edit links.
          */
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
         /**

--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -33,6 +33,7 @@ module.exports = {
         /**
          * Base url to edit your site.
          * Docusaurus will compute the final editUrl with "editUrl + relativeDocPath"
+         * Omitting this variable entirely will disable edit liks.
          */
         editUrl: 'https://github.com/facebook/docusaurus/edit/master/website/',
         /**


### PR DESCRIPTION
## Motivation

I tried to disable all "Edit this page" links using several ways and almost started to swizzle components when I found another PR that explained how to disable the edit links by omitting the `editURL` variable entirely. This small change will hopefully make it easier for future users.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This change does not require a test plan.

## Related PRs

None.
