### PR TITLE
fix(website): fix APITable anchor ID having extra hash

### DIFF
--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -41,11 +41,12 @@ const APITableRow = forwardRef(
     ref: React.RefObject<HTMLTableRowElement>,
   ) => {
     const entryName = getText(children);
-    const anchor = name ? `#${name}-${entryName}` : `#${entryName}`;
+    const id = name ? `${name}-${entryName}` : entryName;
+    const anchor = `#${id}`;
     const history = useHistory();
     return (
       <tr
-        id={anchor}
+        id={id}
         tabIndex={0}
         ref={history.location.hash === anchor ? ref : undefined}
         onClick={() => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Anchors are still broken ㄟ(▔,▔)ㄏ

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes