### PR TITLE
chore: fix e2e yarn berry tests

### DIFF
--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -41,7 +41,7 @@ jobs:
         run: cd test-website && yarn build
         env:
           CI: true
-  yarn-v2:
+  yarn-berry-node-modules:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
@@ -65,7 +65,7 @@ jobs:
         run: |
           cd test-website
           yarn set version berry
-          yarn config set pnpMode loose
+          yarn config set nodeLinker node-modules
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'
           yarn config set enableGlobalCache true
@@ -78,3 +78,5 @@ jobs:
         run: cd test-website && yarn build
         env:
           CI: true
+# TODO add yarn-berry-pnp tests
+

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           cd ../test-website
           yarn install
+        env:
+          npm_config_registry: http://localhost:4873
       - name: Start test-website project
         run: cd ../test-website && yarn start --no-open
         env:

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -66,6 +66,8 @@ jobs:
           mv test-website ../test-website
           cd ../test-website
 
+          yarn set version berry
+          yarn --version
           yarn set version canary
           yarn --version
 

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -42,12 +42,13 @@ jobs:
         env:
           CI: true
 
-  yarn-berry-pnp:
+  yarn-berry:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node: ['14']
+        nodeLinker: ['pnp', 'node-modules']
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}
@@ -61,7 +62,7 @@ jobs:
       - name: Setup test-website project against master release
         run: |
           KEEP_CONTAINER=true yarn test:build:v2 -s
-      - name: Setup test-website project for Yarn v2
+      - name: Setup test-website project for Yarn berry with nodeLinker = ${{ matrix.nodeLinker }}
         run: |
           mv test-website ../test-website
           cd ../test-website
@@ -71,7 +72,7 @@ jobs:
           yarn set version canary
           yarn --version
 
-          yarn config set nodeLinker pnp
+          yarn config set nodeLinker ${{ matrix.nodeLinker }}
           yarn config set pnpMode loose
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'
@@ -85,9 +86,8 @@ jobs:
         run: cd ../test-website && yarn start --no-open
         env:
           E2E_TEST: true
+
       - name: Build test-website project
         run: cd ../test-website && yarn build
         env:
           CI: true
-# TODO add yarn-berry-pnp tests
-

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -78,6 +78,8 @@ jobs:
           yarn config set enableGlobalCache true
 
           yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false # because we expect Yarn berry to create the lockfile in CI
 
       - name: Start test-website project
         run: cd ../test-website && yarn start --no-open

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -29,16 +29,20 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           install-command: yarn
-      - name: Setup test-website project against master release
+      - name: Generate test-website project against master release
         run: |
-          yarn test:build:v2
-          rm -rf node_modules
+          yarn test:build:v2 -s
+          mv test-website ../test-website
+      - name: Install test-website project with Yarn v1
+        run: |
+          cd ../test-website
+          yarn install
       - name: Start test-website project
-        run: cd test-website && yarn start --no-open
+        run: cd ../test-website && yarn start --no-open
         env:
           E2E_TEST: true
       - name: Build test-website project
-        run: cd test-website && yarn build
+        run: cd ../test-website && yarn build
         env:
           CI: true
 
@@ -59,19 +63,19 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           install-command: yarn
-      - name: Setup test-website project against master release
+
+      - name: Generate test-website project against master release
         run: |
           KEEP_CONTAINER=true yarn test:build:v2 -s
-      - name: Setup test-website project for Yarn berry with nodeLinker = ${{ matrix.nodeLinker }}
-        run: |
           mv test-website ../test-website
+      - name: Install test-website project with Yarn Berry and nodeLinker = ${{ matrix.nodeLinker }}
+        run: |
           cd ../test-website
 
+          # we have to switch to berry first before setting the version we want
           yarn set version berry
+          # temporary using canary for #5342
           yarn set version canary
-          yarn --version
-          yarn set version canary
-          yarn --version
 
           yarn config set nodeLinker ${{ matrix.nodeLinker }}
           yarn config set pnpMode loose
@@ -81,13 +85,11 @@ jobs:
 
           yarn install
         env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false # because we expect Yarn berry to create the lockfile in CI
