### PR TITLE
misc: show only latest archive alpha/beta versions dropdown

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,6 +11,10 @@ const versions = require('./versions.json');
 const math = require('remark-math');
 const katex = require('rehype-katex');
 const VersionsArchived = require('./versionsArchived.json');
+const ArchivedVersionsDropdownItems = Object.entries(VersionsArchived).splice(
+  0,
+  5,
+);
 const {dogfoodingPluginInstances} = require('./_dogfooding/dogfooding.config');
 
 // This probably only makes sense for the beta phase, temporary
@@ -364,17 +368,12 @@ const config = {
             position: 'right',
             dropdownActiveClassDisabled: true,
             dropdownItemsAfter: [
-              ...[
-                // Latest archived beta version
-                Object.entries(VersionsArchived)[0],
-                // Latest archived alpha version
-                Object.entries(VersionsArchived).filter(
-                  ([versionName]) => !versionName.startsWith('2.0.0-beta.'),
-                )[0],
-              ].map(([versionName, versionUrl]) => ({
-                label: versionName,
-                href: versionUrl,
-              })),
+              ...ArchivedVersionsDropdownItems.map(
+                ([versionName, versionUrl]) => ({
+                  label: versionName,
+                  href: versionUrl,
+                }),
+              ),
               {
                 href: 'https://v1.docusaurus.io',
                 label: '1.x.x',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -364,12 +364,17 @@ const config = {
             position: 'right',
             dropdownActiveClassDisabled: true,
             dropdownItemsAfter: [
-              ...Object.entries(VersionsArchived).map(
-                ([versionName, versionUrl]) => ({
-                  label: versionName,
-                  href: versionUrl,
-                }),
-              ),
+              ...[
+                // Latest archived beta version
+                Object.entries(VersionsArchived)[0],
+                // Latest archived alpha version
+                Object.entries(VersionsArchived).filter(
+                  ([versionName]) => !versionName.startsWith('2.0.0-beta.'),
+                )[0],
+              ].map(([versionName, versionUrl]) => ({
+                label: versionName,
+                href: versionUrl,
+              })),
               {
                 href: 'https://v1.docusaurus.io',
                 label: '1.x.x',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently versions dropdown on the site is quite long, I propose to reduce its items by showing only the latest archived versions, since all available versions already renders on the "Versions" page.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
