### PR TITLE
fix(v2): fix yarn clear command

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test": "cross-env TZ=UTC jest",
     "test:build:v2": "./admin/scripts/test-release.sh",
     "watch": "yarn lerna run --parallel --no-private watch",
-    "clear": "yarn workspace docusaurus-2-website clear && yarn lerna exec --ignore docusaurus yarn rimraf lib",
+    "clear": "(yarn workspace docusaurus-2-website clear || echo 'Failure while running docusaurus clear') && yarn lerna exec --ignore docusaurus yarn rimraf lib lib-next",
     "test:baseUrl": "yarn build:v2:baseUrl && yarn serve:v2:baseUrl",
     "lock:update": "npx yarn-deduplicate"
   },


### PR DESCRIPTION
## Motivation

Fix monorepo `yarn clear` command.

We run it before publishing and it did not clean-up the `lib-next` dist folders, so older/renamed comps remain available for swizzle in recent releases. This makes sure it does not happen again.

