### PR TITLE
refactor(v2): automatically add base URL to PWA head tags

### DIFF
--- a/packages/docusaurus-plugin-pwa/package.json
+++ b/packages/docusaurus-plugin-pwa/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "^7.12.16",
     "@docusaurus/core": "2.0.0-beta.3",
     "@docusaurus/theme-common": "2.0.0-beta.3",
+    "@docusaurus/utils": "2.0.0-beta.3",
     "@docusaurus/utils-validation": "2.0.0-beta.3",
     "babel-loader": "^8.2.2",
     "clsx": "^1.1.1",

--- a/packages/docusaurus-plugin-pwa/src/index.js
+++ b/packages/docusaurus-plugin-pwa/src/index.js
@@ -8,6 +8,7 @@
 const LogPlugin = require('@docusaurus/core/lib/webpack/plugins/LogPlugin')
   .default;
 const {compile} = require('@docusaurus/core/lib/webpack/utils');
+const {normalizeUrl} = require('@docusaurus/utils');
 const path = require('path');
 const webpack = require('webpack');
 const {injectManifest} = require('workbox-build');
@@ -88,12 +89,15 @@ function plugin(context, options) {
     injectHtmlTags() {
       const headTags = [];
       if (isProd && pwaHead) {
-        pwaHead.forEach(({tagName, ...attributes}) =>
-          headTags.push({
+        pwaHead.forEach(({tagName, ...attributes}) => {
+          if (attributes.href) {
+            attributes.href = normalizeUrl([baseUrl, attributes.href]);
+          }
+          return headTags.push({
             tagName,
             attributes,
-          }),
-        );
+          });
+        });
       }
       return {headTags};
     },

--- a/packages/docusaurus-plugin-pwa/src/index.js
+++ b/packages/docusaurus-plugin-pwa/src/index.js
@@ -90,7 +90,7 @@ function plugin(context, options) {
       const headTags = [];
       if (isProd && pwaHead) {
         pwaHead.forEach(({tagName, ...attributes}) => {
-          if (attributes.href) {
+          if (attributes.href && !attributes.href.startsWith(baseUrl)) {
             attributes.href = normalizeUrl([baseUrl, attributes.href]);
           }
           return headTags.push({

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -196,12 +196,12 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
           {
             tagName: 'link',
             rel: 'icon',
-            href: `${baseUrl}img/docusaurus.png`,
+            href: 'img/docusaurus.png',
           },
           {
             tagName: 'link',
             rel: 'manifest',
-            href: `${baseUrl}manifest.json`,
+            href: 'manifest.json',
           },
           {
             tagName: 'meta',
@@ -221,18 +221,18 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
           {
             tagName: 'link',
             rel: 'apple-touch-icon',
-            href: `${baseUrl}img/docusaurus.png`,
+            href: 'img/docusaurus.png',
           },
           {
             tagName: 'link',
             rel: 'mask-icon',
-            href: `${baseUrl}img/docusaurus.png`,
+            href: 'img/docusaurus.png',
             color: 'rgb(62, 204, 94)',
           },
           {
             tagName: 'meta',
             name: 'msapplication-TileImage',
-            href: `${baseUrl}img/docusaurus.png`,
+            href: 'img/docusaurus.png',
           },
           {
             tagName: 'meta',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

For more consistency, by analogy to other fields that take resource path, such as `favicon` or `themeConfig.image`, base URL should not be manually added by user to the head tags fields for PWA plugin.

Given other similar paths fields, it's reasonable for user to expect base URL to be automatically added to head tags related with PWA as well.

However, it will probably have to be marked as BC to notify users to remove `baseUrl` from their `headTags` of PWA config.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
