### PR TITLE
fix(content-blog): make post ID unique

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/feed.test.ts.snap
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/feed.test.ts.snap
@@ -13,14 +13,14 @@ exports[`blogFeed atom shows feed item for each post 1`] = `
     <rights>Copyright</rights>
     <entry>
         <title type=\\"html\\"><![CDATA[MDX Blog Sample with require calls]]></title>
-        <id>MDX Blog Sample with require calls</id>
+        <id>/mdx-require-blog-post</id>
         <link href=\\"https://docusaurus.io/myBaseUrl/blog/mdx-require-blog-post\\"/>
         <updated>2021-03-06T00:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[Test MDX with require calls]]></summary>
     </entry>
     <entry>
         <title type=\\"html\\"><![CDATA[Full Blog Sample]]></title>
-        <id>Full Blog Sample</id>
+        <id>/mdx-blog-post</id>
         <link href=\\"https://docusaurus.io/myBaseUrl/blog/mdx-blog-post\\"/>
         <updated>2021-03-05T00:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[HTML Heading 1]]></summary>
@@ -49,7 +49,7 @@ exports[`blogFeed atom shows feed item for each post 1`] = `
     </entry>
     <entry>
         <title type=\\"html\\"><![CDATA[draft]]></title>
-        <id>draft</id>
+        <id>/draft</id>
         <link href=\\"https://docusaurus.io/myBaseUrl/blog/draft\\"/>
         <updated>2020-02-27T00:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[this post should not be published yet]]></summary>
@@ -57,13 +57,13 @@ exports[`blogFeed atom shows feed item for each post 1`] = `
     </entry>
     <entry>
         <title type=\\"html\\"><![CDATA[some heading]]></title>
-        <id>some heading</id>
+        <id>/heading-as-title</id>
         <link href=\\"https://docusaurus.io/myBaseUrl/blog/heading-as-title\\"/>
         <updated>2019-01-02T00:00:00.000Z</updated>
     </entry>
     <entry>
         <title type=\\"html\\"><![CDATA[date-matter]]></title>
-        <id>date-matter</id>
+        <id>/date-matter</id>
         <link href=\\"https://docusaurus.io/myBaseUrl/blog/date-matter\\"/>
         <updated>2019-01-01T00:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[date inside front matter]]></summary>
@@ -71,7 +71,7 @@ exports[`blogFeed atom shows feed item for each post 1`] = `
     </entry>
     <entry>
         <title type=\\"html\\"><![CDATA[Happy 1st Birthday Slash! (translated)]]></title>
-        <id>Happy 1st Birthday Slash! (translated)</id>
+        <id>/2018/12/14/Happy-First-Birthday-Slash</id>
         <link href=\\"https://docusaurus.io/myBaseUrl/blog/2018/12/14/Happy-First-Birthday-Slash\\"/>
         <updated>2018-12-14T00:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[Happy birthday! (translated)]]></summary>
@@ -100,14 +100,14 @@ exports[`blogFeed rss shows feed item for each post 1`] = `
         <item>
             <title><![CDATA[MDX Blog Sample with require calls]]></title>
             <link>https://docusaurus.io/myBaseUrl/blog/mdx-require-blog-post</link>
-            <guid>MDX Blog Sample with require calls</guid>
+            <guid>/mdx-require-blog-post</guid>
             <pubDate>Sat, 06 Mar 2021 00:00:00 GMT</pubDate>
             <description><![CDATA[Test MDX with require calls]]></description>
         </item>
         <item>
             <title><![CDATA[Full Blog Sample]]></title>
             <link>https://docusaurus.io/myBaseUrl/blog/mdx-blog-post</link>
-            <guid>Full Blog Sample</guid>
+            <guid>/mdx-blog-post</guid>
             <pubDate>Fri, 05 Mar 2021 00:00:00 GMT</pubDate>
             <description><![CDATA[HTML Heading 1]]></description>
             <content:encoded><![CDATA[<h1>HTML Heading 1</h1><h2>HTML Heading 2</h2><p>HTML Paragraph</p><div>Import DOM</div><h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><ul><li>list1</li><li>list2</li><li>list3</li></ul><ul><li>list1</li><li>list2</li><li>list3</li></ul><p>Normal Text <em>Italics Text</em> <strong>Bold Text</strong></p><p><a href=\\"https://v2.docusaurus.io/\\">link</a>
@@ -132,7 +132,7 @@ exports[`blogFeed rss shows feed item for each post 1`] = `
         <item>
             <title><![CDATA[draft]]></title>
             <link>https://docusaurus.io/myBaseUrl/blog/draft</link>
