### PR TITLE
fix: Fix blog feeds not generated

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -519,7 +519,7 @@ export default function pluginContentBlog(
       // TODO: we shouldn't need to re-read the posts here!
       // postBuild should receive loadedContent
       const blogPosts = await generateBlogPosts(contentPaths, context, options);
-      if (blogPosts.length) {
+      if (!blogPosts.length) {
         return;
       }
       await createBlogFeedFiles({


### PR DESCRIPTION

## Motivation

Blog feeds are not generated anymore due to a typo in a recent refactor 😓 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

no :'( we should probably add some tests though

