### PR TITLE
refactor: replace text-based copy code button with icons

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -126,6 +126,14 @@ declare module '@theme/CodeBlock' {
   export default function CodeBlock(props: Props): JSX.Element;
 }
 
+declare module '@theme/CodeBlock/CopyButton' {
+  export interface Props {
+    readonly code: string;
+  }
+
+  export default function CopyButton(props: Props): JSX.Element;
+}
+
 declare module '@theme/DocCard' {
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useState} from 'react';
+import clsx from 'clsx';
+import copy from 'copy-text-to-clipboard';
+import {translate} from '@docusaurus/Translate';
+import type {Props} from '@theme/CodeBlock/CopyButton';
+
+import styles from './styles.module.css';
+
+export default function CopyButton({code}: Props): JSX.Element {
+  const [isCopied, setIsCopied] = useState(false);
+  const handleCopyCode = () => {
+    copy(code);
+    setIsCopied(true);
+
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={
+        isCopied
+          ? translate({
+              id: 'theme.CodeBlock.copied',
+              message: 'Copied',
+              description: 'The copied button label on code blocks',
+            })
+          : translate({
+              id: 'theme.CodeBlock.copyButtonAriaLabel',
+              message: 'Copy code to clipboard',
+              description: 'The ARIA label for copy code blocks button',
+            })
+      }
+      className={clsx(
+        styles.copyButton,
+        'clean-btn',
+        isCopied && styles.copyButtonCopied,
+      )}
+      onClick={handleCopyCode}>
+      <span className={styles.copyButtonIcons} aria-hidden="true">
+        <svg className={styles.copyButtonIcon} viewBox="0 0 24 24">
+          <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
+        </svg>
+        <svg className={styles.copyButtonSuccessIcon} viewBox="0 0 24 24">
+          <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+        </svg>
+      </span>
+    </button>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
@@ -40,6 +40,12 @@ export default function CopyButton({code}: Props): JSX.Element {
               description: 'The ARIA label for copy code blocks button',
             })
       }
