### PR TITLE
fix: remove top margin only from directly first element

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.docItemContainer article *:first-child,
+.docItemContainer article > *:first-child,
 .docItemContainer header + * {
   margin-top: 0;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix small UI bug after #5230 because currently top margin is also removed in first element inside mobile TOC.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/127444891-ec58ba0c-7649-4814-a94f-591b83b8185f.png) | ![image](https://user-images.githubusercontent.com/4408379/127444840-ce449294-3a72-416a-b01d-b265482f8134.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
