### PR TITLE
refactor: make code block shadows consistent with new admonitions

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -210,9 +210,7 @@ export default function CodeBlock({
             <pre
               /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
               tabIndex={0}
-              className={clsx(className, styles.codeBlock, 'thin-scrollbar', {
-                [styles.codeBlockWithTitle]: codeBlockTitle,
-              })}
+              className={clsx(className, styles.codeBlock, 'thin-scrollbar')}
               style={style}>
               <code className={styles.codeBlockLines}>
                 {tokens.map((line, i) => {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -7,6 +7,9 @@
 
 .codeBlockContainer {
   margin-bottom: var(--ifm-leading);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-lw);
+  overflow: hidden;
 }
 
 .codeBlockContent {
@@ -16,8 +19,6 @@
 }
 
 .codeBlockTitle {
-  border-top-left-radius: var(--ifm-global-radius);
-  border-top-right-radius: var(--ifm-global-radius);
   border-bottom: 1px solid var(--ifm-color-emphasis-300);
   font-size: var(--ifm-code-font-size);
   font-weight: 500;
@@ -25,12 +26,9 @@
 }
 
 .codeBlock {
+  margin: 0;
   padding: 0;
-}
-
-.codeBlockWithTitle {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+  border-radius: 0;
 }
 
 .copyButton {

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
@@ -7,6 +7,9 @@
 
 .playgroundContainer {
   margin-bottom: var(--ifm-leading);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-lw);
+  overflow: hidden;
 }
 
 .playgroundHeader {
@@ -22,8 +25,6 @@
 .playgroundHeader:first-of-type {
   background: var(--ifm-color-emphasis-600);
   color: var(--ifm-color-content-inverse);
-  border-top-left-radius: var(--ifm-global-radius);
-  border-top-right-radius: var(--ifm-global-radius);
 }
 
 .playgroundEditor {
@@ -34,11 +35,6 @@
 }
 
 .playgroundPreview {
-  border: 1px solid var(--ifm-color-emphasis-200);
   padding: 1rem;
-}
-
-.playgroundPreview:last-of-type, .playgroundEditor:last-of-type {
-  border-bottom-left-radius: var(--ifm-global-radius);
-  border-bottom-right-radius: var(--ifm-global-radius);
+  background-color: var(--ifm-pre-background);
 }


### PR DESCRIPTION
## Motivation

For consistency we should make the shadows consistent with each others.

Before:

![image](https://user-images.githubusercontent.com/749374/126806799-a93d4d99-b01f-4927-b972-b13625db1976.png)

![image](https://user-images.githubusercontent.com/749374/126806889-cc78d19c-05c6-415f-b82c-62d6151bbde5.png)


After:

![image](https://user-images.githubusercontent.com/749374/126806823-e1a8d5ab-714b-4966-9e3f-257dfc79ded0.png)

![image](https://user-images.githubusercontent.com/749374/126806931-c36ea57f-e928-405e-a6d7-a20ca26964de.png)



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

preview
