### PR TITLE
fix(mdx-loader): make headings containing links properly formatted in ToC

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
@@ -8,31 +8,29 @@
 import escapeHtml from 'escape-html';
 import toString from 'mdast-util-to-string';
 import type {Parent} from 'unist';
-import type {StaticPhrasingContent, Heading} from 'mdast';
+import type {PhrasingContent, Heading} from 'mdast';
 
 export function stringifyContent(node: Parent): string {
-  return ((node.children || []) as StaticPhrasingContent[])
-    .map(toValue)
-    .join('');
+  return ((node.children || []) as PhrasingContent[]).map(toValue).join('');
 }
 
-export function toValue(node: StaticPhrasingContent | Heading): string {
-  if (node && node.type) {
-    switch (node.type) {
-      case 'text':
-        return escapeHtml(node.value);
-      case 'heading':
-        return stringifyContent(node);
-      case 'inlineCode':
-        return `<code>${escapeHtml(node.value)}</code>`;
-      case 'emphasis':
-        return `<em>${stringifyContent(node)}</em>`;
-      case 'strong':
-        return `<strong>${stringifyContent(node)}</strong>`;
-      case 'delete':
-        return `<del>${stringifyContent(node)}</del>`;
-      default:
-    }
+export function toValue(node: PhrasingContent | Heading): string {
+  switch (node?.type) {
+    case 'text':
+      return escapeHtml(node.value);
+    case 'heading':
+      return stringifyContent(node);
+    case 'inlineCode':
+      return `<code>${escapeHtml(node.value)}</code>`;
+    case 'emphasis':
+      return `<em>${stringifyContent(node)}</em>`;
+    case 'strong':
+      return `<strong>${stringifyContent(node)}</strong>`;
+    case 'delete':
+      return `<del>${stringifyContent(node)}</del>`;
+    case 'link':
+      return stringifyContent(node);
+    default:
   }
 
   return toString(node);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Consider the heading ``#### [`guard-for-in`](https://eslint.org/docs/rules/guard-for-in)``. Right now, the inline code is dropped in the final ToC:

<img width="174" alt="image" src="https://user-images.githubusercontent.com/55398995/154608105-e8a6fc28-5e19-4bc7-b32b-ca95bf568486.png">

...because links aren't specially handled in the ToC, and everything in it gets simply formatted as plain string. However, it should be better formatted as `<code>method</code>`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
