### PR TITLE
feat(content-blog): include front matter in loaded content metadata

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -126,6 +126,9 @@ describe('loadBlog', () => {
       authors: [],
       date: new Date('2019-01-01'),
       formattedDate: 'January 1, 2019',
+      frontMatter: {
+        date: new Date('2019-01-01'),
+      },
       prevItem: undefined,
       tags: [],
       nextItem: {
@@ -161,6 +164,15 @@ describe('loadBlog', () => {
       ],
       date: new Date('2018-12-14'),
       formattedDate: 'December 14, 2018',
+      frontMatter: {
+        authors: [
+          {
+            name: 'Yangshun Tay (translated)',
+          },
+          'slorber',
+        ],
+        title: 'Happy 1st Birthday Slash! (translated)',
+      },
       tags: [],
       prevItem: {
         permalink: '/blog/date-matter',
@@ -187,6 +199,11 @@ describe('loadBlog', () => {
       },
       date: new Date('2020-08-16'),
       formattedDate: 'August 16, 2020',
+      frontMatter: {
+        date: new Date('2020-08-16'),
+        slug: '/hey/my super path/héllô',
+        title: 'Complex Slug',
+      },
       tags: [],
       truncated: false,
     });
@@ -216,6 +233,14 @@ describe('loadBlog', () => {
       },
       date: new Date('2020-08-15'),
       formattedDate: 'August 15, 2020',
+      frontMatter: {
+        author: 'Sébastien Lorber',
+        author_title: 'Docusaurus maintainer',
+        author_url: 'https://sebastienlorber.com',
+        date: new Date('2020-08-15'),
+        slug: '/simple/slug',
+        title: 'Simple Slug',
+      },
       tags: [],
       truncated: false,
     });
@@ -233,6 +258,9 @@ describe('loadBlog', () => {
       authors: [],
       date: new Date('2019-01-02'),
       formattedDate: 'January 2, 2019',
+      frontMatter: {
+        date: new Date('2019-01-02'),
+      },
       prevItem: undefined,
       tags: [],
       nextItem: {
@@ -388,6 +416,7 @@ describe('loadBlog', () => {
       authors: [],
       date: noDateSourceBirthTime,
       formattedDate,
+      frontMatter: {},
       tags: [],
       prevItem: undefined,
       nextItem: undefined,

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -234,6 +234,7 @@ async function processBlogSourceFile(
         : undefined,
       truncated: truncateMarker?.test(content) || false,
       authors,
+      frontMatter,
     },
     content,
   };

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -43,6 +43,7 @@ declare module '@theme/BlogPostPage' {
     readonly nextItem?: {readonly title: string; readonly permalink: string};
     readonly prevItem?: {readonly title: string; readonly permalink: string};
     readonly authors: import('./types').Author[];
+    readonly frontMatter: FrontMatter & Record<string, unknown>;
     readonly tags: readonly {
       readonly label: string;
       readonly permalink: string;

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -160,6 +160,7 @@ export interface MetaData {
   truncated: boolean;
   editUrl?: string;
   authors: Author[];
+  frontMatter: BlogPostFrontMatter;
 }
 
 export interface Assets {

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -160,7 +160,7 @@ export interface MetaData {
   truncated: boolean;
   editUrl?: string;
   authors: Author[];
-  frontMatter: BlogPostFrontMatter;
+  frontMatter: BlogPostFrontMatter & Record<string, unknown>;
 }
 
 export interface Assets {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In the spirit of plugin enhancement (#4492) we should allow users to declare additional server-side metadata through front matter. #4495 added the front matter to doc metadata; we should do the same for blog posts as well.

This has been requested on Discord.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes