### PR TITLE
fix(google-tag-manager): Update to latest src

### DIFF
--- a/packages/docusaurus-plugin-google-gtag/src/index.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/index.ts
@@ -60,12 +60,12 @@ export default function pluginGoogleGtag(context: LoadContext): Plugin {
               href: 'https://www.googletagmanager.com',
             },
           },
-          // https://developers.google.com/analytics/devguides/collection/gtagjs/#install_the_global_site_tag
+          // https://developers.google.com/tag-manager/quickstart
           {
             tagName: 'script',
             attributes: {
               async: true,
-              src: `https://www.googletagmanager.com/gtag/js?id=${trackingID}`,
+              src: `https://www.googletagmanager.com/gtm.js?id=${trackingID}`,
             },
           },
           {


### PR DESCRIPTION
## Motivation

I'm using google tag manager assistant to debug a container. I kept getting script load errors, after some digging and comparing the network request against a known working page, I found that docusaurus is using an outdated script.

The new documentation is found at: https://developers.google.com/tag-manager/quickstart

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Debugging from GTM works.

Before change:

![image](https://user-images.githubusercontent.com/199751/137653718-e289cc45-74a9-45af-a2aa-45232df808c7.png)

After change:
![image](https://user-images.githubusercontent.com/199751/137653769-4d9c8e52-35ec-47f8-ae5a-4ed0e3dfe955.png)