### PR TITLE
fix(theme-classic): add outline to focused code blocks

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -28,7 +28,6 @@
   margin: 0;
   padding: 0;
   border-radius: 0;
-  opacity: 1;
 }
 
 .copyButton {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -9,7 +9,6 @@
   margin-bottom: var(--ifm-leading);
   border-radius: var(--ifm-global-radius);
   box-shadow: var(--ifm-global-shadow-lw);
-  overflow: hidden;
 }
 
 .codeBlockContent {
@@ -29,6 +28,7 @@
   margin: 0;
   padding: 0;
   border-radius: 0;
+  opacity: 1;
 }
 
 .copyButton {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #6077 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run `yarn start:website` and go to http://localhost:3000/docs/next/installation#scaffold-project-website. When focusing on the code block, it should like below:

Firefox
<img width="536" alt="Screenshot 2021-12-17 114011" src="https://user-images.githubusercontent.com/53100317/146532173-f368c357-3558-4d62-b75c-702b3be1301e.png">

Chrome
<img width="533" alt="Screenshot 2021-12-17 114258" src="https://user-images.githubusercontent.com/53100317/146532815-eb2ca30d-1ce9-4414-9cb6-d8aefcb14402.png">
