### PR TITLE
fix(theme-classic): fix announcementBar css

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -29,8 +29,8 @@ html[data-announcement-bar-initially-dismissed='true'] .announcementBar {
 .announcementBarClose {
   flex: 0 0 30px;
   align-self: stretch;
-  padding: 0;
-  line-height: 0;
+  padding: 0 !important;
+  line-height: 0 !important;
 }
 
 .announcementBarContent {


### PR DESCRIPTION

## Motivation

After merging this PR: https://github.com/facebook/docusaurus/pull/3104

The insertion order of CSS classes became different 🤷‍♂️ 

![image](https://user-images.githubusercontent.com/749374/140370770-6c11a513-649e-4500-8e88-47cce1c2ef31.png)

This is a temporary fix, the original problem looks related to https://github.com/facebook/docusaurus/issues/3678

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

