### PR TITLE
fix: respect base URL when serving content by webpack dev server

### DIFF
--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -188,6 +188,7 @@ export default async function start(
       stats: 'summary',
     },
     static: {
+      publicPath: baseUrl,
       directory: path.resolve(siteDir, STATIC_DIR_NAME),
       watch: {
         // Useful options for our own monorepo using symlinks!


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #5863

Apparently, as often happens, we forgot to handle the base URL :see_no_evil: 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Set base url and try serve site.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
