### PR TITLE
chore(plugin-pwa): change core-js version in package.json to v3

### DIFF
--- a/packages/docusaurus-plugin-pwa/package.json
+++ b/packages/docusaurus-plugin-pwa/package.json
@@ -30,7 +30,7 @@
     "@docusaurus/utils-validation": "2.0.0-beta.9",
     "babel-loader": "^8.2.2",
     "clsx": "^1.1.1",
-    "core-js": "^2.6.5",
+    "core-js": "^3.18.0",
     "terser-webpack-plugin": "^5.2.4",
     "webpack": "^5.61.0",
     "webpack-merge": "^5.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7484,7 +7484,7 @@ core-js-pure@^3.19.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.1.tgz#edffc1fc7634000a55ba05e95b3f0fe9587a5aa4"
   integrity sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==
 
-core-js@^2.4.1, core-js@^2.6.5:
+core-js@^2.4.1:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

We already use core-js v3 in the actual code (in babel settings), but it's funny that we still declared core-js v2 in package.json. This hasn't caused much trouble so far because the core provides core-js v3.

We can't rid ourselves of core-js v2 entirely, however, because react-live@2.2.3 depends on it. react-live doesn't work with React v17 yet (#5556), and it's on my hate-list of dependencies😅 Users who use pwa but not live-codeblock may be able to get rid of core-js in their node_modules.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The PWA still works in deploy preview