### PR TITLE
fix(v2): keep mobile TOC after hydration

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -59,9 +59,6 @@ function DocItem(props: Props): JSX.Element {
   const canRenderTOC =
     !hideTableOfContents && DocContent.toc && DocContent.toc.length > 0;
 
-  const renderTocMobile =
-    canRenderTOC && (windowSize === 'mobile' || windowSize === 'ssr');
-
   const renderTocDesktop =
     canRenderTOC && (windowSize === 'desktop' || windowSize === 'ssr');
 
@@ -83,7 +80,7 @@ function DocItem(props: Props): JSX.Element {
                 </span>
               )}
 
-              {renderTocMobile && (
+              {canRenderTOC && (
                 <TOCCollapsible
                   toc={DocContent.toc}
                   className={styles.tocMobile}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After we merged the new mobile UX, anchor links in headings broke. The reason for this is that during prerendering we render mobile TOC to avoid layout shift, but after hydration mobile TOC is removed from DOM on desktop. However, this is wrong because we hide mobile TOC on desktop with CSS. Therefore, we need to always render mobile TOC, then anchor links will work again and we still won't have FOUC.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

Test mobile TOC, then open any anchor link in new tab.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