+      // @todo: check it again later
+      title={translate({
+        id: 'theme.CodeBlock.copy',
+        message: 'Copy',
+        description: 'The copy button label on code blocks',
+      })}
       className={clsx(
         styles.copyButton,
         'clean-btn',

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/styles.module.css
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.copyButton {
+  display: flex;
+  background: inherit;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  position: absolute;
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+  transition: opacity 200ms ease-in-out;
+  opacity: 0;
+}
+
+.copyButton:focus-visible,
+.copyButton:hover,
+:global(.theme-code-block:hover) .copyButtonCopied {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .copyButton:not(.copyButtonCopied) {
+  opacity: 0.4;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all 0.15s ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { MouseEvent} from 'react';
 import React, {isValidElement, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
@@ -90,11 +91,16 @@ export default function CodeBlock({
     languageProp ?? parseLanguage(blockClassName) ?? prism.defaultLanguage;
   const {highlightLines, code} = parseLines(content, metastring, language);
 
-  const handleCopyCode = () => {
+  const handleCopyCode = (e: MouseEvent<HTMLButtonElement>) => {
     copy(code);
     setIsCopied(true);
 
-    setTimeout(() => setIsCopied(false), 2000);
+    const button = e.currentTarget;
+
+    setTimeout(() => {
+      setIsCopied(false);
+      button.blur();
+    }, 2000);
   };
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -9,7 +9,7 @@ import React, {isValidElement, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
 import copy from 'copy-text-to-clipboard';
-import {translate} from '@docusaurus/Translate';
+import Translate, {translate} from '@docusaurus/Translate';
 import {
   useThemeConfig,
   parseCodeBlockTitle,
@@ -153,11 +153,30 @@ export default function CodeBlock({
 
             <button
               type="button"
-              aria-label={translate({
-                id: 'theme.CodeBlock.copyButtonAriaLabel',
-                message: 'Copy code to clipboard',
-                description: 'The ARIA label for copy code blocks button',
-              })}
+              // @todo: this needs more tests
+              // aria-label={
+              //   showCopied
+              //     ? translate({
+              //         id: 'theme.CodeBlock.copied',
+              //         message: 'Copied',
+              //         description: 'The copied button label on code blocks',
+              //       })
+              //     : translate({
+              //         id: 'theme.CodeBlock.copyButtonAriaLabel',
+              //         message: 'Copy code to clipboard',
+              //         description: 'The ARIA label for copy code blocks button',
+              //       })
+              // }
+
+              // @todo: not sure about this
+              title={
+                !showCopied &&
+                translate({
+                  id: 'theme.CodeBlock.copy',
+                  message: 'Copy',
+                  description: 'The copy button label on code blocks',
+                })
+              }
               className={clsx(
                 styles.copyButton,
                 'clean-btn',
@@ -178,6 +197,22 @@ export default function CodeBlock({
                   aria-hidden="true">
                   <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
                 </svg>
+              </span>
+              {/* @todo: add similar class to Infima */}
+              <span className="screen-reader-only" aria-live="polite">
+                {showCopied ? (
+                  <Translate
+                    id="theme.CodeBlock.copied"
+                    description="The copied button label on code blocks">
+                    Copied
+                  </Translate>
+                ) : (
+                  <Translate
+                    id="theme.CodeBlock.copyButtonAriaLabel"
+                    description="The copied button label on code blocks">
+                    Copy code to clipboard
+                  </Translate>
+                )}
               </span>
             </button>
           </div>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -9,7 +9,7 @@ import React, {isValidElement, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
 import copy from 'copy-text-to-clipboard';
-import Translate, {translate} from '@docusaurus/Translate';
+import {translate} from '@docusaurus/Translate';
 import {
   useThemeConfig,
   parseCodeBlockTitle,
@@ -120,12 +120,13 @@ export default function CodeBlock({
               {codeBlockTitle}
             </div>
           )}
-          <div className={clsx(styles.codeBlockContent, language)}>
+          <div
+            className={clsx(styles.codeBlockContent, language)}
+            style={style}>
             <pre
               /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
               tabIndex={0}
-              className={clsx(className, styles.codeBlock, 'thin-scrollbar')}
-              style={style}>
+              className={clsx(className, styles.codeBlock, 'thin-scrollbar')}>
               <code className={styles.codeBlockLines}>
                 {tokens.map((line, i) => {
                   if (line.length === 1 && line[0]!.content === '\n') {
@@ -157,21 +158,27 @@ export default function CodeBlock({
                 message: 'Copy code to clipboard',
                 description: 'The ARIA label for copy code blocks button',
               })}
-              className={clsx(styles.copyButton, 'clean-btn')}
-              onClick={handleCopyCode}>
-              {showCopied ? (
-                <Translate
-                  id="theme.CodeBlock.copied"
-                  description="The copied button label on code blocks">
-                  Copied
-                </Translate>
-              ) : (
-                <Translate
-                  id="theme.CodeBlock.copy"
-                  description="The copy button label on code blocks">
-                  Copy
-                </Translate>
+              className={clsx(
+                styles.copyButton,
+                'clean-btn',
+                showCopied && styles.copyButtonCopied,
               )}
+              onClick={handleCopyCode}>
+              <span className={styles.copyButtonIcons}>
+                <svg
+                  className={styles.copyButtonIcon}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true">
+                  <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
+                </svg>
+
+                <svg
+                  className={styles.copyButtonSuccessIcon}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true">
+                  <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+                </svg>
+              </span>
             </button>
           </div>
         </div>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -31,7 +31,7 @@ export default function CodeBlock({
 }: Props): JSX.Element {
   const {prism} = useThemeConfig();
 
-  const [showCopied, setShowCopied] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
   // The Prism theme on SSR is always the default theme but the site theme
   // can be in a different mode. React hydration doesn't update DOM styles
@@ -92,9 +92,9 @@ export default function CodeBlock({
 
   const handleCopyCode = () => {
     copy(code);
-    setShowCopied(true);
+    setIsCopied(true);
 
-    setTimeout(() => setShowCopied(false), 2000);
+    setTimeout(() => setIsCopied(false), 2000);
   };
 
   return (
@@ -170,17 +170,18 @@ export default function CodeBlock({
 
               // @todo: not sure about this
               title={
-                !showCopied &&
-                translate({
-                  id: 'theme.CodeBlock.copy',
-                  message: 'Copy',
-                  description: 'The copy button label on code blocks',
-                })
+                !isCopied
+                  ? translate({
+                      id: 'theme.CodeBlock.copy',
+                      message: 'Copy',
+                      description: 'The copy button label on code blocks',
+                    })
+                  : ''
               }
               className={clsx(
                 styles.copyButton,
                 'clean-btn',
-                showCopied && styles.copyButtonCopied,
+                isCopied && styles.copyButtonCopied,
               )}
               onClick={handleCopyCode}>
               <span className={styles.copyButtonIcons}>
@@ -200,7 +201,7 @@ export default function CodeBlock({
               </span>
               {/* @todo: add similar class to Infima */}
               <span className="screen-reader-only" aria-live="polite">
-                {showCopied ? (
+                {isCopied ? (
                   <Translate
                     id="theme.CodeBlock.copied"
                     description="The copied button label on code blocks">

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { MouseEvent} from 'react';
+import type {MouseEvent} from 'react';
 import React, {isValidElement, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
@@ -178,18 +178,13 @@ export default function CodeBlock({
                 isCopied && styles.copyButtonCopied,
               )}
               onClick={handleCopyCode}>
-              <span className={styles.copyButtonIcons}>
-                <svg
-                  className={styles.copyButtonIcon}
-                  viewBox="0 0 24 24"
-                  aria-hidden="true">
+              <span className={styles.copyButtonIcons} aria-hidden="true">
+                <svg className={styles.copyButtonIcon} viewBox="0 0 24 24">
                   <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
                 </svg>
-
                 <svg
                   className={styles.copyButtonSuccessIcon}
-                  viewBox="0 0 24 24"
-                  aria-hidden="true">
+                  viewBox="0 0 24 24">
                   <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
                 </svg>
               </span>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -8,8 +8,6 @@
 import React, {isValidElement, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
-import copy from 'copy-text-to-clipboard';
-import {translate} from '@docusaurus/Translate';
 import {
   useThemeConfig,
   parseCodeBlockTitle,
@@ -18,6 +16,7 @@ import {
   ThemeClassNames,
   usePrismTheme,
 } from '@docusaurus/theme-common';
+import CopyButton from '@theme/CodeBlock/CopyButton';
 import type {Props} from '@theme/CodeBlock';
 
 import styles from './styles.module.css';
@@ -31,7 +30,6 @@ export default function CodeBlock({
 }: Props): JSX.Element {
   const {prism} = useThemeConfig();
 
-  const [isCopied, setIsCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
   // The Prism theme on SSR is always the default theme but the site theme
   // can be in a different mode. React hydration doesn't update DOM styles
@@ -90,15 +88,6 @@ export default function CodeBlock({
     languageProp ?? parseLanguage(blockClassName) ?? prism.defaultLanguage;
   const {highlightLines, code} = parseLines(content, metastring, language);
 
-  const handleCopyCode = () => {
-    copy(code);
-    setIsCopied(true);
-
-    setTimeout(() => {
-      setIsCopied(false);
-    }, 2000);
-  };
-
   return (
     <Highlight
       {...defaultProps}
@@ -153,38 +142,7 @@ export default function CodeBlock({
               </code>
             </pre>
 
-            <button
-              type="button"
-              aria-label={
-                isCopied
-                  ? translate({
-                      id: 'theme.CodeBlock.copied',
-                      message: 'Copied',
-                      description: 'The copied button label on code blocks',
-                    })
-                  : translate({
-                      id: 'theme.CodeBlock.copyButtonAriaLabel',
-                      message: 'Copy code to clipboard',
-                      description: 'The ARIA label for copy code blocks button',
-                    })
-              }
-              className={clsx(
-                styles.copyButton,
-                'clean-btn',
-                isCopied && styles.copyButtonCopied,
-              )}
-              onClick={handleCopyCode}>
-              <span className={styles.copyButtonIcons} aria-hidden="true">
-                <svg className={styles.copyButtonIcon} viewBox="0 0 24 24">
-                  <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
-                </svg>
-                <svg
-                  className={styles.copyButtonSuccessIcon}
-                  viewBox="0 0 24 24">
-                  <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
-                </svg>
-              </span>
-            </button>
+            <CopyButton code={code} />
           </div>
         </div>
       )}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -9,7 +9,7 @@ import React, {isValidElement, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
 import copy from 'copy-text-to-clipboard';
-import Translate, {translate} from '@docusaurus/Translate';
+import {translate} from '@docusaurus/Translate';
 import {
   useThemeConfig,
   parseCodeBlockTitle,
@@ -153,30 +153,18 @@ export default function CodeBlock({
 
             <button
               type="button"
-              // @todo: this needs more tests
-              // aria-label={
-              //   showCopied
-              //     ? translate({
-              //         id: 'theme.CodeBlock.copied',
-              //         message: 'Copied',
-              //         description: 'The copied button label on code blocks',
-              //       })
-              //     : translate({
-              //         id: 'theme.CodeBlock.copyButtonAriaLabel',
-              //         message: 'Copy code to clipboard',
-              //         description: 'The ARIA label for copy code blocks button',
-              //       })
-              // }
-
-              // @todo: not sure about this
-              title={
-                !isCopied
+              aria-label={
+                isCopied
                   ? translate({
-                      id: 'theme.CodeBlock.copy',
-                      message: 'Copy',
-                      description: 'The copy button label on code blocks',
+                      id: 'theme.CodeBlock.copied',
+                      message: 'Copied',
+                      description: 'The copied button label on code blocks',
                     })
-                  : ''
+                  : translate({
+                      id: 'theme.CodeBlock.copyButtonAriaLabel',
+                      message: 'Copy code to clipboard',
+                      description: 'The ARIA label for copy code blocks button',
+                    })
               }
               className={clsx(
                 styles.copyButton,
@@ -198,22 +186,6 @@ export default function CodeBlock({
                   aria-hidden="true">
                   <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
                 </svg>
-              </span>
-              {/* @todo: add similar class to Infima */}
-              <span className="screen-reader-only" aria-live="polite">
-                {isCopied ? (
-                  <Translate
-                    id="theme.CodeBlock.copied"
-                    description="The copied button label on code blocks">
-                    Copied
-                  </Translate>
-                ) : (
-                  <Translate
-                    id="theme.CodeBlock.copyButtonAriaLabel"
-                    description="The copied button label on code blocks">
-                    Copy code to clipboard
-                  </Translate>
-                )}
               </span>
             </button>
           </div>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {MouseEvent} from 'react';
 import React, {isValidElement, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
@@ -91,15 +90,12 @@ export default function CodeBlock({
     languageProp ?? parseLanguage(blockClassName) ?? prism.defaultLanguage;
   const {highlightLines, code} = parseLines(content, metastring, language);
 
-  const handleCopyCode = (e: MouseEvent<HTMLButtonElement>) => {
+  const handleCopyCode = () => {
     copy(code);
     setIsCopied(true);
 
-    const button = e.currentTarget;
-
     setTimeout(() => {
       setIsCopied(false);
-      button.blur();
     }, 2000);
   };
 

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -53,13 +53,17 @@
   right: calc(var(--ifm-pre-padding) / 2);
   top: calc(var(--ifm-pre-padding) / 2);
   transition: opacity 200ms ease-in-out;
-  opacity: 0.4;
+  opacity: 0;
 }
 
-.copyButton:focus,
+.copyButton:hover,
+.copyButton:focus {
+  opacity: 1 !important;
+}
+
 .codeBlockContent:hover > .copyButton,
 .codeBlockTitle:hover + .codeBlockContent .copyButton {
-  opacity: 1;
+  opacity: 0.4;
 }
 
 .copyButtonIcons {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -81,7 +81,7 @@
   opacity: inherit;
   width: inherit;
   height: inherit;
-  transition: all 0.3s ease;
+  transition: all 0.15s ease;
 }
 
 .copyButtonSuccessIcon {
@@ -100,7 +100,7 @@
 .copyButtonCopied .copyButtonSuccessIcon {
   transform: translate(-50%, -50%) scale(1);
   opacity: 1;
-  transition-delay: 0.15s;
+  transition-delay: 0.075s;
 }
 
 .codeBlockLines {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -43,66 +43,6 @@
   border-radius: var(--ifm-global-radius);
 }
 
-.copyButton {
-  display: flex;
-  background: inherit;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: var(--ifm-global-radius);
-  padding: 0.4rem;
-  position: absolute;
-  right: calc(var(--ifm-pre-padding) / 2);
-  top: calc(var(--ifm-pre-padding) / 2);
-  transition: opacity 200ms ease-in-out;
-  opacity: 0;
-}
-
-.copyButton:focus-visible,
-.copyButton:hover,
-.codeBlockContainer:hover .copyButtonCopied {
-  opacity: 1 !important;
-}
-
-.codeBlockContainer:hover .copyButton:not(.copyButtonCopied) {
-  opacity: 0.4;
-}
-
-.copyButtonIcons {
-  position: relative;
-  width: 1.125rem;
-  height: 1.125rem;
-}
-
-.copyButtonIcon,
-.copyButtonSuccessIcon {
-  position: absolute;
-  top: 0;
-  left: 0;
-  fill: currentColor;
-  opacity: inherit;
-  width: inherit;
-  height: inherit;
-  transition: all 0.15s ease;
-}
-
-.copyButtonSuccessIcon {
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%) scale(0.33);
-  opacity: 0;
-  color: #00d600;
-}
-
-.copyButtonCopied .copyButtonIcon {
-  transform: scale(0.33);
-  opacity: 0;
-}
-
-.copyButtonCopied .copyButtonSuccessIcon {
-  transform: translate(-50%, -50%) scale(1);
-  opacity: 1;
-  transition-delay: 0.075s;
-}
-
 .codeBlockLines {
   font: inherit;
   /* rtl:ignore */

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -56,13 +56,13 @@
   opacity: 0;
 }
 
+.copyButton:focus-visible,
 .copyButton:hover,
-.copyButton:focus {
+.codeBlockContainer:hover .copyButtonCopied {
   opacity: 1 !important;
 }
 
-.codeBlockContent:hover > .copyButton,
-.codeBlockTitle:hover + .codeBlockContent .copyButton {
+.codeBlockContainer:hover .copyButton:not(.copyButtonCopied) {
   opacity: 0.4;
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -30,6 +30,7 @@
   margin: 0;
   padding: 0;
   border-radius: var(--ifm-global-radius);
+  background-color: inherit;
 }
 
 .codeBlockTitle + .codeBlockContent .codeBlock {
@@ -43,22 +44,59 @@
 }
 
 .copyButton {
-  background: rgb(0 0 0 / 30%);
+  display: flex;
+  background: inherit;
+  border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: var(--ifm-global-radius);
-  color: var(--ifm-color-white);
-  opacity: 0;
-  user-select: none;
-  padding: 0.4rem 0.5rem;
+  padding: 0.4rem;
   position: absolute;
   right: calc(var(--ifm-pre-padding) / 2);
   top: calc(var(--ifm-pre-padding) / 2);
   transition: opacity 200ms ease-in-out;
+  opacity: 0.4;
 }
 
 .copyButton:focus,
 .codeBlockContent:hover > .copyButton,
 .codeBlockTitle:hover + .codeBlockContent .copyButton {
   opacity: 1;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all 0.3s ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.15s;
 }
 
 .codeBlockLines {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

I have long noticed that many docs sites use icons instead of text in for copy code buttons. I would call this a modern style that makes sense for us to follow it. Besides better design, icons are shorter than text, for example text of "Copy" in Russian will look long (compared to English one) -- "Copy" vs "Скопировать"

![image](https://user-images.githubusercontent.com/4408379/159585426-4498fe50-50d1-46db-be9e-7f041b7eefae.png)

Also you can see in the screenshot that the default colors don't meet to the WCAG contrast requirement https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=ACADAF

Also, since a clipboard icon turns out to be smaller in size, we can display it in UI with small opacity to demonstrate that the code can be copied. Probably not a big deal but it makes the UI cleaner and more transparent.

Pages/alternative demos for reference/inspiration which uses copy code button with icons:

- https://developers.google.com/cast/docs/android_sender/customize_ui
- https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Three.js#html_structure
- https://docs.github.com/en/actions/quickstart#creating-your-first-workflow
- https://docs.gitlab.com/runner/install/docker.html
- https://docs.flutter.dev/development/data-and-backend/json#serializing-json-manually-using-dartconvert

- https://nuxtjs.org/docs/features/rendering-modes

Docusaurus' alternatives examples:

- GitBook - https://docs.powershelluniversal.com/api/endpoints 
- MkDocs Material - https://squidfunk.github.io/mkdocs-material/getting-started/#with-pip

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![ezgif com-gif-maker](https://user-images.githubusercontent.com/4408379/159588000-31a4b8c7-c562-4108-9407-52d9421cba7f.gif)


## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
