### PR TITLE
Fix Smooth Scrolling

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
+++ b/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
@@ -147,7 +147,7 @@ function useTOCHighlight(config: TOCHighlightConfig | undefined): void {
         }
         link.classList.add(linkActiveClassName);
         lastActiveLinkRef.current = link;
-        link.scrollIntoView({block: 'nearest'});
+        link.scrollIntoView( {behavior: "smooth", block: "start", inline: "nearest"});
       } else {
         link.classList.remove(linkActiveClassName);
       }


### PR DESCRIPTION
**Feature for: #6620** ( _[bug] scroll-behavior: smooth not working together with TOC anchor nav in 2.0.0-beta.15_  )

https://github.com/facebook/docusaurus/pull/6317 breaks pages using scroll-behavior: smooth as both JS and CSS are trying to smoothly scroll the page. For sites like about.supabase.com which uses scroll-behavior: smooth (reasonable thing to add IMO), cliking on the the TOCs don't bring you to the right section of the page. ( _the issue on #6620_ )

This is Pull Request in order to fix this issue and bring the website a better user experience.
