### PR TITLE
fix: pin react-live due to possible mismatch React

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -19,7 +19,7 @@
     "clsx": "^1.1.1",
     "parse-numeric-range": "^1.2.0",
     "prism-react-renderer": "^1.2.1",
-    "react-live": "^2.2.3"
+    "react-live": "2.2.3"
   },
   "peerDependencies": {
     "react": "^16.8.4 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16642,7 +16642,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-live@^2.2.3:
+react-live@2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/react-live/-/react-live-2.2.3.tgz#260f99194213799f0005e473e7a4154c699d6a7c"
   integrity sha512-tpKruvfytNETuzO3o1mrQUj180GVrq35IE8F5gH1NJVPt4szYCx83/dOSCOyjgRhhc3gQvl0pQ3k/CjOjwJkKQ==


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Reported in #5555.

Since [latest minor version of react-live 2.3.0](https://github.com/FormidableLabs/react-live/releases/tag/v2.3.0) is built on hooks and not supports React v17, Docusaurus sites running through npm will not able use live code blocks because of error about React version mismatch (see https://github.com/FormidableLabs/react-live/issues/265#issuecomment-896702161). Of course, users can downgrade React version to make it work, or use webpack alias, but it would be better to handle this internally.

Therefore until react-live will not support React v17,  we should use its previous version of 2.2.0, which without hooks.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test release

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
