### PR TITLE
docs: mention configureWebpack devServer return value

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {RuleSetRule, Configuration} from 'webpack';
+import type {RuleSetRule, Configuration as WebpackConfiguration} from 'webpack';
 import type {CustomizeRuleString} from 'webpack-merge/dist/types';
 import type {CommanderStatic} from 'commander';
 import type {ParsedUrlQueryInput} from 'querystring';
@@ -254,11 +254,13 @@ export interface Plugin<Content = unknown> {
   // TODO refactor the configureWebpack API surface: use an object instead of
   // multiple params (requires breaking change)
   configureWebpack?: (
-    config: Configuration,
+    config: WebpackConfiguration,
     isServer: boolean,
     utils: ConfigureWebpackUtils,
     content: Content,
-  ) => Configuration & {mergeStrategy?: ConfigureWebpackFnMergeStrategy};
+  ) => WebpackConfiguration & {
+    mergeStrategy?: ConfigureWebpackFnMergeStrategy;
+  };
   configurePostCss?: (options: PostCssOptions) => PostCssOptions;
   getThemePath?: () => string;
   getTypeScriptThemePath?: () => string;

--- a/website/docs/api/plugin-methods/lifecycle-apis.md
+++ b/website/docs/api/plugin-methods/lifecycle-apis.md
@@ -233,6 +233,27 @@ module.exports = function (context, options) {
 
 Read the [webpack-merge strategy doc](https://github.com/survivejs/webpack-merge#merging-with-strategies) for more details.
 
+### Configuring dev server {#configuring-dev-server}
+
+The dev server can be configured through returning a `devServer` field.
+
+```js title="docusaurus-plugin/src/index.js"
+module.exports = function (context, options) {
+  return {
+    name: 'custom-docusaurus-plugin',
+    configureWebpack(config, isServer, utils) {
+      return {
+        // highlight-start
+        devServer: {
+          open: '/docs', // Opens localhost:3000/docs instead of localhost:3000/
+        },
+        // highlight-end
+      };
+    },
+  };
+};
+```
+
 ## `configurePostCss(options)` {#configurePostCss}
 
 Modifies [`postcssOptions` of `postcss-loader`](https://webpack.js.org/loaders/postcss-loader/#postcssoptions) during the generation of the client bundle.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

This was added in #6109, and although `Configuration.devServer` is already a thing, I figured that mentioning in documentation is worthwhile.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
