### PR TITLE
fix(create-docusaurus): add useBaseUrl for image URLs

### DIFF
--- a/examples/classic-typescript/src/components/HomepageFeatures.tsx
+++ b/examples/classic-typescript/src/components/HomepageFeatures.tsx
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import React from 'react';
 import clsx from 'clsx';
 import styles from './HomepageFeatures.module.css';
@@ -45,7 +46,11 @@ function Feature({title, image, description}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
-        <img className={styles.featureSvg} alt={title} src={image} />
+        <img
+          className={styles.featureSvg}
+          alt={title}
+          src={useBaseUrl(image)}
+        />
       </div>
       <div className="text--center padding-horiz--md">
         <h3>{title}</h3>

--- a/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures.tsx
+++ b/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures.tsx
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import React from 'react';
 import clsx from 'clsx';
 import styles from './HomepageFeatures.module.css';
@@ -45,7 +46,11 @@ function Feature({title, image, description}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
-        <img className={styles.featureSvg} alt={title} src={image} />
+        <img
+          className={styles.featureSvg}
+          alt={title}
+          src={useBaseUrl(image)}
+        />
       </div>
       <div className="text--center padding-horiz--md">
         <h3>{title}</h3>


### PR DESCRIPTION
## Motivation

This is already provided by the [classic template](https://github.com/facebook/docusaurus/blob/83e04132905dbef05b0553a700fcecec0235ba69/examples/classic/src/components/HomepageFeatures.js#L8) and in TypeScript template wasn't updated.
Based on the [documentation](https://docusaurus.io/docs/static-assets#examples) it is better to use `useBaseUrl` and I don't see the benefit of repeating the same function call in the `FeatureList` array.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Without this change it looks like this:
![Screen Shot 2022-01-14 at 19 27 35](https://user-images.githubusercontent.com/456140/149607242-720cfcef-044e-4b9c-8ce2-86f03ea3fb29.png)

With the change applied the images load correctly:
![Screen Shot 2022-01-14 at 19 29 43](https://user-images.githubusercontent.com/456140/149607270-016d3cb7-4a30-4959-be8b-7efe8d565267.png)

