### PR TITLE
misc: add script to keep starters branch/repos up-to-date

### DIFF
--- a/generateExamples.js
+++ b/generateExamples.js
@@ -88,8 +88,40 @@ rimraf.sync('./examples/classic');
 rimraf.sync('./examples/facebook');
 rimraf.sync('./examples/bootstrap');
 
+/*
+Starters are repositories/branches that only contains a newly initialized Docusaurus site
+Those are useful for users to inspect (may be more convenient than "examples/classic)
+Also some tools like Netlify deploy button currently require using the main branch of a dedicated repo
+See https://github.com/jamstack/jamstack.org/pull/609
+Button visible here: https://jamstack.org/generators/
+ */
+function updateStarters() {
+  console.log('Will update starter repositories / branches');
+
+  execSync(
+    'git subtree push --prefix examples/classic --squash origin starter',
+  );
+  console.log(
+    'Update success for https://github.com/facebook/docusaurus/tree/starter',
+  );
+
+  try {
+    execSync(
+      'git subtree push --prefix examples/classic --squash git@github.com:slorber/docusaurus-starter.git main --squash',
+    );
+    console.log(
+      'Update success for https://github.com/slorber/docusaurus-starter',
+    );
+  } catch {
+    console.error(
+      'could not update https://github.com/slorber/docusaurus-starter , ask permission to @slorber if needed',
+    );
+  }
+}
+
 // get the list of all available templates
 readdir('./packages/docusaurus-init/templates', (err, data) => {
   const templates = data.filter((i) => i !== 'README.MD');
   templates.forEach(generateTemplateExample);
+  updateStarters();
 });


### PR DESCRIPTION

## Motivation

For Netlify deploy button, subfolders such as `examples/classic` won't work and we must have a real starter repository.
See https://github.com/jamstack/jamstack.org/pull/609

This little automation will permit to keep some starter repo/branch up-to-date:
- https://github.com/facebook/docusaurus/tree/starter
- https://github.com/slorber/docusaurus-starter

In the future having an i18n starter could also be helpful for users to inspect it easily.
