### PR TITLE
docs: new APITable comp to render large tables

### DIFF
--- a/website/docs/api/plugins/plugin-content-blog.md
+++ b/website/docs/api/plugins/plugin-content-blog.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-blog'
 slug: '/api/plugins/@docusaurus/plugin-content-blog'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 Provides the [Blog](blog.mdx) feature and is the default blog plugin for Docusaurus.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -60,7 +62,7 @@ Accepted fields:
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
 
-</small>
+</APITable>
 
 ```typescript
 type EditUrlFunction = (params: {
@@ -191,7 +193,7 @@ Markdown documents can use the following Markdown FrontMatter metadata fields, e
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -212,7 +214,7 @@ Accepted fields:
 | `image` | `string` | `undefined` | Cover or thumbnail image that will be used when displaying the link to your post. |
 | `slug` | `string` | File path | Allows to customize the blog post url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-blog-post`, `slug: /my/path/to/blog/post`, slug: `/`. |
 
-</small>
+</APITable>
 
 ```typescript
 type Tag = string | {label: string; permalink: string};

--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-docs'
 slug: '/api/plugins/@docusaurus/plugin-content-docs'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 Provides the [Docs](../../guides/docs/docs-introduction.md) functionality and is the default docs plugin for Docusaurus.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -57,7 +59,7 @@ Accepted fields:
 | `versions` | `Versions` | `{}` | Independent customization of each version's properties. |
 | `onlyIncludeVersions` | `string[]` | All versions available | Only include a subset of all available versions. <br /> Tip: limit to 2 or 3 versions to improve startup and build time in dev and deploy previews. |
 
-</small>
+</APITable>
 
 ```typescript
 type EditUrlFunction = (params: {
@@ -238,7 +240,7 @@ Markdown documents can use the following Markdown FrontMatter metadata fields, e
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -262,7 +264,7 @@ Accepted fields:
 | `slug` | `string` | File path | Allows to customize the document url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-doc`, `slug: /my/path/myDoc`, `slug: /`. |
 | `tags` | `Tag[]` | `undefined` | A list of strings or objects of two string fields `label` and `permalink` to tag to your docs. |
 
-</small>
+</APITable>
 
 ```typescript
 type Tag = string | {label: string; permalink: string};

--- a/website/docs/api/plugins/plugin-content-pages.md
+++ b/website/docs/api/plugins/plugin-content-pages.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-pages'
 slug: '/api/plugins/@docusaurus/plugin-content-pages'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 The default pages plugin for Docusaurus. The classic template ships with this plugin with default configurations. This plugin provides [creating pages](guides/creating-pages.md) functionality.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -38,7 +40,7 @@ Accepted fields:
 | `beforeDefaultRemarkPlugins` | `any[]` | `[]` | Custom Remark plugins passed to MDX before the default Docusaurus Remark plugins. |
 | `beforeDefaultRehypePlugins` | `any[]` | `[]` | Custom Rehype plugins passed to MDX before the default Docusaurus Rehype plugins. |
 
-</small>
+</APITable>
 
 ## Example configuration {#ex-config}
 

--- a/website/docs/api/themes/theme-configuration.md
+++ b/website/docs/api/themes/theme-configuration.md
@@ -5,6 +5,8 @@ slug: '/api/themes/configuration'
 toc_max_heading_level: 4
 ---
 
+import APITable from '@site/src/components/APITable';
+
 This configuration applies to all [main themes](./overview.md).
 
 ## Common {#common}
@@ -17,7 +19,7 @@ It is possible to customize the color mode support within the `colorMode` object
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -30,7 +32,7 @@ Accepted fields:
 | `switchConfig.lightIcon` | `string` | `'🌞'` | Icon for the switch while in light mode. |
 | `switchConfig.lightIconStyle` | JSX style object | `{}` | CSS to apply to light icon. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -74,13 +76,13 @@ You can configure a default image that will be used for your meta tag, in partic
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `image` | `string` | `undefined` | The meta image URL for the site. Relative to your site's "static" directory. Cannot be SVGs. Can be external URLs too. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -99,13 +101,13 @@ You can configure additional html metadatas (and override existing ones).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `metadatas` | `Metadata[]` | `[]` | Any field will be directly passed to the `<meta />` tag. Possible fields include `id`, `name`, `property`, `content`, `itemprop`, etc. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -124,7 +126,7 @@ Sometimes you want to announce something in your website. Just for such a case, 
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -134,7 +136,7 @@ Accepted fields:
 | `textColor` | `string` | `'#000'` | Announcement text color. |
 | `isCloseable` | `boolean` | `true` | Whether this announcement can be dismissed with a '×' button. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -159,7 +161,7 @@ module.exports = {
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -169,7 +171,7 @@ Accepted fields:
 | `hideOnScroll` | `boolean` | `false` | Whether the navbar is hidden when the user scrolls down. |
 | `style` | <code>'primary' \| 'dark'</code> | Same as theme | Sets the navbar style, ignoring the dark/light theme. |
 
-</small>
+</APITable>
 
 ### Navbar logo {#navbar-logo}
 
@@ -179,7 +181,7 @@ To improve dark mode support, you can also set a different logo for this mode.
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -191,7 +193,7 @@ Accepted fields:
 | `height` | <code>string \| number</code> | `undefined` | Specifies the `height` attribute. |
 | `target` | `string` | Calculated based on `href` (external links will open in a new tab, all others in the current one). | The `target` attribute of the link; controls whether the link is opened in a new tab, the current one, or otherwise. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -266,7 +268,7 @@ Outbound (external) links automatically get `target="_blank" rel="noopener noref
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -280,7 +282,7 @@ Accepted fields:
 | `activeBaseRegex` | `string` | `undefined` | Alternative to `activeBasePath` if required. |
 | `className` | `string` | `''` | Custom CSS class (for styling any item). |
 
-</small>
+</APITable>
 
 :::note
 
@@ -326,7 +328,7 @@ Note that the dropdown base item is a clickable link as well, so this item can r
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -335,7 +337,7 @@ Accepted fields:
 | `items` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | **Required** | The items to be contained in the dropdown. |
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -375,7 +377,7 @@ If you want to link to a specific doc, this special navbar item type will render
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -385,7 +387,7 @@ Accepted fields:
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc belongs to. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -416,7 +418,7 @@ The user will be able to switch from one version to another, while staying on th
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -427,7 +429,7 @@ Accepted fields:
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -456,7 +458,7 @@ If you use docs with versioning, this special navbar item type will link to the 
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -466,7 +468,7 @@ Accepted fields:
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -497,7 +499,7 @@ The user will be able to switch from one locale to another, while staying on the
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -506,7 +508,7 @@ Accepted fields:
 | `dropdownItemsBefore` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the beginning of the dropdown. |
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -539,14 +541,14 @@ If you use the [search](../../search.md), the search bar will be the rightmost e
 
 However, with this special navbar item type, you can change the default location.
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `type` | `'search'` | **Required** | Sets the type of this item to a search bar. |
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 ```js title="docusaurus.config.js"
 module.exports = {
@@ -603,7 +605,7 @@ Docusaurus uses [Prism React Renderer](https://github.com/FormidableLabs/prism-r
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -611,7 +613,7 @@ Accepted fields:
 | `darkTheme` | `PrismTheme` | `palenight` | The Prism theme to use for dark-theme code blocks. |
 | `defaultLanguage` | `string` | `undefined` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 ### Theme {#theme}
 
@@ -661,7 +663,7 @@ You can add logo and a copyright to the footer via `themeConfig.footer`. Logo ca
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -670,7 +672,7 @@ Accepted fields:
 | `style` | <code>'dark' \| 'light'</code> | `'light'` | The color theme of the footer component. |
 | `items` | `FooterItem[]` | `[]` | The link groups to be present. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -699,18 +701,18 @@ You can add links to the footer via `themeConfig.footer.links`.
 
 Accepted fields of each link section:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `title` | `string` | `undefined` | Label of the section of these links. |
 | `items` | `FooterLink[]` | `[]` | Links in this section. |
 
-</small>
+</APITable>
 
 Accepted fields of each item in `items`:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -719,7 +721,7 @@ Accepted fields of each item in `items`:
 | `href` | `string` | **Required** | A full-page navigation, used for navigating outside of the website. **Only one of `to` or `href` should be used.** |
 | `html` | `string` | `undefined` | Renders the html pass-through instead of a simple link. In case `html` is used, no other options should be provided. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -775,14 +777,14 @@ module.exports = {
 
 You can adjust the default table of contents via `themeConfig.tableOfContents`.
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `minHeadingLevel` | `number` | `2` | The minimum heading level shown in the table of contents. Must be between 2 and 6 and lower or equal to the max value. |
 | `maxHeadingLevel` | `number` | `3` | Max heading level displayed in the TOC. Should be an integer between 2 and 6. |
 
-</small>
+</APITable>
 
 Example configuration:
 

--- a/website/docs/api/themes/theme-configuration.md
+++ b/website/docs/api/themes/theme-configuration.md
@@ -126,7 +126,7 @@ Sometimes you want to announce something in your website. Just for such a case, 
 
 Accepted fields:
 
-<APITable>
+<APITable name="announcement-bar">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -161,7 +161,7 @@ module.exports = {
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -181,7 +181,7 @@ To improve dark mode support, you can also set a different logo for this mode.
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-logo">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -268,7 +268,7 @@ Outbound (external) links automatically get `target="_blank" rel="noopener noref
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-link">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -328,7 +328,7 @@ Note that the dropdown base item is a clickable link as well, so this item can r
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -377,7 +377,7 @@ If you want to link to a specific doc, this special navbar item type will render
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-doc-link">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -418,7 +418,7 @@ The user will be able to switch from one version to another, while staying on th
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-docs-version-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -458,7 +458,7 @@ If you use docs with versioning, this special navbar item type will link to the 
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-docs-version">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -499,7 +499,7 @@ The user will be able to switch from one locale to another, while staying on the
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-locale-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -541,7 +541,7 @@ If you use the [search](../../search.md), the search bar will be the rightmost e
 
 However, with this special navbar item type, you can change the default location.
 
-<APITable>
+<APITable name="navbar-search">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -605,7 +605,7 @@ Docusaurus uses [Prism React Renderer](https://github.com/FormidableLabs/prism-r
 
 Accepted fields:
 
-<APITable>
+<APITable name="codeblock">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -663,7 +663,7 @@ You can add logo and a copyright to the footer via `themeConfig.footer`. Logo ca
 
 Accepted fields:
 
-<APITable>
+<APITable name="footer">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -701,7 +701,7 @@ You can add links to the footer via `themeConfig.footer.links`.
 
 Accepted fields of each link section:
 
-<APITable>
+<APITable name="footer-links">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -712,7 +712,7 @@ Accepted fields of each link section:
 
 Accepted fields of each item in `items`:
 
-<APITable>
+<APITable name="footer-items">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -14,10 +14,12 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import styles from './styles.module.css';
 
 interface Props {
   readonly children: ReactElement<ComponentProps<'table'>>;
+  readonly name?: string;
 }
 
 // ReactNode equivalent of HTMLElement#innerText
@@ -34,7 +36,8 @@ function getText(node: ReactElement): string {
  * assumptions about how the children looks; however, those assumptions
  * should be generally correct in the MDX context.
  */
-export default function APITable({children}: Props): JSX.Element {
+export default function APITable({children, name}: Props): JSX.Element {
+  const isBrowser = useIsBrowser();
   const [thead, tbody] = Children.toArray(
     children.props.children,
   ) as ReactElement[];
@@ -43,25 +46,26 @@ export default function APITable({children}: Props): JSX.Element {
     tbody.props.children,
     (row: ReactElement<ComponentProps<'tr'>>) => {
       const entryName = getText(row);
-      const anchor = `#${entryName}`;
-      const {props: rowProps} = row;
+      const anchor = name ? `#${name}-${entryName}` : `#${entryName}`;
       return (
         <tr
-          {...rowProps}
+          {...row.props}
           id={entryName}
           tabIndex={0}
-          onClick={() => {
-            window.location.href = anchor;
-          }}
           ref={
             window?.location.href.includes(anchor) ? highlightedRow : undefined
           }
+          onClick={() => {
+            if (isBrowser) {
+              window.location.href = anchor;
+            }
+          }}
           onKeyDown={(e: React.KeyboardEvent) => {
-            if (e.key === 'Enter') {
+            if (e.key === 'Enter' && isBrowser) {
               window.location.href = anchor;
             }
           }}>
-          {rowProps.children}
+          {row.props.children}
         </tr>
       );
     },

--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {
+  Children,
+  ComponentProps,
+  ReactElement,
+  ReactNode,
+  isValidElement,
+  useRef,
+  useEffect,
+} from 'react';
+import styles from './styles.module.css';
+
+interface Props {
+  readonly children: ReactElement<ComponentProps<'table'>>;
+}
+
+// ReactNode equivalent of HTMLElement#innerText
+function getText(node: ReactElement): string {
+  let curNode: ReactNode = node;
+  while (isValidElement(curNode)) {
+    [curNode] = Children.toArray(curNode.props.children);
+  }
+  return curNode as string;
+}
+
+/*
+ * Note: this is not a quite robust component since it makes a lot of
+ * assumptions about how the children looks; however, those assumptions
+ * should be generally correct in the MDX context.
+ */
+export default function APITable({children}: Props): JSX.Element {
+  const [thead, tbody] = Children.toArray(
+    children.props.children,
+  ) as ReactElement[];
+  const highlightedRow = useRef<HTMLTableRowElement>(null);
+  const rows = Children.map(
+    tbody.props.children,
+    (row: ReactElement<ComponentProps<'tr'>>) => {
+      const entryName = getText(row);
+      const anchor = `#${entryName}`;
+      const {props: rowProps} = row;
+      return (
+        <tr
+          {...rowProps}
+          id={entryName}
+          tabIndex={0}
+          onClick={() => {
+            window.location.href = anchor;
+          }}
+          ref={
+            window?.location.href.includes(anchor) ? highlightedRow : undefined
+          }
+          onKeyDown={(e: React.KeyboardEvent) => {
+            if (e.key === 'Enter') {
+              window.location.href = anchor;
+            }
+          }}>
+          {rowProps.children}
+        </tr>
+      );
+    },
+  );
+  useEffect(() => {
+    highlightedRow.current?.focus();
+  }, []);
+
+  return (
+    <table className={styles.apiTable}>
+      {thead}
+      <tbody>{rows}</tbody>
+    </table>
+  );
+}

--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -49,7 +49,6 @@ export default function APITable({children, name}: Props): JSX.Element {
       const anchor = name ? `#${name}-${entryName}` : `#${entryName}`;
       return (
         <tr
-          {...row.props}
           id={entryName}
           tabIndex={0}
           ref={

--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -16,7 +16,6 @@ import React, {
   forwardRef,
 } from 'react';
 import {useHistory} from '@docusaurus/router';
-import useIsBrowser from '@docusaurus/useIsBrowser';
 import styles from './styles.module.css';
 
 interface Props {
@@ -41,7 +40,6 @@ const APITableRow = forwardRef(
     }: {name: string | undefined; children: ReactElement<ComponentProps<'tr'>>},
     ref: React.RefObject<HTMLTableRowElement>,
   ) => {
-    const isBrowser = useIsBrowser();
     const entryName = getText(children);
     const anchor = name ? `#${name}-${entryName}` : `#${entryName}`;
     const history = useHistory();
@@ -49,9 +47,7 @@ const APITableRow = forwardRef(
       <tr
         id={entryName}
         tabIndex={0}
-        ref={
-          isBrowser && history.location.hash.includes(anchor) ? ref : undefined
-        }
+        ref={history.location.hash === anchor ? ref : undefined}
         onClick={() => {
           history.push(anchor);
         }}

--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -53,15 +53,15 @@ export default function APITable({children, name}: Props): JSX.Element {
           id={entryName}
           tabIndex={0}
           ref={
-            window?.location.href.includes(anchor) ? highlightedRow : undefined
+            isBrowser && window.location.href.includes(anchor)
+              ? highlightedRow
+              : undefined
           }
           onClick={() => {
-            if (isBrowser) {
-              window.location.href = anchor;
-            }
+            window.location.href = anchor;
           }}
           onKeyDown={(e: React.KeyboardEvent) => {
-            if (e.key === 'Enter' && isBrowser) {
+            if (e.key === 'Enter') {
               window.location.href = anchor;
             }
           }}>
@@ -72,7 +72,7 @@ export default function APITable({children, name}: Props): JSX.Element {
   );
   useEffect(() => {
     highlightedRow.current?.focus();
-  }, []);
+  }, [highlightedRow]);
 
   return (
     <table className={styles.apiTable}>

--- a/website/src/components/APITable/styles.module.css
+++ b/website/src/components/APITable/styles.module.css
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.apiTable {
+  font-size: small;
+}
+
+.apiTable tbody tr {
+  transition: box-shadow 0.2s;
+}
+
+.apiTable tbody tr:focus,
+.apiTable tbody tr:hover {
+  outline: none;
+  box-shadow: 0px 0px 7px 0px inset var(--ifm-color-warning);
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}

--- a/website/versioned_docs/version-2.0.0-beta.8/api/plugins/plugin-content-blog.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/api/plugins/plugin-content-blog.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-blog'
 slug: '/api/plugins/@docusaurus/plugin-content-blog'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 Provides the [Blog](blog.mdx) feature and is the default blog plugin for Docusaurus.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -60,7 +62,7 @@ Accepted fields:
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
 
-</small>
+</APITable>
 
 ```typescript
 type EditUrlFunction = (params: {
@@ -191,7 +193,7 @@ Markdown documents can use the following Markdown FrontMatter metadata fields, e
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -212,7 +214,7 @@ Accepted fields:
 | `image` | `string` | `undefined` | Cover or thumbnail image that will be used when displaying the link to your post. |
 | `slug` | `string` | File path | Allows to customize the blog post url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-blog-post`, `slug: /my/path/to/blog/post`, slug: `/`. |
 
-</small>
+</APITable>
 
 ```typescript
 type Tag = string | {label: string; permalink: string};

--- a/website/versioned_docs/version-2.0.0-beta.8/api/plugins/plugin-content-docs.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/api/plugins/plugin-content-docs.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-docs'
 slug: '/api/plugins/@docusaurus/plugin-content-docs'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 Provides the [Docs](../../guides/docs/docs-introduction.md) functionality and is the default docs plugin for Docusaurus.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -57,7 +59,7 @@ Accepted fields:
 | `versions` | `Versions` | `{}` | Independent customization of each version's properties. |
 | `onlyIncludeVersions` | `string[]` | All versions available | Only include a subset of all available versions. <br /> Tip: limit to 2 or 3 versions to improve startup and build time in dev and deploy previews. |
 
-</small>
+</APITable>
 
 ```typescript
 type EditUrlFunction = (params: {
@@ -238,7 +240,7 @@ Markdown documents can use the following Markdown FrontMatter metadata fields, e
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -262,7 +264,7 @@ Accepted fields:
 | `slug` | `string` | File path | Allows to customize the document url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-doc`, `slug: /my/path/myDoc`, `slug: /`. |
 | `tags` | `Tag[]` | `undefined` | A list of strings or objects of two string fields `label` and `permalink` to tag to your docs. |
 
-</small>
+</APITable>
 
 ```typescript
 type Tag = string | {label: string; permalink: string};

--- a/website/versioned_docs/version-2.0.0-beta.8/api/plugins/plugin-content-pages.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/api/plugins/plugin-content-pages.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-pages'
 slug: '/api/plugins/@docusaurus/plugin-content-pages'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 The default pages plugin for Docusaurus. The classic template ships with this plugin with default configurations. This plugin provides [creating pages](guides/creating-pages.md) functionality.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -38,7 +40,7 @@ Accepted fields:
 | `beforeDefaultRemarkPlugins` | `any[]` | `[]` | Custom Remark plugins passed to MDX before the default Docusaurus Remark plugins. |
 | `beforeDefaultRehypePlugins` | `any[]` | `[]` | Custom Rehype plugins passed to MDX before the default Docusaurus Rehype plugins. |
 
-</small>
+</APITable>
 
 ## Example configuration {#ex-config}
 

--- a/website/versioned_docs/version-2.0.0-beta.8/api/themes/theme-configuration.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/api/themes/theme-configuration.md
@@ -5,6 +5,8 @@ slug: '/api/themes/configuration'
 toc_max_heading_level: 4
 ---
 
+import APITable from '@site/src/components/APITable';
+
 This configuration applies to all [main themes](./overview.md).
 
 ## Common {#common}
@@ -17,7 +19,7 @@ It is possible to customize the color mode support within the `colorMode` object
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -30,7 +32,7 @@ Accepted fields:
 | `switchConfig.lightIcon` | `string` | `'🌞'` | Icon for the switch while in light mode. |
 | `switchConfig.lightIconStyle` | JSX style object | `{}` | CSS to apply to light icon. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -74,13 +76,13 @@ You can configure a default image that will be used for your meta tag, in partic
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `image` | `string` | `undefined` | The meta image URL for the site. Relative to your site's "static" directory. Cannot be SVGs. Can be external URLs too. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -99,13 +101,13 @@ You can configure additional html metadatas (and override existing ones).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `metadatas` | `Metadata[]` | `[]` | Any field will be directly passed to the `<meta />` tag. Possible fields include `id`, `name`, `property`, `content`, `itemprop`, etc. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -124,7 +126,7 @@ Sometimes you want to announce something in your website. Just for such a case, 
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -134,7 +136,7 @@ Accepted fields:
 | `textColor` | `string` | `'#000'` | Announcement text color. |
 | `isCloseable` | `boolean` | `true` | Whether this announcement can be dismissed with a '×' button. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -159,7 +161,7 @@ module.exports = {
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -169,7 +171,7 @@ Accepted fields:
 | `hideOnScroll` | `boolean` | `false` | Whether the navbar is hidden when the user scrolls down. |
 | `style` | <code>'primary' \| 'dark'</code> | Same as theme | Sets the navbar style, ignoring the dark/light theme. |
 
-</small>
+</APITable>
 
 ### Navbar logo {#navbar-logo}
 
@@ -179,7 +181,7 @@ To improve dark mode support, you can also set a different logo for this mode.
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -189,7 +191,7 @@ Accepted fields:
 | `href` | `string` | `siteConfig.baseUrl` | Link to navigate to when the logo is clicked. |
 | `target` | `string` | Calculated based on `href` (external links will open in a new tab, all others in the current one). | The `target` attribute of the link; controls whether the link is opened in a new tab, the current one, or otherwise. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -262,7 +264,7 @@ Outbound (external) links automatically get `target="_blank" rel="noopener noref
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -276,7 +278,7 @@ Accepted fields:
 | `activeBaseRegex` | `string` | `undefined` | Alternative to `activeBasePath` if required. |
 | `className` | `string` | `''` | Custom CSS class (for styling any item). |
 
-</small>
+</APITable>
 
 :::note
 
@@ -322,7 +324,7 @@ Note that the dropdown base item is a clickable link as well, so this item can r
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -331,7 +333,7 @@ Accepted fields:
 | `items` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | **Required** | The items to be contained in the dropdown. |
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -371,7 +373,7 @@ If you want to link to a specific doc, this special navbar item type will render
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -381,7 +383,7 @@ Accepted fields:
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc belongs to. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -412,7 +414,7 @@ The user will be able to switch from one version to another, while staying on th
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -423,7 +425,7 @@ Accepted fields:
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -452,7 +454,7 @@ If you use docs with versioning, this special navbar item type will link to the 
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -462,7 +464,7 @@ Accepted fields:
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -493,7 +495,7 @@ The user will be able to switch from one locale to another, while staying on the
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -502,7 +504,7 @@ Accepted fields:
 | `dropdownItemsBefore` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the beginning of the dropdown. |
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -535,14 +537,14 @@ If you use the [search](../../search.md), the search bar will be the rightmost e
 
 However, with this special navbar item type, you can change the default location.
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `type` | `'search'` | **Required** | Sets the type of this item to a search bar. |
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 ```js title="docusaurus.config.js"
 module.exports = {
@@ -599,7 +601,7 @@ Docusaurus uses [Prism React Renderer](https://github.com/FormidableLabs/prism-r
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -607,7 +609,7 @@ Accepted fields:
 | `darkTheme` | `PrismTheme` | `palenight` | The Prism theme to use for dark-theme code blocks. |
 | `defaultLanguage` | `string` | `undefined` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 ### Theme {#theme}
 
@@ -657,7 +659,7 @@ You can add logo and a copyright to the footer via `themeConfig.footer`. Logo ca
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -666,7 +668,7 @@ Accepted fields:
 | `style` | <code>'dark' \| 'light'</code> | `'light'` | The color theme of the footer component. |
 | `items` | `FooterItem[]` | `[]` | The link groups to be present. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -693,18 +695,18 @@ You can add links to the footer via `themeConfig.footer.links`.
 
 Accepted fields of each link section:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `title` | `string` | `undefined` | Label of the section of these links. |
 | `items` | `FooterLink[]` | `[]` | Links in this section. |
 
-</small>
+</APITable>
 
 Accepted fields of each item in `items`:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -713,7 +715,7 @@ Accepted fields of each item in `items`:
 | `href` | `string` | **Required** | A full-page navigation, used for navigating outside of the website. **Only one of `to` or `href` should be used.** |
 | `html` | `string` | `undefined` | Renders the html pass-through instead of a simple link. In case `html` is used, no other options should be provided. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -769,14 +771,14 @@ module.exports = {
 
 You can adjust the default table of contents via `themeConfig.tableOfContents`.
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `minHeadingLevel` | `number` | `2` | The minimum heading level shown in the table of contents. Must be between 2 and 6 and lower or equal to the max value. |
 | `maxHeadingLevel` | `number` | `3` | Max heading level displayed in the TOC. Should be an integer between 2 and 6. |
 
-</small>
+</APITable>
 
 Example configuration:
 

--- a/website/versioned_docs/version-2.0.0-beta.8/api/themes/theme-configuration.md
+++ b/website/versioned_docs/version-2.0.0-beta.8/api/themes/theme-configuration.md
@@ -126,7 +126,7 @@ Sometimes you want to announce something in your website. Just for such a case, 
 
 Accepted fields:
 
-<APITable>
+<APITable name="announcement-bar">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -161,7 +161,7 @@ module.exports = {
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -181,7 +181,7 @@ To improve dark mode support, you can also set a different logo for this mode.
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-logo">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -264,7 +264,7 @@ Outbound (external) links automatically get `target="_blank" rel="noopener noref
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-link">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -324,7 +324,7 @@ Note that the dropdown base item is a clickable link as well, so this item can r
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -373,7 +373,7 @@ If you want to link to a specific doc, this special navbar item type will render
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-doc-link">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -414,7 +414,7 @@ The user will be able to switch from one version to another, while staying on th
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-docs-version-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -454,7 +454,7 @@ If you use docs with versioning, this special navbar item type will link to the 
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-docs-version">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -495,7 +495,7 @@ The user will be able to switch from one locale to another, while staying on the
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-locale-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -537,7 +537,7 @@ If you use the [search](../../search.md), the search bar will be the rightmost e
 
 However, with this special navbar item type, you can change the default location.
 
-<APITable>
+<APITable name="navbar-search">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -601,7 +601,7 @@ Docusaurus uses [Prism React Renderer](https://github.com/FormidableLabs/prism-r
 
 Accepted fields:
 
-<APITable>
+<APITable name="codeblock">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -659,7 +659,7 @@ You can add logo and a copyright to the footer via `themeConfig.footer`. Logo ca
 
 Accepted fields:
 
-<APITable>
+<APITable name="footer">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -695,7 +695,7 @@ You can add links to the footer via `themeConfig.footer.links`.
 
 Accepted fields of each link section:
 
-<APITable>
+<APITable name="footer-links">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -706,7 +706,7 @@ Accepted fields of each link section:
 
 Accepted fields of each item in `items`:
 
-<APITable>
+<APITable name="footer-items">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/website/versioned_docs/version-2.0.0-beta.9/api/plugins/plugin-content-blog.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/api/plugins/plugin-content-blog.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-blog'
 slug: '/api/plugins/@docusaurus/plugin-content-blog'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 Provides the [Blog](blog.mdx) feature and is the default blog plugin for Docusaurus.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -60,7 +62,7 @@ Accepted fields:
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
 
-</small>
+</APITable>
 
 ```typescript
 type EditUrlFunction = (params: {
@@ -191,7 +193,7 @@ Markdown documents can use the following Markdown FrontMatter metadata fields, e
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -212,7 +214,7 @@ Accepted fields:
 | `image` | `string` | `undefined` | Cover or thumbnail image that will be used when displaying the link to your post. |
 | `slug` | `string` | File path | Allows to customize the blog post url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-blog-post`, `slug: /my/path/to/blog/post`, slug: `/`. |
 
-</small>
+</APITable>
 
 ```typescript
 type Tag = string | {label: string; permalink: string};

--- a/website/versioned_docs/version-2.0.0-beta.9/api/plugins/plugin-content-docs.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/api/plugins/plugin-content-docs.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-docs'
 slug: '/api/plugins/@docusaurus/plugin-content-docs'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 Provides the [Docs](../../guides/docs/docs-introduction.md) functionality and is the default docs plugin for Docusaurus.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -57,7 +59,7 @@ Accepted fields:
 | `versions` | `Versions` | `{}` | Independent customization of each version's properties. |
 | `onlyIncludeVersions` | `string[]` | All versions available | Only include a subset of all available versions. <br /> Tip: limit to 2 or 3 versions to improve startup and build time in dev and deploy previews. |
 
-</small>
+</APITable>
 
 ```typescript
 type EditUrlFunction = (params: {
@@ -238,7 +240,7 @@ Markdown documents can use the following Markdown FrontMatter metadata fields, e
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -262,7 +264,7 @@ Accepted fields:
 | `slug` | `string` | File path | Allows to customize the document url (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-doc`, `slug: /my/path/myDoc`, `slug: /`. |
 | `tags` | `Tag[]` | `undefined` | A list of strings or objects of two string fields `label` and `permalink` to tag to your docs. |
 
-</small>
+</APITable>
 
 ```typescript
 type Tag = string | {label: string; permalink: string};

--- a/website/versioned_docs/version-2.0.0-beta.9/api/plugins/plugin-content-pages.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/api/plugins/plugin-content-pages.md
@@ -4,6 +4,8 @@ title: '📦 plugin-content-pages'
 slug: '/api/plugins/@docusaurus/plugin-content-pages'
 ---
 
+import APITable from '@site/src/components/APITable';
+
 The default pages plugin for Docusaurus. The classic template ships with this plugin with default configurations. This plugin provides [creating pages](guides/creating-pages.md) functionality.
 
 ## Installation {#installation}
@@ -24,7 +26,7 @@ You can configure this plugin through the [preset options](#ex-config-preset).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -38,7 +40,7 @@ Accepted fields:
 | `beforeDefaultRemarkPlugins` | `any[]` | `[]` | Custom Remark plugins passed to MDX before the default Docusaurus Remark plugins. |
 | `beforeDefaultRehypePlugins` | `any[]` | `[]` | Custom Rehype plugins passed to MDX before the default Docusaurus Rehype plugins. |
 
-</small>
+</APITable>
 
 ## Example configuration {#ex-config}
 

--- a/website/versioned_docs/version-2.0.0-beta.9/api/themes/theme-configuration.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/api/themes/theme-configuration.md
@@ -5,6 +5,8 @@ slug: '/api/themes/configuration'
 toc_max_heading_level: 4
 ---
 
+import APITable from '@site/src/components/APITable';
+
 This configuration applies to all [main themes](./overview.md).
 
 ## Common {#common}
@@ -17,7 +19,7 @@ It is possible to customize the color mode support within the `colorMode` object
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -30,7 +32,7 @@ Accepted fields:
 | `switchConfig.lightIcon` | `string` | `'🌞'` | Icon for the switch while in light mode. |
 | `switchConfig.lightIconStyle` | JSX style object | `{}` | CSS to apply to light icon. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -74,13 +76,13 @@ You can configure a default image that will be used for your meta tag, in partic
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `image` | `string` | `undefined` | The meta image URL for the site. Relative to your site's "static" directory. Cannot be SVGs. Can be external URLs too. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -99,13 +101,13 @@ You can configure additional html metadatas (and override existing ones).
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `metadatas` | `Metadata[]` | `[]` | Any field will be directly passed to the `<meta />` tag. Possible fields include `id`, `name`, `property`, `content`, `itemprop`, etc. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -124,7 +126,7 @@ Sometimes you want to announce something in your website. Just for such a case, 
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -134,7 +136,7 @@ Accepted fields:
 | `textColor` | `string` | `'#000'` | Announcement text color. |
 | `isCloseable` | `boolean` | `true` | Whether this announcement can be dismissed with a '×' button. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -159,7 +161,7 @@ module.exports = {
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -169,7 +171,7 @@ Accepted fields:
 | `hideOnScroll` | `boolean` | `false` | Whether the navbar is hidden when the user scrolls down. |
 | `style` | <code>'primary' \| 'dark'</code> | Same as theme | Sets the navbar style, ignoring the dark/light theme. |
 
-</small>
+</APITable>
 
 ### Navbar logo {#navbar-logo}
 
@@ -179,7 +181,7 @@ To improve dark mode support, you can also set a different logo for this mode.
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -191,7 +193,7 @@ Accepted fields:
 | `height` | <code>string \| number</code> | `undefined` | Specifies the `height` attribute. |
 | `target` | `string` | Calculated based on `href` (external links will open in a new tab, all others in the current one). | The `target` attribute of the link; controls whether the link is opened in a new tab, the current one, or otherwise. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -266,7 +268,7 @@ Outbound (external) links automatically get `target="_blank" rel="noopener noref
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -280,7 +282,7 @@ Accepted fields:
 | `activeBaseRegex` | `string` | `undefined` | Alternative to `activeBasePath` if required. |
 | `className` | `string` | `''` | Custom CSS class (for styling any item). |
 
-</small>
+</APITable>
 
 :::note
 
@@ -326,7 +328,7 @@ Note that the dropdown base item is a clickable link as well, so this item can r
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -335,7 +337,7 @@ Accepted fields:
 | `items` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | **Required** | The items to be contained in the dropdown. |
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -375,7 +377,7 @@ If you want to link to a specific doc, this special navbar item type will render
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -385,7 +387,7 @@ Accepted fields:
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc belongs to. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -416,7 +418,7 @@ The user will be able to switch from one version to another, while staying on th
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -427,7 +429,7 @@ Accepted fields:
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -456,7 +458,7 @@ If you use docs with versioning, this special navbar item type will link to the 
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -466,7 +468,7 @@ Accepted fields:
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -497,7 +499,7 @@ The user will be able to switch from one locale to another, while staying on the
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -506,7 +508,7 @@ Accepted fields:
 | `dropdownItemsBefore` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the beginning of the dropdown. |
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -539,14 +541,14 @@ If you use the [search](../../search.md), the search bar will be the rightmost e
 
 However, with this special navbar item type, you can change the default location.
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `type` | `'search'` | **Required** | Sets the type of this item to a search bar. |
 | `position` | <code>'left' \| 'right'</code> | `'left'` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 ```js title="docusaurus.config.js"
 module.exports = {
@@ -603,7 +605,7 @@ Docusaurus uses [Prism React Renderer](https://github.com/FormidableLabs/prism-r
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -611,7 +613,7 @@ Accepted fields:
 | `darkTheme` | `PrismTheme` | `palenight` | The Prism theme to use for dark-theme code blocks. |
 | `defaultLanguage` | `string` | `undefined` | The side of the navbar this item should appear on. |
 
-</small>
+</APITable>
 
 ### Theme {#theme}
 
@@ -661,7 +663,7 @@ You can add logo and a copyright to the footer via `themeConfig.footer`. Logo ca
 
 Accepted fields:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -670,7 +672,7 @@ Accepted fields:
 | `style` | <code>'dark' \| 'light'</code> | `'light'` | The color theme of the footer component. |
 | `items` | `FooterItem[]` | `[]` | The link groups to be present. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -699,18 +701,18 @@ You can add links to the footer via `themeConfig.footer.links`.
 
 Accepted fields of each link section:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `title` | `string` | `undefined` | Label of the section of these links. |
 | `items` | `FooterLink[]` | `[]` | Links in this section. |
 
-</small>
+</APITable>
 
 Accepted fields of each item in `items`:
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -719,7 +721,7 @@ Accepted fields of each item in `items`:
 | `href` | `string` | **Required** | A full-page navigation, used for navigating outside of the website. **Only one of `to` or `href` should be used.** |
 | `html` | `string` | `undefined` | Renders the html pass-through instead of a simple link. In case `html` is used, no other options should be provided. |
 
-</small>
+</APITable>
 
 Example configuration:
 
@@ -775,14 +777,14 @@ module.exports = {
 
 You can adjust the default table of contents via `themeConfig.tableOfContents`.
 
-<small>
+<APITable>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `minHeadingLevel` | `number` | `2` | The minimum heading level shown in the table of contents. Must be between 2 and 6 and lower or equal to the max value. |
 | `maxHeadingLevel` | `number` | `3` | Max heading level displayed in the TOC. Should be an integer between 2 and 6. |
 
-</small>
+</APITable>
 
 Example configuration:
 

--- a/website/versioned_docs/version-2.0.0-beta.9/api/themes/theme-configuration.md
+++ b/website/versioned_docs/version-2.0.0-beta.9/api/themes/theme-configuration.md
@@ -126,7 +126,7 @@ Sometimes you want to announce something in your website. Just for such a case, 
 
 Accepted fields:
 
-<APITable>
+<APITable name="announcement-bar">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -161,7 +161,7 @@ module.exports = {
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -181,7 +181,7 @@ To improve dark mode support, you can also set a different logo for this mode.
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-logo">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -268,7 +268,7 @@ Outbound (external) links automatically get `target="_blank" rel="noopener noref
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-link">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -328,7 +328,7 @@ Note that the dropdown base item is a clickable link as well, so this item can r
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -377,7 +377,7 @@ If you want to link to a specific doc, this special navbar item type will render
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-doc-link">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -418,7 +418,7 @@ The user will be able to switch from one version to another, while staying on th
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-docs-version-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -458,7 +458,7 @@ If you use docs with versioning, this special navbar item type will link to the 
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-docs-version">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -499,7 +499,7 @@ The user will be able to switch from one locale to another, while staying on the
 
 Accepted fields:
 
-<APITable>
+<APITable name="navbar-locale-dropdown">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -541,7 +541,7 @@ If you use the [search](../../search.md), the search bar will be the rightmost e
 
 However, with this special navbar item type, you can change the default location.
 
-<APITable>
+<APITable name="navbar-search">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -605,7 +605,7 @@ Docusaurus uses [Prism React Renderer](https://github.com/FormidableLabs/prism-r
 
 Accepted fields:
 
-<APITable>
+<APITable name="codeblock">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -663,7 +663,7 @@ You can add logo and a copyright to the footer via `themeConfig.footer`. Logo ca
 
 Accepted fields:
 
-<APITable>
+<APITable name="footer">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -701,7 +701,7 @@ You can add links to the footer via `themeConfig.footer.links`.
 
 Accepted fields of each link section:
 
-<APITable>
+<APITable name="footer-links">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -712,7 +712,7 @@ Accepted fields of each link section:
 
 Accepted fields of each item in `items`:
 
-<APITable>
+<APITable name="footer-items">
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When giving instructions on how to enable a particular option, it usually is quite awkward to give a link to the entire API table instead of pointing them to a specific row.

This PR introduces a new `APITable` on the website which allows us to direct to a specific row through anchor links. When visitors click on that link, the respective entry will also be highlighted.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

https://deploy-preview-5891--docusaurus-2.netlify.app/docs/api/plugins/@docusaurus/plugin-content-blog#archiveBasePath