### PR TITLE
docs: move markdown-specified things out of global static-assets

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -117,6 +117,24 @@ html[data-theme='dark'] .themedDocusaurus [fill='#FFFF50'] {
 
 <DocusaurusSvg className="themedDocusaurus" />
 
+## useBaseUrl {#use-base-url}
+
+Thanks to MDX, you can also use `useBaseUrl` utility function in Markdown files! You'd have to use html tags like `<img>` instead of the Markdown image syntax though. The syntax is exactly the same as in JSX.
+
+```jsx title="my-doc.mdx"
+---
+id: my-doc
+title: My Doc
+---
+
+// Add to the top of the file below the front matter.
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+...
+
+<img alt="Docusaurus with Keytar" src={useBaseUrl('/img/docusaurus_keytar.svg')} />
+```
+
 ## Themed Images {#themed-images}
 
 Docusaurus supports themed images: the `ThemedImage` component (included in the themes) allows you to switch the image source based on the current theme.

--- a/website/docs/static-assets.md
+++ b/website/docs/static-assets.md
@@ -52,21 +52,7 @@ Markdown links and images referencing assets of the static folder will be conver
 ![Docusaurus](/img/docusaurus.png)
 ```
 
-Thanks to MDX, you can also use `useBaseUrl` utility function in Markdown files! You'd have to use html tags like `<img>` instead of the Markdown image syntax though. The syntax is exactly the same as in JSX.
-
-```jsx title="my-doc.mdx"
----
-id: my-doc
-title: My Doc
----
-
-// Add to the top of the file below the front matter.
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
-...
-
-<img alt="Docusaurus with Keytar" src={useBaseUrl('/img/docusaurus_keytar.svg')} />
-```
+More details about assets in `md` and `mdx` files see in [Guides/Markdown&nbspFeatures/Assets](markdown-features/assets).
 
 ### Caveats {#caveats}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Extract markdown-specifiс knowledge about assets to corresponding chapter.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

run `yarn start`
see `Markdown example` in  [http://localhost:3000/docs/static-assets](http://localhost:3000/docs/static-assets) and 
`use-base-url` in [http://localhost:3000/docs/markdown-features/assets](http://localhost:3000/docs/markdown-features/assets)

## Related Issue

#3198 