### PR TITLE
fix(cli): disable directory listing in serve

### DIFF
--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -67,6 +67,7 @@ export default async function serve(
       cleanUrls: true,
       public: dir,
       trailingSlash,
+      directoryListing: false,
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix #6699. This should be more in line with almost every hosting provider.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run `yarn serve` and go to http://localhost:3000/blog/2022. Before, it served

<img width="494" alt="image" src="https://user-images.githubusercontent.com/55398995/154454547-380b24c7-fd45-44f9-b260-11c1a4feda5a.png">

While now, it's the normal "page not found" page.