### PR TITLE
fix(utils): make SVGO not remove title

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/webpackUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/webpackUtils.test.ts
@@ -8,7 +8,7 @@
 import {getFileLoaderUtils} from '../webpackUtils';
 
 describe('getFileLoaderUtils()', () => {
-  test('plugin svgo/removeViewBox should be disabled', () => {
+  test('plugin svgo/removeViewBox and removeTitle should be disabled', () => {
     const {oneOf} = getFileLoaderUtils().rules.svg();
     expect(oneOf[0].use).toContainEqual(
       expect.objectContaining({
@@ -20,6 +20,7 @@ describe('getFileLoaderUtils()', () => {
                 name: 'preset-default',
                 params: {
                   overrides: {
+                    removeTitle: false,
                     removeViewBox: false,
                   },
                 },

--- a/packages/docusaurus-utils/src/webpackUtils.ts
+++ b/packages/docusaurus-utils/src/webpackUtils.ts
@@ -112,6 +112,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
                       name: 'preset-default',
                       params: {
                         overrides: {
+                          removeTitle: false,
                           removeViewBox: false,
                         },
                       },


### PR DESCRIPTION
## Motivation

By default, SVGR removes the `<title>` tag from SVG inputs. This hinders a11y since "the `<title>` element provides an accessible, short-text description of any SVG container element or graphics element."

See: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title


The `<title>` tag can be set via the SVG React component's `title` prop, but it's unintuitive that existing `<title>` tags from the SVG files themselves get stripped beforehand.

This will not break behaviour for existing users since the `title` prop seems to override the image's default `<title>` tag if set according to the SVGR API docs:

> If titleProp is set to true and no title is provided (title={undefined}) at render time, this will fallback to an existing title element in the svg if exists.

See: https://react-svgr.com/docs/options/#title

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated the existing test at `packages/docusaurus-utils/src/__tests__/webpackUtils.test.ts`.

## Related PRs

N/A
