### PR TITLE
feat(theme-classic): make first tab the default default tab

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -43,7 +43,8 @@ function Tabs(props: Props): JSX.Element {
     });
   const defaultValue =
     defaultValueProp ??
-    children.find((child) => child.props.default)?.props.value;
+    children.find((child) => child.props.default)?.props.value ??
+    children[0]?.props.value;
 
   const {tabGroupChoices, setTabGroupChoices} = useUserPreferencesContext();
   const [selectedValue, setSelectedValue] = useState(defaultValue);

--- a/website/docs/blog.mdx
+++ b/website/docs/blog.mdx
@@ -177,7 +177,7 @@ Blog post authors can be declared directly inside the FrontMatter:
 
 ````mdx-code-block
 <Tabs groupId="author-frontmatter">
-  <TabItem value="single" label="Single author" default>
+  <TabItem value="single" label="Single author">
 
 ```yml title="my-blog-post.md"
 ---
@@ -261,7 +261,7 @@ In blog posts FrontMatter, you can reference the authors declared in the global 
 
 ````mdx-code-block
 <Tabs groupId="author-frontmatter">
-  <TabItem value="single" label="Single author" default>
+  <TabItem value="single" label="Single author">
 
 ```yml title="my-blog-post.md"
 ---

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -144,7 +144,7 @@ Finally, to deploy your site to GitHub Pages, run:
 
 ````mdx-code-block
 <Tabs>
-<TabItem value="bash" label="Bash" default>
+<TabItem value="bash" label="Bash">
 
 ```bash
 GIT_USER=<GITHUB_USERNAME> yarn deploy

--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -97,7 +97,7 @@ import TabItem from '@theme/TabItem';
 :::tip Use tabs in admonitions
 
 <Tabs>
-  <TabItem value="apple" label="Apple" default>This is an apple 🍎</TabItem>
+  <TabItem value="apple" label="Apple">This is an apple 🍎</TabItem>
   <TabItem value="orange" label="Orange">This is an orange 🍊</TabItem>
   <TabItem value="banana" label="Banana">This is a banana 🍌</TabItem>
 </Tabs>
@@ -114,7 +114,7 @@ import TabItem from '@theme/TabItem';
 
 ```mdx-code-block
 <Tabs>
-  <TabItem value="apple" label="Apple" default>This is an apple 🍎</TabItem>
+  <TabItem value="apple" label="Apple">This is an apple 🍎</TabItem>
   <TabItem value="orange" label="Orange">This is an orange 🍊</TabItem>
   <TabItem value="banana" label="Banana">This is a banana 🍌</TabItem>
 </Tabs>

--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -375,7 +375,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-<TabItem value="js" label="JavaScript" default>
+<TabItem value="js" label="JavaScript">
 
 ```js
 function helloWorld() {
@@ -410,7 +410,7 @@ And you will get the following:
 
 ````mdx-code-block
 <Tabs>
-<TabItem value="js" label="JavaScript" default>
+<TabItem value="js" label="JavaScript">
 
 ```js
 function helloWorld() {

--- a/website/docs/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-tabs.mdx
@@ -35,7 +35,7 @@ import TabItem from '@theme/TabItem';
 ```mdx-code-block
 <BrowserWindow>
   <Tabs>
-    <TabItem value="apple" label="Apple" default>This is an apple 🍎</TabItem>
+    <TabItem value="apple" label="Apple">This is an apple 🍎</TabItem>
     <TabItem value="orange" label="Orange">This is an orange 🍊</TabItem>
     <TabItem value="banana" label="Banana">This is a banana 🍌</TabItem>
   </Tabs>
@@ -91,10 +91,10 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
   <TabItem value="apple" label="Apple 2">
     This is an apple 🍎
   </TabItem>
-  <TabItem value="orange" label="Orange 2">
+  <TabItem value="orange" label="Orange 2" default>
     This is an orange 🍊
   </TabItem>
-  <TabItem value="banana" label="Banana 2" default>
+  <TabItem value="banana" label="Banana 2">
     This is a banana 🍌
   </TabItem>
 </Tabs>
@@ -110,7 +110,7 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
       {label: 'Banana 1', value: 'banana'},
     ]}>
     <TabItem value="apple" label="Apple 2">This is an apple 🍎</TabItem>
-    <TabItem value="orange" label="Orange 2">This is an orange 🍊</TabItem>
+    <TabItem value="orange" label="Orange 2" default>This is an orange 🍊</TabItem>
     <TabItem value="banana" label="Banana 2">This is a banana 🍌</TabItem>
   </Tabs>
 </BrowserWindow>
@@ -123,17 +123,15 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
 
 By default, all tabs are rendered eagerly during the build process, and search engines can index hidden tabs.
 
-It is possible to only render the default tab with `<Tabs lazy={true} />`.
+It is possible to only render the default tab with `<Tabs lazy />`.
 
 :::
 
 ## Displaying a default tab
 
-Add `default` to one of the tab items to make it displayed by default. You can also set the `defaultValue` prop in the `Tabs` component to the label value of your choice.
+The first tab is displayed by default, and to override this behavior, you can specify a default tab by add `default` to one of the tab items. You can also set the `defaultValue` prop in the `Tabs` component to the label value of your choice. For example, in the example above, setting `default` for the `value="apple"` tab forces it to be open by default.
 
-For example, in the example above, setting `default` for the `value="apple"` tab forces it to be open by default.
-
-If none of the children contains the `default` prop, neither is the `defaultValue` provided for the `Tabs`, or it refers to an non-existing value, only the tab headings appear until the user clicks on a tab.
+If `defaultValue` is provided for the `Tabs`, but it refers to an non-existing value, only the tab headings appear until the user clicks on a tab.
 
 ## Syncing tab choices {#syncing-tab-choices}
 
@@ -142,13 +140,13 @@ You may want choices of the same kind of tabs to sync with each other. For examp
 ```jsx
 // highlight-next-line
 <Tabs groupId="operating-systems">
-  <TabItem value="win" label="Windows" default>Use Ctrl + C to copy.</TabItem>
+  <TabItem value="win" label="Windows">Use Ctrl + C to copy.</TabItem>
   <TabItem value="mac" label="MacOS">Use Command + C to copy.</TabItem>
 </Tabs>
 
 // highlight-next-line
 <Tabs groupId="operating-systems">
-  <TabItem value="win" label="Windows" default>Use Ctrl + V to paste.</TabItem>
+  <TabItem value="win" label="Windows">Use Ctrl + V to paste.</TabItem>
   <TabItem value="mac" label="MacOS">Use Command + V to paste.</TabItem>
 </Tabs>
 ```
@@ -156,12 +154,12 @@ You may want choices of the same kind of tabs to sync with each other. For examp
 ```mdx-code-block
 <BrowserWindow>
   <Tabs groupId="operating-systems">
-    <TabItem value="win" label="Windows" default>Use Ctrl + C to copy.</TabItem>
+    <TabItem value="win" label="Windows">Use Ctrl + C to copy.</TabItem>
     <TabItem value="mac" label="MacOS">Use Command + C to copy.</TabItem>
   </Tabs>
 
   <Tabs groupId="operating-systems">
-    <TabItem value="win" label="Windows" default>Use Ctrl + V to paste.</TabItem>
+    <TabItem value="win" label="Windows">Use Ctrl + V to paste.</TabItem>
     <TabItem value="mac" label="MacOS">Use Command + V to paste.</TabItem>
   </Tabs>
 </BrowserWindow>
@@ -172,7 +170,7 @@ For all tab groups that have the same `groupId`, the possible values do not need
 
 ```jsx
 <Tabs groupId="operating-systems">
-  <TabItem value="win" label="Windows" default>
+  <TabItem value="win" label="Windows">
     I am Windows.
   </TabItem>
   <TabItem value="mac" label="MacOS">
@@ -187,7 +185,7 @@ For all tab groups that have the same `groupId`, the possible values do not need
 ```mdx-code-block
 <BrowserWindow>
   <Tabs groupId="operating-systems">
-    <TabItem value="win" label="Windows" default>I am Windows.</TabItem>
+    <TabItem value="win" label="Windows">I am Windows.</TabItem>
     <TabItem value="mac" label="MacOS">I am macOS.</TabItem>
     <TabItem value="linux" label="Linux">I am Linux.</TabItem>
   </Tabs>
@@ -201,13 +199,13 @@ Tab choices with different `groupId`s will not interfere with each other:
 ```jsx
 // highlight-next-line
 <Tabs groupId="operating-systems">
-  <TabItem value="win" label="Windows" default>Windows in windows.</TabItem>
+  <TabItem value="win" label="Windows">Windows in windows.</TabItem>
   <TabItem value="mac" label="MacOS">macOS is macOS.</TabItem>
 </Tabs>
 
 // highlight-next-line
 <Tabs groupId="non-mac-operating-systems">
-  <TabItem value="win" label="Windows" default>Windows is windows.</TabItem>
+  <TabItem value="win" label="Windows">Windows is windows.</TabItem>
   <TabItem value="unix" label="Unix">Unix is unix.</TabItem>
 </Tabs>
 ```
@@ -215,12 +213,12 @@ Tab choices with different `groupId`s will not interfere with each other:
 ```mdx-code-block
 <BrowserWindow>
   <Tabs groupId="operating-systems">
-    <TabItem value="win" label="Windows" default>Windows in windows.</TabItem>
+    <TabItem value="win" label="Windows">Windows in windows.</TabItem>
     <TabItem value="mac" label="MacOS">macOS is macOS.</TabItem>
   </Tabs>
 
   <Tabs groupId="non-mac-operating-systems">
-    <TabItem value="win" label="Windows" default>Windows is windows.</TabItem>
+    <TabItem value="win" label="Windows">Windows is windows.</TabItem>
     <TabItem value="unix" label="Unix">Unix is unix.</TabItem>
   </Tabs>
 </BrowserWindow>
@@ -236,9 +234,7 @@ import TabItem from '@theme/TabItem';
 
 // highlight-next-line
 <Tabs className="unique-tabs">
-  <TabItem value="Apple" default>
-    This is an apple 🍎
-  </TabItem>
+  <TabItem value="Apple">This is an apple 🍎</TabItem>
   <TabItem value="Orange">This is an orange 🍊</TabItem>
   <TabItem value="Banana">This is a banana 🍌</TabItem>
 </Tabs>;
@@ -247,7 +243,7 @@ import TabItem from '@theme/TabItem';
 ```mdx-code-block
 <BrowserWindow>
   <Tabs className="unique-tabs">
-    <TabItem value="Apple" default>This is an apple 🍎</TabItem>
+    <TabItem value="Apple">This is an apple 🍎</TabItem>
     <TabItem value="Orange">This is an orange 🍊</TabItem>
     <TabItem value="Banana">This is a banana 🍌</TabItem>
   </Tabs>

--- a/website/docs/i18n/i18n-crowdin.mdx
+++ b/website/docs/i18n/i18n-crowdin.mdx
@@ -364,7 +364,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-  <TabItem value="bash" label="Bash" default>
+  <TabItem value="bash" label="Bash">
 
   ```bash
   GIT_USER=<GITHUB_USERNAME> yarn deploy


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It's quite weird UX to display no tabs if no `default` has been provided—how many users would want only headings with no content anyways? (This behavior is still achievable with `<Tabs defaultValue="none">`)

A further fix I can think of is to throw an error when `defaultValue` is non-existent, and use `defaultValue={null}` to specially indicate no tabs open by default. This helps to catch typos early.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated all the tabs usage on the website.
