### PR TITLE
fix: apply proper class for active doc item on mobiles + avoid duplicated classes

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
@@ -108,7 +108,6 @@ describe('themeConfig', () => {
             position: 'left',
             docId: 'intro',
             label: 'Introduction',
-            activeSidebarClassName: 'custom-class',
           },
           // Regular link
           {
@@ -142,7 +141,6 @@ describe('themeConfig', () => {
             items: [
               {
                 type: 'doc',
-                activeSidebarClassName: 'custom-class',
                 docId: 'npm',
                 label: 'NPM',
               },

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -25,7 +25,7 @@ export function NavLink({
   to,
   href,
   label,
-  activeClassName = 'navbar__link--active',
+  activeClassName = '',
   prependBaseUrlToHref,
   ...props
 }: NavLinkProps): JSX.Element {
@@ -45,7 +45,9 @@ export function NavLink({
           }
         : {
             isNavLink: true,
-            activeClassName,
+            activeClassName: !props.className?.includes(activeClassName)
+              ? activeClassName
+              : '',
             to: toUrl,
             ...(activeBasePath || activeBaseRegex
               ? {

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -31,7 +31,6 @@ Available doc ids are:\n- ${docIds}`,
 
 export default function DocNavbarItem({
   docId,
-  activeSidebarClassName,
   label: staticLabel,
   docsPluginId,
   ...props
@@ -45,20 +44,19 @@ export default function DocNavbarItem({
     [activeVersion, preferredVersion, latestVersion].filter(Boolean),
   );
   const doc = getDocInVersions(versions, docId);
-  const isCurrentDoc = activeDoc && activeDoc.sidebar === doc.sidebar;
   const activeDocInfimaClassName = props.mobile
     ? 'menu__link--active'
     : 'navbar__link--active';
-  props.activeClassName = activeDocInfimaClassName;
 
   return (
     <DefaultNavbarItem
       exact
       {...props}
       className={clsx(props.className, {
-        [activeDocInfimaClassName]: isCurrentDoc,
-        [activeSidebarClassName]: activeSidebarClassName && isCurrentDoc,
+        [activeDocInfimaClassName]:
+          activeDoc && activeDoc.sidebar === doc.sidebar,
       })}
+      activeClassName={activeDocInfimaClassName}
       label={staticLabel ?? doc.id}
       to={doc.path}
     />

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -45,14 +45,19 @@ export default function DocNavbarItem({
     [activeVersion, preferredVersion, latestVersion].filter(Boolean),
   );
   const doc = getDocInVersions(versions, docId);
+  const isCurrentDoc = activeDoc && activeDoc.sidebar === doc.sidebar;
+  const activeDocInfimaClassName = props.mobile
+    ? 'menu__link--active'
+    : 'navbar__link--active';
+  props.activeClassName = activeDocInfimaClassName;
 
   return (
     <DefaultNavbarItem
       exact
       {...props}
       className={clsx(props.className, {
-        [activeSidebarClassName]:
-          activeDoc && activeDoc.sidebar === doc.sidebar,
+        [activeDocInfimaClassName]: isCurrentDoc,
+        [activeSidebarClassName]: activeSidebarClassName && isCurrentDoc,
       })}
       label={staticLabel ?? doc.id}
       to={doc.path}

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -446,7 +446,6 @@ declare module '@theme/NavbarItem/DocNavbarItem' {
 
   export type Props = DefaultNavbarItemProps & {
     readonly docId: string;
-    readonly activeSidebarClassName: string;
     readonly docsPluginId?: string;
   };
 

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -79,7 +79,7 @@ const DocItemSchema = NavbarItemBaseSchema.append({
   type: Joi.string().equal('doc').required(),
   docId: Joi.string().required(),
   docsPluginId: Joi.string(),
-  activeSidebarClassName: Joi.string().default('navbar__link--active'),
+  activeSidebarClassName: Joi.string(),
 });
 
 const itemWithType = (type) => {

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.js
@@ -79,7 +79,6 @@ const DocItemSchema = NavbarItemBaseSchema.append({
   type: Joi.string().equal('doc').required(),
   docId: Joi.string().required(),
   docsPluginId: Joi.string(),
-  activeSidebarClassName: Joi.string(),
 });
 
 const itemWithType = (type) => {

--- a/website/docs/api/themes/theme-configuration.md
+++ b/website/docs/api/themes/theme-configuration.md
@@ -351,7 +351,6 @@ Accepted fields:
 | `docId` | `string` | The ID of the doc that this item links to. | Yes |  |
 | `label` | `string` | The name to be shown for this item. | No | `docId` |
 | `position` | <code>'left' &#124; 'right'</code> | The side of the navbar this item should appear on. | No | `'left'` |
-| `activeSidebarClassName` | `string` | The CSS class name to apply when this doc's sidebar is active. | No |  |
 | `docsPluginId` | `string` | The ID of the docs plugin that the doc belongs to. | No | `'default'` |
 
 Example configuration:

--- a/website/docs/api/themes/theme-configuration.md
+++ b/website/docs/api/themes/theme-configuration.md
@@ -351,7 +351,7 @@ Accepted fields:
 | `docId` | `string` | The ID of the doc that this item links to. | Yes |  |
 | `label` | `string` | The name to be shown for this item. | No | `docId` |
 | `position` | <code>'left' &#124; 'right'</code> | The side of the navbar this item should appear on. | No | `'left'` |
-| `activeSidebarClassName` | `string` | The CSS class name to apply when this doc's sidebar is active. | No | `'navbar__link--active'` |
+| `activeSidebarClassName` | `string` | The CSS class name to apply when this doc's sidebar is active. | No |  |
 | `docsPluginId` | `string` | The ID of the docs plugin that the doc belongs to. | No | `'default'` |
 
 Example configuration:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Breaking Changes

- Remove `activeSidebarClassName` config, as it was probably never used by anyone and is confusing to use with Infima. Please let us know if you have a use-case for it, and we'll figure out a better api.

## Motivation

First of all, currently CSS class for active navbar item is duplicated, for example:

| Result   | Current HTML  | Expected HTML |
| -------- | -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/127777261-d02381b8-a294-430a-bd9c-710d2f9f3658.png) |  \<a aria-current="page" class="navbar__item navbar__link **navbar__link--active navbar__link--active**" href="/docs/next">Docs\</a>| \<a aria-current="page" class="navbar__item navbar__link **navbar__link--active**" href="/docs/next">Docs\</a> |

* * *

In addition to that, in mobile sidebar uses wrong `navbar__link--active` class instead of `menu__link--active` for active doc item.

| Result   | Current HTML    | Expected HTML |
| -------- | -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/127777397-54533583-f424-43fa-90a9-227c0c1d857a.png) | \<a aria-current="page" class="***menu__link*** **navbar__link--active navbar__link--active**" href="/docs/next">Docs\</a> | \<a aria-current="page" class="***menu__link*** **menu__link--active**" href="/docs/next">Docs\</a> |

The duplication of CSS class occurs because option for adding custom class `activeSidebarClassName` is set by default in `navbar__link--active` . Although it's quite strange, because this option, as I understand it, is intended to add custom class to active doc item. So adding custom class via `activeSidebarClassName` option should not remove built-in Infima's active CSS classes.
BTW I'm not sure this option `activeSidebarClassName`  is needed at all at this moment. If you browse [public repositories](https://github.com/search?p=1&q=activeSidebarClassName+filename%3Adocusaurus.config.js&type=Code), you'll find that no one uses it -- default Infima class is set in all available repos.  Well, maybe we should remove it? 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview. 

On `/docs` page:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/127777712-f2e39a58-fe14-4772-994e-ec1b5ebe1166.png) | ![image](https://user-images.githubusercontent.com/4408379/127777740-6259db27-f86b-4581-b327-6b8657e50561.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
