### PR TITLE
fix(content-docs): getMainDocId should return doc with both versioned or unversioned id

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -356,7 +356,11 @@ export function getMainDocId({
     if (versionHomeDoc) {
       return versionHomeDoc;
     } else if (firstDocIdOfFirstSidebar) {
-      return docs.find((doc) => doc.id === firstDocIdOfFirstSidebar)!;
+      return docs.find(
+        (doc) =>
+          doc.id === firstDocIdOfFirstSidebar ||
+          doc.unversionedId === firstDocIdOfFirstSidebar,
+      )!;
     } else {
       return docs[0];
     }


### PR DESCRIPTION
## Motivation

Little retro compatibility issue after updating the sidebar versioning strategy (see also https://github.com/facebook/docusaurus/issues/6018)

Affecting the Jest website, which is not using `slug: /` unlike our website, so we didn't see this issue on our own website

![image](https://user-images.githubusercontent.com/749374/145607893-dfb874db-c24f-49e0-bab5-4a188ae25033.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

local only, it's code that we'll remove quite soon anyway (as part of https://github.com/facebook/docusaurus/issues/6018)

