### PR TITLE
docs: '5 minutes tutorial' -> '5-minute tutorial'

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minute tutorial](https://tutorial.docusaurus.io)** online.
+Or read the **[5-minute tutorial](https://tutorial.docusaurus.io)** online.
 
 :::
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io)** online.
+Or read the **[5 minute tutorial](https://tutorial.docusaurus.io)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.8/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minute tutorial](https://tutorial.docusaurus.io)** online.
+Or read the **[5-minute tutorial](https://tutorial.docusaurus.io)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.8/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io)** online.
+Or read the **[5 minute tutorial](https://tutorial.docusaurus.io)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.9/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minute tutorial](https://tutorial.docusaurus.io)** online.
+Or read the **[5-minute tutorial](https://tutorial.docusaurus.io)** online.
 
 :::
 

--- a/website/versioned_docs/version-2.0.0-beta.9/introduction.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/introduction.md
@@ -42,7 +42,7 @@ Open `http://localhost:3000` and follow the tutorial.
 
 Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately in your browser!
 
-Or read the **[5 minutes tutorial](https://tutorial.docusaurus.io)** online.
+Or read the **[5 minute tutorial](https://tutorial.docusaurus.io)** online.
 
 :::
 


### PR DESCRIPTION
## Motivation
There is a typo or grammatical error in a few portions of the documentation, where people are invited to "read the 5 minutes tutorial" rather than the "5 minute tutorial".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan
Just a copy change, no test changes should be required.