### PR TITLE
chore(module-type-aliases): add react as peer dependency

### DIFF
--- a/packages/docusaurus-module-type-aliases/package.json
+++ b/packages/docusaurus-module-type-aliases/package.json
@@ -18,5 +18,9 @@
     "@types/react-router-dom": "*",
     "react-helmet-async": "*"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix the last installation warning we have: `@docusaurus/module-type-aliases@npm:0.0.0-4615 doesn't provide react (peecbe), requested by react-helmet-async`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
