### PR TITLE
fix(theme-classic): fix mobile version dropdown label with only one version

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -17,6 +17,7 @@ import type {Props} from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 import {translate} from '@docusaurus/Translate';
 import type {GlobalVersion} from '@docusaurus/plugin-content-docs/client';
+import type {LinkLikeNavbarItemProps} from '@theme/NavbarItem';
 
 const getVersionMainDoc = (version: GlobalVersion) =>
   version.docs.find((doc) => doc.id === version.mainDocId)!;
@@ -36,7 +37,7 @@ export default function DocsVersionDropdownNavbarItem({
   const {preferredVersion, savePreferredVersionName} =
     useDocsPreferredVersion(docsPluginId);
 
-  function getItems() {
+  function getItems(): LinkLikeNavbarItemProps[] {
     const versionLinks = versions.map((version) => {
       // We try to link to the same doc, in another version
       // When not possible, fallback to the "main doc" of the version
@@ -64,7 +65,7 @@ export default function DocsVersionDropdownNavbarItem({
 
   // Mobile dropdown is handled a bit differently
   const dropdownLabel =
-    mobile && items
+    mobile && items.length > 1
       ? translate({
           id: 'theme.navbar.mobileVersionsDropdown.label',
           message: 'Versions',
@@ -73,7 +74,9 @@ export default function DocsVersionDropdownNavbarItem({
         })
       : dropdownVersion.label;
   const dropdownTo =
-    mobile && items ? undefined : getVersionMainDoc(dropdownVersion).path;
+    mobile && items.length > 1
+      ? undefined
+      : getVersionMainDoc(dropdownVersion).path;
 
   // We don't want to render a version dropdown with 0 or 1 item
   // If we build the site with a single docs version (onlyIncludeVersions: ['1.0.0'])
@@ -83,7 +86,7 @@ export default function DocsVersionDropdownNavbarItem({
       <DefaultNavbarItem
         {...props}
         mobile={mobile}
-        label={dropdownVersion.label} // Don't use the "Versions" label, even for mobile!
+        label={dropdownLabel}
         to={dropdownTo}
         isActive={dropdownActiveClassDisabled ? () => false : undefined}
       />

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -83,7 +83,7 @@ export default function DocsVersionDropdownNavbarItem({
       <DefaultNavbarItem
         {...props}
         mobile={mobile}
-        label={dropdownLabel}
+        label={dropdownVersion.label} // Don't use the "Versions" label, even for mobile!
         to={dropdownTo}
         isActive={dropdownActiveClassDisabled ? () => false : undefined}
       />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #6309. #4986 is actually not very correct.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
