### PR TITLE
docs: remove mention of 'UA-' in gtag

### DIFF
--- a/website/docs/api/plugins/plugin-google-gtag.md
+++ b/website/docs/api/plugins/plugin-google-gtag.md
@@ -52,7 +52,7 @@ Most Docusaurus users configure this plugin through the [preset options](#ex-con
 
 ```js
 const config = {
-  trackingID: 'UA-141789564-1',
+  trackingID: '141789564',
   anonymizeIP: true,
 };
 ```
@@ -69,7 +69,7 @@ module.exports = {
       {
         // highlight-start
         gtag: {
-          trackingID: 'UA-141789564-1',
+          trackingID: '141789564',
           anonymizeIP: true,
         },
         // highlight-end
@@ -90,7 +90,7 @@ module.exports = {
       '@docusaurus/plugin-google-gtag',
       // highlight-start
       {
-        trackingID: 'UA-141789564-1',
+        trackingID: '141789564',
         anonymizeIP: true,
       },
       // highlight-end


### PR DESCRIPTION
## Motivation

To make the gtag docs less confusing.

To quote the docs here: https://support.google.com/analytics/answer/9744165?hl=en-GB&utm_id=ad#use_existing_tags

> Make a note of your GA4 property's name so you can find it later. If your Universal Analytics property name is "Example property (UA-nnnnnnn)", your GA4 property name will be "Example property (xxxxxxx)", without a "UA-" prefix, and where xxxxxxx is a new property number. 

The docs as is suggest that gtag's should include "UA-" as universal analytics does.  This PR amends that to make it less confusing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

n/a

## Related PRs

