### PR TITLE
fix(website): fix config-tabs breaking after translation

### DIFF
--- a/website/docs/api/plugins/plugin-content-blog.md
+++ b/website/docs/api/plugins/plugin-content-blog.md
@@ -111,8 +111,8 @@ Most Docusaurus users configure this plugin through the preset options.
 :::
 
 ```js config-tabs
-// preset option name: blog
-// plugin name: @docusaurus/plugin-content-blog
+// Preset Options: blog
+// Plugin Options: @docusaurus/plugin-content-blog
 
 const config = {
   path: 'blog',

--- a/website/docs/api/plugins/plugin-content-docs.md
+++ b/website/docs/api/plugins/plugin-content-docs.md
@@ -114,8 +114,8 @@ Most Docusaurus users configure this plugin through the preset options.
 :::
 
 ```js config-tabs
-// preset option name: docs
-// plugin name: @docusaurus/plugin-content-docs
+// Preset Options: docs
+// Plugin Options: @docusaurus/plugin-content-docs
 
 const config = {
   path: 'docs',

--- a/website/docs/api/plugins/plugin-content-pages.md
+++ b/website/docs/api/plugins/plugin-content-pages.md
@@ -54,8 +54,8 @@ Most Docusaurus users configure this plugin through the preset options.
 :::
 
 ```js config-tabs
-// preset option name: pages
-// plugin name: @docusaurus/plugin-content-pages
+// Preset Options: pages
+// Plugin Options: @docusaurus/plugin-content-pages
 
 const config = {
   path: 'src/pages',

--- a/website/docs/api/plugins/plugin-google-analytics.md
+++ b/website/docs/api/plugins/plugin-google-analytics.md
@@ -53,8 +53,8 @@ Most Docusaurus users configure this plugin through the preset options.
 :::
 
 ```js config-tabs
-// preset option name: googleAnalytics
-// plugin name: @docusaurus/plugin-google-analytics
+// Preset Options: googleAnalytics
+// Plugin Options: @docusaurus/plugin-google-analytics
 
 const config = {
   trackingID: 'UA-141789564-1',

--- a/website/docs/api/plugins/plugin-google-gtag.md
+++ b/website/docs/api/plugins/plugin-google-gtag.md
@@ -59,8 +59,8 @@ Most Docusaurus users configure this plugin through the preset options.
 :::
 
 ```js config-tabs
-// preset option name: gtag
-// plugin name: @docusaurus/plugin-google-gtag
+// Preset Options: gtag
+// Plugin Options: @docusaurus/plugin-google-gtag
 
 const config = {
   trackingID: '141789564',

--- a/website/docs/api/plugins/plugin-sitemap.md
+++ b/website/docs/api/plugins/plugin-sitemap.md
@@ -62,8 +62,8 @@ Most Docusaurus users configure this plugin through the preset options.
 :::
 
 ```js config-tabs
-// preset option name: sitemap
-// plugin name: @docusaurus/plugin-sitemap
+// Preset Options: sitemap
+// Plugin Options: @docusaurus/plugin-sitemap
 
 const config = {
   changefreq: 'weekly',

--- a/website/src/remark/configTabs.js
+++ b/website/src/remark/configTabs.js
@@ -27,13 +27,15 @@ const plugin = () => {
         const {value} = node;
         const [presetMeta, pluginMeta] = value.split('\n');
         const {
-          groups: {presetOptionName},
+          groups: {presetOptionName, presetOptionText},
         } = presetMeta.match(
-          /preset option name: (?<presetOptionName>[A-Za-z]+)/i,
+          /(?<presetOptionText>.*?): (?<presetOptionName>[A-Za-z]+)/i,
         );
         const {
-          groups: {pluginName},
-        } = pluginMeta.match(/plugin name: (?<pluginName>[A-Za-z@/-]+)/i);
+          groups: {pluginName, pluginText},
+        } = pluginMeta.match(
+          /(?<pluginText>.*?): (?<pluginName>[A-Za-z@/-]+)/i,
+        );
         // Replace leading "const config = " and trailing semi
         const config = value
           .replace(presetMeta, '')
@@ -46,7 +48,7 @@ const plugin = () => {
         const newNodes = [
           {
             type: 'jsx',
-            value: `<Tabs>\n<TabItem value="Preset Options">`,
+            value: `<Tabs>\n<TabItem value="${presetOptionText}">`,
           },
           {
             type: 'paragraph',
@@ -97,7 +99,7 @@ const plugin = () => {
           },
           {
             type: 'jsx',
-            value: '</TabItem>\n<TabItem value="Plugin Options">',
+            value: `</TabItem>\n<TabItem value="${pluginText}">`,
           },
           {
             type: 'paragraph',

--- a/website/src/remark/configTabs.js
+++ b/website/src/remark/configTabs.js
@@ -30,12 +30,22 @@ const plugin = () => {
           groups: {presetOptionName, presetOptionText},
         } = presetMeta.match(
           /(?<presetOptionText>.*?): (?<presetOptionName>[A-Za-z]+)/i,
-        );
+        ) ?? {
+          groups: {
+            presetOptionName: '[translation failure]',
+            presetOptionText: 'Preset Options',
+          },
+        };
         const {
           groups: {pluginName, pluginText},
         } = pluginMeta.match(
           /(?<pluginText>.*?): (?<pluginName>[A-Za-z@/-]+)/i,
-        );
+        ) ?? {
+          groups: {
+            pluginName: '[translation failure]',
+            pluginText: 'Plugin Options',
+          },
+        };
         // Replace leading "const config = " and trailing semi
         const config = value
           .replace(presetMeta, '')


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Our build has been failing because once the config tabs are translated, the remark plugin fails to find relevant text. I made it more robust to translations, and even made the tab texts translatable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
