### PR TITLE
fix: attempt to restore native smooth scrolling if supported

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
@@ -10,14 +10,32 @@ import clsx from 'clsx';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
 
 import styles from './styles.module.css';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 const threshold = 300;
 
-// Not all have support for smooth scrolling (particularly Safari mobile iOS)
-// TODO proper detection is currently unreliable!
-// see https://github.com/wessberg/scroll-behavior-polyfill/issues/16
-const SupportsNativeSmoothScrolling = false;
-// const SupportsNativeSmoothScrolling = ExecutionEnvironment.canUseDOM && 'scrollBehavior' in document.documentElement.style;
+// Not all have support for smooth scrolling (particularly Safari mobile iOS, Chrome on Windows...)
+// This test is not reliable: 'scrollBehavior' in document.documentElement.style;
+// See https://github.com/wessberg/scroll-behavior-polyfill/issues/16
+// We use another one found here: https://nolanlawson.com/2019/02/
+// https://github.com/nolanlawson/pinafore/blob/b05855f7caae483aaa0f317c3acc2ac878eb83bf/src/routes/_utils/smoothScroll.js
+function testSupportsSmoothScroll() {
+  let supports = false;
+  try {
+    const div = document.createElement('div');
+    div.scrollTo({
+      top: 0,
+      get behavior(): ScrollBehavior {
+        supports = true;
+        return 'smooth';
+      },
+    });
+  } catch (err) {} // Edge throws an error
+  return supports;
+}
+
+const SupportsNativeSmoothScrolling =
+  ExecutionEnvironment.canUseDOM && testSupportsSmoothScroll;
 
 type CancelScrollTop = () => void;
 

--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
@@ -35,7 +35,7 @@ function testSupportsSmoothScroll() {
 }
 
 const SupportsNativeSmoothScrolling =
-  ExecutionEnvironment.canUseDOM && testSupportsSmoothScroll;
+  ExecutionEnvironment.canUseDOM && testSupportsSmoothScroll();
 
 type CancelScrollTop = () => void;
 


### PR DESCRIPTION
## Motivation

Current implementation always use a polyfill for smooth scrollTo top.

We should rather use the native implementation (if supported)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview + browserstack

