### PR TITLE
misc(workflow): E2E tests should not be run with website changes

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -1,16 +1,20 @@
-name: Tests E2E
+name: E2E Tests
 
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - website/**
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - website/**
 
 jobs:
   yarn-v1:
-    name: E2E Test with Yarn v1
+    name: E2E — Yarn v1
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
@@ -43,7 +47,7 @@ jobs:
           CI: true
 
   yarn-berry:
-    name: E2E Test with Yarn Berry
+    name: E2E — Yarn Berry
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The E2E tests don't even involve the website — not running them saves bandwidth & review noise. Also made the job names more succinct.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
