### PR TITLE
fix(website): fix APITable anchor link

### DIFF
--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -45,7 +45,7 @@ const APITableRow = forwardRef(
     const history = useHistory();
     return (
       <tr
-        id={entryName}
+        id={anchor}
         tabIndex={0}
         ref={history.location.hash === anchor ? ref : undefined}
         onClick={() => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The anchor links are currently broken because `id` is not set to `anchor`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes