### PR TITLE
refactor: properly type docs version

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -137,3 +137,32 @@ declare module '@theme/Seo' {
   const Seo: (props: Props) => JSX.Element;
   export default Seo;
 }
+
+declare module '@theme/hooks/useDocs' {
+  type GlobalPluginData = import('./types').GlobalPluginData;
+  type GlobalVersion = import('./types').GlobalVersion;
+  type ActivePlugin = import('./client/docsClientUtils').ActivePlugin;
+  type ActiveDocContext = import('./client/docsClientUtils').ActiveDocContext;
+  type DocVersionSuggestions = import('./client/docsClientUtils').DocVersionSuggestions;
+
+  export type {GlobalPluginData, GlobalVersion};
+  export const useAllDocsData: () => Record<string, GlobalPluginData>;
+  export const useDocsData: (pluginId?: string) => GlobalPluginData;
+  export const useActivePlugin: (
+    options: GetActivePluginOptions = {},
+  ) => ActivePlugin | undefined;
+  export const useActivePluginAndVersion: (
+    options: GetActivePluginOptions = {},
+  ) =>
+    | {activePlugin: ActivePlugin; activeVersion: GlobalVersion | undefined}
+    | undefined;
+  export const useVersions: (pluginId?: string) => GlobalVersion[];
+  export const useLatestVersion: (pluginId?: string) => GlobalVersion;
+  export const useActiveVersion: (
+    pluginId?: string,
+  ) => GlobalVersion | undefined;
+  export const useActiveDocContext: (pluginId?: string) => ActiveDocContext;
+  export const useDocVersionSuggestions: (
+    pluginId?: string,
+  ) => DocVersionSuggestions;
+}

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -40,7 +40,7 @@ function DocItem(props: Props): JSX.Element {
     lastUpdatedBy,
   } = metadata;
 
-  const {pluginId} = useActivePlugin({failfast: true});
+  const {pluginId} = useActivePlugin({failfast: true})!;
   const versions = useVersions(pluginId);
 
   // If site is not versioned or only one version is included

