### PR TITLE
docs: fix a typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4494,7 +4494,7 @@ presets: [
 - Remove the following config options:
   - `docsUrl`. Use the plugin option on `docusaurus-plugin-content-docs` instead.
   - `customDocsPath`. Use the plugin option on `docusaurus-plugin-content-docs` instead.
-  - `sidebars.json` now has to be explicitly loaded by users and passed into the the plugin option on `docusaurus-plugin-content-docs`.
+  - `sidebars.json` now has to be explicitly loaded by users and passed into the plugin option on `docusaurus-plugin-content-docs`.
   - `headerLinks` doc, page, blog is deprecated and has been to moved into `themeConfig` under the name `navbar`. The syntax is now:
 
 ```js

--- a/crowdin-v2.yaml
+++ b/crowdin-v2.yaml
@@ -12,7 +12,7 @@ api_token_env: 'CROWDIN_PERSONAL_TOKEN'
 #
 preserve_hierarchy: true
 
-# We generally want to use the the "two-letters-code" of a locale (ie the language)
+# We generally want to use the "two-letters-code" of a locale (ie the language)
 # But not for all locales!
 # "pt-BR" may be better to remain as "pt-BR" instead of being transformed to "pt"
 # Note: &/* is Yaml anchor syntax: https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/


### PR DESCRIPTION
Hello,
I've found some minor typos in the documentation, solved with this PR.

Fix typo:
the the -> the