-            <guid>draft</guid>
+            <guid>/draft</guid>
             <pubDate>Thu, 27 Feb 2020 00:00:00 GMT</pubDate>
             <description><![CDATA[this post should not be published yet]]></description>
             <content:encoded><![CDATA[<p>this post should not be published yet</p>]]></content:encoded>
@@ -140,13 +140,13 @@ exports[`blogFeed rss shows feed item for each post 1`] = `
         <item>
             <title><![CDATA[some heading]]></title>
             <link>https://docusaurus.io/myBaseUrl/blog/heading-as-title</link>
-            <guid>some heading</guid>
+            <guid>/heading-as-title</guid>
             <pubDate>Wed, 02 Jan 2019 00:00:00 GMT</pubDate>
         </item>
         <item>
             <title><![CDATA[date-matter]]></title>
             <link>https://docusaurus.io/myBaseUrl/blog/date-matter</link>
-            <guid>date-matter</guid>
+            <guid>/date-matter</guid>
             <pubDate>Tue, 01 Jan 2019 00:00:00 GMT</pubDate>
             <description><![CDATA[date inside front matter]]></description>
             <content:encoded><![CDATA[<p>date inside front matter</p>]]></content:encoded>
@@ -154,7 +154,7 @@ exports[`blogFeed rss shows feed item for each post 1`] = `
         <item>
             <title><![CDATA[Happy 1st Birthday Slash! (translated)]]></title>
             <link>https://docusaurus.io/myBaseUrl/blog/2018/12/14/Happy-First-Birthday-Slash</link>
-            <guid>Happy 1st Birthday Slash! (translated)</guid>
+            <guid>/2018/12/14/Happy-First-Birthday-Slash</guid>
             <pubDate>Fri, 14 Dec 2018 00:00:00 GMT</pubDate>
             <description><![CDATA[Happy birthday! (translated)]]></description>
             <content:encoded><![CDATA[<p>Happy birthday! (translated)</p>]]></content:encoded>

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -219,7 +219,7 @@ async function processBlogSourceFile(
   const authors = getBlogPostAuthors({authorsMap, frontMatter});
 
   return {
-    id: frontMatter.slug ?? title,
+    id: slug,
     metadata: {
       permalink,
       editUrl: getBlogEditUrl(),

--- a/website/_dogfooding/_blog tests/2021-09-13-dup-title.md
+++ b/website/_dogfooding/_blog tests/2021-09-13-dup-title.md
@@ -1,3 +1,3 @@
 # Post with duplicate title
 
-See https://github.com/facebook/docusaurus/issues/6059. This one and [2021-11-13-dup-title.md](2021-11-13-dup-title.md) should both show up.
+See https://github.com/facebook/docusaurus/issues/6059. This one and [2021-11-13-dup-title.md](./2021-11-13-dup-title.md) should both show up.

--- a/website/_dogfooding/_blog tests/2021-09-13-dup-title.md
+++ b/website/_dogfooding/_blog tests/2021-09-13-dup-title.md
@@ -1,0 +1,3 @@
+# Post with duplicate title
+
+See https://github.com/facebook/docusaurus/issues/6059. This one and [2021-11-13-dup-title.md](2021-11-13-dup-title.md) should both show up.

--- a/website/_dogfooding/_blog tests/2021-11-13-dup-title.md
+++ b/website/_dogfooding/_blog tests/2021-11-13-dup-title.md
@@ -1,0 +1,3 @@
+# Post with duplicate title
+
+I hope I'm still here


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Breaking change

The blog posts' ID may have changed. Previously, they represented neither the slug nor the title: it was a weird mix of the two, which makes it pretty useless for rendering. Moreover, we discovered that this ID generation is not guaranteed to be unique either. Now, we have normalized all IDs into the posts' slugs. If you relied on the whacky IDs before in your swizzled component, consider using either `metadata.title` or `slug` instead.

## Motivation

Fix #6059

## Test plans

Added two dogfooding posts
