### PR TITLE
fix: ignore code block lines when creating excerpt

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
@@ -129,6 +129,19 @@ describe('createExcerpt', () => {
         `),
     ).toEqual('Markdown title');
   });
+
+  test('should create excerpt for content with various code blocks', () => {
+    expect(
+      createExcerpt(dedent`
+          \`\`\`jsx
+          import React from 'react';
+          import Layout from '@theme/Layout';
+          \`\`\`
+
+          Lorem \`ipsum\` dolor sit amet, consectetur \`adipiscing elit\`.
+        `),
+    ).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
+  });
 });
 
 describe('parseMarkdownContentTitle', () => {

--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -18,6 +18,7 @@ export function createExcerpt(fileString: string): string | undefined {
     // Remove Markdown alternate title
     .replace(/^[^\n]*\n[=]+/g, '')
     .split('\n');
+  let inCode = false;
 
   /* eslint-disable no-continue */
   // eslint-disable-next-line no-restricted-syntax
@@ -29,6 +30,14 @@ export function createExcerpt(fileString: string): string | undefined {
 
     // Skip import/export declaration.
     if (/^\s*?import\s.*(from.*)?;?|export\s.*{.*};?/.test(fileLine)) {
+      continue;
+    }
+
+    // Skip code block line.
+    if (fileLine.trim().startsWith('```')) {
+      inCode = !inCode;
+      continue;
+    } else if (inCode) {
       continue;
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves rather rare use case of improperly creating excerpt if multiline code block is at the beginning of MD document. For example, the React Native docs contains [the page](http://reactnative.dev/docs/usecolorscheme) with code block at first, which creates excerpt containing "`jsx" only.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
