### PR TITLE
docs: npm run tsc -> npx tsc

### DIFF
--- a/website/docs/typescript-support.md
+++ b/website/docs/typescript-support.md
@@ -115,7 +115,7 @@ By default, the Docusaurus TypeScript config does not type-check JavaScript file
 The `// @ts-check` comment ensures the config file is properly type-checked when running:
 
 ```bash npm2yarn
-npm run tsc
+npm run typecheck
 ```
 
 :::

--- a/website/docs/typescript-support.md
+++ b/website/docs/typescript-support.md
@@ -115,7 +115,7 @@ By default, the Docusaurus TypeScript config does not type-check JavaScript file
 The `// @ts-check` comment ensures the config file is properly type-checked when running:
 
 ```bash npm2yarn
-npm run typecheck
+npx tsc
 ```
 
 :::


### PR DESCRIPTION
According to the page generated from website/docs/typescript-support.md, you should run `npm run tsc` to run `tsc` to do a type check. However, in the package.json file for Docusaurus version 2.0.0-beta.17 the command is actually `npm run typecheck`, which runs `tsc`.

This update only replaces `tsc` with `typecheck` so the npm script will run correctly.

## Motivation

This is a very small but inconvenient typo. I wanted to save others the trouble of the docs having a wrong command.

This typo does not appear to be corrected in the next version of the documentation website either.

### Have you read the [Contributing Guidelines on pull requests]

I have read the community guidelines on pull requests. I hope I have followed them correctly for what I hope is a simple fix.

## Test Plan

There should not need to be a test plan since this is a documentation change of a single word on a single line and should not have any impact on functionality.

## Related PRs

No other PRs related to this request as far as I could find.