### PR TITLE
docs: improve algolia integration instructions

### DIFF
--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -60,12 +60,6 @@ It is highly recommended using a config similar to the [**Docusaurus 2 website c
 
 Docusaurus' own `@docusaurus/preset-classic` supports an Algolia DocSearch integration.
 
-To connect your docs with Algolia, first add the package to your website:
-
-```bash npm2yarn
-npm install --save @docusaurus/theme-search-algolia
-```
-
 Then, add an `algolia` field in your `themeConfig`. **[Apply for DocSearch](https://docsearch.algolia.com/apply/)** to get your Algolia index and API key.
 
 ```jsx title="docusaurus.config.js"

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -61,11 +61,7 @@ It is highly recommended using a config similar to the [**Docusaurus 2 website c
 Docusaurus' own `@docusaurus/preset-classic` supports Algolia DocSearch integration. If you use the classic preset, no additional installation is needed.
 
 <details>
-<summary>
-
-Installation steps when not using `@docusaurus/preset-classic`
-
-</summary>
+<summary>Installation steps when not using <code>@docusaurus/preset-classic</code></summary>
 
 1. Install the package:
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -58,7 +58,35 @@ It is highly recommended using a config similar to the [**Docusaurus 2 website c
 
 ### Connecting Algolia {#connecting-algolia}
 
-Docusaurus' own `@docusaurus/preset-classic` supports an Algolia DocSearch integration.
+Docusaurus' own `@docusaurus/preset-classic` supports Algolia DocSearch integration. If you use the classic preset, no additional installation is needed.
+
+<details>
+<summary>
+
+Installation steps when not using `@docusaurus/preset-classic`
+
+</summary>
+
+1. Install the package:
+
+```bash npm2yarn
+npm install --save @docusaurus/theme-search-algolia
+```
+
+2. Register the theme in `docusaurus.config.js`:
+
+```js title="docusaurus.config.js"
+module.exports = {
+  title: 'My site',
+  // ...
+  themes: ['@docusaurus/theme-search-algolia'],
+  themeConfig: {
+    // ...
+  },
+};
+```
+
+</details>
 
 Then, add an `algolia` field in your `themeConfig`. **[Apply for DocSearch](https://docsearch.algolia.com/apply/)** to get your Algolia index and API key.
 


### PR DESCRIPTION
## Motivation

The current version makes it look like you need to install `@docusaurus/theme-search-algolia` on top the classic version to work, but it already works with the classic version. Adding `@docusaurus/theme-search-algolia` on top leads to errors.
