### PR TITLE
docs(v2): Update tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 
 Docusaurus is a project for building, deploying, and maintaining open source project websites easily.
 
+No time? Check our [5 minutes tutorial ⏱️](https://tutorial.docusaurus.io).
+
 **Tip**: use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immediately in CodeSandbox.
 
 - **Simple to Start**

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://docusaurus.sse.codesandbox.io/)** online.
+Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.0/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.0/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://docusaurus.sse.codesandbox.io/)** online.
+Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io/)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.1/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.1/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://docusaurus.sse.codesandbox.io/)** online.
+Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io/)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.2/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.2/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://docusaurus.sse.codesandbox.io/)** online.
+Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io/)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.3/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.3/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[new.docusaurus.io](https://new.docusaurus.io)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://docusaurus.sse.codesandbox.io/)** online.
+Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io/)** online.
 
 :::
 


### PR DESCRIPTION
## Motivation

Tutorial in codesandbox is often 502
https://docusaurus.sse.codesandbox.io/ 

Moved to standalone deployment
=> https://tutorial.docusaurus.io
