### PR TITLE
docs: fix remark code sample

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-plugins.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-plugins.mdx
@@ -127,7 +127,7 @@ The writeup below is **not** meant to be a comprehensive guide to creating a plu
 For example, let's make a plugin that visits every `h2` heading and adds a `Section X. ` prefix. First, create your plugin source file anywhere—you can even publish it as a separate NPM package and install it like explained above. We would put ours at `src/remark/section-prefix.js`. A remark/rehype plugin is just a function that receives the `options` and returns a `transformer` that operates on the AST.
 
 ```js "src/remark/section-prefix.js"
-const visit = require('unist-util-visit');
+const { visit } = require('unist-util-visit');
 
 const plugin = (options) => {
   const transformer = async (ast) => {


### PR DESCRIPTION
## Motivation

Code sample for Remark plugin creation is broken. `unist-util-visit` does not export `visit` at default, but as named export.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Not really.

## Test Plan

No need for tests.

## Related PRs

No related issue/PR found.
