### PR TITLE
feat: Markdown page-specific head metadatas

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,10 @@ module.exports = {
     'no-nested-ternary': WARNING,
     '@typescript-eslint/no-empty-function': OFF,
     '@typescript-eslint/no-non-null-assertion': OFF, // Have to use type assertion anyways
-    '@typescript-eslint/no-unused-vars': [ERROR, {argsIgnorePattern: '^_'}],
+    '@typescript-eslint/no-unused-vars': [
+      ERROR,
+      {argsIgnorePattern: '^_', ignoreRestSiblings: true},
+    ],
     '@typescript-eslint/ban-ts-comment': [
       ERROR,
       {'ts-expect-error': 'allow-with-description'},

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -6,13 +6,33 @@
  */
 
 import React, {ComponentProps, isValidElement, ReactElement} from 'react';
+import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import CodeBlock, {Props} from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 import Details from '@theme/Details';
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 
+// MDX elements are wrapped through the MDX pragma
+// In some cases (notably usage with Head/Helmet) we need to unwrap those elements.
+function unwrapMDXElement(element: ReactElement) {
+  if (element?.props?.mdxType && element?.props?.originalType) {
+    return React.createElement(element.props.originalType, {
+      ...element.props,
+      mdxType: undefined,
+      originalType: undefined,
+    });
+  }
+  return element;
+}
+
 const MDXComponents: MDXComponentsObject = {
+  head: (props) => {
+    const unwrappedChildren = React.Children.map(props.children, (child) =>
+      unwrapMDXElement(child as ReactElement),
+    );
+    return <Head {...props}>{unwrappedChildren}</Head>;
+  },
   code: (props) => {
     const {children} = props;
 

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -17,13 +17,7 @@ import type {MDXComponentsObject} from '@theme/MDXComponents';
 // In some cases (notably usage with Head/Helmet) we need to unwrap those elements.
 function unwrapMDXElement(element: ReactElement) {
   if (element?.props?.mdxType && element?.props?.originalType) {
-    const newProps = {
-      ...element.props,
-      mdxType: undefined,
-      originalType: undefined,
-    };
-    delete newProps.mdxType;
-    delete newProps.originalType;
+    const {mdxType, originalType, ...newProps} = element.props;
     return React.createElement(element.props.originalType, newProps);
   }
   return element;

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -17,11 +17,14 @@ import type {MDXComponentsObject} from '@theme/MDXComponents';
 // In some cases (notably usage with Head/Helmet) we need to unwrap those elements.
 function unwrapMDXElement(element: ReactElement) {
   if (element?.props?.mdxType && element?.props?.originalType) {
-    return React.createElement(element.props.originalType, {
+    const newProps = {
       ...element.props,
       mdxType: undefined,
       originalType: undefined,
-    });
+    };
+    delete newProps.mdxType;
+    delete newProps.originalType;
+    return React.createElement(element.props.originalType, newProps);
   }
   return element;
 }

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -333,8 +333,10 @@ declare module '@theme/SkipToContent' {
 declare module '@theme/MDXComponents' {
   import type {ComponentProps} from 'react';
   import type CodeBlock from '@theme/CodeBlock';
+  import type Head from '@docusaurus/Head';
 
   export type MDXComponentsObject = {
+    readonly head: typeof Head;
     readonly code: typeof CodeBlock;
     readonly a: (props: ComponentProps<'a'>) => JSX.Element;
     readonly pre: typeof CodeBlock;

--- a/website/docs/guides/markdown-features/markdown-features-head-metadatas.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-head-metadatas.mdx
@@ -1,0 +1,61 @@
+---
+id: head-metadatas
+title: Head Metadatas
+description: Declaring page-specific head metadatas through MDX
+slug: /markdown-features/head-metadatas
+---
+
+# Head Metadatas
+
+Docusaurus automatically sets useful page metadatas in `<html>`, `<head>` and `<body>` for you.
+
+It is possible to add (or override) metadatas by using the `<head>` tag directly in Markdown files:
+
+```md title="markdown-features-head-metadatas.mdx"
+---
+id: head-metadatas
+title: Head Metadatas
+---
+
+<!-- highlight-start -->
+<head>
+  <html className="some-extra-class" />
+  <body className="other-extra-class" />
+  <title>Head Metadatas customized title!</title>
+  <meta charSet="utf-8" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="canonical" href="https://docusaurus.io/docs/markdown-features/head-metadatas" />
+</head>
+<!-- highlight-end -->
+
+# Head Metadatas
+
+My text
+```
+
+```mdx-code-block
+<head>
+  <html className="html-head-metadatas-extra-class" lang="en" />
+  <body className="body-head-metadatas-extra-class" />
+  <title>Head Metadatas customized title!</title>
+  <meta charSet="utf-8" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="canonical" href="https://docusaurus.io/docs/markdown-features/head-metadatas" />
+</head>
+```
+
+:::tip
+
+We used this `<head>` declaration in this Markdown file as a demo.
+
+Open your browser DevTools and check how this page's metadatas have been affected.
+
+:::
+
+:::note
+
+This feature is built on top of the Docusaurus [`<Head>`](./../../docusaurus-core.md#head) component.
+
+Refer to [react-helmet](https://github.com/nfl/react-helmet) for exhaustive documentation.
+
+:::

--- a/website/docs/guides/markdown-features/markdown-features-head-metadatas.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-head-metadatas.mdx
@@ -9,7 +9,7 @@ slug: /markdown-features/head-metadatas
 
 Docusaurus automatically sets useful page metadatas in `<html>`, `<head>` and `<body>` for you.
 
-It is possible to add (or override) metadatas by using the `<head>` tag directly in Markdown files:
+It is possible to add extra metadatas (or override existing ones) by using the `<head>` tag in Markdown files:
 
 ```md title="markdown-features-head-metadatas.mdx"
 ---
@@ -19,8 +19,8 @@ title: Head Metadatas
 
 <!-- highlight-start -->
 <head>
-  <html className="some-extra-class" />
-  <body className="other-extra-class" />
+  <html className="some-extra-html-class" />
+  <body className="other-extra-body-class" />
   <title>Head Metadatas customized title!</title>
   <meta charSet="utf-8" />
   <meta name="twitter:card" content="summary" />
@@ -35,8 +35,8 @@ My text
 
 ```mdx-code-block
 <head>
-  <html className="html-head-metadatas-extra-class" lang="en" />
-  <body className="body-head-metadatas-extra-class" />
+  <html className="some-extra-html-class" />
+  <body className="other-extra-body-class" />
   <title>Head Metadatas customized title!</title>
   <meta charSet="utf-8" />
   <meta name="twitter:card" content="summary" />
@@ -46,7 +46,7 @@ My text
 
 :::tip
 
-We used this `<head>` declaration in this Markdown file as a demo.
+This `<head>` declaration has been added to the current Markdown doc, as a demo.
 
 Open your browser DevTools and check how this page's metadatas have been affected.
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -49,6 +49,7 @@ module.exports = {
             'guides/markdown-features/assets',
             'guides/markdown-features/plugins',
             'guides/markdown-features/math-equations',
+            'guides/markdown-features/head-metadatas',
           ],
         },
         'styling-layout',


### PR DESCRIPTION
## Motivation

To give maximum control to the user, we should enable the user to declare page head metadatas on a per-md-file basis.

Fixes https://github.com/facebook/docusaurus/issues/2603


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

dogfooding on our site

Preview: https://deploy-preview-5330--docusaurus-2.netlify.app/docs/next/markdown-features/head-metadatas/

