### PR TITLE
docs: elaborate on Markdown asset linking; document pathname:// protocol

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-assets.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-assets.mdx
@@ -87,6 +87,12 @@ or
 
 </BrowserWindow>
 
+:::info markdown links are always file paths
+
+If you use the Markdown image or link syntax, all asset paths will be resolved as file paths by Docusaurus and automatically converted to `require()` calls. You don't need to use `require()` in Markdown unless you use the JSX syntax.
+
+:::
+
 ## Inline SVGs {#inline-svgs}
 
 Docusaurus supports inlining SVGs out of the box.
@@ -191,7 +197,15 @@ If a Markdown link or image has an absolute path, the path will be seen as a fil
 ![An image from the static](/img/docusaurus.png)
 ```
 
-Docusaurus will try to look for it in both `static/img/docusaurus.png` and `public/img/docusaurus.png`. The link will then be converted to a `require` call instead of staying as a URL. This is desirable in two regards:
+Docusaurus will try to look for it in both `static/img/docusaurus.png` and `public/img/docusaurus.png`. The link will then be converted to a `require()` call instead of staying as a URL. This is desirable in two regards:
 
 1. You don't have to worry about the base URL, which Docusaurus will take care of when serving the asset;
 2. The image enters Webpack's build pipeline and its name will be appended by a hash, which enables browsers to aggressively cache the image and improves your site's performance.
+
+If you intend to write URLs, you can use the `pathname://` protocol to disable automatic asset linking.
+
+```md
+![banner](pathname:///img/docusaurus-asset-example-banner.png)
+```
+
+This link will be generated as `<img src="/img/docusaurus-asset-example-banner.png" alt="banner" />`, without any processing or file existence checking.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

There's a bit of confusion in #6403.

@slorber It's time for us to formalize the `pathname://` protocol. We have many, many users using it now. Probably #3309 can be closed as well?

The non-SPA redirect part of the `pathname://` usage will be documented in #6296.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
