### PR TITLE
fix(v2): remove top margin from first element inside doc article

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+.docItemContainer article *:first-child,
 .docItemContainer header + * {
   margin-top: 0;
 }

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
@@ -21,7 +21,6 @@ export default function TOCCollapsible({toc, className}: TOCCollapsibleProps) {
   return (
     <div
       className={clsx(
-        'margin-vert--md',
         styles.tocCollapsible,
         {
           [styles.tocCollapsibleExpanded]: !collapsed,

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/styles.module.css
@@ -8,6 +8,7 @@
 .tocCollapsible {
   background-color: var(--ifm-menu-color-background-active);
   border-radius: var(--ifm-global-radius);
+  margin: 1rem 0;
 }
 
 .tocCollapsibleButton {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

For example, if site does not use versioning, mobile TOC will be the first element in doc article section, and adding large and unnecessary margin at the top. I suggest removing top margin from first element inside article element as should be by design.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/127242044-634430e9-334a-48e7-b627-bf4fb90e3fb3.png) |  ![image](https://user-images.githubusercontent.com/4408379/127242081-16af097e-7531-4b3f-b2b3-473ea16c30e5.png)|

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
