### PR TITLE
docs: fix broken links

### DIFF
--- a/website/blog/2022-01-24-docusaurus-2021-recap/index.md
+++ b/website/blog/2022-01-24-docusaurus-2021-recap/index.md
@@ -116,7 +116,7 @@ With the official release of Docusaurus 2.0, we are confident to see much more n
 
 We'd like to express our gratitude to [all the contributors in 2021](https://github.com/facebook/docusaurus/graphs/contributors?from=2021-01-01&to=2022-01-01&type=c), including:
 
-- The core team: [Alexey Pyltsyn](https://github.com/lex111), [Sébastien Lorber](https://github.com/slorber), [Joshua Chen](https://github.com/Josh-Cena), and [Yangshun Tay](https://github/yangshun) for moderating the community, publicizing Docusaurus, triaging issues, and implementing new features
+- The core team: [Alexey Pyltsyn](https://github.com/lex111), [Sébastien Lorber](https://github.com/slorber), [Joshua Chen](https://github.com/Josh-Cena), and [Yangshun Tay](https://github.com/yangshun) for moderating the community, publicizing Docusaurus, triaging issues, and implementing new features
 - [Joel Marcey](https://github.com/JoelMarcey) for creating Docusaurus and supporting its development all along
 - The Algolia team for helping Docusaurus users [migrate to the new DocSearch](../2021-11-21-algolia-docsearch-migration/index.md) and answering search-related questions
 - All the active community members for making valuable code contributions, improving our documentation, and answering questions on Discord

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -213,7 +213,7 @@ Refer to [slorber/trailing-slash-guide](https://github.com/slorber/trailing-slas
 
 Deploying your Docusaurus project to [Vercel](https://vercel.com/) will provide you with [various benefits](https://vercel.com/) in the areas of performance and ease of use.
 
-To deploy your Docusaurus project with a [Vercel for Git Integration](https://vercel.com/docs/git-integrations), make sure it has been pushed to a Git repository.
+To deploy your Docusaurus project with a [Vercel for Git Integration](https://vercel.com/docs/concepts/git), make sure it has been pushed to a Git repository.
 
 Import the project into Vercel using the [Import Flow](https://vercel.com/import/git). During the import, you will find all relevant options preconfigured for you; however, you can choose to change any of these options, a list of which can be found [here](https://vercel.com/docs/build-step#build-&-development-settings).
 

--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -1925,8 +1925,8 @@ const Users: User[] = [
       'IT enthusiast that loves to write code, try new things and share knowledge. If not sitting in front of computer, then I am playing badminton, riding bike or hiking.',
     preview: require('./showcase/juffalow.png'),
     website: 'https://juffalow.com/',
-    source: 'https://github.com/juffalow/juffalow-com',
-    tags: ['personal', 'opensource'],
+    source: null,
+    tags: ['personal'],
   },
   {
     title: 'SigNoz',

--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -865,8 +865,8 @@ const Users: User[] = [
     description: 'Creation of technical trading tools',
     preview: require('./showcase/lux-algo.png'),
     website: 'https://docs.luxalgo.com',
-    source: 'https://github.com/smack0202/luxdocs',
-    tags: ['opensource', 'design', 'i18n', 'product'],
+    source: null,
+    tags: ['design', 'i18n', 'product'],
   },
   {
     title: 'SICOPE Model',

--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -456,7 +456,7 @@ const Users: User[] = [
       'A persian tutorial website strive to make quality education for everyone.',
     preview: require('./showcase/datagit.png'),
     website: 'https://datagit.ir/',
-    source: 'https://github.com/massoudmaboudi/datagit_v2.docusaurus',
+    source: 'https://github.com/ghaseminya/datagit_v2.docusaurus',
     tags: ['opensource', 'favorite', 'rtl'],
   },
   {

--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -949,7 +949,7 @@ const Users: User[] = [
     description:
       'Molecule is a lightweight Web IDE UI framework built with React.js and inspired by VSCode.',
     preview: require('./showcase/molecule-home.png'),
-    website: 'https://dtstack.github.io/molecule/en',
+    website: 'https://dtstack.github.io/molecule/',
     source: 'https://github.com/DTStack/molecule',
     tags: ['opensource', 'i18n'],
   },


### PR DESCRIPTION
## Motivation

I recently crawled my website for broken links and I found it quite useful. 
Out of curiosity I did the docusaurus website and found errors, so I have fixed them. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Notes

I'd also like to say that the following websites in the showcase don't seem to work:

https://www.amphoradata.com
https://developer.axioms.io
https://www.ocpeasy.org
https://developers.getwisdom.io