### PR TITLE
fix(theme-classic): apply width/height for footer logos without href

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -179,7 +179,12 @@ function Footer(): JSX.Element | null {
                     />
                   </Link>
                 ) : (
-                  <FooterLogo alt={logo.alt} sources={sources} />
+                  <FooterLogo
+                    alt={logo.alt}
+                    sources={sources}
+                    width={logo.width}
+                    height={logo.height}
+                  />
                 )}
               </div>
             )}


### PR DESCRIPTION

## Motivation

Fixes #6503 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I manually tested the `Footer` component using my local packages to ensure the `height` and `width` attributes were set on the logo image element with the following configuration:
```
footer: {
  logo: {
    alt: "Logo",
    src: "img/logo.png",
    height: 50,
    width: 50,
  }
}
```
