### PR TITLE
refactor: improve styles of Details component

### DIFF
--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -18,25 +18,23 @@ CSS variables, meant to be overriden by final theme
   position: relative;
   cursor: pointer;
   list-style: none;
-  margin-left: 1.8rem;
+  padding-left: 1rem;
 }
 
-.details > summary::-webkit-details-marker {
+.details > summary:marker {
   display: none;
 }
 
 .details > summary:before {
   position: absolute;
   top: 0.45rem;
-  left: -1.2rem;
+  left: 0;
 
   /* CSS-only Arrow */
   content: '';
-  width: 0;
-  height: 0;
-  border-top: var(--docusaurus-details-summary-arrow-size) solid transparent;
-  border-bottom: var(--docusaurus-details-summary-arrow-size) solid transparent;
-  border-left: var(--docusaurus-details-summary-arrow-size) solid
+  border-width: var(--docusaurus-details-summary-arrow-size);
+  border-style: solid;
+  border-color: transparent transparent transparent
     var(--docusaurus-details-decoration-color);
 
   /* Arrow rotation anim */

--- a/website/docs/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-intro.mdx
@@ -91,10 +91,10 @@ Markdown can embed HTML elements, and [`details`](https://developer.mozilla.org/
   <summary>Toggle me!</summary>
   <div>
     <div>This is the detailed content</div>
+    <br/>
     <details>
       <summary>
-        <div>Nested toggle!</div>
-        <div>Some surprise inside...</div>
+        Nested toggle! Some surprise inside...
       </summary>
       <div>
         😲😲😲😲😲


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Fix browser warning below
> [Deprecation] ::-webkit-details-marker pseudo element selector is deprecated. Please use ::marker instead. See https://chromestatus.com/feature/6730096436051968 for more details.
- Make clickable space around marker
- Minor styles cleanup
- Fix example (div cannot be inside details)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
