### PR TITLE
docs(v2): Fix typo in using-plugins.md

### DIFF
--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -133,7 +133,7 @@ You can use a plugin as a function, directly in the Docusaurus config file:
 module.exports = {
   // ...
   plugins: [
-    // highligh-start
+    // highlight-start
     function myPlugin(context, options) {
       // ...
       return {


### PR DESCRIPTION
I just noticed a minor typo in the documentation website, and decided to open a PR to fix it!

Sorry if I'm missing any of the contributing guidelines!