### PR TITLE
fix(v2): improve work of useCollapsible hook with multiple clicks

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/useCollapsible.tsx
+++ b/packages/docusaurus-theme-common/src/utils/useCollapsible.tsx
@@ -119,23 +119,26 @@ function useCollapseAnimation({
     el.style.willChange = 'height';
 
     function startAnimation(): () => void {
-      // When collapsing
-      if (collapsed) {
-        applyTransitionStyles();
-        const animationFrame = requestAnimationFrame(() => {
-          el.style.height = CollapsedStyles.height;
-          el.style.overflow = CollapsedStyles.overflow;
-        });
-        return () => cancelAnimationFrame(animationFrame);
-      }
-      // When expanding
-      else {
-        el.style.display = 'block';
-        const animationFrame = requestAnimationFrame(() => {
+      const animationFrame = requestAnimationFrame(() => {
+        // When collapsing
+        if (collapsed) {
           applyTransitionStyles();
-        });
-        return () => cancelAnimationFrame(animationFrame);
-      }
+
+          requestAnimationFrame(() => {
+            el.style.height = CollapsedStyles.height;
+            el.style.overflow = CollapsedStyles.overflow;
+          });
+        }
+        // When expanding
+        else {
+          el.style.display = 'block';
+          requestAnimationFrame(() => {
+            applyTransitionStyles();
+          });
+        }
+      });
+
+      return () => cancelAnimationFrame(animationFrame);
     }
 
     return startAnimation();
@@ -169,8 +172,22 @@ export function Collapsible({
       // @ts-expect-error: see https://twitter.com/sebastienlorber/status/1412784677795110914
       ref={collapsibleRef}
       onTransitionEnd={(e) => {
-        if (e.propertyName === 'height') {
-          applyCollapsedStyle(collapsibleRef.current!, collapsed);
+        if (e.propertyName !== 'height') {
+          return;
+        }
+
+        const el = collapsibleRef.current!;
+        const currentCollapsibleElementHeight = el.style.height;
+
+        if (
+          !collapsed &&
+          parseInt(currentCollapsibleElementHeight, 10) === el.scrollHeight
+        ) {
+          applyCollapsedStyle(el, false);
+        }
+
+        if (currentCollapsibleElementHeight === CollapsedStyles.height) {
+          applyCollapsedStyle(el, true);
         }
       }}
       className={className}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, the `useCollapsible` hook does not respond well to multiple clicks, especially when the current transition has not yet completed.

This is especially noticeable on mobile devices: for example, transition for collapsed action is not smooth anymore, so that the content is hidden instantly.

| Before   | After    |
| -------- | -------- |
| ![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/4408379/125249392-ddc1c900-e2fd-11eb-93f9-6b93f65d3a8d.gif) | ![ezgif com-gif-maker (11)](https://user-images.githubusercontent.com/4408379/125249415-e3b7aa00-e2fd-11eb-94fa-7b3261260b2f.gif) |

Moreover, you have to wait for the transition to finish before starting new one, otherwise there will also be "sharp" transition.

| Before   | After    |
| -------- | -------- |
| ![ezgif com-gif-maker (15)](https://user-images.githubusercontent.com/4408379/125249813-490b9b00-e2fe-11eb-8dfb-7f7ae11617f2.gif) | ![ezgif com-gif-maker (14)](https://user-images.githubusercontent.com/4408379/125250020-79ebd000-e2fe-11eb-8263-2d5fe57e8007.gif) |

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
