### PR TITLE
fix(preset-classic): throw if preset finds GA options in theme config

### DIFF
--- a/packages/docusaurus-plugin-google-analytics/src/index.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/index.ts
@@ -82,7 +82,7 @@ export function validateOptions({
 export function validateThemeConfig({
   themeConfig,
 }: ThemeConfigValidationContext<ThemeConfig>): ValidationResult<ThemeConfig> {
-  if (themeConfig.googleAnalytics) {
+  if ('googleAnalytics' in themeConfig) {
     throw new Error(
       'The "googleAnalytics" field in themeConfig should now be specified as option for plugin-google-analytics. More information at https://github.com/facebook/docusaurus/pull/5832.',
     );

--- a/packages/docusaurus-plugin-google-gtag/src/index.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/index.ts
@@ -95,7 +95,7 @@ export function validateOptions({
 export function validateThemeConfig({
   themeConfig,
 }: ThemeConfigValidationContext<ThemeConfig>): ValidationResult<ThemeConfig> {
-  if (themeConfig.gtag) {
+  if ('gtag' in themeConfig) {
     throw new Error(
       'The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. More information at https://github.com/facebook/docusaurus/pull/5832.',
     );

--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -48,6 +48,16 @@ export default function preset(
   if (algolia) {
     themes.push(require.resolve('@docusaurus/theme-search-algolia'));
   }
+  if (themeConfig.gtag) {
+    throw new Error(
+      'The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. For preset-classic, simply move themeConfig.gtag to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
+    );
+  }
+  if (themeConfig.googleAnalytics) {
+    throw new Error(
+      'The "googleAnalytics" field in themeConfig should now be specified as option for plugin-google-analytics. For preset-classic, simply move themeConfig.googleAnalytics to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
+    );
+  }
 
   const plugins: PluginConfig[] = [];
   if (docs !== false) {
@@ -59,7 +69,7 @@ export default function preset(
   if (pages !== false) {
     plugins.push(makePluginConfig('@docusaurus/plugin-content-pages', pages));
   }
-  if (isProd && googleAnalytics) {
+  if (googleAnalytics) {
     plugins.push(
       makePluginConfig('@docusaurus/plugin-google-analytics', googleAnalytics),
     );
@@ -67,7 +77,7 @@ export default function preset(
   if (debug || (debug === undefined && !isProd)) {
     plugins.push(require.resolve('@docusaurus/plugin-debug'));
   }
-  if (isProd && gtag) {
+  if (gtag) {
     plugins.push(makePluginConfig('@docusaurus/plugin-google-gtag', gtag));
   }
   if (isProd && sitemap !== false) {

--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -48,12 +48,12 @@ export default function preset(
   if (algolia) {
     themes.push(require.resolve('@docusaurus/theme-search-algolia'));
   }
-  if (themeConfig.gtag) {
+  if ('gtag' in themeConfig) {
     throw new Error(
       'The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. For preset-classic, simply move themeConfig.gtag to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
     );
   }
-  if (themeConfig.googleAnalytics) {
+  if ('googleAnalytics' in themeConfig) {
     throw new Error(
       'The "googleAnalytics" field in themeConfig should now be specified as option for plugin-google-analytics. For preset-classic, simply move themeConfig.googleAnalytics to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.',
     );

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -348,7 +348,6 @@ const config = {
         indexName: 'docusaurus-2',
         contextualSearch: true,
       },
-      googleAnalytics: {trackingID: 'hey'},
       navbar: {
         hideOnScroll: true,
         title: 'Docusaurus',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -348,6 +348,7 @@ const config = {
         indexName: 'docusaurus-2',
         contextualSearch: true,
       },
+      googleAnalytics: {trackingID: 'hey'},
       navbar: {
         hideOnScroll: true,
         title: 'Docusaurus',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

To prevent the legacy config from ever silently passing. Reported in https://github.com/facebook/docusaurus/pull/5832#issuecomment-1007122465.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally