### PR TITLE
fix(mdx-loader): suppress image reading warning in Yarn PnP; log warning instead of error

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/__tests__/index.test.ts
@@ -59,7 +59,7 @@ describe('transformImage plugin', () => {
   });
 
   test('does not choke on invalid image', async () => {
-    const errorMock = jest.spyOn(console, 'error').mockImplementation();
+    const errorMock = jest.spyOn(console, 'warn').mockImplementation();
     const result = await processFixture('invalid-img', {staticDirs});
     expect(result).toMatchSnapshot();
     expect(errorMock).toBeCalledTimes(1);

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
@@ -67,8 +67,12 @@ async function toImageRequireNode(
       height = ` height="${size.height}"`;
     }
   } catch (err) {
-    logger.error`The image at path=${imagePath} can't be read correctly. Please ensure it's a valid image.
+    // Workaround for https://github.com/yarnpkg/berry/pull/3889#issuecomment-1034469784
+    // TODO remove this check once fixed in Yarn PnP
+    if (!process.versions.pnp) {
+      logger.warn`The image at path=${imagePath} can't be read correctly. Please ensure it's a valid image.
 ${(err as Error).message}`;
+    }
   }
 
   Object.keys(jsxNode).forEach(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix #6774. Yarn PnP patches FS and generates a virtual file handle, but they forgot to map it back to the actual file handle when calling `stat()`. This makes `image-size` unhappy. More information in https://github.com/yarnpkg/berry/pull/3889#issuecomment-1034469784.

In addition, I've downgraded the error to a warning, hoping it would be less intimidating for users.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
