### PR TITLE
fix(content-docs): restore behavior when pagination front matter is null

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docs/foo/bar.md
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docs/foo/bar.md
@@ -2,6 +2,8 @@
 id: bar
 title: Bar
 description: This is custom description
+pagination_next: null
+pagination_prev: null
 ---
 
 # Remarkable

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/docs.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/docs.test.ts.snap
@@ -3,14 +3,8 @@
 exports[`simple site custom pagination 1`] = `
 Array [
   Array [
-    Object {
-      "permalink": "/docs/rootTryToEscapeSlug",
-      "title": "rootTryToEscapeSlug",
-    },
-    Object {
-      "permalink": "/docs/foo/bazSlug.html",
-      "title": "baz pagination_label",
-    },
+    undefined,
+    undefined,
   ],
   Array [
     Object {

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -127,15 +127,14 @@ Object {
   "frontMatter": Object {
     "description": "This is custom description",
     "id": "bar",
+    "pagination_next": null,
+    "pagination_prev": null,
     "title": "Bar",
   },
   "id": "foo/bar",
   "lastUpdatedAt": undefined,
   "lastUpdatedBy": undefined,
-  "next": Object {
-    "permalink": "/docs/foo/bazSlug.html",
-    "title": "baz pagination_label",
-  },
+  "next": undefined,
   "permalink": "/docs/foo/bar",
   "previous": undefined,
   "sidebar": "docs",
@@ -341,13 +340,11 @@ Object {
   \\"frontMatter\\": {
     \\"id\\": \\"bar\\",
     \\"title\\": \\"Bar\\",
-    \\"description\\": \\"This is custom description\\"
+    \\"description\\": \\"This is custom description\\",
+    \\"pagination_next\\": null,
+    \\"pagination_prev\\": null
   },
-  \\"sidebar\\": \\"docs\\",
-  \\"next\\": {
-    \\"title\\": \\"baz pagination_label\\",
-    \\"permalink\\": \\"/docs/foo/bazSlug.html\\"
-  }
+  \\"sidebar\\": \\"docs\\"
 }",
   "site-docs-foo-baz-md-a69.json": "{
   \\"unversionedId\\": \\"foo/baz\\",

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -227,6 +227,8 @@ describe('simple site', () => {
         description: 'This is custom description',
         id: 'bar',
         title: 'Bar',
+        pagination_next: null,
+        pagination_prev: null,
       },
       tags: [],
     });

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -319,12 +319,14 @@ export function addDocNavigation(
       return toDocNavigationLink(navDoc);
     };
 
-    const previous: DocNavLink | undefined = doc.frontMatter.pagination_prev
-      ? toNavigationLinkByDocId(doc.frontMatter.pagination_prev, 'prev')
-      : toNavigationLink(navigation.previous, docsById);
-    const next: DocNavLink | undefined = doc.frontMatter.pagination_next
-      ? toNavigationLinkByDocId(doc.frontMatter.pagination_next, 'next')
-      : toNavigationLink(navigation.next, docsById);
+    const previous =
+      doc.frontMatter.pagination_prev !== undefined
+        ? toNavigationLinkByDocId(doc.frontMatter.pagination_prev, 'prev')
+        : toNavigationLink(navigation.previous, docsById);
+    const next =
+      doc.frontMatter.pagination_next !== undefined
+        ? toNavigationLinkByDocId(doc.frontMatter.pagination_next, 'next')
+        : toNavigationLink(navigation.next, docsById);
 
     return {...doc, sidebar: navigation.sidebarName, previous, next};
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #6103 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added one fixture test