### PR TITLE
refactor: standardize using media queries

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -51,7 +51,7 @@ html[data-announcement-bar-initially-dismissed='true'] .announcementBar {
   text-decoration: underline;
 }
 
-@media screen and (min-width: 1024px) {
+@media (min-width: 1024px) {
   :root {
     --docusaurus-announcement-bar-height: 30px;
   }

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -51,7 +51,7 @@ html[data-announcement-bar-initially-dismissed='true'] .announcementBar {
   text-decoration: underline;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 997px) {
   :root {
     --docusaurus-announcement-bar-height: 30px;
   }

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
@@ -37,7 +37,7 @@
   color: var(--ifm-color-primary) !important;
 }
 
-@media only screen and (max-width: 996px) {
+@media (max-width: 996px) {
   .sidebar {
     display: none;
   }

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -10,7 +10,7 @@
   margin-top: 0;
 }
 
-@media only screen and (min-width: 997px) {
+@media (min-width: 997px) {
   .docItemCol {
     max-width: 75% !important;
   }

--- a/packages/docusaurus-theme-classic/src/theme/DocItemFooter/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItemFooter/styles.module.css
@@ -11,7 +11,7 @@
   font-size: smaller;
 }
 
-@media only screen and (min-width: 997px) {
+@media (min-width: 997px) {
   .lastUpdated {
     text-align: right;
   }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
@@ -8,7 +8,7 @@
 /*
 Hide toggle in small viewports
  */
-@media screen and (max-width: 997px) {
+@media (max-width: 996px) {
   .toggle {
     display: none;
   }

--- a/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
@@ -12,7 +12,7 @@
   top: calc(var(--ifm-navbar-height) + 1rem);
 }
 
-@media only screen and (max-width: 996px) {
+@media (max-width: 996px) {
   .tableOfContents {
     display: none;
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

For better minification of CSS bundle we should use the same media queries that will be consistent with all CSS code. In this case, that means getting rid of extra "only screen and" part.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
