### PR TITLE
chore: fix iframe background color in dark mode

### DIFF
--- a/website/src/pages/feedback/styles.module.css
+++ b/website/src/pages/feedback/styles.module.css
@@ -9,4 +9,5 @@
   padding: var(--ifm-spacing-horizontal);
   border-radius: 4px;
   background: var(--ifm-color-feedback-background);
+  color-scheme: auto;
 }

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -115,6 +115,7 @@
 .indexCtasGitHubButton {
   border: none;
   overflow: hidden;
+  color-scheme: auto;
 }
 
 .indexCtaTryNowButton:hover {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It turns out that using `color-scheme` can lead to incorrect backgrounds in iframes on dark scheme. At least on our site:

![image](https://user-images.githubusercontent.com/4408379/127150117-b1115c20-62e8-4138-8605-3246dc982de9.png)

![image](https://user-images.githubusercontent.com/4408379/127150616-50676c4a-a0dd-4747-b0bb-5c5ff15f9a6b.png)

Not sure if we should globally assign `color-scheme` to `auto` to avoid this issues on our client sites?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![image](https://user-images.githubusercontent.com/4408379/127150759-7adc944f-bafb-4518-a74c-021eb05b783b.png)


![image](https://user-images.githubusercontent.com/4408379/127150713-71cf063b-a7c0-4a02-b57c-0b85ba1481ac.png)



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
