### PR TITLE
fix: stable callbacks in useSearchQuery + refactor

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -129,8 +129,7 @@ function SearchPage() {
   const documentsFoundPlural = useDocumentsFoundPlural();
 
   const docsSearchVersionsHelpers = useDocsSearchVersionsHelpers();
-  const {searchValue, updateSearchPath} = useSearchQuery();
-  const [searchQuery, setSearchQuery] = useState(searchValue);
+  const {searchQuery, setSearchQuery} = useSearchQuery();
   const initialSearchResultState = {
     items: [],
     query: null,
@@ -303,8 +302,6 @@ function SearchPage() {
   }, [loaderRef]);
 
   useEffect(() => {
-    updateSearchPath(searchQuery);
-
     searchResultStateDispatcher({type: 'reset'});
 
     if (searchQuery) {
@@ -314,12 +311,7 @@ function SearchPage() {
         makeSearch();
       }, 300);
     }
-  }, [
-    searchQuery,
-    docsSearchVersionsHelpers.searchVersions,
-    updateSearchPath,
-    makeSearch,
-  ]);
+  }, [searchQuery, docsSearchVersionsHelpers.searchVersions, makeSearch]);
 
   useEffect(() => {
     if (!searchResultState.lastPage || searchResultState.lastPage === 0) {
@@ -328,12 +320,6 @@ function SearchPage() {
 
     makeSearch(searchResultState.lastPage);
   }, [makeSearch, searchResultState.lastPage]);
-
-  useEffect(() => {
-    if (searchValue && searchValue !== searchQuery) {
-      setSearchQuery(searchValue);
-    }
-  }, [searchQuery, searchValue]);
 
   return (
     <Layout wrapperClassName="search-page-wrapper">


### PR DESCRIPTION
Breaking change: the returned value of `useSearchQuery` has been updated

## Motivation

This PR introduced a SearchPage regression: https://github.com/facebook/docusaurus/pull/5714

https://docusaurus.io/search

Unmemoized callbacks in `useSearchQuery` lead to infinite render loops.

This PR memoize the callbacks to fix the bug + refactor a little bit `useSearchQuery` + `SearchPage` to avoid some useless duplicated search query state (more refactorings should be done on the search page)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview
