### PR TITLE
docs: improve explanation for url config in GH Pages

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -88,7 +88,7 @@ Each GitHub repository is associated with a GitHub Pages service. If the deploym
 
 :::info
 
-In case you want to use your custom domain for GitHub Pages, create a `CNAME` file in the `static` directory. Anything within the `static` directory will be copied to the root of the `build` directory for deployment. When using a custom domain, you should be able to move back from `baseUrl: '/projectName/'` to `baseUrl: '/'`.
+In case you want to use your custom domain for GitHub Pages, create a `CNAME` file in the `static` directory. Anything within the `static` directory will be copied to the root of the `build` directory for deployment. When using a custom domain, you should be able to move back from `baseUrl: '/projectName/'` to `baseUrl: '/'`, and also set your `url` to your custom domain.
 
 You may refer to GitHub Pages' documentation [User, Organization, and Project Pages](https://help.github.com/en/articles/user-organization-and-project-pages) for more details.
 


### PR DESCRIPTION
Motivated by https://github.com/facebook/docusaurus/issues/6004 -> docs mention what to change when custom domain is used with github pages, but don't mention changing the `url`, which can be confusing (it was for me).