### PR TITLE
fix: v1 Algolia DocSearch migration

### DIFF
--- a/website-1.x/blog/2021-11-05-algolia-migration.md
+++ b/website-1.x/blog/2021-11-05-algolia-migration.md
@@ -1,0 +1,35 @@
+---
+title: Algolia DocSearch Migration
+author: Sébastien Lorber
+authorTitle: Docusaurus maintainer
+authorURL: https://sebastienlorber.com
+authorImageURL: https://github.com/slorber.png
+authorTwitter: sebastienlorber
+tags: [algolia]
+image: /img/blog/2021-05-12-announcing-docusaurus-two-beta/social-card.png
+---
+
+Algolia DocSearch is migrating to a new system.
+
+Docusaurus v1 sites should upgrade too or search will stop working.
+
+<!--truncate-->
+
+From now on, it is required to use an `appId` in your Docusaurus v1 site configuration:
+
+```js
+const siteConfig = {
+  algolia: {
+    appId: '...', // Now required!
+    apiKey: '...',
+  },
+};
+
+module.exports = siteConfig;
+```
+
+You should have received an `appId` + `apiKey` by email with an invitation to join the Algolia SaaS application.
+
+If you didn't receive any email, please reach out to the Algolia DocSearch support team and they'll invite you.
+
+Further information will be provided on the Docusaurus v2 blog.

--- a/website-1.x/siteConfig.js
+++ b/website-1.x/siteConfig.js
@@ -36,7 +36,9 @@ const siteConfig = {
   footerIcon: 'img/docusaurus_monochrome.svg',
   favicon: 'img/docusaurus.ico',
   algolia: {
-    apiKey: '3eb9507824b8be89e7a199ecaa1a9d2c',
+    // apiKey: '3eb9507824b8be89e7a199ecaa1a9d2c',
+    appId: 'NHNLQ9RRTP',
+    apiKey: '9fd932b3605878e173f39bf8e2049466',
     indexName: 'docusaurus',
     algoliaOptions: {
       facetFilters: ['language:LANGUAGE', 'version:VERSION'],


### PR DESCRIPTION

## Motivation

Algolia Docsearch is migration to a new system.

Docusaurus v1 config must be updated to keep the search working.

Also added a v1 blog post so that v1 users that still visit it can be notified