### PR TITLE
fix(theme-classic): reset default style for task lists

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -13,6 +13,8 @@ import Heading from '@theme/Heading';
 import Details from '@theme/Details';
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 
+import './styles.css';
+
 // MDX elements are wrapped through the MDX pragma
 // In some cases (notably usage with Head/Helmet) we need to unwrap those elements.
 function unwrapMDXElement(element: ReactElement) {

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
@@ -1,0 +1,5 @@
+ul.contains-task-list {
+  margin-left: 0;
+  padding-left: 0;
+  list-style-type: none;
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
@@ -1,5 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 ul.contains-task-list {
-  margin-left: 0;
   padding-left: 0;
-  list-style-type: none;
+  list-style: none;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve https://github.com/facebook/docusaurus/issues/5409

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I fixed displaying of the list 
![Screenshot from 2021-10-03 18-37-02](https://user-images.githubusercontent.com/15523524/135752174-a255c592-f98b-4efd-9f12-0654d122751d.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
