### PR TITLE
fix(docs): create tags route if only tags exists

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1019,8 +1019,6 @@ Object {
   },
   \\"sidebar\\": \\"community\\"
 }",
-  "tags-list-1-0-0-prop-483.json": "[]",
-  "tags-list-current-prop-15a.json": "[]",
   "version-1-0-0-metadata-prop-608.json": "{
   \\"pluginId\\": \\"community\\",
   \\"version\\": \\"1.0.0\\",
@@ -1102,22 +1100,6 @@ Object {
 
 exports[`versioned website (community) content: route config 1`] = `
 Array [
-  Object {
-    "component": "@theme/DocTagsListPage",
-    "exact": true,
-    "modules": Object {
-      "tags": "~docs/tags-list-current-prop-15a.json",
-    },
-    "path": "/community/next/tags",
-  },
-  Object {
-    "component": "@theme/DocTagsListPage",
-    "exact": true,
-    "modules": Object {
-      "tags": "~docs/tags-list-1-0-0-prop-483.json",
-    },
-    "path": "/community/tags",
-  },
   Object {
     "component": "@theme/DocPage",
     "exact": false,
@@ -1654,8 +1636,6 @@ Object {
   ],
   \\"allTagsPath\\": \\"/docs/next/tags\\"
 }",
-  "tags-list-1-0-0-prop-483.json": "[]",
-  "tags-list-1-0-1-prop-c39.json": "[]",
   "tags-list-current-prop-15a.json": "[
   {
     \\"name\\": \\"barTag 1\\",
@@ -1673,7 +1653,6 @@ Object {
     \\"count\\": 1
   }
 ]",
-  "tags-list-with-slugs-prop-1ca.json": "[]",
   "version-1-0-0-metadata-prop-608.json": "{
   \\"pluginId\\": \\"default\\",
   \\"version\\": \\"1.0.0\\",
@@ -1974,14 +1953,6 @@ Array [
     "component": "@theme/DocTagsListPage",
     "exact": true,
     "modules": Object {
-      "tags": "~docs/tags-list-1-0-0-prop-483.json",
-    },
-    "path": "/docs/1.0.0/tags",
-  },
-  Object {
-    "component": "@theme/DocTagsListPage",
-    "exact": true,
-    "modules": Object {
       "tags": "~docs/tags-list-current-prop-15a.json",
     },
     "path": "/docs/next/tags",
@@ -2009,22 +1980,6 @@ Array [
       "tag": "~docs/tag-docs-next-tags-bar-tag-3-permalink-94a.json",
     },
     "path": "/docs/next/tags/barTag-3-permalink",
-  },
-  Object {
-    "component": "@theme/DocTagsListPage",
-    "exact": true,
-    "modules": Object {
-      "tags": "~docs/tags-list-1-0-1-prop-c39.json",
-    },
-    "path": "/docs/tags",
-  },
-  Object {
-    "component": "@theme/DocTagsListPage",
-    "exact": true,
-    "modules": Object {
-      "tags": "~docs/tags-list-with-slugs-prop-1ca.json",
-    },
-    "path": "/docs/withSlugs/tags",
   },
   Object {
     "component": "@theme/DocPage",

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -328,18 +328,22 @@ export default function pluginContentDocs(
             permalink: tagValue.permalink,
             count: tagValue.docIds.length,
           }));
-          const tagsPropPath = await createData(
-            `${docuHash(`tags-list-${loadedVersion.versionName}-prop`)}.json`,
-            JSON.stringify(tagsProp, null, 2),
-          );
-          addRoute({
-            path: loadedVersion.tagsPath,
-            exact: true,
-            component: options.docTagsListComponent,
-            modules: {
-              tags: aliasedSource(tagsPropPath),
-            },
-          });
+
+          // Only create /tags page if there are tags.
+          if (Object.keys(tagsProp).length > 0) {
+            const tagsPropPath = await createData(
+              `${docuHash(`tags-list-${loadedVersion.versionName}-prop`)}.json`,
+              JSON.stringify(tagsProp, null, 2),
+            );
+            addRoute({
+              path: loadedVersion.tagsPath,
+              exact: true,
+              component: options.docTagsListComponent,
+              modules: {
+                tags: aliasedSource(tagsPropPath),
+              },
+            });
+          }
         }
 
         async function createTagDocListPage(tag: VersionTag) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Just fixes #5599.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Resolves

## Test Plan

Preview (since we don't use tags, `/tags` should return 404 error)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
