### PR TITLE
polish(v2): more suitable code block line highlight color

### DIFF
--- a/packages/docusaurus-init/templates/classic/src/css/custom.css
+++ b/packages/docusaurus-init/templates/classic/src/css/custom.css
@@ -18,12 +18,12 @@
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgb(250, 250, 200);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
 html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgb(66, 80, 80);
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -21,14 +21,14 @@ html[data-theme='dark'] {
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgb(250, 250, 200);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
 html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgb(66, 80, 80);
 }
 
 .header-github-link:hover {


### PR DESCRIPTION
## Motivation

- With current code line highlight colours for the classic theme, it is sometimes hard to infer which is highlighted line and which is not especially when there are several consecutive highlighted and non-highlighted lines are present. 
- For the classic dark theme, the code line highlight colour is very close to the page background colour. Hence, it might appear the highlighted line dividing the code block vertically.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![code-highlight](https://user-images.githubusercontent.com/31024886/125412464-88ff7a80-e3f1-11eb-9513-c494ce4cea4a.png)

