### PR TITLE
fix(v2): revert webpack.resolve.symlinks = false

### DIFF
--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -185,8 +185,12 @@ export default async function start(
       },
       publicPath: baseUrl,
       watchOptions: {
-        ignored: /node_modules/,
         poll: cliOptions.poll,
+
+        // Useful options for our own monorepo using symlinks!
+        // See https://github.com/webpack/webpack/issues/11612#issuecomment-879259806
+        followSymlinks: true,
+        ignored: /node_modules\/(?!@docusaurus)/,
       },
       historyApiFallback: {
         rewrites: [{from: /\/*/, to: baseUrl}],

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -139,7 +139,7 @@ export function createBaseConfig(
     resolve: {
       unsafeCache: false, // not enabled, does not seem to improve perf much
       extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
-      symlinks: false, // disabled on purpose (https://github.com/facebook/docusaurus/issues/3272)
+      symlinks: true, // see https://github.com/facebook/docusaurus/issues/3272
       roots: [
         // Allow resolution of url("/fonts/xyz.ttf") by webpack
         // See https://webpack.js.org/configuration/resolve/#resolveroots

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const fs = require('fs');
 const path = require('path');
 const versions = require('./versions.json');
 const math = require('remark-math');
@@ -124,10 +125,8 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
         routeBasePath: 'docs-tests',
         sidebarPath: 'dogfooding/docs-tests-sidebars.js',
 
-        // Using a symlinked folder as source, test against https://github.com/facebook/docusaurus/issues/3272
-        // TODO temporarily disabled due to Webpack cache bug, see https://github.com/webpack/webpack/issues/11612#issuecomment-879259806
-        // path: 'dogfooding/docs-tests-symlink',
-        path: 'dogfooding/docs-tests',
+        // Using a symlinked folder as source, test for use-case https://github.com/facebook/docusaurus/issues/3272
+        path: fs.realpathSync('dogfooding/docs-tests-symlink'),
       },
     ],
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -121,10 +121,13 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
       {
         // This plugin instance is used to test fancy edge cases
         id: 'docs-tests',
-        // Using a symlinked folder as source, test against https://github.com/facebook/docusaurus/issues/3272
-        path: 'dogfooding/docs-tests-symlink',
         routeBasePath: 'docs-tests',
         sidebarPath: 'dogfooding/docs-tests-sidebars.js',
+
+        // Using a symlinked folder as source, test against https://github.com/facebook/docusaurus/issues/3272
+        // TODO temporarily disabled due to Webpack cache bug, see https://github.com/webpack/webpack/issues/11612#issuecomment-879259806
+        // path: 'dogfooding/docs-tests-symlink',
+        path: 'dogfooding/docs-tests',
       },
     ],
 


### PR DESCRIPTION
## Motivation

Revert change made in https://github.com/facebook/docusaurus/pull/5126 => back to `webpack.resolve.symlinks = true`

We can't do this change because there's a bug in Webpack 5 cache when `resolve.symlinks = false`. 
Disabling the cache is really painful for the development experience.

More infos reported here: 
- https://github.com/facebook/docusaurus/issues/3272#issuecomment-879295056
- https://github.com/webpack/webpack/issues/11612#issuecomment-879259806

Also adding correct dev `watchOptions` so that it would work if we decide later to change to `resolve.symlinks = false` again, or if the user does this with custom Webpack config.




### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

## Related PRs

https://github.com/facebook/docusaurus/pull/5126
