### PR TITLE
fix(content-docs): render category with no subitems as a normal link

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/props.ts
+++ b/packages/docusaurus-plugin-content-docs/src/props.ts
@@ -70,9 +70,25 @@ Available document ids are:
     }
   }
 
-  function convertCategory(item: SidebarItemCategory): PropSidebarItemCategory {
+  function convertCategory(
+    item: SidebarItemCategory,
+  ): PropSidebarItemCategory | PropSidebarItemLink {
     const {link, ...rest} = item;
     const href = getCategoryLinkHref(link);
+    // If the current category doesn't have subitems, we render a normal doc link instead.
+    if (item.items.length === 0) {
+      if (!href) {
+        throw new Error(
+          `Sidebar category ${item.label} has neither any subitem nor a link. This makes this item not able to link to anything.`,
+        );
+      }
+      return {
+        type: 'link',
+        href,
+        label: item.label,
+        docId: item.link?.type === 'doc' ? item.link.id : undefined,
+      };
+    }
     return {...rest, items: item.items.map(normalizeItem), ...(href && {href})};
   }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -38,9 +38,6 @@ export default function DocSidebarItem({
 }: Props): JSX.Element | null {
   switch (item.type) {
     case 'category':
-      if (item.items.length === 0) {
-        return null;
-      }
       return <DocSidebarItemCategory item={item} {...props} />;
     case 'link':
     default:

--- a/website/_dogfooding/_docs tests/tests/category-links/no-subdoc/index.md
+++ b/website/_dogfooding/_docs tests/tests/category-links/no-subdoc/index.md
@@ -1,0 +1,3 @@
+# No sub-docs
+
+The only doc of this category is the index page. It should show up as a regular doc link.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix #6301. I think this is the most sensible fix?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a dogfooding example
