### PR TITLE
refactor(content-docs): use shelljs instead of execa

### DIFF
--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -34,7 +34,6 @@
     "chalk": "^4.1.2",
     "combine-promises": "^1.1.0",
     "escape-string-regexp": "^4.0.0",
-    "execa": "^5.0.0",
     "fs-extra": "^10.0.0",
     "globby": "^11.0.2",
     "import-fresh": "^3.2.2",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -40,7 +40,7 @@ describe('lastUpdate', () => {
     expect(await getFileLastUpdate(nonExistingFilePath)).toBeNull();
     expect(consoleMock).toHaveBeenCalledTimes(1);
     expect(consoleMock.mock.calls[0][0].message).toContain(
-      `Command failed with exit code 128: git log -1 --format=%ct, %an ${nonExistingFileName}`,
+      `fatal: ambiguous argument '${nonExistingFilePath}': unknown revision or path not in the working tree.`,
     );
     expect(await getFileLastUpdate(null)).toBeNull();
     expect(await getFileLastUpdate(undefined)).toBeNull();

--- a/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
+++ b/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
@@ -6,12 +6,10 @@
  */
 
 import shell from 'shelljs';
-import execa from 'execa';
-import path from 'path';
 
 type FileLastUpdateData = {timestamp?: number; author?: string};
 
-const GIT_COMMIT_TIMESTAMP_AUTHOR_REGEX = /^(\d+), (.+)$/;
+const GIT_COMMIT_TIMESTAMP_AUTHOR_REGEX = /^(\d+),(.+)$/;
 
 let showedGitRequirementError = false;
 
@@ -44,16 +42,11 @@ export async function getFileLastUpdate(
       return null;
     }
 
-    const fileBasename = path.basename(filePath);
-    const fileDirname = path.dirname(filePath);
-    const {stdout} = await execa(
-      'git',
-      ['log', '-1', '--format=%ct, %an', fileBasename],
-      {
-        cwd: fileDirname,
-      },
-    );
-    return getTimestampAndAuthor(stdout);
+    const result = shell.exec(`git log -1 --format=%ct,%an ${filePath}`);
+    if (result.stderr) {
+      throw new Error(result.stderr);
+    }
+    return getTimestampAndAuthor(result.stdout.trim());
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolve #4455. Up to this point, the only thing that we should fix is removing `execa` in favor of `shelljs`. Now, we only have `fs-extra` for FS operations and `shelljs` for "actual shell operations". `del` is used in a forked plugin which I think we shouldn't touch, `mkdirp` isn't used anymore.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated test cases a little bit; can also check preview that updated data is rendered correctly