### PR TITLE
docs: make tutorial code block directly copyable

### DIFF
--- a/packages/create-docusaurus/templates/shared/docs/tutorial-basics/create-a-document.md
+++ b/packages/create-docusaurus/templates/shared/docs/tutorial-basics/create-a-document.md
@@ -41,12 +41,13 @@ This is my **first Docusaurus document**!
 
 It is also possible to create your sidebar explicitly in `sidebars.js`:
 
-```diff title="sidebars.js"
+```js title="sidebars.js"
 module.exports = {
   tutorialSidebar: [
     {
       type: 'category',
       label: 'Tutorial',
+      // highlight-next-line
       items: ['hello'],
     },
   ],

--- a/packages/create-docusaurus/templates/shared/docs/tutorial-basics/create-a-document.md
+++ b/packages/create-docusaurus/templates/shared/docs/tutorial-basics/create-a-document.md
@@ -47,8 +47,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Tutorial',
--     items: [...],
-+     items: ['hello'],
+      items: ['hello'],
     },
   ],
 };


### PR DESCRIPTION
## Motivation

Sample code block could not be copy/pasted as the tutorial mentions with the lines that appear to be from a diff tool.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes! this is so small, wasn't sure if it should be an issue or a PR

## Test Plan

None

## Related PRs

None that I could find