### PR TITLE
docs(v2): Add Rexpondo site to showcase page

### DIFF
--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -1072,6 +1072,14 @@ const Users: User[] = [
     tags: ['opensource'],
   },
   {
+    title: 'Rexpondo',
+    description: 'Ticketing solution based on OTOBO',
+    preview: require('./showcase/repeaterjs.png'),
+    website: 'https://api.rexpondo.com/',
+    source: null,
+    tags: ['product'],
+  },
+  {
     title: 'Rooks',
     description:
       'Supercharge your components with this collection of React hooks.',


### PR DESCRIPTION
## Motivation

Add Rexpondo API website is built using Docusaurus v2.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run yarn run start:v2 and check that the page http://localhost:3000/showcase is rendered properly.

## Related PRs

No.
