### PR TITLE
feat(content-blog): allow sorting posts in ascending order

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -395,11 +395,11 @@ describe('loadBlog', () => {
     });
   });
 
-  test('test asc sort direction of blog post', async () => {
+  test('test ascending sort direction of blog post', async () => {
     const siteDir = path.join(__dirname, '__fixtures__', 'website');
     const normalOrder = await getBlogPosts(siteDir);
     const reversedOrder = await getBlogPosts(siteDir, {
-      postSortDirection: 'asc',
+      sortPosts: 'ascending',
     });
     expect(normalOrder.reverse().map((x) => x.metadata.date)).toEqual(
       reversedOrder.map((x) => x.metadata.date),

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -394,4 +394,15 @@ describe('loadBlog', () => {
       truncated: false,
     });
   });
+
+  test('test asc sort direction of blog post', async () => {
+    const siteDir = path.join(__dirname, '__fixtures__', 'website');
+    const normalOrder = await getBlogPosts(siteDir);
+    const reversedOrder = await getBlogPosts(siteDir, {
+      postSortDirection: 'asc',
+    });
+    expect(normalOrder.reverse().map((x) => x.metadata.date)).toEqual(
+      reversedOrder.map((x) => x.metadata.date),
+    );
+  });
 });

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -294,7 +294,7 @@ export async function generateBlogPosts(
     (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
   );
 
-  if (options.postSortDirection === 'asc') {
+  if (options.sortPosts === 'ascending') {
     return blogPosts.reverse();
   }
   return blogPosts;

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -294,6 +294,9 @@ export async function generateBlogPosts(
     (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
   );
 
+  if (options.postSortDirection === 'asc') {
+    return blogPosts.reverse();
+  }
   return blogPosts;
 }
 

--- a/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
@@ -42,7 +42,7 @@ export const DEFAULT_OPTIONS: PluginOptions = {
   editLocalizedFiles: false,
   authorsMapPath: 'authors.yml',
   readingTime: ({content, defaultReadingTime}) => defaultReadingTime({content}),
-  postSortDirection: 'desc',
+  sortPosts: 'descending',
 };
 
 export const PluginOptionSchema = Joi.object<PluginOptions>({
@@ -116,7 +116,7 @@ export const PluginOptionSchema = Joi.object<PluginOptions>({
   }).default(DEFAULT_OPTIONS.feedOptions),
   authorsMapPath: Joi.string().default(DEFAULT_OPTIONS.authorsMapPath),
   readingTime: Joi.function().default(() => DEFAULT_OPTIONS.readingTime),
-  postSortDirection: Joi.string()
-    .valid('desc', 'asc')
-    .default(DEFAULT_OPTIONS.postSortDirection),
+  sortPosts: Joi.string()
+    .valid('descending', 'ascending')
+    .default(DEFAULT_OPTIONS.sortPosts),
 });

--- a/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
@@ -42,6 +42,7 @@ export const DEFAULT_OPTIONS: PluginOptions = {
   editLocalizedFiles: false,
   authorsMapPath: 'authors.yml',
   readingTime: ({content, defaultReadingTime}) => defaultReadingTime({content}),
+  postSortDirection: 'desc',
 };
 
 export const PluginOptionSchema = Joi.object<PluginOptions>({
@@ -115,4 +116,7 @@ export const PluginOptionSchema = Joi.object<PluginOptions>({
   }).default(DEFAULT_OPTIONS.feedOptions),
   authorsMapPath: Joi.string().default(DEFAULT_OPTIONS.authorsMapPath),
   readingTime: Joi.function().default(() => DEFAULT_OPTIONS.readingTime),
+  postSortDirection: Joi.string()
+    .valid('desc', 'asc')
+    .default(DEFAULT_OPTIONS.postSortDirection),
 });

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -96,6 +96,7 @@ export type PluginOptions = RemarkAndRehypePluginOptions & {
   admonitions: Record<string, unknown>;
   authorsMapPath: string;
   readingTime: ReadingTimeFunctionOption;
+  postSortDirection: string;
 };
 
 // Options, as provided in the user config (before normalization)

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -96,7 +96,7 @@ export type PluginOptions = RemarkAndRehypePluginOptions & {
   admonitions: Record<string, unknown>;
   authorsMapPath: string;
   readingTime: ReadingTimeFunctionOption;
-  postSortDirection: string;
+  sortPosts: 'ascending' | 'descending';
 };
 
 // Options, as provided in the user config (before normalization)

--- a/website/docs/api/plugins/plugin-content-blog.md
+++ b/website/docs/api/plugins/plugin-content-blog.md
@@ -27,7 +27,7 @@ Accepted fields:
 <small>
 
 | Name | Type | Default | Description |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | `path` | `string` | `'blog'` | Path to the blog content directory on the filesystem, relative to site dir. |
 | `editUrl` | <code>string \| EditUrlFunction</code> | `undefined` | Base URL to edit your site. The final URL is computed by `editUrl + relativeDocPath`. Using a function allows more nuanced control for each file. Omitting this variable entirely will disable edit links. |
 | `editLocalizedFiles` | `boolean` | `false` | The edit URL will target the localized file, instead of the original unlocalized file. Ignored when `editUrl` is a function. |
@@ -59,7 +59,7 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`${siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
-| `postSortDirection` | `string` | `'desc'` | One of 'desc', 'asc'. Governs the direction of blog post sorting. |
+| `postSorting` | <code>'descending' | 'ascending' </code> | `'descending'` | Governs the direction of blog post sorting. |
 
 </small>
 

--- a/website/docs/api/plugins/plugin-content-blog.md
+++ b/website/docs/api/plugins/plugin-content-blog.md
@@ -27,7 +27,7 @@ Accepted fields:
 <small>
 
 | Name | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | `path` | `string` | `'blog'` | Path to the blog content directory on the filesystem, relative to site dir. |
 | `editUrl` | <code>string \| EditUrlFunction</code> | `undefined` | Base URL to edit your site. The final URL is computed by `editUrl + relativeDocPath`. Using a function allows more nuanced control for each file. Omitting this variable entirely will disable edit links. |
 | `editLocalizedFiles` | `boolean` | `false` | The edit URL will target the localized file, instead of the original unlocalized file. Ignored when `editUrl` is a function. |
@@ -59,7 +59,7 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`${siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
-| `postSorting` | <code>'descending' | 'ascending' </code> | `'descending'` | Governs the direction of blog post sorting. |
+| `postSorting` | <code>'descending' \| 'ascending' </code> | `'descending'` | Governs the direction of blog post sorting. |
 
 </small>
 

--- a/website/docs/api/plugins/plugin-content-blog.md
+++ b/website/docs/api/plugins/plugin-content-blog.md
@@ -59,6 +59,7 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`${siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
+| `postSortDirection` | `string` | `'desc'` | One of 'desc', 'asc'. Governs the direction of blog post sorting. |
 
 </small>
 

--- a/website/docs/api/plugins/plugin-content-blog.md
+++ b/website/docs/api/plugins/plugin-content-blog.md
@@ -59,7 +59,7 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`${siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
-| `postSorting` | <code>'descending' \| 'ascending' </code> | `'descending'` | Governs the direction of blog post sorting. |
+| `sortPosts` | <code>'descending' \| 'ascending' </code> | `'descending'` | Governs the direction of blog post sorting. |
 
 </small>
 


### PR DESCRIPTION
## Motivation

Solves #5692

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Regression tests for older relevant tests.
Created new test that sorts posts in reverse creation order and compare it to default option.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
