### PR TITLE
fix: various fixes back-to-top button

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
@@ -7,6 +7,7 @@
 
 import React, {useRef, useState} from 'react';
 import clsx from 'clsx';
+import {useLocation} from '@docusaurus/router';
 import useScrollPosition from '@theme/hooks/useScrollPosition';
 
 import styles from './styles.module.css';
@@ -66,38 +67,42 @@ function useSmoothScrollToTop(): UseSmoothScrollTopReturn {
 }
 
 function BackToTopButton(): JSX.Element {
+  const location = useLocation();
   const {smoothScrollTop, cancelScrollToTop} = useSmoothScrollToTop();
   const [show, setShow] = useState(false);
 
-  useScrollPosition(({scrollY: scrollTop}, lastPosition) => {
-    // No lastPosition means component is just being mounted.
-    // Not really a scroll event from the user, so we ignore it
-    if (!lastPosition) {
-      return;
-    }
-    const lastScrollTop = lastPosition.scrollY;
-
-    const isScrollingUp = scrollTop < lastScrollTop;
-
-    if (!isScrollingUp) {
-      cancelScrollToTop();
-    }
-
-    if (scrollTop < threshold) {
-      setShow(false);
-      return;
-    }
-
-    if (isScrollingUp) {
-      const documentHeight = document.documentElement.scrollHeight;
-      const windowHeight = window.innerHeight;
-      if (scrollTop + windowHeight < documentHeight) {
-        setShow(true);
+  useScrollPosition(
+    ({scrollY: scrollTop}, lastPosition) => {
+      // No lastPosition means component is just being mounted.
+      // Not really a scroll event from the user, so we ignore it
+      if (!lastPosition) {
+        return;
       }
-    } else {
-      setShow(false);
-    }
-  }, []);
+      const lastScrollTop = lastPosition.scrollY;
+
+      const isScrollingUp = scrollTop < lastScrollTop;
+
+      if (!isScrollingUp) {
+        cancelScrollToTop();
+      }
+
+      if (scrollTop < threshold) {
+        setShow(false);
+        return;
+      }
+
+      if (isScrollingUp) {
+        const documentHeight = document.documentElement.scrollHeight;
+        const windowHeight = window.innerHeight;
+        if (scrollTop + windowHeight < documentHeight) {
+          setShow(true);
+        }
+      } else {
+        setShow(false);
+      }
+    },
+    [location],
+  );
 
   return (
     <button
@@ -105,7 +110,6 @@ function BackToTopButton(): JSX.Element {
         [styles.backToTopButtonShow]: show,
       })}
       type="button"
-      title="Scroll to top"
       onClick={() => smoothScrollTop()}>
       <svg viewBox="0 0 24 24" width="28">
         <path

--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/styles.module.css
@@ -29,7 +29,7 @@
   transform: scale(0);
 }
 
-.backToTopButton:hover {
+.backToTopButton:not(:focus):hover {
   opacity: 0.8;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Remove redundant and untranslatable `title` attribute, probably it's not needed since the button is self-explanatory.

- Cancel hover state after clicking on the button, that made it semi-transparent when re-render (actual on mobiles).

![image](https://user-images.githubusercontent.com/4408379/130795188-627e48a6-fa30-4c50-8420-cb1bd14663f1.png)

- Avoid showing of the button when clicking on anchor links in TOC since this is strange and unexpected behavior.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
