### PR TITLE
chore: upgrade crowdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.12.16",
     "@babel/plugin-transform-modules-commonjs": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@crowdin/cli": "^3.5.3",
+    "@crowdin/cli": "^3.6.4",
     "@formatjs/intl-datetimeformat": "^3.2.12",
     "@formatjs/intl-numberformat": "^6.2.2",
     "@formatjs/intl-pluralrules": "^4.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,10 +1287,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@crowdin/cli@^3.5.2", "@crowdin/cli@^3.5.3":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@crowdin/cli/-/cli-3.6.1.tgz#3422536781be49808ab6abda8bb17cb29df01dbb"
-  integrity sha512-RUKFrPCX3R1MJPyRpBSqWFwmjbDlVWLHtXAzx2FPeyjnyMXrXLPJ8YEl4t8YU+96q/0t46qTdmMLeQmYyDEvGQ==
+"@crowdin/cli@^3.5.2", "@crowdin/cli@^3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@crowdin/cli/-/cli-3.6.4.tgz#37e872fbbc85fdfb55e8deba4e35d4393a802aad"
+  integrity sha512-kFqTf1dFhtSMfF4YWyJ6EAKjjtBEVtHhX2f9cBYc8I51KMTFIOzqeArKFL2qhhq/1Ition2wuE1z7ySwA341+w==
   dependencies:
     shelljs "^0.8.4"
 


### PR DESCRIPTION


## Motivation

CI is failing to deploy due to a server error. Their support suggested to upgrade.

```
5:55:25 PM: ❌ Fetching project info
5:55:25 PM: ❌ Failed to collect project info. Please contact our support team for help
5:55:25 PM: ❌ Error from server: <Code: <empty_code>, Message: Unrecognized field "customSegmentation" (class com.crowdin.client.sourcefiles.model.OtherFileImportOptions), not marked as ignorable (one known property: "contentSegmentation"])
5:55:25 PM:  at [Source: (String)"{"contentSegmentation":true,"customSegmentation":false}"; line: 1, column: 55] (through reference chain: com.crowdin.client.sourcefiles.model.FileInfoResponseList["data"]->java.util.ArrayList[0]->com.crowdin.client.sourcefiles.model.FileResponseObject["data"]->com.crowdin.client.sourcefiles.model.File["importOptions"]->com.crowdin.client.sourcefiles.model.OtherFileImportOptions["customSegmentation"])>
```