### PR TITLE
chore(ci): add GitHub action for showcase testing

### DIFF
--- a/.github/workflows/showcase-test.yml
+++ b/.github/workflows/showcase-test.yml
@@ -1,0 +1,26 @@
+name: Showcase Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - website/src/data/**
+
+jobs:
+  validate-config:
+    name: Validate Showcase Config
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+      - name: Installation
+        run: yarn
+      - name: Test
+        run: yarn test website/src/data/__tests__/user.test.ts
+  # TODO another job to optimize the images, see https://github.com/facebook/docusaurus/issues/5980


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Tests are not run when only the website is changed—this rule will not be changed because there are far more cases where the tests are useless. Instead, I added another workflow specifically for showcase changes. Even better—if we figured out how to do #5980, we can add it here as another workflow.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

We'll test with the badly configured #6001