### PR TITLE
fix: do not use aria-hidden in heading anchor links

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -49,7 +49,6 @@ const createAnchorHeading =
         id={id}>
         {props.children}
         <a
-          aria-hidden="true"
           className="hash-link"
           href={`#${id}`}
           title={translate({


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix a11y issue with hash links reported by Rocket Validator, I keep forgetting that.

> ARIA hidden element must not contain focusable elements

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
