### PR TITLE
feat: on back navigation, close mobile sidebar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -15,7 +15,7 @@ import {
   useThemeConfig,
   useMobileSecondaryMenuRenderer,
   usePrevious,
-  useHistoryBackwardForwardHandler,
+  useHistoryBlockPop,
 } from '@docusaurus/theme-common';
 import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
@@ -58,14 +58,14 @@ function useMobileSidebar() {
 
   const [shown, setShown] = useState(false);
 
-  // If sidebar is open, replace backward/forward navigation by close sidebar
-  // Useful so that we can close sidebar with Android back button
-  useHistoryBackwardForwardHandler(() => {
+  // When open, prevent pop (backward/forward) navigation and close the sidebar
+  // Useful to close sidebar with Android back button
+  useHistoryBlockPop(() => {
     if (shown) {
       setShown(false);
-      return false; // block transition
+      return false; // prevent pop navigation
     }
-    return undefined; // don't block
+    return undefined;
   });
 
   const toggle = useCallback(() => {

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -15,7 +15,7 @@ import {
   useThemeConfig,
   useMobileSecondaryMenuRenderer,
   usePrevious,
-  useHistoryBlockPop,
+  useHistoryPopHandler,
 } from '@docusaurus/theme-common';
 import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
@@ -58,12 +58,14 @@ function useMobileSidebar() {
 
   const [shown, setShown] = useState(false);
 
-  // When open, prevent pop (backward/forward) navigation and close the sidebar
-  // Useful to close sidebar with Android back button
-  useHistoryBlockPop(() => {
+  // Close mobile sidebar on navigation pop
+  // Most likely firing when using the Android back button (but not only)
+  useHistoryPopHandler(() => {
     if (shown) {
       setShown(false);
-      return false; // prevent pop navigation
+      // Should we prevent the navigation here?
+      // See https://github.com/facebook/docusaurus/pull/5462#issuecomment-911699846
+      // return false; // prevent pop navigation
     }
     return undefined;
   });

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -15,6 +15,7 @@ import {
   useThemeConfig,
   useMobileSecondaryMenuRenderer,
   usePrevious,
+  useHistoryBackwardForwardHandler,
 } from '@docusaurus/theme-common';
 import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
@@ -56,6 +57,16 @@ function useMobileSidebar() {
   const shouldRender = windowSize === 'mobile'; // || windowSize === 'ssr';
 
   const [shown, setShown] = useState(false);
+
+  // If sidebar is open, replace backward/forward navigation by close sidebar
+  // Useful so that we can close sidebar with Android back button
+  useHistoryBackwardForwardHandler(() => {
+    if (shown) {
+      setShown(false);
+      return false; // block transition
+    }
+    return undefined; // don't block
+  });
 
   const toggle = useCallback(() => {
     setShown((s) => !s);

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -71,3 +71,5 @@ export {useLocalPathname} from './utils/useLocalPathname';
 
 export {translateTagsPageTitle, listTagsByLetters} from './utils/tagsUtils';
 export type {TagLetterEntry} from './utils/tagsUtils';
+
+export {useHistoryBackwardForwardHandler} from './utils/historyUtils';

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -72,4 +72,4 @@ export {useLocalPathname} from './utils/useLocalPathname';
 export {translateTagsPageTitle, listTagsByLetters} from './utils/tagsUtils';
 export type {TagLetterEntry} from './utils/tagsUtils';
 
-export {useHistoryBackwardForwardHandler} from './utils/historyUtils';
+export {useHistoryBlock, useHistoryBlockPop} from './utils/historyUtils';

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -72,4 +72,4 @@ export {useLocalPathname} from './utils/useLocalPathname';
 export {translateTagsPageTitle, listTagsByLetters} from './utils/tagsUtils';
 export type {TagLetterEntry} from './utils/tagsUtils';
 
-export {useHistoryBlock, useHistoryBlockPop} from './utils/historyUtils';
+export {useHistoryPopHandler} from './utils/historyUtils';

--- a/packages/docusaurus-theme-common/src/utils/historyUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/historyUtils.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useEffect, useRef} from 'react';
+import {useHistory} from '@docusaurus/router';
+import type {Location} from '@docusaurus/history';
+
+/*
+Permits to register a handler that will be called when a backward/forward navigation is detected
+If the handler returns false, the backward/forward transition will be blocked
+
+Limitations:
+- can't detect backward/forward direction
+- only handles navigation to direct backward/forward "sibling". history.go(-2) won't trigger the handler.
+
+Unfortunately there's no good way to detect the direction of the history POP event.
+This code is a best effort to make it possible to handle Android back-button,
+
+Only use this when it's not a big deal to handle backward/forward navigations in a similar way (like closing menus/sidebars/drawers)
+ */
+export function useHistoryBackwardForwardHandler(
+  handler: () => void | false,
+): void {
+  const {location, block} = useHistory();
+
+  // Avoid stale closure issues without triggering useless re-renders
+  const lastHandlerRef = useRef(handler);
+  useEffect(() => {
+    lastHandlerRef.current = handler;
+  }, [handler]);
+
+  // Unfortunately there's no easy way to detect a backward/forward navigation
+  // We only track the last 2 locations because it's enough to detect a back navigation
+  const last2LocationsRef = useRef<[Location, Location | undefined]>([
+    location,
+    undefined,
+  ]);
+
+  useEffect(() => {
+    last2LocationsRef.current = [location, last2LocationsRef.current[0]];
+  }, [location]);
+
+  useEffect(() => {
+    // See https://github.com/remix-run/history/blob/main/docs/blocking-transitions.md
+    return block((newLocation, action) => {
+      const previousLocation = last2LocationsRef.current[1];
+      const isBackNavigation =
+        action === 'POP' &&
+        newLocation.key &&
+        newLocation.key === previousLocation?.key;
+
+      if (isBackNavigation) {
+        // Block backward/forward navigation if handler returns false
+        return lastHandlerRef.current();
+      }
+      // Don't block other navigation events
+      return undefined;
+    });
+  }, [block, lastHandlerRef]);
+}

--- a/packages/docusaurus-theme-common/src/utils/historyUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/historyUtils.ts
@@ -11,7 +11,11 @@ import type {Location, Action} from '@docusaurus/history';
 
 type HistoryBlockHandler = (location: Location, action: Action) => void | false;
 
-export function useHistoryBlock(handler: HistoryBlockHandler): void {
+/*
+Permits to register a handler that will be called on history actions (pop,push,replace)
+If the handler returns false, the navigation transition will be blocked/cancelled
+ */
+export function useHistoryActionHandler(handler: HistoryBlockHandler): void {
   const {block} = useHistory();
 
   // Avoid stale closure issues without triggering useless re-renders
@@ -33,14 +37,11 @@ Permits to register a handler that will be called on history pop navigation (bac
 If the handler returns false, the backward/forward transition will be blocked
 
 Unfortunately there's no good way to detect the "direction" (backward/forward) of the POP event.
-
-Only use this when it's not a big deal to handle backward/forward navigations in a similar way (like closing menus/sidebars/drawers)
-This code is a best effort to make it possible to handle Android back-button
  */
-export function useHistoryBlockPop(handler: HistoryBlockHandler): void {
-  useHistoryBlock((location, action) => {
+export function useHistoryPopHandler(handler: HistoryBlockHandler): void {
+  useHistoryActionHandler((location, action) => {
     if (action === 'POP') {
-      // Block navigation if handler returns false
+      // Eventually block navigation if handler returns false
       return handler(location, action);
     }
     // Don't block other navigation actions


### PR DESCRIPTION

## Motivation

Android users are used to using the hardware back button of their phone to close menus and drawers (cf Android apps, like Gmail)

Docusaurus users on Android might try that, and instead of closing the opened sidebar drawer, it would navigate to the previous page, potentially leaving the Docusaurus site. We should try to fix that UX issue.


Unfortunately, there's no browser API to easily detect or prevent backward navigation, and we have to use some tricks on top of the `history` package that offers a `block()` feature.

Still, it's not possible to distinguish easily between backward/forward navigation, so this remains a best effort. 
Closing the mobile sidebar on forward navigation is not an UX issue + the probably of an user using forward navigation on mobile with the drawer open is low, so this is a safe usecase.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview on browser + android
