### PR TITLE
fix: docusaurus serve logs wrong port if 3000 is taken

### DIFF
--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -48,7 +48,7 @@ export default async function serve(
     customConfigFilePath: cliOptions.config,
   });
 
-  const servingUrl = `http://${cliOptions.host}:${cliOptions.port}`;
+  const servingUrl = `http://${host}:${port}`;
 
   const server = http.createServer((req, res) => {
     // Automatically redirect requests to /baseUrl/


### PR DESCRIPTION
## Motivation

When I `docusaurus serve` when 3000 port is already used, I expect the modified port to be displayed on the console.
But the original port is displayed by mistake.

So I fixed this problem.

### Before
![image](https://user-images.githubusercontent.com/63966451/128509071-4465d616-4d1f-4369-9a0c-20934faa1e5d.png)

### After
![image](https://user-images.githubusercontent.com/63966451/128509044-6ca761fc-72a4-443b-84e4-c86a8fa8d987.png)


## Test Plan

```
$ yarn build:package
# move to docusaurus project
$ python -m http.server 3000
$ docusaurus serve 
# and you can see 3001 port is displayed on the console.
```
