### PR TITLE
misc: enable jsx-key eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,6 +149,7 @@ module.exports = {
       },
     ],
     'react/jsx-filename-extension': OFF,
+    'react/jsx-key': [ERROR, {checkFragmentShorthand: true}],
     'react/jsx-props-no-spreading': OFF,
     'react/no-array-index-key': OFF, // We build a static site, and nearly all components don't change.
     'react/no-unstable-nested-components': [WARNING, {allowAsProps: true}],

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -120,7 +120,9 @@ describe('Tabs', () => {
               values={tabs.map((t, idx) => ({label: t, value: idx}))}
               defaultValue={0}>
               {tabs.map((t, idx) => (
-                <TabItem value={idx}>{t}</TabItem>
+                <TabItem key={idx} value={idx}>
+                  {t}
+                </TabItem>
               ))}
             </Tabs>
           </TabGroupChoiceProvider>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Suggested here: https://github.com/facebook/docusaurus/pull/6515#discussion_r797483773

It's turned off in the airbnb config: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react.js#L92-L95

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Fixed another one, which is fortunately just a test