### PR TITLE
fix: fix type for navlink label

### DIFF
--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -334,6 +334,7 @@ declare module '@theme/Navbar' {
 }
 
 declare module '@theme/NavbarItem/DefaultNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {LinkProps} from '@docusaurus/Link';
 
   export type NavLinkProps = LinkProps & {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In #5072 I accidentally deleted the type import for `ReactNode`, causing the type of `NavLinkProps.label` to become `any`. This slipped past the review as well.

### Have you read the [Contributing Guidelines on pull requests]?

Yes

