### PR TITLE
docs(v2): GIF format is not suported

### DIFF
--- a/website/docs/api/plugins/plugin-ideal-image.md
+++ b/website/docs/api/plugins/plugin-ideal-image.md
@@ -26,7 +26,7 @@ module.exports = {
 
 ## Usage {#usage}
 
-This plugin supports the PNG, GIF and JPG formats only.
+This plugin supports the PNG and JPG formats only.
 
 ```jsx
 import Image from '@theme/IdealImage';


### PR DESCRIPTION
https://github.com/facebook/docusaurus/issues/2956

Please check the issue above.
GIF format is currently is not supported

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Ideal image plugin does not support gif  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
