### PR TITLE
fix(theme-common): isSamePath should be case-insensitive

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/__tests__/pathUtils.test.ts
+++ b/packages/docusaurus-theme-common/src/utils/__tests__/pathUtils.test.ts
@@ -16,6 +16,14 @@ describe('isSamePath', () => {
     expect(isSamePath('/docs', '/docs/')).toBeTruthy();
   });
 
+  test('should be true for compared path with different case', () => {
+    expect(isSamePath('/doCS', '/DOcs')).toBeTruthy();
+  });
+
+  test('should be true for compared path with different case + trailing slash', () => {
+    expect(isSamePath('/doCS', '/DOcs/')).toBeTruthy();
+  });
+
   test('should be false for compared path with double trailing slash', () => {
     expect(isSamePath('/docs', '/docs//')).toBeFalsy();
   });

--- a/packages/docusaurus-theme-common/src/utils/pathUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/pathUtils.ts
@@ -5,12 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Compare the 2 paths, ignoring trailing /
+// Compare the 2 paths, case insensitive and ignoring trailing slash
 export const isSamePath = (
   path1: string | undefined,
   path2: string | undefined,
 ): boolean => {
   const normalize = (pathname: string | undefined) =>
-    !pathname || pathname?.endsWith('/') ? pathname : `${pathname}/`;
+    (!pathname || pathname?.endsWith('/')
+      ? pathname
+      : `${pathname}/`
+    )?.toLowerCase();
   return normalize(path1) === normalize(path2);
 };

--- a/website/_dogfooding/_docs tests/tests/Case-Sentitive-Doc.md
+++ b/website/_dogfooding/_docs tests/tests/Case-Sentitive-Doc.md
@@ -1,0 +1,5 @@
+# Case-Sensitive doc
+
+This doc has uppercase and lowercase chars in its filename, and thus in its path / slug.
+
+It should still work fine if the doc is server from a lowercase/uppercase path.


### PR DESCRIPTION
## Motivation

Sometimes the user has a filename like `Capitalized.md` leading to a slug with some uppercase chars such as `/docs/Capitalized`

But this URL is often normalized to `/docs/capitalized` by CDN/hosts and then when we try to match the 2 paths we consider they are different.

This leads to subtle UX issues such as:
- empty breadcrumb 
- bad navbar item highlighting
- bad sidebar category/items highlighting

The helper function `isSamePath` should be case-insensitive to fix it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests + dogfood
