### PR TITLE
fix: show secondary menu if even there is no main one

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -19,6 +19,7 @@ import {
 import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
 import useWindowSize from '@theme/hooks/useWindowSize';
+import {useActivePlugin} from '@theme/hooks/useDocs';
 import NavbarItem, {Props as NavbarItemConfig} from '@theme/NavbarItem';
 import Logo from '@theme/Logo';
 import IconMenu from '@theme/IconMenu';
@@ -175,16 +176,18 @@ function NavbarMobileSidebar({
         </div>
 
         <div className="navbar-sidebar__item navbar-sidebar__item--secondary menu">
-          <button
-            type="button"
-            className="clean-btn navbar-sidebar__back"
-            onClick={secondaryMenu.hide}>
-            <Translate
-              id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
-              description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
-              ← Back to main menu
-            </Translate>
-          </button>
+          {items.length > 0 && (
+            <button
+              type="button"
+              className="clean-btn navbar-sidebar__back"
+              onClick={secondaryMenu.hide}>
+              <Translate
+                id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
+                description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
+                ← Back to main menu
+              </Translate>
+            </button>
+          )}
           {secondaryMenu.content}
         </div>
       </div>
@@ -199,7 +202,7 @@ function Navbar(): JSX.Element {
 
   const mobileSidebar = useMobileSidebar();
   const colorModeToggle = useColorModeToggle();
-
+  const activeDocPlugin = useActivePlugin();
   const {navbarRef, isNavbarVisible} = useHideableNavbar(hideOnScroll);
 
   const items = useNavbarItems();
@@ -218,7 +221,7 @@ function Navbar(): JSX.Element {
       })}>
       <div className="navbar__inner">
         <div className="navbar__items">
-          {items?.length > 0 && (
+          {(items?.length > 0 || activeDocPlugin) && (
             <button
               aria-label="Navigation bar toggle"
               className="navbar__toggle clean-btn"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

A quick attempt to fix #5241 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Remove all navbar items in config file and go to docs page. Note that on regular pages such as homepage or blog pages, sidebar icon will not be displayed.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
