### PR TITLE
fix(v2): fix website PWA icon hrefs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -196,7 +196,7 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
           {
             tagName: 'link',
             rel: 'icon',
-            href: 'img/docusaurus.png',
+            href: `${baseUrl}img/docusaurus.png`,
           },
           {
             tagName: 'link',
@@ -221,18 +221,18 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
           {
             tagName: 'link',
             rel: 'apple-touch-icon',
-            href: 'img/docusaurus.png',
+            href: `${baseUrl}img/docusaurus.png`,
           },
           {
             tagName: 'link',
             rel: 'mask-icon',
-            href: 'img/docusaurus.svg',
+            href: `${baseUrl}img/docusaurus.png`,
             color: 'rgb(62, 204, 94)',
           },
           {
             tagName: 'meta',
             name: 'msapplication-TileImage',
-            content: 'img/docusaurus.png',
+            href: `${baseUrl}img/docusaurus.png`,
           },
           {
             tagName: 'meta',


### PR DESCRIPTION

## Motivation

Our site has a few console fetch errors due to using bad relative PWA URLs

![image](https://user-images.githubusercontent.com/749374/125638448-7d60c9fc-17b6-4a47-81b5-fd64e91944bf.png)

Let's fix this and make them baseUrl insensitive too

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

