### PR TITLE
fix: fix canary release versions

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -15,6 +15,8 @@ jobs:
         node-version: [12.x]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Needed to get the commit number with "git rev-list --count HEAD"
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "crowdin:upload:v2": "crowdin upload sources --config ./crowdin-v2.yaml",
     "crowdin:download:v2": "crowdin download --config ./crowdin-v2.yaml",
     "canary": "yarn canary:bumpVersion && yarn canary:publish",
-    "canary:version": "echo `node -e \"console.log(require('./packages/docusaurus/package.json').version)\"`.`git rev-list --count HEAD`.`git rev-parse --short HEAD`",
+    "canary:version": "echo 0.0.0-`git rev-list --count HEAD`+`git rev-parse --short HEAD`",
     "canary:bumpVersion": "yarn lerna version `yarn --silent canary:version` --exact --no-push --yes",
     "canary:publish": "yarn lerna publish from-package --dist-tag canary --yes --no-verify-access",
     "changelog": "lerna-changelog",


### PR DESCRIPTION

## Motivation

Another attempt to fix the canary release naming convention to avoid `^2.0.0-beta.0a668366c2` picking up another version in lockfile after install.

The commit hash should rather not be used as a semver pre-release identifier because commit hashes won't be ordered properly in semver order. Adding the commit hash after the `+` is not used to determine precedence of the canary releases.

Also we can't use `2.0.0` prefix because non pre-release versions are picked up in priority over pre-release versions, so user might end-up with a stable release instead of a canary in the future. Switching to `0.0.0` makes sure that an user that really wants a canary will get a canary (assuming we'll never publish `0.0.0`)

https://semver.org/

Relevant spec paragraphs:

![image](https://user-images.githubusercontent.com/749374/128336939-8c363522-e2d0-4317-ba51-c80cc0ba3eda.png)

![image](https://user-images.githubusercontent.com/749374/128336968-a82ca31f-ec09-4068-85be-4bb5beb06d11.png)


Useful for testing: https://semver.npmjs.com/