### PR TITLE
feat(gtag): cookie consent banner

### DIFF
--- a/packages/docusaurus-plugin-google-gtag/copyUntypedFiles.mjs
+++ b/packages/docusaurus-plugin-google-gtag/copyUntypedFiles.mjs
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import fs from 'fs-extra';
+import {fileURLToPath} from 'url';
+
+/**
+ * Copy all untyped and static assets files to lib.
+ */
+const srcDir = fileURLToPath(new URL('src', import.meta.url));
+const libDir = fileURLToPath(new URL('lib', import.meta.url));
+await fs.copy(srcDir, libDir, {
+  filter(filepath) {
+    return !/__tests__/.test(filepath) && !/\.tsx?$/.test(filepath);
+  },
+});

--- a/packages/docusaurus-plugin-google-gtag/package.json
+++ b/packages/docusaurus-plugin-google-gtag/package.json
@@ -5,8 +5,11 @@
   "main": "lib/index.js",
   "types": "src/plugin-google-gtag.d.ts",
   "scripts": {
-    "build": "tsc",
-    "watch": "tsc --watch"
+    "build": "yarn build:server && yarn build:browser && yarn build:copy && yarn build:format",
+    "build:server": "tsc --project tsconfig.server.json",
+    "build:browser": "tsc --project tsconfig.browser.json",
+    "build:copy": "node copyUntypedFiles.mjs",
+    "build:format": "prettier --config ../../.prettierrc --write \"lib/**/*.js\""
   },
   "publishConfig": {
     "access": "public"
@@ -19,7 +22,9 @@
   "license": "MIT",
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.14",
+    "@docusaurus/theme-common": "2.0.0-beta.14",
     "@docusaurus/utils-validation": "2.0.0-beta.14",
+    "clsx": "^1.1.1",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.tsx
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.tsx
@@ -17,10 +17,10 @@ export default (function () {
     return null;
   }
 
-  const cookieConsentResponse = JSON.parse(
-    localStorage.getItem('docusaurus.cookieConsent') ?? 'null',
-  ) as boolean | null;
   window.onload = () => {
+    const cookieConsentResponse = JSON.parse(
+      localStorage.getItem('docusaurus.cookieConsent') ?? 'null',
+    ) as boolean | null;
     if (cookieConsentResponse === null) {
       const consentBannerContainer = document.createElement('div');
       document
@@ -33,12 +33,15 @@ export default (function () {
   const {trackingID} = globalData['docusaurus-plugin-google-gtag']
     .default as PluginOptions;
 
-  if (!cookieConsentResponse) {
-    return {};
-  }
-
   return {
     onRouteUpdate({location}: {location: Location}) {
+      // Always get the latest value on every route transition
+      const cookieConsentResponse = JSON.parse(
+        localStorage.getItem('docusaurus.cookieConsent') ?? 'null',
+      ) as boolean | null;
+      if (!cookieConsentResponse) {
+        return;
+      }
       // Always refer to the variable on window in-case it gets overridden elsewhere.
       window.gtag('config', trackingID, {
         page_path: location.pathname,

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.tsx
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.tsx
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+import CookieConsent from '@theme/CookieConsent';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import globalData from '@generated/globalData';
 import type {PluginOptions} from '@docusaurus/plugin-google-gtag';
@@ -14,8 +17,25 @@ export default (function () {
     return null;
   }
 
+  const cookieConsentResponse = JSON.parse(
+    localStorage.getItem('docusaurus.cookieConsent') ?? 'null',
+  ) as boolean | null;
+  window.onload = () => {
+    if (cookieConsentResponse === null) {
+      const consentBannerContainer = document.createElement('div');
+      document
+        .getElementById('__docusaurus')!
+        .appendChild(consentBannerContainer);
+      ReactDOM.render(<CookieConsent />, consentBannerContainer);
+    }
+  };
+
   const {trackingID} = globalData['docusaurus-plugin-google-gtag']
     .default as PluginOptions;
+
+  if (!cookieConsentResponse) {
+    return {};
+  }
 
   return {
     onRouteUpdate({location}: {location: Location}) {

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.tsx
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.tsx
@@ -12,6 +12,12 @@ import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import globalData from '@generated/globalData';
 import type {PluginOptions} from '@docusaurus/plugin-google-gtag';
 
+declare global {
+  interface Window {
+    'ga-disable-MEASUREMENT_ID': boolean;
+  }
+}
+
 export default (function () {
   if (!ExecutionEnvironment.canUseDOM) {
     return null;
@@ -40,6 +46,7 @@ export default (function () {
         localStorage.getItem('docusaurus.cookieConsent') ?? 'null',
       ) as boolean | null;
       if (!cookieConsentResponse) {
+        window['ga-disable-MEASUREMENT_ID'] = true;
         return;
       }
       // Always refer to the variable on window in-case it gets overridden elsewhere.

--- a/packages/docusaurus-plugin-google-gtag/src/index.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/index.ts
@@ -35,6 +35,13 @@ export default function pluginGoogleGtag(
       return isProd ? [path.resolve(__dirname, './gtag')] : [];
     },
 
+    getThemePath() {
+      return path.resolve(__dirname, '../lib/theme');
+    },
+    getTypeScriptThemePath() {
+      return path.resolve(__dirname, '../src/theme');
+    },
+
     injectHtmlTags() {
       if (!isProd) {
         return {};

--- a/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
@@ -5,9 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type PluginOptions = {
-  trackingID: string;
-  anonymizeIP: boolean;
-};
+declare module '@docusaurus/plugin-google-gtag' {
+  export type PluginOptions = {
+    trackingID: string;
+    anonymizeIP: boolean;
+  };
 
-export type Options = Partial<PluginOptions>;
+  export type Options = Partial<PluginOptions>;
+}
+
+declare module '@theme/CookieConsent' {
+  export default function CookieConsent(): JSX.Element;
+}

--- a/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/plugin-google-gtag.d.ts
@@ -15,5 +15,5 @@ declare module '@docusaurus/plugin-google-gtag' {
 }
 
 declare module '@theme/CookieConsent' {
-  export default function CookieConsent(): JSX.Element;
+  export default function CookieConsent(): JSX.Element | null;
 }

--- a/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
+++ b/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
@@ -36,7 +36,7 @@ export default function CookieConsent(): JSX.Element | null {
           type="button"
           className={clsx('clean-btn', styles.button)}
           onClick={() => {
-            storage.set('true');
+            storage.set('false');
             setDismissed(true);
           }}>
           Deny

--- a/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
+++ b/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
@@ -20,7 +20,8 @@ export default function CookieConsent(): JSX.Element | null {
   return (
     <div className={styles.banner}>
       <p className={styles.text}>
-        This website uses Cookies to help the developers improve.
+        This website uses cookies to help us improve. Click &quot;accept&quot;
+        to allow us to continue using cookies.
       </p>
       <div className={styles.buttons}>
         <button

--- a/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
+++ b/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+import {createStorageSlot} from '@docusaurus/theme-common';
+
+const storage = createStorageSlot('docusaurus.cookieConsent');
+
+export default function CookieConsent(): JSX.Element {
+  return (
+    <div className={styles.banner}>
+      <p className={styles.text}>
+        This website uses Cookies to help the developers improve.
+      </p>
+      <div className={styles.buttons}>
+        <button
+          type="button"
+          className={clsx('clean-btn', styles.button)}
+          onClick={() => {
+            storage.set('true');
+          }}>
+          Accept
+        </button>
+        <button
+          type="button"
+          className={clsx('clean-btn', styles.button)}
+          onClick={() => {
+            storage.set('true');
+          }}>
+          Deny
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
+++ b/packages/docusaurus-plugin-google-gtag/src/theme/CookieConsent.tsx
@@ -5,14 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 import {createStorageSlot} from '@docusaurus/theme-common';
 
 const storage = createStorageSlot('docusaurus.cookieConsent');
 
-export default function CookieConsent(): JSX.Element {
+export default function CookieConsent(): JSX.Element | null {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed) {
+    return null;
+  }
   return (
     <div className={styles.banner}>
       <p className={styles.text}>
@@ -24,6 +28,7 @@ export default function CookieConsent(): JSX.Element {
           className={clsx('clean-btn', styles.button)}
           onClick={() => {
             storage.set('true');
+            setDismissed(true);
           }}>
           Accept
         </button>
@@ -32,6 +37,7 @@ export default function CookieConsent(): JSX.Element {
           className={clsx('clean-btn', styles.button)}
           onClick={() => {
             storage.set('true');
+            setDismissed(true);
           }}>
           Deny
         </button>

--- a/packages/docusaurus-plugin-google-gtag/src/theme/styles.module.css
+++ b/packages/docusaurus-plugin-google-gtag/src/theme/styles.module.css
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.banner {
+  background-color: var(--ifm-color-primary);
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 300px;
+  height: 200px;
+}
+
+.text {
+  padding: 20px;
+}
+
+.buttons {
+  position: absolute;
+  bottom: 30px;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.button {
+  flex-grow: 1;
+}

--- a/packages/docusaurus-plugin-google-gtag/src/theme/styles.module.css
+++ b/packages/docusaurus-plugin-google-gtag/src/theme/styles.module.css
@@ -6,27 +6,38 @@
  */
 
 .banner {
-  background-color: var(--ifm-color-primary);
+  background-color: var(--ifm-color-emphasis-200);
   position: fixed;
   bottom: 20px;
   right: 20px;
   width: 300px;
   height: 200px;
   border-radius: var(--ifm-global-radius);
+  box-shadow: 0 1.5px 6px 0 rgba(0, 0, 0, 0.15) inset;
 }
 
 .text {
-  padding: 20px;
+  font-size: small;
+  padding: 30px;
 }
 
 .buttons {
   position: absolute;
-  bottom: 30px;
+  bottom: 20px;
   display: flex;
   justify-content: center;
   width: 100%;
 }
 
 .button {
-  flex-grow: 1;
+  width: 100px;
+  background-color: #d0d0d0 !important;
+  margin: 10px;
+  /* TODO this is because the CSS is imported as a client module as well, and happens to be before Infima */
+  padding: 5px !important;
+  border-radius: var(--ifm-global-radius);
+}
+
+html[data-theme='dark'] .button {
+  background: #333333 !important;
 }

--- a/packages/docusaurus-plugin-google-gtag/src/theme/styles.module.css
+++ b/packages/docusaurus-plugin-google-gtag/src/theme/styles.module.css
@@ -12,6 +12,7 @@
   right: 20px;
   width: 300px;
   height: 200px;
+  border-radius: var(--ifm-global-radius);
 }
 
 .text {

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.browser.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.browser.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "jsx": "react-native"
+  },
+  "include": ["src/theme/", "src/*.d.ts"]
+}

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.server.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.server.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/*.ts"]
+}

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.server.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.server.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/*.ts"]
+  "include": ["src/*.ts", "src/*.tsx"]
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -300,11 +300,9 @@ const config = {
         theme: {
           customCss: [require.resolve('./src/css/custom.css')],
         },
-        gtag: !isDeployPreview
-          ? {
-              trackingID: 'UA-141789564-1',
-            }
-          : undefined,
+        gtag: {
+          trackingID: 'UA-141789564-1',
+        },
       }),
     ],
   ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #2407.

The current approach doesn't look clean enough because we need to check local storage on every route transition, but otherwise, the tracking only starts after the user refreshed and the site reloads with the new local storage value. 

Waiting to polish the banner design.

We can port this banner to google analytics after merging this one, or before it's ready to be merged.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Temporarily enabled the plugin in deploy preview to make it show up