### PR TITLE
fix: fix Crowdin mapping for pt-BR

### DIFF
--- a/crowdin-v2.yaml
+++ b/crowdin-v2.yaml
@@ -12,6 +12,14 @@ api_token_env: 'CROWDIN_PERSONAL_TOKEN'
 #
 preserve_hierarchy: true
 
+# We generally want to use the the "two-letters-code" of a locale (ie the language)
+# But not for all locales!
+# "pt-BR" may be better to remain as "pt-BR" instead of being transformed to "pt"
+# Note: &/* is Yaml anchor syntax: https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/
+languages_mapping: &languages_mapping
+  two_letters_code:
+    'pt-BR': 'pt-BR'
+
 #
 # Files configuration
 #
@@ -20,27 +28,33 @@ files:
     {
       source: '/website/i18n/en/**/*',
       translation: '/website/i18n/%two_letters_code%/**/%original_file_name%',
+      languages_mapping: *languages_mapping,
     },
     {
       source: '/website/docs/**/*',
       translation: '/website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%',
+      languages_mapping: *languages_mapping,
     },
     {
       source: '/website/community/**/*',
       translation: '/website/i18n/%two_letters_code%/docusaurus-plugin-content-docs-community/current/**/%original_file_name%',
+      languages_mapping: *languages_mapping,
     },
     {
       source: '/website/versioned_docs/**/*',
       translation: '/website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/**/%original_file_name%',
+      languages_mapping: *languages_mapping,
     },
     {
       source: '/website/blog/**/*',
       translation: '/website/i18n/%two_letters_code%/docusaurus-plugin-content-blog/**/%original_file_name%',
+      languages_mapping: *languages_mapping,
     },
     {
       source: '/website/src/pages/**/*',
       translation: '/website/i18n/%two_letters_code%/docusaurus-plugin-content-pages/**/%original_file_name%',
       ignore: ['/**/*.js', '/**/*.jsx', '/**/*.ts', '/**/*.tsx', '/**/*.css'],
+      languages_mapping: *languages_mapping,
     },
   ]
 #


### PR DESCRIPTION

## Motivation


For languages such as `pt-BR` we want to keep the full locale to distinguish from `pt-PT` so let's add some custom mapping to download translations at `ì18n/pt-BR` instead of `i18n/pt` (site config is already correct)