### PR TITLE
fix(theme-classic): restore docusaurus search meta

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/SearchMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SearchMetadata/index.tsx
@@ -26,6 +26,15 @@ export default function SearchMetadata({
 
   return (
     <Head>
+      {/*
+      Docusaurus metadata, used by third-party search plugin
+      See https://github.com/cmfcmf/docusaurus-search-local/issues/99
+      */}
+      {locale && <meta name="docusaurus_locale" content={locale} />}
+      {version && <meta name="docusaurus_version" content={version} />}
+      {tag && <meta name="docusaurus_tag" content={tag} />}
+
+      {/* Algolia DocSearch metadata */}
       {language && <meta name="docsearch:language" content={language} />}
       {version && <meta name="docsearch:version" content={version} />}
       {tag && <meta name="docsearch:docusaurus_tag" content={tag} />}


### PR DESCRIPTION

## Motivation

In https://github.com/facebook/docusaurus/pull/6707 we replaced docusaurus_x meta by Algolia meta (biasing toward Algolia)

Unfortunately the former metas were actually used by some third-party search plugins: https://github.com/cmfcmf/docusaurus-search-local/issues/99

To avoid annoying anyone for now I'm duplicating the metadata

In the future I'd like to avoid doing so (as it slightly increase page size uselessly), but we'll figure this later


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

