### PR TITLE
feat(core,theme): useRouteContext + HtmlClassNameProvider

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -246,6 +246,12 @@ declare module '@docusaurus/useDocusaurusContext' {
   export default function useDocusaurusContext(): DocusaurusContext;
 }
 
+declare module '@docusaurus/useRouteContext' {
+  import type {PluginRouteContext} from '@docusaurus/types';
+
+  export default function useRouteContext(): PluginRouteContext;
+}
+
 declare module '@docusaurus/useIsBrowser' {
   export default function useIsBrowser(): boolean;
 }

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -191,6 +191,7 @@ declare module '@theme/DocItem' {
   };
 
   export type Metadata = {
+    readonly unversionedId?: string;
     readonly description?: string;
     readonly title?: string;
     readonly permalink?: string;

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -17,7 +17,11 @@ import TOC from '@theme/TOC';
 import TOCCollapsible from '@theme/TOCCollapsible';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
-import {ThemeClassNames, useWindowSize} from '@docusaurus/theme-common';
+import {
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  useWindowSize,
+} from '@docusaurus/theme-common';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import MDXContent from '@theme/MDXContent';
 
@@ -49,7 +53,7 @@ export default function DocItem(props: Props): JSX.Element {
     canRenderTOC && (windowSize === 'desktop' || windowSize === 'ssr');
 
   return (
-    <>
+    <HtmlClassNameProvider className={`docs-doc-id-${metadata.unversionedId}`}>
       <Seo {...{title, description, keywords, image}} />
 
       <div className="row">
@@ -107,6 +111,6 @@ export default function DocItem(props: Props): JSX.Element {
           </div>
         )}
       </div>
-    </>
+    </HtmlClassNameProvider>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -20,14 +20,15 @@ import {translate} from '@docusaurus/Translate';
 
 import clsx from 'clsx';
 import styles from './styles.module.css';
+
 import {
+  HtmlClassNameProvider,
   ThemeClassNames,
   docVersionSearchTag,
   DocsSidebarProvider,
   useDocsSidebar,
   DocsVersionProvider,
 } from '@docusaurus/theme-common';
-import Head from '@docusaurus/Head';
 
 type DocPageContentProps = {
   readonly currentDocRoute: DocumentRoute;
@@ -160,11 +161,7 @@ export default function DocPage(props: Props): JSX.Element {
     : null;
 
   return (
-    <>
-      <Head>
-        {/* TODO we should add a core addRoute({htmlClassName}) action */}
-        <html className={versionMetadata.className} />
-      </Head>
+    <HtmlClassNameProvider className={versionMetadata.className}>
       <DocsVersionProvider version={versionMetadata}>
         <DocsSidebarProvider sidebar={sidebar ?? null}>
           <DocPageContent
@@ -175,6 +172,6 @@ export default function DocPage(props: Props): JSX.Element {
           </DocPageContent>
         </DocsSidebarProvider>
       </DocsVersionProvider>
-    </>
+    </HtmlClassNameProvider>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -18,6 +18,33 @@ import type {Props} from '@theme/Layout';
 import {ThemeClassNames, useKeyboardNavigation} from '@docusaurus/theme-common';
 import ErrorPageContent from '@theme/ErrorPageContent';
 import './styles.css';
+import useRouteContext from '@docusaurus/useRouteContext';
+import Head from '@docusaurus/Head';
+
+function pluginNameToClassName(pluginName: string) {
+  return `plugin-${pluginName.replace(
+    new RegExp(
+      [
+        'docusaurus-plugin-content-',
+        'docusaurus-plugin-',
+        'docusaurus-theme-',
+      ].join('|'),
+      'gi',
+    ),
+    '',
+  )}`;
+}
+
+function PluginHtmlClassName() {
+  const routeContext = useRouteContext();
+  const nameClass = pluginNameToClassName(routeContext.plugin.name);
+  const idClass = `plugin-id-${routeContext.plugin.id}`;
+  return (
+    <Head>
+      <html className={clsx(nameClass, idClass)} />
+    </Head>
+  );
+}
 
 export default function Layout(props: Props): JSX.Element {
   const {children, noFooter, wrapperClassName, pageClassName} = props;
@@ -27,6 +54,8 @@ export default function Layout(props: Props): JSX.Element {
   return (
     <LayoutProviders>
       <LayoutHead {...props} />
+
+      <PluginHtmlClassName />
 
       <SkipToContent />
 

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -18,33 +18,6 @@ import type {Props} from '@theme/Layout';
 import {ThemeClassNames, useKeyboardNavigation} from '@docusaurus/theme-common';
 import ErrorPageContent from '@theme/ErrorPageContent';
 import './styles.css';
-import useRouteContext from '@docusaurus/useRouteContext';
-import Head from '@docusaurus/Head';
-
-function pluginNameToClassName(pluginName: string) {
-  return `plugin-${pluginName.replace(
-    new RegExp(
-      [
-        'docusaurus-plugin-content-',
-        'docusaurus-plugin-',
-        'docusaurus-theme-',
-      ].join('|'),
-      'gi',
-    ),
-    '',
-  )}`;
-}
-
-function PluginHtmlClassName() {
-  const routeContext = useRouteContext();
-  const nameClass = pluginNameToClassName(routeContext.plugin.name);
-  const idClass = `plugin-id-${routeContext.plugin.id}`;
-  return (
-    <Head>
-      <html className={clsx(nameClass, idClass)} />
-    </Head>
-  );
-}
 
 export default function Layout(props: Props): JSX.Element {
   const {children, noFooter, wrapperClassName, pageClassName} = props;
@@ -54,8 +27,6 @@ export default function Layout(props: Props): JSX.Element {
   return (
     <LayoutProviders>
       <LayoutHead {...props} />
-
-      <PluginHtmlClassName />
 
       <SkipToContent />
 

--- a/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LayoutProviders/index.tsx
@@ -13,6 +13,7 @@ import {
   DocsPreferredVersionContextProvider,
   MobileSecondaryMenuProvider,
   ScrollControllerProvider,
+  PluginHtmlClassNameProvider,
 } from '@docusaurus/theme-common';
 import type {Props} from '@theme/LayoutProviders';
 
@@ -24,7 +25,9 @@ export default function LayoutProviders({children}: Props): JSX.Element {
           <ScrollControllerProvider>
             <DocsPreferredVersionContextProvider>
               <MobileSecondaryMenuProvider>
-                {children}
+                <PluginHtmlClassNameProvider>
+                  {children}
+                </PluginHtmlClassNameProvider>
               </MobileSecondaryMenuProvider>
             </DocsPreferredVersionContextProvider>
           </ScrollControllerProvider>

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -135,6 +135,11 @@ export {isRegexpStringMatch} from './utils/regexpUtils';
 
 export {useHomePageRoute} from './utils/routesUtils';
 
+export {
+  HtmlClassNameProvider,
+  PluginHtmlClassNameProvider,
+} from './utils/metadataUtilsTemp';
+
 export {useColorMode, ColorModeProvider} from './utils/colorModeUtils';
 export {
   useTabGroupChoice,

--- a/packages/docusaurus-theme-common/src/utils/metadataUtilsTemp.tsx
+++ b/packages/docusaurus-theme-common/src/utils/metadataUtilsTemp.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactNode} from 'react';
+import Head from '@docusaurus/Head';
+import clsx from 'clsx';
+import useRouteContext from '@docusaurus/useRouteContext';
+
+const HtmlClassNameContext = React.createContext<string | undefined>(undefined);
+
+// This annoying wrapper is necessary because Helmet does not "merge" classes
+// See https://github.com/staylor/react-helmet-async/issues/161
+export function HtmlClassNameProvider({
+  className: classNameProp,
+  children,
+}: {
+  className: string;
+  children: ReactNode;
+}): JSX.Element {
+  const classNameContext = React.useContext(HtmlClassNameContext);
+  const className = clsx(classNameContext, classNameProp);
+  return (
+    <HtmlClassNameContext.Provider value={className}>
+      <Head>
+        <html className={className} />
+      </Head>
+      {children}
+    </HtmlClassNameContext.Provider>
+  );
+}
+
+function pluginNameToClassName(pluginName: string) {
+  return `plugin-${pluginName.replace(
+    new RegExp(
+      [
+        'docusaurus-plugin-content-',
+        'docusaurus-plugin-',
+        'docusaurus-theme-',
+      ].join('|'),
+      'gi',
+    ),
+    '',
+  )}`;
+}
+
+export function PluginHtmlClassNameProvider({children}: {children: ReactNode}) {
+  const routeContext = useRouteContext();
+  const nameClass = pluginNameToClassName(routeContext.plugin.name);
+  const idClass = `plugin-id-${routeContext.plugin.id}`;
+  return (
+    <HtmlClassNameProvider className={clsx(nameClass, idClass)}>
+      {children}
+    </HtmlClassNameProvider>
+  );
+}

--- a/packages/docusaurus-theme-common/src/utils/metadataUtilsTemp.tsx
+++ b/packages/docusaurus-theme-common/src/utils/metadataUtilsTemp.tsx
@@ -12,7 +12,7 @@ import useRouteContext from '@docusaurus/useRouteContext';
 
 const HtmlClassNameContext = React.createContext<string | undefined>(undefined);
 
-// This annoying wrapper is necessary because Helmet does not "merge" classes
+// This wrapper is necessary because Helmet does not "merge" classes
 // See https://github.com/staylor/react-helmet-async/issues/161
 export function HtmlClassNameProvider({
   className: classNameProp,
@@ -35,19 +35,16 @@ export function HtmlClassNameProvider({
 
 function pluginNameToClassName(pluginName: string) {
   return `plugin-${pluginName.replace(
-    new RegExp(
-      [
-        'docusaurus-plugin-content-',
-        'docusaurus-plugin-',
-        'docusaurus-theme-',
-      ].join('|'),
-      'gi',
-    ),
+    /docusaurus-(?:plugin|theme)-(?:content-)?/gi,
     '',
   )}`;
 }
 
-export function PluginHtmlClassNameProvider({children}: {children: ReactNode}) {
+export function PluginHtmlClassNameProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
   const routeContext = useRouteContext();
   const nameClass = pluginNameToClassName(routeContext.plugin.name);
   const idClass = `plugin-id-${routeContext.plugin.id}`;

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -377,6 +377,16 @@ export interface RouteConfig {
   [propName: string]: unknown;
 }
 
+export interface RouteContext<Data = unknown> {
+  data: Data; // plugin-specific contextual data
+}
+
+// Top-level plugin routes automatically add some context data to the route
+// This permits to know which plugin is handling the current route
+export interface PluginRouteContext<Data = unknown> extends RouteContext<Data> {
+  plugin: {id: string; name: string};
+}
+
 export type Route = {
   readonly path: string;
   readonly component: ReturnType<typeof Loadable>;

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -381,7 +381,7 @@ export interface RouteContext {
   /**
    * Plugin-specific context data.
    */
-  data: object | undefined;
+  data?: object | undefined;
 }
 
 /**

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -377,14 +377,23 @@ export interface RouteConfig {
   [propName: string]: unknown;
 }
 
-export interface RouteContext<Data = unknown> {
-  data: Data; // plugin-specific contextual data
+export interface RouteContext<Data = object | undefined> {
+  /**
+   * Plugin-specific context data.
+   */
+  data: Data;
 }
 
-// Top-level plugin routes automatically add some context data to the route
-// This permits to know which plugin is handling the current route
-export interface PluginRouteContext<Data = unknown> extends RouteContext<Data> {
-  plugin: {id: string; name: string};
+/**
+ * Top-level plugin routes automatically add some context data to the route.
+ * This permits us to know which plugin is handling the current route.
+ */
+export interface PluginRouteContext<Data = object | undefined>
+  extends RouteContext<Data> {
+  plugin: {
+    id: string;
+    name: string;
+  };
 }
 
 export type Route = {

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -377,19 +377,18 @@ export interface RouteConfig {
   [propName: string]: unknown;
 }
 
-export interface RouteContext<Data = object | undefined> {
+export interface RouteContext {
   /**
    * Plugin-specific context data.
    */
-  data: Data;
+  data: object | undefined;
 }
 
 /**
  * Top-level plugin routes automatically add some context data to the route.
  * This permits us to know which plugin is handling the current route.
  */
-export interface PluginRouteContext<Data = object | undefined>
-  extends RouteContext<Data> {
+export interface PluginRouteContext extends RouteContext {
   plugin: {
     id: string;
     name: string;

--- a/packages/docusaurus/src/client/exports/ComponentCreator.tsx
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.tsx
@@ -23,7 +23,16 @@ export default function ComponentCreator(
   if (path === '*') {
     return Loadable({
       loading: Loading,
-      loader: () => import('@theme/NotFound'),
+      loader: async () => {
+        const NotFound = (await import('@theme/NotFound')).default;
+        return (props) => (
+          // Is there a better API for this?
+          <RouteContextProvider
+            value={{plugin: {name: 'native', id: 'default'}}}>
+            <NotFound {...(props as never)} />
+          </RouteContextProvider>
+        );
+      },
     });
   }
 

--- a/packages/docusaurus/src/client/exports/ComponentCreator.tsx
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.tsx
@@ -11,6 +11,7 @@ import Loading from '@theme/Loading';
 import routesChunkNames from '@generated/routesChunkNames';
 import registry from '@generated/registry';
 import flat from '../flat';
+import {RouteContextProvider} from '../routeContext';
 
 type OptsLoader = Record<string, typeof registry[keyof typeof registry][0]>;
 
@@ -84,7 +85,18 @@ export default function ComponentCreator(
 
       const Component = loadedModules.component;
       delete loadedModules.component;
-      return <Component {...loadedModules} {...props} />;
+
+      /* eslint-disable no-underscore-dangle */
+      const routeContextModule = loadedModules.__routeContextModule;
+      delete loadedModules.__routeContextModule;
+      /* eslint-enable no-underscore-dangle */
+
+      // Is there any way to put this RouteContextProvider upper in the tree?
+      return (
+        <RouteContextProvider value={routeContextModule}>
+          <Component {...loadedModules} {...props} />;
+        </RouteContextProvider>
+      );
     },
   });
 }

--- a/packages/docusaurus/src/client/exports/useRouteContext.tsx
+++ b/packages/docusaurus/src/client/exports/useRouteContext.tsx
@@ -9,14 +9,12 @@ import React from 'react';
 import type {PluginRouteContext} from '@docusaurus/types';
 import {Context} from '../routeContext';
 
-export default function useRouteContext<
-  Data = unknown,
->(): PluginRouteContext<Data> {
+export default function useRouteContext(): PluginRouteContext {
   const context = React.useContext(Context);
   if (!context) {
     throw new Error(
       'Unexpected: no Docusaurus parent/current route context found',
     );
   }
-  return context as PluginRouteContext<Data>;
+  return context;
 }

--- a/packages/docusaurus/src/client/exports/useRouteContext.tsx
+++ b/packages/docusaurus/src/client/exports/useRouteContext.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {PluginRouteContext} from '@docusaurus/types';
+import {Context} from '../routeContext';
+
+export default function useRouteContext<
+  Data = unknown,
+>(): PluginRouteContext<Data> {
+  const context = React.useContext(Context);
+  if (!context) {
+    throw new Error(
+      'Unexpected: no Docusaurus parent/current route context found',
+    );
+  }
+  return context as PluginRouteContext<Data>;
+}

--- a/packages/docusaurus/src/client/routeContext.tsx
+++ b/packages/docusaurus/src/client/routeContext.tsx
@@ -30,6 +30,7 @@ function mergeContexts({
     return value;
   }
 
+  // TODO deep merge this
   const data = {...parent.data, ...value?.data};
 
   return {

--- a/packages/docusaurus/src/client/routeContext.tsx
+++ b/packages/docusaurus/src/client/routeContext.tsx
@@ -15,7 +15,7 @@ function mergeContexts({
   value,
 }: {
   parent: PluginRouteContext | null;
-  value: PluginRouteContext | RouteContext | null;
+  value: RouteContext | null;
 }): PluginRouteContext {
   if (!parent) {
     if (!value) {

--- a/packages/docusaurus/src/client/routeContext.tsx
+++ b/packages/docusaurus/src/client/routeContext.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useMemo, type ReactNode} from 'react';
+import type {PluginRouteContext, RouteContext} from '@docusaurus/types';
+
+export const Context = React.createContext<PluginRouteContext | null>(null);
+
+function mergeContexts({
+  parent,
+  value,
+}: {
+  parent: PluginRouteContext | null;
+  value: PluginRouteContext | RouteContext | null;
+}): PluginRouteContext {
+  if (!parent) {
+    if (!value) {
+      throw new Error(
+        'Unexpected: no Docusaurus parent/current route context found',
+      );
+    } else if (!('plugin' in value)) {
+      throw new Error(
+        'Unexpected: Docusaurus parent route context has no plugin attribute',
+      );
+    } else {
+      return value;
+    }
+  }
+
+  // See TS issue https://stackoverflow.com/a/51193091/82609
+  // eslint-disable-next-line prefer-object-spread
+  const data = Object.assign({}, parent.data, value?.data);
+
+  return {
+    // nested routes are not supposed to override plugin attribute
+    plugin: parent.plugin,
+    data,
+  };
+}
+
+export function RouteContextProvider({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: PluginRouteContext | null;
+}): JSX.Element {
+  const parent = React.useContext(Context);
+
+  const mergedValue = useMemo(
+    () => mergeContexts({parent, value}),
+    [parent, value],
+  );
+
+  return <Context.Provider value={mergedValue}>{children}</Context.Provider>;
+}

--- a/packages/docusaurus/src/client/routeContext.tsx
+++ b/packages/docusaurus/src/client/routeContext.tsx
@@ -26,14 +26,11 @@ function mergeContexts({
       throw new Error(
         'Unexpected: Docusaurus parent route context has no plugin attribute',
       );
-    } else {
-      return value;
     }
+    return value;
   }
 
-  // See TS issue https://stackoverflow.com/a/51193091/82609
-  // eslint-disable-next-line prefer-object-spread
-  const data = Object.assign({}, parent.data, value?.data);
+  const data = {...parent.data, ...value?.data};
 
   return {
     // nested routes are not supposed to override plugin attribute

--- a/packages/docusaurus/src/webpack/__tests__/__snapshots__/base.test.ts.snap
+++ b/packages/docusaurus/src/webpack/__tests__/__snapshots__/base.test.ts.snap
@@ -21,6 +21,7 @@ exports[`base webpack config creates webpack aliases 1`] = `
   "@docusaurus/useDocusaurusContext": "../../../../client/exports/useDocusaurusContext.ts",
   "@docusaurus/useGlobalData": "../../../../client/exports/useGlobalData.ts",
   "@docusaurus/useIsBrowser": "../../../../client/exports/useIsBrowser.ts",
+  "@docusaurus/useRouteContext": "../../../../client/exports/useRouteContext.tsx",
   "@generated": "../../../../../../..",
   "@site": "",
   "@theme-init/PluginThemeComponentEnhanced": "pluginThemeFolder/PluginThemeComponentEnhanced.js",
@@ -68,5 +69,6 @@ exports[`getDocusaurusAliases() returns appropriate webpack aliases 1`] = `
   "@docusaurus/useDocusaurusContext": "../../client/exports/useDocusaurusContext.ts",
   "@docusaurus/useGlobalData": "../../client/exports/useGlobalData.ts",
   "@docusaurus/useIsBrowser": "../../client/exports/useIsBrowser.ts",
+  "@docusaurus/useRouteContext": "../../client/exports/useRouteContext.tsx",
 }
 `;

--- a/project-words.txt
+++ b/project-words.txt
@@ -40,6 +40,7 @@ chedeau
 cheng
 clément
 clsx
+codegen
 codeql
 codesandbox
 codespaces


### PR DESCRIPTION
## Motivation

Add plugin name + plugin id + docs version + doc id to HTML classes, fixes https://github.com/facebook/docusaurus/issues/4280

Partial implementation for assigning a context to a route (https://github.com/facebook/docusaurus/issues/6885)

For now only plugins add basic data to this context, and it can be used through `useRouteContext()`. For now I keep this API undocumented until we have a full clean implementation. 

This partial implementation was necessary because there was no other easy way to assign pluginId/name to a given route apart from doing more annoying things like adding data to the generated route file.

Had to create a `HtmlClassNameProvider` wrapper because react-helmet does not "merge" classNames and deeply nested class override parent classes (see https://github.com/staylor/react-helmet-async/issues/161). Another option would be to use data-attributes instead of classes for parent selectors? 🤷‍♂️ 

Note that some things are unpolished, but I plan to do more cleanup/merge as part of https://github.com/facebook/docusaurus/pull/6925 (2 smaller PRs instead of one bigger) so I'll merge this one asap to unlock the other reactors. Now is the best time to review.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Not so easy to test 😅 

Preview builds and applies correct classNames

## Related PRs

https://github.com/facebook/docusaurus/pull/6925