### PR TITLE
refactor: capitalize locales when creating i18n config

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -42,7 +42,6 @@ export default function LocaleDropdownNavbarItem({
       target: '_self',
       autoAddBaseUrl: false,
       className: locale === currentLocale ? 'dropdown__link--active' : '',
-      style: {textTransform: 'capitalize'},
     };
   });
 

--- a/packages/docusaurus/src/server/__tests__/i18n.test.ts
+++ b/packages/docusaurus/src/server/__tests__/i18n.test.ts
@@ -39,11 +39,11 @@ describe('defaultLocaleConfig', () => {
 
   test('returns correct labels', () => {
     expect(getDefaultLocaleConfig('fr')).toEqual({
-      label: canComputeLabel ? 'français' : 'fr',
+      label: canComputeLabel ? 'Français' : 'fr',
       direction: 'ltr',
     });
     expect(getDefaultLocaleConfig('fr-FR')).toEqual({
-      label: canComputeLabel ? 'français (France)' : 'fr-FR',
+      label: canComputeLabel ? 'Français (France)' : 'fr-FR',
       direction: 'ltr',
     });
     expect(getDefaultLocaleConfig('en')).toEqual({

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -15,7 +15,10 @@ function getDefaultLocaleLabel(locale: string) {
   // Intl.DisplayNames is ES2021 - Node14+
   // https://v8.dev/features/intl-displaynames
   if (typeof Intl.DisplayNames !== 'undefined') {
-    return new Intl.DisplayNames([locale], {type: 'language'}).of(locale);
+    const languageName = new Intl.DisplayNames(locale, {type: 'language'}).of(
+      locale,
+    );
+    return languageName.charAt(0).toUpperCase() + languageName.slice(1);
   }
   return locale;
 }

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -18,7 +18,10 @@ function getDefaultLocaleLabel(locale: string) {
     const languageName = new Intl.DisplayNames(locale, {type: 'language'}).of(
       locale,
     );
-    return languageName.charAt(0).toLocaleUpperCase() + languageName.slice(1);
+    return (
+      languageName.charAt(0).toLocaleUpperCase(locale) +
+      languageName.substring(1)
+    );
   }
   return locale;
 }

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -18,7 +18,7 @@ function getDefaultLocaleLabel(locale: string) {
     const languageName = new Intl.DisplayNames(locale, {type: 'language'}).of(
       locale,
     );
-    return languageName.charAt(0).toUpperCase() + languageName.slice(1);
+    return languageName.charAt(0).toLocaleUpperCase() + languageName.slice(1);
   }
   return locale;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Locale labels must be initially uppercased, because it is currently renders as lower-cased for active item in dropdown. 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/144704215-0d3df612-8899-4d64-b64b-549488911c51.png) |![image](https://user-images.githubusercontent.com/4408379/144704304-0e750ecd-e614-428b-9e7a-7d620dc3a260.png) |

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
