### PR TITLE
docs: clarify using custom attributes for navbar link

### DIFF
--- a/website/docs/api/themes/theme-configuration.md
+++ b/website/docs/api/themes/theme-configuration.md
@@ -276,6 +276,12 @@ Accepted fields:
 
 </small>
 
+:::note
+
+In addition to the fields above, you can specify other arbitrary attributes that can be applied to a HTML link.
+
+:::
+
 Example configuration:
 
 ```js title="docusaurus.config.js"
@@ -291,6 +297,7 @@ module.exports = {
           label: 'Introduction',
           position: 'left',
           activeBaseRegex: 'docs/(next|v8)',
+          target: '_blank',
         },
         // highlight-end
       ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Although it seems kind of self-evident, not all users understand that for a navbar link they can specify attributes allowable for any HTML link.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
