### PR TITLE
docs: fix highlighting of YAML front matter

### DIFF
--- a/website/docs/blog.mdx
+++ b/website/docs/blog.mdx
@@ -181,7 +181,7 @@ Blog post authors can be declared directly inside the front matter:
 <Tabs groupId="author-frontmatter">
   <TabItem value="single" label="Single author">
 
-```yml title="my-blog-post.md"
+```md title="my-blog-post.md"
 ---
 authors:
   name: Joel Marcey
@@ -194,7 +194,7 @@ authors:
   </TabItem>
   <TabItem value="multiple" label="Multiple authors">
 
-```yml title="my-blog-post.md"
+```md title="my-blog-post.md"
 ---
 authors:
   - name: Joel Marcey
@@ -222,7 +222,7 @@ This option works best to get started, or for casual, irregular authors.
 
 Prefer using the `authors` front matter, but the legacy `author_*` front matter remains supported:
 
-```yml title="my-blog-post.md"
+```md title="my-blog-post.md"
 ---
 author: Joel Marcey
 author_title: Co-creator of Docusaurus 1
@@ -265,7 +265,7 @@ In blog posts front matter, you can reference the authors declared in the global
 <Tabs groupId="author-frontmatter">
   <TabItem value="single" label="Single author">
 
-```yml title="my-blog-post.md"
+```md title="my-blog-post.md"
 ---
 authors: jmarcey
 ---
@@ -274,7 +274,7 @@ authors: jmarcey
   </TabItem>
   <TabItem value="multiple" label="Multiple authors">
 
-```yml title="my-blog-post.md"
+```md title="my-blog-post.md"
 ---
 authors: [jmarcey, slorber]
 ---
@@ -293,7 +293,7 @@ The `authors` system is very flexible and can suit more advanced use-case:
 
 You can use global authors most of the time, and still use inline authors:
 
-```yml title="my-blog-post.md"
+```md title="my-blog-post.md"
 ---
 authors:
   - jmarcey
@@ -312,7 +312,7 @@ authors:
 
 You can customize the global author's data on per-blog-post basis:
 
-```yml title="my-blog-post.md"
+```md title="my-blog-post.md"
 ---
 authors:
   - key: jmarcey

--- a/website/docs/seo.md
+++ b/website/docs/seo.md
@@ -58,7 +58,7 @@ export default function page() {
 
 Docusaurus automatically adds `description`, `title`, canonical URL links, and other useful metadata to each Markdown page. They are configurable through front matter:
 
-```yml
+```md
 ---
 title: Title for search engines; can be different from the actual heading
 description: A short description of this page

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -336,7 +336,11 @@ const config = {
       prism: {
         theme: lightTheme,
         darkTheme,
-        additionalLanguages: ['java'],
+        // We need to load markdown again so that YAML is loaded before MD
+        // and the YAML front matter is highlighted correctly.
+        // TODO after we have forked prism-react-renderer, we should tweak the
+        // import order and fix it there
+        additionalLanguages: ['java', 'markdown'],
       },
       image: 'img/docusaurus-soc.png',
       // metadata: [{name: 'twitter:card', content: 'summary'}],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

See https://github.com/PrismJS/prism/issues/3283

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Check out a page with markdown front matter in code blocks; they are now rendered properly.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/55398995/147530765-678f9ccc-8e61-4cb3-af45-10317d94ea7a.png) | ![image](https://user-images.githubusercontent.com/55398995/147530735-50c8b2fe-bde3-4dbf-b26f-0a00f0915054.png) |

