### PR TITLE
fix(preset-classic): fix TS build issue

### DIFF
--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -29,7 +29,11 @@ export default function preset(
 ): Preset {
   const {siteConfig} = context;
   const {themeConfig} = siteConfig;
-  const {algolia, googleAnalytics, gtag} = themeConfig as ThemeConfig;
+  const {
+    algolia,
+    googleAnalytics,
+    gtag,
+  } = (themeConfig as unknown) as ThemeConfig;
   const isProd = process.env.NODE_ENV === 'production';
 
   const themes: PluginConfig[] = [];


### PR DESCRIPTION


## Motivation

Subsequent merge of https://github.com/facebook/docusaurus/pull/5579 + https://github.com/facebook/docusaurus/pull/5561 produced a TS issue:

![image](https://user-images.githubusercontent.com/749374/134324311-cdd98e82-e3fd-46cf-8341-847cb6b96c51.png)


This is a quick fix to make it work again in main, so I'll merge it asap

There may be a better solution, but not sure it's worth investing too much time on this.

cc @Josh-Cena
