### PR TITLE
Fix: Not generating RSS feed on blog plugin

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -519,7 +519,7 @@ export default function pluginContentBlog(
       // TODO: we shouldn't need to re-read the posts here!
       // postBuild should receive loadedContent
       const blogPosts = await generateBlogPosts(contentPaths, context, options);
-      if (blogPosts.length) {
+      if (blogPosts.length == 0) {
         return;
       }
       await createBlogFeedFiles({


### PR DESCRIPTION
## Motivation

Recently (https://github.com/facebook/docusaurus/commit/29d13351a493dc6f1a302f9a3540f806f2822709#diff-635b297894f2ee11773eececd176e7103bbf55146b368d017449eb6c661b4492L524) the check to see if there were blog posts to generate the feed got broken.

As `0` is falsely, where any other number is truthy. Therefore if there where, say 5 blogposts, then the length would be falsely and would skip generating blog feed files.

I made the check more intention revealing. Knowing that `.length` returns a number, then `==` should suffice to check equality.

## Test Plan

I build https://github.com/yangshun/tech-interview-handbook without this change, and there was not `rss.xml`.
I made the change, `yarn link`ed this change. Rebuild, and now I see the `rss.xml` feed.
