### PR TITLE
feat(preset-classic): guard against unknown keys in options

### DIFF
--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -31,40 +31,42 @@ export default function preset(
   const {themeConfig} = siteConfig;
   const {algolia, googleAnalytics, gtag} = themeConfig as Partial<ThemeConfig>;
   const isProd = process.env.NODE_ENV === 'production';
+  const {debug, docs, blog, pages, sitemap, theme, ...rest} = opts;
 
   const themes: PluginConfig[] = [];
-  themes.push(makePluginConfig('@docusaurus/theme-classic', opts.theme));
+  themes.push(makePluginConfig('@docusaurus/theme-classic', theme));
   if (algolia) {
     themes.push(require.resolve('@docusaurus/theme-search-algolia'));
   }
 
   const plugins: PluginConfig[] = [];
-  if (opts.docs !== false) {
-    plugins.push(
-      makePluginConfig('@docusaurus/plugin-content-docs', opts.docs),
-    );
+  if (docs !== false) {
+    plugins.push(makePluginConfig('@docusaurus/plugin-content-docs', docs));
   }
-  if (opts.blog !== false) {
-    plugins.push(
-      makePluginConfig('@docusaurus/plugin-content-blog', opts.blog),
-    );
+  if (blog !== false) {
+    plugins.push(makePluginConfig('@docusaurus/plugin-content-blog', blog));
   }
-  if (opts.pages !== false) {
-    plugins.push(
-      makePluginConfig('@docusaurus/plugin-content-pages', opts.pages),
-    );
+  if (pages !== false) {
+    plugins.push(makePluginConfig('@docusaurus/plugin-content-pages', pages));
   }
   if (isProd && googleAnalytics) {
     plugins.push(require.resolve('@docusaurus/plugin-google-analytics'));
   }
-  if (opts.debug || (typeof opts.debug === 'undefined' && !isProd)) {
+  if (debug || (debug === undefined && !isProd)) {
     plugins.push(require.resolve('@docusaurus/plugin-debug'));
   }
   if (isProd && gtag) {
     plugins.push(require.resolve('@docusaurus/plugin-google-gtag'));
   }
-  if (isProd && opts.sitemap !== false) {
-    plugins.push(makePluginConfig('@docusaurus/plugin-sitemap', opts.sitemap));
+  if (isProd && sitemap !== false) {
+    plugins.push(makePluginConfig('@docusaurus/plugin-sitemap', sitemap));
+  }
+  if (Object.keys(rest).length > 0) {
+    throw new Error(
+      `Unrecognized keys ${Object.keys(rest).join(
+        ', ',
+      )} found in preset-classic configuration. The allowed keys are debug, docs, blog, pages, sitemap, theme. Check the documentation: https://docusaurus.io/docs/presets#docusauruspreset-classic for more information on how to configure individual plugins.`,
+    );
   }
 
   return {themes, plugins};

--- a/website/docs/presets.md
+++ b/website/docs/presets.md
@@ -74,15 +74,15 @@ This is especially useful when some plugins and themes are intended to be used t
 
 The classic preset that is usually shipped by default to new Docusaurus website. It is a set of plugins and themes.
 
-| Themes                             | Plugins                               |
-| ---------------------------------- | ------------------------------------- |
-| `@docusaurus/theme-classic`        | `@docusaurus/plugin-content-docs`     |
-| `@docusaurus/theme-search-algolia` | `@docusaurus/plugin-content-blog`     |
-|                                    | `@docusaurus/plugin-content-pages`    |
-|                                    | `@docusaurus/plugin-debug`            |
-|                                    | `@docusaurus/plugin-google-analytics` |
-|                                    | `@docusaurus/plugin-google-gtag`      |
-|                                    | `@docusaurus/plugin-sitemap`          |
+| Themes | Plugins |
+| --- | --- |
+| [`@docusaurus/theme-classic`](./api/themes/theme-configuration.md) | [`@docusaurus/plugin-content-docs`](./api/plugins/plugin-content-docs.md) |
+| [`@docusaurus/theme-search-algolia`](./api/themes/theme-search-algolia.md) | [`@docusaurus/plugin-content-blog`](./api/plugins/plugin-content-blog.md) |
+|  | [`@docusaurus/plugin-content-pages`](./api/plugins/plugin-content-pages.md) |
+|  | [`@docusaurus/plugin-debug`](./api/plugins/plugin-debug.md) |
+|  | [`@docusaurus/plugin-google-analytics`](./api/plugins/plugin-google-analytics.md) |
+|  | [`@docusaurus/plugin-google-gtag`](./api/plugins/plugin-google-gtag.md) |
+|  | [`@docusaurus/plugin-sitemap`](./api/plugins/plugin-sitemap.md) |
 
 To specify plugin options individually, you can provide the necessary fields to certain plugins, i.e. `customCss` for `@docusaurus/theme-classic`, pass them in the preset field, like this:
 

--- a/website/versioned_docs/version-2.0.0-beta.7/presets.md
+++ b/website/versioned_docs/version-2.0.0-beta.7/presets.md
@@ -74,15 +74,15 @@ This is especially useful when some plugins and themes are intended to be used t
 
 The classic preset that is usually shipped by default to new Docusaurus website. It is a set of plugins and themes.
 
-| Themes                             | Plugins                               |
-| ---------------------------------- | ------------------------------------- |
-| `@docusaurus/theme-classic`        | `@docusaurus/plugin-content-docs`     |
-| `@docusaurus/theme-search-algolia` | `@docusaurus/plugin-content-blog`     |
-|                                    | `@docusaurus/plugin-content-pages`    |
-|                                    | `@docusaurus/plugin-debug`            |
-|                                    | `@docusaurus/plugin-google-analytics` |
-|                                    | `@docusaurus/plugin-google-gtag`      |
-|                                    | `@docusaurus/plugin-sitemap`          |
+| Themes | Plugins |
+| --- | --- |
+| [`@docusaurus/theme-classic`](./api/themes/theme-configuration.md) | [`@docusaurus/plugin-content-docs`](./api/plugins/plugin-content-docs.md) |
+| [`@docusaurus/theme-search-algolia`](./api/themes/theme-search-algolia.md) | [`@docusaurus/plugin-content-blog`](./api/plugins/plugin-content-blog.md) |
+|  | [`@docusaurus/plugin-content-pages`](./api/plugins/plugin-content-pages.md) |
+|  | [`@docusaurus/plugin-debug`](./api/plugins/plugin-debug.md) |
+|  | [`@docusaurus/plugin-google-analytics`](./api/plugins/plugin-google-analytics.md) |
+|  | [`@docusaurus/plugin-google-gtag`](./api/plugins/plugin-google-gtag.md) |
+|  | [`@docusaurus/plugin-sitemap`](./api/plugins/plugin-sitemap.md) |
 
 To specify plugin options individually, you can provide the necessary fields to certain plugins, i.e. `customCss` for `@docusaurus/theme-classic`, pass them in the preset field, like this:
 

--- a/website/versioned_docs/version-2.0.0-beta.8/presets.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/presets.md
@@ -74,15 +74,15 @@ This is especially useful when some plugins and themes are intended to be used t
 
 The classic preset that is usually shipped by default to new Docusaurus website. It is a set of plugins and themes.
 
-| Themes                             | Plugins                               |
-| ---------------------------------- | ------------------------------------- |
-| `@docusaurus/theme-classic`        | `@docusaurus/plugin-content-docs`     |
-| `@docusaurus/theme-search-algolia` | `@docusaurus/plugin-content-blog`     |
-|                                    | `@docusaurus/plugin-content-pages`    |
-|                                    | `@docusaurus/plugin-debug`            |
-|                                    | `@docusaurus/plugin-google-analytics` |
-|                                    | `@docusaurus/plugin-google-gtag`      |
-|                                    | `@docusaurus/plugin-sitemap`          |
+| Themes | Plugins |
+| --- | --- |
+| [`@docusaurus/theme-classic`](./api/themes/theme-configuration.md) | [`@docusaurus/plugin-content-docs`](./api/plugins/plugin-content-docs.md) |
+| [`@docusaurus/theme-search-algolia`](./api/themes/theme-search-algolia.md) | [`@docusaurus/plugin-content-blog`](./api/plugins/plugin-content-blog.md) |
+|  | [`@docusaurus/plugin-content-pages`](./api/plugins/plugin-content-pages.md) |
+|  | [`@docusaurus/plugin-debug`](./api/plugins/plugin-debug.md) |
+|  | [`@docusaurus/plugin-google-analytics`](./api/plugins/plugin-google-analytics.md) |
+|  | [`@docusaurus/plugin-google-gtag`](./api/plugins/plugin-google-gtag.md) |
+|  | [`@docusaurus/plugin-sitemap`](./api/plugins/plugin-sitemap.md) |
 
 To specify plugin options individually, you can provide the necessary fields to certain plugins, i.e. `customCss` for `@docusaurus/theme-classic`, pass them in the preset field, like this:
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #4239. After 8 months with no updates, let's do it ourselves

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add an unknown key in the website's config and `yarn start` fails

<details>
<summary>Error stack</summary>

```
$ docusaurus start
Starting the development server...
Error: Unrecognized keys badOption found in preset-classic configuration. The allowed keys are debug, docs, blog, pages, sitemap, theme. Check the documentation: https://docusaurus.io/docs/presets#docusauruspreset-classic for more information.
    at preset (/Users/joshcena/Desktop/work/Tech/Projects/docusaurus/packages/docusaurus-preset-classic/lib/index.js:49:15)
    at /Users/joshcena/Desktop/work/Tech/Projects/docusaurus/packages/docusaurus/lib/server/presets/index.js:32:62
    at Array.forEach (<anonymous>)
    at loadPresets (/Users/joshcena/Desktop/work/Tech/Projects/docusaurus/packages/docusaurus/lib/server/presets/index.js:19:13)
    at loadPluginConfigs (/Users/joshcena/Desktop/work/Tech/Projects/docusaurus/packages/docusaurus/lib/server/index.js:85:84)
    at load (/Users/joshcena/Desktop/work/Tech/Projects/docusaurus/packages/docusaurus/lib/server/index.js:185:27)
    at async start (/Users/joshcena/Desktop/work/Tech/Projects/docusaurus/packages/docusaurus/lib/commands/start.js:40:19)
error Command failed with exit code 1.
```

</details>