### PR TITLE
feat: structured data for blog posts

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import BlogLayout from '@theme/BlogLayout';
 import BlogPostItem from '@theme/BlogPostItem';
+import BlogPostStructuredData from '@theme/BlogPostStructuredData';
 import BlogPostPaginator from '@theme/BlogPostPaginator';
 import type {Props} from '@theme/BlogPostPage';
 import {ThemeClassNames} from '@docusaurus/theme-common';
@@ -30,6 +31,11 @@ function BlogPostPage(props: Props): JSX.Element {
           ? BlogPostContents.toc
           : undefined
       }>
+      <BlogPostStructuredData
+        frontMatter={frontMatter}
+        frontMatterAssets={frontMatterAssets}
+        metadata={metadata}
+      />
       <BlogPostItem
         frontMatter={frontMatter}
         frontMatterAssets={frontMatterAssets}

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostStructuredData/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostStructuredData/index.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Head from '@docusaurus/Head';
+import type {Props} from '@theme/BlogPostStructuredData';
+
+function BlogPostStructuredData(props: Props): JSX.Element {
+  const {frontMatter, frontMatterAssets, metadata} = props;
+  const {date, title, description} = metadata;
+
+  const image = frontMatterAssets.image ?? frontMatter.image;
+
+  const authorURL = frontMatter.author_url || frontMatter.authorURL;
+  const authorTitle = frontMatter.author_title || frontMatter.authorTitle;
+
+  // details on structured data support: https://developers.google.com/search/docs/data-types/article#non-amp
+  // and https://schema.org/BlogPosting
+  const blogPostStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: title,
+    description,
+    ...(image ? {image: [image]} : {}),
+    datePublished: date,
+    author: {
+      '@type': 'Person',
+      name: authorTitle,
+      url: authorURL,
+    },
+  };
+
+  return (
+    <Head>
+      <script type="application/ld+json">
+        {JSON.stringify(blogPostStructuredData)}
+      </script>
+    </Head>
+  );
+}
+
+export default BlogPostStructuredData;

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -46,6 +46,24 @@ declare module '@theme/BlogPostItem' {
   export default BlogPostItem;
 }
 
+declare module '@theme/BlogPostStructuredData' {
+  import type {
+    FrontMatter,
+    FrontMatterAssets,
+    Metadata,
+  } from '@theme/BlogPostPage';
+
+  export type Props = {
+    readonly frontMatter: FrontMatter;
+    readonly frontMatterAssets: FrontMatterAssets;
+    readonly metadata: Metadata;
+    readonly truncated?: string | boolean;
+  };
+
+  const BlogPostStructuredData: (props: Props) => JSX.Element;
+  export default BlogPostStructuredData;
+}
+
 declare module '@theme/BlogPostPaginator' {
   type Item = {readonly title: string; readonly permalink: string};
 


### PR DESCRIPTION
## Motivation

This is an implementation of adding structured data support to blog posts, as discussed here: https://github.com/facebook/docusaurus/discussions/5321

The aim being to improve SEO of blog posts rendered with Docusaurus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

It doesn't look like there's any automated tests for this area, so let me show you what my manual testing resulted in.  With the change in place, blog posts have a new JSON-LD [structured data section](https://developers.google.com/search/docs/data-types/article#non-amp) of [`BlogPosting` type](https://schema.org/BlogPosting) appearing in the head which contains a subset of the frontmatter metadata:

```html
<script type="application/ld+json" data-react-helmet="true">
{
    "@context":"https://schema.org",
    "@type":"BlogPosting",
    "headline":"Announcing Docusaurus 2 Beta",
    "description":"After a lengthy alpha stage in order to ensure feature parity and quality, we are excited to officially release the first Docusaurus 2 beta.",
    "image":["/assets/images/social-card-414bbe5147ecc177bbe8d858616709c5.png"],
    "datePublished":"2021-05-12T00:00:00.000Z",
    "author":{"@type":"Person","name":"Docusaurus maintainer","url":"imageurl"}
}
</script>
```

![screenshot of chrome devtools showing new section](https://user-images.githubusercontent.com/1010525/128668813-57928889-ac8d-4d84-9642-cf09f17ce80e.png)

This results in structure data which Google can parse - as tested using the Rich Results Test tool: https://search.google.com/test/rich-results

![screenshot of rich results test](https://user-images.githubusercontent.com/1010525/128669180-0991767c-a308-4844-a50e-4c06eded16bf.png)
