### PR TITLE
polish: remove unused eslint-disable

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier-docs": "prettier --config .prettierrc --write \"**/*.{md,mdx}\"",
     "prettier-docs:diff": "prettier --config .prettierrc --list-different \"**/*.{md,mdx}\"",
     "lint": "yarn lint:js && yarn lint:style",
-    "lint:ci": "yarn lint:js --quiet && yarn lint:style",
+    "lint:ci": "yarn lint:js --quiet --report-unused-disable-directives && yarn lint:style",
     "lint:js": "eslint --cache \"**/*.{js,jsx,ts,tsx}\"",
     "lint:style": "stylelint \"**/*.css\"",
     "lerna": "lerna",

--- a/packages/docusaurus-mdx-loader/src/remark/headings/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/headings/__tests__/index.test.ts
@@ -7,8 +7,6 @@
 
 /* Based on remark-slug (https://github.com/remarkjs/remark-slug) and gatsby-remark-autolink-headers (https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-autolink-headers) */
 
-/* eslint-disable no-param-reassign */
-
 import remark from 'remark';
 import u from 'unist-builder';
 import removePosition from 'unist-util-remove-position';

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
@@ -53,8 +53,6 @@ function toAssetRequireNode({
   filePath: string;
   requireAssetPath: string;
 }) {
-  /* eslint-disable no-param-reassign */
-
   let relativeRequireAssetPath = posixPath(
     path.relative(path.dirname(filePath), requireAssetPath),
   );

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import fs from 'fs-extra';
 import path from 'path';
 import pluginContentBlog from '../index';

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import path from 'path';
 import {isMatch} from 'picomatch';
 import commander from 'commander';

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/sidebars.test.ts
@@ -30,8 +30,6 @@ import {
 } from '../types';
 import {DefaultSidebarItemsGenerator} from '../sidebarItemsGenerator';
 
-/* eslint-disable global-require, import/no-dynamic-require */
-
 describe('loadSidebars', () => {
   const fixtureDir = path.join(__dirname, '__fixtures__', 'sidebars');
   const options: SidebarOptions = {

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="@docusaurus/module-type-aliases" />
 
 import type {RemarkAndRehypePluginOptions} from '@docusaurus/mdx-loader';

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.js
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.js
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable no-param-reassign */
-
 import remark from 'remark';
 import npm2yarn from '../index';
 import vfile from 'to-vfile';

--- a/packages/docusaurus-theme-bootstrap/src/types.d.ts
+++ b/packages/docusaurus-theme-bootstrap/src/types.d.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable import/no-duplicates */
-/* eslint-disable spaced-comment */
 /// <reference types="@docusaurus/module-type-aliases" />
 /// <reference types="@docusaurus/plugin-content-blog" />
 /// <reference types="@docusaurus/plugin-content-docs" />

--- a/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
@@ -65,7 +65,7 @@ function listPostsByYears(blogPosts: readonly ArchiveBlogPost[]): YearProp[] {
   }));
 }
 
-export default function BlogArchive({archive}: Props) {
+export default function BlogArchive({archive}: Props): JSX.Element {
   const title = translate({
     id: 'theme.blog.archive.title',
     message: 'Archive',

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -224,7 +224,7 @@ export default function CodeBlock({
               <code className={styles.codeBlockLines}>
                 {tokens.map((line, i) => {
                   if (line.length === 1 && line[0].content === '') {
-                    line[0].content = '\n'; // eslint-disable-line no-param-reassign
+                    line[0].content = '\n';
                   }
 
                   const lineProps = getLineProps({line, key: i});

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import clsx from 'clsx';
 import type {HeadingType, Props} from '@theme/Heading';

--- a/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
@@ -13,7 +13,7 @@ import type {Props} from '@theme/TagsListInline';
 
 import styles from './styles.module.css';
 
-export default function TagsListInline({tags}: Props) {
+export default function TagsListInline({tags}: Props): JSX.Element {
   return (
     <>
       <b>

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable import/no-duplicates */
-/* eslint-disable spaced-comment */
 /// <reference types="@docusaurus/module-type-aliases" />
 /// <reference types="@docusaurus/plugin-content-blog" />
 /// <reference types="@docusaurus/plugin-content-docs" />

--- a/packages/docusaurus-theme-common/src/types.d.ts
+++ b/packages/docusaurus-theme-common/src/types.d.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable spaced-comment */
 /// <reference types="@docusaurus/module-type-aliases" />
 /// <reference types="@docusaurus/plugin-content-blog" />
 /// <reference types="@docusaurus/plugin-content-docs" />

--- a/packages/docusaurus-theme-common/src/utils/tagsUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/tagsUtils.ts
@@ -7,7 +7,7 @@
 
 import {translate} from '@docusaurus/Translate';
 
-export const translateTagsPageTitle = () =>
+export const translateTagsPageTitle = (): string =>
   translate({
     id: 'theme.tags.tagsPageTitle',
     message: 'Tags',

--- a/packages/docusaurus/src/client/docusaurus.ts
+++ b/packages/docusaurus/src/client/docusaurus.ts
@@ -15,7 +15,7 @@ const fetched: Record<string, boolean> = {};
 const loaded: Record<string, boolean> = {};
 
 declare global {
-  // eslint-disable-next-line camelcase, @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line camelcase
   const __webpack_require__: {gca: (name: string) => string};
   interface Navigator {
     connection: {effectiveType: string; saveData: boolean};
@@ -82,7 +82,6 @@ const docusaurus = {
     chunkNamesNeeded.forEach((chunkName) => {
       // "__webpack_require__.gca" is a custom function provided by ChunkAssetPlugin.
       // Pass it the chunkName or chunkId you want to load and it will return the URL for that chunk.
-      // eslint-disable-next-line no-undef
       const chunkAsset = __webpack_require__.gca(chunkName);
 
       // In some cases, webpack might decide to optimize further & hence the chunk assets are merged to another chunk/previous chunk.

--- a/packages/docusaurus/src/client/types.d.ts
+++ b/packages/docusaurus/src/client/types.d.ts
@@ -5,7 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// triple slash is important to keep,
-// see https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
-// eslint-disable-next-line
 /// <reference types="@docusaurus/module-type-aliases" />

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -37,7 +37,7 @@ const createRouteCodeString = ({
   routeHash: string;
   exact?: boolean;
   subroutesCodeStrings?: string[];
-  props: {[propName: string]: any};
+  props: {[propName: string]: unknown};
 }) => {
   const parts = [
     `path: '${routePath}'`,

--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -19,10 +19,8 @@ function buildThemeAliases(
   Object.keys(themeAliases).forEach((aliasKey) => {
     if (aliasKey in aliases) {
       const componentName = aliasKey.substring(aliasKey.indexOf('/') + 1);
-      // eslint-disable-next-line no-param-reassign
       aliases[`@theme-init/${componentName}`] = aliases[aliasKey];
     }
-    // eslint-disable-next-line no-param-reassign
     aliases[aliasKey] = themeAliases[aliasKey];
   });
   return aliases;

--- a/packages/docusaurus/src/server/types.d.ts
+++ b/packages/docusaurus/src/server/types.d.ts
@@ -5,7 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// triple slash is important to keep,
-// see https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html
-// eslint-disable-next-line
 /// <reference types="@docusaurus/module-type-aliases" />

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -244,7 +244,7 @@ export function applyConfigurePostCss(
 
   // TODO not ideal heuristic but good enough for our usecase?
   function isPostCssLoader(loader: unknown): loader is LocalPostCSSLoader {
-    return !!(loader as any)?.options?.postcssOptions;
+    return !!(loader as LocalPostCSSLoader)?.options?.postcssOptions;
   }
 
   // Does not handle all edge cases, but good enough for now

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -89,7 +89,7 @@ export function getStyleLoaders(
           // https://github.com/facebook/create-react-app/issues/2677
           ident: 'postcss',
           plugins: [
-            // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+            // eslint-disable-next-line global-require
             require('autoprefixer'),
           ],
         },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Unused `eslint-disable` not only adds excess noise but also hides away future errors. Also a lot of the rules were simply disabled globally through `.eslintrc.js`, so the in-line disables are of no use.

We should enforce this by adding
```
eslint --cache "**/*.{js,jsx,ts,tsx} --report-unused-disable-directives
```
to the CI

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
