### PR TITLE
docs: minor fix in the sample config for ESM

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-math-equations.mdx
@@ -187,7 +187,6 @@ async function createConfig() {
     ],
     // highlight-end
   };
-  return config;
 }
 
 module.exports = createConfig;


### PR DESCRIPTION
## Motivation

I guess this line (`return config;`) was left in the sample code by mistake while making modifications. The `createConfig` function is already returning the `config` as object.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes