### PR TITLE
fix: make hash link in heading not selectable

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.css
@@ -9,6 +9,7 @@
   opacity: 0;
   padding-left: 0.5rem;
   transition: opacity var(--ifm-transition-fast);
+  user-select: none;
 }
 
 .hash-link:before {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #5990. I added an attribute about 'user-select' to the hash-link class. And it can help me to copy the text without worrying about ZWSP.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manual verification.

