### PR TITLE
test: sort migration test FS mock calls

### DIFF
--- a/packages/docusaurus-migrate/src/__tests__/__snapshots__/migration.test.ts.snap
+++ b/packages/docusaurus-migrate/src/__tests__/__snapshots__/migration.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`migration test complex website: copy 1`] = `
 Array [
   Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/static",
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/static",
-  ],
-  Array [
     "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/blog",
     "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/blog",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/complex_website/website/static",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/static",
   ],
 ]
 `;
@@ -16,10 +16,10 @@ Array [
 exports[`migration test complex website: mkdirp 1`] = `
 Array [
   Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/pages/",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/css",
   ],
   Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/css",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/pages/",
   ],
 ]
 `;
@@ -28,29 +28,6 @@ exports[`migration test complex website: mkdirs 1`] = `Array []`;
 
 exports[`migration test complex website: write 1`] = `
 Array [
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/pages/index.js",
-    "import Layout from \\"@theme/Layout\\";
-      import React from \\"react\\";
-
-      export default () => {
-        return <Layout />;
-      };
-      ",
-  ],
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/css/customTheme.css",
-    ":root{
-  --ifm-color-primary-lightest: #3CAD6E;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-light: #33925D;
-  --ifm-color-primary: #2E8555;
-  --ifm-color-primary-dark: #29784C;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205D3B;
-}
-",
-  ],
   Array [
     "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/docusaurus.config.js",
     "module.exports={
@@ -189,49 +166,8 @@ Array [
   }
 }",
   ],
-]
-`;
-
-exports[`migration test missing versions: copy 1`] = `
-Array [
   Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/static",
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/static",
-  ],
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/blog",
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/blog",
-  ],
-]
-`;
-
-exports[`migration test missing versions: mkdirp 1`] = `
-Array [
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/pages/",
-  ],
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/css",
-  ],
-]
-`;
-
-exports[`migration test missing versions: mkdirs 1`] = `Array []`;
-
-exports[`migration test missing versions: write 1`] = `
-Array [
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/pages/index.js",
-    "import Layout from \\"@theme/Layout\\";
-      import React from \\"react\\";
-
-      export default () => {
-        return <Layout />;
-      };
-      ",
-  ],
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/css/customTheme.css",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/css/customTheme.css",
     ":root{
   --ifm-color-primary-lightest: #3CAD6E;
   --ifm-color-primary-lighter: #359962;
@@ -243,6 +179,47 @@ Array [
 }
 ",
   ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_complex_site/src/pages/index.js",
+    "import Layout from \\"@theme/Layout\\";
+      import React from \\"react\\";
+
+      export default () => {
+        return <Layout />;
+      };
+      ",
+  ],
+]
+`;
+
+exports[`migration test missing versions: copy 1`] = `
+Array [
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/blog",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/blog",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/missing_version_website/website/static",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/static",
+  ],
+]
+`;
+
+exports[`migration test missing versions: mkdirp 1`] = `
+Array [
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/css",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/pages/",
+  ],
+]
+`;
+
+exports[`migration test missing versions: mkdirs 1`] = `Array []`;
+
+exports[`migration test missing versions: write 1`] = `
+Array [
   Array [
     "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/docusaurus.config.js",
     "module.exports={
@@ -381,6 +358,29 @@ Array [
   }
 }",
   ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/css/customTheme.css",
+    ":root{
+  --ifm-color-primary-lightest: #3CAD6E;
+  --ifm-color-primary-lighter: #359962;
+  --ifm-color-primary-light: #33925D;
+  --ifm-color-primary: #2E8555;
+  --ifm-color-primary-dark: #29784C;
+  --ifm-color-primary-darker: #277148;
+  --ifm-color-primary-darkest: #205D3B;
+}
+",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_missing_version_site/src/pages/index.js",
+    "import Layout from \\"@theme/Layout\\";
+      import React from \\"react\\";
+
+      export default () => {
+        return <Layout />;
+      };
+      ",
+  ],
 ]
 `;
 
@@ -396,10 +396,10 @@ Array [
 exports[`migration test simple website: mkdirp 1`] = `
 Array [
   Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/pages/",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/css",
   ],
   Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/css",
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/pages/",
   ],
 ]
 `;
@@ -408,47 +408,6 @@ exports[`migration test simple website: mkdirs 1`] = `Array []`;
 
 exports[`migration test simple website: write 1`] = `
 Array [
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/pages/index.js",
-    "import Layout from \\"@theme/Layout\\";
-      import React from \\"react\\";
-
-      export default () => {
-        return <Layout />;
-      };
-      ",
-  ],
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/docs/api-commands.md",
-    "---
-id: commands
-title: CLI Commands
----
-
-## Doc ",
-  ],
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/docs/api-doc-markdown.md",
-    "---
-id: doc-markdown
-title: Markdown Features
----
-
-## Doc",
-  ],
-  Array [
-    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/css/customTheme.css",
-    ":root{
-  --ifm-color-primary-lightest: #3CAD6E;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-light: #33925D;
-  --ifm-color-primary: #2E8555;
-  --ifm-color-primary-dark: #29784C;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205D3B;
-}
-",
-  ],
   Array [
     "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/docusaurus.config.js",
     "module.exports={
@@ -587,6 +546,47 @@ title: Markdown Features
     \\"react-dom\\": \\"^17.0.2\\"
   }
 }",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/css/customTheme.css",
+    ":root{
+  --ifm-color-primary-lightest: #3CAD6E;
+  --ifm-color-primary-lighter: #359962;
+  --ifm-color-primary-light: #33925D;
+  --ifm-color-primary: #2E8555;
+  --ifm-color-primary-dark: #29784C;
+  --ifm-color-primary-darker: #277148;
+  --ifm-color-primary-darkest: #205D3B;
+}
+",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/migrated_simple_site/src/pages/index.js",
+    "import Layout from \\"@theme/Layout\\";
+      import React from \\"react\\";
+
+      export default () => {
+        return <Layout />;
+      };
+      ",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/docs/api-commands.md",
+    "---
+id: commands
+title: CLI Commands
+---
+
+## Doc ",
+  ],
+  Array [
+    "<PROJECT_ROOT>/packages/docusaurus-migrate/src/__tests__/__fixtures__/simple_website/docs/api-doc-markdown.md",
+    "---
+id: doc-markdown
+title: Markdown Features
+---
+
+## Doc",
   ],
 ]
 `;

--- a/packages/docusaurus-migrate/src/__tests__/migration.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/migration.test.ts
@@ -15,10 +15,26 @@ async function testMigration(siteDir: string, newDir: string) {
   const mkdirsMock = jest.spyOn(fs, 'mkdirs').mockImplementation();
   const copyMock = jest.spyOn(fs, 'copy').mockImplementation();
   await migrateDocusaurusProject(siteDir, newDir);
-  expect(writeMock.mock.calls).toMatchSnapshot('write');
-  expect(mkdirpMock.mock.calls).toMatchSnapshot('mkdirp');
-  expect(mkdirsMock.mock.calls).toMatchSnapshot('mkdirs');
-  expect(copyMock.mock.calls).toMatchSnapshot('copy');
+  expect(
+    writeMock.mock.calls.sort((a, b) =>
+      (a[0] as string).localeCompare(b[0] as string),
+    ),
+  ).toMatchSnapshot('write');
+  expect(
+    mkdirpMock.mock.calls.sort((a, b) =>
+      (a[0] as string).localeCompare(b[0] as string),
+    ),
+  ).toMatchSnapshot('mkdirp');
+  expect(
+    mkdirsMock.mock.calls.sort((a, b) =>
+      (a[0] as string).localeCompare(b[0] as string),
+    ),
+  ).toMatchSnapshot('mkdirs');
+  expect(
+    copyMock.mock.calls.sort((a, b) =>
+      (a[0] as string).localeCompare(b[0] as string),
+    ),
+  ).toMatchSnapshot('copy');
   writeMock.mockRestore();
   mkdirpMock.mockRestore();
   mkdirsMock.mockRestore();

--- a/packages/docusaurus-migrate/src/__tests__/migration.test.ts
+++ b/packages/docusaurus-migrate/src/__tests__/migration.test.ts
@@ -8,6 +8,7 @@
 import {migrateDocusaurusProject} from '../index';
 import path from 'path';
 import fs from 'fs-extra';
+import {posixPath} from '@docusaurus/utils';
 
 async function testMigration(siteDir: string, newDir: string) {
   const writeMock = jest.spyOn(fs, 'writeFile').mockImplementation();
@@ -17,22 +18,22 @@ async function testMigration(siteDir: string, newDir: string) {
   await migrateDocusaurusProject(siteDir, newDir);
   expect(
     writeMock.mock.calls.sort((a, b) =>
-      (a[0] as string).localeCompare(b[0] as string),
+      posixPath(a[0] as string).localeCompare(posixPath(b[0] as string)),
     ),
   ).toMatchSnapshot('write');
   expect(
     mkdirpMock.mock.calls.sort((a, b) =>
-      (a[0] as string).localeCompare(b[0] as string),
+      posixPath(a[0] as string).localeCompare(posixPath(b[0] as string)),
     ),
   ).toMatchSnapshot('mkdirp');
   expect(
     mkdirsMock.mock.calls.sort((a, b) =>
-      (a[0] as string).localeCompare(b[0] as string),
+      posixPath(a[0] as string).localeCompare(posixPath(b[0] as string)),
     ),
   ).toMatchSnapshot('mkdirs');
   expect(
     copyMock.mock.calls.sort((a, b) =>
-      (a[0] as string).localeCompare(b[0] as string),
+      posixPath(a[0] as string).localeCompare(posixPath(b[0] as string)),
     ),
   ).toMatchSnapshot('copy');
   writeMock.mockRestore();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

After #6755, the migration test uses an FS mock snapshot to validate the _content_ of the migrated site, not just that it succeeds. However, because of paralleling FS ops, these calls can resolve in a random order, creating random CI failures. Sorting the calls by the file path should mitigate the issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before merging, the Jest tests will be re-attempted for three times.