### PR TITLE
chore: e2e tests should stay on Yarn v2 for now

### DIFF
--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Setup test-website project for Yarn v2
         run: |
           cd test-website
+          yarn set version 2
           yarn set version 2.2.0
           yarn --version
           yarn config set pnpMode loose

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -59,7 +59,7 @@ jobs:
           install-command: yarn
       - name: Setup test-website project against master release
         run: |
-          KEEP_CONTAINER=true yarn test:build:v2
+          KEEP_CONTAINER=true yarn test:build:v2 -s
           rm -rf node_modules
       - name: Setup test-website project for Yarn v2
         run: |

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -59,7 +59,7 @@ jobs:
           install-command: yarn
       - name: Setup test-website project against master release
         run: |
-          KEEP_CONTAINER=true yarn test:build:v2 -s
+          KEEP_CONTAINER=true yarn test:build:v2
           rm -rf node_modules
       - name: Setup test-website project for Yarn v2
         run: |

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -63,20 +63,20 @@ jobs:
           rm -rf node_modules
       - name: Setup test-website project for Yarn v2
         run: |
-          cd test-website
+          mv test-website ../test-website
+          cd ../test-website
           yarn set version 2
-          yarn set version 2.2.0
-          yarn --version
           yarn config set pnpMode loose
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'
           yarn config set enableGlobalCache true
+          yarn --version
           yarn install
       - name: Start test-website project
-        run: cd test-website && yarn start --no-open
+        run: cd ../test-website && yarn start --no-open
         env:
           E2E_TEST: true
       - name: Build test-website project
-        run: cd test-website && yarn build
+        run: cd ../test-website && yarn build
         env:
           CI: true

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -59,18 +59,22 @@ jobs:
           install-command: yarn
       - name: Setup test-website project against master release
         run: |
-          KEEP_CONTAINER=true yarn test:build:v2
-          rm -rf node_modules
+          KEEP_CONTAINER=true yarn test:build:v2 -s
+          ls -l test-website
       - name: Setup test-website project for Yarn v2
         run: |
           mv test-website ../test-website
           cd ../test-website
+
+          yarn set version berry
+          yarn --version
           yarn set version 2
+          yarn --version
+
           yarn config set pnpMode loose
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'
           yarn config set enableGlobalCache true
-          yarn --version
           yarn install
       - name: Start test-website project
         run: cd ../test-website && yarn start --no-open

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Setup test-website project for Yarn v2
         run: |
           cd test-website
-          yarn set version 2
+          yarn set version 2.2.0
+          yarn --version
           yarn config set pnpMode loose
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup test-website project for Yarn v2
         run: |
           cd test-website
-          yarn set version berry
+          yarn set version 2
           yarn config set pnpMode loose
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'

--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -12,8 +12,27 @@ NEW_VERSION="$(node -p "require('./packages/docusaurus/package.json').version").
 CONTAINER_NAME="verdaccio"
 EXTRA_OPTS=""
 
-if getopts ":n" arg; then
-  EXTRA_OPTS="--use-npm"
+usage() { echo "Usage: $0 [-n] [-s]" 1>&2; exit 1; }
+
+while getopts ":ns" o; do
+  case "${o}" in
+    n)
+      EXTRA_OPTS="--use-npm"
+      ;;
+    s)
+      EXTRA_OPTS="--skip-install"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+
+if [ ! -z $EXTRA_OPTS ]
+then
+  echo docusaurus-init extra options = ${EXTRA_OPTS}
 fi
 
 # Run Docker container with private npm registry Verdaccio

--- a/packages/docusaurus-init/templates/classic/package.json
+++ b/packages/docusaurus-init/templates/classic/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.4",
+    "@docusaurus/mdx-loader": "2.0.0-beta.4",
     "@docusaurus/preset-classic": "2.0.0-beta.4",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -117,6 +117,7 @@
     "webpackbar": "^5.0.0-3"
   },
   "peerDependencies": {
+    "@docusaurus/mdx-loader": "2.0.0-beta.4",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -149,6 +149,9 @@ export function createBaseConfig(
         process.cwd(),
       ],
       alias: {
+        // Node.js polyfill aliases, see https://sanchit3b.medium.com/how-to-polyfill-node-core-modules-in-webpack-5-905c1f5504a0
+        url: 'url',
+
         ...SharedModuleAliases,
 
         '@site': siteDir,


### PR DESCRIPTION
## Motivation

`yarn set version berry` now picks Yarn v3 instead of v2, and e2e tests time out, so we'll figure out how to bring Yarn 3 support in a separate PR

Example CI failures:
- https://github.com/facebook/docusaurus/pull/5322/checks?check_run_id=3294409591
- https://github.com/facebook/docusaurus/runs/3301363961?check_suite_focus=true

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

ci