### PR TITLE
fix(v2): Fix Collapsible hydration layout shift

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/useCollapsible.tsx
+++ b/packages/docusaurus-theme-common/src/utils/useCollapsible.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import React, {
   useState,
   useEffect,
@@ -146,8 +147,16 @@ function useCollapseAnimation({
 }
 
 type CollapsibleElementType = React.ElementType<
-  Pick<React.HTMLAttributes<unknown>, 'className' | 'onTransitionEnd'>
+  Pick<React.HTMLAttributes<unknown>, 'className' | 'onTransitionEnd' | 'style'>
 >;
+
+// Prevent hydration layout shift before anims are handled imperatively with JS
+function getSSRStyle(collapsed: boolean) {
+  if (ExecutionEnvironment.canUseDOM) {
+    return undefined;
+  }
+  return collapsed ? CollapsedStyles : ExpandedStyles;
+}
 
 export function Collapsible({
   as: As = 'div',
@@ -171,6 +180,7 @@ export function Collapsible({
     <As
       // @ts-expect-error: see https://twitter.com/sebastienlorber/status/1412784677795110914
       ref={collapsibleRef}
+      style={getSSRStyle(collapsed)}
       onTransitionEnd={(e) => {
         if (e.propertyName !== 'height') {
           return;


### PR DESCRIPTION


## Motivation

On the server rendering, the collapsible component is not collapsed properly when `props.collapsed=true`

This affects collapsible mobile TOC, not the navbar / sidebar items because they have extra CSS from Infima.

Can be seen with JS disabled:

![image](https://user-images.githubusercontent.com/749374/125450370-c6db31b8-eb9f-4be4-9a85-b1d15f54104a.png)


This is because collapsed style is applied through JS only after hydration, so the collapsing happens with a little delay.

This PR make sure we apply collapsed style on the server to avoid that layout shift


(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

## Related PRs

https://github.com/facebook/docusaurus/pull/4273
