### PR TITLE
fix: plugin ideal-image should generate filename with a hash even in development 

### DIFF
--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -41,9 +41,7 @@ export default function (
                     disable: !isProd,
                     // eslint-disable-next-line global-require
                     adapter: require('@docusaurus/responsive-loader/sharp'),
-                    name: isProd
-                      ? 'assets/ideal-img/[name].[hash:hex:7].[width].[ext]'
-                      : 'assets/ideal-img/[name].[width].[ext]',
+                    name: 'assets/ideal-img/[name].[hash:hex:7].[width].[ext]',
                     ...options,
                   },
                 },


### PR DESCRIPTION
Hi! Following our discussion here (https://github.com/facebook/docusaurus/issues/5326), I wrote a PR to generate hash filename even in dev environnement.

I've run the test suites, linter & prettier and it seems fine. I've started the Docusaurus website locally as well.

I haven't found any tests for this plugin so I don't know if I should write some?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes


