### PR TITLE
docs: clarify the usage of slug

### DIFF
--- a/website/docs/guides/docs/docs-introduction.md
+++ b/website/docs/guides/docs/docs-introduction.md
@@ -37,16 +37,38 @@ id: part1
 Lorem ipsum
 ```
 
-If you want more control over the last part of the document URL, it is possible to add a `slug` (defaults to the `id`).
+### Customize the last part of the document URL {#slugs}
+
+Use the `slug` variable to change a document's URL.
+
+:::note
+
+The default `slug` value is the `id` value.
+
+:::
+
+For example, suppose your site structure looks like this:
+
+```bash
+website # Root directory of your site
+└── docs
+   └── guide
+      └── hello.md
+```
+
+By default `hello.md` will be available at `/docs/guide/hello`. The
+code below makes it available at `/docs/bonjour`.
 
 ```md
 ---
-id: part1
-slug: part1.html
+slug: /bonjour
 ---
 
 Lorem ipsum
 ```
+
+See [Docs-only mode](#docs-only-mode) if you're trying to remove the
+`/docs` part from the URL.
 
 :::note
 

--- a/website/docs/guides/docs/docs-introduction.md
+++ b/website/docs/guides/docs/docs-introduction.md
@@ -37,27 +37,20 @@ id: part1
 Lorem ipsum
 ```
 
-### Customize the last part of the document URL {#slugs}
+### Customizing doc URLs {#customizing-doc-urls}
 
-Use the `slug` variable to change a document's URL.
-
-:::note
-
-The default `slug` value is the `id` value.
-
-:::
+By default, a document's URL location is its file path relative to the `docs` folder. Use the `slug` front matter to change a document's URL.
 
 For example, suppose your site structure looks like this:
 
 ```bash
 website # Root directory of your site
 └── docs
-   └── guide
-      └── hello.md
+    └── guide
+        └── hello.md
 ```
 
-By default `hello.md` will be available at `/docs/guide/hello`. The
-code below makes it available at `/docs/bonjour`.
+By default `hello.md` will be available at `/docs/guide/hello`. You can change its URL location to `/docs/bonjour`:
 
 ```md
 ---
@@ -67,8 +60,7 @@ slug: /bonjour
 Lorem ipsum
 ```
 
-See [Docs-only mode](#docs-only-mode) if you're trying to remove the
-`/docs` part from the URL.
+`slug` will be appended to the doc plugin's `routeBasePath`, which is `/docs` by default. See [Docs-only mode](#docs-only-mode) for how to remove the `/docs` part from the URL.
 
 :::note
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

As a new user it was unclear whether setting `slug` would change the URL relative to the root directory or relative to the docs directory. The example I added should make that clear without needing to test out the functionality in a Docusaurus instance (which is what I had to do).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I tested out the sample code in a Docusaurus instance.

## Related PRs

None.
