### PR TITLE
docs: remove docusaurus-preset-name from preset doc

### DIFF
--- a/website/docs/presets.md
+++ b/website/docs/presets.md
@@ -10,7 +10,7 @@ Presets are collections of plugins and themes.
 A preset is usually a npm package, so you install them like other npm packages using npm.
 
 ```bash npm2yarn
-npm install --save docusaurus-preset-name
+npm install --save @docusaurus/preset-classic
 ```
 
 Then, add it in your site's `docusaurus.config.js`'s `presets` option:
@@ -18,7 +18,7 @@ Then, add it in your site's `docusaurus.config.js`'s `presets` option:
 ```jsx {3} title="docusaurus.config.js"
 module.exports = {
   // ...
-  presets: ['@docusaurus/preset-xxxx'],
+  presets: ['@docusaurus/preset-classic'],
 };
 ```
 

--- a/website/versioned_docs/version-2.0.0-beta.3/presets.md
+++ b/website/versioned_docs/version-2.0.0-beta.3/presets.md
@@ -18,7 +18,7 @@ Then, add it in your site's `docusaurus.config.js`'s `presets` option:
 ```jsx {3} title="docusaurus.config.js"
 module.exports = {
   // ...
-  presets: ['@docusaurus/preset-xxxx'],
+  presets: ['@docusaurus/preset-classic'],
 };
 ```
 

--- a/website/versioned_docs/version-2.0.0-beta.3/presets.md
+++ b/website/versioned_docs/version-2.0.0-beta.3/presets.md
@@ -10,7 +10,7 @@ Presets are collections of plugins and themes.
 A preset is usually a npm package, so you install them like other npm packages using npm.
 
 ```bash npm2yarn
-npm install --save docusaurus-preset-name
+npm install --save @docusaurus/preset-classic
 ```
 
 Then, add it in your site's `docusaurus.config.js`'s `presets` option:

--- a/website/versioned_docs/version-2.0.0-beta.4/presets.md
+++ b/website/versioned_docs/version-2.0.0-beta.4/presets.md
@@ -18,7 +18,7 @@ Then, add it in your site's `docusaurus.config.js`'s `presets` option:
 ```jsx {3} title="docusaurus.config.js"
 module.exports = {
   // ...
-  presets: ['@docusaurus/preset-xxxx'],
+  presets: ['@docusaurus/preset-classic'],
 };
 ```
 

--- a/website/versioned_docs/version-2.0.0-beta.4/presets.md
+++ b/website/versioned_docs/version-2.0.0-beta.4/presets.md
@@ -10,7 +10,7 @@ Presets are collections of plugins and themes.
 A preset is usually a npm package, so you install them like other npm packages using npm.
 
 ```bash npm2yarn
-npm install --save docusaurus-preset-name
+npm install --save @docusaurus/preset-classic
 ```
 
 Then, add it in your site's `docusaurus.config.js`'s `presets` option:


### PR DESCRIPTION


## Motivation

Using a real existing preset name as an example seems less confusing for users.

Fix https://github.com/facebook/docusaurus/issues/5358