### PR TITLE
refactor: hide hash link from crawlers

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -51,6 +51,7 @@ const createAnchorHeading = (
         id={id}>
         {props.children}
         <a
+          aria-hidden="true"
           className="hash-link"
           href={`#${id}`}
           title={translate({
@@ -58,7 +59,7 @@ const createAnchorHeading = (
             message: 'Direct link to heading',
             description: 'Title for link to heading',
           })}>
-          #
+          &#8203;
         </a>
       </Tag>
     );

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -11,6 +11,10 @@
   transition: opacity var(--ifm-transition-fast);
 }
 
+.hash-link:before {
+  content: '#';
+}
+
 .hash-link:focus,
 *:hover > .hash-link {
   opacity: 1;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Let's completely hide "#" char from the headings so crawlers don't index it.


![image](https://user-images.githubusercontent.com/4408379/137436844-a1f8f8fb-42cd-41c3-86c7-a11bb2d8e44a.png)

![image](https://user-images.githubusercontent.com/4408379/137436885-b1b1856c-152b-430c-ac01-1e63def22567.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I'm not sure how this can be tested, but it is solution that will work.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
