### PR TITLE
fix(v2): blog should parse frontMatter.date even when time is present

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -193,7 +193,7 @@ export async function generateBlogPosts(
 
     // Prefer user-defined date.
     if (frontMatter.date) {
-      date = frontMatter.date;
+      date = new Date(frontMatter.date);
     }
 
     // Use file create time for blog.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

frontMatter date is string, cause build error

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

the problem is obvious, cause error like this https://github.com/wenerme/wener/runs/3180667805#step:5:782

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
