### PR TITLE
fix(theme-classic): fix translation when footer has no links

### DIFF
--- a/packages/docusaurus-theme-classic/src/translations.ts
+++ b/packages/docusaurus-theme-classic/src/translations.ts
@@ -74,21 +74,21 @@ function translateNavbar(
 function isMultiColumnFooterLinks(
   links: MultiColumnFooter['links'] | SimpleFooter['links'],
 ): links is MultiColumnFooter['links'] {
-  return 'title' in links[0];
+  return links.length > 0 && 'title' in links[0];
 }
 
 function getFooterTranslationFile(footer: Footer): TranslationFileContent {
-  const footerLinkTitles: TranslationFileContent = isMultiColumnFooterLinks(
-    footer.links,
+  const footerLinkTitles: TranslationFileContent = chain(
+    isMultiColumnFooterLinks(footer.links)
+      ? footer.links.filter((link) => !!link.title)
+      : [],
   )
-    ? chain(footer.links.filter((link) => !!link.title))
-        .keyBy((link) => `link.title.${link.title}`)
-        .mapValues((link) => ({
-          message: link.title!,
-          description: `The title of the footer links column with title=${link.title} in the footer`,
-        }))
-        .value()
-    : {};
+    .keyBy((link) => `link.title.${link.title}`)
+    .mapValues((link) => ({
+      message: link.title!,
+      description: `The title of the footer links column with title=${link.title} in the footer`,
+    }))
+    .value();
 
   const footerLinkLabels: TranslationFileContent = chain(
     isMultiColumnFooterLinks(footer.links)

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -312,18 +312,18 @@ const ThemeConfigSchema = Joi.object({
     }),
     copyright: Joi.string(),
     links: Joi.alternatives(
-      Joi.array()
-        .items(
-          Joi.object({
-            title: Joi.string().allow(null).default(null),
-            items: Joi.array().items(FooterLinkItemSchema).default([]),
-          }),
-        )
-        .default([]),
-      Joi.array().items(FooterLinkItemSchema).default([]),
-    ).messages({
-      'alternatives.match': `The footer must be either simple or multi-column, and not a mix of the two. See: https://docusaurus.io/docs/api/themes/configuration#footer-links`,
-    }),
+      Joi.array().items(
+        Joi.object({
+          title: Joi.string().allow(null).default(null),
+          items: Joi.array().items(FooterLinkItemSchema).default([]),
+        }),
+      ),
+      Joi.array().items(FooterLinkItemSchema),
+    )
+      .messages({
+        'alternatives.match': `The footer must be either simple or multi-column, and not a mix of the two. See: https://docusaurus.io/docs/api/themes/configuration#footer-links`,
+      })
+      .default([]),
   }).optional(),
   prism: Joi.object({
     theme: Joi.object({


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Little bug in #6132 when footer contains no links. Surfaced because our blog-only test build has a footer without links.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally with `yarn workspace website build:blogOnly`