### PR TITLE
chore: prepare Algolia migration

### DIFF
--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -75,7 +75,12 @@ module.exports = {
     // ...
     // highlight-start
     algolia: {
+      // If Algolia did not provide you any appId, use 'BH4D9OD16A'
+      appId: 'YOUR_APP_ID',
+
+      // Public API key: it is safe to commit it
       apiKey: 'YOUR_API_KEY',
+
       indexName: 'YOUR_INDEX_NAME',
 
       // Optional: see doc section below
@@ -130,24 +135,6 @@ module.exports = {
 When using `contextualSearch: true`, the contextual facet filters will be merged with the ones provided with `algolia.searchParameters.facetFilters`.
 
 :::
-
-### Custom Application ID {#custom-application-id}
-
-When [running your own](https://docsearch.algolia.com/docs/run-your-own/) DocSearch crawler, it is [required to set the `appId` configuration key](https://docsearch.algolia.com/docs/behavior/#appid) to your own Application ID. If left unset, the `appId` will fallback to the one used with the free, hosted version of Algolia DocSearch.
-
-```jsx title="docusaurus.config.js"
-module.exports = {
-  // ...
-  themeConfig: {
-    // ...
-    // highlight-start
-    algolia: {
-      appId: 'YOUR_APP_ID',
-    },
-    // highlight-end
-  },
-};
-```
 
 ### Styling your Algolia search {#styling-your-algolia-search}
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -79,7 +79,7 @@ module.exports = {
       appId: 'YOUR_APP_ID',
 
       // Public API key: it is safe to commit it
-      apiKey: 'YOUR_API_KEY',
+      apiKey: 'YOUR_SEARCH_API_KEY',
 
       indexName: 'YOUR_INDEX_NAME',
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -318,7 +318,8 @@ const config = {
           }
         : undefined,
       algolia: {
-        apiKey: '47ecd3b21be71c5822571b9f59e52544',
+        appId: 'X1Z85QJPUV',
+        apiKey: 'bf7211c161e8205da2f933a02534105a',
         indexName: 'docusaurus-2',
         contextualSearch: true,
       },


### PR DESCRIPTION

## Motivation

Algolia is migrating to a new system where each app has an `appId` instead of all apps sharing the same `appId`

This allows them to provide a dashboard for each app, with access to the indice content, a query UI, the ability to trigger crawls manually... much helpful for users to debug their search issues

A progressive batched rollout has started, with the Docusaurus site as one of the first migrated site.

This PR is just some initial doc/config changes we can do today.

We'll write a blog post and update the doc later.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview
