### PR TITLE
fix(v2): wrap dropdown item to missing li element + remove extra attributes

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {cloneElement} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -74,7 +74,7 @@ function DefaultNavbarItemDesktop({
   isDropdownItem = false,
   ...props
 }: DesktopOrMobileNavBarItemProps) {
-  let element = (
+  const element = (
     <NavLink
       className={clsx(
         isDropdownItem ? 'dropdown__link' : 'navbar__item navbar__link',
@@ -85,7 +85,7 @@ function DefaultNavbarItemDesktop({
   );
 
   if (isDropdownItem) {
-    element = cloneElement(<li />, {}, element);
+    return <li>{element}</li>;
   }
 
   return element;

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -72,6 +72,8 @@ export function NavLink({
 function DefaultNavbarItemDesktop({
   className,
   isDropdownItem = false,
+  type: _type,
+  position: _position,
   ...props
 }: DesktopOrMobileNavBarItemProps) {
   let element = (

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -72,8 +72,6 @@ export function NavLink({
 function DefaultNavbarItemDesktop({
   className,
   isDropdownItem = false,
-  type: _type,
-  position: _position,
   ...props
 }: DesktopOrMobileNavBarItemProps) {
   let element = (

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {cloneElement} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -74,7 +74,7 @@ function DefaultNavbarItemDesktop({
   isDropdownItem = false,
   ...props
 }: DesktopOrMobileNavBarItemProps) {
-  return (
+  let element = (
     <NavLink
       className={clsx(
         isDropdownItem ? 'dropdown__link' : 'navbar__item navbar__link',
@@ -83,6 +83,12 @@ function DefaultNavbarItemDesktop({
       {...props}
     />
   );
+
+  if (isDropdownItem) {
+    element = cloneElement(<li />, {}, element);
+  }
+
+  return element;
 }
 
 function DefaultNavbarItemMobile({

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -103,7 +103,11 @@ function DefaultNavbarItemMobile({
   );
 }
 
-function DefaultNavbarItem({mobile = false, ...props}: Props): JSX.Element {
+function DefaultNavbarItem({
+  mobile = false,
+  position: _position, // Need to destructure position from props so that it doesn't get passed on.
+  ...props
+}: Props): JSX.Element {
   const Comp = mobile ? DefaultNavbarItemMobile : DefaultNavbarItemDesktop;
   return <Comp {...props} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
@@ -84,7 +84,6 @@ function DropdownNavbarItemDesktop({
     <div
       ref={dropdownRef}
       className={clsx('navbar__item', 'dropdown', 'dropdown--hoverable', {
-        'dropdown--left': position === 'left',
         'dropdown--right': position === 'right',
         'dropdown--show': showDropdown,
       })}>

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -43,18 +43,27 @@ const getNavbarItemComponent = (type: NavbarItemComponentType) => {
   return navbarItemComponentFn();
 };
 
-function getComponentType({type, ...props}: Props): NavbarItemComponentType {
+function getComponentType(
+  type: string | undefined,
+  isDropdown: boolean,
+): NavbarItemComponentType {
   // Backward compatibility: navbar item with no type set
   // but containing dropdown items should use the type "dropdown"
   if (!type || type === 'default') {
-    const isDropdown = (props as DropdownNavbarItemProps).items !== undefined;
     return isDropdown ? 'dropdown' : 'default';
   }
   return type as NavbarItemComponentType;
 }
 
-export default function NavbarItem(props: Props): JSX.Element {
-  const componentType = getComponentType(props);
+export default function NavbarItem({
+  type,
+  position: _position,
+  ...props
+}: Props): JSX.Element {
+  const componentType = getComponentType(
+    type,
+    (props as DropdownNavbarItemProps).items !== undefined,
+  );
   const NavbarItemComponent = getNavbarItemComponent(componentType);
   return <NavbarItemComponent {...props} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -55,11 +55,7 @@ function getComponentType(
   return type as NavbarItemComponentType;
 }
 
-export default function NavbarItem({
-  type,
-  position: _position,
-  ...props
-}: Props): JSX.Element {
+export default function NavbarItem({type, ...props}: Props): JSX.Element {
   const componentType = getComponentType(
     type,
     (props as DropdownNavbarItemProps).items !== undefined,

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -44,7 +44,7 @@ const getNavbarItemComponent = (type: NavbarItemComponentType) => {
 };
 
 function getComponentType(
-  type: string | undefined,
+  type: Types,
   isDropdown: boolean,
 ): NavbarItemComponentType {
   // Backward compatibility: navbar item with no type set

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -347,7 +347,6 @@ declare module '@theme/NavbarItem/DefaultNavbarItem' {
   export type DesktopOrMobileNavBarItemProps = NavLinkProps & {
     readonly isDropdownItem?: boolean;
     readonly className?: string;
-    readonly position?: 'left' | 'right';
   };
 
   export type Props = DesktopOrMobileNavBarItemProps & {

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -347,6 +347,7 @@ declare module '@theme/NavbarItem/DefaultNavbarItem' {
   export type DesktopOrMobileNavBarItemProps = NavLinkProps & {
     readonly isDropdownItem?: boolean;
     readonly className?: string;
+    readonly position?: 'left' | 'right';
   };
 
   export type Props = DesktopOrMobileNavBarItemProps & {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After merging #5072 there is small regression where dropdown loses wrapper element `<li>`, which is bad for a11y.

> Element “a” not allowed as child of element “ul” in this context. (Suppressing further errors from this subtree.)

![image](https://user-images.githubusercontent.com/4408379/125794852-a3bff170-8681-418e-88cf-1745842c68e0.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

![image](https://user-images.githubusercontent.com/4408379/125795080-77e06493-18fa-471f-806d-0b75b8d6385b.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
