### PR TITLE
fix: allow ColorGenerator to parse colors with prefix `#`

### DIFF
--- a/website/src/components/ColorGenerator/index.tsx
+++ b/website/src/components/ColorGenerator/index.tsx
@@ -91,7 +91,10 @@ function ColorGenerator() {
           className={styles.input}
           defaultValue={baseColor}
           onChange={(event) => {
-            const colorValue = event.target.value;
+            // Replace all the prefix '#' with an empty string.
+            // For example, '#ccc' -> 'ccc', '##ccc' -> 'ccc'
+            const colorValue = event.target.value.replace(/^#+/, '');
+
             try {
               Color('#' + colorValue);
               setBaseColor(colorValue);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #5665 

Currently, the color generator at [Styling Your File With Infima](https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima) doesn't handle input string with the prefix `#`.  More than often, users copy colors from design apps, dev tools or config files with a prefix `#` in them.

Therefore, I removed any leading `#` so `Color` won't throw when there is a prefix `#`.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Inside preview, go to Guides > Styling and Layout > Styling Your File With Infima. Enter these values for Primary color:

`ccc` -> table should update with new colors.
`#abc` -> table should update with new colors.
`##cba` -> table should update with new colors.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
