### PR TITLE
fix: use heading itself as anchor for better crawling

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -44,16 +44,13 @@ const createAnchorHeading = (
     }
 
     return (
-      <Tag {...props}>
-        <a
-          aria-hidden="true"
-          tabIndex={-1}
-          className={clsx('anchor', `anchor__${Tag}`, {
-            [styles.anchorWithHideOnScrollNavbar]: hideOnScroll,
-            [styles.anchorWithStickyNavbar]: !hideOnScroll,
-          })}
-          id={id}
-        />
+      <Tag
+        {...props}
+        className={clsx('anchor', `anchor__${Tag}`, {
+          [styles.anchorWithHideOnScrollNavbar]: hideOnScroll,
+          [styles.anchorWithStickyNavbar]: !hideOnScroll,
+        })}
+        id={id}>
         {props.children}
         <a
           className="hash-link"

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -5,12 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.anchor {
-  display: block;
-  position: relative;
-  top: -0.5rem;
-}
-
 .hash-link {
   opacity: 0;
   padding-left: 0.5rem;

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
@@ -12,7 +12,6 @@ See https://twitter.com/JoshWComeau/status/1332015868725891076
  */
 .anchorWithStickyNavbar {
   scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
-  /*   top: calc(var(--ifm-navbar-height) * -1 - 0.5rem); */
 }
 
 .anchorWithHideOnScrollNavbar {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves https://github.com/facebook/docusaurus/discussions/5470

We have anchor link for headings without `href` attribute, which causes warning from Lighthouse https://developers.google.com/search/docs/advanced/guidelines/links-crawlable

But since we already use new `scroll-margin-top`, we can remove separate element for heading anchor, and instead just add this property on heading tag itself.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview + Lighthouse report

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
