### PR TITLE
feat(search-algolia): allow disabling search page and configuring path

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/index.ts
+++ b/packages/docusaurus-theme-search-algolia/src/index.ts
@@ -23,8 +23,9 @@ const getCompiledOpenSearchTemplate = memoize(() =>
 
 function renderOpenSearchTemplate(data: {
   title: string;
-  url: string;
-  favicon: string | null;
+  siteUrl: string;
+  searchUrl: string;
+  faviconUrl: string | null;
 }) {
   const compiled = getCompiledOpenSearchTemplate();
   return compiled(data, defaultConfig);
@@ -78,13 +79,16 @@ export default function themeSearchAlgolia(context: LoadContext): Plugin<void> {
         return;
       }
 
+      const siteUrl = normalizeUrl([url, baseUrl]);
+
       try {
         fs.writeFileSync(
           path.join(outDir, OPEN_SEARCH_FILENAME),
           renderOpenSearchTemplate({
             title,
-            url: url + baseUrl,
-            favicon: favicon ? normalizeUrl([url, baseUrl, favicon]) : null,
+            siteUrl,
+            searchUrl: normalizeUrl([siteUrl, searchPagePath as string]),
+            faviconUrl: favicon ? normalizeUrl([siteUrl, favicon]) : null,
           }),
         );
       } catch (e) {

--- a/packages/docusaurus-theme-search-algolia/src/index.ts
+++ b/packages/docusaurus-theme-search-algolia/src/index.ts
@@ -39,9 +39,9 @@ export default function themeSearchAlgolia(context: LoadContext): Plugin<void> {
     i18n: {currentLocale},
   } = context;
   const {
-    algolia: {searchPage},
+    algolia: {searchPagePath},
   } = themeConfig as ThemeConfig;
-  const isSearchPageDisabled = searchPage === false;
+  const isSearchPageDisabled = Boolean(searchPagePath) === false;
 
   return {
     name: 'docusaurus-theme-search-algolia',
@@ -67,7 +67,7 @@ export default function themeSearchAlgolia(context: LoadContext): Plugin<void> {
       }
 
       addRoute({
-        path: normalizeUrl([baseUrl, searchPage as string]),
+        path: normalizeUrl([baseUrl, searchPagePath as string]),
         component: '@theme/SearchPage',
         exact: true,
       });

--- a/packages/docusaurus-theme-search-algolia/src/index.ts
+++ b/packages/docusaurus-theme-search-algolia/src/index.ts
@@ -42,7 +42,6 @@ export default function themeSearchAlgolia(context: LoadContext): Plugin<void> {
   const {
     algolia: {searchPagePath},
   } = themeConfig as ThemeConfig;
-  const isSearchPageDisabled = Boolean(searchPagePath) === false;
 
   return {
     name: 'docusaurus-theme-search-algolia',
@@ -63,42 +62,38 @@ export default function themeSearchAlgolia(context: LoadContext): Plugin<void> {
     },
 
     async contentLoaded({actions: {addRoute}}) {
-      if (isSearchPageDisabled) {
-        return;
+      if (searchPagePath) {
+        addRoute({
+          path: normalizeUrl([baseUrl, searchPagePath]),
+          component: '@theme/SearchPage',
+          exact: true,
+        });
       }
-
-      addRoute({
-        path: normalizeUrl([baseUrl, searchPagePath as string]),
-        component: '@theme/SearchPage',
-        exact: true,
-      });
     },
 
     async postBuild({outDir}) {
-      if (isSearchPageDisabled) {
-        return;
-      }
+      if (searchPagePath) {
+        const siteUrl = normalizeUrl([url, baseUrl]);
 
-      const siteUrl = normalizeUrl([url, baseUrl]);
-
-      try {
-        fs.writeFileSync(
-          path.join(outDir, OPEN_SEARCH_FILENAME),
-          renderOpenSearchTemplate({
-            title,
-            siteUrl,
-            searchUrl: normalizeUrl([siteUrl, searchPagePath as string]),
-            faviconUrl: favicon ? normalizeUrl([siteUrl, favicon]) : null,
-          }),
-        );
-      } catch (e) {
-        logger.error('Generating OpenSearch file failed.');
-        throw e;
+        try {
+          fs.writeFileSync(
+            path.join(outDir, OPEN_SEARCH_FILENAME),
+            renderOpenSearchTemplate({
+              title,
+              siteUrl,
+              searchUrl: normalizeUrl([siteUrl, searchPagePath]),
+              faviconUrl: favicon ? normalizeUrl([siteUrl, favicon]) : null,
+            }),
+          );
+        } catch (e) {
+          logger.error('Generating OpenSearch file failed.');
+          throw e;
+        }
       }
     },
 
     injectHtmlTags() {
-      if (isSearchPageDisabled) {
+      if (!searchPagePath) {
         return {};
       }
 

--- a/packages/docusaurus-theme-search-algolia/src/templates/opensearch.ts
+++ b/packages/docusaurus-theme-search-algolia/src/templates/opensearch.ts
@@ -12,11 +12,11 @@ export default `
   <ShortName><%= it.title %></ShortName>
   <Description>Search <%= it.title %></Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <% if (it.favicon) { _%>
-    <Image width="16" height="16" type="image/x-icon"><%= it.favicon %></Image>
+  <% if (it.faviconUrl) { _%>
+    <Image width="16" height="16" type="image/x-icon"><%= it.faviconUrl %></Image>
   <% } _%>
-  <Url type="text/html" method="get" template="<%= it.url %>search?q={searchTerms}"/>
-  <Url type="application/opensearchdescription+xml" rel="self" template="<%= it.url %>opensearch.xml" />
-  <moz:SearchForm><%= it.url %></moz:SearchForm>
+  <Url type="text/html" method="get" template="<%= it.searchUrl %>?q={searchTerms}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="<%= it.siteUrl %>opensearch.xml" />
+  <moz:SearchForm><%= it.siteUrl %></moz:SearchForm>
 </OpenSearchDescription>
 `;

--- a/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
+++ b/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
@@ -16,7 +16,7 @@ declare module '@docusaurus/theme-search-algolia' {
       apiKey: string;
       indexName: string;
       searchParameters: Record<string, unknown>;
-      searchPage: boolean | string;
+      searchPagePath: boolean | string | null;
     };
   };
   export type UserThemeConfig = DeepPartial<ThemeConfig>;

--- a/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
+++ b/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
@@ -16,7 +16,7 @@ declare module '@docusaurus/theme-search-algolia' {
       apiKey: string;
       indexName: string;
       searchParameters: Record<string, unknown>;
-      searchPagePath: boolean | string | null;
+      searchPagePath: string | false | null;
     };
   };
   export type UserThemeConfig = DeepPartial<ThemeConfig>;

--- a/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
+++ b/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
@@ -16,6 +16,7 @@ declare module '@docusaurus/theme-search-algolia' {
       apiKey: string;
       indexName: string;
       searchParameters: Record<string, unknown>;
+      searchPage: boolean | string;
     };
   };
   export type UserThemeConfig = DeepPartial<ThemeConfig>;

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -34,6 +34,7 @@ type DocSearchProps = Omit<
 > & {
   contextualSearch?: string;
   externalUrlRegex?: string;
+  searchPage: boolean | string;
 };
 
 let DocSearchModal: typeof DocSearchModalType | null = null;
@@ -256,8 +257,10 @@ function DocSearch({
             navigator={navigator}
             transformItems={transformItems}
             hitComponent={Hit}
-            resultsFooterComponent={resultsFooterComponent}
             transformSearchClient={transformSearchClient}
+            {...(props.searchPage && {
+              resultsFooterComponent,
+            })}
             {...props}
             searchParameters={searchParameters}
           />,

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -34,7 +34,7 @@ type DocSearchProps = Omit<
 > & {
   contextualSearch?: string;
   externalUrlRegex?: string;
-  searchPage: boolean | string;
+  searchPagePath: boolean | string;
 };
 
 let DocSearchModal: typeof DocSearchModalType | null = null;
@@ -258,7 +258,7 @@ function DocSearch({
             transformItems={transformItems}
             hitComponent={Hit}
             transformSearchClient={transformSearchClient}
-            {...(props.searchPage && {
+            {...(props.searchPagePath && {
               resultsFooterComponent,
             })}
             {...props}

--- a/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
@@ -18,6 +18,7 @@ export const DEFAULT_CONFIG = {
   appId: 'BH4D9OD16A',
 
   searchParameters: {},
+  searchPage: 'search',
 };
 
 export const Schema = Joi.object({
@@ -32,6 +33,9 @@ export const Schema = Joi.object({
     searchParameters: Joi.object()
       .default(DEFAULT_CONFIG.searchParameters)
       .unknown(),
+    searchPage: Joi.alternatives()
+      .try(Joi.boolean().invalid(true), Joi.string())
+      .default(DEFAULT_CONFIG.searchPage),
   })
     .label('themeConfig.algolia')
     .required()

--- a/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-search-algolia/src/validateThemeConfig.ts
@@ -18,7 +18,7 @@ export const DEFAULT_CONFIG = {
   appId: 'BH4D9OD16A',
 
   searchParameters: {},
-  searchPage: 'search',
+  searchPagePath: 'search',
 };
 
 export const Schema = Joi.object({
@@ -33,9 +33,10 @@ export const Schema = Joi.object({
     searchParameters: Joi.object()
       .default(DEFAULT_CONFIG.searchParameters)
       .unknown(),
-    searchPage: Joi.alternatives()
+    searchPagePath: Joi.alternatives()
       .try(Joi.boolean().invalid(true), Joi.string())
-      .default(DEFAULT_CONFIG.searchPage),
+      .allow(null)
+      .default(DEFAULT_CONFIG.searchPagePath),
   })
     .label('themeConfig.algolia')
     .required()

--- a/website/docs/api/themes/theme-search-algolia.md
+++ b/website/docs/api/themes/theme-search-algolia.md
@@ -11,7 +11,7 @@ This theme provides a `@theme/SearchBar` component that integrates with Algolia 
 npm install --save @docusaurus/theme-search-algolia
 ```
 
-This theme also adds search page available at `/search` (as swizzlable `SearchPage` component) path with OpenSearch support.
+This theme also adds search page available at `/search` (as swizzlable `SearchPage` component) path with OpenSearch support. You can this default path via `themeConfig.algolia.searchPage`. Use `false` to disable search page.
 
 :::tip
 

--- a/website/docs/api/themes/theme-search-algolia.md
+++ b/website/docs/api/themes/theme-search-algolia.md
@@ -11,7 +11,7 @@ This theme provides a `@theme/SearchBar` component that integrates with Algolia 
 npm install --save @docusaurus/theme-search-algolia
 ```
 
-This theme also adds search page available at `/search` (as swizzlable `SearchPage` component) path with OpenSearch support. You can this default path via `themeConfig.algolia.searchPage`. Use `false` to disable search page.
+This theme also adds search page available at `/search` (as swizzlable `SearchPage` component) path with OpenSearch support. You can this default path via `themeConfig.algolia.searchPagePath`. Use `false` to disable search page.
 
 :::tip
 

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -107,6 +107,9 @@ module.exports = {
       // Optional: Algolia search parameters
       searchParameters: {},
 
+      // Optional: path for search page that enabled by default (`false` to disable it)
+      searchPage: 'search',
+
       //... other Algolia params
     },
     // highlight-end

--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -108,7 +108,7 @@ module.exports = {
       searchParameters: {},
 
       // Optional: path for search page that enabled by default (`false` to disable it)
-      searchPage: 'search',
+      searchPagePath: 'search',
 
       //... other Algolia params
     },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

As was rightly pointed out [earlier](https://github.com/facebook/docusaurus/pull/2756#issuecomment-1039456032), the search page from the Algolia theme should be disableable like as well as its default path should be changeable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Try to set `false` value for `algolia.searchPage` to disable search page. 

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
