### PR TITLE
fix(content-docs): create assets for frontmatter images

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -362,7 +362,7 @@ export default async function pluginContentDocs(
                   return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
                 },
                 // Assets allow to convert some relative images paths to
-                // require() calls
+                // require(...) calls
                 createAssets: ({
                   frontMatter,
                 }: {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -38,6 +38,7 @@ import type {
   DocFile,
   DocsMarkdownOption,
   VersionTag,
+  DocFrontMatter,
 } from './types';
 import type {RuleSetRule} from 'webpack';
 import {cliDocsVersionCommand} from './cli';
@@ -360,6 +361,15 @@ export default async function pluginContentDocs(
                   const aliasedPath = aliasedSitePath(mdxPath, siteDir);
                   return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
                 },
+                // Assets allow to convert some relative images paths to
+                // require() calls
+                createAssets: ({
+                  frontMatter,
+                }: {
+                  frontMatter: DocFrontMatter;
+                }) => ({
+                  image: frontMatter.image,
+                }),
               },
             },
             {


### PR DESCRIPTION
fixes: #6718

create asstes for the frontmatter image in documentation (`plugin-content-docs`) aswell. The implementation is adapted from the [plugin-content-blog/src/index.ts#L477](https://github.com/facebook/docusaurus/blob/6996ed2f2ffe7a68a14f8b07d4674124163bbd7f/packages/docusaurus-plugin-content-blog/src/index.ts#L477)