### PR TITLE
misc: add "name" field for root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "root",
   "private": true,
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When I want to submit patches to docusaurus, I use a separate branch for each PR. I like to work in different git worktrees, so I can get a clean base repo for each patch to apply. What I like to do is use the format `docusaurus@branch-name` as the worktree directory name.

However, `@` is not a valid character in an npm package name, so `yarn install` will fail when calling `lerna bootstrap`. This patch allows this use case by adding a `"name": "root"` property to package.json. It's actually done by default by newer versions of lerna when we run `yarn lerna init`. This behaviour has been [observed here](https://github.com/lerna/lerna/issues/1835#issuecomment-955625905) (it's my own comment).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Clone docusaurus repo or make a worktree in a directory named `docusaurus@lerna-dirname-workaround`
1. Apply this patch
1. `yarn install` succeeds

Without this patch, `yarn install` fails:

```shell-session
$ yarn install
yarn install v1.22.17
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
[4/5] Linking dependencies...
[...]
[5/5] Building fresh packages...
$ run-p postinstall:**
yarn run v1.22.17
yarn run v1.22.17
$ yarn lock:update && yarn build:packages
$ is-ci || husky install
husky - Git hooks installed
Done in 0.22s.
$ npx yarn-deduplicate
$ lerna run build --no-private
lerna notice cli v3.22.1
lerna ERR! ENOPKG `package.json` does not exist, have you run `lerna init`?
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "postinstall:main" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
