### PR TITLE
refactor(theme-classic): consistently add span wrapper for layout links

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -269,8 +269,10 @@ function DocSidebarItemLink({
           onClick: onItemClick ? () => onItemClick(item) : undefined,
         })}
         {...props}>
-        {label}
-        {!isInternalUrl(href) && <IconExternalLink />}
+        <span>
+          {label}
+          {!isInternalUrl(href) && <IconExternalLink />}
+        </span>
       </Link>
     </li>
   );

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -269,14 +269,8 @@ function DocSidebarItemLink({
           onClick: onItemClick ? () => onItemClick(item) : undefined,
         })}
         {...props}>
-        {isInternalUrl(href) ? (
-          label
-        ) : (
-          <span>
-            {label}
-            <IconExternalLink />
-          </span>
-        )}
+        {label}
+        {!isInternalUrl(href) && <IconExternalLink />}
       </Link>
     </li>
   );

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -42,8 +42,10 @@ function FooterLink({
             to: toUrl,
           })}
       {...props}>
-      {label}
-      {href && !isInternalUrl(href) && <IconExternalLink />}
+      <span>
+        {label}
+        {href && !isInternalUrl(href) && <IconExternalLink />}
+      </span>
     </Link>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -42,14 +42,8 @@ function FooterLink({
             to: toUrl,
           })}
       {...props}>
-      {href && !isInternalUrl(href) ? (
-        <span>
-          {label}
-          <IconExternalLink />
-        </span>
-      ) : (
-        label
-      )}
+      {label}
+      {href && !isInternalUrl(href) && <IconExternalLink />}
     </Link>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -55,13 +55,9 @@ export default function NavbarNavLink({
               : null),
           })}
       {...props}>
-      {isExternalLink ? (
-        <span>
-          {label}
-          <IconExternalLink {...(isDropdownLink && {width: 12, height: 12})} />
-        </span>
-      ) : (
-        label
+      {label}
+      {isExternalLink && (
+        <IconExternalLink {...(isDropdownLink && {width: 12, height: 12})} />
       )}
     </Link>
   );

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -55,10 +55,12 @@ export default function NavbarNavLink({
               : null),
           })}
       {...props}>
-      {label}
-      {isExternalLink && (
-        <IconExternalLink {...(isDropdownLink && {width: 12, height: 12})} />
-      )}
+      <span>
+        {label}
+        {isExternalLink && (
+          <IconExternalLink {...(isDropdownLink && {width: 12, height: 12})} />
+        )}
+      </span>
     </Link>
   );
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

I'm constantly frustrated by the inconsistent DOM between internal and external links, because that means if I want to apply CSS to the text, I have to target both `a` and `a > span`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Should have no layout changes