### PR TITLE
fix: avoid extra default active class on doc sidebar item

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -166,10 +166,9 @@ function DocSidebarItemLink({
         className={clsx('menu__link', {
           'menu__link--active': isActive,
         })}
+        aria-current={isActive ? 'page' : undefined}
         to={href}
         {...(isInternalUrl(href) && {
-          isNavLink: true,
-          exact: true,
           onClick: onItemClick,
         })}
         {...props}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, unnecessary `active` CSS class (it's default class in [react-router](https://reactrouter.com/web/api/NavLink/activeclassname-string)) is added to active doc sidebar link. This happens because we use `NavLink`, which in this case we don't need, because we set our own logic to determine link activity.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Results on `docs/configuration` path:

| Before   | After    |
| -------- | -------- |
| `<a class="menu__link menu__link--active active" tabindex="0" href="/docs/next/configuration" aria-current="page">Configuration</a>` | `<a class="menu__link menu__link--active" tabindex="0" href="/docs/configuration" aria-current="page">Configuration</a>` |



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
