### PR TITLE
docs: improve Github Actions example jobs

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -365,9 +365,11 @@ We will use a popular third-party deployment action: [peaceiris/actions-gh-pages
 
 Add these two workflow files:
 
-:::warning
+:::warning Tweak the parameters for your setup
 
 These files assume you are using yarn. If you use npm, change `cache: yarn`, `yarn install --frozen-lockfile`, `yarn build` to `cache: npm`, `npm ci`, `npm run build` accordingly.
+
+If your Docusaurus project is not at the root of the repo, you would need to change the paths as well.
 
 :::
 
@@ -389,23 +391,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-prescrypto-docs-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-prescrypto-docs-
-
-      - run: yarn install --frozen-lockfile
-      - run: yarn build
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build website
+        run: yarn build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
@@ -442,13 +434,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
-      - name: Test build
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Test build website
+        run: yarn build
 ```
 
 </details>
@@ -494,12 +486,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
-      - name: Test deployment
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Test build website
+        run: yarn build
   deploy:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -355,7 +355,7 @@ Here are two approaches to deploying your docs with GitHub Actions. Based on the
 <Tabs>
 <TabItem value="same" label="Same">
 
-While you can have both jobs defined in the same workflow file, the `deploy` job will always be listed as skipped in the PR check suite status. That's added noise providing no value to the review process, and as you cannot easily share common snippets, it is better to manage them as separate workflows instead.
+While you can have both jobs defined in the same workflow file, the original `deploy` workflow will always be listed as skipped in the PR check suite status, which is not communicative of the actual status and provides no value to the review process. We therefore propose to manage them as separate workflows instead.
 
 We will use a popular third-party deployment action: [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus).
 
@@ -376,8 +376,10 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
-    paths: [website/**]
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
 jobs:
   deploy:
@@ -389,11 +391,21 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
-      - name: Build website
-        working-directory: website
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-prescrypto-docs-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-prescrypto-docs-
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
@@ -402,8 +414,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./website/build
-          # Assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch:
+          publish_dir: ./build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           # The GH actions bot is used by default if you didn't specify the two fields.
           # You can swap them out with your own user credentials.
@@ -416,8 +429,10 @@ name: Test deployment
 
 on:
   pull_request:
-    branches: [main]
-    paths: [website/**]
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
 jobs:
   test-deploy:
@@ -429,8 +444,8 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
+
       - name: Test build
-        working-directory: website
         run: |
           yarn install --frozen-lockfile
           yarn build

--- a/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
@@ -320,7 +320,7 @@ Here are two approaches to deploying your docs with GitHub Actions. Based on the
 <Tabs>
 <TabItem value="same" label="Same">
 
-While you can have both jobs defined in the same workflow file, the `deploy` job will always be listed as skipped in the PR check suite status. That's added noise providing no value to the review process, and as you cannot easily share common snippets, it is better to manage them as separate workflows instead.
+While you can have both jobs defined in the same workflow file, the original `deploy` workflow will always be listed as skipped in the PR check suite status, which is not communicative of the actual status and provides no value to the review process. We therefore propose to manage them as separate workflows instead.
 
 We will use a popular third-party deployment action: [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus).
 
@@ -341,8 +341,9 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
-    paths: [website/**]
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
 jobs:
   deploy:
@@ -354,11 +355,21 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
-      - name: Build website
-        working-directory: website
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-prescrypto-docs-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-prescrypto-docs-
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
@@ -367,8 +378,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./website/build
-          # Assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch:
+          publish_dir: ./build
+          # The following lines assign commit authorship to the official 
+          # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           # The GH actions bot is used by default if you didn't specify the two fields.
           # You can swap them out with your own user credentials.

--- a/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
@@ -343,7 +343,8 @@ on:
   push:
     branches:
       - main
-    # Review gh actions docs if you want to further define triggers, paths, etc - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
 jobs:
   deploy:
@@ -379,7 +380,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
-          # The following lines assign commit authorship to the official 
+          # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           # The GH actions bot is used by default if you didn't specify the two fields.
@@ -393,8 +394,10 @@ name: Test deployment
 
 on:
   pull_request:
-    branches: [main]
-    paths: [website/**]
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
 jobs:
   test-deploy:
@@ -406,8 +409,12 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Test build
-        working-directory: website
         run: |
           yarn install --frozen-lockfile
           yarn build

--- a/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
@@ -320,7 +320,7 @@ Here are two approaches to deploying your docs with GitHub Actions. Based on the
 <Tabs>
 <TabItem value="same" label="Same">
 
-While you can have both jobs defined in the same workflow file, the original `deploy` workflow will always be listed as skipped in the PR check suite status, which is not communicative of the actual status and provides no value to the review process. We therefore propose to manage them as separate workflows instead.
+While you can have both jobs defined in the same workflow file, the `deploy` job will always be listed as skipped in the PR check suite status. That's added noise providing no value to the review process, and as you cannot easily share common snippets, it is better to manage them as separate workflows instead.
 
 We will use a popular third-party deployment action: [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus).
 
@@ -341,10 +341,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+    branches: [main]
+    paths: [website/**]
 
 jobs:
   deploy:
@@ -356,21 +354,11 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
-
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-prescrypto-docs-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-prescrypto-docs-
-
-      - run: yarn install --frozen-lockfile
-      - run: yarn build
+      - name: Build website
+        working-directory: website
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
@@ -379,9 +367,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
+          publish_dir: ./website/build
+          # Assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           # The GH actions bot is used by default if you didn't specify the two fields.
           # You can swap them out with your own user credentials.
@@ -394,10 +381,8 @@ name: Test deployment
 
 on:
   pull_request:
-    branches:
-      - main
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+    branches: [main]
+    paths: [website/**]
 
 jobs:
   test-deploy:
@@ -409,8 +394,8 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
-
       - name: Test build
+        working-directory: website
         run: |
           yarn install --frozen-lockfile
           yarn build

--- a/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.14/deployment.mdx
@@ -410,10 +410,6 @@ jobs:
           node-version: 14.x
           cache: yarn
 
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
       - name: Test build
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION
## Motivation

I've just automated the deployment of our implementation of docusaurus and stumbled upon some errors in the GH Actions files that were proposed in the website docs.

### Have you read the [Contributing Guidelines on pull requests] - (https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes 👍 

## Test Plan

Only updated v. simple markdown, here are some screenshot previewing the markdown with a browser engine, unsure how to test deploy the website, but will try later tonight:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/8750702/152271745-98afbca0-fe01-4c09-95fb-6d1f399ee88a.png">

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/8750702/152271762-6fe45b8e-d8af-48cf-8c51-65aa9eba4938.png">


## Related PRs

No related PRs found.
