### PR TITLE
docs: update Netlify url config option

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -496,7 +496,7 @@ To deploy your Docusaurus 2 sites to [Netlify](https://www.netlify.com/), first 
 
 ```js {2-3} title="docusaurus.config.js"
 module.exports = {
-  url: 'https://docusaurus-2.netlify.com', // Url to your site with no trailing slash
+  url: 'https://docusaurus-2.netlify.app', // Url to your site with no trailing slash
   baseUrl: '/', // Base directory of your site relative to your repo
   // ...
 };


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Netlify now provides `*.netlify.app` subdomains instead of `*.netlify.com` for project sites. Redirects still work, so the current config option isn't wrong but it's a good idea to keep the docs up to date.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes!

## Test Plan


## Related PRs

