### PR TITLE
fix(v2): Don't error if site has no dependencies list

### DIFF
--- a/packages/docusaurus/bin/beforeCli.js
+++ b/packages/docusaurus/bin/beforeCli.js
@@ -57,7 +57,9 @@ if (notifier.update && notifier.update.current !== notifier.update.latest) {
 
   // eslint-disable-next-line import/no-dynamic-require, global-require
   const sitePkg = require(path.resolve(process.cwd(), 'package.json'));
-  const siteDocusaurusPackagesForUpdate = Object.keys(sitePkg.dependencies)
+  const siteDocusaurusPackagesForUpdate = Object.keys(
+    sitePkg.dependencies || [],
+  )
     .filter((p) => p.startsWith('@docusaurus'))
     .map((p) => p.concat('@latest'))
     .join(' ');


### PR DESCRIPTION
We noticed that when a site has no `dependencies` in its package.json, you *sometimes* get errors when running `yarn start`.

Oddly, its intermittent, seems to occur the first or second time you run `yarn start` after a yarn install, but not consistently. We observed it on the [flipper website](https://github.com/facebook/flipper/blob/master/website/package.json#L13) which only has devDependencies, and no dependencies array.

I think it's reasonable that a lot of sites only need `devDependencies` so this prevents erroring in those cases.

### Have you read the [Contributing Guidelines on pull requests]?

Yes

## Test Plan

Happy case still succeeds:
```
cd docusaurus
yarn
cd website
yarn start
```

I'm unfortunately submitting this fix blind as the issue is intermittent and hard to reproduce.
This is a stack trace from when the problem occurred, which pretty clearly points to where it's happening:
```
/Users/mweststrate/fbsource/xplat/sonar/website/node_modules/@docusaurus/core/bin/docusaurus.js:50
  const siteDocusaurusPackagesForUpdate = Object.keys(sitePkg.dependencies)
                                                 ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.<anonymous> (/Users/mweststrate/fbsource/xplat/sonar/website/node_modules/@docusaurus/core/bin/docusaurus.js:50:50)
```

Searching the code for `dependencies` doesn't show any other references except for the [migration script](https://github.com/facebook/docusaurus/blob/master/packages/docusaurus-migrate/src/index.ts#L758) which already deals with the undefined case.
