### PR TITLE
fix: fix wrong regex that removes extra letters from swizzled component names

### DIFF
--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -50,8 +50,8 @@ export function getPluginNames(plugins: PluginConfig[]): string[] {
 
 const formatComponentName = (componentName: string): string =>
   componentName
-    .replace(/(\/|\\)index.(js|tsx|ts|jsx)/, '')
-    .replace(/.(js|tsx|ts|jsx)/, '');
+    .replace(/(\/|\\)index\.(js|tsx|ts|jsx)/, '')
+    .replace(/\.(js|tsx|ts|jsx)/, '');
 
 function readComponent(themePath: string) {
   function walk(dir: string): Array<string> {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The `.` should be escaped so it doesn't match any letter. Previously it would remove any `*ts` in the name, leading to some wrongly displayed names like `BlogTagsPoPage` and `MDXCompone`:

![image](https://user-images.githubusercontent.com/55398995/127826092-b7901445-5fcb-4b1d-9c32-4f2a1b97b149.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Verify by running `yarn swizzle @docusaurus/theme-classic` and see that the component names list is now displayed correctly.