### PR TITLE
fix: add docs tag validation to solve #5478

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
@@ -314,7 +314,7 @@ describe('validateBlogPostFrontMatter tags', () => {
       {tags: ['hello', {label: 'tagLabel', permalink: '/tagPermalink'}]},
     ],
     invalidFrontMatters: [
-      [{tags: ''}, 'must be an array'],
+      [{tags: ''}, '"tags" does not look like a valid FrontMatter Yaml array.'],
       [{tags: ['']}, 'not allowed to be empty'],
     ],
     // See https://github.com/facebook/docusaurus/issues/4642

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
@@ -242,3 +242,24 @@ describe('validateDocFrontMatter parse_number_prefixes', () => {
     ],
   });
 });
+
+describe('validateDocFrontMatter tags', () => {
+  testField({
+    fieldName: 'tags',
+    validFrontMatters: [{}, {tags: undefined}, {tags: ['tag1', 'tag2']}],
+    convertibleFrontMatter: [[{tags: ['tag1', 42]}, {tags: ['tag1', '42']}]],
+    invalidFrontMatters: [
+      [{tags: 42}, '"tags" does not look like a valid FrontMatter Yaml array.'],
+      [
+        {tags: 'tag1, tag2'},
+        '"tags" does not look like a valid FrontMatter Yaml array.',
+      ],
+      [{tags: [{}]}, '"tags[0]" does not look like a valid tag'],
+      [{tags: [true]}, '"tags[0]" does not look like a valid tag'],
+      [
+        {tags: ['tag1', {hey: 'test'}]},
+        '"tags[1]" does not look like a valid tag',
+      ],
+    ],
+  });
+});

--- a/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
@@ -27,6 +27,10 @@ const DocFrontMatterSchema = Joi.object<DocFrontMatter>({
   slug: Joi.string(),
   sidebar_label: Joi.string(),
   sidebar_position: Joi.number(),
+  tags: [Joi.string(), Joi.array().items(Joi.object({
+    label: Joi.string,
+    permalink: Joi.string
+  }))]
   pagination_label: Joi.string(),
   custom_edit_url: URISchema.allow('', null),
   parse_number_prefixes: Joi.boolean(),

--- a/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
@@ -8,6 +8,7 @@
 import {
   JoiFrontMatter as Joi, // Custom instance for frontmatter
   URISchema,
+  FrontMatterTagsSchema,
   validateFrontMatter,
 } from '@docusaurus/utils-validation';
 import {DocFrontMatter} from './types';
@@ -27,10 +28,7 @@ const DocFrontMatterSchema = Joi.object<DocFrontMatter>({
   slug: Joi.string(),
   sidebar_label: Joi.string(),
   sidebar_position: Joi.number(),
-  tags: [Joi.string(), Joi.array().items(Joi.object({
-    label: Joi.string,
-    permalink: Joi.string
-  }))]
+  tags: FrontMatterTagsSchema,
   pagination_label: Joi.string(),
   custom_edit_url: URISchema.allow('', null),
   parse_number_prefixes: Joi.boolean(),

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -61,12 +61,22 @@ export const PathnameSchema = Joi.string()
     '{{#label}} is not a valid pathname. Pathname should start with slash and not contain any domain or query string.',
   );
 
-export const FrontMatterTagsSchema = JoiFrontMatter.array().items(
-  JoiFrontMatter.alternatives().try(
+const FrontMatterTagSchema = JoiFrontMatter.alternatives()
+  .try(
     JoiFrontMatter.string().required(),
     JoiFrontMatter.object<Tag>({
       label: JoiFrontMatter.string().required(),
       permalink: JoiFrontMatter.string().required(),
     }).required(),
-  ),
-);
+  )
+  .messages({
+    'alternatives.match': '{{#label}} does not look like a valid tag',
+    'alternatives.types': '{{#label}} does not look like a valid tag',
+  });
+
+export const FrontMatterTagsSchema = JoiFrontMatter.array()
+  .items(FrontMatterTagSchema)
+  .messages({
+    'array.base':
+      '{{#label}} does not look like a valid FrontMatter Yaml array.',
+  });

--- a/website/docs/guides/docs/docs-create-doc.mdx
+++ b/website/docs/guides/docs/docs-create-doc.mdx
@@ -98,6 +98,12 @@ tags:
   - Getting started
 ---
 ```
-
-If you want to have a list of tags inline, you can also do this: `tags: [Demo, Getting started]`
 <!-- prettier-ignore-end -->
+
+:::tip
+
+Tags can also be declared with `tags [Demo, Getting started]`
+
+Read more about all the possible [Yaml array syntaxes](https://www.w3schools.io/file/yaml-arrays/).
+
+:::

--- a/website/docs/guides/docs/docs-create-doc.mdx
+++ b/website/docs/guides/docs/docs-create-doc.mdx
@@ -98,4 +98,6 @@ tags:
   - Getting started
 ---
 ```
+
+If you want to have a list of tags inline, you can also do this: `tags: [Demo, Getting started]`
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
fix: add docs tag validation to solve #5478

## Motivation

nicer developer experience when people put in malformed tags, as suggested by @Josh-Cena  https://github.com/facebook/docusaurus/issues/5478#issuecomment-912118520

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

i confess i did not test this one locally. hoping its a simple one.