### PR TITLE
fix: remove unexpected whitespaces in CSS bundle

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -61,7 +61,7 @@
     "boxen": "^5.0.1",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",
-    "clean-css": "^5.1.2",
+    "clean-css": "^5.1.5",
     "commander": "^5.1.0",
     "copy-webpack-plugin": "^9.0.0",
     "core-js": "^3.9.1",

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -561,6 +561,7 @@ export function getMinimizer(
             level: {
               1: {
                 all: false,
+                removeWhitespace: true,
               },
               2: {
                 all: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6448,10 +6448,10 @@ clean-css@^4.2.3:
   dependencies:
     source-map "~0.6.0"
 
-clean-css@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.2.tgz#6ea0da7286b4ddc2469a1b776e2461a5007eed54"
-  integrity sha512-QcaGg9OuMo+0Ds933yLOY+gHPWbxhxqF0HDexmToPf8pczvmvZGYzd+QqWp9/mkucAOKViI+dSFOqoZIvXbeBw==
+clean-css@^5.1.5:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.5.tgz#3b0af240dcfc9a3779a08c2332df3ebd4474f232"
+  integrity sha512-9dr/cU/LjMpU57PXlSvDkVRh0rPxJBXiBtD0+SgYt8ahTCsXtfKjCkNYgIoTC6mBg8CFr5EKhW3DKCaGMUbUfQ==
   dependencies:
     source-map "~0.6.0"
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Bumping version of clean-css because there was bug where spaces and line breaks were not removed around `var` calls (if any) in CSS code. This was fixed in 5.1.5, but `removeWhitespace` option in level 1 also needs to be enabled for correct work.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/128487512-34f26489-f8b9-4737-a418-f59c5869d92d.png) | ![image](https://user-images.githubusercontent.com/4408379/128487582-854b856e-a461-4f3b-be09-c74c7f47ca2f.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
