### PR TITLE
feat(core): give more hints when plugins have duplicate IDs

### DIFF
--- a/packages/docusaurus/src/server/plugins/__tests__/__snapshots__/pluginIds.test.ts.snap
+++ b/packages/docusaurus/src/server/plugins/__tests__/__snapshots__/pluginIds.test.ts.snap
@@ -9,12 +9,12 @@ exports[`ensureUniquePluginInstanceIds reject multi instance plugins without id 
 "Plugin \\"plugin-docs\\" is used 2 times with ID \\"default\\".
 To use the same plugin multiple times on a Docusaurus site, you need to assign a unique ID to each plugin instance.
 
-The plugin ID is \\"default\\" by default. It's possible that the preset you are using already includes a default plugin, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances)."
+The plugin ID is \\"default\\" by default. It's possible that the preset you are using already includes a plugin instance, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances)."
 `;
 
 exports[`ensureUniquePluginInstanceIds reject multi instance plugins without id 2`] = `
 "Plugin \\"plugin-docs\\" is used 2 times with ID \\"default\\".
 To use the same plugin multiple times on a Docusaurus site, you need to assign a unique ID to each plugin instance.
 
-The plugin ID is \\"default\\" by default. It's possible that the preset you are using already includes a default plugin, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances)."
+The plugin ID is \\"default\\" by default. It's possible that the preset you are using already includes a plugin instance, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances)."
 `;

--- a/packages/docusaurus/src/server/plugins/__tests__/__snapshots__/pluginIds.test.ts.snap
+++ b/packages/docusaurus/src/server/plugins/__tests__/__snapshots__/pluginIds.test.ts.snap
@@ -1,16 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ensureUniquePluginInstanceIds reject multi instance plugins with same id 1`] = `
-"Plugin \\"plugin-docs\\" is used 2 times with id sameId.
-To use the same plugin multiple times on a Docusaurus site, you need to assign a unique id to each plugin instance."
+"Plugin \\"plugin-docs\\" is used 2 times with ID \\"sameId\\".
+To use the same plugin multiple times on a Docusaurus site, you need to assign a unique ID to each plugin instance."
 `;
 
 exports[`ensureUniquePluginInstanceIds reject multi instance plugins without id 1`] = `
-"Plugin \\"plugin-docs\\" is used 2 times with id default.
-To use the same plugin multiple times on a Docusaurus site, you need to assign a unique id to each plugin instance."
+"Plugin \\"plugin-docs\\" is used 2 times with ID \\"default\\".
+To use the same plugin multiple times on a Docusaurus site, you need to assign a unique ID to each plugin instance.
+
+The plugin ID is \\"default\\" by default. It's possible that the preset you are using already includes a default plugin, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances)."
 `;
 
 exports[`ensureUniquePluginInstanceIds reject multi instance plugins without id 2`] = `
-"Plugin \\"plugin-docs\\" is used 2 times with id default.
-To use the same plugin multiple times on a Docusaurus site, you need to assign a unique id to each plugin instance."
+"Plugin \\"plugin-docs\\" is used 2 times with ID \\"default\\".
+To use the same plugin multiple times on a Docusaurus site, you need to assign a unique ID to each plugin instance.
+
+The plugin ID is \\"default\\" by default. It's possible that the preset you are using already includes a default plugin, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances)."
 `;

--- a/packages/docusaurus/src/server/plugins/pluginIds.ts
+++ b/packages/docusaurus/src/server/plugins/pluginIds.ts
@@ -24,7 +24,13 @@ export function ensureUniquePluginInstanceIds(
       ([pluginId, pluginInstancesWithId]) => {
         if (pluginInstancesWithId.length !== 1) {
           throw new Error(
-            `Plugin "${pluginName}" is used ${pluginInstancesWithId.length} times with id ${pluginId}.\nTo use the same plugin multiple times on a Docusaurus site, you need to assign a unique id to each plugin instance.`,
+            `Plugin "${pluginName}" is used ${
+              pluginInstancesWithId.length
+            } times with ID "${pluginId}".\nTo use the same plugin multiple times on a Docusaurus site, you need to assign a unique ID to each plugin instance.${
+              pluginId === DEFAULT_PLUGIN_ID
+                ? `\n\nThe plugin ID is "${DEFAULT_PLUGIN_ID}" by default. It's possible that the preset you are using already includes a plugin instance, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances).`
+                : ''
+            }`,
           );
         }
       },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It has happened not a single time that a user enhanced a plugin and forgot to turn off the default plugin in the preset. I think we can benefit from some more hints on how to solve the error.

In the future we are to have a better middleware / enhancement system, and we can further mitigate the problem of duplicating IDs after enhancing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
