### PR TITLE
misc: fix stylelint erroring when lint-staged passed ignored file

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
       "eslint --fix"
     ],
     "*.css": [
-      "stylelint --fix"
+      "stylelint --allow-empty-input --fix"
     ],
     "*": [
       "prettier --ignore-unknown --write"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This would fix the "no paths match..." error in lint-staged.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
