### PR TITLE
refactor: use js-yaml to parse both JSON and YAML

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,6 +119,7 @@ module.exports = {
     'global-require': WARNING,
     'prefer-destructuring': WARNING,
     yoda: WARNING,
+    'no-await-in-loop': OFF,
     'no-control-regex': WARNING,
     'no-empty': [WARNING, {allowEmptyCatch: true}],
     'no-prototype-builtins': WARNING,

--- a/packages/docusaurus-plugin-content-blog/src/authors.ts
+++ b/packages/docusaurus-plugin-content-blog/src/authors.ts
@@ -43,12 +43,8 @@ export async function readAuthorsMapFile(
 ): Promise<AuthorsMap | undefined> {
   if (await fs.pathExists(filePath)) {
     const contentString = await fs.readFile(filePath, {encoding: 'utf8'});
-    const parse =
-      filePath.endsWith('.yml') || filePath.endsWith('.yaml')
-        ? Yaml.load
-        : JSON.parse;
     try {
-      const unsafeContent = parse(contentString);
+      const unsafeContent = Yaml.load(contentString);
       return validateAuthorsMapFile(unsafeContent);
     } catch (e) {
       // TODO replace later by error cause: see https://v8.dev/features/error-cause

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
@@ -42,6 +42,9 @@ describe('DefaultSidebarItemsGenerator', () => {
     jest.spyOn(fs, 'pathExists').mockImplementation((metadataFilePath) => {
       return typeof categoryMetadataFiles[metadataFilePath] !== 'undefined';
     });
+    jest.spyOn(fs, 'pathExistsSync').mockImplementation((metadataFilePath) => {
+      return typeof categoryMetadataFiles[metadataFilePath] !== 'undefined';
+    });
     jest.spyOn(fs, 'readFile').mockImplementation(
       // @ts-expect-error: annoying TS error due to overrides
       async (metadataFilePath: string) => {

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
@@ -42,9 +42,6 @@ describe('DefaultSidebarItemsGenerator', () => {
     jest.spyOn(fs, 'pathExists').mockImplementation((metadataFilePath) => {
       return typeof categoryMetadataFiles[metadataFilePath] !== 'undefined';
     });
-    jest.spyOn(fs, 'pathExistsSync').mockImplementation((metadataFilePath) => {
-      return typeof categoryMetadataFiles[metadataFilePath] !== 'undefined';
-    });
     jest.spyOn(fs, 'readFile').mockImplementation(
       // @ts-expect-error: annoying TS error due to overrides
       async (metadataFilePath: string) => {

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
@@ -65,37 +65,31 @@ const CategoryMetadatasFileSchema = Joi.object<CategoryMetadatasFile>({
 async function readCategoryMetadatasFile(
   categoryDirPath: string,
 ): Promise<CategoryMetadatasFile | null> {
-  async function tryReadFile(
-    fileNameWithExtension: string,
-    parse: (content: string) => unknown,
-  ): Promise<CategoryMetadatasFile | null> {
+  async function tryReadFile(filePath: string): Promise<CategoryMetadatasFile> {
+    const contentString = await fs.readFile(filePath, {encoding: 'utf8'});
+    const unsafeContent = Yaml.load(contentString);
+    try {
+      return Joi.attempt(unsafeContent, CategoryMetadatasFileSchema);
+    } catch (e) {
+      console.error(
+        chalk.red(
+          `The docs sidebar category metadata file looks invalid!\nPath: ${filePath}`,
+        ),
+      );
+      throw e;
+    }
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const ext of ['.json', '.yml', '.yaml']) {
     // Simpler to use only posix paths for mocking file metadatas in tests
     const filePath = posixPath(
-      path.join(categoryDirPath, fileNameWithExtension),
+      path.join(categoryDirPath, `${CategoryMetadataFilenameBase}${ext}`),
     );
-    if (await fs.pathExists(filePath)) {
-      const contentString = await fs.readFile(filePath, {encoding: 'utf8'});
-      const unsafeContent = parse(contentString);
-      try {
-        return Joi.attempt(unsafeContent, CategoryMetadatasFileSchema);
-      } catch (e) {
-        console.error(
-          chalk.red(
-            `The docs sidebar category metadata file looks invalid!\nPath: ${filePath}`,
-          ),
-        );
-        throw e;
-      }
+    if (fs.pathExistsSync(filePath)) {
+      return tryReadFile(filePath);
     }
-    return null;
   }
-
-  return (
-    (await tryReadFile(`${CategoryMetadataFilenameBase}.json`, JSON.parse)) ??
-    (await tryReadFile(`${CategoryMetadataFilenameBase}.yml`, Yaml.load)) ??
-    // eslint-disable-next-line no-return-await
-    (await tryReadFile(`${CategoryMetadataFilenameBase}.yaml`, Yaml.load))
-  );
+  return null;
 }
 
 // Comment for this feature: https://github.com/facebook/docusaurus/issues/3464#issuecomment-818670449

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
@@ -85,7 +85,7 @@ async function readCategoryMetadatasFile(
     const filePath = posixPath(
       path.join(categoryDirPath, `${CategoryMetadataFilenameBase}${ext}`),
     );
-    if (fs.pathExistsSync(filePath)) {
+    if (await fs.pathExists(filePath)) {
       return tryReadFile(filePath);
     }
   }

--- a/packages/docusaurus-theme-classic/update-code-translations.js
+++ b/packages/docusaurus-theme-classic/update-code-translations.js
@@ -216,7 +216,6 @@ async function updateCodeTranslations() {
   // eslint-disable-next-line no-restricted-syntax
   for (const localeFile of localesFiles) {
     logSection(`Will update ${path.basename(localeFile)}`);
-    // eslint-disable-next-line no-await-in-loop
     await updateLocaleCodeTranslations(localeFile, baseFileMessages);
   }
 }

--- a/packages/docusaurus-utils/src/codeTranslationsUtils.ts
+++ b/packages/docusaurus-utils/src/codeTranslationsUtils.ts
@@ -44,9 +44,7 @@ export async function readDefaultCodeTranslationMessages({
   for (const fileName of localesToTry) {
     const filePath = path.resolve(dirPath, `${fileName}.json`);
 
-    // eslint-disable-next-line no-await-in-loop
     if (await fs.pathExists(filePath)) {
-      // eslint-disable-next-line no-await-in-loop
       const fileContent = await fs.readFile(filePath, 'utf8');
       return JSON.parse(fileContent);
     }

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -313,7 +313,6 @@ export async function mapAsyncSequencial<T extends unknown, R extends unknown>(
   const results: R[] = [];
   // eslint-disable-next-line no-restricted-syntax
   for (const t of array) {
-    // eslint-disable-next-line no-await-in-loop
     const result = await action(t);
     results.push(result);
   }
@@ -326,7 +325,6 @@ export async function findAsyncSequential<T>(
 ): Promise<T | undefined> {
   // eslint-disable-next-line no-restricted-syntax
   for (const t of array) {
-    // eslint-disable-next-line no-await-in-loop
     if (await predicate(t)) {
       return t;
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

YAML 1.2 has made YAML a strict superset of JSON, so we don't need `JSON.parse` anymore.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests that read JSON fixtures still pass

