### PR TITLE
fix(content-docs): do not echo git history to console

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
+++ b/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
@@ -42,7 +42,9 @@ export async function getFileLastUpdate(
       return null;
     }
 
-    const result = shell.exec(`git log -1 --format=%ct,%an ${filePath}`);
+    const result = shell.exec(`git log -1 --format=%ct,%an ${filePath}`, {
+      silent: true,
+    });
     if (result.code !== 0) {
       throw new Error(
         `Retrieval of git history failed at ${filePath} with exit code ${result.code}: ${result.stderr}`,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In #5904 I forgot to inspect the log... `shell.exec` outputs the result to the console which isn't necessary.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes