### PR TITLE
fix(content-docs): make getActivePlugin match plugin paths more exactly

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsClientUtils.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsClientUtils.test.ts
@@ -6,14 +6,17 @@
  */
 
 import {
-  type ActivePlugin,
   getActivePlugin,
   getLatestVersion,
   getActiveDocContext,
   getActiveVersion,
   getDocVersionSuggestions,
 } from '../docsClientUtils';
-import type {GlobalPluginData, GlobalVersion} from '../../types';
+import type {
+  GlobalPluginData,
+  GlobalVersion,
+  ActivePlugin,
+} from '@docusaurus/plugin-content-docs/client';
 import {shuffle} from 'lodash';
 
 describe('docsClientUtils', () => {
@@ -58,6 +61,34 @@ describe('docsClientUtils', () => {
     expect(getActivePlugin(data, '/android')).toEqual(activePluginAndroid);
     expect(getActivePlugin(data, '/android/')).toEqual(activePluginAndroid);
     expect(getActivePlugin(data, '/android/ijk')).toEqual(activePluginAndroid);
+
+    // https://github.com/facebook/docusaurus/issues/6434
+    const onePluginAtRoot = {
+      pluginIosId: {
+        path: '/',
+        versions: [],
+      },
+      pluginAndroidId: {
+        path: '/android',
+        versions: [],
+      },
+    };
+    expect(getActivePlugin(onePluginAtRoot, '/android/foo').pluginId).toEqual(
+      'pluginAndroidId',
+    );
+    const onePluginAtRootReversed = {
+      pluginAndroidId: {
+        path: '/android',
+        versions: [],
+      },
+      pluginIosId: {
+        path: '/',
+        versions: [],
+      },
+    };
+    expect(
+      getActivePlugin(onePluginAtRootReversed, '/android/foo').pluginId,
+    ).toEqual('pluginAndroidId');
   });
 
   test('getLatestVersion', () => {

--- a/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
@@ -31,7 +31,7 @@ export function getActivePlugin(
     // A quick route sorting: '/android/foo' should match '/android' instead of '/'
     .sort((a, b) => b[1].path.localeCompare(a[1].path))
     .find(
-      ([_id, pluginData]) =>
+      ([, pluginData]) =>
         !!matchPath(pathname, {
           path: pluginData.path,
           exact: false,

--- a/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsClientUtils.ts
@@ -27,14 +27,17 @@ export function getActivePlugin(
   pathname: string,
   options: GetActivePluginOptions = {},
 ): ActivePlugin | undefined {
-  const activeEntry = Object.entries(allPluginDatas).find(
-    ([_id, pluginData]) =>
-      !!matchPath(pathname, {
-        path: pluginData.path,
-        exact: false,
-        strict: false,
-      }),
-  );
+  const activeEntry = Object.entries(allPluginDatas)
+    // A quick route sorting: '/android/foo' should match '/android' instead of '/'
+    .sort((a, b) => b[1].path.localeCompare(a[1].path))
+    .find(
+      ([_id, pluginData]) =>
+        !!matchPath(pathname, {
+          path: pluginData.path,
+          exact: false,
+          strict: false,
+        }),
+    );
 
   const activePlugin: ActivePlugin | undefined = activeEntry
     ? {pluginId: activeEntry[0], pluginData: activeEntry[1]}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #6434 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added two tests