### PR TITLE
fix(theme-classic): do not switch color modes when printing

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -45,11 +45,7 @@ const noFlashColorMode = ({
   }
 
   var storedTheme = getStoredTheme();
-
-  // print doesn't print background colors by default, so we coerce to light
-  if (window.matchMedia('print').matches) {
-    setDataThemeAttribute('light');
-  } else if (storedTheme !== null) {
+  if (storedTheme !== null) {
     setDataThemeAttribute(storedTheme);
   } else {
     if (

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -22,13 +22,15 @@ const requireFromDocusaurusCore = createRequire(
 const ContextReplacementPlugin: typeof webpack.ContextReplacementPlugin =
   requireFromDocusaurusCore('webpack/lib/ContextReplacementPlugin');
 
+const js = String.raw;
+
 // Need to be inlined to prevent dark mode FOUC
 // Make sure that the 'storageKey' is the same as the one in `/theme/hooks/useTheme.js`
 const ThemeStorageKey = 'theme';
 const noFlashColorMode = ({
   defaultMode,
   respectPrefersColorScheme,
-}: ThemeConfig['colorMode']) => `(function() {
+}: ThemeConfig['colorMode']) => js`(function() {
   var defaultMode = '${defaultMode}';
   var respectPrefersColorScheme = ${respectPrefersColorScheme};
 
@@ -45,7 +47,11 @@ const noFlashColorMode = ({
   }
 
   var storedTheme = getStoredTheme();
-  if (storedTheme !== null) {
+
+  // print doesn't print background colors by default, so we coerce to light
+  if (window.matchMedia('print').matches) {
+    setDataThemeAttribute('light');
+  } else if (storedTheme !== null) {
     setDataThemeAttribute(storedTheme);
   } else {
     if (

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -22,15 +22,13 @@ const requireFromDocusaurusCore = createRequire(
 const ContextReplacementPlugin: typeof webpack.ContextReplacementPlugin =
   requireFromDocusaurusCore('webpack/lib/ContextReplacementPlugin');
 
-const js = String.raw;
-
 // Need to be inlined to prevent dark mode FOUC
 // Make sure that the 'storageKey' is the same as the one in `/theme/hooks/useTheme.js`
 const ThemeStorageKey = 'theme';
 const noFlashColorMode = ({
   defaultMode,
   respectPrefersColorScheme,
-}: ThemeConfig['colorMode']) => js`(function() {
+}: ThemeConfig['colorMode']) => `(function() {
   var defaultMode = '${defaultMode}';
   var respectPrefersColorScheme = ${respectPrefersColorScheme};
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #6479.

We probably misunderstood the issue. The actual offending place is the media query listener. You can try with this minimal HTML:

```html
<body>
  <script>
    window.matchMedia('(prefers-color-scheme: dark)').addListener((e) => {
      console.log('dark', e.matches);
      console.log('print', window.matchMedia('print').matches);
    });
  </script>
</body>
```

When you press print, the PCS is coerced to light mode during printing, but then it was switched back to dark mode. This is because when printing, the browser wants the app to behave like it's in light mode. So the actual fix is to get rid of this fluctuation.

Problem is, which behavior do we actually prefer? Coercing the entire app to light mode when printing (and make the print result always look like light mode), or respect the current color mode? However, previously, printing in dark mode results in bad colors anyways (lighter theme color on a white background), so at least there isn't a regression with this change...

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Follow the repro steps in #6479; now when printing in dark mode, no changes are made.