### PR TITLE
fix(v2): Invalid type definition for injectHtmlTags

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -247,6 +247,8 @@ export interface Plugin<Content = unknown> {
   getClientModules?(): string[];
   extendCli?(cli: Command): void;
   injectHtmlTags?({
+    content,
+  }: {
     content: Content,
   }): {
     headTags?: HtmlTags;


### PR DESCRIPTION
This was likely a typo, and resulted in the following error when using Typescript strict mode:

> node_modules/@docusaurus/types/src/index.d.ts(250,14): error TS7031: Binding element 'Content' implicitly has an 'any' type.

## Motivation

I'd like my Typescript Docusaurus plugin to type-check without errors.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

The error is gone in my project :) Also, the code is now aligned with similar definitions, like the one for `getTranslationFiles` (a few lines down).

## Related PRs

none
