### PR TITLE
refactor(website): make deploy preview open next version docs by default

### DIFF
--- a/website/docs/guides/docs/sidebar.md
+++ b/website/docs/guides/docs/sidebar.md
@@ -391,7 +391,7 @@ module.exports = {
 };
 ```
 
-See it in action in the [Docusaurus Guides pages](/docs/next/category/guides).
+See it in action in the [Docusaurus Guides pages](/docs/category/guides).
 
 :::tip
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -268,13 +268,15 @@ const config = {
           remarkPlugins: [math, [npm2yarn, {sync: true}]],
           rehypePlugins: [katex],
           disableVersioning: isVersioningDisabled,
-          lastVersion: isDev ? 'current' : undefined,
-          // eslint-disable-next-line no-nested-ternary
-          onlyIncludeVersions: isBuildFast
-            ? ['current']
-            : !isVersioningDisabled && (isDev || isDeployPreview)
-            ? ['current', ...versions.slice(0, 2)]
-            : undefined,
+          lastVersion: isDev || isDeployPreview ? 'current' : undefined,
+          onlyIncludeVersions: (() => {
+            if (isBuildFast) {
+              return ['current'];
+            } else if (!isVersioningDisabled && (isDev || isDeployPreview)) {
+              return ['current', ...versions.slice(0, 2)];
+            }
+            return undefined;
+          })(),
           versions: {
             current: {
               path: isDev || isBuildFast ? 'next' : undefined,

--- a/website/versioned_docs/version-2.0.0-beta.10/guides/docs/sidebar.md
+++ b/website/versioned_docs/version-2.0.0-beta.10/guides/docs/sidebar.md
@@ -391,7 +391,7 @@ module.exports = {
 };
 ```
 
-See it in action in the [Docusaurus Guides pages](/docs/next/category/guides).
+See it in action in the [Docusaurus Guides pages](/docs/category/guides).
 
 :::tip
 

--- a/website/versioned_docs/version-2.0.0-beta.13/guides/docs/sidebar.md
+++ b/website/versioned_docs/version-2.0.0-beta.13/guides/docs/sidebar.md
@@ -391,7 +391,7 @@ module.exports = {
 };
 ```
 
-See it in action in the [Docusaurus Guides pages](/docs/next/category/guides).
+See it in action in the [Docusaurus Guides pages](/docs/category/guides).
 
 :::tip
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Motivated by #3212, there had been confusions in the past about doc edits not taking effect in deploy preview.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes