### PR TITLE
refactor: mark all functions that import external modules as async

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,8 +28,8 @@
 *.swp binary
 *.webp binary
 
-# Make GitHub not index certain files in the languages overview and minify their diff
+# Make GitHub not index certain files in the languages overview and/or minify their diff
 # See https://github.com/github/linguist/blob/master/docs/overrides.md
-__fixtures__ linguist-generated
-website linguist-documentation
-admin linguist-documentation
+__fixtures__/**  linguist-generated
+website/**       linguist-documentation
+admin/**         linguist-documentation

--- a/packages/docusaurus-migrate/src/index.ts
+++ b/packages/docusaurus-migrate/src/index.ts
@@ -78,7 +78,7 @@ export async function migrateDocusaurusProject(
   shouldMigrateMdFiles: boolean = false,
   shouldMigratePages: boolean = false,
 ): Promise<void> {
-  function createMigrationContext(): MigrationContext {
+  async function createMigrationContext(): Promise<MigrationContext> {
     const v1Config = importFresh(`${siteDir}/siteConfig`) as VersionOneConfig;
     logger.info('Starting migration from v1 to v2...');
     const partialMigrationContext = {
@@ -95,7 +95,7 @@ export async function migrateDocusaurusProject(
     };
   }
 
-  const migrationContext = createMigrationContext();
+  const migrationContext = await createMigrationContext();
 
   // TODO need refactor legacy, we pass migrationContext to all methods
   const siteConfig = migrationContext.v1Config;
@@ -187,7 +187,7 @@ export async function migrateDocusaurusProject(
     errorCount += 1;
   }
   try {
-    migratePackageFile(siteDir, deps, newDir);
+    await migratePackageFile(siteDir, deps, newDir);
   } catch (e) {
     logger.error(
       `Error occurred while creating package.json file for project: ${e}`,
@@ -715,11 +715,11 @@ function migrateLatestDocs(
   }
 }
 
-function migratePackageFile(
+async function migratePackageFile(
   siteDir: string,
   deps: {[key: string]: string},
   newDir: string,
-): void {
+): Promise<void> {
   const packageFile = importFresh(`${siteDir}/package.json`) as {
     scripts?: Record<string, string>;
     dependencies?: Record<string, string>;

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/cli.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/cli.test.ts
@@ -32,159 +32,159 @@ describe('docsVersion', () => {
     sidebarCollapsible: true,
   };
 
-  test('no version tag provided', () => {
-    expect(() =>
+  test('no version tag provided', async () => {
+    await expect(() =>
       cliDocsVersionCommand(
         null,
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: no version tag specified! Pass the version you wish to create as an argument, for example: 1.0.0."`,
     );
-    expect(() =>
+    await expect(() =>
       cliDocsVersionCommand(
         undefined,
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: no version tag specified! Pass the version you wish to create as an argument, for example: 1.0.0."`,
     );
-    expect(() =>
+    await expect(() =>
       cliDocsVersionCommand(
         '',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: no version tag specified! Pass the version you wish to create as an argument, for example: 1.0.0."`,
     );
   });
 
-  test('version tag should not have slash', () => {
-    expect(() =>
+  test('version tag should not have slash', async () => {
+    await expect(() =>
       cliDocsVersionCommand(
         'foo/bar',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Do not include slash (/) or backslash (\\\\). Try something like: 1.0.0."`,
     );
-    expect(() =>
+    await expect(() =>
       cliDocsVersionCommand(
         'foo\\bar',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Do not include slash (/) or backslash (\\\\). Try something like: 1.0.0."`,
     );
   });
 
-  test('version tag should not be too long', () => {
-    expect(() =>
+  test('version tag should not be too long', async () => {
+    await expect(() =>
       cliDocsVersionCommand(
         'a'.repeat(255),
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Length cannot exceed 32 characters. Try something like: 1.0.0."`,
     );
   });
 
-  test('version tag should not be a dot or two dots', () => {
-    expect(() =>
+  test('version tag should not be a dot or two dots', async () => {
+    await expect(() =>
       cliDocsVersionCommand(
         '..',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Do not name your version \\".\\" or \\"..\\". Try something like: 1.0.0."`,
     );
-    expect(() =>
+    await expect(() =>
       cliDocsVersionCommand(
         '.',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Do not name your version \\".\\" or \\"..\\". Try something like: 1.0.0."`,
     );
   });
 
-  test('version tag should be a valid pathname', () => {
-    expect(() =>
+  test('version tag should be a valid pathname', async () => {
+    await expect(() =>
       cliDocsVersionCommand(
         '<foo|bar>',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Please ensure its a valid pathname too. Try something like: 1.0.0."`,
     );
-    expect(() =>
+    await expect(() =>
       cliDocsVersionCommand(
         'foo\x00bar',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Please ensure its a valid pathname too. Try something like: 1.0.0."`,
     );
-    expect(() =>
+    await expect(() =>
       cliDocsVersionCommand(
         'foo:bar',
         simpleSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: invalid version tag specified! Please ensure its a valid pathname too. Try something like: 1.0.0."`,
     );
   });
 
-  test('version tag already exist', () => {
-    expect(() =>
+  test('version tag already exist', async () => {
+    await expect(() =>
       cliDocsVersionCommand(
         '1.0.0',
         versionedSiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: this version already exists! Use a version tag that does not already exist."`,
     );
   });
 
-  test('no docs file to version', () => {
+  test('no docs file to version', async () => {
     const emptySiteDir = path.join(fixtureDir, 'empty-site');
-    expect(() =>
+    await expect(() =>
       cliDocsVersionCommand(
         '1.0.0',
         emptySiteDir,
         DEFAULT_PLUGIN_ID,
         DEFAULT_OPTIONS,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"[docs]: there is no docs to version!"`,
     );
   });
 
-  test('first time versioning', () => {
+  test('first time versioning', async () => {
     const copyMock = jest.spyOn(fs, 'copySync').mockImplementation();
     const ensureMock = jest.spyOn(fs, 'ensureDirSync').mockImplementation();
     const writeMock = jest.spyOn(fs, 'writeFileSync');
@@ -205,7 +205,12 @@ describe('docsVersion', () => {
       ...DEFAULT_OPTIONS,
       sidebarPath: path.join(simpleSiteDir, 'sidebars.json'),
     };
-    cliDocsVersionCommand('1.0.0', simpleSiteDir, DEFAULT_PLUGIN_ID, options);
+    await cliDocsVersionCommand(
+      '1.0.0',
+      simpleSiteDir,
+      DEFAULT_PLUGIN_ID,
+      options,
+    );
     expect(copyMock).toHaveBeenCalledWith(
       path.join(simpleSiteDir, options.path),
       path.join(
@@ -236,7 +241,7 @@ describe('docsVersion', () => {
     ensureMock.mockRestore();
   });
 
-  test('not the first time versioning', () => {
+  test('not the first time versioning', async () => {
     const copyMock = jest.spyOn(fs, 'copySync').mockImplementation();
     const ensureMock = jest.spyOn(fs, 'ensureDirSync').mockImplementation();
     const writeMock = jest.spyOn(fs, 'writeFileSync');
@@ -257,7 +262,7 @@ describe('docsVersion', () => {
       ...DEFAULT_OPTIONS,
       sidebarPath: path.join(versionedSiteDir, 'sidebars.json'),
     };
-    cliDocsVersionCommand(
+    await cliDocsVersionCommand(
       '2.0.0',
       versionedSiteDir,
       DEFAULT_PLUGIN_ID,
@@ -293,7 +298,7 @@ describe('docsVersion', () => {
     ensureMock.mockRestore();
   });
 
-  test('second docs instance versioning', () => {
+  test('second docs instance versioning', async () => {
     const pluginId = 'community';
 
     const copyMock = jest.spyOn(fs, 'copySync').mockImplementation();
@@ -317,7 +322,7 @@ describe('docsVersion', () => {
       path: 'community',
       sidebarPath: path.join(versionedSiteDir, 'community_sidebars.json'),
     };
-    cliDocsVersionCommand('2.0.0', versionedSiteDir, pluginId, options);
+    await cliDocsVersionCommand('2.0.0', versionedSiteDir, pluginId, options);
     expect(copyMock).toHaveBeenCalledWith(
       path.join(versionedSiteDir, options.path),
       path.join(

--- a/packages/docusaurus-plugin-content-docs/src/cli.ts
+++ b/packages/docusaurus-plugin-content-docs/src/cli.ts
@@ -20,7 +20,7 @@ import {loadSidebarsFile, resolveSidebarPathOption} from './sidebars';
 import {DEFAULT_PLUGIN_ID} from '@docusaurus/utils';
 import logger from '@docusaurus/logger';
 
-function createVersionedSidebarFile({
+async function createVersionedSidebarFile({
   siteDir,
   pluginId,
   sidebarPath,
@@ -34,7 +34,7 @@ function createVersionedSidebarFile({
   // Load current sidebar and create a new versioned sidebars file (if needed).
   // Note: we don't need the sidebars file to be normalized: it's ok to let
   // plugin option changes to impact older, versioned sidebars
-  const sidebars = loadSidebarsFile(sidebarPath);
+  const sidebars = await loadSidebarsFile(sidebarPath);
 
   // Do not create a useless versioned sidebars file if sidebars file is empty
   // or sidebars are disabled/false)
@@ -56,12 +56,12 @@ function createVersionedSidebarFile({
 }
 
 // Tests depend on non-default export for mocking.
-export function cliDocsVersionCommand(
+export async function cliDocsVersionCommand(
   version: string | null | undefined,
   siteDir: string,
   pluginId: string,
   options: PathOptions & SidebarOptions,
-): void {
+): Promise<void> {
   // It wouldn't be very user-friendly to show a [default] log prefix,
   // so we use [docs] instead of [default]
   const pluginIdLogPrefix =
@@ -127,7 +127,7 @@ export function cliDocsVersionCommand(
     throw new Error(`${pluginIdLogPrefix}: there is no docs to version!`);
   }
 
-  createVersionedSidebarFile({
+  await createVersionedSidebarFile({
     siteDir,
     pluginId,
     version,

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/index.test.ts
@@ -25,13 +25,13 @@ describe('loadNormalizedSidebars', () => {
   };
   test('sidebars with known sidebar item type', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars.json');
-    const result = loadNormalizedSidebars(sidebarPath, options);
+    const result = await loadNormalizedSidebars(sidebarPath, options);
     expect(result).toMatchSnapshot();
   });
 
   test('sidebars with deep level of category', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-category.js');
-    const result = loadNormalizedSidebars(sidebarPath, options);
+    const result = await loadNormalizedSidebars(sidebarPath, options);
     expect(result).toMatchSnapshot();
   });
 
@@ -41,8 +41,8 @@ describe('loadNormalizedSidebars', () => {
       fixtureDir,
       'sidebars-category-shorthand.js',
     );
-    const sidebar1 = loadNormalizedSidebars(sidebarPath1, options);
-    const sidebar2 = loadNormalizedSidebars(sidebarPath2, options);
+    const sidebar1 = await loadNormalizedSidebars(sidebarPath1, options);
+    const sidebar2 = await loadNormalizedSidebars(sidebarPath2, options);
     expect(sidebar1).toEqual(sidebar2);
   });
 
@@ -51,7 +51,7 @@ describe('loadNormalizedSidebars', () => {
       fixtureDir,
       'sidebars-category-wrong-items.json',
     );
-    expect(() => loadNormalizedSidebars(sidebarPath, options))
+    await expect(() => loadNormalizedSidebars(sidebarPath, options)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "{
         \\"type\\": \\"category\\",
@@ -68,7 +68,7 @@ describe('loadNormalizedSidebars', () => {
       fixtureDir,
       'sidebars-category-wrong-label.json',
     );
-    expect(() => loadNormalizedSidebars(sidebarPath, options))
+    await expect(() => loadNormalizedSidebars(sidebarPath, options)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "{
         \\"type\\": \\"category\\",
@@ -87,7 +87,7 @@ describe('loadNormalizedSidebars', () => {
       fixtureDir,
       'sidebars-doc-id-not-string.json',
     );
-    expect(() => loadNormalizedSidebars(sidebarPath, options))
+    await expect(() => loadNormalizedSidebars(sidebarPath, options)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "{
         \\"type\\": \\"doc\\",
@@ -105,19 +105,19 @@ describe('loadNormalizedSidebars', () => {
       fixtureDir,
       'sidebars-first-level-not-category.js',
     );
-    const result = loadNormalizedSidebars(sidebarPath, options);
+    const result = await loadNormalizedSidebars(sidebarPath, options);
     expect(result).toMatchSnapshot();
   });
 
   test('sidebars link', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-link.json');
-    const result = loadNormalizedSidebars(sidebarPath, options);
+    const result = await loadNormalizedSidebars(sidebarPath, options);
     expect(result).toMatchSnapshot();
   });
 
   test('sidebars link wrong label', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-link-wrong-label.json');
-    expect(() => loadNormalizedSidebars(sidebarPath, options))
+    await expect(() => loadNormalizedSidebars(sidebarPath, options)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "{
         \\"type\\": \\"link\\",
@@ -131,7 +131,7 @@ describe('loadNormalizedSidebars', () => {
 
   test('sidebars link wrong href', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-link-wrong-href.json');
-    expect(() => loadNormalizedSidebars(sidebarPath, options))
+    await expect(() => loadNormalizedSidebars(sidebarPath, options)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "{
         \\"type\\": \\"link\\",
@@ -147,7 +147,7 @@ describe('loadNormalizedSidebars', () => {
 
   test('sidebars with unknown sidebar item type', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-unknown-type.json');
-    expect(() => loadNormalizedSidebars(sidebarPath, options))
+    await expect(() => loadNormalizedSidebars(sidebarPath, options)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "{
         \\"type\\": \\"superman\\",
@@ -160,7 +160,7 @@ describe('loadNormalizedSidebars', () => {
 
   test('sidebars with known sidebar item type but wrong field', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-wrong-field.json');
-    expect(() => loadNormalizedSidebars(sidebarPath, options))
+    await expect(() => loadNormalizedSidebars(sidebarPath, options)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "{
         \\"type\\": \\"category\\",
@@ -173,23 +173,27 @@ describe('loadNormalizedSidebars', () => {
     `);
   });
 
-  test('unexisting path', () => {
-    expect(loadNormalizedSidebars('badpath', options)).toEqual(
+  test('unexisting path', async () => {
+    await expect(loadNormalizedSidebars('badpath', options)).resolves.toEqual(
       DisabledSidebars,
     );
   });
 
-  test('undefined path', () => {
-    expect(loadNormalizedSidebars(undefined, options)).toEqual(DefaultSidebars);
+  test('undefined path', async () => {
+    await expect(loadNormalizedSidebars(undefined, options)).resolves.toEqual(
+      DefaultSidebars,
+    );
   });
 
-  test('literal false path', () => {
-    expect(loadNormalizedSidebars(false, options)).toEqual(DisabledSidebars);
+  test('literal false path', async () => {
+    await expect(loadNormalizedSidebars(false, options)).resolves.toEqual(
+      DisabledSidebars,
+    );
   });
 
   test('sidebars with category.collapsed property', async () => {
     const sidebarPath = path.join(fixtureDir, 'sidebars-collapsed.json');
-    const result = loadNormalizedSidebars(sidebarPath, options);
+    const result = await loadNormalizedSidebars(sidebarPath, options);
     expect(result).toMatchSnapshot();
   });
 
@@ -198,7 +202,7 @@ describe('loadNormalizedSidebars', () => {
       fixtureDir,
       'sidebars-collapsed-first-level.json',
     );
-    const result = loadNormalizedSidebars(sidebarPath, options);
+    const result = await loadNormalizedSidebars(sidebarPath, options);
     expect(result).toMatchSnapshot();
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/index.ts
@@ -38,9 +38,9 @@ export function resolveSidebarPathOption(
     : sidebarPathOption;
 }
 
-function loadSidebarsFileUnsafe(
+async function loadSidebarsFileUnsafe(
   sidebarFilePath: string | false | undefined,
-): SidebarsConfig {
+): Promise<SidebarsConfig> {
   // false => no sidebars
   if (sidebarFilePath === false) {
     return DisabledSidebars;
@@ -62,19 +62,19 @@ function loadSidebarsFileUnsafe(
   return importFresh(sidebarFilePath);
 }
 
-export function loadSidebarsFile(
+export async function loadSidebarsFile(
   sidebarFilePath: string | false | undefined,
-): SidebarsConfig {
-  const sidebarsConfig = loadSidebarsFileUnsafe(sidebarFilePath);
+): Promise<SidebarsConfig> {
+  const sidebarsConfig = await loadSidebarsFileUnsafe(sidebarFilePath);
   validateSidebars(sidebarsConfig);
   return sidebarsConfig;
 }
 
-export function loadNormalizedSidebars(
+export async function loadNormalizedSidebars(
   sidebarFilePath: string | false | undefined,
   params: NormalizeSidebarsParams,
-): NormalizedSidebars {
-  return normalizeSidebars(loadSidebarsFile(sidebarFilePath), params);
+): Promise<NormalizedSidebars> {
+  return normalizeSidebars(await loadSidebarsFile(sidebarFilePath), params);
 }
 
 // Note: sidebarFilePath must be absolute, use resolveSidebarPathOption
@@ -87,7 +87,7 @@ export async function loadSidebars(
     version: options.version,
     categoryLabelSlugger: createSlugger(),
   };
-  const normalizedSidebars = loadNormalizedSidebars(
+  const normalizedSidebars = await loadNormalizedSidebars(
     sidebarFilePath,
     normalizeSidebarsParams,
   );

--- a/packages/docusaurus/src/commands/external.ts
+++ b/packages/docusaurus/src/commands/external.ts
@@ -14,7 +14,7 @@ export default async function externalCommand(
   siteDir: string,
 ): Promise<void> {
   const context = await loadContext(siteDir);
-  const pluginConfigs = loadPluginConfigs(context);
+  const pluginConfigs = await loadPluginConfigs(context);
   const plugins = await initPlugins({pluginConfigs, context});
 
   // Plugin Lifecycle - extendCli.

--- a/packages/docusaurus/src/commands/swizzle.ts
+++ b/packages/docusaurus/src/commands/swizzle.ts
@@ -147,7 +147,7 @@ export default async function swizzle(
   danger?: boolean,
 ): Promise<void> {
   const context = await loadContext(siteDir);
-  const pluginConfigs = loadPluginConfigs(context);
+  const pluginConfigs = await loadPluginConfigs(context);
   const pluginNames = getPluginNames(pluginConfigs);
   const plugins = await initPlugins({
     pluginConfigs,

--- a/packages/docusaurus/src/commands/writeHeadingIds.ts
+++ b/packages/docusaurus/src/commands/writeHeadingIds.ts
@@ -124,7 +124,7 @@ async function transformMarkdownFile(
  */
 async function getPathsToWatch(siteDir: string): Promise<string[]> {
   const context = await loadContext(siteDir);
-  const pluginConfigs = loadPluginConfigs(context);
+  const pluginConfigs = await loadPluginConfigs(context);
   const plugins = await initPlugins({
     pluginConfigs,
     context,

--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -80,7 +80,7 @@ export default async function writeTranslations(
     customConfigFilePath: options.config,
     locale: options.locale,
   });
-  const pluginConfigs = loadPluginConfigs(context);
+  const pluginConfigs = await loadPluginConfigs(context);
   const plugins = await initPlugins({
     pluginConfigs,
     context,

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -129,8 +129,12 @@ export async function loadContext(
   };
 }
 
-export function loadPluginConfigs(context: LoadContext): PluginConfig[] {
-  let {plugins: presetPlugins, themes: presetThemes} = loadPresets(context);
+export async function loadPluginConfigs(
+  context: LoadContext,
+): Promise<PluginConfig[]> {
+  let {plugins: presetPlugins, themes: presetThemes} = await loadPresets(
+    context,
+  );
   const {siteConfig, siteConfigPath} = context;
   const require = createRequire(siteConfigPath);
   function normalizeShorthand(
@@ -298,7 +302,7 @@ export async function load(
     codeTranslations,
   } = context;
   // Plugins.
-  const pluginConfigs: PluginConfig[] = loadPluginConfigs(context);
+  const pluginConfigs: PluginConfig[] = await loadPluginConfigs(context);
   const {plugins, pluginsRouteConfigs, globalData, themeConfigTranslated} =
     await loadPlugins({pluginConfigs, context});
 

--- a/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
@@ -20,7 +20,7 @@ describe('initPlugins', () => {
   async function loadSite(options: LoadContextOptions = {}) {
     const siteDir = path.join(__dirname, '__fixtures__', 'site-with-plugin');
     const context = await loadContext(siteDir, options);
-    const pluginConfigs = loadPluginConfigs(context);
+    const pluginConfigs = await loadPluginConfigs(context);
     const plugins = await initPlugins({
       pluginConfigs,
       context,

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -34,10 +34,10 @@ type NormalizedPluginConfig = {
   };
 };
 
-function normalizePluginConfig(
+async function normalizePluginConfig(
   pluginConfig: PluginConfig,
   pluginRequire: NodeRequire,
-): NormalizedPluginConfig {
+): Promise<NormalizedPluginConfig> {
   // plugins: ['./plugin']
   if (typeof pluginConfig === 'string') {
     const pluginModuleImport = pluginConfig;
@@ -182,7 +182,7 @@ export default async function initPlugins({
   async function initializePlugin(
     pluginConfig: PluginConfig,
   ): Promise<InitializedPlugin> {
-    const normalizedPluginConfig = normalizePluginConfig(
+    const normalizedPluginConfig = await normalizePluginConfig(
       pluginConfig,
       pluginRequire,
     );

--- a/packages/docusaurus/src/server/presets/__tests__/index.test.ts
+++ b/packages/docusaurus/src/server/presets/__tests__/index.test.ts
@@ -11,12 +11,12 @@ import loadPresets from '../index';
 import type {LoadContext} from '@docusaurus/types';
 
 describe('loadPresets', () => {
-  test('no presets', () => {
+  test('no presets', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {},
     } as LoadContext;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [],
@@ -25,14 +25,14 @@ describe('loadPresets', () => {
     `);
   });
 
-  test('string form', () => {
+  test('string form', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {
         presets: [path.join(__dirname, '__fixtures__/preset-bar.js')],
       },
     } as LoadContext;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [
@@ -50,7 +50,7 @@ describe('loadPresets', () => {
     `);
   });
 
-  test('string form composite', () => {
+  test('string form composite', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {
@@ -60,7 +60,7 @@ describe('loadPresets', () => {
         ],
       },
     } as LoadContext;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [
@@ -86,14 +86,14 @@ describe('loadPresets', () => {
     `);
   });
 
-  test('array form', () => {
+  test('array form', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {
         presets: [[path.join(__dirname, '__fixtures__/preset-bar.js')]],
       },
     } as Partial<LoadContext>;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [
@@ -111,7 +111,7 @@ describe('loadPresets', () => {
     `);
   });
 
-  test('array form with options', () => {
+  test('array form with options', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {
@@ -123,7 +123,7 @@ describe('loadPresets', () => {
         ],
       },
     } as Partial<LoadContext>;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [
@@ -143,7 +143,7 @@ describe('loadPresets', () => {
     `);
   });
 
-  test('array form composite', () => {
+  test('array form composite', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {
@@ -159,7 +159,7 @@ describe('loadPresets', () => {
         ],
       },
     } as Partial<LoadContext>;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [
@@ -189,7 +189,7 @@ describe('loadPresets', () => {
     `);
   });
 
-  test('mixed form', () => {
+  test('mixed form', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {
@@ -202,7 +202,7 @@ describe('loadPresets', () => {
         ],
       },
     } as LoadContext;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [
@@ -230,7 +230,7 @@ describe('loadPresets', () => {
     `);
   });
 
-  test('mixed form with themes', () => {
+  test('mixed form with themes', async () => {
     const context = {
       siteConfigPath: __dirname,
       siteConfig: {
@@ -244,7 +244,7 @@ describe('loadPresets', () => {
         ],
       },
     } as LoadContext;
-    const presets = loadPresets(context);
+    const presets = await loadPresets(context);
     expect(presets).toMatchInlineSnapshot(`
       Object {
         "plugins": Array [

--- a/packages/docusaurus/src/server/presets/index.ts
+++ b/packages/docusaurus/src/server/presets/index.ts
@@ -15,10 +15,10 @@ import type {
 } from '@docusaurus/types';
 import {resolveModuleName} from '../moduleShorthand';
 
-export default function loadPresets(context: LoadContext): {
+export default async function loadPresets(context: LoadContext): Promise<{
   plugins: PluginConfig[];
   themes: PluginConfig[];
-} {
+}> {
   // We need to resolve presets from the perspective of the siteDir, since the
   // siteDir's package.json declares the dependency on these presets.
   const presetRequire = createRequire(context.siteConfigPath);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Part of #6520. If we allow external modules (plugins, configs) to be ESM, they have to be imported asynchronously.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
