### PR TITLE
feat: maintain page position for grouped tabs

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import ThemeProvider from '@theme/ThemeProvider';
 import UserPreferencesProvider from '@theme/UserPreferencesProvider';
+import ScrollMonitorProvider from '@theme/ScrollMonitorProvider';
 import {
   AnnouncementBarProvider,
   DocsPreferredVersionContextProvider,
@@ -20,11 +21,13 @@ export default function LayoutProviders({children}: Props): JSX.Element {
     <ThemeProvider>
       <AnnouncementBarProvider>
         <UserPreferencesProvider>
-          <DocsPreferredVersionContextProvider>
-            <MobileSecondaryMenuProvider>
-              {children}
-            </MobileSecondaryMenuProvider>
-          </DocsPreferredVersionContextProvider>
+          <ScrollMonitorProvider>
+            <DocsPreferredVersionContextProvider>
+              <MobileSecondaryMenuProvider>
+                {children}
+              </MobileSecondaryMenuProvider>
+            </DocsPreferredVersionContextProvider>
+          </ScrollMonitorProvider>
         </UserPreferencesProvider>
       </AnnouncementBarProvider>
     </ThemeProvider>

--- a/packages/docusaurus-theme-classic/src/theme/ScrollMonitorContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/ScrollMonitorContext.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.tabItem {
-  margin-top: 0 !important;
-}
+import {createContext} from 'react';
+
+const ScrollMonitorContext = createContext(undefined);
+
+export default ScrollMonitorContext;

--- a/packages/docusaurus-theme-classic/src/theme/ScrollMonitorProvider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ScrollMonitorProvider/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useMemo, useRef} from 'react';
+
+import ScrollMonitorContext from '@theme/ScrollMonitorContext';
+import type {Props} from '@theme/ScrollMonitorProvider';
+
+function ScrollMonitorProvider(props: Props): JSX.Element {
+  const isScrollMonitorEnabledRef = useRef(true);
+
+  const handlers = useMemo(
+    () => ({
+      enableScrollMonitor: () => {
+        isScrollMonitorEnabledRef.current = true;
+      },
+      disableScrollMonitor: () => {
+        isScrollMonitorEnabledRef.current = false;
+      },
+    }),
+    [],
+  );
+
+  return (
+    <ScrollMonitorContext.Provider
+      value={{...handlers, isScrollMonitorEnabledRef}}>
+      {props.children}
+    </ScrollMonitorContext.Provider>
+  );
+}
+
+export default ScrollMonitorProvider;

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useRestoreTop.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useRestoreTop.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useCallback, useRef} from 'react';
+import {UseRestoreTopReturn} from '@theme/hooks/useRestoreTop';
+
+export const useRestoreTop = (): UseRestoreTopReturn => {
+  const lastElementRef = useRef<{elem: HTMLElement | null; top: number}>({
+    elem: null,
+    top: 0,
+  });
+
+  const measureTop = useCallback((elem: HTMLElement) => {
+    lastElementRef.current = {
+      elem,
+      top: elem.getBoundingClientRect().top,
+    };
+  }, []);
+
+  const restoreTop = useCallback(() => {
+    const {
+      current: {elem, top},
+    } = lastElementRef;
+    if (!elem) {
+      return;
+    }
+    const newTop = elem.getBoundingClientRect().top;
+    const heightDiff = newTop - top;
+    if (heightDiff) {
+      window.scrollBy({left: 0, top: heightDiff});
+    }
+    lastElementRef.current = {elem: null, top: 0};
+  }, []);
+
+  return {measureTop, restoreTop};
+};

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useScrollMonitorContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useScrollMonitorContext.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {useContext} from 'react';
+
+import ScrollMonitorContext from '@theme/ScrollMonitorContext';
+import type {ScrollMonitorContextProps} from '@theme/hooks/useScrollMonitorContext';
+
+function useScrollMonitorContext(): ScrollMonitorContextProps {
+  const context = useContext<ScrollMonitorContextProps | undefined>(
+    ScrollMonitorContext,
+  );
+  if (context == null) {
+    throw new Error(
+      '"useScrollMonitorContext" is used outside of "Layout" component.',
+    );
+  }
+  return context;
+}
+
+export default useScrollMonitorContext;

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useScrollPosition.ts
@@ -8,6 +8,7 @@
 import {useEffect, useRef} from 'react';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import type {ScrollPosition} from '@theme/hooks/useScrollPosition';
