### PR TITLE
polish(v2): attempt to use color-scheme

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -10,6 +10,13 @@ body {
   height: 100%;
 }
 
+html[data-theme='light'] {
+  color-scheme: light;
+}
+html[data-theme='dark'] {
+  color-scheme: dark;
+}
+
 #__docusaurus {
   min-height: 100%;
   display: flex;


### PR DESCRIPTION
## Motivation

We should use a native dark mode scrollbar if possible.

`color-scheme` CSS property seems to help to that:

https://caniuse.com/?search=color-scheme

https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme

https://blog.okikio.dev/psa-add-dark-mode-to-your-sites-or-at-least-let-the-browsers-do-it-for-you

https://web.dev/color-scheme/

Fix https://github.com/facebook/docusaurus/issues/3023

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview


