### PR TITLE
feat: support config locale baseUrl

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -70,6 +70,7 @@ declare module '@generated/i18n' {
         label: string;
         direction: string;
         htmlLang: string;
+        baseUrl: string;
       }
     >;
   };

--- a/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
@@ -22,21 +22,33 @@ export function useAlternatePageUtils(): {
 } {
   const {
     siteConfig: {baseUrl, url},
-    i18n: {defaultLocale, currentLocale},
+    i18n: {defaultLocale, currentLocale, localeConfigs},
   } = useDocusaurusContext();
   const {pathname} = useLocation();
 
-  const baseUrlUnlocalized =
-    currentLocale === defaultLocale
-      ? baseUrl
-      : baseUrl.replace(`/${currentLocale}/`, '/');
+  function getLocalizedPath(locale: string) {
+    if (localeConfigs[locale].baseUrl) {
+      return localeConfigs[locale].baseUrl
+        .replace(/^\//, '')
+        .replace(/\/$/, '');
+    }
+    return locale === defaultLocale ? '' : locale;
+  }
 
-  const pathnameSuffix = pathname.replace(baseUrl, '');
+  const currentLocalizedPath = getLocalizedPath(currentLocale);
+  const baseUrlUnlocalized = baseUrl.replace(
+    new RegExp(`/${currentLocalizedPath}/$`),
+    '/',
+  );
 
+  const pathnameSuffix = pathname.match(new RegExp(`^${baseUrl}`))
+    ? pathname.replace(new RegExp(`^${baseUrl}`), '')
+    : pathname.replace(new RegExp(`^${baseUrlUnlocalized}`), '');
   function getLocalizedBaseUrl(locale: string) {
-    return locale === defaultLocale
-      ? `${baseUrlUnlocalized}`
-      : `${baseUrlUnlocalized}${locale}/`;
+    const localizedPath = getLocalizedPath(locale);
+    return localizedPath
+      ? `${baseUrlUnlocalized}${localizedPath}/`
+      : baseUrlUnlocalized;
   }
 
   // TODO support correct alternate url when localized site is deployed on another domain

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -122,6 +122,7 @@ export type I18nLocaleConfig = {
   label: string;
   htmlLang: string;
   direction: string;
+  baseUrl: string;
 };
 
 export type I18nConfig = {

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -98,6 +98,7 @@ const LocaleConfigSchema = Joi.object({
   label: Joi.string(),
   htmlLang: Joi.string(),
   direction: Joi.string().equal('ltr', 'rtl').default('ltr'),
+  baseUrl: Joi.string(),
 });
 
 const I18N_CONFIG_SCHEMA = Joi.object<I18nConfig>({

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -25,6 +25,7 @@ export function getDefaultLocaleConfig(locale: string): I18nLocaleConfig {
     label: getDefaultLocaleLabel(locale),
     direction: getLangDir(locale),
     htmlLang: locale,
+    baseUrl: '',
   };
 }
 
@@ -74,6 +75,30 @@ Note: Docusaurus only support running one locale at a time.`;
   };
 }
 
+function shouldLocalizePath({
+  i18n,
+  options = {},
+}: {
+  i18n: I18n;
+  options?: {localizePath?: boolean};
+}): boolean {
+  // console.log(`i18n: %o`, i18n);
+  // if (typeof options.localizePath === 'undefined') {
+  //   return i18n.currentLocale !== i18n.defaultLocale;
+  // }
+  // return options.localizePath;
+  if (options.localizePath === true || options.localizePath === false) {
+    return options.localizePath;
+  }
+  if (
+    i18n.currentLocale !== i18n.defaultLocale ||
+    i18n.localeConfigs[i18n.currentLocale].baseUrl
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function localizePath({
   pathType,
   path: originalPath,
@@ -85,20 +110,16 @@ export function localizePath({
   i18n: I18n;
   options?: {localizePath?: boolean};
 }): string {
-  const shouldLocalizePath: boolean =
-    typeof options.localizePath === 'undefined'
-      ? // By default, we don't localize the path of defaultLocale
-        i18n.currentLocale !== i18n.defaultLocale
-      : options.localizePath;
-
-  if (shouldLocalizePath) {
+  if (shouldLocalizePath({i18n, options})) {
     // FS paths need special care, for Windows support
+    const localePath =
+      i18n.localeConfigs[i18n.currentLocale].baseUrl || i18n.currentLocale;
     if (pathType === 'fs') {
-      return path.join(originalPath, path.sep, i18n.currentLocale, path.sep);
+      return path.join(originalPath, path.sep, localePath, path.sep);
     }
     // Url paths
     else if (pathType === 'url') {
-      return normalizeUrl([originalPath, '/', i18n.currentLocale, '/']);
+      return normalizeUrl([originalPath, '/', localePath, '/']);
     }
     // should never happen
     else {

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -82,11 +82,6 @@ function shouldLocalizePath({
   i18n: I18n;
   options?: {localizePath?: boolean};
 }): boolean {
-  // console.log(`i18n: %o`, i18n);
-  // if (typeof options.localizePath === 'undefined') {
-  //   return i18n.currentLocale !== i18n.defaultLocale;
-  // }
-  // return options.localizePath;
   if (options.localizePath === true || options.localizePath === false) {
     return options.localizePath;
   }

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -134,11 +134,13 @@ module.exports = {
         label: 'English',
         direction: 'ltr',
         htmlLang: 'en-US',
+        baseUrl: 'en-US',
       },
       fr: {
         label: 'Français',
         direction: 'ltr',
         htmlLang: 'fr-FR',
+        baseUrl: '/fr-FR/',
       },
     },
   },
@@ -148,6 +150,7 @@ module.exports = {
 - `label`: the label to use for this locale
 - `direction`: `ltr` (default) or `rtl` (for [right-to-left languages](https://developer.mozilla.org/en-US/docs/Glossary/rtl) like Arabic, Hebrew, etc.)
 - `htmlLang`: BCP 47 language tag to use in `<html lang="...">` and in `<link ... hreflang="...">`
+- `baseUrl`: the baseUrl to use for this locale
 
 ### `noIndex` {#noindex}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

<!-- Write your motivation here. -->
Make the locale baseUrl support configurable.

In my case, i want the url of English docs(default locale) to be like `http://localhost:3000/en-US/`, the url of Chinese docs to be like `http://localhost:3000/zh-CN/`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

<!-- Write your answer here. -->
yes

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
### Default Config Test
1. use [docusaurus website](https://github.com/facebook/docusaurus/)  i18n config to test
2. `yarn start`
	The url of English docs homepage is `http://localhost:3000/`.
	The url of English docs homepage is `http://localhost:3000/zh-CN/`.

3. `yarn build`
	The generated static file directories are build and build/zh-CN.
4. `yarn workspace website serve`
	The url of English docs homepage is `http://localhost:3000/`.
	The url of English docs homepage is `http://localhost:3000/zh-CN/`.

### Custom Config Test
1. change [docusaurus website](https://github.com/facebook/docusaurus/)  i18n config
```js
        localeConfigs: {
          en: {
            label: 'English',
            direction: 'ltr',
            baseUrl: '/en-US/',
          },
          'zh-cn': {
            label: '中文（中国）',
            direction: 'ltr',
            baseUrl: 'zh-CN',
          },
        },
```
2. `yarn start`
	The url of English docs homepage is `http://localhost:3000/en-US/`.
	The url of English docs homepage is `http://localhost:3000/zh-CN/`.

3. `yarn build`
	The generated static file directories are `build/en-US` and `build/zh-CN`.
4. `yarn workspace website serve`
	The url of English docs homepage is `http://localhost:3000/en-US/`.
	The url of English docs homepage is `http://localhost:3000/zh-CN/`.

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
https://github.com/facebook/docusaurus/issues/4723#issuecomment-831773202
