### PR TITLE
feat(theme-classic): allow stylizing doc paginator arrows

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -37,7 +37,7 @@
     "clsx": "^1.1.1",
     "copy-text-to-clipboard": "^3.0.1",
     "globby": "^11.0.2",
-    "infima": "0.2.0-alpha.36",
+    "infima": "0.2.0-alpha.37",
     "lodash": "^4.17.20",
     "postcss": "^8.3.7",
     "prism-react-renderer": "^1.2.1",

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -109,13 +109,22 @@ declare module '@theme/CodeBlock' {
 declare module '@theme/DocPaginator' {
   import type {PropNavigation} from '@docusaurus/plugin-content-docs';
 
-  type PageInfo = {readonly permalink: string; readonly title: string};
-
   // May be simpler to provide a {navigation: PropNavigation} prop?
   export interface Props extends PropNavigation {}
 
-  const DocPaginator: (props: Props) => JSX.Element;
-  export default DocPaginator;
+  export default function DocPaginator(props: Props): JSX.Element;
+}
+
+declare module '@theme/DocPaginatorNavLink' {
+  import type {PropNavigationLink} from '@docusaurus/plugin-content-docs';
+
+  // May be simpler to provide a {navigation: PropNavigation} prop?
+  export interface Props {
+    navLink: PropNavigationLink;
+    next?: boolean;
+  }
+
+  export default function DocPaginatorNavLink(props: Props): JSX.Element;
 }
 
 declare module '@theme/DocSidebar' {

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -6,9 +6,12 @@
  */
 
 import React from 'react';
+import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import Translate, {translate} from '@docusaurus/Translate';
 import type {PropNavigation} from '@docusaurus/plugin-content-docs';
+
+import styles from './styles.module.css';
 
 function DocPaginator(props: PropNavigation): JSX.Element {
   const {previous, next} = props;
@@ -31,8 +34,8 @@ function DocPaginator(props: PropNavigation): JSX.Element {
                 Previous
               </Translate>
             </div>
-            <div className="pagination-nav__label">
-              &laquo; {previous.title}
+            <div className={clsx(styles.labelPrev, 'pagination-nav__label')}>
+              {previous.title}
             </div>
           </Link>
         )}
@@ -47,7 +50,9 @@ function DocPaginator(props: PropNavigation): JSX.Element {
                 Next
               </Translate>
             </div>
-            <div className="pagination-nav__label">{next.title} &raquo;</div>
+            <div className={clsx(styles.labelNext, 'pagination-nav__label')}>
+              {next.title}
+            </div>
           </Link>
         )}
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -6,11 +6,11 @@
  */
 
 import React from 'react';
-import Link from '@docusaurus/Link';
-import Translate, {translate} from '@docusaurus/Translate';
-import type {PropNavigation} from '@docusaurus/plugin-content-docs';
+import {translate} from '@docusaurus/Translate';
+import DocPaginatorNavLink from '@theme/DocPaginatorNavLink';
+import type {Props} from '@theme/DocPaginator';
 
-function DocPaginator(props: PropNavigation): JSX.Element {
+function DocPaginator(props: Props): JSX.Element {
   const {previous, next} = props;
 
   return (
@@ -22,32 +22,10 @@ function DocPaginator(props: PropNavigation): JSX.Element {
         description: 'The ARIA label for the docs pagination',
       })}>
       <div className="pagination-nav__item">
-        {previous && (
-          <Link className="pagination-nav__link" to={previous.permalink}>
-            <div className="pagination-nav__sublabel">
-              <Translate
-                id="theme.docs.paginator.previous"
-                description="The label used to navigate to the previous doc">
-                Previous
-              </Translate>
-            </div>
-            <div className="pagination-nav__label">{previous.title}</div>
-          </Link>
-        )}
+        {previous && <DocPaginatorNavLink navLink={previous} />}
       </div>
       <div className="pagination-nav__item pagination-nav__item--next">
-        {next && (
-          <Link className="pagination-nav__link" to={next.permalink}>
-            <div className="pagination-nav__sublabel">
-              <Translate
-                id="theme.docs.paginator.next"
-                description="The label used to navigate to the next doc">
-                Next
-              </Translate>
-            </div>
-            <div className="pagination-nav__label">{next.title}</div>
-          </Link>
-        )}
+        {next && <DocPaginatorNavLink navLink={next} next />}
       </div>
     </nav>
   );

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -31,9 +31,7 @@ function DocPaginator(props: PropNavigation): JSX.Element {
                 Previous
               </Translate>
             </div>
-            <div className="pagination-nav__label">
-              {previous.title}
-            </div>
+            <div className="pagination-nav__label">{previous.title}</div>
           </Link>
         )}
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -6,12 +6,9 @@
  */
 
 import React from 'react';
