### PR TITLE
docs: add doc for generated-index keyword/image metadata

### DIFF
--- a/website/docs/guides/docs/sidebar/items.md
+++ b/website/docs/guides/docs/sidebar/items.md
@@ -269,6 +269,8 @@ module.exports = {
         title: 'Docusaurus Guides',
         description: 'Learn about the most important Docusaurus concepts!',
         slug: '/category/docusaurus-guides',
+        keywords: ['guides'],
+        image: '/img/docusaurus.png',
       },
       // highlight-end
       items: ['pages', 'docs', 'blog', 'search'],


### PR DESCRIPTION
## Motivation

Missing doc after https://github.com/facebook/docusaurus/pull/6239