### PR TITLE
docs: mention admonition quirks with Prettier

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -69,26 +69,9 @@ Some **content** with _markdown_ `syntax`. Check [this `api`](#).
 
 :::
 
-## Usage with Prettier
+## Usage with Prettier {#usage-with-prettier}
 
-If you use [Prettier](https://prettier.io) to format your Markdown files, Prettier might autoformatting your code which results in invalid the admonition syntax. To avoid this problem, add empty lines around your content. This is also why the examples we show here all have empty lines around the content.
-
-```md
-<!-- Prettier doesn't change this -->
-::: note
-
-Hello world
-
-:::
-
-<!-- Prettier changes this -->
-::: note
-Hello world
-:::
-
-<!-- to this -->
-::: note Hello world:::
-```
+If you use [Prettier](https://prettier.io) to format your Markdown files, Prettier might autoformat your code which results in invalid admonition syntax. To avoid this problem, add empty lines around your content. This is also why the examples we show here all have empty lines around the content.
 
 ## Specifying title {#specifying-title}
 

--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -69,6 +69,27 @@ Some **content** with _markdown_ `syntax`. Check [this `api`](#).
 
 :::
 
+## Usage with Prettier
+
+If you use [Prettier](https://prettier.io) to format your Markdown files, Prettier might autoformatting your code which results in invalid the admonition syntax. To avoid this problem, add empty lines around your content. This is also why the examples we show here all have empty lines around the content.
+
+```md
+<!-- Prettier doesn't change this -->
+::: note
+
+Hello world
+
+:::
+
+<!-- Prettier changes this -->
+::: note
+Hello world
+:::
+
+<!-- to this -->
+::: note Hello world:::
+```
+
 ## Specifying title {#specifying-title}
 
 You may also specify an optional title

--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -73,6 +73,24 @@ Some **content** with _markdown_ `syntax`. Check [this `api`](#).
 
 If you use [Prettier](https://prettier.io) to format your Markdown files, Prettier might autoformat your code to invalid admonition syntax. To avoid this problem, add empty lines around the starting and ending directives. This is also why the examples we show here all have empty lines around the content.
 
+<!-- prettier-ignore -->
+```md
+<!-- Prettier doesn't change this -->
+::: note
+
+Hello world
+
+:::
+
+<!-- Prettier changes this -->
+::: note 
+Hello world 
+:::
+
+<!-- to this -->
+::: note Hello world:::
+```
+
 ## Specifying title {#specifying-title}
 
 You may also specify an optional title

--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -71,7 +71,7 @@ Some **content** with _markdown_ `syntax`. Check [this `api`](#).
 
 ## Usage with Prettier {#usage-with-prettier}
 
-If you use [Prettier](https://prettier.io) to format your Markdown files, Prettier might autoformat your code which results in invalid admonition syntax. To avoid this problem, add empty lines around your content. This is also why the examples we show here all have empty lines around the content.
+If you use [Prettier](https://prettier.io) to format your Markdown files, Prettier might autoformat your code to invalid admonition syntax. To avoid this problem, add empty lines around the starting and ending directives. This is also why the examples we show here all have empty lines around the content.
 
 ## Specifying title {#specifying-title}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Some people at Meta were confused when they ran Prettier on their Markdown files and Prettier messed up their admonition syntax.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Netlify preview

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
