### PR TITLE
feat: allow numbers in plugin ID

### DIFF
--- a/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
+++ b/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
@@ -12,13 +12,13 @@ exports[`validation schemas PathnameSchema: for value="foo" 1`] = `"\\"value\\" 
 
 exports[`validation schemas PathnameSchema: for value="https://github.com/foo" 1`] = `"\\"value\\" is not a valid pathname. Pathname should start with slash and not contain any domain or query string."`;
 
-exports[`validation schemas PluginIdSchema: for value="/docs" 1`] = `"\\"value\\" with value \\"/docs\\" fails to match the required pattern: /^[a-zA-Z_-]+$/"`;
+exports[`validation schemas PluginIdSchema: for value="/docs" 1`] = `"Illegal plugin ID value \\"/docs\\": it should only contain alphanumerics, underscores, and dashes."`;
 
-exports[`validation schemas PluginIdSchema: for value="do cs" 1`] = `"\\"value\\" with value \\"do cs\\" fails to match the required pattern: /^[a-zA-Z_-]+$/"`;
+exports[`validation schemas PluginIdSchema: for value="do cs" 1`] = `"Illegal plugin ID value \\"do cs\\": it should only contain alphanumerics, underscores, and dashes."`;
 
-exports[`validation schemas PluginIdSchema: for value="do/cs" 1`] = `"\\"value\\" with value \\"do/cs\\" fails to match the required pattern: /^[a-zA-Z_-]+$/"`;
+exports[`validation schemas PluginIdSchema: for value="do/cs" 1`] = `"Illegal plugin ID value \\"do/cs\\": it should only contain alphanumerics, underscores, and dashes."`;
 
-exports[`validation schemas PluginIdSchema: for value="docs/" 1`] = `"\\"value\\" with value \\"docs/\\" fails to match the required pattern: /^[a-zA-Z_-]+$/"`;
+exports[`validation schemas PluginIdSchema: for value="docs/" 1`] = `"Illegal plugin ID value \\"docs/\\": it should only contain alphanumerics, underscores, and dashes."`;
 
 exports[`validation schemas PluginIdSchema: for value=[] 1`] = `"\\"value\\" must be a string"`;
 

--- a/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
@@ -69,6 +69,7 @@ describe('validation schemas', () => {
     testOK('docs');
     testOK('default');
     testOK('plugin-id_with-simple-special-chars');
+    testOK('doc1');
 
     testFail('/docs');
     testFail('docs/');

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -11,7 +11,10 @@ import type {Tag} from '@docusaurus/utils';
 import {JoiFrontMatter} from './JoiFrontMatter';
 
 export const PluginIdSchema = Joi.string()
-  .regex(/^[a-zA-Z_-]+$/)
+  .regex(/^[a-zA-Z0-9_-]+$/)
+  .message(
+    'Illegal plugin ID value "{#value}": it should only contain alphanumerics, underscores, and dashes.',
+  )
   .default(DEFAULT_PLUGIN_ID);
 
 const MarkdownPluginsSchema = Joi.array()

--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -90,7 +90,7 @@ module.exports = {
       '@docusaurus/plugin-content-docs',
       {
         // highlight-next-line
-        id: 'docs-A',
+        id: 'docs-1',
         // other options
       },
     ],
@@ -98,7 +98,7 @@ module.exports = {
       '@docusaurus/plugin-content-docs',
       {
         // highlight-next-line
-        id: 'docs-B',
+        id: 'docs-2',
         // other options
       },
     ],
@@ -169,9 +169,9 @@ module.exports = function preset(context, opts = {}) {
     plugins: [
       // Using three docs plugins at the same time!
       // Assigning a unique ID for each without asking the user to do it
-      ['@docusaurus/plugin-content-docs', {...opts.docs1, id: 'docsA'}],
-      ['@docusaurus/plugin-content-docs', {...opts.docs2, id: 'docsB'}],
-      ['@docusaurus/plugin-content-docs', {...opts.docs3, id: 'docsC'}],
+      ['@docusaurus/plugin-content-docs', {...opts.docs1, id: 'docs1'}],
+      ['@docusaurus/plugin-content-docs', {...opts.docs2, id: 'docs2'}],
+      ['@docusaurus/plugin-content-docs', {...opts.docs3, id: 'docs3'}],
     ],
   };
 };
@@ -203,9 +203,9 @@ This is equivalent of doing:
 module.exports = {
   themes: [['docusaurus-theme-awesome', {hello: 'world'}]],
   plugins: [
-    ['@docusaurus/plugin-content-docs', {id: 'docsA', path: '/docs'}],
-    ['@docusaurus/plugin-content-docs', {id: 'docsB', path: '/community'}],
-    ['@docusaurus/plugin-content-docs', {id: 'docsC', path: '/api'}],
+    ['@docusaurus/plugin-content-docs', {id: 'docs1', path: '/docs'}],
+    ['@docusaurus/plugin-content-docs', {id: 'docs2', path: '/community'}],
+    ['@docusaurus/plugin-content-docs', {id: 'docs3', path: '/api'}],
   ],
 };
 ```

--- a/website/docs/using-plugins.md
+++ b/website/docs/using-plugins.md
@@ -90,7 +90,7 @@ module.exports = {
       '@docusaurus/plugin-content-docs',
       {
         // highlight-next-line
-        id: 'docs-1',
+        id: 'docs-A',
         // other options
       },
     ],
@@ -98,7 +98,7 @@ module.exports = {
       '@docusaurus/plugin-content-docs',
       {
         // highlight-next-line
-        id: 'docs-2',
+        id: 'docs-B',
         // other options
       },
     ],
@@ -169,9 +169,9 @@ module.exports = function preset(context, opts = {}) {
     plugins: [
       // Using three docs plugins at the same time!
       // Assigning a unique ID for each without asking the user to do it
-      ['@docusaurus/plugin-content-docs', {...opts.docs1, id: 'docs1'}],
-      ['@docusaurus/plugin-content-docs', {...opts.docs2, id: 'docs2'}],
-      ['@docusaurus/plugin-content-docs', {...opts.docs3, id: 'docs3'}],
+      ['@docusaurus/plugin-content-docs', {...opts.docs1, id: 'docsA'}],
+      ['@docusaurus/plugin-content-docs', {...opts.docs2, id: 'docsB'}],
+      ['@docusaurus/plugin-content-docs', {...opts.docs3, id: 'docsC'}],
     ],
   };
 };
@@ -203,9 +203,9 @@ This is equivalent of doing:
 module.exports = {
   themes: [['docusaurus-theme-awesome', {hello: 'world'}]],
   plugins: [
-    ['@docusaurus/plugin-content-docs', {id: 'docs1', path: '/docs'}],
-    ['@docusaurus/plugin-content-docs', {id: 'docs2', path: '/community'}],
-    ['@docusaurus/plugin-content-docs', {id: 'docs3', path: '/api'}],
+    ['@docusaurus/plugin-content-docs', {id: 'docsA', path: '/docs'}],
+    ['@docusaurus/plugin-content-docs', {id: 'docsB', path: '/community'}],
+    ['@docusaurus/plugin-content-docs', {id: 'docsC', path: '/api'}],
   ],
 };
 ```


### PR DESCRIPTION
example for id don't work with version 2.0.0-beta.15:
ValidationError: "id" with value "docs1" fails to match the required pattern: /^[a-zA-Z_-]+$/
Error: Process completed with exit code 1.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

id given as example are wrong and break build

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Sure why not

## Test Plan

See example

## Related PRs

None
