### PR TITLE
fix(utils): do not resolve Markdown paths with @site prefix

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
@@ -30,6 +30,7 @@ describe('replaceMarkdownLinks', () => {
 [http](http://github.com/facebook/docusaurus/README.md)
 [https](https://github.com/facebook/docusaurus/README.md)
 [asset](./foo.js)
+[asset as well](@site/docs/_partial.md)
 [looks like http...](http.foo.md)
 [nonexistent](hmmm.md)
 `,
@@ -53,6 +54,7 @@ describe('replaceMarkdownLinks', () => {
       [http](http://github.com/facebook/docusaurus/README.md)
       [https](https://github.com/facebook/docusaurus/README.md)
       [asset](./foo.js)
+      [asset as well](@site/docs/_partial.md)
       [looks like http...](/doc/http)
       [nonexistent](hmmm.md)
       ",

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -65,7 +65,7 @@ export function replaceMarkdownLinks<T extends ContentPaths>({
     // This is [Document 1](doc1.md) -> we replace this doc1.md with correct link
     // [doc1]: doc1.md -> we replace this doc1.md with correct link
     const mdRegex =
-      /(?:(?:\]\()|(?:\]:\s?))(?!https?:\/\/)([^'")\]\s>]+\.mdx?)/g;
+      /(?:(?:\]\()|(?:\]:\s?))(?!https?:\/\/|@site\/)([^'")\]\s>]+\.mdx?)/g;
     let mdMatch = mdRegex.exec(modifiedLine);
     while (mdMatch !== null) {
       // Replace it to correct html link.

--- a/website/docs/advanced/routing.md
+++ b/website/docs/advanced/routing.md
@@ -75,6 +75,8 @@ Throughout the documentation, we always try to be unambiguous about whether we a
 
 When writing links in Markdown, you could either mean a _file path_, or a _URL path_, which Docusaurus would use several heuristics to determine.
 
+- If the path has a `@site` prefix, it is _always_ an asset file path.
+- If the path has an `http(s)://` prefix, it is _always_ a URL path.
 - If the path doesn't have an extension, it is a URL path. For example, a link `[page](../plugins)` on a page with URL `/docs/advanced/routing` will link to `/docs/plugins`. Docusaurus will only detect broken links when building your site (when it knows the full route structure), but will make no assumptions about the existence of a file. It is exactly equivalent to writing `<a href="../plugins">page</a>` in a JSX file.
 - If the path has an `.md(x)` extension, Docusaurus would try to resolve that Markdown file to a URL, and replace the file path with a URL path.
 - If the path has any other extension, Docusaurus would treat it as [an asset](../guides/markdown-features/markdown-features-assets.mdx) and bundle it.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Reported in https://github.com/facebook/docusaurus/pull/5782#issuecomment-1022808093. `@site` prefix _always_ indicates an asset.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test case