### PR TITLE
fix: text/link hydration bug

### DIFF
--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -133,7 +133,7 @@ async function doRender(locals) {
   try {
     // Minify html with https://github.com/DanielRuf/html-minifier-terser
     return await minify(renderedHtml, {
-      removeComments: true,
+      removeComments: false,
       removeRedundantAttributes: true,
       removeEmptyAttributes: true,
       removeScriptTypeAttributes: true,

--- a/website/_dogfooding/_pages tests/hydration-tests.js
+++ b/website/_dogfooding/_pages tests/hydration-tests.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+// Repro for hydration issue https://github.com/facebook/docusaurus/issues/5617
+function BuggyText() {
+  return (
+    <span>
+      Built using the{' '}
+      <a href="https://www.electronjs.org/" target="_blank">
+        Electron
+      </a>{' '}
+      , based on{' '}
+      <a href="https://www.chromium.org/" target="_blank">
+        Chromium
+      </a>
+      , and written using{' '}
+      <a href="https://www.typescriptlang.org/" target="_blank">
+        TypeScript
+      </a>{' '}
+      , Xplorer promises you an unprecedented experience.
+    </span>
+  );
+}
+
+export default function Home() {
+  return (
+    <Layout>
+      <BuggyText />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Motivation

Fix long-standing React hydration problem on text with links where links end-up with the wrong href after React hydration, due to mismatch between SSR HTML and client hydration.

Issue https://github.com/facebook/docusaurus/issues/5617 
(Also seen on React-Native and/or websites in the past)

Using `html-minifier-terser` `removeComments: true` is causing this hydration problem by turning this React SSR output:

```html
<div id="__docusaurus">
   <span>
      Built using the<!-- --> <a href="https://www.electronjs.org/" target="_blank">Electron</a> <!-- -->, 
      based on<!-- --> <a href="https://www.chromium.org/" target="_blank">Chromium</a>
   </span>
</div>
```

into this:

```html 
<div id="__docusaurus">
   <span>Built using the <a href="https://www.electronjs.org/" target="_blank">Electron</a> , 
   based on <a href="https://www.chromium.org/" target="_blank">Chromium</a>
</div>
```

Dan Abramov confirms those comments are necessary: https://twitter.com/dan_abramov/status/1443628592097898498

See also https://github.com/terser/html-minifier-terser/pull/87

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

dogfood preview

https://deploy-preview-5629--docusaurus-2.netlify.app/tests/pages/hydration-tests

(it used to fail and href of first link was wrong before the fix was applied)