+import useScrollMonitorContext from '@theme/hooks/useScrollMonitorContext';
 
 const getScrollPosition = (): ScrollPosition | null => {
   return ExecutionEnvironment.canUseDOM
@@ -25,9 +26,13 @@ const useScrollPosition = (
   ) => void,
   deps = [],
 ): void => {
+  const {isScrollMonitorEnabledRef} = useScrollMonitorContext();
   const lastPositionRef = useRef<ScrollPosition | null>(getScrollPosition());
 
   const handleScroll = () => {
+    if (!isScrollMonitorEnabledRef.current) {
+      return;
+    }
     const currentPosition = getScrollPosition()!;
 
     if (effect) {

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -272,6 +272,44 @@ declare module '@theme/hooks/useUserPreferencesContext' {
   export default function useUserPreferencesContext(): UserPreferencesContextProps;
 }
 
+declare module '@theme/hooks/useScrollMonitorContext' {
+  export type ScrollMonitorContextProps = {
+    /**
+     * Enables scroll position monitoring for `useScrollPosition`
+     */
+    enableScrollMonitor: () => void;
+    /**
+     * Disables scroll position monitoring for `useScrollPosition`
+     */
+    disableScrollMonitor: () => void;
+    /**
+     * A boolean ref tracking whether scroll monitoring is enabled
+     */
+    isScrollMonitorEnabledRef: React.MutableRefObject<boolean>;
+  };
+
+  export default function useScrollMonitorContext(): ScrollMonitorContextProps;
+}
+
+declare module '@theme/hooks/useRestoreTop' {
+  export type UseRestoreTopReturn = {
+    /**
+     * Measure the top of an element, and store the details
+     */
+    measureTop: (elem: HTMLElement) => void;
+    /**
+     * Restore the page position to keep the stored element's position from
+     * the top of the viewport, and remove the stored details
+     */
+    restoreTop: () => void;
+  };
+
+  /**
+   * Provides methods to store & restore an element's position from the top of the viewport
+   */
+  export function useRestoreTop(): UseRestoreTopReturn;
+}
+
 declare module '@theme/hooks/useWindowSize' {
   export const windowSizes: {
     desktop: 'desktop';
@@ -640,6 +678,15 @@ declare module '@theme/UserPreferencesProvider' {
 
   const UserPreferencesProvider: (props: Props) => JSX.Element;
   export default UserPreferencesProvider;
+}
+
+declare module '@theme/ScrollMonitorProvider' {
+  import type {ReactNode} from 'react';
+
+  export type Props = {readonly children: ReactNode};
+
+  const ScrollMonitorProvider: (props: Props) => JSX.Element;
+  export default ScrollMonitorProvider;
 }
 
 declare module '@theme/LayoutProviders' {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Attempts to address issues such as https://github.com/facebook/docusaurus/issues/3728

When using tab groups for content with significantly different heights in each group, switching between the tabs can cause the page content to appear to jump around.

We use this feature on the [Redux Toolkit](https://github.com/reduxjs/redux-toolkit) docs, with the intent to begin using it for the core [Redux](https://github.com/reduxjs/redux) docs shortly. We use it to show `Typescript` and `Javascript` snippets in separate tab groups, and are affected by this as often the `Typescript` snippet will contain extra lines compared to the `Javascript` snippets.

e.g. switch between the `typescript` & `javascript` tabs in the snippet here and observe the page shift: https://redux-toolkit.js.org/rtk-query/usage/cache-behavior#re-fetching-on-network-reconnection-with-refetchonreconnect

My understanding is that #4209 was introduced to alleviate some of the symptoms, but we still find it to have a jarring effect.

The goal here is to replace the implementation of #4209 by maintaining the position of the clicked tab completely.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Alter the snippets on the local copy of the docusaurus site under the [syncing tab choices section](https://docusaurus.io/docs/markdown-features/tabs#syncing-tab-choices) such that the groups have noticeably different snippet heights
- Toggle between tabs and observe the behaviour

| before | after |
|-----|-----------|
![grouped-tabs-demo-before](https://user-images.githubusercontent.com/22929669/134792838-d80eed1a-33c8-43dd-9280-22d20f1b10d6.gif)  |   ![grouped-tabs-demo-after](https://user-images.githubusercontent.com/22929669/134792844-452b37fe-a3bd-4893-b801-a4423115d104.gif)   |

As shown above:  
- before: the shifting content is jarring and disorienting when toggling between tabs
- after: maintaining the position relative to the viewport of the tab that was clicked avoids the disorienting behaviour

## Related PRs

Previous iteration which is removed as part of this PR: #4209
