### PR TITLE
refactor(plugin-content-docs): move isCategoriesShorthand to utils

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../docs';
 import {loadSidebars} from '../sidebars';
 import {readVersionsMetadata} from '../versions';
-import {
+import type {
   DocFile,
   DocMetadataBase,
   MetadataOptions,
@@ -24,7 +24,7 @@ import {
   EditUrlFunction,
   DocNavLink,
 } from '../types';
-import {LoadContext} from '@docusaurus/types';
+import type {LoadContext} from '@docusaurus/types';
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
 import {DEFAULT_OPTIONS} from '../options';
 import {Optional} from 'utility-types';

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -14,7 +14,7 @@ import fs from 'fs-extra';
 import pluginContentDocs from '../index';
 import {loadContext} from '@docusaurus/core/src/server/index';
 import {applyConfigureWebpack} from '@docusaurus/core/src/webpack/utils';
-import {RouteConfig} from '@docusaurus/types';
+import type {RouteConfig} from '@docusaurus/types';
 import {posixPath} from '@docusaurus/utils';
 import {sortConfig} from '@docusaurus/core/src/server/plugins';
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/versions.test.ts
@@ -15,7 +15,7 @@ import {
 import {DEFAULT_OPTIONS} from '../options';
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
 import {PluginOptions, VersionMetadata} from '../types';
-import {I18n} from '@docusaurus/types';
+import type {I18n} from '@docusaurus/types';
 
 const DefaultI18N: I18n = {
   currentLocale: 'en',

--- a/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docFrontMatter.ts
@@ -12,7 +12,7 @@ import {
   FrontMatterTOCHeadingLevels,
   validateFrontMatter,
 } from '@docusaurus/utils-validation';
-import {DocFrontMatter} from './types';
+import type {DocFrontMatter} from './types';
 
 // NOTE: we don't add any default value on purpose here
 // We don't want default values to magically appear in doc metadata and props

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -19,7 +19,7 @@ import {
   Globby,
   normalizeFrontMatterTags,
 } from '@docusaurus/utils';
-import {LoadContext} from '@docusaurus/types';
+import type {LoadContext} from '@docusaurus/types';
 
 import {getFileLastUpdate} from './lastUpdate';
 import {

--- a/packages/docusaurus-plugin-content-docs/src/globalData.ts
+++ b/packages/docusaurus-plugin-content-docs/src/globalData.ts
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {DocMetadata, GlobalDoc, LoadedVersion, GlobalVersion} from './types';
+import type {
+  DocMetadata,
+  GlobalDoc,
+  LoadedVersion,
+  GlobalVersion,
+} from './types';
 
 export function toGlobalDataDoc(doc: DocMetadata): GlobalDoc {
   return {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -20,7 +20,7 @@ import {
   addTrailingPathSeparator,
   createAbsoluteFilePathMatcher,
 } from '@docusaurus/utils';
-import {LoadContext, Plugin, RouteConfig} from '@docusaurus/types';
+import type {LoadContext, Plugin, RouteConfig} from '@docusaurus/types';
 import {loadSidebars} from './sidebars';
 import {CategoryMetadataFilenamePattern} from './sidebars/generator';
 import {readVersionDocs, processDocMetadata, handleNavigation} from './docs';
@@ -39,7 +39,7 @@ import {
   DocsMarkdownOption,
   VersionTag,
 } from './types';
-import {RuleSetRule} from 'webpack';
+import type {RuleSetRule} from 'webpack';
 import {cliDocsVersionCommand} from './cli';
 import {VERSIONS_JSON_FILE} from './constants';
 import {keyBy, mapValues} from 'lodash';

--- a/packages/docusaurus-plugin-content-docs/src/numberPrefix.ts
+++ b/packages/docusaurus-plugin-content-docs/src/numberPrefix.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {NumberPrefixParser} from './types';
+import type {NumberPrefixParser} from './types';
 
 // Best-effort to avoid parsing some patterns as number prefix
 const IgnoredPrefixPatterns = (function () {

--- a/packages/docusaurus-plugin-content-docs/src/options.ts
+++ b/packages/docusaurus-plugin-content-docs/src/options.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {PluginOptions} from './types';
+import type {PluginOptions} from './types';
 import {
   Joi,
   RemarkPluginsSchema,
@@ -14,7 +14,10 @@ import {
 } from '@docusaurus/utils-validation';
 import {GlobExcludeDefault} from '@docusaurus/utils';
 
-import {OptionValidationContext, ValidationResult} from '@docusaurus/types';
+import type {
+  OptionValidationContext,
+  ValidationResult,
+} from '@docusaurus/types';
 import chalk from 'chalk';
 import admonitions from 'remark-admonitions';
 import {DefaultSidebarItemsGenerator} from './sidebars/generator';

--- a/packages/docusaurus-plugin-content-docs/src/props.ts
+++ b/packages/docusaurus-plugin-content-docs/src/props.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {LoadedVersion, VersionTag, DocMetadata} from './types';
+import type {LoadedVersion, VersionTag, DocMetadata} from './types';
 import type {
   SidebarItemDoc,
   SidebarItemLink,

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
@@ -6,7 +6,7 @@
  */
 
 import type {SidebarOptions} from '../types';
-import {
+import type {
   NormalizedSidebarItem,
   NormalizedSidebar,
   NormalizedSidebars,
@@ -15,9 +15,9 @@ import {
   SidebarItemConfig,
   SidebarConfig,
   SidebarsConfig,
-  isCategoriesShorthand,
 } from './types';
 import {mapValues} from 'lodash';
+import {isCategoriesShorthand} from './utils';
 
 function normalizeCategoriesShorthand(
   sidebar: SidebarCategoriesShorthand,

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Optional} from 'utility-types';
+import type {Optional} from 'utility-types';
 import type {
   DocMetadataBase,
   VersionMetadata,
@@ -55,12 +55,6 @@ export type SidebarItemCategoryConfig = Expand<
 export type SidebarCategoriesShorthand = {
   [sidebarCategory: string]: SidebarItemConfig[];
 };
-
-export function isCategoriesShorthand(
-  item: SidebarItemConfig,
-): item is SidebarCategoriesShorthand {
-  return typeof item !== 'string' && !item.type;
-}
 
 export type SidebarItemConfig =
   | SidebarItemDoc

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -13,9 +13,17 @@ import type {
   SidebarItemLink,
   SidebarItemDoc,
   SidebarItemType,
+  SidebarCategoriesShorthand,
+  SidebarItemConfig,
 } from './types';
 import {mapValues, difference} from 'lodash';
 import {getElementsAround, toMessageRelativeFilePath} from '@docusaurus/utils';
+
+export function isCategoriesShorthand(
+  item: SidebarItemConfig,
+): item is SidebarCategoriesShorthand {
+  return typeof item !== 'string' && !item.type;
+}
 
 export function transformSidebarItems(
   sidebar: Sidebar,

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
@@ -6,7 +6,7 @@
  */
 
 import {Joi, URISchema} from '@docusaurus/utils-validation';
-import {
+import type {
   SidebarItemConfig,
   SidebarCategoriesShorthand,
   SidebarItemBase,
@@ -15,8 +15,8 @@ import {
   SidebarItemLink,
   SidebarItemCategoryConfig,
   SidebarsConfig,
-  isCategoriesShorthand,
 } from './types';
+import {isCategoriesShorthand} from './utils';
 
 const sidebarItemBaseSchema = Joi.object<SidebarItemBase>({
   className: Joi.string(),

--- a/packages/docusaurus-plugin-content-docs/src/slug.ts
+++ b/packages/docusaurus-plugin-content-docs/src/slug.ts
@@ -15,7 +15,7 @@ import {
   DefaultNumberPrefixParser,
   stripPathNumberPrefixes,
 } from './numberPrefix';
-import {NumberPrefixParser} from './types';
+import type {NumberPrefixParser} from './types';
 
 export default function getSlug({
   baseID,

--- a/packages/docusaurus-plugin-content-docs/src/tags.ts
+++ b/packages/docusaurus-plugin-content-docs/src/tags.ts
@@ -6,7 +6,7 @@
  */
 
 import {groupTaggedItems} from '@docusaurus/utils';
-import {VersionTags, DocMetadata} from './types';
+import type {VersionTags, DocMetadata} from './types';
 import {mapValues} from 'lodash';
 
 export function getVersionTags(docs: DocMetadata[]): VersionTags {

--- a/packages/docusaurus-plugin-content-docs/src/translations.ts
+++ b/packages/docusaurus-plugin-content-docs/src/translations.ts
@@ -14,7 +14,7 @@ import {
   transformSidebarItems,
   collectSidebarLinks,
 } from './sidebars/utils';
-import {
+import type {
   TranslationFileContent,
   TranslationFile,
   TranslationFiles,

--- a/packages/docusaurus-plugin-content-docs/src/versions.ts
+++ b/packages/docusaurus-plugin-content-docs/src/versions.ts
@@ -7,7 +7,7 @@
 
 import path from 'path';
 import fs from 'fs-extra';
-import {
+import type {
   PluginOptions,
   VersionBanner,
   VersionMetadata,
@@ -22,7 +22,7 @@ import {
 } from './constants';
 
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/core/lib/constants';
-import {LoadContext} from '@docusaurus/types';
+import type {LoadContext} from '@docusaurus/types';
 import {getPluginI18nPath, normalizeUrl, posixPath} from '@docusaurus/utils';
 import {difference} from 'lodash';
 import {resolveSidebarPathOption} from './sidebars';


### PR DESCRIPTION
## Motivation

Move isCategoriesShorthand from types to utils
Ensure that type imports are marked as such

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

### Note

maybe we should consider enabling
```ts
    {
      files: ['*.ts', '*.tsx'],
      rules: {
        '@typescript-eslint/consistent-type-imports': [
          ERROR,
          {
            prefer: 'type-imports',
            disallowTypeAnnotations: false,
          },
        ],
      },
    },
```

