### PR TITLE
fix: Don't ignore options.transforms for buble

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/custom-buble.js
+++ b/packages/docusaurus-theme-live-codeblock/src/custom-buble.js
@@ -26,4 +26,3 @@ exports.transform = function customTransform(source, options) {
     },
   });
 };
-


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Customizing transformer is not possible, which means disabling transforms like classes etc don't work. This is clearly a bug as it works in normal buble, and the options is spread in but not the options.transforms.

Additionally, we default to allowing classes and getter/setters as these are very useful features.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

```tsx
<LiveProvider
        transpileOptions={{
          target: { chrome: 71 },
          transforms: {
            classes: false,
            letConst: false,
            getterSetter: false,
            generator: false,
            asyncAwait: false,
            moduleImport: false,
            moduleExport: false,
          },
        }}
      >
```

Make sure it doesn't break on classes or getter setters

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
