### PR TITLE
refactor: simplify imported code blocks

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -352,7 +352,7 @@ Now you can import code snippets from another file as it is:
 import CodeBlock from '@theme/CodeBlock';
 import MyComponentSource from '!!raw-loader!./myComponent';
 
-<CodeBlock className="language-jsx">{MyComponentSource}</CodeBlock>
+<CodeBlock language="jsx">{MyComponentSource}</CodeBlock>
 ```
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
- Use `language=<lang>` prop instead of "className="language-<lang>" for imported code blocks

I've been using this in my personal projects ([example](https://raw.githubusercontent.com/nathan-contino-mongo/docusaurus-realm/9a2ebb6a43bbbd7b38899fcc86c903dcc1f61283/docs/sdk/kotlin/migrate-from-java-sdk.mdx)) since it is less verbose.
If this interface is somehow less stable than the `className` prop, feel free to close this. But if both will work going forward
we should probably recommend the simpler of the two.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

<!-- Write your motivation here. -->

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

<!-- Write your answer here. -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
