### PR TITLE
docs: update link to init template README.md

### DIFF
--- a/website/docs/migration/migration-manual.md
+++ b/website/docs/migration/migration-manual.md
@@ -123,7 +123,7 @@ yarn-error.log*
 
 ### `README` {#readme}
 
-The D1 website may have an existing README file. You can modify it to reflect the D2 changes, or copy the default [Docusaurus v2 README](https://github.com/facebook/docusaurus/blob/main/packages/create-docusaurus/templates/classic/README.md).
+The D1 website may have an existing README file. You can modify it to reflect the D2 changes, or copy the default [Docusaurus v2 README](https://github.com/facebook/docusaurus/blob/main/packages/create-docusaurus/templates/shared/README.md).
 
 ## Site configurations {#site-configurations}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The v2 migration documentation links to a README that does not exist:

https://docusaurus.io/docs/migration/manual#readme

In this section, this link throws a 404:

https://github.com/facebook/docusaurus/blob/main/packages/create-docusaurus/templates/classic/README.md

This PR introduces a README.md file at the desired location, referencing the other READMEs found in the `packages/create-docusaurus/templates/` directory.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Testing cannot take place until the README is merged into the main branch and the blob exists.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
