### PR TITLE
docs(v2): add docusaurus-prince-pdf to resources

### DIFF
--- a/website/community/2-resources.md
+++ b/website/community/2-resources.md
@@ -40,6 +40,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-plugin-react-docgen](https://github.com/atomicpages/docusaurus-plugin-react-docgen) - A Docusaurus v2 plugin for loading type annotations from `react-docgen`
 - [docusaurus-plugin-module-alias](https://github.com/atomicpages/docusaurus-plugin-module-alias) - A Docusaurus v2 plugin for quickly aliasing local modules
 - [docusaurus-protobuffet](https://github.com/protobuffet/docusaurus-protobuffet) - Docusaurus toolset for Protobuf contract documentation
+- [docusaurus-prince-pdf](https://github.com/signcl/docusaurus-prince-pdf) - Generate PDF with PrinceXML for better font subsetting and ToC features. Support Docusaurs v2 sites
 
 ## Enterprise usage {#enterprise-usage}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I found several PDF generation tools like mr-pdf can generate PDF for Docusaurus sites. But the output doesn't in good quality with some glitches:

- Doesn't work well with system Dark Mode. You will get a dark background in generated PDF. But it's not an issue in Ci/CD environments
- No Table of Contents support
- Based on Puppeteer make the text cannot be copied or searched correctly
- Link anchors (links start with `#`) not well handled

So I created a separate tool to generate PDF using Prince.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

No tests required

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)

No related PRs