### PR TITLE
refactor(theme-classic): little breadcrumbs improvements

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
@@ -24,7 +24,7 @@ function BreadcrumbsItemLink({
   children: ReactNode;
   href?: string;
 }): JSX.Element {
-  const className = clsx('breadcrumbs__link', styles.breadcrumbsItemLink);
+  const className = 'breadcrumbs__link';
   return href ? (
     <Link className={className} href={href} itemProp="item">
       <span itemProp="name">{children}</span>
@@ -98,7 +98,8 @@ export default function DocBreadcrumbs(): JSX.Element | null {
             key={idx}
             active={idx === breadcrumbs.length - 1}
             index={idx}>
-            <BreadcrumbsItemLink href={item.href}>
+            <BreadcrumbsItemLink
+              href={idx < breadcrumbs.length - 1 ? item.href : undefined}>
               {item.label}
             </BreadcrumbsItemLink>
           </BreadcrumbsItem>

--- a/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/styles.module.css
@@ -6,21 +6,6 @@
  */
 
 .breadcrumbsContainer {
-  margin-bottom: 0.4rem;
-}
-
-.breadcrumbsItemLink {
-  --ifm-breadcrumb-size-multiplier: 0.7 !important;
-  margin-bottom: 0.4rem;
-  background: var(--ifm-color-gray-100);
-}
-
-html[data-theme='dark'] .breadcrumbsItemLink {
-  background-color: var(--ifm-color-gray-900);
-}
-
-@media (min-width: 997px) {
-  .breadcrumbsItemLink {
-    --ifm-breadcrumb-size-multiplier: 0.8;
-  }
+  --ifm-breadcrumb-size-multiplier: 0.7;
+  margin-bottom: 0.8rem;
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/styles.module.css
@@ -6,6 +6,6 @@
  */
 
 .breadcrumbsContainer {
-  --ifm-breadcrumb-size-multiplier: 0.7;
+  --ifm-breadcrumb-size-multiplier: 0.8;
   margin-bottom: 0.8rem;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

- turn a last breadcrumb item into a text (see https://usersnap.com/blog/breadcrumbs/ or https://martech.org/breadcrumb-links-good-user-experience-yes/)
> Don’t link current page in breadcrumb navigation
The last item in the breadcrumb trail (current user’s location) is optional — if you want to display it, make sure that it’s not clickable or tappable. Since users are already on the page, it does not make any sense to add a link of the current page to the breadcrumb navigation.

- clean up CSS styles -- background for breadcrumb item is supposed to apply only to active state (hover or current item), now it looks weird, so I don't see the point in changing that default design.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
