### PR TITLE
fix(module-type-aliases): add svg declaration

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -330,14 +330,14 @@ declare module '*.svg' {
   export default src;
 }
 
-declare module '*.css' {
-  const src: string;
-  export default src;
-}
-
 declare module '*.module.css' {
   const classes: {readonly [key: string]: string};
   export default classes;
+}
+
+declare module '*.css' {
+  const src: string;
+  export default src;
 }
 
 declare module '*.scss' {

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -339,18 +339,3 @@ declare module '*.css' {
   const src: string;
   export default src;
 }
-
-declare module '*.scss' {
-  const src: string;
-  export default src;
-}
-
-declare module '*.module.scss' {
-  const classes: {readonly [key: string]: string};
-  export default classes;
-}
-
-declare module '*.module.sass' {
-  const classes: {readonly [key: string]: string};
-  export default classes;
-}

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -320,14 +320,11 @@ declare module '@docusaurus/useGlobalData' {
 }
 
 declare module '*.svg' {
-  import type {FunctionComponent, SVGProps} from 'react';
+  import type {ComponentType, SVGProps} from 'react';
 
-  export const ReactComponent: FunctionComponent<
-    SVGProps<SVGSVGElement> & {title?: string}
-  >;
+  const ReactComponent: ComponentType<SVGProps<SVGSVGElement>>;
 
-  const src: string;
-  export default src;
+  export default ReactComponent;
 }
 
 declare module '*.module.css' {

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -319,12 +319,38 @@ declare module '@docusaurus/useGlobalData' {
   export default useGlobalData;
 }
 
-declare module '*.module.css' {
-  const classes: {readonly [key: string]: string};
-  export default classes;
+declare module '*.svg' {
+  import type {FunctionComponent, SVGProps} from 'react';
+
+  export const ReactComponent: FunctionComponent<
+    SVGProps<SVGSVGElement> & {title?: string}
+  >;
+
+  const src: string;
+  export default src;
 }
 
 declare module '*.css' {
   const src: string;
   export default src;
+}
+
+declare module '*.module.css' {
+  const classes: {readonly [key: string]: string};
+  export default classes;
+}
+
+declare module '*.scss' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.module.scss' {
+  const classes: {readonly [key: string]: string};
+  export default classes;
+}
+
+declare module '*.module.sass' {
+  const classes: {readonly [key: string]: string};
+  export default classes;
 }


### PR DESCRIPTION
## Motivation

Try to fix https://github.com/facebook/docusaurus/issues/3424#issuecomment-846462626 by adding module declarations in `packages/docusaurus-module-type-aliases/src/index.d.ts`:

Currently, if one uses `import` ending with `.module.scss`, `.scss`, `.svg` in a `.tsx` file, VSCode (ESLint) will display errors like:

```
Cannot find module '[some_file].module.scss' or its corresponding type declarations.
Cannot find module '[some_file].scss' or its corresponding type declarations.
Cannot find module '[some_file].svg' or its corresponding type declarations.
```

These errors don't appear in `.js` files.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Just tested with `yarn run start` (after `cd website`), `yarn prettier`, `yarn lint`, and `yarn test`.
