### PR TITLE
feat(content-blog): Allow pagination for BlogTagsPostsPage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -153,7 +153,6 @@ module.exports = {
               // 'compact', // TODO: TS doesn't make Boolean a narrowing function yet, so filter(Boolean) is problematic type-wise
               'filter',
               'flatten',
-              'flatMap',
               'map',
               'reduce',
               'take',

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -31,6 +31,7 @@ import {
   BlogMarkdownLoaderOptions,
   MetaData,
   Assets,
+  BlogTagPostPaginated,
 } from './types';
 import {PluginOptionSchema} from './pluginOptionSchema';
 import {
@@ -48,6 +49,7 @@ import {
   getContentPathList,
   getSourceToPermalink,
   getBlogTags,
+  getBlogTagsPostPaginated,
 } from './blogUtils';
 import {BlogPostFrontMatter} from './blogFrontMatter';
 import {createBlogFeedFiles} from './feed';
@@ -133,6 +135,7 @@ export default async function pluginContentBlog(
           blogListPaginated: [],
           blogTags: {},
           blogTagsListPath: null,
+          blogTagsPostListPaginated: [],
         };
       }
 
@@ -195,6 +198,17 @@ export default async function pluginContentBlog(
       }
 
       const blogTags: BlogTags = getBlogTags(blogPosts);
+      const blogTagsPostListPaginated: BlogTagPostPaginated[] =
+        getBlogTagsPostPaginated(
+          blogPosts,
+          postsPerPageOption,
+          baseUrl,
+          routeBasePath,
+          blogDescription,
+          blogTitle,
+        );
+
+      console.log(blogTagsPostListPaginated);
 
       const tagsPath = normalizeUrl([baseBlogUrl, tagsBasePath]);
 
@@ -207,6 +221,7 @@ export default async function pluginContentBlog(
         blogListPaginated,
         blogTags,
         blogTagsListPath,
+        blogTagsPostListPaginated,
       };
     },
 
@@ -231,6 +246,8 @@ export default async function pluginContentBlog(
         blogListPaginated,
         blogTags,
         blogTagsListPath,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        blogTagsPostListPaginated,
       } = blogContents;
 
       const blogItemsToMetadata: BlogItemsToMetadata = {};

--- a/packages/docusaurus-plugin-content-blog/src/types.ts
+++ b/packages/docusaurus-plugin-content-blog/src/types.ts
@@ -22,6 +22,7 @@ export interface BlogContent {
   blogListPaginated: BlogPaginated[];
   blogTags: BlogTags;
   blogTagsListPath: string | null;
+  blogTagsPostListPaginated: BlogTagPostPaginated[];
 }
 
 export type FeedType = 'rss' | 'atom' | 'json';
@@ -134,6 +135,12 @@ export interface BlogPaginatedMetadata {
 }
 
 export interface BlogPaginated {
+  metadata: BlogPaginatedMetadata;
+  items: string[];
+}
+
+export interface BlogTagPostPaginated {
+  tag: string;
   metadata: BlogPaginatedMetadata;
   items: string[];
 }


### PR DESCRIPTION
todo:
- [ ] Map `blogTagsPostListPaginated` to `BlogTagsPostsPage` props
- [ ] Add pagination to `BlogTagsPostsPage`
- [ ] Make sure `BlogTagsListPage` shows the correct number of posts under tags.
- [ ] Tests
- [ ] Refactor if needed

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix https://github.com/facebook/docusaurus/issues/6182.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Test the pagination with `postsPerPage: 1` and with `recap` tag in the generated [Docusaurus 2 Website](https://github.com/facebook/docusaurus/tree/main/website).

## Related PRs

N/A
