### PR TITLE
fix(theme-common): useLocationChange fire un-necessarily twice

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
@@ -25,9 +25,11 @@ export function useLocationChange(onLocationChange: OnLocationChange): void {
   const onLocationChangeDynamic = useDynamicCallback(onLocationChange);
 
   useEffect(() => {
-    onLocationChangeDynamic({
-      location,
-      previousLocation,
-    });
+    if (location !== previousLocation) {
+      onLocationChangeDynamic({
+        location,
+        previousLocation,
+      });
+    }
   }, [onLocationChangeDynamic, location, previousLocation]);
 }


### PR DESCRIPTION

## Motivation

Fix little issue reported by @lex111  here: https://github.com/facebook/docusaurus/pull/5714#discussion_r760685024

The `useLocationChange` always fires again on the very first re-render

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview (tried to write tests but ReactRouter makes this quite hard, `<StaticRouter>` can't update location :s

