### PR TITLE
refactor(v2): use Collapsible for mobile nav items

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -10,7 +10,11 @@ import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import {useLocation} from '@docusaurus/router';
-import {isSamePath} from '@docusaurus/theme-common';
+import {
+  isSamePath,
+  useCollapsible,
+  Collapsible,
+} from '@docusaurus/theme-common';
 import type {
   NavLinkProps,
   DesktopOrMobileNavBarItemProps,
@@ -167,11 +171,11 @@ function NavItemMobile({
   position: _position, // Need to destructure position from props so that it doesn't get passed on.
   ...props
 }: DesktopOrMobileNavBarItemProps) {
-  const menuListRef = useRef<HTMLUListElement>(null);
   const {pathname} = useLocation();
-  const [collapsed, setCollapsed] = useState(
-    () => !items?.some((item) => isSamePath(item.to, pathname)) ?? true,
-  );
+  const {collapsed, toggleCollapsed} = useCollapsible({
+    initialState: () =>
+      !items?.some((item) => isSamePath(item.to, pathname)) ?? true,
+  });
 
   const navLinkClassNames = (extraClassName?: string, isSubList = false) =>
     clsx(
@@ -190,10 +194,6 @@ function NavItemMobile({
     );
   }
 
-  const menuListHeight = menuListRef.current?.scrollHeight
-    ? `${menuListRef.current?.scrollHeight}px`
-    : undefined;
-
   return (
     <li
       className={clsx('menu__list-item', {
@@ -205,16 +205,11 @@ function NavItemMobile({
         {...props}
         onClick={(e) => {
           e.preventDefault();
-          setCollapsed((state) => !state);
+          toggleCollapsed();
         }}>
         {props.children ?? props.label}
       </NavLink>
-      <ul
-        className="menu__list"
-        ref={menuListRef}
-        style={{
-          height: !collapsed ? menuListHeight : undefined,
-        }}>
+      <Collapsible as="ul" className="menu__list" collapsed={collapsed}>
         {items.map(({className: childItemClassName, ...childItemProps}, i) => (
           <li className="menu__list-item" key={i}>
             <NavLink
@@ -225,7 +220,7 @@ function NavItemMobile({
             />
           </li>
         ))}
-      </ul>
+      </Collapsible>
     </li>
   );
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

We can now use the built-in `Collapsible` component for nav items on mobiles.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
