### PR TITLE
Update broken image URLs in typescript template example

### DIFF
--- a/examples/classic-typescript/src/components/HomepageFeatures/index.tsx
+++ b/examples/classic-typescript/src/components/HomepageFeatures/index.tsx
@@ -11,7 +11,7 @@ type FeatureItem = {
 const FeatureList: FeatureItem[] = [
   {
     title: 'Easy to Use',
-    image: require('@site/src/static/img/undraw_docusaurus_mountain.svg'),
+    image: require('@site/static/img/undraw_docusaurus_mountain.svg'),
     description: (
       <>
         Docusaurus was designed from the ground up to be easily installed and
@@ -21,7 +21,7 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Focus on What Matters',
-    image: require('@site/src/static/img/undraw_docusaurus_tree.svg'),
+    image: require('@site/static/img/undraw_docusaurus_tree.svg'),
     description: (
       <>
         Docusaurus lets you focus on your docs, and we&apos;ll do the chores. Go
@@ -31,7 +31,7 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Powered by React',
-    image: require('@site/src/static/img/undraw_docusaurus_react.svg'),
+    image: require('@site/static/img/undraw_docusaurus_react.svg'),
     description: (
       <>
         Extend or customize your website layout by reusing React. Docusaurus can


### PR DESCRIPTION
## Motivation

I recently tried a simple out-of-the-box setup of Docusaurus using the following script:

```sh
npx create-docusaurus@latest website classic --typescript --package-manager pnpm
```

This installed cleanly, but after starting or building the site I got the following errors:

```
Module not found: Error: Can't resolve '@site/src/static/img/undraw_docusaurus_mountain.svg' in '/Users/alex.nicholls/code/design/quantum/apps/website/src/components/HomepageFeatures'
Module not found: Error: Can't resolve '@site/src/static/img/undraw_docusaurus_tree.svg' in '/Users/alex.nicholls/code/design/quantum/apps/website/src/components/HomepageFeatures'
Module not found: Error: Can't resolve '@site/src/static/img/undraw_docusaurus_react.svg' in '/Users/alex.nicholls/code/design/quantum/apps/website/src/components/HomepageFeatures'
```

After inspection, it appeared that an unnecessary `src/` had been put in the image src. The `static/` folder in this example is in the root, not in `src/`, so removing this fixed the errors.