### PR TITLE
fix(v2): hide mobile collapsible doc toc if no headings

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -56,15 +56,14 @@ function DocItem(props: Props): JSX.Element {
 
   const windowSize = useWindowSize();
 
+  const canRenderTOC =
+    !hideTableOfContents && DocContent.toc && DocContent.toc.length > 0;
+
   const renderTocMobile =
-    !hideTableOfContents &&
-    DocContent.toc &&
-    (windowSize === 'mobile' || windowSize === 'ssr');
+    canRenderTOC && (windowSize === 'mobile' || windowSize === 'ssr');
 
   const renderTocDesktop =
-    !hideTableOfContents &&
-    DocContent.toc &&
-    (windowSize === 'desktop' || windowSize === 'ssr');
+    canRenderTOC && (windowSize === 'desktop' || windowSize === 'ssr');
 
   return (
     <>


### PR DESCRIPTION

## Motivation

When a page has no heading (empty toc), we should not display the mobile collapsible toc button because it does not reveal any TOC.

Problem can be seen on:
- https://docusaurus.io/docs/create-doc
- https://docs.temporal.io/docs/glossary

![image](https://user-images.githubusercontent.com/749374/125747182-f63a1525-6774-46ea-95a9-cdaa7dd84c4e.png)



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

## Related PRs

https://github.com/facebook/docusaurus/pull/4273