### PR TITLE
docs: user should restart docusaurus after adding prism additionalLanguage

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -81,6 +81,8 @@ module.exports = {
 };
 ```
 
+Aftre adding `additionalLanguages` you may restart your server if you are running your project in a local server.
+
 If you want to add highlighting for languages not yet supported by Prism, you can swizzle `prism-include-languages`:
 
 ```bash npm2yarn

--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -81,7 +81,7 @@ module.exports = {
 };
 ```
 
-Aftre adding `additionalLanguages` you may restart your server if you are running your project in a local server.
+After adding `additionalLanguages`, restart Docusaurus.
 
 If you want to add highlighting for languages not yet supported by Prism, you can swizzle `prism-include-languages`:
 


### PR DESCRIPTION
if you add php language and don't restart your server, you will get an error like this

uncaught Error: Cannot find module './prism-php'

until you restart your server

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
