### PR TITLE
fix(core): make plugin lifecycles consistently bound to the plugin instance

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -174,7 +174,10 @@ async function buildLocale({
     const {configureWebpack, configurePostCss} = plugin;
 
     if (configurePostCss) {
-      clientConfig = applyConfigurePostCss(configurePostCss, clientConfig);
+      clientConfig = applyConfigurePostCss(
+        configurePostCss.bind(plugin),
+        clientConfig,
+      );
     }
 
     if (configureWebpack) {

--- a/packages/docusaurus/src/commands/external.ts
+++ b/packages/docusaurus/src/commands/external.ts
@@ -19,12 +19,6 @@ export default async function externalCommand(
 
   // Plugin Lifecycle - extendCli.
   plugins.forEach((plugin) => {
-    const {extendCli} = plugin;
-
-    if (!extendCli) {
-      return;
-    }
-
-    extendCli(cli);
+    plugin.extendCli?.(cli);
   });
 }

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -146,12 +146,12 @@ export default async function start(
     const {configureWebpack, configurePostCss} = plugin;
 
     if (configurePostCss) {
-      config = applyConfigurePostCss(configurePostCss, config);
+      config = applyConfigurePostCss(configurePostCss.bind(plugin), config);
     }
 
     if (configureWebpack) {
       config = applyConfigureWebpack(
-        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`. // TODO remove this implicit api: inject in callback instead
+        configureWebpack.bind(plugin), // The plugin lifecycle may reference `this`.
         config,
         false,
         props.siteConfig.webpack?.jsLoader,

--- a/packages/docusaurus/src/server/themes/index.ts
+++ b/packages/docusaurus/src/server/themes/index.ts
@@ -51,7 +51,7 @@ export function loadPluginsThemeAliases({
   plugins: LoadedPlugin[];
 }): Promise<ThemeAliases> {
   const pluginThemes: string[] = plugins
-    .map((plugin) => (plugin.getThemePath ? plugin.getThemePath() : undefined))
+    .map((plugin) => plugin.getThemePath?.())
     .filter((x): x is string => Boolean(x));
   const userTheme = path.resolve(siteDir, THEME_PATH);
   return loadThemeAliases([ThemeFallbackDir, ...pluginThemes], [userTheme]);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

This should always work:

```js
function plugin() {
  return {
    foo() { console.log("Bar"); }
    configureWebpack() { this.foo(); }
  };
}
```

Unfortunately, it doesn't work if `configureWebpack` is unbound from the plugin instance. We should always bind the lifecycle so plugin authors can write code in the most intuitive way.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
