### PR TITLE
fix: code blocks should scroll in RTL direction

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -52,6 +52,7 @@
 
 .codeBlockLines {
   font: inherit;
+  /*rtl:ignore*/
   float: left;
   min-width: 100%;
   padding: var(--ifm-pre-padding);


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/5324

