### PR TITLE
feat(core, theme-classic): allow overriding htmlLang

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -64,7 +64,14 @@ declare module '@generated/i18n' {
     defaultLocale: string;
     locales: [string, ...string[]];
     currentLocale: string;
-    localeConfigs: Record<string, {label: string; direction: string}>;
+    localeConfigs: Record<
+      string,
+      {
+        label: string;
+        direction: string;
+        htmlLang: string;
+      }
+    >;
   };
   export = i18n;
 }

--- a/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutHead/index.tsx
@@ -25,7 +25,7 @@ import {useLocation} from '@docusaurus/router';
 // See https://github.com/facebook/docusaurus/issues/3317
 function AlternateLangHeaders(): JSX.Element {
   const {
-    i18n: {defaultLocale, locales},
+    i18n: {defaultLocale, localeConfigs},
   } = useDocusaurusContext();
   const alternatePageUtils = useAlternatePageUtils();
 
@@ -33,7 +33,7 @@ function AlternateLangHeaders(): JSX.Element {
   // See https://www.searchviu.com/en/multiple-hreflang-tags-one-url/
   return (
     <Head>
-      {locales.map((locale) => (
+      {Object.entries(localeConfigs).map(([locale, {htmlLang}]) => (
         <link
           key={locale}
           rel="alternate"
@@ -41,7 +41,7 @@ function AlternateLangHeaders(): JSX.Element {
             locale,
             fullyQualified: true,
           })}
-          hrefLang={locale}
+          hrefLang={htmlLang}
         />
       ))}
       <link
@@ -91,11 +91,7 @@ export default function LayoutHead(props: Props): JSX.Element {
   const {title, description, image, keywords, searchMetadata} = props;
   const faviconUrl = useBaseUrl(favicon);
   const pageTitle = useTitleFormatter(title);
-
-  // See https://github.com/facebook/docusaurus/issues/3317#issuecomment-754661855
-  // const htmlLang = currentLocale.split('-')[0];
-  const htmlLang = currentLocale; // should we allow the user to override htmlLang with localeConfig?
-  const htmlDir = localeConfigs[currentLocale].direction;
+  const {htmlLang, direction: htmlDir} = localeConfigs[currentLocale];
 
   return (
     <>

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -120,6 +120,7 @@ export type TranslationFiles = TranslationFile[];
 
 export type I18nLocaleConfig = {
   label: string;
+  htmlLang: string;
   direction: string;
 };
 

--- a/packages/docusaurus/src/server/__tests__/i18n.test.ts
+++ b/packages/docusaurus/src/server/__tests__/i18n.test.ts
@@ -40,38 +40,47 @@ describe('defaultLocaleConfig', () => {
     expect(getDefaultLocaleConfig('fr')).toEqual({
       label: canComputeLabel ? 'Français' : 'fr',
       direction: 'ltr',
+      htmlLang: 'fr',
     });
     expect(getDefaultLocaleConfig('fr-FR')).toEqual({
       label: canComputeLabel ? 'Français (France)' : 'fr-FR',
       direction: 'ltr',
+      htmlLang: 'fr-FR',
     });
     expect(getDefaultLocaleConfig('en')).toEqual({
       label: canComputeLabel ? 'English' : 'en',
       direction: 'ltr',
+      htmlLang: 'en',
     });
     expect(getDefaultLocaleConfig('en-US')).toEqual({
       label: canComputeLabel ? 'American English' : 'en-US',
       direction: 'ltr',
+      htmlLang: 'en-US',
     });
     expect(getDefaultLocaleConfig('zh')).toEqual({
       label: canComputeLabel ? '中文' : 'zh',
       direction: 'ltr',
+      htmlLang: 'zh',
     });
     expect(getDefaultLocaleConfig('zh-CN')).toEqual({
       label: canComputeLabel ? '中文（中国）' : 'zh-CN',
       direction: 'ltr',
+      htmlLang: 'zh-CN',
     });
     expect(getDefaultLocaleConfig('en-US')).toEqual({
       label: canComputeLabel ? 'American English' : 'en-US',
       direction: 'ltr',
+      htmlLang: 'en-US',
     });
     expect(getDefaultLocaleConfig('fa')).toEqual({
       label: canComputeLabel ? 'فارسی' : 'fa',
       direction: 'rtl',
+      htmlLang: 'fa',
     });
     expect(getDefaultLocaleConfig('fa-IR')).toEqual({
       label: canComputeLabel ? 'فارسی (ایران)' : 'fa-IR',
       direction: 'rtl',
+      htmlLang: 'fa-IR',
     });
   });
 });
@@ -156,7 +165,7 @@ describe('loadI18n', () => {
       locales: ['en', 'fr', 'de'],
       currentLocale: 'de',
       localeConfigs: {
-        fr: {label: 'Français', direction: 'ltr'},
+        fr: {label: 'Français', direction: 'ltr', htmlLang: 'fr'},
         en: getDefaultLocaleConfig('en'),
         de: getDefaultLocaleConfig('de'),
       },

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -98,6 +98,7 @@ const PresetSchema = Joi.alternatives().try(
 
 const LocaleConfigSchema = Joi.object({
   label: Joi.string(),
+  htmlLang: Joi.string(),
   direction: Joi.string().equal('ltr', 'rtl').default('ltr'),
 });
 

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -24,6 +24,7 @@ export function getDefaultLocaleConfig(locale: string): I18nLocaleConfig {
   return {
     label: getDefaultLocaleLabel(locale),
     direction: getLangDir(locale),
+    htmlLang: locale,
   };
 }
 


### PR DESCRIPTION
## Motivation

1. I'm in the middle of building [a website](https://interslavic.fun) for Interslavic language which is available in multiple locales and scripts. The problem is that Interslavic language has quite a long BCP-47 language tag: `art-x-interslv`.[^1]
    
    ![](https://user-images.githubusercontent.com/1962469/149620890-3b20a5fd-23bb-4cab-a7fb-753ba6f43d15.png)
    
    Besides, since it supports equally the Latin and Cyrillic scripts, you ought[^2] to specify the script as well: `art-Latn-x-interslv` and `art-Cyrl-x-interslv` respectively. Also, the language has a for-internal-use script with extra etymological letters[^3], the so-called Etymological (or Scientific) alphabet, which we agreed to have under `art-Latn-x-interslv-etymolog`.
    
    [^1]: See ConLang Code Registry: https://www.kreativekorp.com/clcr/
    [^2]: See page 12: https://tools.ietf.org/search/bcp47
    [^3]: http://steen.free.fr/interslavic/orthography.html#etymological_alphabet

2. Docusaurus is too coupled at the moment to the language code – you have to maintain directory and URL structure accordingly to the code. I'd like to shorten my directory names and URLs to `.../sla-Latn/...` and `.../sla-Cyrl/...`, for example, but I'd still want to render the adopted BCP 47 language tag in the document markup.

   Without this feature, even the home page would have a URL like `https://interslavic.fun/art-Latn-x-interslv-etymolog`, which looks clumsy.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, although some parts I skimmed. 🙏 

## Test Plan

In your `docusaurus.config.js`, try overriding your `i18n` section, e.g.:

```diff
   i18n: {
     defaultLocale: 'en',
+    localeConfig: {
+      en: { htmlLang: 'en-GB' }
+    }
```

After reloading the website, check that you see `<html lang="en-GB">` in the rendered HTML markup.

## Related PRs

* feat(v2): add support for RTL direction: https://github.com/facebook/docusaurus/pull/4140
* fix(v2): fix/enhance minor i18n issues reported: https://github.com/facebook/docusaurus/pull/4092