### PR TITLE
fix: properly sanitize HTML tags

### DIFF
--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -44,6 +44,7 @@ export function createExcerpt(fileString: string): string | undefined {
     const cleanedLine = fileLine
       // Remove HTML tags.
       .replace(/<[^>]*>/g, '')
+      // .replace(/<\/?[A-Za-z][^>]*>/gm, '')
       // Remove Title headers
       .replace(/^#\s*([^#]*)\s*#?/gm, '')
       // Remove Markdown + ATX-style headers
@@ -181,6 +182,7 @@ export async function parseMarkdownFile(
   const markdownString = await fs.readFile(source, 'utf-8');
   try {
     return parseMarkdownString(markdownString, options);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
     throw new Error(
       `Error while parsing Markdown file ${source}: "${e.message}".`,

--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -44,6 +44,8 @@ export function createExcerpt(fileString: string): string | undefined {
     const cleanedLine = fileLine
       // Remove HTML tags.
       .replace(/<\/?[A-Za-z][^>]*>/gm, '')
+      // Remove incomplete tags. This is impossible to happen (build time errors) but makes CI happy
+      .replace(/<\/?[A-Za-z][^>]*/g, '')
       // Remove Title headers
       .replace(/^#\s*([^#]*)\s*#?/gm, '')
       // Remove Markdown + ATX-style headers

--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -43,8 +43,7 @@ export function createExcerpt(fileString: string): string | undefined {
 
     const cleanedLine = fileLine
       // Remove HTML tags.
-      .replace(/<[^>]*>/g, '')
-      // .replace(/<\/?[A-Za-z][^>]*>/gm, '')
+      .replace(/<\/?[A-Za-z][^>]*>/gm, '')
       // Remove Title headers
       .replace(/^#\s*([^#]*)\s*#?/gm, '')
       // Remove Markdown + ATX-style headers


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Clear CodeQL errors. The current code doesn't handle HTML tags 100% correctly either, because a `<` has to be followed by a latin character to be considered an HTML tag.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
