### PR TITLE
fix(theme-classic): make Prism additional languages properly server-side rendered

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
+++ b/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
@@ -5,32 +5,29 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import siteConfig from '@generated/docusaurus.config';
 import type * as PrismNamespace from 'prismjs';
 
 const prismIncludeLanguages = (PrismObject: typeof PrismNamespace): void => {
-  if (ExecutionEnvironment.canUseDOM) {
-    const {
-      themeConfig: {prism},
-    } = siteConfig;
-    const {additionalLanguages} = prism as {additionalLanguages: string[]};
+  const {
+    themeConfig: {prism},
+  } = siteConfig;
+  const {additionalLanguages} = prism as {additionalLanguages: string[]};
 
-    // Prism components work on the Prism instance on the window, while
-    // prism-react-renderer uses its own Prism instance. We temporarily mount
-    // the instance onto window, import components to enhance it, then remove it
-    // to avoid polluting global namespace.
-    // You can mutate this object: registering plugins, deleting languages... As
-    // long as you don't re-assign it
-    window.Prism = PrismObject;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
 
-    additionalLanguages.forEach((lang) => {
-      // eslint-disable-next-line global-require, import/no-dynamic-require
-      require(`prismjs/components/prism-${lang}`);
-    });
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
 
-    delete (window as Window & {Prism?: typeof PrismNamespace}).Prism;
-  }
+  delete (globalThis as Global & {Prism?: typeof PrismNamespace}).Prism;
 };
 
 export default prismIncludeLanguages;

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -3,6 +3,14 @@ import BrowserWindow from '@site/src/components/BrowserWindow';
 
 # Code block tests
 
+```java
+class HelloWorld {
+  public static void main(String args[]) {
+    System.out.println("Hello, World");
+  }
+}
+```
+
 See:
 
 - https://github.com/facebook/docusaurus/pull/1584


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Currently, the additional languages are only effective on the client side. It takes minimal effort to make it work in Node, though, as long as we use `globalThis`—the Prism components are nothing but IIFEs that expect a global called `Prism`. It will be properly shimmed in Webpack and the Node versions we support have this, so there won't be regressions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

https://deploy-preview-6612--docusaurus-2.netlify.app/tests/pages/code-block-tests/

(With Javascript disabled)

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/55398995/152633712-9a180da2-341c-4ae9-8c77-a7dd2ee7b640.png) | ![image](https://user-images.githubusercontent.com/55398995/152633771-78c55910-bbb9-475f-ba2f-75ec32e632c7.png) |

