### PR TITLE
feat: details/summary theme / MDX component

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -36,7 +36,8 @@ const Details = ({
       data-collapsed={collapsed}
       className={clsx(baseClassName, styles.details, props.className)}
       onMouseDown={(e) => {
-        if (e.detail > 1) {
+        // Prevent a double-click to highlight summary text
+        if ((e.target as HTMLElement).tagName === 'SUMMARY' && e.detail > 1) {
           e.preventDefault();
         }
       }}

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useRef, useState} from 'react';
+import clsx from 'clsx';
+import {useCollapsible, Collapsible} from '@docusaurus/theme-common';
+import type {Props} from '@theme/Details';
+import styles from './styles.module.css';
+
+const BaseClassName = 'alert alert--info';
+
+const Details = ({
+  baseClassName = BaseClassName,
+  summary,
+  children,
+  ...props
+}: Props): JSX.Element => {
+  const ref = useRef<HTMLDetailsElement>(null);
+
+  const {collapsed, setCollapsed} = useCollapsible({
+    initialState: !props.open,
+  });
+  // We use a separate prop because it must be set only after animation completes
+  // Otherwise close anim won't work
+  const [open, setOpen] = useState(props.open);
+
+  return (
+    <details
+      {...props}
+      ref={ref}
+      open={open}
+      onMouseDown={(e) => {
+        if (e.detail > 1) {
+          e.preventDefault();
+        }
+      }}
+      onClick={(e) => {
+        const isSummaryChildClick =
+          (e.target as HTMLElement).tagName === 'SUMMARY' &&
+          (e.target as HTMLElement).parentElement === ref.current;
+        if (!isSummaryChildClick) {
+          return;
+        }
+        e.preventDefault();
+        // const isOpening = (e.target as HTMLDetailsElement).open;
+        const isOpening = collapsed;
+        if (isOpening) {
+          setCollapsed(false);
+          setOpen(true);
+        } else {
+          setCollapsed(true);
+          // setOpen(false); // Don't do this, it breaks close animation!
+        }
+      }}
+      className={clsx(baseClassName, styles.details, props.className)}>
+      {summary}
+
+      <Collapsible
+        lazy={false} // Content might matter for SEO in this case
+        collapsed={collapsed}
+        onCollapseTransitionEnd={(newCollapsed) => {
+          setCollapsed(newCollapsed);
+          setOpen(!newCollapsed);
+        }}>
+        <div className={styles.collapsibleContent}>{children}</div>
+      </Collapsible>
+    </details>
+  );
+};
+
+export default Details;

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -33,6 +33,8 @@ const Details = ({
       {...props}
       ref={ref}
       open={open}
+      data-collapsed={collapsed}
+      className={clsx(baseClassName, styles.details, props.className)}
       onMouseDown={(e) => {
         if (e.detail > 1) {
           e.preventDefault();
@@ -55,8 +57,7 @@ const Details = ({
           setCollapsed(true);
           // setOpen(false); // Don't do this, it breaks close animation!
         }
-      }}
-      className={clsx(baseClassName, styles.details, props.className)}>
+      }}>
       {summary}
 
       <Collapsible

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -11,6 +11,7 @@ import {Details as DetailsGeneric} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Details';
 import styles from './styles.module.css';
 
+// Should we have a custom details/summary comp in Infima instead of reusing alert classes?
 const InfimaClasses = 'alert alert--info';
 
 export default function Details({...props}: Props): JSX.Element {

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -5,87 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useRef, useState} from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import {useCollapsible, Collapsible} from '@docusaurus/theme-common';
+import {Details as DetailsGeneric} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Details';
 import styles from './styles.module.css';
 
-const BaseClassName = 'alert alert--info';
+const InfimaClasses = 'alert alert--info';
 
-function isInSummary(node: HTMLElement | null): boolean {
-  if (!node) {
-    return false;
-  }
-  return node.tagName === 'SUMMARY' || isInSummary(node.parentElement);
-}
-
-function hasParent(node: HTMLElement | null, parent: HTMLElement): boolean {
-  if (!node) {
-    return false;
-  }
-  return node === parent || hasParent(node.parentElement, parent);
-}
-
-const Details = ({
-  baseClassName = BaseClassName,
-  summary,
-  children,
-  ...props
-}: Props): JSX.Element => {
-  const detailsRef = useRef<HTMLDetailsElement>(null);
-
-  const {collapsed, setCollapsed} = useCollapsible({
-    initialState: !props.open,
-  });
-  // We use a separate prop because it must be set only after animation completes
-  // Otherwise close anim won't work
-  const [open, setOpen] = useState(props.open);
-
+export default function Details({...props}: Props): JSX.Element {
   return (
-    <details
+    <DetailsGeneric
       {...props}
-      ref={detailsRef}
-      open={open}
-      data-collapsed={collapsed}
-      className={clsx(baseClassName, styles.details, props.className)}
-      onMouseDown={(e) => {
-        const target = e.target as HTMLElement;
-        // Prevent a double-click to highlight summary text
-        if (isInSummary(target) && e.detail > 1) {
-          e.preventDefault();
-        }
-      }}
-      onClick={(e) => {
-        e.stopPropagation(); // For isolation of multiple nested details/summary
-        const target = e.target as HTMLElement;
-        const shouldToggle =
-          isInSummary(target) && hasParent(target, detailsRef.current!);
-        if (!shouldToggle) {
-          return;
-        }
-        e.preventDefault();
-        if (collapsed) {
-          setCollapsed(false);
-          setOpen(true);
-        } else {
-          setCollapsed(true);
-          // setOpen(false); // Don't do this, it breaks close animation!
-        }
-      }}>
-      {summary}
-
-      <Collapsible
-        lazy={false} // Content might matter for SEO in this case
-        collapsed={collapsed}
-        onCollapseTransitionEnd={(newCollapsed) => {
-          setCollapsed(newCollapsed);
-          setOpen(!newCollapsed);
-        }}>
-        <div className={styles.collapsibleContent}>{children}</div>
-      </Collapsible>
-    </details>
+      className={clsx(InfimaClasses, styles.details, props.className)}
+    />
   );
-};
-
-export default Details;
+}

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -6,7 +6,33 @@
  */
 
 .details > summary {
+  position: relative;
   cursor: pointer;
+  list-style: none;
+  margin-left: 1.8rem;
+}
+
+.details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.details > summary:before {
+  --summary-arrow-size: 0.5rem;
+  position: absolute;
+  content: '';
+  top: 0.25rem;
+  width: 0;
+  height: 0;
+  border-width: var(--summary-arrow-size);
+  border-style: solid;
+  border-color: transparent transparent transparent var(--ifm-alert-border-color);
+  transform: translateX(-1.2rem) rotate(0deg);
+  transform-origin: calc(var(--summary-arrow-size) / 2) 50%;
+  transition: transform var(--ifm-transition-fast) ease;
+}
+
+.details[data-collapsed='false'] > summary:before {
+  transform: translateX(-1.2rem) rotate(90deg);
 }
 
 .collapsibleContent {

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+.details {
+  --details-decoration-color: var(--ifm-alert-border-color);
+  --details-summary-arrow-size: 0.5rem;
+}
+
 .details > summary {
   position: relative;
   cursor: pointer;
@@ -17,17 +22,16 @@
 }
 
 .details > summary:before {
-  --summary-arrow-size: 0.5rem;
   position: absolute;
   content: '';
   top: 0.25rem;
   width: 0;
   height: 0;
-  border-width: var(--summary-arrow-size);
+  border-width: var(--details-summary-arrow-size);
   border-style: solid;
-  border-color: transparent transparent transparent var(--ifm-alert-border-color);
+  border-color: transparent transparent transparent var(--details-decoration-color);
   transform: translateX(-1.2rem) rotate(0deg);
-  transform-origin: calc(var(--summary-arrow-size) / 2) 50%;
+  transform-origin: calc(var(--details-summary-arrow-size) / 2) 50%;
   transition: transform var(--ifm-transition-fast) ease;
 }
 
@@ -37,6 +41,6 @@
 
 .collapsibleContent {
   margin-top: 1rem;
-  border-top: 1px solid var(--ifm-color-emphasis-300);
+  border-top: 1px solid var(--details-decoration-color);
   padding-top: 1rem;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -7,40 +7,5 @@
 
 .details {
   --details-decoration-color: var(--ifm-alert-border-color);
-  --details-summary-arrow-size: 0.5rem;
-}
-
-.details > summary {
-  position: relative;
-  cursor: pointer;
-  list-style: none;
-  margin-left: 1.8rem;
-}
-
-.details > summary::-webkit-details-marker {
-  display: none;
-}
-
-.details > summary:before {
-  position: absolute;
-  content: '';
-  top: 0.25rem;
-  width: 0;
-  height: 0;
-  border-width: var(--details-summary-arrow-size);
-  border-style: solid;
-  border-color: transparent transparent transparent var(--details-decoration-color);
-  transform: translateX(-1.2rem) rotate(0deg);
-  transform-origin: calc(var(--details-summary-arrow-size) / 2) 50%;
-  transition: transform var(--ifm-transition-fast) ease;
-}
-
-.details[data-collapsed='false'] > summary:before {
-  transform: translateX(-1.2rem) rotate(90deg);
-}
-
-.collapsibleContent {
-  margin-top: 1rem;
-  border-top: 1px solid var(--details-decoration-color);
-  padding-top: 1rem;
+  --details-transition: transform var(--ifm-transition-fast) ease;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.details > summary {
+  cursor: pointer;
+}
+
+.collapsibleContent {
+  margin-top: 1rem;
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+  padding-top: 1rem;
+}

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -6,6 +6,6 @@
  */
 
 .details {
-  --details-decoration-color: var(--ifm-alert-border-color);
-  --details-transition: transform var(--ifm-transition-fast) ease;
+  --docusaurus-details-decoration-color: var(--ifm-alert-border-color);
+  --docusaurus-details-transition: transform var(--ifm-transition-fast) ease;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -8,4 +8,6 @@
 .details {
   --docusaurus-details-decoration-color: var(--ifm-alert-border-color);
   --docusaurus-details-transition: transform var(--ifm-transition-fast) ease;
+  margin: 0 0 var(--ifm-spacing-vertical);
+  border: 1px solid var(--ifm-alert-border-color);
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {isValidElement} from 'react';
+import React, {ComponentProps, isValidElement, ReactElement} from 'react';
 import Link from '@docusaurus/Link';
 import CodeBlock, {Props} from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
+import Details from '@theme/Details';
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 
 const MDXComponents: MDXComponentsObject = {
@@ -42,6 +43,20 @@ const MDXComponents: MDXComponentsObject = {
           ? children?.props
           : {...props}) as Props)}
       />
+    );
+  },
+  details: (props): JSX.Element => {
+    const items = React.Children.toArray(props.children);
+    // Split summary item from the rest to pass it as a separate prop to the Detais theme component
+    const summary: ReactElement<
+      ComponentProps<'summary'>
+    > = (items as any[]).find((item) => item?.props?.mdxType === 'summary');
+    const children = <>{items.filter((item) => item !== summary)}</>;
+
+    return (
+      <Details {...props} summary={summary}>
+        {children}
+      </Details>
     );
   },
   h1: Heading('h1'),

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -328,6 +328,7 @@ declare module '@theme/MDXComponents' {
     readonly code: typeof CodeBlock;
     readonly a: (props: ComponentProps<'a'>) => JSX.Element;
     readonly pre: typeof CodeBlock;
+    readonly details: (props: ComponentProps<'details'>) => JSX.Element;
     readonly h1: (props: ComponentProps<'h1'>) => JSX.Element;
     readonly h2: (props: ComponentProps<'h2'>) => JSX.Element;
     readonly h3: (props: ComponentProps<'h3'>) => JSX.Element;
@@ -527,6 +528,18 @@ declare module '@theme/ThemedImage' {
 
   const ThemedImage: (props: Props) => JSX.Element;
   export default ThemedImage;
+}
+
+declare module '@theme/Details' {
+  import type {ComponentProps} from 'react';
+
+  export type Props = {
+    baseClassName?: string;
+    summary?: ReactElement;
+  } & ComponentProps<'details'>;
+
+  const Props: (props: Props) => JSX.Element;
+  export default Props;
 }
 
 declare module '@theme/ThemeProvider' {

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -531,13 +531,7 @@ declare module '@theme/ThemedImage' {
 }
 
 declare module '@theme/Details' {
-  import type {ComponentProps} from 'react';
-
-  export type Props = {
-    baseClassName?: string;
-    summary?: ReactElement;
-  } & ComponentProps<'details'>;
-
+  export type Props = import('@docusaurus/theme-common').Details;
   const Props: (props: Props) => JSX.Element;
   export default Props;
 }

--- a/packages/docusaurus-theme-common/copyUntypedFiles.js
+++ b/packages/docusaurus-theme-common/copyUntypedFiles.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const path = require('path');
+const fs = require('fs-extra');
+
+/**
+ * Copy all untyped and static assets files to lib.
+ */
+const srcDir = path.resolve(__dirname, 'src');
+const libDir = path.resolve(__dirname, 'lib');
+fs.copySync(srcDir, libDir, {
+  filter(filepath) {
+    return !/__tests__/.test(filepath) && !/\.tsx?$/.test(filepath);
+  },
+});

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -5,8 +5,8 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "watch": "tsc --watch"
+    "build": "node copyUntypedFiles.js && tsc",
+    "watch": "node copyUntypedFiles.js && tsc --watch"
   },
   "publishConfig": {
     "access": "public"
@@ -23,6 +23,8 @@
     "@docusaurus/plugin-content-docs": "2.0.0-beta.3",
     "@docusaurus/plugin-content-pages": "2.0.0-beta.3",
     "@docusaurus/types": "2.0.0-beta.3",
+    "clsx": "^1.1.1",
+    "fs-extra": "^10.0.0",
     "tslib": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -243,7 +243,7 @@ type CollapsibleProps = CollapsibleBaseProps & {
   lazy: boolean;
 };
 
-export function Collapsible({lazy, ...props}: CollapsibleProps) {
+export function Collapsible({lazy, ...props}: CollapsibleProps): JSX.Element {
   const Comp = lazy ? CollapsibleLazy : CollapsibleBase;
   return <Comp {...props} />;
 }

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -166,6 +166,10 @@ type CollapsibleBaseProps = {
   animation?: CollapsibleAnimationConfig;
   onCollapseTransitionEnd?: (collapsed: boolean) => void;
   className?: string;
+
+  // This is mostly useful for details/summary component where ssrStyle is not needed (as details are hidden natively)
+  // and can mess-up with the default native behavior of the browser when JS fails to load or is disabled
+  disableSSRStyle?: boolean;
 };
 
 function CollapsibleBase({
@@ -175,6 +179,7 @@ function CollapsibleBase({
   animation,
   onCollapseTransitionEnd,
   className,
+  disableSSRStyle,
 }: CollapsibleBaseProps) {
   // any because TS is a pain for HTML element refs, see https://twitter.com/sebastienlorber/status/1412784677795110914
   const collapsibleRef = useRef<any>(null);
@@ -185,7 +190,7 @@ function CollapsibleBase({
     <As
       // @ts-expect-error: see https://twitter.com/sebastienlorber/status/1412784677795110914
       ref={collapsibleRef}
-      style={getSSRStyle(collapsed)}
+      style={disableSSRStyle ? undefined : getSSRStyle(collapsed)}
       onTransitionEnd={(e) => {
         if (e.propertyName !== 'height') {
           return;

--- a/packages/docusaurus-theme-common/src/components/Details/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Details/index.tsx
@@ -74,6 +74,7 @@ const Details = ({summary, children, ...props}: DetailsProps): JSX.Element => {
       <Collapsible
         lazy={false} // Content might matter for SEO in this case
         collapsed={collapsed}
+        disableSSRStyle // Allows component to work fine even with JS disabled!
         onCollapseTransitionEnd={(newCollapsed) => {
           setCollapsed(newCollapsed);
           setOpen(!newCollapsed);

--- a/packages/docusaurus-theme-common/src/components/Details/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Details/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {ComponentProps, ReactElement, useRef, useState} from 'react';
+import clsx from 'clsx';
+import {useCollapsible, Collapsible} from '../Collapsible';
+import styles from './styles.module.css';
+
+function isInSummary(node: HTMLElement | null): boolean {
+  if (!node) {
+    return false;
+  }
+  return node.tagName === 'SUMMARY' || isInSummary(node.parentElement);
+}
+
+function hasParent(node: HTMLElement | null, parent: HTMLElement): boolean {
+  if (!node) {
+    return false;
+  }
+  return node === parent || hasParent(node.parentElement, parent);
+}
+
+export type DetailsProps = {
+  summary?: ReactElement;
+} & ComponentProps<'details'>;
+
+const Details = ({summary, children, ...props}: DetailsProps): JSX.Element => {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  const {collapsed, setCollapsed} = useCollapsible({
+    initialState: !props.open,
+  });
+  // We use a separate prop because it must be set only after animation completes
+  // Otherwise close anim won't work
+  const [open, setOpen] = useState(props.open);
+
+  return (
+    <details
+      {...props}
+      ref={detailsRef}
+      open={open}
+      data-collapsed={collapsed}
+      className={clsx(styles.details, props.className)}
+      onMouseDown={(e) => {
+        const target = e.target as HTMLElement;
+        // Prevent a double-click to highlight summary text
+        if (isInSummary(target) && e.detail > 1) {
+          e.preventDefault();
+        }
+      }}
+      onClick={(e) => {
+        e.stopPropagation(); // For isolation of multiple nested details/summary
+        const target = e.target as HTMLElement;
+        const shouldToggle =
+          isInSummary(target) && hasParent(target, detailsRef.current!);
+        if (!shouldToggle) {
+          return;
+        }
+        e.preventDefault();
+        if (collapsed) {
+          setCollapsed(false);
+          setOpen(true);
+        } else {
+          setCollapsed(true);
+          // setOpen(false); // Don't do this, it breaks close animation!
+        }
+      }}>
+      {summary}
+
+      <Collapsible
+        lazy={false} // Content might matter for SEO in this case
+        collapsed={collapsed}
+        onCollapseTransitionEnd={(newCollapsed) => {
+          setCollapsed(newCollapsed);
+          setOpen(!newCollapsed);
+        }}>
+        <div className={styles.collapsibleContent}>{children}</div>
+      </Collapsible>
+    </details>
+  );
+};
+
+export default Details;

--- a/packages/docusaurus-theme-common/src/components/Details/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Details/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, {ComponentProps, ReactElement, useRef, useState} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import clsx from 'clsx';
 import {useCollapsible, Collapsible} from '../Collapsible';
 import styles from './styles.module.css';
@@ -29,6 +30,7 @@ export type DetailsProps = {
 } & ComponentProps<'details'>;
 
 const Details = ({summary, children, ...props}: DetailsProps): JSX.Element => {
+  const {isClient} = useDocusaurusContext();
   const detailsRef = useRef<HTMLDetailsElement>(null);
 
   const {collapsed, setCollapsed} = useCollapsible({
@@ -44,7 +46,11 @@ const Details = ({summary, children, ...props}: DetailsProps): JSX.Element => {
       ref={detailsRef}
       open={open}
       data-collapsed={collapsed}
-      className={clsx(styles.details, props.className)}
+      className={clsx(
+        styles.details,
+        {[styles.isClient]: isClient},
+        props.className,
+      )}
       onMouseDown={(e) => {
         const target = e.target as HTMLElement;
         // Prevent a double-click to highlight summary text

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -33,12 +33,16 @@ CSS variables, meant to be overriden by final theme
   height: 0;
   border-width: var(--details-summary-arrow-size);
   border-style: solid;
-  border-color: transparent transparent transparent var(--details-decoration-color);
+  border-color: transparent transparent transparent
+    var(--details-decoration-color);
   transform: translateX(-1.2rem) rotate(0deg);
   transform-origin: calc(var(--details-summary-arrow-size) / 2) 50%;
   transition: var(--details-transition);
 }
 
+/* When JS disabled/failed to load: */
+.details[open] > summary:before,
+/* When JS work: */
 .details[data-collapsed='false'] > summary:before {
   transform: translateX(-1.2rem) rotate(90deg);
 }

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+CSS variables, meant to be overriden by final theme
+ */
+.details {
+  --details-summary-arrow-size: 0.5rem;
+  --details-transition: transform 200ms ease;
+  --details-decoration-color: grey;
+}
+
+.details > summary {
+  position: relative;
+  cursor: pointer;
+  list-style: none;
+  margin-left: 1.8rem;
+}
+
+.details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.details > summary:before {
+  position: absolute;
+  content: '';
+  top: 0.25rem;
+  width: 0;
+  height: 0;
+  border-width: var(--details-summary-arrow-size);
+  border-style: solid;
+  border-color: transparent transparent transparent var(--details-decoration-color);
+  transform: translateX(-1.2rem) rotate(0deg);
+  transform-origin: calc(var(--details-summary-arrow-size) / 2) 50%;
+  transition: var(--details-transition);
+}
+
+.details[data-collapsed='false'] > summary:before {
+  transform: translateX(-1.2rem) rotate(90deg);
+}
+
+.collapsibleContent {
+  margin-top: 1rem;
+  border-top: 1px solid var(--details-decoration-color);
+  padding-top: 1rem;
+}

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -9,7 +9,7 @@
 CSS variables, meant to be overriden by final theme
  */
 .details {
-  --docusaurus-details-summary-arrow-size: 0.5rem;
+  --docusaurus-details-summary-arrow-size: 0.38rem;
   --docusaurus-details-transition: transform 200ms ease;
   --docusaurus-details-decoration-color: grey;
 }
@@ -27,18 +27,22 @@ CSS variables, meant to be overriden by final theme
 
 .details > summary:before {
   position: absolute;
-  content: '';
-  top: 0.25rem;
+  top: 0.45rem;
   left: -1.2rem;
+
+  /* CSS-only Arrow */
+  content: '';
   width: 0;
   height: 0;
-  border-width: var(--docusaurus-details-summary-arrow-size);
-  border-style: solid;
-  border-color: transparent transparent transparent
+  border-top: var(--docusaurus-details-summary-arrow-size) solid transparent;
+  border-bottom: var(--docusaurus-details-summary-arrow-size) solid transparent;
+  border-left: var(--docusaurus-details-summary-arrow-size) solid
     var(--docusaurus-details-decoration-color);
+
+  /* Arrow rotation anim */
   transform: rotate(0deg);
-  transform-origin: calc(var(--docusaurus-details-summary-arrow-size) / 2) 50%;
   transition: var(--docusaurus-details-transition);
+  transform-origin: calc(var(--docusaurus-details-summary-arrow-size) / 2) 50%;
 }
 
 /* When JS disabled/failed to load: we use the open property for arrow animation: */

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -29,13 +29,14 @@ CSS variables, meant to be overriden by final theme
   position: absolute;
   content: '';
   top: 0.25rem;
+  left: -1.2rem;
   width: 0;
   height: 0;
   border-width: var(--details-summary-arrow-size);
   border-style: solid;
   border-color: transparent transparent transparent
     var(--details-decoration-color);
-  transform: translateX(-1.2rem) rotate(0deg);
+  transform: rotate(0deg);
   transform-origin: calc(var(--details-summary-arrow-size) / 2) 50%;
   transition: var(--details-transition);
 }

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -41,11 +41,11 @@ CSS variables, meant to be overriden by final theme
   transition: var(--details-transition);
 }
 
-/* When JS disabled/failed to load: */
-.details[open] > summary:before,
-/* When JS work: */
-.details[data-collapsed='false'] > summary:before {
-  transform: translateX(-1.2rem) rotate(90deg);
+/* When JS disabled/failed to load: we use the open property for arrow animation: */
+.details[open]:not(.isClient) > summary:before,
+/* When JS works: we use the data-attribute for arrow animation */
+.details[data-collapsed='false'].isClient > summary:before {
+  transform: rotate(90deg);
 }
 
 .collapsibleContent {

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -9,9 +9,9 @@
 CSS variables, meant to be overriden by final theme
  */
 .details {
-  --details-summary-arrow-size: 0.5rem;
-  --details-transition: transform 200ms ease;
-  --details-decoration-color: grey;
+  --docusaurus-details-summary-arrow-size: 0.5rem;
+  --docusaurus-details-transition: transform 200ms ease;
+  --docusaurus-details-decoration-color: grey;
 }
 
 .details > summary {
@@ -32,13 +32,13 @@ CSS variables, meant to be overriden by final theme
   left: -1.2rem;
   width: 0;
   height: 0;
-  border-width: var(--details-summary-arrow-size);
+  border-width: var(--docusaurus-details-summary-arrow-size);
   border-style: solid;
   border-color: transparent transparent transparent
-    var(--details-decoration-color);
+    var(--docusaurus-details-decoration-color);
   transform: rotate(0deg);
-  transform-origin: calc(var(--details-summary-arrow-size) / 2) 50%;
-  transition: var(--details-transition);
+  transform-origin: calc(var(--docusaurus-details-summary-arrow-size) / 2) 50%;
+  transition: var(--docusaurus-details-transition);
 }
 
 /* When JS disabled/failed to load: we use the open property for arrow animation: */
@@ -50,6 +50,6 @@ CSS variables, meant to be overriden by final theme
 
 .collapsibleContent {
   margin-top: 1rem;
-  border-top: 1px solid var(--details-decoration-color);
+  border-top: 1px solid var(--docusaurus-details-decoration-color);
   padding-top: 1rem;
 }

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -37,11 +37,14 @@ export {useLocationChange} from './utils/useLocationChange';
 
 export {usePrevious} from './utils/usePrevious';
 
-export {useCollapsible, Collapsible} from './utils/useCollapsible';
+export {useCollapsible, Collapsible} from './components/Collapsible';
 export type {
   UseCollapsibleConfig,
   UseCollapsibleReturns,
-} from './utils/useCollapsible';
+} from './components/Collapsible';
+
+export {default as Details} from './components/Details';
+export type {DetailsProps} from './components/Details';
 
 export {
   MobileSecondaryMenuProvider,

--- a/packages/docusaurus-theme-common/src/utils/useCollapsible.tsx
+++ b/packages/docusaurus-theme-common/src/utils/useCollapsible.tsx
@@ -164,6 +164,7 @@ type CollapsibleBaseProps = {
   collapsed: boolean;
   children: ReactNode;
   animation?: CollapsibleAnimationConfig;
+  onCollapseTransitionEnd?: (collapsed: boolean) => void;
   className?: string;
 };
 
@@ -172,6 +173,7 @@ function CollapsibleBase({
   collapsed,
   children,
   animation,
+  onCollapseTransitionEnd,
   className,
 }: CollapsibleBaseProps) {
   // any because TS is a pain for HTML element refs, see https://twitter.com/sebastienlorber/status/1412784677795110914
@@ -197,10 +199,12 @@ function CollapsibleBase({
           parseInt(currentCollapsibleElementHeight, 10) === el.scrollHeight
         ) {
           applyCollapsedStyle(el, false);
+          onCollapseTransitionEnd?.(false);
         }
 
         if (currentCollapsibleElementHeight === CollapsedStyles.height) {
           applyCollapsedStyle(el, true);
+          onCollapseTransitionEnd?.(true);
         }
       }}
       className={className}>

--- a/website/docs/guides/markdown-features/_markdown-partial-example.mdx
+++ b/website/docs/guides/markdown-features/_markdown-partial-example.mdx
@@ -1,0 +1,3 @@
+<span>Hello {props.name}</span>
+
+This is text some content from `_markdown-partial-example.md`.

--- a/website/docs/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-intro.mdx
@@ -1,10 +1,14 @@
 ---
 id: introduction
-title: Markdown Features introduction
+title: Markdown Features
 sidebar_label: Introduction
 description: Docusaurus uses GitHub Flavored Markdown (GFM). Find out more about Docusaurus-specific features when writing Markdown.
 slug: /markdown-features
 ---
+
+```mdx-code-block
+import BrowserWindow from '@site/src/components/BrowserWindow';
+```
 
 Documentation is one of your product's interfaces with your users. A well-written and well-organized set of docs helps your users understand your product quickly. Our aligned goal here is to help your users find and understand the information they need, as quickly as possible.
 
@@ -12,12 +16,100 @@ Docusaurus 2 uses modern tooling to help you compose your interactive documentat
 
 In this section, we'd like to introduce you to the tools we've picked that we believe will help you build a powerful documentation. Let us walk you through with an example.
 
+:::important
+
+This section assumes you are using the official Docusaurus content plugins.
+
+:::
+
+## Standard features
+
 Markdown is a syntax that enables you to write formatted content in a readable syntax.
 
 The [standard Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is supported, and we use [MDX](https://mdxjs.com/) as the parsing engine, which can do much more than just parsing Markdown, like rendering React components inside your documents.
 
-:::important
+```md
+### My Doc Section
 
-This section assumes you are using the official Docusaurus content plugins.
+Hello world message with some **bold** text, some _italic_ text and a [link](/)
+
+![img alt](/img/docusaurus.png)
+```
+
+```mdx-code-block
+<BrowserWindow>
+
+<h2>My Doc Section</h2>
+
+Hello world message with some **bold** text, some _italic_ text and a [link](/)
+
+![img alt](/img/docusaurus.png)
+
+</BrowserWindow>
+```
+
+## Quotes
+
+Markdown quotes are beautifully styled:
+
+```md
+> This is a quote
+```
+
+> This is a quote
+
+## Details
+
+Markdown can embed HTML elements, and [`details`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) HTML elements are beautifully styled:
+
+```md
+### Details element example
+
+<details>
+  <summary>Toggle me!</summary>
+  <div>
+    <div>This is the detailed content</div>
+    <details>
+      <summary>
+        <div>Nested toggle!</div>
+        <div>Some surprise inside...</div>
+      </summary>
+      <div>
+        😲😲😲😲😲
+      </div>
+    </details>
+  </div>
+</details>
+```
+
+```mdx-code-block
+<BrowserWindow>
+
+<h3>Details element example</h3>
+
+<details>
+  <summary>Toggle me!</summary>
+  <div>
+    <div>This is the detailed content</div>
+    <details>
+      <summary>
+        <div>Nested toggle!</div>
+        <div>Some surprise inside...</div>
+      </summary>
+      <div>
+        😲😲😲😲😲
+      </div>
+    </details>
+  </div>
+</details>
+
+</BrowserWindow>
+
+<br/>
+```
+
+:::note
+
+In practice, those are not really HTML elements, but React JSX elements, which we'll cover next!
 
 :::

--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -9,9 +9,15 @@ slug: /markdown-features/react
   <summary>Toggle me!</summary>
   <div>
     <div>This is the detailed content</div>
-    <details>
-      <summary>Toggle me!</summary>
+    <details style={{marginTop: '1rem'}}>
+      <summary>
+        <div>Nested toggle!</div>
+        <div>click me too!</div>
+      </summary>
       <div>
+        <div>This is the detailed content</div>
+        <div>This is the detailed content</div>
+        <div>This is the detailed content</div>
         <div>This is the detailed content</div>
       </div>
     </details>

--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -9,7 +9,7 @@ slug: /markdown-features/react
   <summary>Toggle me!</summary>
   <div>
     <div>This is the detailed content</div>
-    <details style={{marginTop: '1rem'}}>
+    <details style={{marginTop: '1rem'}} baseClassName={'alert alert--danger'}>
       <summary>
         <div>Nested toggle!</div>
         <div>click me too!</div>

--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -5,6 +5,19 @@ description: Using the power of React in Docusaurus Markdown documents, thanks t
 slug: /markdown-features/react
 ---
 
+<details>
+  <summary>Toggle me!</summary>
+  <div>
+    <div>This is the detailed content</div>
+    <details>
+      <summary>Toggle me!</summary>
+      <div>
+        <div>This is the detailed content</div>
+      </div>
+    </details>
+  </div>
+</details>
+
 import BrowserWindow from '@site/src/components/BrowserWindow';
 
 ## Using JSX in Markdown {#using-jsx-in-markdown}

--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -1,30 +1,13 @@
 ---
 id: react
-title: Using React
+title: MDX and React
 description: Using the power of React in Docusaurus Markdown documents, thanks to MDX
 slug: /markdown-features/react
 ---
 
-<details>
-  <summary>Toggle me!</summary>
-  <div>
-    <div>This is the detailed content</div>
-    <details style={{marginTop: '1rem'}} baseClassName={'alert alert--danger'}>
-      <summary>
-        <div>Nested toggle!</div>
-        <div>click me too!</div>
-      </summary>
-      <div>
-        <div>This is the detailed content</div>
-        <div>This is the detailed content</div>
-        <div>This is the detailed content</div>
-        <div>This is the detailed content</div>
-      </div>
-    </details>
-  </div>
-</details>
-
+```mdx-code-block
 import BrowserWindow from '@site/src/components/BrowserWindow';
+```
 
 ## Using JSX in Markdown {#using-jsx-in-markdown}
 
@@ -33,6 +16,14 @@ Docusaurus has built-in support for [MDX](https://mdxjs.com/), which allows you 
 :::note
 
 While both `.md` and `.mdx` files are parsed using MDX, some of the syntax are treated slightly differently. For the most accurate parsing and better editor support, we recommend using the `.mdx` extension for files containing MDX syntax.
+
+:::
+
+:::caution
+
+MDX is not [100% compatible with CommonMark](https://github.com/facebook/docusaurus/issues/3018).
+
+Use the **[MDX playground](https://mdxjs.com/playground)** to ensure that your syntax is valid MDX.
 
 :::
 
@@ -145,21 +136,27 @@ This feature is experimental and might be subject to API breaking changes in the
 
 ## Importing Markdown {#importing-markdown}
 
-You can use Markdown files as components and import them elsewhere, either in Markdown files or in React pages. Below we are importing from [another file](./markdown-features-intro.mdx) and inserting it as a component.
+You can use Markdown files as components and import them elsewhere, either in Markdown files or in React pages.
 
-```jsx
-import Intro from './markdown-features-intro.mdx';
+By convention, using the **`_` filename prefix** will not create any doc page and means the markdown file is a **"partial"**, to be imported by other files.
 
-<Intro />;
+```md title="_markdown-partial-example.mdx"
+<span>Hello {props.name}</span>
+
+This is text some content from `_markdown-partial-example.mdx`.
+```
+
+```jsx title="someOtherDoc.mdx"
+import PartialExample from './_markdown-partial-example.mdx';
+
+<PartialExample name="Sebastien" />;
 ```
 
 ```mdx-code-block
-import Intro from './markdown-features-intro.mdx';
+import PartialExample from './_markdown-partial-example.mdx';
 
 <BrowserWindow url="http://localhost:3000">
-
-<Intro />
-
+  <PartialExample name="Sebastien" />
 </BrowserWindow>
 
 <br />


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/2924

Instead of using the default rendering for details/summary, we should leverage summary to plug our own themed and animated details component.

Before: 

from https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components (using some additional custom CSS)

![image](https://user-images.githubusercontent.com/749374/127158889-905c1c17-f446-4171-b76e-e857a2206bbd.png)


After:

![image](https://user-images.githubusercontent.com/749374/127158708-43d52658-207e-4177-96dd-7128ee4ba30b.png)


If JS is disabled, this component should still work, falling back to default HTML behavior.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

https://deploy-preview-5216--docusaurus-2.netlify.app/docs/next/markdown-features

