### PR TITLE
fix: include all branch tips for shallow clone in deploy command

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -168,7 +168,9 @@ Try using DEPLOYMENT_BRANCH=main or DEPLOYMENT_BRANCH=master`);
       path.join(os.tmpdir(), `${projectName}-${deploymentBranch}`),
     );
     if (
-      shellExecLog(`git clone --depth 1 ${remoteBranch} ${toPath}`).code !== 0
+      shellExecLog(
+        `git clone --depth 1 --no-single-branch ${remoteBranch} ${toPath}`,
+      ).code !== 0
     ) {
       throw new Error(`Running "git clone" command in "${toPath}" failed.`);
     }


### PR DESCRIPTION
Fixes #5827

## Motivation

Shallow clone of repository (introduced in https://github.com/facebook/docusaurus/pull/5748) fetches the default branch only.

From [Git - git-clone Documentation](https://git-scm.com/docs/git-clone):
> **`--depth <depth>`**
Create a shallow clone with a history truncated to the specified number of commits. Implies `--single-branch` unless `--no-single-branch` is given to fetch the histories near the tips of all branches.

This causes `git checkout` of the deployment branch to fail (with version `2.0.0-beta.8` of `@docusaurus/core`):
```
Cloning into '/tmp/my-docs-gh-pagesQ1g5AP'...
CMD: git clone --depth 1 ***github.com/my-org/my-docs.git /tmp/my-docs-gh-pagesQ1g5AP (code: 0)
main
error: pathspec 'origin/gh-pages' did not match any file(s) known to git
CMD: git checkout origin/gh-pages (code: 1)
CMD: git checkout --orphan gh-pages (code: 0)
```
As a result of this, the command will go on to attempt to force push the orphan branch, and thereby overwrite any existing commits on the deployment branch (unless there is a branch protection rule preventing force pushes, in which case the deployment will fail altogether).

Adding `--no-single-branch` to the command should solve this issue.

An alternative solution with `--branch ${deploymentBranch}` could probably also be used here.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested command locally.

## Related PRs

#5748