### PR TITLE
fix: fix write-translations warning for theme-common translations

### DIFF
--- a/packages/docusaurus/src/server/translations/translationsExtractor.ts
+++ b/packages/docusaurus/src/server/translations/translationsExtractor.ts
@@ -80,6 +80,7 @@ export async function extractSiteSourceCodeTranslations(
   siteDir: string,
   plugins: InitializedPlugin[],
   babelOptions: TransformOptions,
+  extraSourceCodeFilePaths: string[] = [],
 ): Promise<TranslationFileContent> {
   // Should we warn here if the same translation "key" is found in multiple source code files?
   function toTranslationFileContent(
@@ -92,8 +93,13 @@ export async function extractSiteSourceCodeTranslations(
 
   const sourceCodeFilePaths = await getSourceCodeFilePaths(siteDir, plugins);
 
+  const allSourceCodeFilePaths = [
+    ...sourceCodeFilePaths,
+    ...extraSourceCodeFilePaths,
+  ];
+
   const sourceCodeFilesTranslations = await extractAllSourceCodeFileTranslations(
-    sourceCodeFilePaths,
+    allSourceCodeFilePaths,
     babelOptions,
   );
 


### PR DESCRIPTION

## Motivation

The `write-translations` cli is not able to extract theme-common translations, and we get a warning:

![image](https://user-images.githubusercontent.com/749374/130262797-406c96bc-c9cd-40d7-96f5-602ae15b07c0.png)

Instead of introducing a new plugin lifecycle just to extract from `theme-common`, I made a little hacky exception to solve this problem and automatically extract from this package that 99% of Docusaurus will use anyway.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

CI does not report the warning anymore

