### PR TITLE
fix(theme-common): do not run useLocationChange when hot reloading

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
+++ b/packages/docusaurus-theme-common/src/utils/useLocationChange.ts
@@ -25,6 +25,10 @@ export function useLocationChange(onLocationChange: OnLocationChange): void {
   const onLocationChangeDynamic = useDynamicCallback(onLocationChange);
 
   useEffect(() => {
+    if (!previousLocation) {
+      return;
+    }
+
     if (location !== previousLocation) {
       onLocationChangeDynamic({
         location,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Just noticed that we have the problem described in the issue again > https://github.com/facebook/docusaurus/issues/4794

This is still caused by the SkipContent component, but actually because the useLocationChange hook was triggered when it was not expected (changed doc -> hot reload -> re-render, but in fact the current location has not changed).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Start dev server
2. Go to any doc page and scroll it a bit
3. Edit any doc
4. The scroll position of the current doc page should same as before

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
