### PR TITLE
fix: install deps for new project via Yarn on Windows properly

### DIFF
--- a/packages/docusaurus-init/package.json
+++ b/packages/docusaurus-init/package.json
@@ -29,9 +29,13 @@
     "prompts": "^2.4.1",
     "semver": "^7.3.4",
     "shelljs": "^0.8.4",
+    "supports-color": "^8.1.1",
     "tslib": "^2.2.0"
   },
   "engines": {
     "node": ">=12.13.0"
+  },
+  "devDependencies": {
+    "@types/supports-color": "^8.1.1"
   }
 }

--- a/packages/docusaurus-init/src/index.ts
+++ b/packages/docusaurus-init/src/index.ts
@@ -12,6 +12,7 @@ import prompts, {Choice} from 'prompts';
 import path from 'path';
 import shell from 'shelljs';
 import {kebabCase, sortBy} from 'lodash';
+import supportsColor from 'supports-color';
 
 const RecommendedTemplate = 'classic';
 const TypeScriptTemplateSuffix = '-typescript';
@@ -239,11 +240,15 @@ ${chalk.cyan('Creating new Docusaurus project...')}
     console.log(`Installing dependencies with ${chalk.cyan(pkgManager)}...`);
 
     try {
+      // Use force coloring the output, since the command is invoked by shelljs, which is not the interactive shell
       shell.exec(
-        `cd "${name}" && ${
-          // Force coloring the output, because the command is invoked by shelljs, not in the interative shell
-          useYarn ? 'FORCE_COLOR=true yarn' : 'npm install --color always'
-        }`,
+        `cd "${name}" && ${useYarn ? 'yarn' : 'npm install --color always'}`,
+        {
+          env: {
+            ...process.env,
+            ...(supportsColor.stdout ? {FORCE_COLOR: '1'} : {}),
+          },
+        },
       );
     } catch (err) {
       console.log(chalk.red('Installation failed.'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4486,6 +4486,11 @@
   resolved "https://registry.yarnpkg.com/@types/stringify-object/-/stringify-object-3.3.1.tgz#9ee394931e63468de0412a8e19c9f021a7d1d24d"
   integrity sha512-bpCBW0O+QrMLNFBY/+rkZtGzcYRmc2aTD8qYHOMNUmednqETfEZtFcGEA11l9xqbIeiT1PgXG0eq3zqayVzZSQ==
 
+"@types/supports-color@^8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-8.1.1.tgz#1b44b1b096479273adf7f93c75fc4ecc40a61ee4"
+  integrity sha512-dPWnWsf+kzIG140B8z2w3fr5D03TLWbOAFQl45xUpI3vcizeXriNR5VYkWZ+WTMsUHqZ9Xlt3hrxGNANFyNQfw==
+
 "@types/tapable@^1":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
@@ -18787,7 +18792,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0:
+supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #5466 

Currently after #5233 merge dependencies are not install when initializing of new project via Yarn on Windows. This is probably because `FORCE_COLOR` environment variable is set  in command itself, but should be set in `env` object as second parameter in `shell.exec` call.
However just in case I use `supports-color` to make sure that terminal supports colorized output. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try initialize new Docusaurus project on Windows with Yarn using Command Prompt or Git Bash locally.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
