### PR TITLE
fix: use realpath for site dir to resolve symlink

### DIFF
--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -7,7 +7,7 @@
  */
 
 const chalk = require('chalk');
-const path = require('path');
+const fs = require('fs');
 const cli = require('commander');
 const {
   build,
@@ -22,6 +22,8 @@ const {
 } = require('../lib');
 
 require('./beforeCli');
+
+const resolveDir = (dir = '.') => fs.realpathSync(dir);
 
 cli.version(require('../package.json').version).usage('<command> [options]');
 
@@ -48,8 +50,8 @@ cli
     '--no-minify',
     'build website without minimizing JS bundles (default: false)',
   )
-  .action((siteDir = '.', {bundleAnalyzer, config, outDir, locale, minify}) => {
-    build(path.resolve(siteDir), {
+  .action((siteDir, {bundleAnalyzer, config, outDir, locale, minify}) => {
+    build(resolveDir(siteDir), {
       bundleAnalyzer,
       outDir,
       config,
@@ -66,14 +68,8 @@ cli
     'copy TypeScript theme files when possible (default: false)',
   )
   .option('--danger', 'enable swizzle for internal component of themes')
-  .action((themeName, componentName, siteDir = '.', {typescript, danger}) => {
-    swizzle(
-      path.resolve(siteDir),
-      themeName,
-      componentName,
-      typescript,
-      danger,
-    );
+  .action((themeName, componentName, siteDir, {typescript, danger}) => {
+    swizzle(resolveDir(siteDir), themeName, componentName, typescript, danger);
   });
 
 cli
@@ -95,8 +91,8 @@ cli
     '--skip-build',
     'skip building website before deploy it (default: false)',
   )
-  .action((siteDir = '.', {outDir, skipBuild, config}) => {
-    deploy(path.resolve(siteDir), {
+  .action((siteDir, {outDir, skipBuild, config}) => {
+    deploy(resolveDir(siteDir), {
       outDir,
       config,
       skipBuild,
@@ -122,19 +118,17 @@ cli
     '--poll [interval]',
     'use polling rather than watching for reload (default: false). Can specify a poll interval in milliseconds',
   )
-  .action(
-    (siteDir = '.', {port, host, locale, config, hotOnly, open, poll}) => {
-      start(path.resolve(siteDir), {
-        port,
-        host,
-        locale,
-        config,
-        hotOnly,
-        open,
-        poll,
-      });
-    },
-  );
+  .action((siteDir, {port, host, locale, config, hotOnly, open, poll}) => {
+    start(resolveDir(siteDir), {
+      port,
+      host,
+      locale,
+      config,
+      hotOnly,
+      open,
+      poll,
+    });
+  });
 
 cli
   .command('serve [siteDir]')
@@ -152,7 +146,7 @@ cli
   .option('-h, --host <host>', 'use specified host (default: localhost)')
   .action(
     (
-      siteDir = '.',
+      siteDir,
       {
         dir = 'build',
         port = 3000,
@@ -161,7 +155,7 @@ cli
         config,
       },
     ) => {
-      serve(path.resolve(siteDir), {
+      serve(resolveDir(siteDir), {
         dir,
         port,
         build: buildSite,
@@ -174,8 +168,8 @@ cli
 cli
   .command('clear [siteDir]')
   .description('Remove build artifacts.')
-  .action((siteDir = '.') => {
-    clear(path.resolve(siteDir));
+  .action((siteDir) => {
+    clear(resolveDir(siteDir));
   });
 
 cli
@@ -199,10 +193,10 @@ cli
   )
   .action(
     (
-      siteDir = '.',
+      siteDir,
       {locale = undefined, override = false, messagePrefix = '', config},
     ) => {
-      writeTranslations(path.resolve(siteDir), {
+      writeTranslations(resolveDir(siteDir), {
         locale,
         override,
         config,
@@ -214,7 +208,7 @@ cli
 cli
   .command('write-heading-ids [contentDir]')
   .description('Generate heading ids in Markdown content.')
-  .action((siteDir = '.') => {
+  .action((siteDir) => {
     writeHeadingIds(siteDir);
   });
 
@@ -239,7 +233,7 @@ function isInternalCommand(command) {
 
 async function run() {
   if (!isInternalCommand(process.argv.slice(2)[0])) {
-    await externalCommand(cli, path.resolve('.'));
+    await externalCommand(cli, resolveDir('.'));
   }
 
   cli.parse(process.argv);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #5679

This is mainly to resolve `@site` webpack alias when using soft links, but for consistency let's use realpath for `siteDir` arguments in all commands.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Locally.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
