### PR TITLE
refactor(v2): mobile dropdown navbar: expand when subitem become active

### DIFF
--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -63,3 +63,5 @@ export {
   AnnouncementBarProvider,
   useAnnouncementBar,
 } from './utils/announcementBarUtils';
+
+export {useLocalPathname} from './utils/useLocalPathname';

--- a/packages/docusaurus-theme-common/src/utils/useLocalPathname.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocalPathname.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useLocation} from '@docusaurus/router';
+
+// Get the pathname of current route, without the optional site baseUrl
+// - /docs/myDoc => /docs/myDoc
+// - /baseUrl/docs/myDoc => /docs/myDoc
+export function useLocalPathname(): string {
+  const {
+    siteConfig: {baseUrl},
+  } = useDocusaurusContext();
+  const {pathname} = useLocation();
+  return pathname.replace(baseUrl, '/');
+}


### PR DESCRIPTION


## Motivation

Little UX detail reported here: https://github.com/facebook/docusaurus/pull/4273#issuecomment-877360318

The mobile sidebar dropdowns should auto-expand when they contain an active item (+ handle activeBaseRegex too)



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

We don't really have the use-case on Docusaurus site so used another site/PR for tests: 
https://github.com/temporalio/documentation/pull/515


