### PR TITLE
refactor: reduce exported members of docusaurus router

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -240,12 +240,8 @@ declare module '@docusaurus/Translate' {
 }
 
 declare module '@docusaurus/router' {
-  // eslint-disable-next-line import/no-extraneous-dependencies, no-restricted-syntax
-  export * from 'react-router-dom';
-}
-declare module '@docusaurus/history' {
-  // eslint-disable-next-line import/no-extraneous-dependencies, no-restricted-syntax
-  export * from 'history';
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  export {useHistory, useLocation, Redirect, matchPath} from 'react-router-dom';
 }
 
 declare module '@docusaurus/useDocusaurusContext' {

--- a/packages/docusaurus-theme-common/src/utils/historyUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/historyUtils.ts
@@ -7,7 +7,7 @@
 
 import {useEffect, useRef} from 'react';
 import {useHistory} from '@docusaurus/router';
-import type {Location, Action} from '@docusaurus/history';
+import type {Location, Action} from 'history';
 
 type HistoryBlockHandler = (location: Location, action: Action) => void | false;
 

--- a/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
@@ -7,7 +7,7 @@
 
 import {useEffect} from 'react';
 import {useLocation} from '@docusaurus/router';
-import type {Location} from '@docusaurus/history';
+import type {Location} from 'history';
 import {usePrevious} from './usePrevious';
 import {useDynamicCallback} from './reactUtils';
 

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -13,7 +13,7 @@ import nprogress from 'nprogress';
 import clientLifecyclesDispatcher from './client-lifecycles-dispatcher';
 import preload from './preload';
 import normalizeLocation from './normalizeLocation';
-import type {Location} from '@docusaurus/history';
+import type {Location} from 'history';
 
 import './nprogress.css';
 

--- a/packages/docusaurus/src/client/exports/router.ts
+++ b/packages/docusaurus/src/client/exports/router.ts
@@ -5,5 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line no-restricted-syntax
-export * from 'react-router-dom';
+export {useHistory, useLocation, Redirect, matchPath} from 'react-router-dom';

--- a/packages/docusaurus/src/client/normalizeLocation.ts
+++ b/packages/docusaurus/src/client/normalizeLocation.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {Location} from '@docusaurus/history';
+import type {Location} from 'history';
 
 // Memoize previously normalized pathnames.
 const pathnames: Record<string, string> = {};


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Breaking changes

If you imported some undocumented member of `@docusaurus/router` (that's not one of `useLocation`, `useHistory`, `matchPath`, or `Redirect`), it is no longer be available. You need to import directly from `react-router-dom` instead.

## Motivation

1. This makes further refactors/upgrades less risky
2. We are going to do breaking changes with the React router v6 migration anyways, because the `useHistory` hook doens't exist: https://reactrouter.com/docs/en/v6/upgrading/v5#use-usenavigate-instead-of-usehistory

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
