### PR TITLE
docs: Update Drone Deployment docs

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -354,15 +354,16 @@ trigger:
   commands:
     - mkdir -p $HOME/.ssh
     - ssh-keyscan -t rsa github.com >> $HOME/.ssh/known_hosts
-    - echo "$GITHUB_PRIVATE_KEY > $HOME/.ssh/id_rsa"
+    - echo "$GITHUB_PRIVATE_KEY" > "$HOME/.ssh/id_rsa"
     - chmod 0600 $HOME/.ssh/id_rsa
     - cd website
     - npm i
-    - npm run publish-gh-pages
+    - npm run deploy
   environment:
     USE_SSH: true
     GIT_USER: $DRONE_COMMIT_AUTHOR
-    GITHUB_PRIVATE_KEY: git_deploy_private_key
+    GITHUB_PRIVATE_KEY: 
+      from_secret: "git_deploy_private_key"
 ```
 
 Now, whenever you push a new tag to github, this trigger will start the drone ci job to publish your website.


### PR DESCRIPTION
## Motivation

I was following the docs to deploy on Drone, but ran into a few issues:

- The key was not being properly set
- The command `npm run publish-gh-pages` no longer works.
- The latest version of Drone retrieves secrets differently.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes.

## Relevant Changes

- Fix typo in "echo" command
- Update command to "npm run deploy"
- Update Drone config to use secrets properly
