### PR TITLE
chore: Change copyright from Facebook, Inc to Meta Platforms, Inc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -57,7 +57,7 @@ module.exports = {
       'block',
       [
         '*',
-        ' * Copyright (c) Facebook, Inc. and its affiliates.',
+        ' * Copyright (c) Meta. and its affiliates.',
         ' *',
         ' * This source code is licensed under the MIT license found in the',
         ' * LICENSE file in the root directory of this source tree.',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -57,7 +57,7 @@ module.exports = {
       'block',
       [
         '*',
-        ' * Copyright (c) Meta. and its affiliates.',
+        ' * Copyright (c) Meta Platforms, Inc. and its affiliates.',
         ' *',
         ' * This source code is licensed under the MIT license found in the',
         ' * LICENSE file in the root directory of this source tree.',

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ Copy and paste this to the top of your new file(s):
 
 ```js
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ Copy and paste this to the top of your new file(s):
 
 ```js
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Facebook, Inc. and its affiliates.
+Copyright (c) Meta. and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Meta. and its affiliates.
+Copyright (c) Meta Platforms, Inc. and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/__tests__/validate-package-json.test.ts
+++ b/__tests__/validate-package-json.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/__tests__/validate-package-json.test.ts
+++ b/__tests__/validate-package-json.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
+++ b/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
+++ b/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functions/codesandbox.ts
+++ b/admin/new.docusaurus.io/functions/codesandbox.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functions/codesandbox.ts
+++ b/admin/new.docusaurus.io/functions/codesandbox.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functions/index.ts
+++ b/admin/new.docusaurus.io/functions/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functions/index.ts
+++ b/admin/new.docusaurus.io/functions/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functions/stackblitz.ts
+++ b/admin/new.docusaurus.io/functions/stackblitz.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/new.docusaurus.io/functions/stackblitz.ts
+++ b/admin/new.docusaurus.io/functions/stackblitz.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) Meta. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/classic-typescript/src/components/HomepageFeatures.tsx
+++ b/examples/classic-typescript/src/components/HomepageFeatures.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/classic-typescript/src/components/HomepageFeatures.tsx
+++ b/examples/classic-typescript/src/components/HomepageFeatures.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/.eslintrc.js
+++ b/examples/facebook/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ module.exports = {
 
       [
         '*',
-        ' * Copyright (c) Facebook, Inc. and its affiliates.',
+        ' * Copyright (c) Meta. and its affiliates.',
         ' *',
         ' * This source code is licensed under the MIT license found in the',
         ' * LICENSE file in the root directory of this source tree.',

--- a/examples/facebook/.eslintrc.js
+++ b/examples/facebook/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ module.exports = {
 
       [
         '*',
-        ' * Copyright (c) Meta. and its affiliates.',
+        ' * Copyright (c) Meta Platforms, Inc. and its affiliates.',
         ' *',
         ' * This source code is licensed under the MIT license found in the',
         ' * LICENSE file in the root directory of this source tree.',

--- a/examples/facebook/.stylelintrc.js
+++ b/examples/facebook/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/.stylelintrc.js
+++ b/examples/facebook/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/babel.config.js
+++ b/examples/facebook/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/babel.config.js
+++ b/examples/facebook/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/docusaurus.config.js
+++ b/examples/facebook/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -144,7 +144,7 @@ const config = {
           href: 'https://opensource.facebook.com',
         },
         // Please do not remove the credits, help to publicize Docusaurus :)
-        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc. Built with Docusaurus.`,
       },
     }),
 };

--- a/examples/facebook/docusaurus.config.js
+++ b/examples/facebook/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -144,7 +144,7 @@ const config = {
           href: 'https://opensource.facebook.com',
         },
         // Please do not remove the credits, help to publicize Docusaurus :)
-        copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
       },
     }),
 };

--- a/examples/facebook/sidebars.js
+++ b/examples/facebook/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/sidebars.js
+++ b/examples/facebook/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/src/css/custom.css
+++ b/examples/facebook/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/src/css/custom.css
+++ b/examples/facebook/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/src/pages/index.js
+++ b/examples/facebook/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/src/pages/index.js
+++ b/examples/facebook/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/src/pages/styles.module.css
+++ b/examples/facebook/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/examples/facebook/src/pages/styles.module.css
+++ b/examples/facebook/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/generateExamples.js
+++ b/generateExamples.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/generateExamples.js
+++ b/generateExamples.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest/emptyModule.js
+++ b/jest/emptyModule.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest/emptyModule.js
+++ b/jest/emptyModule.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest/polyfills.js
+++ b/jest/polyfills.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest/polyfills.js
+++ b/jest/polyfills.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest/stylelint-rule-test.js
+++ b/jest/stylelint-rule-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/jest/stylelint-rule-test.js
+++ b/jest/stylelint-rule-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/bin/index.js
+++ b/packages/create-docusaurus/bin/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/bin/index.js
+++ b/packages/create-docusaurus/bin/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures.tsx
+++ b/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures.tsx
+++ b/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/.eslintrc.js
+++ b/packages/create-docusaurus/templates/facebook/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ module.exports = {
 
       [
         '*',
-        ' * Copyright (c) Facebook, Inc. and its affiliates.',
+        ' * Copyright (c) Meta. and its affiliates.',
         ' *',
         ' * This source code is licensed under the MIT license found in the',
         ' * LICENSE file in the root directory of this source tree.',

--- a/packages/create-docusaurus/templates/facebook/.eslintrc.js
+++ b/packages/create-docusaurus/templates/facebook/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ module.exports = {
 
       [
         '*',
-        ' * Copyright (c) Meta. and its affiliates.',
+        ' * Copyright (c) Meta Platforms, Inc. and its affiliates.',
         ' *',
         ' * This source code is licensed under the MIT license found in the',
         ' * LICENSE file in the root directory of this source tree.',

--- a/packages/create-docusaurus/templates/facebook/.stylelintrc.js
+++ b/packages/create-docusaurus/templates/facebook/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/.stylelintrc.js
+++ b/packages/create-docusaurus/templates/facebook/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/babel.config.js
+++ b/packages/create-docusaurus/templates/facebook/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/babel.config.js
+++ b/packages/create-docusaurus/templates/facebook/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/facebook/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -144,7 +144,7 @@ const config = {
           href: 'https://opensource.facebook.com',
         },
         // Please do not remove the credits, help to publicize Docusaurus :)
-        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc. Built with Docusaurus.`,
       },
     }),
 };

--- a/packages/create-docusaurus/templates/facebook/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/facebook/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -144,7 +144,7 @@ const config = {
           href: 'https://opensource.facebook.com',
         },
         // Please do not remove the credits, help to publicize Docusaurus :)
-        copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
       },
     }),
 };

--- a/packages/create-docusaurus/templates/facebook/sidebars.js
+++ b/packages/create-docusaurus/templates/facebook/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/sidebars.js
+++ b/packages/create-docusaurus/templates/facebook/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/src/css/custom.css
+++ b/packages/create-docusaurus/templates/facebook/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/src/css/custom.css
+++ b/packages/create-docusaurus/templates/facebook/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/src/pages/index.js
+++ b/packages/create-docusaurus/templates/facebook/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/src/pages/index.js
+++ b/packages/create-docusaurus/templates/facebook/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/src/pages/styles.module.css
+++ b/packages/create-docusaurus/templates/facebook/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/create-docusaurus/templates/facebook/src/pages/styles.module.css
+++ b/packages/create-docusaurus/templates/facebook/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-cssnano-preset/index.js
+++ b/packages/docusaurus-cssnano-preset/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-cssnano-preset/index.js
+++ b/packages/docusaurus-cssnano-preset/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/__tests__/index.test.js
+++ b/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/__tests__/index.test.js
+++ b/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/index.js
+++ b/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/index.js
+++ b/packages/docusaurus-cssnano-preset/src/remove-overridden-custom-properties/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/index.ts
+++ b/packages/docusaurus-mdx-loader/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/index.ts
+++ b/packages/docusaurus-mdx-loader/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/headings/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/headings/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/headings/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/headings/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/headings/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/headings/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/headings/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/headings/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/search.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/search.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/search.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/__tests__/search.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/search.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/search.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/toc/search.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/search.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/unwrapMdxCodeBlocks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/types.d.ts
+++ b/packages/docusaurus-mdx-loader/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-mdx-loader/src/types.d.ts
+++ b/packages/docusaurus-mdx-loader/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/bin/index.js
+++ b/packages/docusaurus-migrate/bin/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/bin/index.js
+++ b/packages/docusaurus-migrate/bin/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/external_types/index.d.ts
+++ b/packages/docusaurus-migrate/external_types/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/external_types/index.d.ts
+++ b/packages/docusaurus-migrate/external_types/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/pages/en/index.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/pages/en/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/pages/en/index.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/pages/en/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/siteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/siteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/siteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/siteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/expectedSiteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/pages/en/index.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/pages/en/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/pages/en/index.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/pages/en/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/siteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/siteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/siteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/siteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/pages/en/index.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/pages/en/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/pages/en/index.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/pages/en/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/siteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/siteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/siteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/website/siteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/sourceSiteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/sourceSiteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/__fixtures__/sourceSiteConfig.js
+++ b/packages/docusaurus-migrate/src/__tests__/__fixtures__/sourceSiteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/frontMatter.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/migration.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/migration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/migration.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/migration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/migrationConfig.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/migrationConfig.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/__tests__/migrationConfig.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/migrationConfig.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/frontMatter.ts
+++ b/packages/docusaurus-migrate/src/frontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/frontMatter.ts
+++ b/packages/docusaurus-migrate/src/frontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/index.ts
+++ b/packages/docusaurus-migrate/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/index.ts
+++ b/packages/docusaurus-migrate/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/sanitizeMD.ts
+++ b/packages/docusaurus-migrate/src/sanitizeMD.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/sanitizeMD.ts
+++ b/packages/docusaurus-migrate/src/sanitizeMD.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/transform.ts
+++ b/packages/docusaurus-migrate/src/transform.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/transform.ts
+++ b/packages/docusaurus-migrate/src/transform.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/types.ts
+++ b/packages/docusaurus-migrate/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-migrate/src/types.ts
+++ b/packages/docusaurus-migrate/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/collectRedirects.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/createRedirectPageContent.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/createRedirectPageContent.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/createRedirectPageContent.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/createRedirectPageContent.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/extensionRedirects.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/extensionRedirects.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/extensionRedirects.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/extensionRedirects.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/normalizePluginOptions.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/normalizePluginOptions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/normalizePluginOptions.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/normalizePluginOptions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/redirectValidation.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/redirectValidation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/redirectValidation.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/redirectValidation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/__tests__/writeRedirectFiles.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/createRedirectPageContent.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/createRedirectPageContent.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/createRedirectPageContent.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/createRedirectPageContent.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/extensionRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/extensionRedirects.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/extensionRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/extensionRedirects.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/index.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/index.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/normalizePluginOptions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/plugin-client-redirects.d.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/plugin-client-redirects.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/plugin-client-redirects.d.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/plugin-client-redirects.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/redirectValidation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/templates/redirectPage.template.html.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/templates/redirectPage.template.html.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/templates/redirectPage.template.html.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/templates/redirectPage.template.html.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/types.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/types.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/writeRedirectFiles.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/authors.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/authors.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/authors.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/authors.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogFrontMatter.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/linkify.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/linkify.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/linkify.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/linkify.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/pluginOptionSchema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/pluginOptionSchema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/authors.ts
+++ b/packages/docusaurus-plugin-content-blog/src/authors.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/authors.ts
+++ b/packages/docusaurus-plugin-content-blog/src/authors.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogFrontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/feed.ts
+++ b/packages/docusaurus-plugin-content-blog/src/feed.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/feed.ts
+++ b/packages/docusaurus-plugin-content-blog/src/feed.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-blog/src/markdownLoader.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-blog/src/pluginOptionSchema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/translations.ts
+++ b/packages/docusaurus-plugin-content-blog/src/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/translations.ts
+++ b/packages/docusaurus-plugin-content-blog/src/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/types.d.ts
+++ b/packages/docusaurus-plugin-content-blog/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-blog/types.d.ts
+++ b/packages/docusaurus-plugin-content-blog/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/empty-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/empty-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/empty-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/empty-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars2.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars2.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars2.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/partialAutogeneratedSidebars2.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-doc-label/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-doc-label/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-doc-label/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-doc-label/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/cli.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/cli.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docFrontMatter.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/numberPrefix.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/numberPrefix.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/numberPrefix.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/numberPrefix.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/options.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/slug.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/slug.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/slug.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/slug.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/cli.ts
+++ b/packages/docusaurus-plugin-content-docs/src/cli.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/cli.ts
+++ b/packages/docusaurus-plugin-content-docs/src/cli.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsClientUtils.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsClientUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsClientUtils.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsClientUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/constants.ts
+++ b/packages/docusaurus-plugin-content-docs/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/constants.ts
+++ b/packages/docusaurus-plugin-content-docs/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/globalData.ts
+++ b/packages/docusaurus-plugin-content-docs/src/globalData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/globalData.ts
+++ b/packages/docusaurus-plugin-content-docs/src/globalData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
+++ b/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
+++ b/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/markdown/__tests__/linkify.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/__tests__/linkify.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/markdown/__tests__/linkify.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/__tests__/linkify.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/numberPrefix.ts
+++ b/packages/docusaurus-plugin-content-docs/src/numberPrefix.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/numberPrefix.ts
+++ b/packages/docusaurus-plugin-content-docs/src/numberPrefix.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/props.ts
+++ b/packages/docusaurus-plugin-content-docs/src/props.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/props.ts
+++ b/packages/docusaurus-plugin-content-docs/src/props.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category-shorthand.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category-shorthand.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category-shorthand.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category-shorthand.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-category.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-first-level-not-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-first-level-not-category.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-first-level-not-category.js
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/__fixtures__/sidebars/sidebars-first-level-not-category.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/processor.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/processor.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/processor.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/processor.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/generator.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/processor.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/processor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/processor.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/processor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/slug.ts
+++ b/packages/docusaurus-plugin-content-docs/src/slug.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/slug.ts
+++ b/packages/docusaurus-plugin-content-docs/src/slug.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/tags.ts
+++ b/packages/docusaurus-plugin-content-docs/src/tags.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/tags.ts
+++ b/packages/docusaurus-plugin-content-docs/src/tags.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/theme/hooks/useDocs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/translations.ts
+++ b/packages/docusaurus-plugin-content-docs/src/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/translations.ts
+++ b/packages/docusaurus-plugin-content-docs/src/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/versions.ts
+++ b/packages/docusaurus-plugin-content-docs/src/versions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/src/versions.ts
+++ b/packages/docusaurus-plugin-content-docs/src/versions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/types.d.ts
+++ b/packages/docusaurus-plugin-content-docs/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-docs/types.d.ts
+++ b/packages/docusaurus-plugin-content-docs/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/i18n/fr/docusaurus-plugin-content-pages/hello/translatedJs.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/i18n/fr/docusaurus-plugin-content-pages/hello/translatedJs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/i18n/fr/docusaurus-plugin-content-pages/hello/translatedJs.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/i18n/fr/docusaurus-plugin-content-pages/hello/translatedJs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/translatedJs.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/translatedJs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/translatedJs.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/translatedJs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/world.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/world.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/world.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/hello/world.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/index.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.tsx
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.tsx
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/pluginOptionSchema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/pluginOptionSchema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-pages/src/markdownLoader.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/markdownLoader.ts
+++ b/packages/docusaurus-plugin-content-pages/src/markdownLoader.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
+++ b/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
+++ b/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-pages/src/pluginOptionSchema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-content-pages/src/pluginOptionSchema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/types.ts
+++ b/packages/docusaurus-plugin-content-pages/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/src/types.ts
+++ b/packages/docusaurus-plugin-content-pages/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/types.d.ts
+++ b/packages/docusaurus-plugin-content-pages/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-content-pages/types.d.ts
+++ b/packages/docusaurus-plugin-content-pages/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/copyUntypedFiles.js
+++ b/packages/docusaurus-plugin-debug/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/copyUntypedFiles.js
+++ b/packages/docusaurus-plugin-debug/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/index.ts
+++ b/packages/docusaurus-plugin-debug/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/index.ts
+++ b/packages/docusaurus-plugin-debug/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugConfig/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugConfig/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugConfig/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugConfig/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugContent/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugContent/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugContent/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugContent/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugGlobalData/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugGlobalData/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugGlobalData/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugGlobalData/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugLayout/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugLayout/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugLayout/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugLayout/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugLayout/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugLayout/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugLayout/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugLayout/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/types.d.ts
+++ b/packages/docusaurus-plugin-debug/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-debug/src/types.d.ts
+++ b/packages/docusaurus-plugin-debug/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/analytics.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/analytics.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/analytics.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/analytics.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/index.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/index.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/plugin-google-analytics.d.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/plugin-google-analytics.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/plugin-google-analytics.d.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/plugin-google-analytics.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/types.d.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-analytics/src/types.d.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/index.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/index.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/types.d.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-google-gtag/src/types.d.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/copyUntypedFiles.js
+++ b/packages/docusaurus-plugin-ideal-image/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/copyUntypedFiles.js
+++ b/packages/docusaurus-plugin-ideal-image/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/src/index.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/src/plugin-ideal-image.d.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/plugin-ideal-image.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/src/plugin-ideal-image.d.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/plugin-ideal-image.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/src/theme/IdealImage.js
+++ b/packages/docusaurus-plugin-ideal-image/src/theme/IdealImage.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-ideal-image/src/theme/IdealImage.js
+++ b/packages/docusaurus-plugin-ideal-image/src/theme/IdealImage.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/index.js
+++ b/packages/docusaurus-plugin-pwa/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/index.js
+++ b/packages/docusaurus-plugin-pwa/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/pluginOptionSchema.js
+++ b/packages/docusaurus-plugin-pwa/src/pluginOptionSchema.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/pluginOptionSchema.js
+++ b/packages/docusaurus-plugin-pwa/src/pluginOptionSchema.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/registerSw.js
+++ b/packages/docusaurus-plugin-pwa/src/registerSw.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/registerSw.js
+++ b/packages/docusaurus-plugin-pwa/src/registerSw.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/renderReloadPopup.js
+++ b/packages/docusaurus-plugin-pwa/src/renderReloadPopup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/renderReloadPopup.js
+++ b/packages/docusaurus-plugin-pwa/src/renderReloadPopup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/sw.js
+++ b/packages/docusaurus-plugin-pwa/src/sw.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/sw.js
+++ b/packages/docusaurus-plugin-pwa/src/sw.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/index.js
+++ b/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/index.js
+++ b/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/styles.module.css
+++ b/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/styles.module.css
+++ b/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/pluginOptionSchema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/pluginOptionSchema.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/pluginOptionSchema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/index.ts
+++ b/packages/docusaurus-plugin-sitemap/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/index.ts
+++ b/packages/docusaurus-plugin-sitemap/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
+++ b/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
+++ b/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-sitemap/src/pluginOptionSchema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/pluginOptionSchema.ts
+++ b/packages/docusaurus-plugin-sitemap/src/pluginOptionSchema.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/types.ts
+++ b/packages/docusaurus-plugin-sitemap/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-plugin-sitemap/src/types.ts
+++ b/packages/docusaurus-plugin-sitemap/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-preset-classic/src/preset-classic.d.ts
+++ b/packages/docusaurus-preset-classic/src/preset-classic.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-preset-classic/src/preset-classic.d.ts
+++ b/packages/docusaurus-preset-classic/src/preset-classic.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.js
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.js
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/babel.config.js
+++ b/packages/docusaurus-theme-classic/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/babel.config.js
+++ b/packages/docusaurus-theme-classic/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -89,7 +89,7 @@ describe('themeConfig', () => {
           src: 'img/oss_logo.png',
           href: 'https://opensource.facebook.com',
         },
-        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc. Built with Docusaurus.`,
       },
       tableOfContents: {
         minHeadingLevel: 2,

--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -89,7 +89,7 @@ describe('themeConfig', () => {
           src: 'img/oss_logo.png',
           href: 'https://opensource.facebook.com',
         },
-        copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
       },
       tableOfContents: {
         minHeadingLevel: 2,

--- a/packages/docusaurus-theme-classic/src/admonitions.css
+++ b/packages/docusaurus-theme-classic/src/admonitions.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/admonitions.css
+++ b/packages/docusaurus-theme-classic/src/admonitions.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/prism-include-languages.ts
+++ b/packages/docusaurus-theme-classic/src/prism-include-languages.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/prism-include-languages.ts
+++ b/packages/docusaurus-theme-classic/src/prism-include-languages.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthor/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostAuthors/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Details/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItemFooter/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItemFooter/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItemFooter/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItemFooter/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItemFooter/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItemFooter/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocItemFooter/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocItemFooter/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocTagsListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocTagsListPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconArrow/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconArrow/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconArrow/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconArrow/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconClose/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconClose/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconClose/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconClose/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconEdit/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconEdit/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconEdit/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconEdit/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconEdit/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/IconEdit/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconEdit/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/IconEdit/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconExternalLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconExternalLink/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconExternalLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconExternalLink/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconExternalLink/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/IconExternalLink/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconExternalLink/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/IconExternalLink/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconLanguage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconLanguage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconLanguage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconLanguage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconMenu/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconMenu/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/IconMenu/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/IconMenu/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NotFound.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NotFound.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/NotFound.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NotFound.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/SearchBar.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SearchBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/SearchBar.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SearchBar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/SearchMetadatas/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SearchMetadatas/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/SearchMetadatas/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SearchMetadatas/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Seo/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCInline/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOCInline/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCInline/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TOCInline/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCItems/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCItems/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TOCItems/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCItems/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tag/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tag/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tag/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tag/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListInline/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListInline/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/TagsListInline/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListInline/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemeContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemeContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ThemeProvider/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemedImage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/ThemedImage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/ThemedImage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/ThemedImage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Toggle/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/UserPreferencesContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/UserPreferencesProvider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/UserPreferencesProvider/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/UserPreferencesProvider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/UserPreferencesProvider/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useContextualSearchFilters.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useDocs.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useHideableNavbar.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useKeyboardNavigation.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useKeyboardNavigation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useKeyboardNavigation.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useKeyboardNavigation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLocationHash.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLockBodyScroll.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLockBodyScroll.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useLockBodyScroll.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useLockBodyScroll.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/usePrismTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/usePrismTheme.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/usePrismTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/usePrismTheme.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTabGroupChoice.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTabGroupChoice.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTabGroupChoice.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTabGroupChoice.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useThemeContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useUserPreferencesContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.ts
+++ b/packages/docusaurus-theme-classic/src/theme/hooks/useWindowSize.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
+++ b/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
+++ b/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/translations.ts
+++ b/packages/docusaurus-theme-classic/src/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/translations.ts
+++ b/packages/docusaurus-theme-classic/src/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/types.d.ts
+++ b/packages/docusaurus-theme-classic/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/update-code-translations.js
+++ b/packages/docusaurus-theme-classic/update-code-translations.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/update-code-translations.js
+++ b/packages/docusaurus-theme-classic/update-code-translations.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/update-code-translations.test.js
+++ b/packages/docusaurus-theme-classic/update-code-translations.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-classic/update-code-translations.test.js
+++ b/packages/docusaurus-theme-classic/update-code-translations.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/copyUntypedFiles.js
+++ b/packages/docusaurus-theme-common/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/copyUntypedFiles.js
+++ b/packages/docusaurus-theme-common/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/components/Details/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Details/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/components/Details/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Details/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/types.d.ts
+++ b/packages/docusaurus-theme-common/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/types.d.ts
+++ b/packages/docusaurus-theme-common/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
+++ b/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
+++ b/packages/docusaurus-theme-common/src/utils/ThemeClassNames.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/codeBlockUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/pathUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/pathUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/pathUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/pathUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/tagUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/tagUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/tagUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/tagUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/tocUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/tocUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/__tests__/tocUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/tocUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/announcementBarUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/announcementBarUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/announcementBarUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/announcementBarUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionProvider.tsx
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionProvider.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionProvider.tsx
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionProvider.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionStorage.ts
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionStorage.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionStorage.ts
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/DocsPreferredVersionStorage.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/useDocsPreferredVersion.ts
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/useDocsPreferredVersion.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/useDocsPreferredVersion.ts
+++ b/packages/docusaurus-theme-common/src/utils/docsPreferredVersion/useDocsPreferredVersion.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/docsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/docsUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/docsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/generalUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/generalUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/generalUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/generalUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/historyUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/historyUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/historyUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/historyUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/jsUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/jsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/jsUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/jsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/mobileSecondaryMenu.tsx
+++ b/packages/docusaurus-theme-common/src/utils/mobileSecondaryMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/mobileSecondaryMenu.tsx
+++ b/packages/docusaurus-theme-common/src/utils/mobileSecondaryMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/pathUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/pathUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/pathUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/pathUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/regexpUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/regexpUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/regexpUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/regexpUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/searchUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/searchUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/searchUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/searchUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/storageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/storageUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/storageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/storageUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/tagsUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/tagsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/tagsUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/tagsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/tocUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/tocUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/tocUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/tocUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useLocalPathname.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocalPathname.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useLocalPathname.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocalPathname.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/usePluralForm.ts
+++ b/packages/docusaurus-theme-common/src/utils/usePluralForm.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/usePluralForm.ts
+++ b/packages/docusaurus-theme-common/src/utils/usePluralForm.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/usePrevious.ts
+++ b/packages/docusaurus-theme-common/src/utils/usePrevious.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/usePrevious.ts
+++ b/packages/docusaurus-theme-common/src/utils/usePrevious.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
+++ b/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
+++ b/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/copyUntypedFiles.js
+++ b/packages/docusaurus-theme-live-codeblock/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/copyUntypedFiles.js
+++ b/packages/docusaurus-theme-live-codeblock/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/__tests__/validateThemeConfig.test.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/__tests__/validateThemeConfig.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/__tests__/validateThemeConfig.test.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/__tests__/validateThemeConfig.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/custom-buble.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/custom-buble.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/custom-buble.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/custom-buble.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/index.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/index.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/ReactLiveScope/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/ReactLiveScope/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/theme/ReactLiveScope/index.js
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/ReactLiveScope/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/types.d.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/types.d.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/validateThemeConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-live-codeblock/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/validateThemeConfig.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.js
+++ b/packages/docusaurus-theme-search-algolia/src/__tests__/validateThemeConfig.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/templates/opensearch.js
+++ b/packages/docusaurus-theme-search-algolia/src/templates/opensearch.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/templates/opensearch.js
+++ b/packages/docusaurus-theme-search-algolia/src/templates/opensearch.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchMetadatas/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchMetadatas/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchMetadatas/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchMetadatas/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/hooks/useAlgoliaContextualFacetFilters.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/hooks/useSearchQuery.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/hooks/useSearchQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/theme/hooks/useSearchQuery.js
+++ b/packages/docusaurus-theme-search-algolia/src/theme/hooks/useSearchQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.js
+++ b/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/applyTrailingSlash.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/__tests__/uniq.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/uniq.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/__tests__/uniq.test.ts
+++ b/packages/docusaurus-utils-common/src/__tests__/uniq.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/applyTrailingSlash.tsx
+++ b/packages/docusaurus-utils-common/src/applyTrailingSlash.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/applyTrailingSlash.tsx
+++ b/packages/docusaurus-utils-common/src/applyTrailingSlash.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/index.ts
+++ b/packages/docusaurus-utils-common/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/index.ts
+++ b/packages/docusaurus-utils-common/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/uniq.ts
+++ b/packages/docusaurus-utils-common/src/uniq.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-common/src/uniq.ts
+++ b/packages/docusaurus-utils-common/src/uniq.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/Joi.ts
+++ b/packages/docusaurus-utils-validation/src/Joi.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/Joi.ts
+++ b/packages/docusaurus-utils-validation/src/Joi.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/JoiFrontMatter.ts
+++ b/packages/docusaurus-utils-validation/src/JoiFrontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/JoiFrontMatter.ts
+++ b/packages/docusaurus-utils-validation/src/JoiFrontMatter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/__tests__/validationUtils.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/__tests__/validationUtils.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/index.ts
+++ b/packages/docusaurus-utils-validation/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/index.ts
+++ b/packages/docusaurus-utils-validation/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/validationUtils.ts
+++ b/packages/docusaurus-utils-validation/src/validationUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils-validation/src/validationUtils.ts
+++ b/packages/docusaurus-utils-validation/src/validationUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/codeTranslationsUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/codeTranslationsUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/codeTranslationsUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/codeTranslationsUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/escapePath.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/escapePath.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/escapePath.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/escapePath.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/globUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/hashUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/hashUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/hashUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/hashUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/index.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownParser.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/mdxUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/mdxUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/mdxUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/mdxUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/normalizeUrl.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/normalizeUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/normalizeUrl.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/normalizeUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/pathUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/pathUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/pathUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/pathUtils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/posixPath.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/posixPath.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/posixPath.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/posixPath.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/tags.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/tags.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/__tests__/tags.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/tags.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/codeTranslationsUtils.ts
+++ b/packages/docusaurus-utils/src/codeTranslationsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/codeTranslationsUtils.ts
+++ b/packages/docusaurus-utils/src/codeTranslationsUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/dependencies.d.ts
+++ b/packages/docusaurus-utils/src/dependencies.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/dependencies.d.ts
+++ b/packages/docusaurus-utils/src/dependencies.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/escapePath.ts
+++ b/packages/docusaurus-utils/src/escapePath.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/escapePath.ts
+++ b/packages/docusaurus-utils/src/escapePath.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/globUtils.ts
+++ b/packages/docusaurus-utils/src/globUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/globUtils.ts
+++ b/packages/docusaurus-utils/src/globUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/hashUtils.ts
+++ b/packages/docusaurus-utils/src/hashUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/hashUtils.ts
+++ b/packages/docusaurus-utils/src/hashUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/markdownParser.ts
+++ b/packages/docusaurus-utils/src/markdownParser.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/mdxUtils.ts
+++ b/packages/docusaurus-utils/src/mdxUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/mdxUtils.ts
+++ b/packages/docusaurus-utils/src/mdxUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/normalizeUrl.ts
+++ b/packages/docusaurus-utils/src/normalizeUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/normalizeUrl.ts
+++ b/packages/docusaurus-utils/src/normalizeUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/pathUtils.ts
+++ b/packages/docusaurus-utils/src/pathUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/pathUtils.ts
+++ b/packages/docusaurus-utils/src/pathUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/posixPath.ts
+++ b/packages/docusaurus-utils/src/posixPath.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/posixPath.ts
+++ b/packages/docusaurus-utils/src/posixPath.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/tags.ts
+++ b/packages/docusaurus-utils/src/tags.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/tags.ts
+++ b/packages/docusaurus-utils/src/tags.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/types.d.ts
+++ b/packages/docusaurus-utils/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus-utils/src/types.d.ts
+++ b/packages/docusaurus-utils/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/bin/beforeCli.js
+++ b/packages/docusaurus/bin/beforeCli.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/bin/beforeCli.js
+++ b/packages/docusaurus/bin/beforeCli.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/bin/docusaurus.js
+++ b/packages/docusaurus/bin/docusaurus.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/copyUntypedFiles.js
+++ b/packages/docusaurus/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/copyUntypedFiles.js
+++ b/packages/docusaurus/copyUntypedFiles.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/babel/preset.ts
+++ b/packages/docusaurus/src/babel/preset.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/babel/preset.ts
+++ b/packages/docusaurus/src/babel/preset.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/choosePort.ts
+++ b/packages/docusaurus/src/choosePort.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/choosePort.ts
+++ b/packages/docusaurus/src/choosePort.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/.eslintrc.js
+++ b/packages/docusaurus/src/client/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/.eslintrc.js
+++ b/packages/docusaurus/src/client/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/LinksCollector.tsx
+++ b/packages/docusaurus/src/client/LinksCollector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/LinksCollector.tsx
+++ b/packages/docusaurus/src/client/LinksCollector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/__tests__/flat.test.ts
+++ b/packages/docusaurus/src/client/__tests__/flat.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/__tests__/flat.test.ts
+++ b/packages/docusaurus/src/client/__tests__/flat.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
+++ b/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
+++ b/packages/docusaurus/src/client/__tests__/normalizeLocation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
+++ b/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
+++ b/packages/docusaurus/src/client/baseUrlIssueBanner/BaseUrlIssueBanner.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/baseUrlIssueBanner/styles.module.css
+++ b/packages/docusaurus/src/client/baseUrlIssueBanner/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/baseUrlIssueBanner/styles.module.css
+++ b/packages/docusaurus/src/client/baseUrlIssueBanner/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/client-lifecycles-dispatcher.ts
+++ b/packages/docusaurus/src/client/client-lifecycles-dispatcher.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/client-lifecycles-dispatcher.ts
+++ b/packages/docusaurus/src/client/client-lifecycles-dispatcher.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/clientEntry.tsx
+++ b/packages/docusaurus/src/client/clientEntry.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/clientEntry.tsx
+++ b/packages/docusaurus/src/client/clientEntry.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/docusaurus.ts
+++ b/packages/docusaurus/src/client/docusaurus.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/docusaurus.ts
+++ b/packages/docusaurus/src/client/docusaurus.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/ComponentCreator.tsx
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/ComponentCreator.tsx
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/ExecutionEnvironment.ts
+++ b/packages/docusaurus/src/client/exports/ExecutionEnvironment.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/ExecutionEnvironment.ts
+++ b/packages/docusaurus/src/client/exports/ExecutionEnvironment.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Head.tsx
+++ b/packages/docusaurus/src/client/exports/Head.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Head.tsx
+++ b/packages/docusaurus/src/client/exports/Head.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Interpolate.tsx
+++ b/packages/docusaurus/src/client/exports/Interpolate.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Interpolate.tsx
+++ b/packages/docusaurus/src/client/exports/Interpolate.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Noop.ts
+++ b/packages/docusaurus/src/client/exports/Noop.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Noop.ts
+++ b/packages/docusaurus/src/client/exports/Noop.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Translate.tsx
+++ b/packages/docusaurus/src/client/exports/Translate.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/Translate.tsx
+++ b/packages/docusaurus/src/client/exports/Translate.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/Translate.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Translate.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/Translate.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Translate.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/isInternalUrl.test.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/isInternalUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/isInternalUrl.test.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/isInternalUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.test.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.test.ts
+++ b/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/browserContext.tsx
+++ b/packages/docusaurus/src/client/exports/browserContext.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/browserContext.tsx
+++ b/packages/docusaurus/src/client/exports/browserContext.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/constants.ts
+++ b/packages/docusaurus/src/client/exports/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/constants.ts
+++ b/packages/docusaurus/src/client/exports/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/docusaurusContext.tsx
+++ b/packages/docusaurus/src/client/exports/docusaurusContext.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/docusaurusContext.tsx
+++ b/packages/docusaurus/src/client/exports/docusaurusContext.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/isInternalUrl.ts
+++ b/packages/docusaurus/src/client/exports/isInternalUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/isInternalUrl.ts
+++ b/packages/docusaurus/src/client/exports/isInternalUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/renderRoutes.ts
+++ b/packages/docusaurus/src/client/exports/renderRoutes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/renderRoutes.ts
+++ b/packages/docusaurus/src/client/exports/renderRoutes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/router.ts
+++ b/packages/docusaurus/src/client/exports/router.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/router.ts
+++ b/packages/docusaurus/src/client/exports/router.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useBaseUrl.ts
+++ b/packages/docusaurus/src/client/exports/useBaseUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useBaseUrl.ts
+++ b/packages/docusaurus/src/client/exports/useBaseUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
+++ b/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
+++ b/packages/docusaurus/src/client/exports/useDocusaurusContext.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useGlobalData.ts
+++ b/packages/docusaurus/src/client/exports/useGlobalData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useGlobalData.ts
+++ b/packages/docusaurus/src/client/exports/useGlobalData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useIsBrowser.ts
+++ b/packages/docusaurus/src/client/exports/useIsBrowser.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/exports/useIsBrowser.ts
+++ b/packages/docusaurus/src/client/exports/useIsBrowser.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/flat.ts
+++ b/packages/docusaurus/src/client/flat.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/flat.ts
+++ b/packages/docusaurus/src/client/flat.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/normalizeLocation.ts
+++ b/packages/docusaurus/src/client/normalizeLocation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/normalizeLocation.ts
+++ b/packages/docusaurus/src/client/normalizeLocation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/nprogress.css
+++ b/packages/docusaurus/src/client/nprogress.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/nprogress.css
+++ b/packages/docusaurus/src/client/nprogress.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/prefetch.ts
+++ b/packages/docusaurus/src/client/prefetch.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/prefetch.ts
+++ b/packages/docusaurus/src/client/prefetch.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/preload.ts
+++ b/packages/docusaurus/src/client/preload.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/preload.ts
+++ b/packages/docusaurus/src/client/preload.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/serverEntry.js
+++ b/packages/docusaurus/src/client/serverEntry.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/templates/ssr.html.template.d.ts
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/templates/ssr.html.template.d.ts
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/templates/ssr.html.template.js
+++ b/packages/docusaurus/src/client/templates/ssr.html.template.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Error/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Error/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Error/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Error/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Layout/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Layout/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Layout/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Layout/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Loading/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Loading/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Loading/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Loading/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/NotFound/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/NotFound/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/NotFound/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/NotFound/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Root/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Root/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/theme-fallback/Root/index.js
+++ b/packages/docusaurus/src/client/theme-fallback/Root/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/types.d.ts
+++ b/packages/docusaurus/src/client/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/client/types.d.ts
+++ b/packages/docusaurus/src/client/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/buildRemoteBranchUrl.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/__tests__/writeHeadingIds.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/writeHeadingIds.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/__tests__/writeHeadingIds.test.ts
+++ b/packages/docusaurus/src/commands/__tests__/writeHeadingIds.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
+++ b/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
+++ b/packages/docusaurus/src/commands/buildRemoteBranchUrl.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/clear.ts
+++ b/packages/docusaurus/src/commands/clear.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/clear.ts
+++ b/packages/docusaurus/src/commands/clear.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/commandUtils.ts
+++ b/packages/docusaurus/src/commands/commandUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/commandUtils.ts
+++ b/packages/docusaurus/src/commands/commandUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/external.ts
+++ b/packages/docusaurus/src/commands/external.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/external.ts
+++ b/packages/docusaurus/src/commands/external.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/writeHeadingIds.ts
+++ b/packages/docusaurus/src/commands/writeHeadingIds.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/writeHeadingIds.ts
+++ b/packages/docusaurus/src/commands/writeHeadingIds.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/constants.ts
+++ b/packages/docusaurus/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/constants.ts
+++ b/packages/docusaurus/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/bad-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/bad-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/bad-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/bad-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/bar/baz.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/bar/baz.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/bar/baz.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/bar/baz.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo/index.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo/index.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/foo/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/index.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/index.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/sidebars.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/sidebars.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/sidebars.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/sidebars.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/hello/world.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/hello/world.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/hello/world.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/hello/world.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/index.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/index.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/wrong-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/wrong-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/wrong-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/wrong-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
+++ b/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
+++ b/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/config.test.ts
+++ b/packages/docusaurus/src/server/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/config.test.ts
+++ b/packages/docusaurus/src/server/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/duplicateRoutes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/duplicateRoutes.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/duplicateRoutes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/duplicateRoutes.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/i18n.test.ts
+++ b/packages/docusaurus/src/server/__tests__/i18n.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/i18n.test.ts
+++ b/packages/docusaurus/src/server/__tests__/i18n.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/routes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/routes.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/routes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/routes.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/utils.test.ts
+++ b/packages/docusaurus/src/server/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/__tests__/utils.test.ts
+++ b/packages/docusaurus/src/server/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/brokenLinks.ts
+++ b/packages/docusaurus/src/server/brokenLinks.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/brokenLinks.ts
+++ b/packages/docusaurus/src/server/brokenLinks.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-empty.js
+++ b/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-empty.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-empty.js
+++ b/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-empty.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-foo-bar.js
+++ b/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-foo-bar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-foo-bar.js
+++ b/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-foo-bar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-hello-world.js
+++ b/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-hello-world.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-hello-world.js
+++ b/packages/docusaurus/src/server/client-modules/__tests__/__fixtures__/plugin-hello-world.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/client-modules/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/client-modules/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/index.ts
+++ b/packages/docusaurus/src/server/client-modules/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/client-modules/index.ts
+++ b/packages/docusaurus/src/server/client-modules/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/config.ts
+++ b/packages/docusaurus/src/server/config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/duplicateRoutes.ts
+++ b/packages/docusaurus/src/server/duplicateRoutes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/duplicateRoutes.ts
+++ b/packages/docusaurus/src/server/duplicateRoutes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-empty.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-empty.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-empty.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-empty.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-headTags.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-headTags.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-headTags.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-headTags.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-postBodyTags.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-postBodyTags.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-postBodyTags.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-postBodyTags.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-preBodyTags.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-preBodyTags.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-preBodyTags.js
+++ b/packages/docusaurus/src/server/html-tags/__tests__/__fixtures__/plugin-preBodyTags.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/htmlTags.test.ts
+++ b/packages/docusaurus/src/server/html-tags/__tests__/htmlTags.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/htmlTags.test.ts
+++ b/packages/docusaurus/src/server/html-tags/__tests__/htmlTags.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/html-tags/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/html-tags/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/htmlTags.ts
+++ b/packages/docusaurus/src/server/html-tags/htmlTags.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/htmlTags.ts
+++ b/packages/docusaurus/src/server/html-tags/htmlTags.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/index.ts
+++ b/packages/docusaurus/src/server/html-tags/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/html-tags/index.ts
+++ b/packages/docusaurus/src/server/html-tags/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/loadSetup.ts
+++ b/packages/docusaurus/src/server/loadSetup.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/loadSetup.ts
+++ b/packages/docusaurus/src/server/loadSetup.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/badPlugins.docusaurus.config.js
+++ b/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/badPlugins.docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/badPlugins.docusaurus.config.js
+++ b/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/badPlugins.docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/docusaurus.config.js
+++ b/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/docusaurus.config.js
+++ b/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/applyRouteTrailingSlash.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/applyRouteTrailingSlash.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/applyRouteTrailingSlash.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/applyRouteTrailingSlash.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/pluginIds.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/pluginIds.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/__tests__/pluginIds.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/pluginIds.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/applyRouteTrailingSlash.ts
+++ b/packages/docusaurus/src/server/plugins/applyRouteTrailingSlash.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/applyRouteTrailingSlash.ts
+++ b/packages/docusaurus/src/server/plugins/applyRouteTrailingSlash.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/pluginIds.ts
+++ b/packages/docusaurus/src/server/plugins/pluginIds.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/plugins/pluginIds.ts
+++ b/packages/docusaurus/src/server/plugins/pluginIds.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-bar.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-bar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-bar.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-bar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-foo.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-foo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-foo.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-foo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-qux.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-qux.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-qux.js
+++ b/packages/docusaurus/src/server/presets/__tests__/__fixtures__/preset-qux.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/presets/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/presets/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Footer/index.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Footer/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Footer/index.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Footer/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Layout.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Layout.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Layout.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-1/Layout.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Layout/index.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Layout/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Layout/index.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Layout/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Navbar.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Navbar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Navbar.js
+++ b/packages/docusaurus/src/server/themes/__tests__/__fixtures__/theme-2/Navbar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/alias.test.ts
+++ b/packages/docusaurus/src/server/themes/__tests__/alias.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/alias.test.ts
+++ b/packages/docusaurus/src/server/themes/__tests__/alias.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/themes/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/themes/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/alias.ts
+++ b/packages/docusaurus/src/server/themes/alias.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/alias.ts
+++ b/packages/docusaurus/src/server/themes/alias.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translationsExtractor.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/translations.ts
+++ b/packages/docusaurus/src/server/translations/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/translations.ts
+++ b/packages/docusaurus/src/server/translations/translations.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/translationsExtractor.ts
+++ b/packages/docusaurus/src/server/translations/translationsExtractor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/translations/translationsExtractor.ts
+++ b/packages/docusaurus/src/server/translations/translationsExtractor.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/types.d.ts
+++ b/packages/docusaurus/src/server/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/types.d.ts
+++ b/packages/docusaurus/src/server/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/utils.ts
+++ b/packages/docusaurus/src/server/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/utils.ts
+++ b/packages/docusaurus/src/server/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/versions/__tests/index.test.ts
+++ b/packages/docusaurus/src/server/versions/__tests/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/versions/__tests/index.test.ts
+++ b/packages/docusaurus/src/server/versions/__tests/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/versions/index.ts
+++ b/packages/docusaurus/src/server/versions/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/server/versions/index.ts
+++ b/packages/docusaurus/src/server/versions/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/types.d.ts
+++ b/packages/docusaurus/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/types.d.ts
+++ b/packages/docusaurus/src/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/base.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/base.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/base.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/base.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/client.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/client.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/server.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/server.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/server.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/server.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/utils.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/__tests__/utils.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/CleanWebpackPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/CleanWebpackPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/CleanWebpackPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/CleanWebpackPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/LogPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/LogPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/LogPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/LogPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/WaitPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/WaitPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/plugins/WaitPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/WaitPlugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/server.ts
+++ b/packages/docusaurus/src/webpack/server.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/server.ts
+++ b/packages/docusaurus/src/webpack/server.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/__tests__/index.test.ts
+++ b/packages/lqip-loader/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/__tests__/index.test.ts
+++ b/packages/lqip-loader/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/index.ts
+++ b/packages/lqip-loader/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/index.ts
+++ b/packages/lqip-loader/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/lqip.ts
+++ b/packages/lqip-loader/src/lqip.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/lqip.ts
+++ b/packages/lqip-loader/src/lqip.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/utils.ts
+++ b/packages/lqip-loader/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/lqip-loader/src/utils.ts
+++ b/packages/lqip-loader/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/stylelint-copyright/__tests__/index.js
+++ b/packages/stylelint-copyright/__tests__/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/stylelint-copyright/__tests__/index.js
+++ b/packages/stylelint-copyright/__tests__/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/stylelint-copyright/index.js
+++ b/packages/stylelint-copyright/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/stylelint-copyright/index.js
+++ b/packages/stylelint-copyright/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/_dogfooding/clientModuleExample.ts
+++ b/website/_dogfooding/clientModuleExample.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/_dogfooding/clientModuleExample.ts
+++ b/website/_dogfooding/clientModuleExample.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/_dogfooding/docs-tests-sidebars.js
+++ b/website/_dogfooding/docs-tests-sidebars.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/_dogfooding/docs-tests-sidebars.js
+++ b/website/_dogfooding/docs-tests-sidebars.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/_dogfooding/dogfooding.config.js
+++ b/website/_dogfooding/dogfooding.config.js
@@ -29,7 +29,7 @@ const dogfoodingPluginInstances = [
       feedOptions: {
         type: 'all',
         title: 'Docusaurus Tests Blog',
-        copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`,
       },
       readingTime: ({content, frontMatter, defaultReadingTime}) =>
         frontMatter.hide_reading_time

--- a/website/_dogfooding/dogfooding.config.js
+++ b/website/_dogfooding/dogfooding.config.js
@@ -29,7 +29,7 @@ const dogfoodingPluginInstances = [
       feedOptions: {
         type: 'all',
         title: 'Docusaurus Tests Blog',
-        copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
       },
       readingTime: ({content, frontMatter, defaultReadingTime}) =>
         frontMatter.hide_reading_time

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/community/3-contributing.md
+++ b/website/community/3-contributing.md
@@ -174,7 +174,7 @@ Copy and paste this to the top of your new file(s):
 
 ```js
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/community/3-contributing.md
+++ b/website/community/3-contributing.md
@@ -174,7 +174,7 @@ Copy and paste this to the top of your new file(s):
 
 ```js
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/delayCrowdin.js
+++ b/website/delayCrowdin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/delayCrowdin.js
+++ b/website/delayCrowdin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -297,7 +297,7 @@ module.exports = {
         width: 160,
         height: 51,
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`, // You can also put own HTML here
     },
   },
 };

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -297,7 +297,7 @@ module.exports = {
         width: 160,
         height: 51,
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here
+      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here
     },
   },
 };

--- a/website/docs/blog.mdx
+++ b/website/docs/blog.mdx
@@ -481,7 +481,7 @@ module.exports = {
         blog: {
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`,
           },
         },
       },

--- a/website/docs/blog.mdx
+++ b/website/docs/blog.mdx
@@ -481,7 +481,7 @@ module.exports = {
         blog: {
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
           },
         },
       },

--- a/website/docs/migration/migration-manual.md
+++ b/website/docs/migration/migration-manual.md
@@ -227,7 +227,7 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here.
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`, // You can also put own HTML here.
     },
     image: 'img/docusaurus.png',
     // ...

--- a/website/docs/migration/migration-manual.md
+++ b/website/docs/migration/migration-manual.md
@@ -227,7 +227,7 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here.
+      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here.
     },
     image: 'img/docusaurus.png',
     // ...

--- a/website/docusaurus.config-blog-only.js
+++ b/website/docusaurus.config-blog-only.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,7 +30,7 @@ module.exports = {
           postsPerPage: 3,
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
           },
         },
         theme: {
@@ -62,7 +62,7 @@ module.exports = {
         src: 'img/oss_logo.png',
         href: 'https://opensource.facebook.com',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
     },
   },
 };

--- a/website/docusaurus.config-blog-only.js
+++ b/website/docusaurus.config-blog-only.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,7 +30,7 @@ module.exports = {
           postsPerPage: 3,
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`,
           },
         },
         theme: {
@@ -62,7 +62,7 @@ module.exports = {
         src: 'img/oss_logo.png',
         href: 'https://opensource.facebook.com',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc. Built with Docusaurus.`,
     },
   },
 };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -282,7 +282,7 @@ const config = {
           postsPerPage: 5,
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
           },
           blogSidebarCount: 'ALL',
           blogSidebarTitle: 'All our posts',
@@ -497,7 +497,7 @@ const config = {
           height: 51,
           href: 'https://opensource.facebook.com',
         },
-        copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
       },
     }),
 };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -282,7 +282,7 @@ const config = {
           postsPerPage: 5,
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`,
           },
           blogSidebarCount: 'ALL',
           blogSidebarTitle: 'All our posts',
@@ -497,7 +497,7 @@ const config = {
           height: 51,
           href: 'https://opensource.facebook.com',
         },
-        copyright: `Copyright © ${new Date().getFullYear()} Meta. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc. Built with Docusaurus.`,
       },
     }),
 };

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/sidebarsCommunity.js
+++ b/website/sidebarsCommunity.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/sidebarsCommunity.js
+++ b/website/sidebarsCommunity.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/BrowserWindow/index.tsx
+++ b/website/src/components/BrowserWindow/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/BrowserWindow/index.tsx
+++ b/website/src/components/BrowserWindow/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/BrowserWindow/styles.module.css
+++ b/website/src/components/BrowserWindow/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/BrowserWindow/styles.module.css
+++ b/website/src/components/BrowserWindow/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/ColorGenerator/index.tsx
+++ b/website/src/components/ColorGenerator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/ColorGenerator/index.tsx
+++ b/website/src/components/ColorGenerator/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/ColorGenerator/styles.module.css
+++ b/website/src/components/ColorGenerator/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/ColorGenerator/styles.module.css
+++ b/website/src/components/ColorGenerator/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/ErrorBoundaryTestButton/index.tsx
+++ b/website/src/components/ErrorBoundaryTestButton/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/ErrorBoundaryTestButton/index.tsx
+++ b/website/src/components/ErrorBoundaryTestButton/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/TeamProfileCards/index.tsx
+++ b/website/src/components/TeamProfileCards/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/TeamProfileCards/index.tsx
+++ b/website/src/components/TeamProfileCards/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCard/index.tsx
+++ b/website/src/components/showcase/ShowcaseCard/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCard/index.tsx
+++ b/website/src/components/showcase/ShowcaseCard/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCard/styles.module.css
+++ b/website/src/components/showcase/ShowcaseCard/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCard/styles.module.css
+++ b/website/src/components/showcase/ShowcaseCard/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCheckbox/index.tsx
+++ b/website/src/components/showcase/ShowcaseCheckbox/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCheckbox/index.tsx
+++ b/website/src/components/showcase/ShowcaseCheckbox/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCheckbox/styles.module.css
+++ b/website/src/components/showcase/ShowcaseCheckbox/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseCheckbox/styles.module.css
+++ b/website/src/components/showcase/ShowcaseCheckbox/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseSelect/index.tsx
+++ b/website/src/components/showcase/ShowcaseSelect/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseSelect/index.tsx
+++ b/website/src/components/showcase/ShowcaseSelect/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseSelect/styles.module.css
+++ b/website/src/components/showcase/ShowcaseSelect/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/components/showcase/ShowcaseSelect/styles.module.css
+++ b/website/src/components/showcase/ShowcaseSelect/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/featureRequests/FeatureRequestsPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/featureRequests/FeatureRequestsPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/FeatureRequestsPlugin.js
+++ b/website/src/featureRequests/FeatureRequestsPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/FeatureRequestsPlugin.js
+++ b/website/src/featureRequests/FeatureRequestsPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/cannyScript.js
+++ b/website/src/featureRequests/cannyScript.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/cannyScript.js
+++ b/website/src/featureRequests/cannyScript.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/styles.module.css
+++ b/website/src/featureRequests/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/featureRequests/styles.module.css
+++ b/website/src/featureRequests/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/examples/_myComponent.tsx
+++ b/website/src/pages/examples/_myComponent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/examples/_myComponent.tsx
+++ b/website/src/pages/examples/_myComponent.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/showcase/index.tsx
+++ b/website/src/pages/showcase/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/showcase/index.tsx
+++ b/website/src/pages/showcase/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/showcase/styles.module.css
+++ b/website/src/pages/showcase/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/showcase/styles.module.css
+++ b/website/src/pages/showcase/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/versions.tsx
+++ b/website/src/pages/versions.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/versions.tsx
+++ b/website/src/pages/versions.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/sw.js
+++ b/website/src/sw.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/sw.js
+++ b/website/src/sw.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/theme/ReactLiveScope/index.ts
+++ b/website/src/theme/ReactLiveScope/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/theme/ReactLiveScope/index.ts
+++ b/website/src/theme/ReactLiveScope/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/versioned_docs/version-2.0.0-beta.8/api/docusaurus.config.js.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/api/docusaurus.config.js.md
@@ -281,7 +281,7 @@ module.exports = {
         alt: 'Facebook Open Source Logo',
         src: 'https://docusaurus.io/img/oss_logo.png',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`, // You can also put own HTML here
     },
   },
 };

--- a/website/versioned_docs/version-2.0.0-beta.8/api/docusaurus.config.js.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/api/docusaurus.config.js.md
@@ -281,7 +281,7 @@ module.exports = {
         alt: 'Facebook Open Source Logo',
         src: 'https://docusaurus.io/img/oss_logo.png',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here
+      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here
     },
   },
 };

--- a/website/versioned_docs/version-2.0.0-beta.8/blog.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.8/blog.mdx
@@ -481,7 +481,7 @@ module.exports = {
         blog: {
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`,
           },
         },
       },

--- a/website/versioned_docs/version-2.0.0-beta.8/blog.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.8/blog.mdx
@@ -481,7 +481,7 @@ module.exports = {
         blog: {
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
           },
         },
       },

--- a/website/versioned_docs/version-2.0.0-beta.8/migration/migration-manual.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/migration/migration-manual.md
@@ -227,7 +227,7 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here.
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`, // You can also put own HTML here.
     },
     image: 'img/docusaurus.png',
     // ...

--- a/website/versioned_docs/version-2.0.0-beta.8/migration/migration-manual.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/migration/migration-manual.md
@@ -227,7 +227,7 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here.
+      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here.
     },
     image: 'img/docusaurus.png',
     // ...

--- a/website/versioned_docs/version-2.0.0-beta.9/api/docusaurus.config.js.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/api/docusaurus.config.js.md
@@ -297,7 +297,7 @@ module.exports = {
         width: 160,
         height: 51,
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`, // You can also put own HTML here
     },
   },
 };

--- a/website/versioned_docs/version-2.0.0-beta.9/api/docusaurus.config.js.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/api/docusaurus.config.js.md
@@ -297,7 +297,7 @@ module.exports = {
         width: 160,
         height: 51,
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here
+      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here
     },
   },
 };

--- a/website/versioned_docs/version-2.0.0-beta.9/blog.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.9/blog.mdx
@@ -481,7 +481,7 @@ module.exports = {
         blog: {
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`,
           },
         },
       },

--- a/website/versioned_docs/version-2.0.0-beta.9/blog.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.9/blog.mdx
@@ -481,7 +481,7 @@ module.exports = {
         blog: {
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Meta.`,
           },
         },
       },

--- a/website/versioned_docs/version-2.0.0-beta.9/migration/migration-manual.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/migration/migration-manual.md
@@ -227,7 +227,7 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here.
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc.`, // You can also put own HTML here.
     },
     image: 'img/docusaurus.png',
     // ...

--- a/website/versioned_docs/version-2.0.0-beta.9/migration/migration-manual.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/migration/migration-manual.md
@@ -227,7 +227,7 @@ module.exports = {
         src: 'https://docusaurus.io/img/oss_logo.png',
         href: 'https://opensource.facebook.com/',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`, // You can also put own HTML here.
+      copyright: `Copyright © ${new Date().getFullYear()} Meta.`, // You can also put own HTML here.
     },
     image: 'img/docusaurus.png',
     // ...

--- a/website/waitForCrowdin.js
+++ b/website/waitForCrowdin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/waitForCrowdin.js
+++ b/website/waitForCrowdin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
## Motivation

I work for Meta as a Software Engineer Apprentice and I was looking at the Docusaurus website and noticed the copyright needed updating. I updated all the instances of Facebook, Inc to Meta even in code comments.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

My changes are only string changes so just running yarn test will verify that my simple changes have not broken anything.