--- a/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
@@ -116,7 +116,7 @@ function DocVersionBannerEnabled({versionMetadata}: Props): JSX.Element {
   const {pluginId} = useActivePlugin({failfast: true})!;
 
   const getVersionMainDoc = (version: GlobalVersion) =>
-    version.docs.find((doc) => doc.id === version.mainDocId);
+    version.docs.find((doc) => doc.id === version.mainDocId)!;
 
   const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
 
@@ -138,7 +138,7 @@ function DocVersionBannerEnabled({versionMetadata}: Props): JSX.Element {
       <div className="margin-top--md">
         <LatestVersionSuggestionLabel
           versionLabel={latestVersionSuggestion.label}
-          to={latestVersionSuggestedDoc!.path}
+          to={latestVersionSuggestedDoc.path}
           onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
         />
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
@@ -9,7 +9,11 @@ import React, {ComponentType} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
-import {useActivePlugin, useDocVersionSuggestions} from '@theme/hooks/useDocs';
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+  GlobalVersion,
+} from '@theme/hooks/useDocs';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 
 import type {Props} from '@theme/DocVersionBanner';
@@ -109,9 +113,9 @@ function DocVersionBannerEnabled({versionMetadata}: Props): JSX.Element {
   const {
     siteConfig: {title: siteTitle},
   } = useDocusaurusContext();
-  const {pluginId} = useActivePlugin({failfast: true});
+  const {pluginId} = useActivePlugin({failfast: true})!;
 
-  const getVersionMainDoc = (version) =>
+  const getVersionMainDoc = (version: GlobalVersion) =>
     version.docs.find((doc) => doc.id === version.mainDocId);
 
   const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
@@ -134,7 +138,7 @@ function DocVersionBannerEnabled({versionMetadata}: Props): JSX.Element {
       <div className="margin-top--md">
         <LatestVersionSuggestionLabel
           versionLabel={latestVersionSuggestion.label}
-          to={latestVersionSuggestedDoc.path}
+          to={latestVersionSuggestedDoc!.path}
           onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
         />
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -41,8 +41,10 @@ export default function DocNavbarItem({
   const latestVersion = useLatestVersion(docsPluginId);
 
   // Versions used to look for the doc to link to, ordered + no duplicate
-  const versions: GlobalDataVersion[] = uniq(
-    [activeVersion, preferredVersion, latestVersion].filter(Boolean),
+  const versions = uniq(
+    [activeVersion, preferredVersion, latestVersion].filter(
+      Boolean,
+    ) as GlobalDataVersion[],
   );
   const doc = getDocInVersions(versions, docId);
 

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
@@ -7,11 +7,15 @@
 
 import React from 'react';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
-import {useActiveVersion, useLatestVersion} from '@theme/hooks/useDocs';
+import {
+  useActiveVersion,
+  useLatestVersion,
+  GlobalVersion,
+} from '@theme/hooks/useDocs';
 import type {Props} from '@theme/NavbarItem/DocsVersionNavbarItem';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 
-const getVersionMainDoc = (version) =>
+const getVersionMainDoc = (version: GlobalVersion) =>
   version.docs.find((doc) => doc.id === version.mainDocId);
 
 export default function DocsVersionNavbarItem({
@@ -25,6 +29,6 @@ export default function DocsVersionNavbarItem({
   const latestVersion = useLatestVersion(docsPluginId);
   const version = activeVersion ?? preferredVersion ?? latestVersion;
   const label = staticLabel ?? version.label;
-  const path = staticTo ?? getVersionMainDoc(version).path;
+  const path = staticTo ?? getVersionMainDoc(version)!.path;
   return <DefaultNavbarItem {...props} label={label} to={path} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
@@ -16,7 +16,7 @@ import type {Props} from '@theme/NavbarItem/DocsVersionNavbarItem';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 
 const getVersionMainDoc = (version: GlobalVersion) =>
-  version.docs.find((doc) => doc.id === version.mainDocId);
+  version.docs.find((doc) => doc.id === version.mainDocId)!;
 
 export default function DocsVersionNavbarItem({
   label: staticLabel,
@@ -29,6 +29,6 @@ export default function DocsVersionNavbarItem({
   const latestVersion = useLatestVersion(docsPluginId);
   const version = activeVersion ?? preferredVersion ?? latestVersion;
   const label = staticLabel ?? version.label;
-  const path = staticTo ?? getVersionMainDoc(version)!.path;
+  const path = staticTo ?? getVersionMainDoc(version).path;
   return <DefaultNavbarItem {...props} label={label} to={path} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
@@ -37,7 +37,7 @@ export default function useContextualSearchFilters(): ContextualSearchFilters {
 
     const version = activeVersion ?? preferredVersion ?? latestVersion;
 
-    return docVersionSearchTag(pluginId, version.name);
+    return docVersionSearchTag(pluginId, version!.name);
   }
 
   const tags = [

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
@@ -33,11 +33,11 @@ export default function useContextualSearchFilters(): ContextualSearchFilters {
 
     const preferredVersion = docsPreferredVersionByPluginId[pluginId];
 
-    const latestVersion = allDocsData[pluginId].versions.find((v) => v.isLast);
+    const latestVersion = allDocsData[pluginId].versions.find((v) => v.isLast)!;
 
     const version = activeVersion ?? preferredVersion ?? latestVersion;
 
-    return docVersionSearchTag(pluginId, version!.name);
+    return docVersionSearchTag(pluginId, version.name);
   }
 
   const tags = [

--- a/packages/docusaurus-theme-common/src/types.d.ts
+++ b/packages/docusaurus-theme-common/src/types.d.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable import/no-duplicates */
 /* eslint-disable spaced-comment */
 /// <reference types="@docusaurus/module-type-aliases" />
 /// <reference types="@docusaurus/plugin-content-blog" />

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionProvider.tsx
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionProvider.tsx
@@ -15,7 +15,7 @@ import React, {
 import {useThemeConfig, DocsVersionPersistence} from '../useThemeConfig';
 import {isDocsPluginEnabled} from '../docsUtils';
 
-import {useAllDocsData} from '@theme/hooks/useDocs';
+import {useAllDocsData, GlobalPluginData} from '@theme/hooks/useDocs';
 
 import DocsPreferredVersionStorage from './DocsPreferredVersionStorage';
 
@@ -54,7 +54,7 @@ function readStorageState({
 }: {
   pluginIds: string[];
   versionPersistence: DocsVersionPersistence;
-  allDocsData: any; // TODO find a way to type it :(
+  allDocsData: Record<string, GlobalPluginData>;
 }): DocsPreferredVersionState {
   // The storage value we read might be stale,
   // and belong to a version that does not exist in the site anymore
@@ -68,7 +68,7 @@ function readStorageState({
     );
     const pluginData = allDocsData[pluginId];
     const versionExists = pluginData.versions.some(
-      (version: any) => version.name === preferredVersionNameUnsafe,
+      (version) => version.name === preferredVersionNameUnsafe,
     );
     if (versionExists) {
       return {preferredVersionName: preferredVersionNameUnsafe};

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/useDocsPreferredVersion.ts
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/useDocsPreferredVersion.ts
@@ -6,25 +6,24 @@
  */
 import {useCallback} from 'react';
 import {useDocsPreferredVersionContext} from './DocsPreferredVersionProvider';
-import {useAllDocsData, useDocsData} from '@theme/hooks/useDocs';
+import {useAllDocsData, useDocsData, GlobalVersion} from '@theme/hooks/useDocs';
 
-import {DEFAULT_PLUGIN_ID} from '@docusaurus/constants';
-
-// TODO improve typing
+import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
 
 // Note, the preferredVersion attribute will always be null before mount
 export function useDocsPreferredVersion(
   pluginId: string | undefined = DEFAULT_PLUGIN_ID,
-) {
+): {
+  preferredVersion: GlobalVersion | null | undefined;
+  savePreferredVersionName: (versionName: string) => void;
+} {
   const docsData = useDocsData(pluginId);
   const [state, api] = useDocsPreferredVersionContext();
 
   const {preferredVersionName} = state[pluginId];
 
   const preferredVersion = preferredVersionName
-    ? docsData.versions.find(
-        (version: any) => version.name === preferredVersionName,
-      )
+    ? docsData.versions.find((version) => version.name === preferredVersionName)
     : null;
 
   const savePreferredVersionName = useCallback(
@@ -37,7 +36,10 @@ export function useDocsPreferredVersion(
   return {preferredVersion, savePreferredVersionName} as const;
 }
 
-export function useDocsPreferredVersionByPluginId(): Record<string, any> {
+export function useDocsPreferredVersionByPluginId(): Record<
+  string,
+  GlobalVersion | null | undefined
+> {
   const allDocsData = useAllDocsData();
   const [state] = useDocsPreferredVersionContext();
 
@@ -47,17 +49,14 @@ export function useDocsPreferredVersionByPluginId(): Record<string, any> {
 
     return preferredVersionName
       ? docsData.versions.find(
-          (version: any) => version.name === preferredVersionName,
+          (version) => version.name === preferredVersionName,
         )
       : null;
   }
 
   const pluginIds = Object.keys(allDocsData);
 
-  const result: Record<
-    string,
-    any // TODO find a way to type this properly!
-  > = {};
+  const result: Record<string, GlobalVersion | null | undefined> = {};
   pluginIds.forEach((pluginId) => {
     result[pluginId] = getPluginIdPreferredVersion(pluginId);
   });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Remove the TODO & Reduce ESLint warnings about `no-explicit-any`. 

There were far more implicit `any`'s than captured by CI; for example, all the `useActivePlugin` hook usage was wrongly colored as green (for classes/types) rather than yellow (for functions) in my VSCode because the editor doesn't know what's the module `@theme/hooks/useDocs` at all.

Used some non-null assertions, but probably little side-effects (considering it's still an improvement from the previous `any`)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The build passes