### PR TITLE
fix(theme-algolia): declare content-docs as dependency

### DIFF
--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -28,6 +28,7 @@
     "@docsearch/react": "^3.0.0",
     "@docusaurus/core": "2.0.0-beta.17",
     "@docusaurus/logger": "2.0.0-beta.17",
+    "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
     "@docusaurus/theme-common": "2.0.0-beta.17",
     "@docusaurus/theme-translations": "2.0.0-beta.17",
     "@docusaurus/utils": "2.0.0-beta.17",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

This throws an error in pnp:

```
Module not found: Error: Can't resolve '@docusaurus/plugin-content-docs/client' in './.yarn/__virtual__/@docusaurus-theme-search-algolia-virtual-8b78fceaa5/0/cache/@docusaurus-theme-search-algolia-npm-2.0.0-beta.17-609067fadc-8a603d743a.zip/node_modules/@docusaurus/theme-search-algolia/lib/theme/SearchPage'
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Sadly our E2E test doesn't cover the search function