### PR TITLE
fix: expand tag column on truncated post

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -64,6 +64,7 @@ function BlogPostItem(props: Props): JSX.Element {
 
   const image = assets.image ?? frontMatter.image;
   const truncatedPost = !isBlogPostPage && truncated;
+  const tagsExists = tags.length > 0;
 
   const renderPostHeader = () => {
     const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
@@ -112,12 +113,12 @@ function BlogPostItem(props: Props): JSX.Element {
         <MDXProvider components={MDXComponents}>{children}</MDXProvider>
       </div>
 
-      {(tags.length > 0 || truncated) && (
+      {(tagsExists || truncated) && (
         <footer
           className={clsx('row docusaurus-mt-lg', {
             [styles.blogPostDetailsFull]: isBlogPostPage,
           })}>
-          {tags.length > 0 && (
+          {tagsExists && (
             <div className={clsx('col', {'col--9': truncatedPost})}>
               <TagsListInline tags={tags} />
             </div>
@@ -130,7 +131,10 @@ function BlogPostItem(props: Props): JSX.Element {
           )}
 
           {truncatedPost && (
-            <div className="col col--3 text--right">
+            <div
+              className={clsx('col text--right', {
+                'col--3': tagsExists,
+              })}>
               <Link
                 to={metadata.permalink}
                 aria-label={`Read more about ${title}`}>

--- a/website/_dogfooding/_blog tests/2021-08-23-multiple-authors.md
+++ b/website/_dogfooding/_blog tests/2021-08-23-multiple-authors.md
@@ -4,6 +4,16 @@ authors:
   - name: Josh-Cena
     image_url: https://avatars.githubusercontent.com/u/55398995?v=4
     url: https://joshcena.com
+tags:
+  [
+    blog,
+    docusaurus,
+    long,
+    long-long,
+    long-long-long,
+    long-long-long-long,
+    long-long-long-long-long,
+  ]
 ---
 
 # Multiple authors

--- a/website/_dogfooding/_blog tests/2021-10-07-blog-post-mdx-feed-tests.mdx
+++ b/website/_dogfooding/_blog tests/2021-10-07-blog-post-mdx-feed-tests.mdx
@@ -2,6 +2,7 @@
 title: Blog post MDX Feed tests
 authors:
   - slorber
+tags: [blog, docusaurus, long-long, long-long-long, long-long-long-long]
 ---
 
 Some MDX tests, mostly to test how the RSS feed render those


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Just noticed on one of sites added to the showcase (https://cloudywithachanceofbigdata.com/) a small bug related with tags layout.

Current behavior:

![image](https://user-images.githubusercontent.com/4408379/136578413-20bf7eed-9dac-475d-bd52-3c53fb6cda36.png)

But it should be like this:

![image](https://user-images.githubusercontent.com/4408379/136578510-f026ee1b-54ad-48b1-a315-b25dfd075ed4.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview (but we have too little tags on our blog to reproduce this issue)

Or see test posts https://deploy-preview-5667--docusaurus-2.netlify.app/tests/blog

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
