### PR TITLE
fix: consistently use `max-width: 996px` in media queries

### DIFF
--- a/examples/classic-typescript/src/pages/index.module.css
+++ b/examples/classic-typescript/src/pages/index.module.css
@@ -10,7 +10,7 @@
   overflow: hidden;
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 966px) {
   .heroBanner {
     padding: 2rem;
   }

--- a/examples/classic/src/pages/index.module.css
+++ b/examples/classic/src/pages/index.module.css
@@ -10,7 +10,7 @@
   overflow: hidden;
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 966px) {
   .heroBanner {
     padding: 2rem;
   }

--- a/examples/facebook/src/pages/styles.module.css
+++ b/examples/facebook/src/pages/styles.module.css
@@ -19,7 +19,7 @@
   overflow: hidden;
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 966px) {
   .heroBanner {
     padding: 2rem;
   }


### PR DESCRIPTION
Follow `docusaurus-theme-classic` ([ref](https://github.com/search?l=&q=996px+repo%3Afacebook%2Fdocusaurus+path%3Apackages%2Fdocusaurus-theme-classic&type=code)) and use `996px` as the cutoff between desktop and mobile screen width.