-import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import Translate, {translate} from '@docusaurus/Translate';
 import type {PropNavigation} from '@docusaurus/plugin-content-docs';
-
-import styles from './styles.module.css';
 
 function DocPaginator(props: PropNavigation): JSX.Element {
   const {previous, next} = props;
@@ -34,7 +31,7 @@ function DocPaginator(props: PropNavigation): JSX.Element {
                 Previous
               </Translate>
             </div>
-            <div className={clsx(styles.labelPrev, 'pagination-nav__label')}>
+            <div className="pagination-nav__label">
               {previous.title}
             </div>
           </Link>
@@ -50,9 +47,7 @@ function DocPaginator(props: PropNavigation): JSX.Element {
                 Next
               </Translate>
             </div>
-            <div className={clsx(styles.labelNext, 'pagination-nav__label')}>
-              {next.title}
-            </div>
+            <div className="pagination-nav__label">{next.title}</div>
           </Link>
         )}
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/styles.module.css
@@ -1,7 +1,0 @@
-.labelPrev::before {
-  content: '« ';
-}
-
-.labelNext::after {
-  content: ' »';
-}

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/styles.module.css
@@ -1,0 +1,7 @@
+.labelPrev::before {
+  content: '« ';
+}
+
+.labelNext::after {
+  content: ' »';
+}

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginatorNavLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginatorNavLink/index.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import type {Props} from '@theme/DocPaginatorNavLink';
+
+function DocPaginatorNavLink(props: Props): JSX.Element {
+  const {navLink, next} = props;
+  return (
+    <Link className={clsx('pagination-nav__link')} to={navLink.permalink}>
+      <div className="pagination-nav__sublabel">
+        {next ? (
+          <Translate
+            id="theme.docs.paginator.next"
+            description="The label used to navigate to the next doc">
+            Next
+          </Translate>
+        ) : (
+          <Translate
+            id="theme.docs.paginator.previous"
+            description="The label used to navigate to the previous doc">
+            Previous
+          </Translate>
+        )}
+      </div>
+      <div className="pagination-nav__label">{navLink.title}</div>
+    </Link>
+  );
+}
+
+export default DocPaginatorNavLink;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10645,10 +10645,10 @@ infer-owner@^1.0.3, infer-owner@^1.0.4:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-infima@0.2.0-alpha.36:
-  version "0.2.0-alpha.36"
-  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.36.tgz#205515680e2dc588ec1a07b6ce108e49b29cc810"
-  integrity sha512-tlhQa7S09+QzQs8hCZ9oBeD6xOFap1f2zDO4I5HRZ4SMFKKGk9sIhwaou1FWpYoqM6aaoK2YN+G1fND+Sad1Qw==
+infima@0.2.0-alpha.37:
+  version "0.2.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.37.tgz#b87ff42d528d6d050098a560f0294fbdd12adb78"
+  integrity sha512-4GX7Baw+/lwS4PPW/UJNY89tWSvYG1DL6baKVdpK6mC593iRgMssxNtORMTFArLPJ/A/lzsGhRmx+z6MaMxj0Q==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
## Motivation

I'd like to stylize the DocPaginator so it looks like this:

![image](https://user-images.githubusercontent.com/1962469/144716732-1635dabb-ef7f-4909-98fc-e55c08abc624.png)

The problem is that the arrows `»` are just inlined into the markup and cannot be hidden via CSS:

![image](https://user-images.githubusercontent.com/1962469/144716765-258132cc-62b0-41d2-8ebb-954dcd49756b.png)
![Screenshot 2021-12-04 at 18 22 43](https://user-images.githubusercontent.com/1962469/144716832-73713615-bf94-4f5c-b0ad-57e3c0886d11.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Not yet. 😊 

## Test Plan

No plan so far, but I'd like to check with you if you agree that this change makes sense. I would refrain from swizzling currently, but I cannot.