### PR TITLE
fix(content-blog): remove double leading slash in blog-only paginated view

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/blogUtils.test.ts.snap
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/__snapshots__/blogUtils.test.ts.snap
@@ -22,3 +22,138 @@ title: This post links to another one!
 
 [Linked post](/blog/2018/12/14/Happy-First-Birthday-Slash)"
 `;
+
+exports[`paginateBlogPosts generates right pages 1`] = `
+[
+  {
+    "items": [
+      "post1",
+      "post2",
+    ],
+    "metadata": {
+      "blogDescription": "Blog Description",
+      "blogTitle": "Blog Title",
+      "nextPage": "/blog/page/2",
+      "page": 1,
+      "permalink": "/blog",
+      "postsPerPage": 2,
+      "previousPage": null,
+      "totalCount": 5,
+      "totalPages": 3,
+    },
+  },
+  {
+    "items": [
+      "post3",
+      "post4",
+    ],
+    "metadata": {
+      "blogDescription": "Blog Description",
+      "blogTitle": "Blog Title",
+      "nextPage": "/blog/page/3",
+      "page": 2,
+      "permalink": "/blog/page/2",
+      "postsPerPage": 2,
+      "previousPage": "/blog",
+      "totalCount": 5,
+      "totalPages": 3,
+    },
+  },
+  {
+    "items": [
+      "post5",
+    ],
+    "metadata": {
+      "blogDescription": "Blog Description",
+      "blogTitle": "Blog Title",
+      "nextPage": null,
+      "page": 3,
+      "permalink": "/blog/page/3",
+      "postsPerPage": 2,
+      "previousPage": "/blog/page/2",
+      "totalCount": 5,
+      "totalPages": 3,
+    },
+  },
+]
+`;
+
+exports[`paginateBlogPosts generates right pages 2`] = `
+[
+  {
+    "items": [
+      "post1",
+      "post2",
+    ],
+    "metadata": {
+      "blogDescription": "Blog Description",
+      "blogTitle": "Blog Title",
+      "nextPage": "/page/2",
+      "page": 1,
+      "permalink": "/",
+      "postsPerPage": 2,
+      "previousPage": null,
+      "totalCount": 5,
+      "totalPages": 3,
+    },
+  },
+  {
+    "items": [
+      "post3",
+      "post4",
+    ],
+    "metadata": {
+      "blogDescription": "Blog Description",
+      "blogTitle": "Blog Title",
+      "nextPage": "/page/3",
+      "page": 2,
+      "permalink": "/page/2",
+      "postsPerPage": 2,
+      "previousPage": "/",
+      "totalCount": 5,
+      "totalPages": 3,
+    },
+  },
+  {
+    "items": [
+      "post5",
+    ],
+    "metadata": {
+      "blogDescription": "Blog Description",
+      "blogTitle": "Blog Title",
+      "nextPage": null,
+      "page": 3,
+      "permalink": "/page/3",
+      "postsPerPage": 2,
+      "previousPage": "/page/2",
+      "totalCount": 5,
+      "totalPages": 3,
+    },
+  },
+]
+`;
+
+exports[`paginateBlogPosts generates right pages 3`] = `
+[
+  {
+    "items": [
+      "post1",
+      "post2",
+      "post3",
+      "post4",
+      "post5",
+    ],
+    "metadata": {
+      "blogDescription": "Blog Description",
+      "blogTitle": "Blog Title",
+      "nextPage": null,
+      "page": 1,
+      "permalink": "/",
+      "postsPerPage": 10,
+      "previousPage": null,
+      "totalCount": 5,
+      "totalPages": 1,
+    },
+  },
+]
+`;

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -72,7 +72,9 @@ export function paginateBlogPosts({
   const pages: BlogPaginated[] = [];
 
   function permalink(page: number) {
-    return page > 0 ? `${basePageUrl}/page/${page + 1}` : basePageUrl;
+    return page > 0
+      ? normalizeUrl([basePageUrl, `page/${page + 1}`])
+      : basePageUrl;
   }
 
   for (let page = 0; page < numberOfPages; page += 1) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix #6917 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

<!-- Write your answer here. -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
