### PR TITLE
refactor: print trailing new line when outputting JSON

### DIFF
--- a/generateExamples.js
+++ b/generateExamples.js
@@ -66,7 +66,7 @@ function generateTemplateExample(template) {
     // rewrite the package.json file with the new edit
     writeFileSync(
       `./examples/${template}/package.json`,
-      JSON.stringify(templatePackageJson, null, 2),
+      `${JSON.stringify(templatePackageJson, null, 2)}\n`,
     );
 
     // create sandbox.config.json file at the root of template
@@ -82,7 +82,7 @@ function generateTemplateExample(template) {
     };
     writeFileSync(
       `./examples/${template}/sandbox.config.json`,
-      JSON.stringify(codeSanboxConfig, null, 2),
+      `${JSON.stringify(codeSanboxConfig, null, 2)}\n`,
     );
 
     const stackBlitzConfig = {
@@ -91,7 +91,7 @@ function generateTemplateExample(template) {
     };
     writeFileSync(
       `./examples/${template}/.stackblitzrc`,
-      JSON.stringify(stackBlitzConfig, null, 2),
+      `${JSON.stringify(stackBlitzConfig, null, 2)}\n`,
     );
 
     console.log(`Generated example for template ${template}`);

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -35,7 +35,7 @@ async function updatePkg(pkgPath: string, obj: Record<string, unknown>) {
   const pkg = JSON.parse(content);
   const newPkg = Object.assign(pkg, obj);
 
-  await fs.outputFile(pkgPath, JSON.stringify(newPkg, null, 2));
+  await fs.outputFile(pkgPath, `${JSON.stringify(newPkg, null, 2)}\n`);
 }
 
 function readTemplates(templatesDir: string) {

--- a/packages/docusaurus/src/server/translations/translations.ts
+++ b/packages/docusaurus/src/server/translations/translations.ts
@@ -133,7 +133,7 @@ Maybe you should remove them? ${unknownKeys}`;
       filePath,
     )}.`;
     await fs.ensureDir(path.dirname(filePath));
-    await fs.writeFile(filePath, JSON.stringify(mergedContent, null, 2));
+    await fs.writeFile(filePath, `${JSON.stringify(mergedContent, null, 2)}\n`);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Many people (unfortunately including me) configure their editors to add trailing new lines. Annoys me every time to fix translation files after running `write-translations`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
