### PR TITLE
refactor: make dynamic authors layout via CSS only

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/index.tsx
@@ -21,7 +21,7 @@ export default function BlogPostAuthors({authors, assets}: Props): JSX.Element {
   return (
     <div className="row margin-top--md margin-bottom--sm">
       {authors.map((author, idx) => (
-        <div className={clsx('col col--6', styles.author)} key={idx}>
+        <div className={clsx('col col--6', styles.authorCol)} key={idx}>
           <BlogPostAuthor
             author={{
               ...author,

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/styles.module.css
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.author {
+.authorCol {
   max-width: inherit !important;
   flex-grow: 1 !important;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When we have two-column layout for authors, we can remove JS logic of adding right class depending of authors numbers -- just we need to add little extra CSS code to get the same result.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

![2021-08-26_14-14](https://user-images.githubusercontent.com/4408379/130955769-d3b37d5a-9293-48d0-807e-3c5d0d7bc1a5.png)

![2021-08-26_14-14_1](https://user-images.githubusercontent.com/4408379/130955776-ca53ab32-8349-4c75-94f3-854479d31788.png)



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
