### PR TITLE
fix: move docusaurus core back to hard dependencies

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/package.json
+++ b/packages/docusaurus-plugin-client-redirects/package.json
@@ -32,7 +32,7 @@
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-client-redirects/package.json
+++ b/packages/docusaurus-plugin-client-redirects/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
     "@docusaurus/utils-common": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10",
@@ -28,11 +29,9 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/mdx-loader": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10",
@@ -36,11 +37,9 @@
     "webpack": "^5.61.0"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-content-blog/package.json
+++ b/packages/docusaurus-plugin-content-blog/package.json
@@ -40,7 +40,7 @@
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/mdx-loader": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10",
@@ -37,7 +38,6 @@
     "webpack": "^5.61.0"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/module-type-aliases": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10",
     "@types/js-yaml": "^4.0.0",
@@ -47,7 +47,6 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -47,7 +47,7 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-content-pages/package.json
+++ b/packages/docusaurus-plugin-content-pages/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/mdx-loader": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10",
@@ -27,11 +28,9 @@
     "webpack": "^5.61.0"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-content-pages/package.json
+++ b/packages/docusaurus-plugin-content-pages/package.json
@@ -31,7 +31,7 @@
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-debug/package.json
+++ b/packages/docusaurus-plugin-debug/package.json
@@ -18,17 +18,16 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
     "fs-extra": "^10.0.0",
     "react-json-view": "^1.21.3",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-debug/package.json
+++ b/packages/docusaurus-plugin-debug/package.json
@@ -28,7 +28,7 @@
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-google-analytics/package.json
+++ b/packages/docusaurus-plugin-google-analytics/package.json
@@ -25,7 +25,7 @@
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-google-analytics/package.json
+++ b/packages/docusaurus-plugin-google-analytics/package.json
@@ -18,14 +18,13 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-google-gtag/package.json
+++ b/packages/docusaurus-plugin-google-gtag/package.json
@@ -25,7 +25,7 @@
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-google-gtag/package.json
+++ b/packages/docusaurus-plugin-google-gtag/package.json
@@ -18,14 +18,13 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-ideal-image/package.json
+++ b/packages/docusaurus-plugin-ideal-image/package.json
@@ -35,7 +35,7 @@
     "fs-extra": "^10.0.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-ideal-image/package.json
+++ b/packages/docusaurus-plugin-ideal-image/package.json
@@ -21,6 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/lqip-loader": "2.0.0-beta.10",
     "@docusaurus/responsive-loader": "1.5.0",
     "@endiliey/react-ideal-image": "^0.0.11",
@@ -30,12 +31,10 @@
     "webpack": "^5.61.0"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10",
     "fs-extra": "^10.0.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-pwa/package.json
+++ b/packages/docusaurus-plugin-pwa/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   }

--- a/packages/docusaurus-plugin-pwa/package.json
+++ b/packages/docusaurus-plugin-pwa/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.0",
     "@babel/plugin-proposal-optional-chaining": "^7.16.0",
     "@babel/preset-env": "^7.16.4",
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/theme-common": "2.0.0-beta.10",
     "@docusaurus/theme-translations": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
@@ -43,7 +44,6 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   }

--- a/packages/docusaurus-plugin-sitemap/package.json
+++ b/packages/docusaurus-plugin-sitemap/package.json
@@ -30,7 +30,7 @@
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-plugin-sitemap/package.json
+++ b/packages/docusaurus-plugin-sitemap/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
     "@docusaurus/utils-common": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10",
@@ -26,11 +27,9 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-preset-classic/package.json
+++ b/packages/docusaurus-preset-classic/package.json
@@ -29,7 +29,7 @@
     "@docusaurus/theme-search-algolia": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "2.0.0-beta.10",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-preset-classic/package.json
+++ b/packages/docusaurus-preset-classic/package.json
@@ -29,7 +29,7 @@
     "@docusaurus/theme-search-algolia": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-preset-classic/package.json
+++ b/packages/docusaurus-preset-classic/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/plugin-content-blog": "2.0.0-beta.10",
     "@docusaurus/plugin-content-docs": "2.0.0-beta.10",
     "@docusaurus/plugin-content-pages": "2.0.0-beta.10",
@@ -29,7 +30,6 @@
     "@docusaurus/theme-search-algolia": "2.0.0-beta.10"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -55,7 +55,7 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -45,6 +45,7 @@
     "rtlcss": "^3.3.0"
   },
   "devDependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/module-type-aliases": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10",
     "@types/mdx-js__react": "^1.5.4",
@@ -55,7 +56,6 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.20"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "prism-react-renderer": "^1.2.1",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -28,13 +28,13 @@
     "utility-types": "^3.10.0"
   },
   "devDependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/module-type-aliases": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10",
     "@testing-library/react-hooks": "^7.0.2",
     "lodash": "^4.17.20"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "prism-react-renderer": "^1.2.1",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/theme-translations": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
     "@docusaurus/utils-validation": "2.0.0-beta.10",
@@ -28,12 +29,10 @@
     "react-live": "2.2.3"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/types": "2.0.0-beta.10",
     "@types/buble": "^0.20.1"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -33,7 +33,7 @@
     "@types/buble": "^0.20.1"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -36,7 +36,7 @@
     "fs-extra": "^10.0.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.39",
+    "@docusaurus/core": "2.0.0-beta.10",
     "@docusaurus/theme-common": "2.0.0-beta.10",
     "@docusaurus/theme-translations": "2.0.0-beta.10",
     "@docusaurus/utils": "2.0.0-beta.10",
@@ -36,7 +37,6 @@
     "fs-extra": "^10.0.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-beta.9",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },


### PR DESCRIPTION
While upgrading to latest beta 10, it gives `@docusaurus/core` peer dependency error due to different versions required by `@docusaurus/preset-classic` and root `@docusaurus/core`. Current canary release seems broken as well because of this inconsistent requirements.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Trying to fix the peer dependency error while upgrading to the latest beta 10.

Details of error:
```
$ npm i @docusaurus/core@latest @docusaurus/preset-classic@latest
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: XXXXXXXX@0.2.1
npm ERR! Found: @docusaurus/core@2.0.0-beta.10
npm ERR! node_modules/@docusaurus/core
npm ERR!   @docusaurus/core@"2.0.0-beta.10" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @docusaurus/core@"2.0.0-beta.9" from @docusaurus/preset-classic@2.0.0-beta.10
npm ERR! node_modules/@docusaurus/preset-classic
npm ERR!   @docusaurus/preset-classic@"2.0.0-beta.10" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/XXXX/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/XXXX/.npm/_logs/2021-12-XXXX_30_21_115Z-debug.log
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Sorry, I don't know how to test npm releases.

