### PR TITLE
fix: apply announcement bar class if only needed

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
@@ -7,20 +7,21 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import {useAnnouncementBar} from '@docusaurus/theme-common';
+import {useThemeConfig, useAnnouncementBar} from '@docusaurus/theme-common';
 import {translate} from '@docusaurus/Translate';
 import IconClose from '@theme/IconClose';
 
 import styles from './styles.module.css';
 
 function AnnouncementBar(): JSX.Element | null {
-  const {isActive, close, ...announcementBar} = useAnnouncementBar();
+  const {isActive, close} = useAnnouncementBar();
+  const {announcementBar} = useThemeConfig();
 
   if (!isActive) {
     return null;
   }
 
-  const {content, backgroundColor, textColor, isCloseable} = announcementBar;
+  const {content, backgroundColor, textColor, isCloseable} = announcementBar!;
 
   return (
     <div
@@ -32,7 +33,7 @@ function AnnouncementBar(): JSX.Element | null {
         className={styles.announcementBarContent}
         // Developer provided the HTML, so assume it's safe.
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{__html: content as string}}
+        dangerouslySetInnerHTML={{__html: content}}
       />
       {isCloseable ? (
         <button

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -28,12 +28,14 @@ function useShowAnnouncementBar() {
   const {isActive} = useAnnouncementBar();
   const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive);
 
-  useScrollPosition(({scrollY}) => {
-    if (isActive) {
-      setShowAnnouncementBar(scrollY === 0);
-    }
-  });
-
+  useScrollPosition(
+    ({scrollY}) => {
+      if (isActive) {
+        setShowAnnouncementBar(scrollY === 0);
+      }
+    },
+    [isActive],
+  );
   return isActive && showAnnouncementBar;
 }
 

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -269,7 +269,7 @@ const ThemeConfigSchema = Joi.object({
     .default(DEFAULT_CONFIG.metadatas),
   announcementBar: Joi.object({
     id: Joi.string().default('announcement-bar'),
-    content: Joi.string(),
+    content: Joi.string().required(),
     backgroundColor: Joi.string(),
     textColor: Joi.string(),
     isCloseable: Joi.bool().default(true),

--- a/packages/docusaurus-theme-common/src/utils/announcementBarUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/announcementBarUtils.tsx
@@ -16,7 +16,7 @@ import React, {
 } from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import {createStorageSlot} from './storageUtils';
-import {AnnouncementBarConfig, useThemeConfig} from './useThemeConfig';
+import {useThemeConfig} from './useThemeConfig';
 
 export const AnnouncementBarDismissStorageKey =
   'docusaurus.announcement.dismiss';
@@ -32,7 +32,7 @@ const isDismissedInStorage = () =>
 const setDismissedInStorage = (bool: boolean) =>
   AnnouncementBarDismissStorage.set(String(bool));
 
-type AnnouncementBarAPI = AnnouncementBarConfig & {
+type AnnouncementBarAPI = {
   readonly isActive: boolean;
   readonly close: () => void;
 };
@@ -74,7 +74,7 @@ const useAnnouncementBarContextValue = (): AnnouncementBarAPI => {
 
     const isNewAnnouncement = id !== viewedId;
 
-    IdStorage.set(id as string);
+    IdStorage.set(id);
 
     if (isNewAnnouncement) {
       setDismissedInStorage(false);
@@ -87,9 +87,8 @@ const useAnnouncementBarContextValue = (): AnnouncementBarAPI => {
 
   return useMemo(() => {
     return {
-      isActive: !!(announcementBar && announcementBar?.content) && !isClosed,
+      isActive: !!announcementBar && !isClosed,
       close: handleClose,
-      ...announcementBar,
     };
   }, [isClosed]);
 };

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -49,11 +49,11 @@ export type ColorModeConfig = {
 };
 
 export type AnnouncementBarConfig = {
-  id?: string;
-  content?: string;
-  backgroundColor?: string;
-  textColor?: string;
-  isCloseable?: boolean;
+  id: string;
+  content: string;
+  backgroundColor: string;
+  textColor: string;
+  isCloseable: boolean;
 };
 
 export type PrismConfig = {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, a "special" CSS class `menuWithAnnouncementBar` mistakenly applies to a sidebar menu even if announcement bar is not used.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Remove `announcementBar` field from config file and inspect layout via dev tools.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
