### PR TITLE
fix(website): update colors correctly when palette is only customized in one color mode

### DIFF
--- a/website/src/theme/Toggle.tsx
+++ b/website/src/theme/Toggle.tsx
@@ -13,6 +13,11 @@ import {
   darkStorage,
   type ColorState,
   updateDOMColors,
+  LIGHT_PRIMARY_COLOR,
+  DARK_PRIMARY_COLOR,
+  LIGHT_BACKGROUND_COLOR,
+  DARK_BACKGROUND_COLOR,
+  COLOR_SHADES,
 } from '@site/src/utils/colorUtils';
 
 // The ColorGenerator modifies the DOM styles. The styles are persisted in
@@ -27,12 +32,14 @@ export default function Toggle(props: Props): JSX.Element {
         props.onChange(e);
         const isDarkMode = e.target.checked;
         const storage = isDarkMode ? darkStorage : lightStorage;
-        const colorState = JSON.parse(
-          storage.get() ?? 'null',
-        ) as ColorState | null;
-        if (colorState) {
-          updateDOMColors(colorState);
-        }
+        const colorState: ColorState = JSON.parse(storage.get() ?? 'null') ?? {
+          baseColor: isDarkMode ? DARK_PRIMARY_COLOR : LIGHT_PRIMARY_COLOR,
+          background: isDarkMode
+            ? DARK_BACKGROUND_COLOR
+            : LIGHT_BACKGROUND_COLOR,
+          shades: COLOR_SHADES,
+        };
+        updateDOMColors(colorState);
       }}
     />
   );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

An edge case where the colors have been hardcoded in the DOM but the other color mode doesn't exist yet (because right before merging #5822 we removed the effect that save both color modes during init). We should always use JS to manipulate styles provided JS is available—there isn't harm in doing so.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
