### PR TITLE
fix: add admonitions support to mdx partials loaded through the fallback mdx loader

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -98,6 +98,7 @@
     "react-router": "^5.2.0",
     "react-router-config": "^5.1.1",
     "react-router-dom": "^5.2.0",
+    "remark-admonitions": "^1.2.1",
     "resolve-pathname": "^3.0.0",
     "rtl-detect": "^1.0.3",
     "semver": "^7.3.4",

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -39,6 +39,7 @@ import {
 } from './translations/translations';
 import {mapValues} from 'lodash';
 import {RuleSetRule} from 'webpack';
+import admonitions from 'remark-admonitions';
 
 export type LoadContextOptions = {
   customOutDir?: string;
@@ -225,6 +226,7 @@ function createMDXFallbackPlugin({siteDir}: {siteDir: string}): LoadedPlugin {
                     staticDir: path.join(siteDir, STATIC_DIR_NAME),
                     isMDXPartial: (_filename) => true, // External mdx files are always meant to be imported as partials
                     isMDXPartialFrontMatterWarningDisabled: true, // External mdx files might have frontmatter, let's just disable the warning
+                    remarkPlugins: [admonitions],
                   },
                 },
               ],


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/5333

Note it's a good-enough solution but not ideal because the admonition config is static and can't be disabled (unlike content plugins): we'll expose a global way to configure markdown/mdx for the whole docusaurus site later

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Not automated but works locally on the changelog page:

![image](https://user-images.githubusercontent.com/749374/129045850-0ba85dcf-e62e-45a1-837c-30813f76ac90.png)


