### PR TITLE
refactor: remove deprecated Webpack utils & validation escape hatch

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -391,18 +391,6 @@ export interface ConfigureWebpackUtils {
     isServer: boolean;
     babelOptions?: Record<string, unknown>;
   }) => RuleSetRule;
-
-  // TODO deprecated: remove before end of 2021?
-  getCacheLoader: (
-    isServer: boolean,
-    cacheOptions?: Record<string, unknown>,
-  ) => RuleSetRule | null;
-
-  // TODO deprecated: remove before end of 2021?
-  getBabelLoader: (
-    isServer: boolean,
-    options?: Record<string, unknown>,
-  ) => RuleSetRule;
 }
 
 interface HtmlTagObject {

--- a/packages/docusaurus-utils-validation/src/index.ts
+++ b/packages/docusaurus-utils-validation/src/index.ts
@@ -10,8 +10,6 @@ export {default as Joi} from './Joi';
 export {JoiFrontMatter} from './JoiFrontMatter';
 
 export {
-  isValidationDisabledEscapeHatch,
-  logValidationBugReportHint,
   printWarning,
   normalizePluginOptions,
   normalizeThemeConfig,

--- a/packages/docusaurus-utils-validation/src/validationUtils.ts
+++ b/packages/docusaurus-utils-validation/src/validationUtils.ts
@@ -9,26 +9,6 @@ import type Joi from './Joi';
 import logger from '@docusaurus/logger';
 import {PluginIdSchema} from './validationSchemas';
 
-// TODO temporary escape hatch for alpha-60: to be removed soon
-// Our validation schemas might be buggy at first
-// will permit users to bypass validation until we fix all validation errors
-// see for example: https://github.com/facebook/docusaurus/pull/3120
-// Undocumented on purpose, as we don't want users to keep using it over time
-// Maybe we'll make this escape hatch official some day, with a better api?
-export const isValidationDisabledEscapeHatch =
-  process.env.DISABLE_DOCUSAURUS_VALIDATION === 'true';
-
-if (isValidationDisabledEscapeHatch) {
-  logger.error`You should avoid using code=${'DISABLE_DOCUSAURUS_VALIDATION'} escape hatch, this will be removed.`;
-}
-
-export const logValidationBugReportHint = (): void => {
-  logger.error('A validation error occurred.');
-  logger.info(`The validation system was added recently to Docusaurus as an attempt to avoid user configuration errors.
-We may have made some mistakes.
-If you think your configuration is valid and should keep working, please open a bug report.`);
-};
-
 export function printWarning(warning?: Joi.ValidationError): void {
   if (warning) {
     const warningMessages = warning.details
@@ -54,11 +34,6 @@ export function normalizePluginOptions<T extends {id?: string}>(
   printWarning(warning);
 
   if (error) {
-    logValidationBugReportHint();
-    if (isValidationDisabledEscapeHatch) {
-      logger.error(error);
-      return options as T;
-    }
     throw error;
   }
 
@@ -81,11 +56,6 @@ export function normalizeThemeConfig<T>(
   printWarning(warning);
 
   if (error) {
-    logValidationBugReportHint();
-    if (isValidationDisabledEscapeHatch) {
-      logger.error(error);
-      return themeConfig as T;
-    }
     throw error;
   }
   return value!; // TODO remove this ! in TS 4.6
@@ -107,8 +77,6 @@ export function validateFrontMatter<T>(
     const frontMatterString = JSON.stringify(frontMatter, null, 2);
     const errorDetails = error.details;
     const invalidFields = errorDetails.map(({path}) => path).join(', ');
-
-    logValidationBugReportHint();
 
     logger.error`The following front matter:
 ${logger.yellow(frontMatterString)}

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -5,16 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import logger from '@docusaurus/logger';
 import type {DocusaurusConfig, I18nConfig} from '@docusaurus/types';
 import {DEFAULT_CONFIG_FILE_NAME, STATIC_DIR_NAME} from '@docusaurus/utils';
-import {
-  Joi,
-  logValidationBugReportHint,
-  isValidationDisabledEscapeHatch,
-  URISchema,
-  printWarning,
-} from '@docusaurus/utils-validation';
+import {Joi, URISchema, printWarning} from '@docusaurus/utils-validation';
 
 const DEFAULT_I18N_LOCALE = 'en';
 
@@ -218,12 +211,6 @@ export function validateConfig(
   printWarning(warning);
 
   if (error) {
-    logValidationBugReportHint();
-    if (isValidationDisabledEscapeHatch) {
-      logger.error(error.message);
-      return config as DocusaurusConfig;
-    }
-
     const unknownFields = error.details.reduce((formattedError, err) => {
       if (err.type === 'object.unknown') {
         return `${formattedError}"${err.path}",`;

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -31,7 +31,6 @@ import type {
   ConfigureWebpackUtils,
 } from '@docusaurus/types';
 import {BABEL_CONFIG_FILE_NAME} from '@docusaurus/utils';
-import _ from 'lodash';
 
 // Utility method to get style loaders
 export function getStyleLoaders(
@@ -163,27 +162,6 @@ export const getCustomizableJSLoader =
       ? getDefaultBabelLoader({isServer, babelOptions})
       : jsLoader(isServer);
 
-// TODO remove this before end of 2021?
-const warnBabelLoaderOnce = _.memoize(() => {
-  logger.warn`Docusaurus plans to support multiple JS loader strategies (Babel, esbuild...): code=${'getBabelLoader(isServer)'} is now deprecated in favor of code=${'getJSLoader(isServer)'}.`;
-});
-const getBabelLoaderDeprecated = function getBabelLoaderDeprecated(
-  isServer: boolean,
-  babelOptions?: TransformOptions | string,
-) {
-  warnBabelLoaderOnce();
-  return getDefaultBabelLoader({isServer, babelOptions});
-};
-
-// TODO remove this before end of 2021 ?
-const warnCacheLoaderOnce = _.memoize(() => {
-  logger.warn`Docusaurus uses Webpack 5 and code=${'getCacheLoader()'} usage is now deprecated.`;
-});
-function getCacheLoaderDeprecated() {
-  warnCacheLoaderOnce();
-  return null;
-}
-
 /**
  * Helper function to modify webpack config
  * @param configureWebpack a webpack config or a function to modify config
@@ -204,8 +182,6 @@ export function applyConfigureWebpack(
   const utils: ConfigureWebpackUtils = {
     getStyleLoaders,
     getJSLoader: getCustomizableJSLoader(jsLoader),
-    getBabelLoader: getBabelLoaderDeprecated,
-    getCacheLoader: getCacheLoaderDeprecated,
   };
   if (typeof configureWebpack === 'function') {
     const {mergeStrategy, ...res} = configureWebpack(

--- a/website/docs/api/plugin-methods/lifecycle-apis.md
+++ b/website/docs/api/plugin-methods/lifecycle-apis.md
@@ -188,13 +188,13 @@ module.exports = function (context, options) {
     name: 'custom-docusaurus-plugin',
     // highlight-start
     configureWebpack(config, isServer, utils) {
-      const {getCacheLoader} = utils;
+      const {getJSLoader} = utils;
       return {
         module: {
           rules: [
             {
               test: /\.foo$/,
-              use: [getCacheLoader(isServer), 'my-custom-webpack-loader'],
+              use: [getJSLoader(isServer), 'my-custom-webpack-loader'],
             },
           ],
         },

--- a/website/versioned_docs/version-2.0.0-beta.14/api/plugin-methods/lifecycle-apis.md
+++ b/website/versioned_docs/version-2.0.0-beta.14/api/plugin-methods/lifecycle-apis.md
@@ -182,13 +182,13 @@ module.exports = function (context, options) {
     name: 'custom-docusaurus-plugin',
     // highlight-start
     configureWebpack(config, isServer, utils) {
-      const {getCacheLoader} = utils;
+      const {getJSLoader} = utils;
       return {
         module: {
           rules: [
             {
               test: /\.foo$/,
-              use: [getCacheLoader(isServer), 'my-custom-webpack-loader'],
+              use: [getJSLoader(isServer), 'my-custom-webpack-loader'],
             },
           ],
         },

--- a/website/versioned_docs/version-2.0.0-beta.15/api/plugin-methods/lifecycle-apis.md
+++ b/website/versioned_docs/version-2.0.0-beta.15/api/plugin-methods/lifecycle-apis.md
@@ -188,13 +188,13 @@ module.exports = function (context, options) {
     name: 'custom-docusaurus-plugin',
     // highlight-start
     configureWebpack(config, isServer, utils) {
-      const {getCacheLoader} = utils;
+      const {getJSLoader} = utils;
       return {
         module: {
           rules: [
             {
               test: /\.foo$/,
-              use: [getCacheLoader(isServer), 'my-custom-webpack-loader'],
+              use: [getJSLoader(isServer), 'my-custom-webpack-loader'],
             },
           ],
         },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

The webpack loaders don't do anything, and no-one has complained so far, so let's remove them.

The validation system is quite stable now (although we did have a few mistakes, but those are inevitable), so we can remove that long hint message and the escape hatch (since it isn't documented anyways)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
