### PR TITLE
docs: remove duplicated appId property

### DIFF
--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -89,9 +89,6 @@ module.exports = {
       // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
       externalUrlRegex: 'external\\.com|domain\\.com',
 
-      // Optional: see doc section below
-      appId: 'YOUR_APP_ID',
-
       // Optional: Algolia search parameters
       searchParameters: {},
 


### PR DESCRIPTION
## Motivation

I notice there has one duplicated property called `appId`.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

No

## Related PRs

https://github.com/facebook/docusaurus/pull/5632