### PR TITLE
refactor: cleanup scroll handlers

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {useState, useCallback, useRef, useEffect} from 'react';
+import {useState, useCallback, useRef} from 'react';
 import {useLocationChange, useScrollPosition} from '@docusaurus/theme-common';
 import type {useHideableNavbarReturns} from '@theme/hooks/useHideableNavbar';
 
 const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
   const [isNavbarVisible, setIsNavbarVisible] = useState(hideOnScroll);
-  // const [isFocusedAnchor, setIsFocusedAnchor] = useState(false);
   const isFocusedAnchor = useRef(false);
   const navbarHeight = useRef(0);
   const navbarRef = useCallback((node: HTMLElement | null) => {
@@ -20,65 +19,37 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
     }
   }, []);
 
-  useScrollPosition(
-    (currentPosition, lastPosition) => {
-      if (!hideOnScroll) {
-        return;
-      }
+  useScrollPosition((currentPosition, lastPosition) => {
+    if (!hideOnScroll) {
+      return;
+    }
 
-      if (isFocusedAnchor.current) {
-        console.log('01');
-        // setIsFocusedAnchor(false);
-        isFocusedAnchor.current = false;
-        setIsNavbarVisible(false);
-        return;
-      }
+    if (isFocusedAnchor.current) {
+      isFocusedAnchor.current = false;
+      return;
+    }
 
-      console.log('s', isFocusedAnchor.current);
+    const scrollTop = currentPosition.scrollY;
+    const lastScrollTop = lastPosition?.scrollY;
+    const documentHeight =
+      document.documentElement.scrollHeight - navbarHeight.current;
+    const windowHeight = window.innerHeight;
 
-      const scrollTop = currentPosition.scrollY;
-      const lastScrollTop = lastPosition?.scrollY;
-      const documentHeight =
-        document.documentElement.scrollHeight - navbarHeight.current;
-      const windowHeight = window.innerHeight;
-
-      if (lastScrollTop && scrollTop >= lastScrollTop) {
-        setIsNavbarVisible(false);
-      } else if (scrollTop + windowHeight < documentHeight) {
-        setIsNavbarVisible(true);
-      }
-    },
-    // [isFocusedAnchor],
-  );
-
-  // useEffect(() => {
-  //   if (!hideOnScroll) {
-  //     return;
-  //   }
-
-  //   console.log('foc', isFocusedAnchor.current);
-
-  //   if (isFocusedAnchor) {
-  //     console.log('0');
-  //     // setIsFocusedAnchor(false);
-  //     isFocusedAnchor.current = false;
-  //     setIsNavbarVisible(false);
-  //     return;
-  //   }
-  // }, [isFocusedAnchor]);
+    if (lastScrollTop && scrollTop >= lastScrollTop) {
+      setIsNavbarVisible(false);
+    } else if (scrollTop + windowHeight < documentHeight) {
+      setIsNavbarVisible(true);
+    }
+  });
 
   useLocationChange((locationChangeEvent) => {
     if (!hideOnScroll) {
       return;
     }
 
-    console.log(locationChangeEvent.location.hash);
-
     if (locationChangeEvent.location.hash) {
-      console.log(1);
-
-      // setIsFocusedAnchor(true);
       isFocusedAnchor.current = true;
+      setIsNavbarVisible(false);
       return;
     }
 

--- a/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 import {useLocation} from '@docusaurus/router';
 import {Location} from '@docusaurus/history';
 import {usePrevious} from './usePrevious';
@@ -20,16 +20,8 @@ type OnLocationChange = (locationChangeEvent: LocationChangeEvent) => void;
 export function useLocationChange(onLocationChange: OnLocationChange): void {
   const location = useLocation();
   const previousLocation = usePrevious(location);
-  const isFirst = useRef<boolean>(true);
 
   useEffect(() => {
-    // Prevent first effect to trigger the listener on mount
-    // if (isFirst.current) {
-    //   console.log('2');
-    //   isFirst.current = false;
-    //   return;
-    // }
-
     onLocationChange({
       location,
       previousLocation,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR tries to unify use of scroll handlers in `useScrollPosition`, as there are quite a few non-obvious and unnecessary things right now. Beside that, it improves performance a bit, at least hideable navbar is no longer rendered twice on first mount.

It also fixes proper closing of hideable navbar when navigating from search (eg, "docs/next/versioning#docs"):

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/137467080-68046bd3-a6dc-47ae-958c-64fa0d6f618d.png) | ![image](https://user-images.githubusercontent.com/4408379/137467737-ea290905-3767-40d1-acba-aab87f1eb4a7.png) |

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview. It's not that simple, you have to check hideable navbar and back-to-top-button.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
