### PR TITLE
refactor: move module declarations for non-route components to theme-classic

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -148,21 +148,6 @@ declare module '@docusaurus/plugin-content-blog' {
   >;
 }
 
-declare module '@theme/BlogSidebar' {
-  export type BlogSidebarItem = {title: string; permalink: string};
-  export type BlogSidebar = {
-    title: string;
-    items: BlogSidebarItem[];
-  };
-
-  export interface Props {
-    readonly sidebar: BlogSidebar;
-  }
-
-  const BlogSidebar: (props: Props) => JSX.Element;
-  export default BlogSidebar;
-}
-
 declare module '@theme/BlogPostPage' {
   import type {BlogSidebar} from '@theme/BlogSidebar';
   import type {TOCItem} from '@docusaurus/types';

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -209,26 +209,6 @@ declare module '@theme/DocItem' {
   export default DocItem;
 }
 
-declare module '@theme/DocCard' {
-  import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
-
-  export interface Props {
-    readonly item: PropSidebarItem;
-  }
-
-  export default function DocCard(props: Props): JSX.Element;
-}
-
-declare module '@theme/DocCardList' {
-  import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
-
-  export interface Props {
-    readonly items: PropSidebarItem[];
-  }
-
-  export default function DocCardList(props: Props): JSX.Element;
-}
-
 declare module '@theme/DocCategoryGeneratedIndexPage' {
   import type {PropCategoryGeneratedIndex} from '@docusaurus/plugin-content-docs';
 
@@ -239,12 +219,6 @@ declare module '@theme/DocCategoryGeneratedIndexPage' {
   export default function DocCategoryGeneratedIndexPage(
     props: Props,
   ): JSX.Element;
-}
-
-declare module '@theme/DocItemFooter' {
-  import type {Props} from '@theme/DocItem';
-
-  export default function DocItemFooter(props: Props): JSX.Element;
 }
 
 declare module '@theme/DocTagsListPage' {
@@ -263,22 +237,6 @@ declare module '@theme/DocTagDocListPage' {
   export default function DocTagDocListPage(props: Props): JSX.Element;
 }
 
-declare module '@theme/DocVersionBanner' {
-  export interface Props {
-    readonly className?: string;
-  }
-
-  export default function DocVersionBanner(props: Props): JSX.Element;
-}
-
-declare module '@theme/DocVersionBadge' {
-  export interface Props {
-    readonly className?: string;
-  }
-
-  export default function DocVersionBadge(props: Props): JSX.Element;
-}
-
 declare module '@theme/DocPage' {
   import type {PropVersionMetadata} from '@docusaurus/plugin-content-docs';
   import type {DocumentRoute} from '@theme/DocItem';
@@ -295,21 +253,6 @@ declare module '@theme/DocPage' {
 
   const DocPage: (props: Props) => JSX.Element;
   export default DocPage;
-}
-
-declare module '@theme/Seo' {
-  import type {ReactNode} from 'react';
-
-  export interface Props {
-    readonly title?: string;
-    readonly description?: string;
-    readonly keywords?: readonly string[] | string;
-    readonly image?: string;
-    readonly children?: ReactNode;
-  }
-
-  const Seo: (props: Props) => JSX.Element;
-  export default Seo;
 }
 
 // TODO until TS supports exports field... hope it's in 4.6

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -43,6 +43,21 @@ declare module '@theme/BlogListPaginator' {
   export default BlogListPaginator;
 }
 
+declare module '@theme/BlogSidebar' {
+  export type BlogSidebarItem = {title: string; permalink: string};
+  export type BlogSidebar = {
+    title: string;
+    items: BlogSidebarItem[];
+  };
+
+  export interface Props {
+    readonly sidebar: BlogSidebar;
+  }
+
+  const BlogSidebar: (props: Props) => JSX.Element;
+  export default BlogSidebar;
+}
+
 declare module '@theme/BlogPostItem' {
   import type {FrontMatter, Metadata} from '@theme/BlogPostPage';
   import type {Assets} from '@docusaurus/plugin-content-blog';
@@ -123,6 +138,32 @@ declare module '@theme/CodeBlock' {
   export default CodeBlock;
 }
 
+declare module '@theme/DocCard' {
+  import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
+
+  export interface Props {
+    readonly item: PropSidebarItem;
+  }
+
+  export default function DocCard(props: Props): JSX.Element;
+}
+
+declare module '@theme/DocCardList' {
+  import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
+
+  export interface Props {
+    readonly items: PropSidebarItem[];
+  }
+
+  export default function DocCardList(props: Props): JSX.Element;
+}
+
+declare module '@theme/DocItemFooter' {
+  import type {Props} from '@theme/DocItem';
+
+  export default function DocItemFooter(props: Props): JSX.Element;
+}
+
 declare module '@theme/DocPaginator' {
   import type {PropNavigation} from '@docusaurus/plugin-content-docs';
 
@@ -172,6 +213,22 @@ declare module '@theme/DocSidebarItems' {
   };
 
   export default function DocSidebarItems(props: Props): JSX.Element;
+}
+
+declare module '@theme/DocVersionBanner' {
+  export interface Props {
+    readonly className?: string;
+  }
+
+  export default function DocVersionBanner(props: Props): JSX.Element;
+}
+
+declare module '@theme/DocVersionBadge' {
+  export interface Props {
+    readonly className?: string;
+  }
+
+  export default function DocVersionBadge(props: Props): JSX.Element;
 }
 
 declare module '@theme/DocVersionSuggestions' {
@@ -726,4 +783,19 @@ declare module '@theme/prism-include-languages' {
   export default function prismIncludeLanguages(
     PrismObject: typeof PrismNamespace,
   ): void;
+}
+
+declare module '@theme/Seo' {
+  import type {ReactNode} from 'react';
+
+  export interface Props {
+    readonly title?: string;
+    readonly description?: string;
+    readonly keywords?: readonly string[] | string;
+    readonly image?: string;
+    readonly children?: ReactNode;
+  }
+
+  const Seo: (props: Props) => JSX.Element;
+  export default Seo;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Continuation of #6175. This fixes #6262 hopefully, and even if it doesn't, it's the best we can do. The theme aliases will be removed in the near future altogether, but for now, we will just put the components that the plugin directly references in the plugin typedef.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
