### PR TITLE
fix(content-docs): read last update from inner git repositories

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -55,7 +55,7 @@ describe('lastUpdate', () => {
     await expect(getFileLastUpdate(nonExistingFilePath)).resolves.toBeNull();
     expect(consoleMock).toHaveBeenCalledTimes(1);
     expect(consoleMock).toHaveBeenLastCalledWith(
-      expect.stringMatching(/with exit code 128/),
+      expect.stringMatching(/because the file does not exist./),
     );
     await expect(getFileLastUpdate(null)).resolves.toBeNull();
     await expect(getFileLastUpdate(undefined)).resolves.toBeNull();


### PR DESCRIPTION
This reapplies https://github.com/facebook/docusaurus/pull/5048, because it somehow got reverted during a refactoring (I believe).

To prevent it from happening again in future, I added a comment in the code.

This also:

- Expand `-1` into `--max-count=1` (long options are always preferred for better readability)

- Add `--` to prevent file names who looks like git options to clash

- Check if the file exists before issuing `git` and return a proper error message
    - `git log` is known to return exit code 0 but no output in some cases, such as when using `--` and the file does not exist
    - If preferred, I can instead check if stdout is empty rather than proactively checking the file