### PR TITLE
docs: append file extension in Crowdin config to avoid conflict

### DIFF
--- a/website/docs/i18n/i18n-crowdin.mdx
+++ b/website/docs/i18n/i18n-crowdin.mdx
@@ -124,19 +124,19 @@ api_token_env: CROWDIN_PERSONAL_TOKEN
 preserve_hierarchy: true
 files:
   # JSON translation files
-  - source: /i18n/en/**/*
+  - source: /i18n/en/**/*.json
     translation: /i18n/%two_letters_code%/**/%original_file_name%
   # Docs Markdown files
-  - source: /docs/**/*
+  - source: /docs/**/*.md
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
   # Blog Markdown files
-  - source: /blog/**/*
+  - source: /blog/**/*.md
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-blog/**/%original_file_name%
 ```
 
 Crowdin has its own syntax for declaring source/translation paths:
 
-- `**/*`: everything in a subfolder
+- `**/*.md`: all markdown files in a subfolder.
 - `%two_letters_code%`: the 2-letters variant of Crowdin target languages (`fr` in our case)
 - `**/%original_file_name%`: the translations will preserve the original folder/file hierarchy
 
@@ -149,7 +149,7 @@ We advise to:
 - change one thing at a time
 - re-upload sources after any configuration change
 - use paths starting with `/` (`./` does not work)
-- avoid fancy globbing patterns like `/docs/**/*.(md|mdx)` (does not work)
+- use one file type and avoid fancy globbing patterns like `/docs/**/*.(md|mdx)` (does not work)
 
 :::
 


### PR DESCRIPTION
Crowdin fails to synchronize when a path contains multiple file types.

  As an example, `_category_.json` and `markdown.md` in the same directory will output an error and stop the synchronization process.

  It has to be excluded, regardless, I am unable to find a clear statement in the Crowdin documentation on this specific case. I tested it with my project as this was the reason for the failure.

### References

https://support.crowdin.com/configuration-file/#general-configuration
https://support.crowdin.com/configuration-file/#usage-of-wildcards

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

<!-- Write your motivation here. -->

Have my own Docusaurus websites so it is reasonable to fix issues and propose changes along the way.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

<!-- Write your answer here. -->

 - [x] Yes

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Minor change which has been tested on my own project.

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->