### PR TITLE
docs: `docusaurus clear` to load swizzle component

### DIFF
--- a/website/docs/using-themes.md
+++ b/website/docs/using-themes.md
@@ -126,7 +126,7 @@ Although we highly discourage swizzling of all components, if you wish to do tha
 npm run swizzle @docusaurus/theme-classic
 ```
 
-**Note**: You need to restart your webpack dev server in order for Docusaurus to know about the new component.
+**Note**: You need to restart your webpack dev server and clear cache (`docusaurus clear`) in order for Docusaurus to know about the new component.
 
 ## Wrapping theme components {#wrapping-theme-components}
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Docs should indicate swizzle components don't reflect unless you run `docusaurus clear`, I ended up joining discord channel and searching a bunch of comments before finding out, I think it could be potentially helpful for many for this to be in the docs

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
