### PR TITLE
fix(core): forward ref to Link's anchor element

### DIFF
--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect, useRef, type ComponentType} from 'react';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  type ComponentType,
+} from 'react';
 
 import {NavLink, Link as RRLink} from 'react-router-dom';
 import useDocusaurusContext from './useDocusaurusContext';
@@ -31,145 +37,159 @@ declare global {
 // like "introduction" to "/baseUrl/introduction" => bad behavior to fix
 const shouldAddBaseUrlAutomatically = (to: string) => to.startsWith('/');
 
-function Link({
-  isNavLink,
-  to,
-  href,
-  activeClassName,
-  isActive,
-  'data-noBrokenLinkCheck': noBrokenLinkCheck,
-  autoAddBaseUrl = true,
-  ...props
-}: LinkProps): JSX.Element {
-  const {
-    siteConfig: {trailingSlash, baseUrl},
-  } = useDocusaurusContext();
-  const {withBaseUrl} = useBaseUrlUtils();
-  const linksCollector = useLinksCollector();
+const Link = forwardRef<HTMLAnchorElement>(
+  (
+    {
+      isNavLink,
+      to,
+      href,
+      activeClassName,
+      isActive,
+      'data-noBrokenLinkCheck': noBrokenLinkCheck,
+      autoAddBaseUrl = true,
+      ...props
+    }: LinkProps,
+    forwardedRef,
+  ): JSX.Element => {
+    const {
+      siteConfig: {trailingSlash, baseUrl},
+    } = useDocusaurusContext();
+    const {withBaseUrl} = useBaseUrlUtils();
+    const linksCollector = useLinksCollector();
+    const innerRef = useRef<HTMLAnchorElement | null>(null);
 
-  // IMPORTANT: using to or href should not change anything
-  // For example, MDX links will ALWAYS give us the href props
-  // Using one prop or the other should not be used to distinguish
-  // internal links (/docs/myDoc) from external links (https://github.com)
-  const targetLinkUnprefixed = to || href;
+    useImperativeHandle(
+      forwardedRef,
+      () => innerRef.current as HTMLAnchorElement,
+    );
 
-  function maybeAddBaseUrl(str: string) {
-    return autoAddBaseUrl && shouldAddBaseUrlAutomatically(str)
-      ? withBaseUrl(str)
-      : str;
-  }
+    // IMPORTANT: using to or href should not change anything
+    // For example, MDX links will ALWAYS give us the href props
+    // Using one prop or the other should not be used to distinguish
+    // internal links (/docs/myDoc) from external links (https://github.com)
+    const targetLinkUnprefixed = to || href;
 
-  const isInternal = isInternalUrl(targetLinkUnprefixed);
+    function maybeAddBaseUrl(str: string) {
+      return autoAddBaseUrl && shouldAddBaseUrlAutomatically(str)
+        ? withBaseUrl(str)
+        : str;
+    }
 
-  // pathname:// is a special "protocol" we use to tell Docusaurus link
-  // that a link is not "internal" and that we shouldn't use history.push()
-  // this is not ideal but a good enough escape hatch for now
-  // see https://github.com/facebook/docusaurus/issues/3309
-  // note: we want baseUrl to be appended (see issue for details)
-  // TODO read routes and automatically detect internal/external links?
-  const targetLinkWithoutPathnameProtocol = targetLinkUnprefixed?.replace(
-    'pathname://',
-    '',
-  );
+    const isInternal = isInternalUrl(targetLinkUnprefixed);
 
-  // TODO we should use ReactRouter basename feature instead!
-  // Automatically apply base url in links that start with /
-  let targetLink =
-    typeof targetLinkWithoutPathnameProtocol !== 'undefined'
-      ? maybeAddBaseUrl(targetLinkWithoutPathnameProtocol)
-      : undefined;
+    // pathname:// is a special "protocol" we use to tell Docusaurus link
+    // that a link is not "internal" and that we shouldn't use history.push()
+    // this is not ideal but a good enough escape hatch for now
+    // see https://github.com/facebook/docusaurus/issues/3309
+    // note: we want baseUrl to be appended (see issue for details)
+    // TODO read routes and automatically detect internal/external links?
+    const targetLinkWithoutPathnameProtocol = targetLinkUnprefixed?.replace(
+      'pathname://',
+      '',
+    );
 
-  if (targetLink && isInternal) {
-    targetLink = applyTrailingSlash(targetLink, {trailingSlash, baseUrl});
-  }
+    // TODO we should use ReactRouter basename feature instead!
+    // Automatically apply base url in links that start with /
+    let targetLink =
+      typeof targetLinkWithoutPathnameProtocol !== 'undefined'
+        ? maybeAddBaseUrl(targetLinkWithoutPathnameProtocol)
+        : undefined;
 
-  const preloaded = useRef(false);
-  const LinkComponent = (
-    isNavLink ? NavLink : RRLink
-  ) as ComponentType<LinkProps>;
+    if (targetLink && isInternal) {
+      targetLink = applyTrailingSlash(targetLink, {trailingSlash, baseUrl});
+    }
 
-  const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
+    const preloaded = useRef(false);
+    const LinkComponent = (
+      isNavLink ? NavLink : RRLink
+    ) as ComponentType<LinkProps>;
 
-  const ioRef = useRef<IntersectionObserver>();
-  const handleIntersection = (el: HTMLAnchorElement, cb: () => void) => {
-    ioRef.current = new window.IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (el === entry.target) {
-          // If element is in viewport, stop observing and run callback.
-          // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
-          if (entry.isIntersecting || entry.intersectionRatio > 0) {
-            ioRef.current!.unobserve(el);
-            ioRef.current!.disconnect();
-            cb();
+    const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
+
+    const ioRef = useRef<IntersectionObserver>();
+    const handleIntersection = (el: HTMLAnchorElement, cb: () => void) => {
+      ioRef.current = new window.IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (el === entry.target) {
+            // If element is in viewport, stop observing and run callback.
+            // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+            if (entry.isIntersecting || entry.intersectionRatio > 0) {
+              ioRef.current!.unobserve(el);
+              ioRef.current!.disconnect();
+              cb();
+            }
           }
-        }
+        });
       });
-    });
 
-    // Add element to the observer.
-    ioRef.current!.observe(el);
-  };
+      // Add element to the observer.
+      ioRef.current!.observe(el);
+    };
 
-  const handleRef = (ref: HTMLAnchorElement | null) => {
-    if (IOSupported && ref && isInternal) {
-      // If IO supported and element reference found, set up Observer.
-      handleIntersection(ref, () => {
+    const handleRef = (ref: HTMLAnchorElement | null) => {
+      innerRef.current = ref;
+
+      if (IOSupported && ref && isInternal) {
+        // If IO supported and element reference found, set up Observer.
+        handleIntersection(ref, () => {
+          if (targetLink != null) {
+            window.docusaurus.prefetch(targetLink);
+          }
+        });
+      }
+    };
+
+    const onMouseEnter = () => {
+      if (!preloaded.current && targetLink != null) {
+        window.docusaurus.preload(targetLink);
+        preloaded.current = true;
+      }
+    };
+
+    useEffect(() => {
+      // If IO is not supported. We prefetch by default (only once).
+      if (!IOSupported && isInternal) {
         if (targetLink != null) {
           window.docusaurus.prefetch(targetLink);
         }
-      });
-    }
-  };
-
-  const onMouseEnter = () => {
-    if (!preloaded.current && targetLink != null) {
-      window.docusaurus.preload(targetLink);
-      preloaded.current = true;
-    }
-  };
-
-  useEffect(() => {
-    // If IO is not supported. We prefetch by default (only once).
-    if (!IOSupported && isInternal) {
-      if (targetLink != null) {
-        window.docusaurus.prefetch(targetLink);
       }
+
+      // When unmounting, stop intersection observer from watching.
+      return () => {
+        if (IOSupported && ioRef.current) {
+          ioRef.current.disconnect();
+        }
+      };
+    }, [ioRef, targetLink, IOSupported, isInternal]);
+
+    const isAnchorLink = targetLink?.startsWith('#') ?? false;
+    const isRegularHtmlLink = !targetLink || !isInternal || isAnchorLink;
+
+    if (targetLink && isInternal && !isAnchorLink && !noBrokenLinkCheck) {
+      linksCollector.collectLink(targetLink);
     }
 
-    // When unmounting, stop intersection observer from watching.
-    return () => {
-      if (IOSupported && ioRef.current) {
-        ioRef.current.disconnect();
-      }
-    };
-  }, [ioRef, targetLink, IOSupported, isInternal]);
-
-  const isAnchorLink = targetLink?.startsWith('#') ?? false;
-  const isRegularHtmlLink = !targetLink || !isInternal || isAnchorLink;
-
-  if (targetLink && isInternal && !isAnchorLink && !noBrokenLinkCheck) {
-    linksCollector.collectLink(targetLink);
-  }
-
-  return isRegularHtmlLink ? (
-    // eslint-disable-next-line jsx-a11y/anchor-has-content
-    <a
-      href={targetLink}
-      {...(targetLinkUnprefixed &&
-        !isInternal && {target: '_blank', rel: 'noopener noreferrer'})}
-      {...props}
-    />
-  ) : (
-    <LinkComponent
-      {...props}
-      onMouseEnter={onMouseEnter}
-      innerRef={handleRef}
-      to={targetLink || ''}
-      // avoid "React does not recognize the `activeClassName` prop on a DOM
-      // element"
-      {...(isNavLink && {isActive, activeClassName})}
-    />
-  );
-}
+    return isRegularHtmlLink ? (
+      // eslint-disable-next-line jsx-a11y/anchor-has-content
+      <a
+        ref={innerRef}
+        href={targetLink}
+        {...(targetLinkUnprefixed &&
+          !isInternal && {target: '_blank', rel: 'noopener noreferrer'})}
+        {...props}
+      />
+    ) : (
+      <LinkComponent
+        {...props}
+        onMouseEnter={onMouseEnter}
+        innerRef={handleRef}
+        to={targetLink || ''}
+        // avoid "React does not recognize the `activeClassName` prop on a DOM
+        // element"
+        {...(isNavLink && {isActive, activeClassName})}
+      />
+    );
+  },
+);
 
 export default Link;

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, {
-  forwardRef,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -37,159 +36,157 @@ declare global {
 // like "introduction" to "/baseUrl/introduction" => bad behavior to fix
 const shouldAddBaseUrlAutomatically = (to: string) => to.startsWith('/');
 
-const Link = forwardRef<HTMLAnchorElement>(
-  (
-    {
-      isNavLink,
-      to,
-      href,
-      activeClassName,
-      isActive,
-      'data-noBrokenLinkCheck': noBrokenLinkCheck,
-      autoAddBaseUrl = true,
-      ...props
-    }: LinkProps,
+function Link(
+  {
+    isNavLink,
+    to,
+    href,
+    activeClassName,
+    isActive,
+    'data-noBrokenLinkCheck': noBrokenLinkCheck,
+    autoAddBaseUrl = true,
+    ...props
+  }: LinkProps,
+  forwardedRef: React.ForwardedRef<HTMLAnchorElement>,
+): JSX.Element {
+  const {
+    siteConfig: {trailingSlash, baseUrl},
+  } = useDocusaurusContext();
+  const {withBaseUrl} = useBaseUrlUtils();
+  const linksCollector = useLinksCollector();
+  const innerRef = useRef<HTMLAnchorElement | null>(null);
+
+  useImperativeHandle(
     forwardedRef,
-  ): JSX.Element => {
-    const {
-      siteConfig: {trailingSlash, baseUrl},
-    } = useDocusaurusContext();
-    const {withBaseUrl} = useBaseUrlUtils();
-    const linksCollector = useLinksCollector();
-    const innerRef = useRef<HTMLAnchorElement | null>(null);
+    () => innerRef.current as HTMLAnchorElement,
+  );
 
-    useImperativeHandle(
-      forwardedRef,
-      () => innerRef.current as HTMLAnchorElement,
-    );
+  // IMPORTANT: using to or href should not change anything
+  // For example, MDX links will ALWAYS give us the href props
+  // Using one prop or the other should not be used to distinguish
+  // internal links (/docs/myDoc) from external links (https://github.com)
+  const targetLinkUnprefixed = to || href;
 
-    // IMPORTANT: using to or href should not change anything
-    // For example, MDX links will ALWAYS give us the href props
-    // Using one prop or the other should not be used to distinguish
-    // internal links (/docs/myDoc) from external links (https://github.com)
-    const targetLinkUnprefixed = to || href;
+  function maybeAddBaseUrl(str: string) {
+    return autoAddBaseUrl && shouldAddBaseUrlAutomatically(str)
+      ? withBaseUrl(str)
+      : str;
+  }
 
-    function maybeAddBaseUrl(str: string) {
-      return autoAddBaseUrl && shouldAddBaseUrlAutomatically(str)
-        ? withBaseUrl(str)
-        : str;
-    }
+  const isInternal = isInternalUrl(targetLinkUnprefixed);
 
-    const isInternal = isInternalUrl(targetLinkUnprefixed);
+  // pathname:// is a special "protocol" we use to tell Docusaurus link
+  // that a link is not "internal" and that we shouldn't use history.push()
+  // this is not ideal but a good enough escape hatch for now
+  // see https://github.com/facebook/docusaurus/issues/3309
+  // note: we want baseUrl to be appended (see issue for details)
+  // TODO read routes and automatically detect internal/external links?
+  const targetLinkWithoutPathnameProtocol = targetLinkUnprefixed?.replace(
+    'pathname://',
+    '',
+  );
 
-    // pathname:// is a special "protocol" we use to tell Docusaurus link
-    // that a link is not "internal" and that we shouldn't use history.push()
-    // this is not ideal but a good enough escape hatch for now
-    // see https://github.com/facebook/docusaurus/issues/3309
-    // note: we want baseUrl to be appended (see issue for details)
-    // TODO read routes and automatically detect internal/external links?
-    const targetLinkWithoutPathnameProtocol = targetLinkUnprefixed?.replace(
-      'pathname://',
-      '',
-    );
+  // TODO we should use ReactRouter basename feature instead!
+  // Automatically apply base url in links that start with /
+  let targetLink =
+    typeof targetLinkWithoutPathnameProtocol !== 'undefined'
+      ? maybeAddBaseUrl(targetLinkWithoutPathnameProtocol)
+      : undefined;
 
-    // TODO we should use ReactRouter basename feature instead!
-    // Automatically apply base url in links that start with /
-    let targetLink =
-      typeof targetLinkWithoutPathnameProtocol !== 'undefined'
-        ? maybeAddBaseUrl(targetLinkWithoutPathnameProtocol)
-        : undefined;
+  if (targetLink && isInternal) {
+    targetLink = applyTrailingSlash(targetLink, {trailingSlash, baseUrl});
+  }
 
-    if (targetLink && isInternal) {
-      targetLink = applyTrailingSlash(targetLink, {trailingSlash, baseUrl});
-    }
+  const preloaded = useRef(false);
+  const LinkComponent = (
+    isNavLink ? NavLink : RRLink
+  ) as ComponentType<LinkProps>;
 
-    const preloaded = useRef(false);
-    const LinkComponent = (
-      isNavLink ? NavLink : RRLink
-    ) as ComponentType<LinkProps>;
+  const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
 
-    const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
-
-    const ioRef = useRef<IntersectionObserver>();
-    const handleIntersection = (el: HTMLAnchorElement, cb: () => void) => {
-      ioRef.current = new window.IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (el === entry.target) {
-            // If element is in viewport, stop observing and run callback.
-            // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
-            if (entry.isIntersecting || entry.intersectionRatio > 0) {
-              ioRef.current!.unobserve(el);
-              ioRef.current!.disconnect();
-              cb();
-            }
+  const ioRef = useRef<IntersectionObserver>();
+  const handleIntersection = (el: HTMLAnchorElement, cb: () => void) => {
+    ioRef.current = new window.IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (el === entry.target) {
+          // If element is in viewport, stop observing and run callback.
+          // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+          if (entry.isIntersecting || entry.intersectionRatio > 0) {
+            ioRef.current!.unobserve(el);
+            ioRef.current!.disconnect();
+            cb();
           }
-        });
+        }
       });
+    });
 
-      // Add element to the observer.
-      ioRef.current!.observe(el);
-    };
+    // Add element to the observer.
+    ioRef.current!.observe(el);
+  };
 
-    const handleRef = (ref: HTMLAnchorElement | null) => {
-      innerRef.current = ref;
+  const handleRef = (ref: HTMLAnchorElement | null) => {
+    innerRef.current = ref;
 
-      if (IOSupported && ref && isInternal) {
-        // If IO supported and element reference found, set up Observer.
-        handleIntersection(ref, () => {
-          if (targetLink != null) {
-            window.docusaurus.prefetch(targetLink);
-          }
-        });
-      }
-    };
-
-    const onMouseEnter = () => {
-      if (!preloaded.current && targetLink != null) {
-        window.docusaurus.preload(targetLink);
-        preloaded.current = true;
-      }
-    };
-
-    useEffect(() => {
-      // If IO is not supported. We prefetch by default (only once).
-      if (!IOSupported && isInternal) {
+    if (IOSupported && ref && isInternal) {
+      // If IO supported and element reference found, set up Observer.
+      handleIntersection(ref, () => {
         if (targetLink != null) {
           window.docusaurus.prefetch(targetLink);
         }
+      });
+    }
+  };
+
+  const onMouseEnter = () => {
+    if (!preloaded.current && targetLink != null) {
+      window.docusaurus.preload(targetLink);
+      preloaded.current = true;
+    }
+  };
+
+  useEffect(() => {
+    // If IO is not supported. We prefetch by default (only once).
+    if (!IOSupported && isInternal) {
+      if (targetLink != null) {
+        window.docusaurus.prefetch(targetLink);
       }
-
-      // When unmounting, stop intersection observer from watching.
-      return () => {
-        if (IOSupported && ioRef.current) {
-          ioRef.current.disconnect();
-        }
-      };
-    }, [ioRef, targetLink, IOSupported, isInternal]);
-
-    const isAnchorLink = targetLink?.startsWith('#') ?? false;
-    const isRegularHtmlLink = !targetLink || !isInternal || isAnchorLink;
-
-    if (targetLink && isInternal && !isAnchorLink && !noBrokenLinkCheck) {
-      linksCollector.collectLink(targetLink);
     }
 
-    return isRegularHtmlLink ? (
-      // eslint-disable-next-line jsx-a11y/anchor-has-content
-      <a
-        ref={innerRef}
-        href={targetLink}
-        {...(targetLinkUnprefixed &&
-          !isInternal && {target: '_blank', rel: 'noopener noreferrer'})}
-        {...props}
-      />
-    ) : (
-      <LinkComponent
-        {...props}
-        onMouseEnter={onMouseEnter}
-        innerRef={handleRef}
-        to={targetLink || ''}
-        // avoid "React does not recognize the `activeClassName` prop on a DOM
-        // element"
-        {...(isNavLink && {isActive, activeClassName})}
-      />
-    );
-  },
-);
+    // When unmounting, stop intersection observer from watching.
+    return () => {
+      if (IOSupported && ioRef.current) {
+        ioRef.current.disconnect();
+      }
+    };
+  }, [ioRef, targetLink, IOSupported, isInternal]);
 
-export default Link;
+  const isAnchorLink = targetLink?.startsWith('#') ?? false;
+  const isRegularHtmlLink = !targetLink || !isInternal || isAnchorLink;
+
+  if (targetLink && isInternal && !isAnchorLink && !noBrokenLinkCheck) {
+    linksCollector.collectLink(targetLink);
+  }
+
+  return isRegularHtmlLink ? (
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    <a
+      ref={innerRef}
+      href={targetLink}
+      {...(targetLinkUnprefixed &&
+        !isInternal && {target: '_blank', rel: 'noopener noreferrer'})}
+      {...props}
+    />
+  ) : (
+    <LinkComponent
+      {...props}
+      onMouseEnter={onMouseEnter}
+      innerRef={handleRef}
+      to={targetLink || ''}
+      // avoid "React does not recognize the `activeClassName` prop on a DOM
+      // element"
+      {...(isNavLink && {isActive, activeClassName})}
+    />
+  );
+}
+
+export default React.forwardRef(Link);

--- a/website/_dogfooding/_pages tests/index.md
+++ b/website/_dogfooding/_pages tests/index.md
@@ -21,6 +21,7 @@ import Readme from "../README.md"
 ### Other tests
 
 - [Code block tests](/tests/pages/code-block-tests)
+- [Link tests](/tests/pages/link-tests)
 - [Error boundary tests](/tests/pages/error-boundary-tests)
 - [Hydration tests](/tests/pages/hydration-tests)
 - [Asset linking tests](/tests/pages/markdown-tests)

--- a/website/_dogfooding/_pages tests/link-tests.tsx
+++ b/website/_dogfooding/_pages tests/link-tests.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+
+export default function LinkTest(): JSX.Element {
+  const anchorRef = React.useRef<HTMLAnchorElement>(null);
+  return (
+    <Layout>
+      <main className="container margin-vert--xl">
+        <Link ref={anchorRef} to="/">
+          A little link
+        </Link>
+        <button
+          type="button"
+          onClick={() => {
+            anchorRef.current!.style.backgroundColor = 'red';
+          }}>
+          Change the link
+        </button>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Motivation

Make it possible to use `Link` component with 3rd party libraries that rely on forwarding `ref` when using it as the base:

```jsx
<Button component={Link} href="/me">Click me!</Button>
```

At the very least, it will be possible to call `ref.current.focus()` from under the parent component using `Link` as the base. This also eliminates console errors in the browser when using `Link` with 3rd party libraries as in the example above.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes