### PR TITLE
docs: add additional search options, typesense and local search

### DIFF
--- a/website/community/2-resources.md
+++ b/website/community/2-resources.md
@@ -22,6 +22,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-lunr-search](https://github.com/lelouch77/docusaurus-lunr-search) - Offline Search for Docusaurus v2
 - [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) - Offline/local search for Docusaurus v2
 - [@easyops-cn/docusaurus-search-local](https://github.com/easyops-cn/docusaurus-search-local) - Offline/local search for Docusaurus v2 (language of zh supported)
+- [docusaurus-theme-search-typesense](https://github.com/typesense/docusaurus-theme-search-typesense) - Docusaurus v2 plugin for [Typesense DocSearch](https://typesense.org/docs/latest/guide/docsearch.html).
 
 ### Integrations {#integrations}
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -6,17 +6,22 @@ keywords:
   - search
 ---
 
-Docusaurus' own `@docusaurus/preset-classic` supports a search integration.
+There are a few options you can use to add search to your website:
 
-There are two main options, you can use [Algolia DocSearch](https://docsearch.algolia.com) or bring in your own `SearchBar` component.
+- [Algolia DocSearch](#using-algolia-docsearch)
+- [Typesense DocSearch](#using-typesense-docsearch)
+- [Local Search](#using-local-search)
+- [Your own `SearchBar` component](#using-your-own-search)
 
 ## Using Algolia DocSearch {#using-algolia-docsearch}
 
-Algolia DocSearch works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API. Note that your website needs to be publicly available for this to work (i.e., not behind a firewall). The service is free.
+[Algolia DocSearch](https://docsearch.algolia.com) works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API. Note that your website needs to be publicly available for this to work (i.e., not behind a firewall). The service is free.
 
 If your website is [not eligible](https://docsearch.algolia.com/docs/who-can-apply) for the free, hosted version of DocSearch, or if your website sits behind a firewall, then you can [run your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler. For best results, you may want to use a config file based on the [Docusaurus 2 config](https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json).
 
 ### Connecting Algolia {#connecting-algolia}
+
+Docusaurus' own `@docusaurus/preset-classic` supports an Algolia DocSearch integration.
 
 To connect your docs with Algolia, first add the package to your website:
 
@@ -181,6 +186,30 @@ If you prefer to edit the Algolia search React component, swizzle the `SearchBar
 ```bash npm2yarn
 npm run swizzle @docusaurus/theme-search-algolia SearchBar
 ```
+
+## Using Typesense DocSearch {#using-typesense-docsearch}
+
+[Typesense](https://typesense.org) DocSearch works similar to Algolia DocSearch, except that your website is indexed into a Typesense search cluster.
+
+Typesense is an [open source](https://github.com/typesense/typesense) instant-search engine that you can either:
+
+- [Self-Host](https://typesense.org/docs/latest/guide/install-typesense.html#option-2-local-machine-self-hosting) on your own servers or
+- Use the Managed [Typesense Cloud](https://cloud.typesense.org) service.
+
+Similar to Algolia DocSearch, there are two components:
+
+- [typesense-docsearch-scraper](https://github.com/typesense/typesense-docsearch-scraper) - which scrapes your website and indexes the data in your Typesense cluster.
+- [docusaurus-theme-search-typesense](https://github.com/typesense/docusaurus-theme-search-typesense) - a search bar UI component to add to your website.
+
+### Instructions
+
+Read a step-by-step walk-through of how to [run typesense-docsearch-scraper here](https://typesense.org/docs/latest/guide/docsearch.html#step-1-set-up-docsearch-scraper) and how to [install the Search Bar in your Docusaurus Site here](https://typesense.org/docs/latest/guide/docsearch.html#option-a-docusaurus-powered-sites).
+
+## Using Local Search {#using-local-search}
+
+You can use a local search plugin for websites where the search index is small and can be downloaded to your users' browsers when they visit your website.
+
+You'll find a list of community-supported [local search plugins listed here](https://docusaurus.io/community/resources#search).
 
 ## Using your own search {#using-your-own-search}
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -25,11 +25,11 @@ There are a few options you can use to add search to your website:
 
 Docusaurus has **official support** for [Algolia DocSearch](https://docsearch.algolia.com).
 
-It works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API. Note that your website needs to be publicly available for this to work (i.e., not behind a firewall). The service is free.
+It works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API.
 
 The service is **free for most Docusaurus sites**, and require you to [apply to the DocSearch program](https://docsearch.algolia.com/docs/apply).
 
-If your website is [not eligible](https://docsearch.algolia.com/docs/who-can-apply) for the free, hosted version of DocSearch, or if your website sits behind a firewall, then you can [run your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler.
+If your website is [not eligible](https://docsearch.algolia.com/docs/who-can-apply) for the free, hosted version of DocSearch, or if your website sits behind a firewall and is not public, then you can [run your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler.
 
 :::note
 
@@ -39,9 +39,16 @@ By default, the Docusaurus preset generates a [sitemap.xml](https://docusaurus.i
 
 ### Index Configuration {#algolia-index-configuration}
 
-After applying, your site's DocSearch config should be created at `https://github.com/algolia/docsearch-configs/blob/master/configs/<indexName>.json`.
+After applying, your site's DocSearch config should be created at:
 
-You can ask the DocSearch team to [help you](#algolia-support) create and maintain this configuration, or update it yourself by opening a pull-requests to [algolia/docsearch-configs](https://github.com/algolia/docsearch-configs).
+```
+https://github.com/algolia/docsearch-configs/blob/master/configs/<indexName>.json
+```
+
+This configuration file can be updated by:
+
+- [**asking for help**](#algolia-support): the DocSearch team can help you maintain it
+- opening a pull-requests in [algolia/docsearch-configs](https://github.com/algolia/docsearch-configs)
 
 :::caution
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -25,9 +25,9 @@ There are a few options you can use to add search to your website:
 
 Docusaurus has **official support** for [Algolia DocSearch](https://docsearch.algolia.com).
 
-It works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API.
+The service is **free** in most cases: just [apply to the DocSearch program](https://docsearch.algolia.com/docs/apply).
 
-The service is **free for most Docusaurus sites**, and require you to [apply to the DocSearch program](https://docsearch.algolia.com/docs/apply).
+It works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API.
 
 If your website is [not eligible](https://docsearch.algolia.com/docs/who-can-apply) for the free, hosted version of DocSearch, or if your website sits behind a firewall and is not public, then you can [run your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler.
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -8,16 +8,46 @@ keywords:
 
 There are a few options you can use to add search to your website:
 
-- [Algolia DocSearch](#using-algolia-docsearch)
-- [Typesense DocSearch](#using-typesense-docsearch)
-- [Local Search](#using-local-search)
-- [Your own `SearchBar` component](#using-your-own-search)
+- 🥇 [Algolia DocSearch](#using-algolia-docsearch) (**official**)
+- 👥 [Typesense DocSearch](#using-typesense-docsearch)
+- 👥 [Local Search](#using-local-search)
+- 👥 [Your own `SearchBar` component](#using-your-own-search)
 
-## Using Algolia DocSearch {#using-algolia-docsearch}
+:::info
 
-[Algolia DocSearch](https://docsearch.algolia.com) works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API. Note that your website needs to be publicly available for this to work (i.e., not behind a firewall). The service is free.
+🥇 Docusaurus provides **first-class support** for [Algolia DocSearch](#using-algolia-docsearch).
 
-If your website is [not eligible](https://docsearch.algolia.com/docs/who-can-apply) for the free, hosted version of DocSearch, or if your website sits behind a firewall, then you can [run your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler. For best results, you may want to use a config file based on the [Docusaurus 2 config](https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json).
+👥 Other options are **maintained by the community**: please report bugs to their respective repositories.
+
+:::
+
+## 🥇 Using Algolia DocSearch {#using-algolia-docsearch}
+
+Docusaurus has **official support** for [Algolia DocSearch](https://docsearch.algolia.com).
+
+It works by crawling the content of your website every 24 hours and putting all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API. Note that your website needs to be publicly available for this to work (i.e., not behind a firewall). The service is free.
+
+The service is **free for most Docusaurus sites**, and require you to [apply to the DocSearch program](https://docsearch.algolia.com/docs/apply).
+
+If your website is [not eligible](https://docsearch.algolia.com/docs/who-can-apply) for the free, hosted version of DocSearch, or if your website sits behind a firewall, then you can [run your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler.
+
+:::note
+
+By default, the Docusaurus preset generates a [sitemap.xml](https://docusaurus.io/sitemap.xml) that the Algolia crawler can use.
+
+:::
+
+### Index Configuration {#algolia-index-configuration}
+
+After applying, your site's DocSearch config should be created at `https://github.com/algolia/docsearch-configs/blob/master/configs/<indexName>.json`.
+
+You can ask the DocSearch team to [help you](#algolia-support) create and maintain this configuration, or update it yourself by opening a pull-requests to [algolia/docsearch-configs](https://github.com/algolia/docsearch-configs).
+
+:::caution
+
+It is highly recommended using a config similar to the [**Docusaurus 2 website config**](https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json).
+
+:::
 
 ### Connecting Algolia {#connecting-algolia}
 
@@ -187,7 +217,15 @@ If you prefer to edit the Algolia search React component, swizzle the `SearchBar
 npm run swizzle @docusaurus/theme-search-algolia SearchBar
 ```
 
-## Using Typesense DocSearch {#using-typesense-docsearch}
+### Support {#algolia-support}
+
+The Algolia DocSearch team can help you figure out search problems on your site.
+
+You can contact them by [email](mailto:documentationsearch@algolia.com) or on [Discord](https://discord.gg/tXdr5mP).
+
+Docusaurus also has an `#algolia` channel on [Discord](https://discordapp.com/invite/docusaurus).
+
+## 👥 Using Typesense DocSearch {#using-typesense-docsearch}
 
 [Typesense](https://typesense.org) DocSearch works similar to Algolia DocSearch, except that your website is indexed into a Typesense search cluster.
 
@@ -201,17 +239,15 @@ Similar to Algolia DocSearch, there are two components:
 - [typesense-docsearch-scraper](https://github.com/typesense/typesense-docsearch-scraper) - which scrapes your website and indexes the data in your Typesense cluster.
 - [docusaurus-theme-search-typesense](https://github.com/typesense/docusaurus-theme-search-typesense) - a search bar UI component to add to your website.
 
-### Instructions
-
 Read a step-by-step walk-through of how to [run typesense-docsearch-scraper here](https://typesense.org/docs/latest/guide/docsearch.html#step-1-set-up-docsearch-scraper) and how to [install the Search Bar in your Docusaurus Site here](https://typesense.org/docs/latest/guide/docsearch.html#option-a-docusaurus-powered-sites).
 
-## Using Local Search {#using-local-search}
+## 👥 Using Local Search {#using-local-search}
 
 You can use a local search plugin for websites where the search index is small and can be downloaded to your users' browsers when they visit your website.
 
 You'll find a list of community-supported [local search plugins listed here](https://docusaurus.io/community/resources#search).
 
-## Using your own search {#using-your-own-search}
+## 👥 Using your own search {#using-your-own-search}
 
 To use your own search, swizzle the `SearchBar` component in `@docusaurus/theme-classic`
 


### PR DESCRIPTION
## Motivation

This PR is a follow-up to https://github.com/facebook/docusaurus/issues/5446#issuecomment-910164722.

The motivation behind this PR is to provide multiple options for a search bar for users, in addition to Algolia. To this end, I've updated the first section of the docs to list out all the options, I've then added a section about Typesense (linking to Typesense's documentation) and another section about local search plugins.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've already run this locally to make sure formatting is good, and that all links I added work fine.

## Related PRs

None.