### PR TITLE
fix: update page url of obtaining access token of crowdin.

### DIFF
--- a/website/docs/i18n/i18n-crowdin.mdx
+++ b/website/docs/i18n/i18n-crowdin.mdx
@@ -163,7 +163,7 @@ We advise to:
 
 The `api_token_env` attribute defines the **env variable name** read by the Crowdin CLI.
 
-You can obtain a `Personal Access Token` on [your personal profile page](https://crowdin.com/settings#api-key).
+You can obtain a `Personal Access Token` on your personal profile page by clicking your profile photo and selecting "Account Settings - Access Tokens".
 
 :::tip
 


### PR DESCRIPTION
## Motivation

The page url that to obtain access token has been changed. The old url is not accessible. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Test it manually.

## Related PRs

No.
