### PR TITLE
fix(theme-classic): temporarily disable toc heading autoscrolling

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
+++ b/packages/docusaurus-theme-common/src/utils/useTOCHighlight.ts
@@ -147,7 +147,7 @@ function useTOCHighlight(config: TOCHighlightConfig | undefined): void {
         }
         link.classList.add(linkActiveClassName);
         lastActiveLinkRef.current = link;
-        link.scrollIntoView({block: 'nearest'});
+        // link.scrollIntoView({block: 'nearest'});
       } else {
         link.classList.remove(linkActiveClassName);
       }


### PR DESCRIPTION

## Motivation

This change (https://github.com/facebook/docusaurus/pull/6317) led to issues, for which we don't have a perfect solution yet.

Let's disable this temporarily so that next release does not have the bugs, we'll reapply it properly later.

See 
- initial PR: https://github.com/facebook/docusaurus/pull/6317
- issue: https://github.com/facebook/docusaurus/issues/6620
- fix attempt: https://github.com/facebook/docusaurus/pull/6666


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview, basic revert

