### PR TITLE
chore: publish stylelint-copyright again

### DIFF
--- a/packages/stylelint-copyright/package.json
+++ b/packages/stylelint-copyright/package.json
@@ -4,7 +4,6 @@
   "description": "Stylelint plugin to check CSS files for a copyright header.",
   "main": "index.js",
   "license": "MIT",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/docusaurus.git",


### PR DESCRIPTION
## Motivation

Not sure to remember why exactly (was related to canary releases and Docusaurus v1) but publish of stylelint-copyright has been disabled

I guess we can safely re-enable it now that v1 is not part of the main branch anymore? 🤷‍♂️ 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

CI


