### PR TITLE
docs: Adding a note for how to access frontMatter within pages

### DIFF
--- a/website/docs/guides/creating-pages.md
+++ b/website/docs/guides/creating-pages.md
@@ -86,6 +86,19 @@ You can use the full power of React in Markdown pages too, refer to the [MDX](ht
 
 :::
 
+## Available exports
+
+Within a page Node.js variable like __filename and __dirname are available but more usefully the contents of current page frontmatter are exported and available for use in the `frontMatter` variable. So the following will work:
+
+```
+---
+goo: Shoe
+---
+
+<h1>{frontMatter.goo}</h1>
+```
+
+
 ## Routing {#routing}
 
 If you are familiar with other static site generators like Jekyll and Next, this routing approach will feel familiar to you. Any JavaScript file you create under `/src/pages/` directory will be automatically converted to a website page, following the `/src/pages/` directory hierarchy. For example:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
