### PR TITLE
fix: declare missing dependencies

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -79,6 +79,7 @@ jobs:
           yarn config set enableGlobalCache true
 
           # Make PnP as strict as possible
+          # https://yarnpkg.com/features/pnp#fallback-mode
           yarn config set pnpFallbackMode none
 
           # Patch package so that peer deps are provided. This has been fixed in terser by making acorn a direct dependency

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -78,6 +78,9 @@ jobs:
           yarn config set unsafeHttpWhitelist --json '["localhost"]'
           yarn config set enableGlobalCache true
 
+          # Make PnP as strict as possible
+          yarn config set pnpFallbackMode none
+
           # Patch package so that peer deps are provided. This has been fixed in terser by making acorn a direct dependency
           # TODO watch out for the next terser release. Commit: https://github.com/terser/terser/commit/05b23eeb682d732484ad51b19bf528258fd5dc2a
           yarn config set packageExtensions --json '{"terser-webpack-plugin@*": {"dependencies": {"acorn": "^8.6.0"}}, "html-minifier-terser@*": {"dependencies": {"acorn": "^8.6.0"}}}'

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -56,6 +56,7 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
+    "@docusaurus/core": "2.0.0-beta.13",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -23,6 +23,7 @@
     "update-code-translations": "node -e 'require(\"./update-code-translations.js\").run()'"
   },
   "dependencies": {
+    "@docusaurus/core": "2.0.0-beta.13",
     "@docusaurus/plugin-content-blog": "2.0.0-beta.13",
     "@docusaurus/plugin-content-docs": "2.0.0-beta.13",
     "@docusaurus/plugin-content-pages": "2.0.0-beta.13",
@@ -45,7 +46,6 @@
     "rtlcss": "^3.3.0"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.13",
     "@docusaurus/module-type-aliases": "2.0.0-beta.13",
     "@docusaurus/types": "2.0.0-beta.13",
     "@types/mdx-js__react": "^1.5.4",
@@ -56,7 +56,6 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
-    "@docusaurus/core": "2.0.0-beta.13",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-utils-validation/package.json
+++ b/packages/docusaurus-utils-validation/package.json
@@ -23,6 +23,10 @@
     "joi": "^17.4.2",
     "tslib": "^2.3.1"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  },
   "engines": {
     "node": ">=14"
   }


### PR DESCRIPTION
## Motivation

https://github.com/facebook/docusaurus/pull/6047 made Docusaurus PnP strict mode compatible but by default PnP [still allows some fallbacks](https://yarnpkg.com/features/pnp/#fallback-mode), this PR disables that fallback in the e2e test and adds the remaining undeclared dependencies.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

The e2e test passes