### PR TITLE
fix(v2): remove webpackConfig.resolve.symlinks: true

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -139,7 +139,6 @@ export function createBaseConfig(
     resolve: {
       unsafeCache: false, // not enabled, does not seem to improve perf much
       extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
-      symlinks: true,
       roots: [
         // Allow resolution of url("/fonts/xyz.ttf") by webpack
         // See https://webpack.js.org/configuration/resolve/#resolveroots

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -139,7 +139,7 @@ export function createBaseConfig(
     resolve: {
       unsafeCache: false, // not enabled, does not seem to improve perf much
       extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
-      symlinks: false,
+      symlinks: false, // disabled on purpose (https://github.com/facebook/docusaurus/issues/3272)
       roots: [
         // Allow resolution of url("/fonts/xyz.ttf") by webpack
         // See https://webpack.js.org/configuration/resolve/#resolveroots

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -139,6 +139,7 @@ export function createBaseConfig(
     resolve: {
       unsafeCache: false, // not enabled, does not seem to improve perf much
       extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
+      symlinks: false,
       roots: [
         // Allow resolution of url("/fonts/xyz.ttf") by webpack
         // See https://webpack.js.org/configuration/resolve/#resolveroots

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -119,10 +119,11 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
     [
       '@docusaurus/plugin-content-docs',
       {
+        // This plugin instance is used to test fancy edge cases
         id: 'docs-tests',
+        // Using a symlinked folder as source, test against https://github.com/facebook/docusaurus/issues/3272
         path: 'dogfooding/docs-tests-symlink',
         routeBasePath: 'docs-tests',
-        // sidebarPath: require.resolve('./sidebarsCommunity.js'),
       },
     ],
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -117,6 +117,16 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
       },
     ],
     [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'docs-tests',
+        path: 'dogfooding/docs-tests-symlink',
+        routeBasePath: 'docs-tests',
+        // sidebarPath: require.resolve('./sidebarsCommunity.js'),
+      },
+    ],
+
+    [
       '@docusaurus/plugin-content-blog',
       {
         id: 'second-blog',

--- a/website/dogfooding/docs-tests-symlink
+++ b/website/dogfooding/docs-tests-symlink
@@ -1,0 +1,1 @@
+docs-tests

--- a/website/dogfooding/docs-tests/index.md
+++ b/website/dogfooding/docs-tests/index.md
@@ -1,0 +1,7 @@
+---
+slug: /
+---
+
+# Docs tests
+
+This Docusaurus docs plugin instance is meant to test fancy edge-cases that regular unit tests don't really cover.


### PR DESCRIPTION
## Motivation

remove `webpackConfig.resolve.symlinks: true`

This might not be intuitive, but to make Docusaurus work with symlinked folders, we have to use default/false instead.

Should fix https://github.com/facebook/docusaurus/issues/3272

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests + preview

