### PR TITLE
fix: refactor TOC highlighting + handle edge cases

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -48,7 +48,7 @@ const createAnchorHeading = (
         <a
           aria-hidden="true"
           tabIndex={-1}
-          className={clsx('anchor', {
+          className={clsx('anchor', `anchor__${Tag}`, {
             [styles.enhancedAnchor]: !hideOnScroll,
           })}
           id={id}

--- a/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
@@ -7,13 +7,18 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import useTOCHighlight from '@theme/hooks/useTOCHighlight';
+import useTOCHighlight, {
+  Params as TOCHighlightParams,
+} from '@theme/hooks/useTOCHighlight';
 import type {TOCProps, TOCHeadingsProps} from '@theme/TOC';
 import styles from './styles.module.css';
 
 const LINK_CLASS_NAME = 'table-of-contents__link';
-const ACTIVE_LINK_CLASS_NAME = 'table-of-contents__link--active';
-const TOP_OFFSET = 100;
+
+const TOC_HIGHLIGHT_PARAMS: TOCHighlightParams = {
+  linkClassName: LINK_CLASS_NAME,
+  linkActiveClassName: 'table-of-contents__link--active',
+};
 
 /* eslint-disable jsx-a11y/control-has-associated-label */
 export function TOCHeadings({
@@ -45,7 +50,7 @@ export function TOCHeadings({
 }
 
 function TOC({toc}: TOCProps): JSX.Element {
-  useTOCHighlight(LINK_CLASS_NAME, ACTIVE_LINK_CLASS_NAME, TOP_OFFSET);
+  useTOCHighlight(TOC_HIGHLIGHT_PARAMS);
   return (
     <div className={clsx(styles.tableOfContents, 'thin-scrollbar')}>
       <TOCHeadings toc={toc} />

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -255,11 +255,11 @@ declare module '@theme/hooks/useThemeContext' {
 }
 
 declare module '@theme/hooks/useTOCHighlight' {
-  export default function useTOCHighlight(
-    linkClassName: string,
-    linkActiveClassName: string,
-    topOffset: number,
-  ): void;
+  export type Params = {
+    linkClassName: string;
+    linkActiveClassName: string;
+  };
+  export default function useTOCHighlight(params: Params): void;
 }
 
 declare module '@theme/hooks/useUserPreferencesContext' {


### PR DESCRIPTION
## Motivation

The TOC highlighting hook was quite messy and hard to understand

This is a total refactor with logic that is easier to reason about, and also solving some edge cases

Fix https://github.com/facebook/docusaurus/issues/5318 where the first anchor can highlighted even if it's way below the viewport.

Fix highlighting bugs due to not ignoring h4/h5/h6 headings

Fix unnecessary usage of state, leading to useless React re-renders on scroll

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

