### PR TITLE
docs: update `docusaurus-plugin-sass` instructions

### DIFF
--- a/website/docs/styling-layout.md
+++ b/website/docs/styling-layout.md
@@ -166,7 +166,7 @@ To use Sass/SCSS as your CSS preprocessor, install the unofficial Docusaurus 2 p
 1. Install [`docusaurus-plugin-sass`](https://github.com/rlamana/docusaurus-plugin-sass):
 
 ```bash npm2yarn
-npm install --save docusaurus-plugin-sass
+npm install --save docusaurus-plugin-sass sass
 ```
 
 2. Include the plugin in your `docusaurus.config.js` file:


### PR DESCRIPTION
## Motivation

The `docusaurus-plugin-sass` plugin has `sass` as a peer dependency, so you
need to install that package as well, as per their README.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan

N/A (docs change)

## Related PRs

N/A
