### PR TITLE
fix(core): configValidation should allow inline theme functions

### DIFF
--- a/packages/docusaurus/src/server/__tests__/__snapshots__/configValidation.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/configValidation.test.ts.snap
@@ -108,7 +108,76 @@ exports[`normalizeConfig should throw error if scripts doesn't have src 1`] = `
 "
 `;
 
+exports[`normalizeConfig should throw error if themes is not a string and it's not an array #1 for the input of: [123] 1`] = `
+" => Bad Docusaurus theme value as path [themes,0].
+Example valid theme config:
+{
+  themes: [
+    [\\"@docusaurus/theme-classic\\",options],
+    \\"./myTheme\\",
+    [\\"./myTheme\\",{someOption: 42}],
+    function myTheme() { },
+    [function myTheme() { },options]
+  ],
+};
+
+"
+`;
+
+exports[`normalizeConfig should throw error if themes is not an array of [string, object][] #1 for the input of: [[Array]] 1`] = `
+" => Bad Docusaurus theme value as path [themes,0].
+Example valid theme config:
+{
+  themes: [
+    [\\"@docusaurus/theme-classic\\",options],
+    \\"./myTheme\\",
+    [\\"./myTheme\\",{someOption: 42}],
+    function myTheme() { },
+    [function myTheme() { },options]
+  ],
+};
+
+"
+`;
+
+exports[`normalizeConfig should throw error if themes is not an array of [string, object][] #2 for the input of: [[Array]] 1`] = `
+" => Bad Docusaurus theme value as path [themes,0].
+Example valid theme config:
+{
+  themes: [
+    [\\"@docusaurus/theme-classic\\",options],
+    \\"./myTheme\\",
+    [\\"./myTheme\\",{someOption: 42}],
+    function myTheme() { },
+    [function myTheme() { },options]
+  ],
+};
+
+"
+`;
+
+exports[`normalizeConfig should throw error if themes is not an array of [string, object][] #3 for the input of: [[Array]] 1`] = `
+" => Bad Docusaurus theme value as path [themes,0].
+Example valid theme config:
+{
+  themes: [
+    [\\"@docusaurus/theme-classic\\",options],
+    \\"./myTheme\\",
+    [\\"./myTheme\\",{someOption: 42}],
+    function myTheme() { },
+    [function myTheme() { },options]
+  ],
+};
+
+"
+`;
+
 exports[`normalizeConfig should throw error if themes is not array 1`] = `
+"\\"themes\\" must be an array
+"
+`;
+
+exports[`normalizeConfig should throw error if themes is not array for the input of: {} 1`] = `
 "\\"themes\\" must be an array
 "
 `;

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -118,6 +118,32 @@ describe('normalizeConfig', () => {
   });
 
   test.each([
+    ['should throw error if themes is not array', {}],
+    [
+      "should throw error if themes is not a string and it's not an array #1",
+      [123],
+    ],
+    [
+      'should throw error if themes is not an array of [string, object][] #1',
+      [['example/path', 'wrong parameter here']],
+    ],
+    [
+      'should throw error if themes is not an array of [string, object][] #2',
+      [[{}, 'example/path']],
+    ],
+    [
+      'should throw error if themes is not an array of [string, object][] #3',
+      [[{}, {}]],
+    ],
+  ])(`%s for the input of: %p`, (_message, themes) => {
+    expect(() => {
+      normalizeConfig({
+        themes,
+      });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test.each([
     ['should accept [string] for plugins', ['plain/string']],
     [
       'should accept string[] for plugins',
@@ -151,6 +177,44 @@ describe('normalizeConfig', () => {
     expect(() => {
       normalizeConfig({
         plugins,
+      });
+    }).not.toThrowError();
+  });
+
+  test.each([
+    ['should accept [string] for themes', ['plain/string']],
+    [
+      'should accept string[] for themes',
+      ['plain/string', 'another/plain/string/path'],
+    ],
+    [
+      'should accept [string, object] for themes',
+      [['plain/string', {it: 'should work'}]],
+    ],
+    [
+      'should accept [string, object][] for themes',
+      [
+        ['plain/string', {it: 'should work'}],
+        ['this/should/work', {too: 'yes'}],
+      ],
+    ],
+    [
+      'should accept ([string, object]|string)[] for themes',
+      [
+        'plain/string',
+        ['plain', {it: 'should work'}],
+        ['this/should/work', {too: 'yes'}],
+      ],
+    ],
+    ['should accept function for theme', [function (_context, _options) {}]],
+    [
+      'should accept [function, object] for theme',
+      [[function (_context, _options) {}, {it: 'should work'}]],
+    ],
+  ])(`%s for the input of: %p`, (_message, themes) => {
+    expect(() => {
+      normalizeConfig({
+        themes,
       });
     }).not.toThrowError();
   });


### PR DESCRIPTION

## Motivation

It is technically legal/valid and it works to provide a theme as an inline function instead of a module name

The validation was wrong, and will now accept such inline function


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests

