### PR TITLE
fix(cli): make docusaurus clear also remove .yarn/.cache folder

### DIFF
--- a/packages/docusaurus/src/commands/clear.ts
+++ b/packages/docusaurus/src/commands/clear.ts
@@ -13,20 +13,38 @@ import {
   GENERATED_FILES_DIR_NAME,
 } from '@docusaurus/utils';
 
-async function removePath(fsPath: string) {
+async function removePath(entry: {path: string; description: string}) {
+  if (!(await fs.pathExists(entry.path))) {
+    return;
+  }
   try {
-    fs.remove(path.join(fsPath));
-    logger.success`Removed the path=${fsPath} directory.`;
+    await fs.remove(entry.path);
+    logger.success`Removed the ${entry.description} at path=${entry.path}.`;
   } catch (e) {
-    logger.error`Could not remove path=${fsPath} directory.
+    logger.error`Could not remove the ${entry.description} at path=${
+      entry.path
+    }.
 ${e as string}`;
   }
 }
 
 export default async function clear(siteDir: string): Promise<unknown> {
-  return Promise.all([
-    removePath(path.join(siteDir, GENERATED_FILES_DIR_NAME)),
-    removePath(path.join(siteDir, DEFAULT_BUILD_DIR_NAME)),
-    removePath(path.join(siteDir, 'node_modules', '.cache')),
-  ]);
+  const generatedFolder = {
+    path: path.join(siteDir, GENERATED_FILES_DIR_NAME),
+    description: 'generated folder',
+  };
+  const buildFolder = {
+    path: path.join(siteDir, DEFAULT_BUILD_DIR_NAME),
+    description: 'build output folder',
+  };
+  // In Yarn PnP, cache is stored in `.yarn/.cache` because n_m doesn't exist
+  const cacheFolders = ['node_modules', '.yarn'].map((p) => ({
+    path: path.join(siteDir, p, '.cache'),
+    description: 'Webpack persistent cache folder',
+  }));
+  return Promise.all(
+    [generatedFolder, buildFolder, ...cacheFolders].map((entry) =>
+      removePath(entry),
+    ),
+  );
 }

--- a/packages/docusaurus/src/commands/clear.ts
+++ b/packages/docusaurus/src/commands/clear.ts
@@ -43,8 +43,6 @@ export default async function clear(siteDir: string): Promise<unknown> {
     description: 'Webpack persistent cache folder',
   }));
   return Promise.all(
-    [generatedFolder, buildFolder, ...cacheFolders].map((entry) =>
-      removePath(entry),
-    ),
+    [generatedFolder, buildFolder, ...cacheFolders].map(removePath),
   );
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Currently, we only remove `node_modules/.cache`; however, if the user is using PnP, there's only the `.yarn` folder, and the cache folder is there.

In addition, the success message is now not shown if the folder doesn't exist at all, which should make the command less confusing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes