### PR TITLE
fix(theme-classic): add missing role=region to SkipToContent

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -40,7 +40,7 @@ function SkipToContent(): JSX.Element {
   });
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} role="region">
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a href="#" className={styles.skipToContent} onClick={handleSkip}>
         <Translate


### PR DESCRIPTION
## Motivation

Even the _Skip to main content_ link on a page needs to be in a region per aXe.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1. Visit a new Docusaurus site with the classic theme, such as today's https://typescript-eslint.io
2. Run aXe on it such as with the [aXe browser extensions](https://www.deque.com/axe/browser-extensions) and Settings > Enable Best Practices enabled

Fixes #6252