### PR TITLE
refactor: make main heading font size changeable via CSS var

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -39,7 +39,7 @@
     "copy-text-to-clipboard": "^3.0.1",
     "fs-extra": "^10.0.0",
     "globby": "^11.0.2",
-    "infima": "0.2.0-alpha.30",
+    "infima": "0.2.0-alpha.31",
     "lodash": "^4.17.20",
     "parse-numeric-range": "^1.2.0",
     "postcss": "^8.2.15",

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -24,7 +24,7 @@ export const MainHeading: HeadingComponent = function MainHeading({...props}) {
       <h1
         {...props}
         id={undefined} // h1 headings do not need an id because they don't appear in the TOC
-        className={styles.h1Heading}>
+      >
         {props.children}
       </h1>
     </header>

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
@@ -8,8 +8,3 @@
 .enhancedAnchor {
   top: calc(var(--ifm-navbar-height) * -1 - 0.5rem);
 }
-
-.h1Heading {
-  font-size: 3rem;
-  margin-bottom: calc(var(--ifm-leading-desktop) * var(--ifm-leading));
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11126,10 +11126,10 @@ infer-owner@^1.0.3, infer-owner@^1.0.4:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-infima@0.2.0-alpha.30:
-  version "0.2.0-alpha.30"
-  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.30.tgz#98c4037796ea134b63b787c030ee1bf46dfadc82"
-  integrity sha512-4VBgaohDbM/viJ11MaBJz7glNODV9NRHAFqrEl+MsBNUflV1RIPEWjTkKa6L6TS/ROXlwimDcspGWKqVjNjBpg==
+infima@0.2.0-alpha.31:
+  version "0.2.0-alpha.31"
+  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.31.tgz#c5b66ef1797551471c49b636d6ed270f981d276e"
+  integrity sha512-ggOAeyiQIFKZeYnH9lbhDBHFZhcYOa0LFKSMLgot33X21aJRu7ruwVUVwYg4kJnZRLGLeAjC5BVgLxKoLixuNQ==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Instead of changing font size of main header via `font-size` property, it should only be possible to change related `--ifm-h1-font-size` CSS var. This is better approach also allows us to get rid of one extra class.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview (actually, there is no visible changes)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
