### PR TITLE
fix(theme-classic): pre element use code from context

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -12,6 +12,7 @@ import CodeBlock, {Props} from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 import Details from '@theme/Details';
 import type {MDXComponentsObject} from '@theme/MDXComponents';
+import {useMDXComponents} from '@mdx-js/react';
 
 import './styles.css';
 
@@ -50,6 +51,7 @@ const MDXComponents: MDXComponentsObject = {
   a: (props) => <Link {...props} />,
   pre: (props) => {
     const {children} = props;
+    const Block = useMDXComponents().code ?? CodeBlock;
 
     // See comment for `code` above
     if (isValidElement(children) && isValidElement(children?.props?.children)) {
@@ -57,7 +59,7 @@ const MDXComponents: MDXComponentsObject = {
     }
 
     return (
-      <CodeBlock
+      <Block
         {...((isValidElement(children)
           ? children?.props
           : {...props}) as Props)}


### PR DESCRIPTION
## Motivation

The current code does not allow weaving in multiple `<MDXProvider />` as `<pre>` is always hard bound to `@theme/CodeBlock`. Consider the following...

```jsx
// src/pages/index.js
import CB from '...'; // my own code block impl
import { MDXProvider } from '@mdx-js/react';

imoprt MDXContent from '@site/docs/button.md';

export default function Example() {
  return (
    <DocPage
      {...{ history, location, match }}
      route={{
        ...route,

        routes: [
          {
            component() {
              return (
                <MDXProvider components={{ code: CB }}>
                  <MDXContent />
                </MDXProvider>
              );
            },
            exact: true,
            path: location.pathname
          }
        ]
      }}
      versionMetadata={{
        docsSidebars: {}
      }}
    />
  );
}
```

```
// docs/button.md

    ```
    bleh
    ```
```

The above `<code>` would not use my custom implementation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Currently only tested with swizzled component

## Related PRs

N/A