### PR TITLE
fix(validation): allow non-object params to remark/rehype plugins

### DIFF
--- a/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
+++ b/packages/docusaurus-utils-validation/src/__tests__/__snapshots__/validationSchemas.test.ts.snap
@@ -32,8 +32,6 @@ exports[`validation schemas rehypePluginsSchema: for value=[[]] 1`] = `"\\"[0]\\
 
 exports[`validation schemas rehypePluginsSchema: for value=[[null,null]] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
 
-exports[`validation schemas rehypePluginsSchema: for value=[[null,true]] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
-
 exports[`validation schemas rehypePluginsSchema: for value=[3] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
 
 exports[`validation schemas rehypePluginsSchema: for value=[false] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
@@ -49,8 +47,6 @@ exports[`validation schemas rehypePluginsSchema: for value=null 1`] = `"\\"value
 exports[`validation schemas remarkPluginsSchema: for value=[[]] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
 
 exports[`validation schemas remarkPluginsSchema: for value=[[null,null]] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
-
-exports[`validation schemas remarkPluginsSchema: for value=[[null,true]] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
 
 exports[`validation schemas remarkPluginsSchema: for value=[3] 1`] = `"\\"[0]\\" does not match any of the allowed types"`;
 

--- a/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
+++ b/packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts
@@ -46,6 +46,10 @@ function testMarkdownPluginSchemas(schema: Joi.Schema) {
   testOK([() => {}]);
   testOK([[() => {}, {attr: 'val'}]]);
   testOK([[() => {}, {attr: 'val'}], () => {}, [() => {}, {attr: 'val'}]]);
+  // cSpell:ignore remarkjs
+  // official `remarkjs/remark-frontmatter` plugin accepts string options
+  testOK([[() => {}, 'string-option']]);
+  testOK([[() => {}, true]]);
 
   testFail(null);
   testFail(false);
@@ -55,7 +59,6 @@ function testMarkdownPluginSchemas(schema: Joi.Schema) {
   testFail([3]);
   testFail([[]]);
   testFail([[() => {}, undefined]]);
-  testFail([[() => {}, true]]);
 }
 
 describe('validation schemas', () => {

--- a/packages/docusaurus-utils-validation/src/validationSchemas.ts
+++ b/packages/docusaurus-utils-validation/src/validationSchemas.ts
@@ -19,7 +19,7 @@ export const PluginIdSchema = Joi.string()
 
 const MarkdownPluginsSchema = Joi.array()
   .items(
-    Joi.array().ordered(Joi.function().required(), Joi.object().required()),
+    Joi.array().ordered(Joi.function().required(), Joi.any().required()),
     Joi.function(),
     Joi.object(),
   )


### PR DESCRIPTION
Remark and Rehype plugins allow having options as a non-object type, such as a string.

For instance, the official MDX docs even have an example of this:

> ```js
> import {compile} from '@mdx-js/mdx'
> // ...
> import remarkFrontmatter from 'remark-frontmatter'
> // ...
> const file = '# hi'
> // ...
> // A plugin with options:
> await compile(file, {remarkPlugins: [[remarkFrontmatter, 'toml']]})
> ```
>
> Copied from https://mdxjs.com/docs/extending-mdx/#using-plugins
>
> This describes an official remarkjs plugin: [remarkjs/remark-frontmatter](https://github.com/remarkjs/remark-frontmatter), which allows passing a string (e.g. `"toml"`) as the options arg, instead of an object.

Apparently it may also be possible for a unified plugin to have multiple option parameters ([see docs](https://github.com/unifiedjs/unified/blob/e597bbf59ab7c09be018812b37b1b4cc076dc453/index.d.ts#L512-L522)), however:
- the docs explicitly discourage this, and
- I'm not sure if this applies to remark/rehype plugins, since I've never seen a remark/rehype plugin that supports this

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Docusaurus validation is too strict for `remarkPlugins` and `rehypePlugins`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes :heavy_check_mark: 

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I've added a test case in `packages/docusaurus-utils-validation/src/__tests__/validationSchemas.test.ts`

Additionally, I've also tested by doing the following:

```bash
npx create-docusaurus@latest my-website classic
cd my-website
# version 4+ is ESM only, so require() doesn't work
npm install remark-frontmatter@3
# add to docusaurus.confing.js: remarkPlugins: [[require("remark-frontmatter"), "toml"]],
vim docusaurus.config.js
# doesn't work due to 
# [ERROR] ValidationError: "remarkPlugins[0]" does not match any of the allowed types
npm start
```

However, once I modified the `node_modules/@docusaurus/utils-validation/lib/validationSchemas.js` to match this PR, `npm start` worked!

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->

#4412 would have made this bug a lot easier to debug.

Additionally, https://github.com/facebook/docusaurus/issues/4412#issuecomment-797722742 has some discussion about whether:

https://github.com/facebook/docusaurus/blob/4b3f568b7865bf6c80e3ee96a021d072b27f6e60/packages/docusaurus-utils-validation/src/validationSchemas.ts#L24

is correct. From my research, I also agree that it's unlikely that it will work too (but I'm not certain)