### PR TITLE
refactor: use SVG for closable button in announcement bar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
@@ -33,9 +33,7 @@ function AnnouncementBar(): JSX.Element | null {
       role="banner">
       {isCloseable && <div className={styles.announcementBarPlaceholder} />}
       <div
-        className={clsx(styles.announcementBarContent, {
-          [styles.announcementBarCloseable]: isCloseable,
-        })}
+        className={styles.announcementBarContent}
         // Developer provided the HTML, so assume it's safe.
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{__html: content}}
@@ -50,7 +48,9 @@ function AnnouncementBar(): JSX.Element | null {
             message: 'Close',
             description: 'The ARIA label for close button of announcement bar',
           })}>
-          <span aria-hidden="true">×</span>
+          <svg width="14" height="14" viewBox="0 0 24 24">
+            <path d="M24 20.188l-8.315-8.209 8.2-8.282-3.697-3.697-8.212 8.318-8.31-8.203-3.666 3.666 8.321 8.24-8.206 8.313 3.666 3.666 8.237-8.318 8.285 8.203z" />
+          </svg>
         </button>
       ) : null}
     </div>

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -28,11 +28,9 @@ html[data-announcement-bar-initially-dismissed='true'] .announcementBar {
 
 .announcementBarClose {
   flex: 0 0 30px;
-}
-
-.announcementBarClose {
   align-self: stretch;
   padding: 0;
+  line-height: 0;
 }
 
 .announcementBarContent {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The vertical centering of Unicode character is unstable, for example in Chrome on Linux, alignment of "x" char looks more or less ok, but in Chrome on Windows, it is much worse:


| Linux   | Windows |
| -------- | -------- |
| ![2021-08-31_10-40](https://user-images.githubusercontent.com/4408379/131463682-60f66f51-6c75-4a54-9e0d-b2ec0d3a567d.png) | ![2021-08-31_10-41](https://user-images.githubusercontent.com/4408379/131463678-aeff4a60-5ed5-4c25-9e7f-a86314deb98d.png) |

That's why I suggest using SVG icon to achieve uniform alignment in all browsers.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

![image](https://user-images.githubusercontent.com/4408379/131464443-5f115365-a5bc-455a-a4b7-ea43681ff153.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
