### PR TITLE
Compass postcss settings added to classic template.

### DIFF
--- a/packages/docusaurus-init/templates/classic/package.json
+++ b/packages/docusaurus-init/templates/classic/package.json
@@ -25,6 +25,9 @@
     "react-dom": "^17.0.1",
     "url-loader": "^4.1.1"
   },
+  "devDependencies": {
+    "postcss-scss": "^4.0.0"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/packages/docusaurus-init/templates/classic/postcss.config.js
+++ b/packages/docusaurus-init/templates/classic/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  syntax: 'postcss-scss',
+}


### PR DESCRIPTION
## Motivation

We had attempted to upgrade from 2.0.0-alpha.70, but got stuck with css compilation error.
```
Syntax error: postcss-custom-properties: <css input> Unknown word (1:1)
> 1 | var(--ifm-font-size-base)/var(--ifm-line-height-base) var(--ifm-font-family-base)
    | ^
Client bundle compiled with errors therefore further build is impossible.
```
The error may be uncommon, google gives nothing about this exact message. Search though sources gave us thought about problems with compass postcss compilation. Here came the fix (thanks to stackoverflow).
The fix was tested for classic template only, you may apply it for typescript template later.

We use docusaurus in website subfolder of our project, that uses babel, typescript, postcss, there may have been some conflicts between node_modules in subfolder and in main folder that might have lead to unexpected usage of main postcss.config (i assume).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

a little bit

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
