### PR TITLE
fix(core): error boundary should allow no children

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -88,7 +88,7 @@ declare module '@theme/Layout' {
   import type {ReactNode} from 'react';
 
   export interface Props {
-    readonly children: ReactNode;
+    readonly children?: ReactNode;
     readonly title?: string;
     readonly description?: string;
   }

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -221,7 +221,7 @@ declare module '@theme/Layout' {
   import type {ReactNode} from 'react';
 
   export interface Props {
-    readonly children: ReactNode;
+    readonly children?: ReactNode;
     readonly title?: string;
     readonly noFooter?: boolean;
     readonly description?: string;

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -40,7 +40,11 @@ class ErrorBoundary extends React.Component<Props, State> {
       });
     }
 
-    return children;
+    return (
+      children ??
+      // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647
+      null
+    );
   }
 }
 

--- a/website/_dogfooding/_pages tests/layout-no-children.tsx
+++ b/website/_dogfooding/_pages tests/layout-no-children.tsx
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Layout from '@theme/Layout';
+
+// See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647
+export default function LayoutNoChildren(): JSX.Element {
+  return <Layout />;
+}


### PR DESCRIPTION
## Motivation

Minor detail but something like `<Layout/>` should be allowed. 

Currently it crashes due to error boundary not allowing undefined children

see https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

dogfood: https://deploy-preview-6338--docusaurus-2.netlify.app/tests/pages/layout-no-children
