### PR TITLE
refactor: perform shallow clone during deploy

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -167,7 +167,9 @@ Try using DEPLOYMENT_BRANCH=main or DEPLOYMENT_BRANCH=master`);
     const toPath = await fs.mkdtemp(
       path.join(os.tmpdir(), `${projectName}-${deploymentBranch}`),
     );
-    if (shellExecLog(`git clone --depth 1 ${remoteBranch} ${toPath}`).code !== 0) {
+    if (
+      shellExecLog(`git clone --depth 1 ${remoteBranch} ${toPath}`).code !== 0
+    ) {
       throw new Error(`Running "git clone" command in "${toPath}" failed.`);
     }
 


### PR DESCRIPTION
## Motivation

For large repos with extensive history, running `git clone` is not a trivial action. Making a shallow clone is more performant and I don't believe a full clone in necessary for deploy to run correctly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I ran the command locally