### PR TITLE
docs: mention where to find the sitemap

### DIFF
--- a/website/docs/api/plugins/plugin-sitemap.md
+++ b/website/docs/api/plugins/plugin-sitemap.md
@@ -70,3 +70,5 @@ const config = {
   priority: 0.5,
 };
 ```
+
+You can find your sitemap in `/sitemap.xml`

--- a/website/docs/api/plugins/plugin-sitemap.md
+++ b/website/docs/api/plugins/plugin-sitemap.md
@@ -71,4 +71,4 @@ const config = {
 };
 ```
 
-You can find your sitemap in `/sitemap.xml`
+You can find your sitemap at `/sitemap.xml`.


### PR DESCRIPTION
So that users know where to locate their sitemaps

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I didn't see the URL to the sitemap so I took a guess. For the other users who don't know where to locate the sitemap, this is handy.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I did not made any code changes.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/docusaurus, and link to your PR here.)
