### PR TITLE
fix(theme-classic): allow code tags containing inline elements to stay inline

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -37,8 +37,22 @@ const MDXComponents: MDXComponentsObject = {
     return <Head {...props}>{unwrappedChildren}</Head>;
   },
   code: (props) => {
+    const inlineElements = [
+      'a',
+      'b',
+      'big',
+      'i',
+      'span',
+      'em',
+      'strong',
+      'sup',
+      'sub',
+      'small',
+    ];
     const shouldBeInline = React.Children.toArray(props.children).every(
-      (el) => typeof el === 'string' && !el.includes('\n'),
+      (el) =>
+        (typeof el === 'string' && !el.includes('\n')) ||
+        (React.isValidElement(el) && inlineElements.includes(el.props.mdxType)),
     );
 
     return shouldBeInline ? <code {...props} /> : <CodeBlock {...props} />;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Noticed this problem on our website: 

<img width="680" alt="image" src="https://user-images.githubusercontent.com/55398995/155830174-47397970-e01d-4e09-af27-53996bfc671c.png">

The `<a>` tag inside `<code>` makes the latter be translated to `CodeBlock`. However, it's possible to make it stay as `<code>` since `<a>` is inline.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The `<code>` works well on https://docusaurus.io/docs/api/themes/configuration#navbar-dropdown.  http://localhost:3000/tests/pages/code-block-tests#code doesn't regress either.