### PR TITLE
fix(utils): convert Markdown links in reference-style links with multiple spaces

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
@@ -62,6 +62,49 @@ describe('replaceMarkdownLinks', () => {
     `);
   });
 
+  test('reference style Markdown links', () => {
+    expect(
+      replaceMarkdownLinks({
+        siteDir: '.',
+        filePath: 'docs/intro/intro.md',
+        contentPaths: {
+          contentPath: 'docs',
+          contentPathLocalized: 'i18n/docs-localized',
+        },
+
+        sourceToPermalink: {
+          '@site/docs/intro/intro.md': '/docs/intro',
+          '@site/docs/api/classes/divine_uri.URI.md': '/docs/api/classes/uri',
+        },
+
+        fileString: `
+The following operations are defined for [URI]s:
+
+* [info]: Returns metadata about the resource,
+* [list]: Returns metadata about the resource's children (like getting the content of a local directory).
+
+[URI]:    ../api/classes/divine_uri.URI.md
+[info]:   ../api/classes/divine_uri.URI.md#info
+[list]:   ../api/classes/divine_uri.URI.md#list
+      `,
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "brokenMarkdownLinks": Array [],
+        "newContent": "
+      The following operations are defined for [URI]s:
+
+      * [info]: Returns metadata about the resource,
+      * [list]: Returns metadata about the resource's children (like getting the content of a local directory).
+
+      [URI]:    /docs/api/classes/uri
+      [info]:   /docs/api/classes/uri#info
+      [list]:   /docs/api/classes/uri#list
+            ",
+      }
+    `);
+  });
+
   // TODO bad
   test('links in HTML comments', () => {
     expect(

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -67,7 +67,7 @@ export function replaceMarkdownLinks<T extends ContentPaths>({
     // ink
     // [doc1]: doc1.md -> we replace this doc1.md with correct link
     const mdRegex =
-      /(?:(?:\]\()|(?:\]:\s?))(?!https?:\/\/|@site\/)(?<filename>[^'")\]\s>]+\.mdx?)/g;
+      /(?:(?:\]\()|(?:\]:\s*))(?!https?:\/\/|@site\/)(?<filename>[^'")\]\s>]+\.mdx?)/g;
     let mdMatch = mdRegex.exec(modifiedLine);
     while (mdMatch !== null) {
       // Replace it to correct html link.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix #6616 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test case