-
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false # Yarn berry should create the lockfile, despite CI env
       - name: Start test-website project
         run: cd ../test-website && yarn start --no-open
         env:
           E2E_TEST: true
-
       - name: Build test-website project
         run: cd ../test-website && yarn build
         env:

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -31,7 +31,7 @@ jobs:
           install-command: yarn
       - name: Generate test-website project against master release
         run: |
-          yarn test:build:v2 -s
+          KEEP_CONTAINER=true yarn test:build:v2 -s
           mv test-website ../test-website
       - name: Install test-website project with Yarn v1
         run: |

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -68,6 +68,7 @@ jobs:
           cd ../test-website
 
           yarn set version berry
+          yarn set version canary
           yarn --version
           yarn set version canary
           yarn --version

--- a/.github/workflows/v2-tests-e2e.yml
+++ b/.github/workflows/v2-tests-e2e.yml
@@ -41,7 +41,8 @@ jobs:
         run: cd test-website && yarn build
         env:
           CI: true
-  yarn-berry-node-modules:
+
+  yarn-berry-pnp:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
@@ -59,23 +60,29 @@ jobs:
           install-command: yarn
       - name: Setup test-website project against master release
         run: |
-          KEEP_CONTAINER=true yarn test:build:v2
-          rm -rf node_modules
+          KEEP_CONTAINER=true yarn test:build:v2 -s
       - name: Setup test-website project for Yarn v2
         run: |
-          cd test-website
-          yarn set version berry
-          yarn config set nodeLinker node-modules
+          mv test-website ../test-website
+          cd ../test-website
+
+          yarn set version canary
+          yarn --version
+
+          yarn config set nodeLinker pnp
+          yarn config set pnpMode loose
           yarn config set npmRegistryServer http://localhost:4873
           yarn config set unsafeHttpWhitelist --json '["localhost"]'
           yarn config set enableGlobalCache true
+
           yarn install
+
       - name: Start test-website project
-        run: cd test-website && yarn start --no-open
+        run: cd ../test-website && yarn start --no-open
         env:
           E2E_TEST: true
       - name: Build test-website project
-        run: cd test-website && yarn build
+        run: cd ../test-website && yarn build
         env:
           CI: true
 # TODO add yarn-berry-pnp tests

--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -12,8 +12,27 @@ NEW_VERSION="$(node -p "require('./packages/docusaurus/package.json').version").
 CONTAINER_NAME="verdaccio"
 EXTRA_OPTS=""
 
-if getopts ":n" arg; then
-  EXTRA_OPTS="--use-npm"
+usage() { echo "Usage: $0 [-n] [-s]" 1>&2; exit 1; }
+
+while getopts ":ns" o; do
+  case "${o}" in
+    n)
+      EXTRA_OPTS="--use-npm"
+      ;;
+    s)
+      EXTRA_OPTS="--skip-install"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+
+if [ ! -z $EXTRA_OPTS ]
+then
+  echo docusaurus-init extra options = ${EXTRA_OPTS}
 fi
 
 # Run Docker container with private npm registry Verdaccio


### PR DESCRIPTION
## Motivation

The Yarn 2 CI is failing for a while now and it's quite difficult to debug those Yarn 2/3 PnP-only issues.

For now, I'm reverting to node-modules linking, but would be happy to add another test with PnP mode if anyone is able to make it work.

CC @SamChou19815 in case you are interested to troubleshoot the issue. I was not able to do so (https://github.com/facebook/docusaurus/pull/5340).

Repro steps:

```js
rm -rf my-website-canary

npx @docusaurus/init@canary init my-website-canary classic --skip-install

cd my-website-canary


rm -rf node_modules yarn.lock .yarn .yarnrc.yml
yarn -v

yarn set version berry
yarn -v

yarn set version 2.4.2
yarn -v

yarn config set pnpMode loose
yarn config set enableGlobalCache true

yarn install

yarn start
```

Apart a few deps error, the main error is:

> Watchpack Error (initial scan): TypeError: Cannot destructure property 'withFileTypes' of '(intermediate value)(intermediate value)(intermediate value)' as it is null.

Unfortunately can't figure out where this comes from, and the PnP zip files do not help debug this problem.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

ci