### PR TITLE
docs(showcase): "much more pages" => "many more pages"

### DIFF
--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -118,7 +118,7 @@ export const Tags: Record<TagType, Tag> = {
   large: {
     label: 'Large',
     description:
-      'Very large Docusaurus sites, including much more pages than the average!',
+      'Very large Docusaurus sites, including many more pages than the average!',
     color: '#8c2f00',
   },
 


### PR DESCRIPTION
## Motivation

Something that a friend noticed when I was sharing screenshots of the preview deploy of #6090, figured I might as well fix it right away.

For the sake of explaining the change if at all necessary, here's a good StackExchange: https://english.stackexchange.com/a/47921. TL;DR is that it's "many more" with countable nouns, and pages are countable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Yes

## Related PRs

N.A.
