### PR TITLE
fix: fix site unlocalized 404 pages + aggressive Netlify /assets caching

### DIFF
--- a/website/static/_headers
+++ b/website/static/_headers
@@ -1,0 +1,18 @@
+
+# /assets folder contain Webpack processed assets with a file hash
+# They are safe for immutable caching, as filename change when content change
+
+/assets/*
+  cache-control: immutable
+
+/fr/assets/*
+  cache-control: immutable
+
+/pt-BR/assets/*
+  cache-control: immutable
+
+/ko/assets/*
+  cache-control: immutable
+
+/zh-CN/assets/*
+  cache-control: immutable

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -19,11 +19,6 @@ https://docusaurus.io/docs/zh-cn/*      https://v1.docusaurus.io/docs/zh-cn/:spl
 /classic/blog/2020/01/19/docusaurus-2020-recap    /classic/blog/2021/01/19/docusaurus-2020-recap
 
 
-# Redirect each country sub-path to appropriate localized 404 file
-# See https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling
-/fr/*         /fr/404.html          404
-
-
 # Redirect Docusaurus v1 blog RSS feed
 /blog/feed.xml   /blog/rss.xml
 
@@ -31,3 +26,14 @@ https://docusaurus.io/docs/zh-cn/*      https://v1.docusaurus.io/docs/zh-cn/:spl
 # Feature requests redirects
 /feedback/*                 /feature-requests/:splat    301!
 /feature-requests/*         /feature-requests           200
+
+
+# FALLBACK: PUT THIS LAST (rules above are more important)
+# Redirect each country sub-path to appropriate localized 404 file
+# Note: the 404 won't be served if the path match an existing static file
+# Note: useless for /* => Netlify already serve /404.html
+# See https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling
+/fr/*             /fr/404             404
+/pt-BR/*          /pt-BR/404          404
+/ko/*             /ko/404             404
+/zh-CN/*          /zh-CN/404          404


### PR DESCRIPTION

## Motivation

Some 404 pages are not properly localized: https://docusaurus.io/ko/xyz

We should apply ourselves patterns that we actually document in the i18n doc.

Also, we should cache `/assets` files aggressively because those are hashed by webpack and safe to cache. This will be documented later on a perf guide if successful.