### PR TITLE
fix: handle rubber band scrolling in hideable navbar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -24,12 +24,19 @@ const useHideableNavbar = (hideOnScroll: boolean): useHideableNavbarReturns => {
       return;
     }
 
+    const scrollTop = currentPosition.scrollY;
+
+    // It needed for mostly to handle rubber band scrolling
+    if (scrollTop < navbarHeight.current) {
+      setIsNavbarVisible(true);
+      return;
+    }
+
     if (isFocusedAnchor.current) {
       isFocusedAnchor.current = false;
       return;
     }
 
-    const scrollTop = currentPosition.scrollY;
     const lastScrollTop = lastPosition?.scrollY;
     const documentHeight =
       document.documentElement.scrollHeight - navbarHeight.current;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #5715

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

On Safari, at the very beginning of any page, try scrolling up this page -- the announcement bar should display as before.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
