### PR TITLE
fix(v2): add base URL to content attribute of head tags PWA

### DIFF
--- a/packages/docusaurus-plugin-pwa/src/index.js
+++ b/packages/docusaurus-plugin-pwa/src/index.js
@@ -90,9 +90,21 @@ function plugin(context, options) {
       const headTags = [];
       if (isProd && pwaHead) {
         pwaHead.forEach(({tagName, ...attributes}) => {
-          if (attributes.href && !attributes.href.startsWith(baseUrl)) {
-            attributes.href = normalizeUrl([baseUrl, attributes.href]);
-          }
+          ['href', 'content'].forEach((attribute) => {
+            const attributeValue = attributes[attribute];
+
+            if (!attributeValue) {
+              return;
+            }
+
+            const attributePath =
+              !!path.extname(attributeValue) && attributeValue;
+
+            if (attributePath && !attributePath.startsWith(baseUrl)) {
+              attributes[attribute] = normalizeUrl([baseUrl, attributeValue]);
+            }
+          });
+
           return headTags.push({
             tagName,
             attributes,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -232,7 +232,7 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
           {
             tagName: 'meta',
             name: 'msapplication-TileImage',
-            href: 'img/docusaurus.png',
+            content: 'img/docusaurus.png',
           },
           {
             tagName: 'meta',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Follow-up of #5169

According to RocketValidator, we have invalid meta tag `msapplication-TileImage` in which `href` attribute should be replaced by `content`. For that case, we should also adding base URL to `content` attribute in addition to current `href` attribute.

> Attribute “href” not allowed on element “meta” at this point.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
