### PR TITLE
feat(content-docs): allow SEO metadata for category index pages

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/categoryGeneratedIndex.ts
+++ b/packages/docusaurus-plugin-content-docs/src/categoryGeneratedIndex.ts
@@ -28,6 +28,8 @@ function getCategoryGeneratedIndexMetadata({
   return {
     title: category.link.title ?? category.label,
     description: category.link.description,
+    image: category.link.image,
+    keywords: category.link.keywords,
     slug: category.link.slug,
     permalink: category.link.permalink,
     sidebar: sidebarName,

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -42,6 +42,8 @@ declare module '@docusaurus/plugin-content-docs' {
   export type PropCategoryGeneratedIndex = {
     title: string;
     description?: string;
+    image?: string;
+    keywords?: string | readonly string[];
     slug: string;
     permalink: string;
     navigation: PropNavigation;

--- a/packages/docusaurus-plugin-content-docs/src/routes.ts
+++ b/packages/docusaurus-plugin-content-docs/src/routes.ts
@@ -30,8 +30,17 @@ export async function createCategoryGeneratedIndexRoutes({
   async function createCategoryGeneratedIndexRoute(
     categoryGeneratedIndex: CategoryGeneratedIndexMetadata,
   ): Promise<RouteConfig> {
-    const {sidebar, title, description, slug, permalink, previous, next} =
-      categoryGeneratedIndex;
+    const {
+      sidebar,
+      title,
+      description,
+      slug,
+      permalink,
+      previous,
+      next,
+      image,
+      keywords,
+    } = categoryGeneratedIndex;
 
     const propFileName = slugs.slug(
       `${version.versionPath}-${categoryGeneratedIndex.sidebar}-category-${categoryGeneratedIndex.title}`,
@@ -42,6 +51,8 @@ export async function createCategoryGeneratedIndexRoutes({
       description,
       slug,
       permalink,
+      image,
+      keywords,
       navigation: {
         previous,
         next,

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
@@ -52,6 +52,8 @@ export type SidebarItemCategoryLinkGeneratedIndexConfig = {
   slug?: string;
   title?: string;
   description?: string;
+  image?: string;
+  keywords?: string | readonly string[];
 };
 export type SidebarItemCategoryLinkGeneratedIndex = {
   type: 'generated-index';
@@ -59,6 +61,8 @@ export type SidebarItemCategoryLinkGeneratedIndex = {
   permalink: string;
   title?: string;
   description?: string;
+  image?: string;
+  keywords?: string | readonly string[];
 };
 
 export type SidebarItemCategoryLinkConfig =

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
@@ -70,12 +70,7 @@ const sidebarItemCategoryLinkSchema = Joi.object<SidebarItemCategoryLink>()
           // permalink: Joi.string().optional(), // No, this one is not in the user config, only in the normalized version
           title: Joi.string().optional(),
           description: Joi.string().optional(),
-          image: Joi.string()
-            .pattern(/^\//)
-            .message(
-              'The category index page image must be an absolute path resolved from the static directory',
-            )
-            .optional(),
+          image: Joi.string().optional(),
           keywords: [Joi.string(), Joi.array().items(Joi.string())],
         }),
       },

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/validation.ts
@@ -70,6 +70,13 @@ const sidebarItemCategoryLinkSchema = Joi.object<SidebarItemCategoryLink>()
           // permalink: Joi.string().optional(), // No, this one is not in the user config, only in the normalized version
           title: Joi.string().optional(),
           description: Joi.string().optional(),
+          image: Joi.string()
+            .pattern(/^\//)
+            .message(
+              'The category index page image must be an absolute path resolved from the static directory',
+            )
+            .optional(),
+          keywords: [Joi.string(), Joi.array().items(Joi.string())],
         }),
       },
       {

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -174,6 +174,8 @@ export type CategoryGeneratedIndexMetadata = {
   sidebar: string;
   previous?: DocNavLink;
   next?: DocNavLink;
+  image?: string;
+  keywords?: string | readonly string[];
 };
 
 export type SourceToPermalink = {

--- a/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -29,7 +29,6 @@ export default function DocCategoryGeneratedIndexPage({
         description={categoryGeneratedIndex.description}
         keywords={categoryGeneratedIndex.keywords}
         // TODO `require` this?
-        // eslint-disable-next-line global-require, import/no-dynamic-require
         image={useBaseUrl(categoryGeneratedIndex.image)}
       />
       <div className={styles.generatedIndexPage}>

--- a/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -14,6 +14,7 @@ import Seo from '@theme/Seo';
 import DocVersionBanner from '@theme/DocVersionBanner';
 import DocVersionBadge from '@theme/DocVersionBadge';
 import {MainHeading} from '@theme/Heading';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import styles from './styles.module.css';
 
@@ -26,6 +27,10 @@ export default function DocCategoryGeneratedIndexPage({
       <Seo
         title={categoryGeneratedIndex.title}
         description={categoryGeneratedIndex.description}
+        keywords={categoryGeneratedIndex.keywords}
+        // TODO `require` this?
+        // eslint-disable-next-line global-require, import/no-dynamic-require
+        image={useBaseUrl(categoryGeneratedIndex.image)}
       />
       <div className={styles.generatedIndexPage}>
         <DocVersionBanner />

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -33,6 +33,8 @@ const sidebars = {
         title: 'Docusaurus Guides',
         description:
           "Let's learn about the most important Docusaurus concepts!",
+        keywords: ['guides'],
+        image: '/img/docusaurus.png',
       },
       items: [
         'guides/creating-pages',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Close #6238.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Dogfooding

## TODO

- [ ] Can't figure out how to turn the image into a `require` call: `require('/img/docusaurus.png')` doesn't seem to work despite we have `resolve.roots`?
- [ ] Documentation