### PR TITLE
fix(website): fix yarn build:website:fast

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -279,7 +279,6 @@ const config = {
           })(),
           versions: {
             current: {
-              path: isDev || isBuildFast ? 'next' : undefined,
               label: `${getNextBetaVersionName()} 🚧`,
             },
           },


### PR DESCRIPTION

## Motivation

This fixes the `yarn build:website:fast` command that reports broken links atm, and revert a temporary change that we had to make temporarily (related to https://github.com/facebook/docusaurus/issues/6041)