### PR TITLE
fix: cli upgrade helper fail when no `package.dependencies`

### DIFF
--- a/packages/docusaurus/bin/beforeCli.js
+++ b/packages/docusaurus/bin/beforeCli.js
@@ -57,7 +57,10 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
 
   // eslint-disable-next-line import/no-dynamic-require, global-require
   const sitePkg = require(path.resolve(process.cwd(), 'package.json'));
-  const siteDocusaurusPackagesForUpdate = Object.keys({...sitePkg.dependencies, ...sitePkg.devDependencies})
+  const siteDocusaurusPackagesForUpdate = Object.keys({
+    ...sitePkg.dependencies,
+    ...sitePkg.devDependencies,
+  })
     .filter((p) => p.startsWith('@docusaurus'))
     .map((p) => p.concat('@latest'))
     .join(' ');

--- a/packages/docusaurus/bin/beforeCli.js
+++ b/packages/docusaurus/bin/beforeCli.js
@@ -57,7 +57,7 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
 
   // eslint-disable-next-line import/no-dynamic-require, global-require
   const sitePkg = require(path.resolve(process.cwd(), 'package.json'));
-  const siteDocusaurusPackagesForUpdate = Object.keys(sitePkg.dependencies)
+  const siteDocusaurusPackagesForUpdate = Object.keys({...sitePkg.dependencies, ...sitePkg.devDependencies})
     .filter((p) => p.startsWith('@docusaurus'))
     .map((p) => p.concat('@latest'))
     .join(' ');


### PR DESCRIPTION
## Motivation

In Flipper, https://github.com/facebook/flipper/blob/master/website/package.json,  all our dependencies live in `devDependecies` of our `package.json`. As a result `dependencies` is not set, causing a crash when running `yarn start`:

```
/Users/mweststrate/fbsource/xplat/sonar/website/node_modules/@docusaurus/core/bin/docusaurus.js:50
  const siteDocusaurusPackagesForUpdate = Object.keys(sitePkg.dependencies)
                                                 ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.<anonymous> (/Users/mweststrate/fbsource/xplat/sonar/website/node_modules/@docusaurus/core/bin/docusaurus.js:50:50)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
    at internal/main/run_main_module.js:17:11
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Setting `"dependencies": {}`, works as work around, but this patch fixes the crash, and makes sure the deps are upgraded as well if they live in `devDependencies` instead of `dependencies`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

skimmed

## Test Plan

`yarn install && yarn start` in the flipper website/ dir, per link above. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
