### PR TITLE
fix(website): fix i18n routes for Canny board

### DIFF
--- a/website/src/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/featureRequests/FeatureRequestsPage.tsx
@@ -14,16 +14,16 @@ import styles from './styles.module.css';
 
 const BOARD_TOKEN = '054e0e53-d951-b14c-7e74-9eb8f9ed2f91';
 
-function FeatureRequests(): JSX.Element {
+function FeatureRequests({basePath}: {basePath: string}): JSX.Element {
   useEffect(() => {
     cannyScript();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const {Canny} = window as any;
     Canny('render', {
       boardToken: BOARD_TOKEN,
-      basePath: '/feature-requests',
+      basePath,
     });
-  }, []);
+  }, [basePath]);
 
   return (
     <Layout title="Feedback" description="Docusaurus 2 Feature Requests page">

--- a/website/src/featureRequests/FeatureRequestsPlugin.js
+++ b/website/src/featureRequests/FeatureRequestsPlugin.js
@@ -15,10 +15,15 @@ function FeatureRequestsPlugin(context) {
   return {
     name: 'feature-requests-plugin',
     async contentLoaded({actions}) {
+      const basePath = normalizeUrl([context.baseUrl, '/feature-requests']);
+      await actions.createData('paths.json', JSON.stringify(basePath));
       actions.addRoute({
-        path: normalizeUrl([context.baseUrl, '/feature-requests']),
+        path: basePath,
         exact: false,
         component: '@site/src/featureRequests/FeatureRequestsPage',
+        modules: {
+          basePath: './feature-requests-plugin/default/paths.json',
+        },
       });
     },
   };


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Pass the base route as props so that canny can handle the route correctly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally with `yarn start --locale zh-Hans` and `https://localhost:3000/zh-Hans/feature-requests` is not redirected to `https://localhost:3000/feature-requests` after Canny loads.