### PR TITLE
feat(sitemap): add ignorePatterns option

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -19,6 +19,7 @@ describe('createSitemap', () => {
       {
         changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
+        ignorePatterns: [],
       },
     );
     expect(sitemap).toContain(
@@ -42,6 +43,7 @@ describe('createSitemap', () => {
       {
         changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
+        ignorePatterns: [],
       },
     );
     expect(sitemap).not.toContain('404');
@@ -52,11 +54,11 @@ describe('createSitemap', () => {
       {
         url: 'https://example.com',
       } as DocusaurusConfig,
-      ['/', '/search', '/tags'],
+      ['/', '/search/', '/tags/'],
       {
         changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
-        ignorePatterns: [/^\/search/, /^\/tags/],
+        ignorePatterns: ['/search/**', '/tags/**'],
       },
     );
     expect(sitemap).not.toContain('/search');
@@ -73,6 +75,7 @@ describe('createSitemap', () => {
       {
         changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
+        ignorePatterns: [],
       },
     );
 
@@ -92,6 +95,7 @@ describe('createSitemap', () => {
       {
         changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
+        ignorePatterns: [],
       },
     );
 
@@ -111,6 +115,7 @@ describe('createSitemap', () => {
       {
         changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
+        ignorePatterns: [],
       },
     );
 

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -49,19 +49,25 @@ describe('createSitemap', () => {
     expect(sitemap).not.toContain('404');
   });
 
-  it('exclusion of ignored paths', async () => {
+  it('excludes patterns configured to be ignored', async () => {
     const sitemap = await createSitemap(
       {
         url: 'https://example.com',
       } as DocusaurusConfig,
-      ['/', '/search/', '/tags/'],
+      ['/', '/search/', '/tags/', '/search/foo', '/tags/foo/bar'],
       {
         changefreq: EnumChangefreq.DAILY,
         priority: 0.7,
-        ignorePatterns: ['/search/**', '/tags/**'],
+        ignorePatterns: [
+          // Shallow ignore
+          '/search/',
+          // Deep ignore
+          '/tags/**',
+        ],
       },
     );
-    expect(sitemap).not.toContain('/search');
+    expect(sitemap).not.toContain('/search/</loc>');
+    expect(sitemap).toContain('/search/foo');
     expect(sitemap).not.toContain('/tags');
   });
 

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -47,6 +47,22 @@ describe('createSitemap', () => {
     expect(sitemap).not.toContain('404');
   });
 
+  it('exclusion of ignored paths', async () => {
+    const sitemap = await createSitemap(
+      {
+        url: 'https://example.com',
+      } as DocusaurusConfig,
+      ['/', '/search', '/tags'],
+      {
+        changefreq: EnumChangefreq.DAILY,
+        priority: 0.7,
+        ignorePatterns: [/^\/search/, /^\/tags/],
+      },
+    );
+    expect(sitemap).not.toContain('/search');
+    expect(sitemap).not.toContain('/tags');
+  });
+
   it('keep trailing slash unchanged', async () => {
     const sitemap = await createSitemap(
       {

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/options.test.ts
@@ -27,7 +27,7 @@ describe('validateOptions', () => {
     const userOptions = {
       changefreq: 'yearly',
       priority: 0.9,
-      ignorePatterns: [/^\/search/],
+      ignorePatterns: ['/search/**'],
     };
     expect(testValidate(userOptions)).toEqual({
       ...defaultOptions,
@@ -53,14 +53,14 @@ describe('validateOptions', () => {
 
   it('rejects bad ignorePatterns inputs', () => {
     expect(() =>
-      testValidate({ignorePatterns: /^search/}),
+      testValidate({ignorePatterns: '/search'}),
     ).toThrowErrorMatchingInlineSnapshot(
       `"\\"ignorePatterns\\" must be an array"`,
     );
     expect(() =>
-      testValidate({ignorePatterns: ['search']}),
+      testValidate({ignorePatterns: [/^\/search/]}),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"\\"ignorePatterns[0]\\" must be of type object"`,
+      `"\\"ignorePatterns[0]\\" must be a string"`,
     );
   });
 });

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/options.test.ts
@@ -27,6 +27,7 @@ describe('validateOptions', () => {
     const userOptions = {
       changefreq: 'yearly',
       priority: 0.9,
+      ignorePatterns: [/^\/search/],
     };
     expect(testValidate(userOptions)).toEqual({
       ...defaultOptions,
@@ -47,6 +48,19 @@ describe('validateOptions', () => {
       testValidate({changefreq: 'annually'}),
     ).toThrowErrorMatchingInlineSnapshot(
       `"\\"changefreq\\" must be one of [daily, monthly, always, hourly, weekly, yearly, never]"`,
+    );
+  });
+
+  it('rejects bad ignorePatterns inputs', () => {
+    expect(() =>
+      testValidate({ignorePatterns: /^search/}),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"\\"ignorePatterns\\" must be an array"`,
+    );
+    expect(() =>
+      testValidate({ignorePatterns: ['search']}),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"\\"ignorePatterns[0]\\" must be of type object"`,
     );
   });
 });

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -9,6 +9,7 @@ import {SitemapStream, streamToPromise} from 'sitemap';
 import type {Options} from '@docusaurus/plugin-sitemap';
 import type {DocusaurusConfig} from '@docusaurus/types';
 import {applyTrailingSlash} from '@docusaurus/utils-common';
+import {createMatcher} from '@docusaurus/utils';
 
 export default async function createSitemap(
   siteConfig: DocusaurusConfig,
@@ -21,15 +22,16 @@ export default async function createSitemap(
   }
   const {changefreq, priority, ignorePatterns} = options;
 
+  const ignoreMatcher =
+    ignorePatterns!.length > 0
+      ? createMatcher(ignorePatterns!)
+      : // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        (str: string) => false;
+
   const sitemapStream = new SitemapStream({hostname});
 
   routesPaths
-    .filter(
-      (route) =>
-        !route.endsWith('404.html') &&
-        (!ignorePatterns ||
-          !ignorePatterns.some((pattern) => pattern.test(route))),
-    )
+    .filter((route) => !route.endsWith('404.html') && !ignoreMatcher(route))
     .forEach((routePath) =>
       sitemapStream.write({
         url: applyTrailingSlash(routePath, {

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -6,7 +6,7 @@
  */
 
 import {SitemapStream, streamToPromise} from 'sitemap';
-import type {Options} from '@docusaurus/plugin-sitemap';
+import type {PluginOptions} from '@docusaurus/plugin-sitemap';
 import type {DocusaurusConfig} from '@docusaurus/types';
 import {applyTrailingSlash} from '@docusaurus/utils-common';
 import {createMatcher} from '@docusaurus/utils';
@@ -14,7 +14,7 @@ import {createMatcher} from '@docusaurus/utils';
 export default async function createSitemap(
   siteConfig: DocusaurusConfig,
   routesPaths: string[],
-  options: Options,
+  options: PluginOptions,
 ): Promise<string> {
   const {url: hostname} = siteConfig;
   if (!hostname) {
@@ -22,11 +22,7 @@ export default async function createSitemap(
   }
   const {changefreq, priority, ignorePatterns} = options;
 
-  const ignoreMatcher =
-    ignorePatterns!.length > 0
-      ? createMatcher(ignorePatterns!)
-      : // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (str: string) => false;
+  const ignoreMatcher = createMatcher(ignorePatterns);
 
   const sitemapStream = new SitemapStream({hostname});
 

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -19,12 +19,17 @@ export default async function createSitemap(
   if (!hostname) {
     throw new Error('URL in docusaurus.config.js cannot be empty/undefined.');
   }
-  const {changefreq, priority} = options;
+  const {changefreq, priority, ignorePatterns} = options;
 
   const sitemapStream = new SitemapStream({hostname});
 
   routesPaths
-    .filter((route) => !route.endsWith('404.html'))
+    .filter(
+      (route) =>
+        !route.endsWith('404.html') &&
+        (!ignorePatterns ||
+          !ignorePatterns.some((pattern) => pattern.test(route))),
+    )
     .forEach((routePath) =>
       sitemapStream.write({
         url: applyTrailingSlash(routePath, {

--- a/packages/docusaurus-plugin-sitemap/src/index.ts
+++ b/packages/docusaurus-plugin-sitemap/src/index.ts
@@ -7,13 +7,13 @@
 
 import fs from 'fs-extra';
 import path from 'path';
-import type {Options} from '@docusaurus/plugin-sitemap';
+import type {PluginOptions} from '@docusaurus/plugin-sitemap';
 import createSitemap from './createSitemap';
 import type {LoadContext, Plugin} from '@docusaurus/types';
 
 export default function pluginSitemap(
   context: LoadContext,
-  options: Options,
+  options: PluginOptions,
 ): Plugin<void> {
   return {
     name: 'docusaurus-plugin-sitemap',

--- a/packages/docusaurus-plugin-sitemap/src/options.ts
+++ b/packages/docusaurus-plugin-sitemap/src/options.ts
@@ -7,10 +7,10 @@
 
 import {Joi} from '@docusaurus/utils-validation';
 import {EnumChangefreq} from 'sitemap';
-import type {Options} from '@docusaurus/plugin-sitemap';
+import type {Options, PluginOptions} from '@docusaurus/plugin-sitemap';
 import type {OptionValidationContext} from '@docusaurus/types';
 
-export const DEFAULT_OPTIONS: Options = {
+export const DEFAULT_OPTIONS: PluginOptions = {
   changefreq: EnumChangefreq.WEEKLY,
   priority: 0.5,
   ignorePatterns: [],
@@ -37,7 +37,7 @@ const PluginOptionSchema = Joi.object({
 export function validateOptions({
   validate,
   options,
-}: OptionValidationContext<Options, Options>): Options {
+}: OptionValidationContext<Options, PluginOptions>): PluginOptions {
   const validatedOptions = validate(PluginOptionSchema, options);
   return validatedOptions;
 }

--- a/packages/docusaurus-plugin-sitemap/src/options.ts
+++ b/packages/docusaurus-plugin-sitemap/src/options.ts
@@ -13,6 +13,7 @@ import type {OptionValidationContext} from '@docusaurus/types';
 export const DEFAULT_OPTIONS: Options = {
   changefreq: EnumChangefreq.WEEKLY,
   priority: 0.5,
+  ignorePatterns: [],
 };
 
 const PluginOptionSchema = Joi.object({
@@ -24,6 +25,9 @@ const PluginOptionSchema = Joi.object({
     .valid(...Object.values(EnumChangefreq))
     .default(DEFAULT_OPTIONS.changefreq),
   priority: Joi.number().min(0).max(1).default(DEFAULT_OPTIONS.priority),
+  ignorePatterns: Joi.array()
+    .items(Joi.object().instance(RegExp))
+    .default(DEFAULT_OPTIONS.ignorePatterns),
   trailingSlash: Joi.forbidden().messages({
     'any.unknown':
       'Please use the new Docusaurus global trailingSlash config instead, and the sitemaps plugin will use it.',

--- a/packages/docusaurus-plugin-sitemap/src/options.ts
+++ b/packages/docusaurus-plugin-sitemap/src/options.ts
@@ -26,7 +26,7 @@ const PluginOptionSchema = Joi.object({
     .default(DEFAULT_OPTIONS.changefreq),
   priority: Joi.number().min(0).max(1).default(DEFAULT_OPTIONS.priority),
   ignorePatterns: Joi.array()
-    .items(Joi.object().instance(RegExp))
+    .items(Joi.string())
     .default(DEFAULT_OPTIONS.ignorePatterns),
   trailingSlash: Joi.forbidden().messages({
     'any.unknown':

--- a/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
+++ b/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
@@ -13,4 +13,5 @@ export type Options = {
   changefreq?: EnumChangefreq;
   /** @see https://www.sitemaps.org/protocol.html#xmlTagDefinitions */
   priority?: number;
+  ignorePatterns?: RegExp[];
 };

--- a/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
+++ b/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
@@ -9,9 +9,13 @@ import type {EnumChangefreq} from 'sitemap';
 
 export type PluginOptions = {
   /** @see https://www.sitemaps.org/protocol.html#xmlTagDefinitions */
-  changefreq?: EnumChangefreq;
+  changefreq: EnumChangefreq;
   /** @see https://www.sitemaps.org/protocol.html#xmlTagDefinitions */
-  priority?: number;
+  priority: number;
+  /**
+   * A list of glob patterns; matching route paths will be filtered from the
+   * sitemap. Note that you may need to include the base URL in here.
+   */
   ignorePatterns: string[];
 };
 

--- a/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
+++ b/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
@@ -13,5 +13,5 @@ export type Options = {
   changefreq?: EnumChangefreq;
   /** @see https://www.sitemaps.org/protocol.html#xmlTagDefinitions */
   priority?: number;
-  ignorePatterns?: RegExp[];
+  ignorePatterns?: string[];
 };

--- a/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
+++ b/packages/docusaurus-plugin-sitemap/src/plugin-sitemap.d.ts
@@ -7,11 +7,12 @@
 
 import type {EnumChangefreq} from 'sitemap';
 
-export type Options = {
-  id?: string;
+export type PluginOptions = {
   /** @see https://www.sitemaps.org/protocol.html#xmlTagDefinitions */
   changefreq?: EnumChangefreq;
   /** @see https://www.sitemaps.org/protocol.html#xmlTagDefinitions */
   priority?: number;
-  ignorePatterns?: string[];
+  ignorePatterns: string[];
 };
+
+export type Options = Partial<PluginOptions>;

--- a/packages/docusaurus-utils/src/globUtils.ts
+++ b/packages/docusaurus-utils/src/globUtils.ts
@@ -31,11 +31,16 @@ type Matcher = (str: string) => boolean;
  * A very thin wrapper around `Micromatch.makeRe`.
  *
  * @see {@link createAbsoluteFilePathMatcher}
- * @param patterns A list of glob patterns.
+ * @param patterns A list of glob patterns. If the list is empty, it defaults to
+ * matching none.
  * @returns A matcher handle that tells if a file path is matched by any of the
  * patterns.
  */
 export function createMatcher(patterns: string[]): Matcher {
+  if (patterns.length === 0) {
+    // `/(?:)/.test("foo")` is `true`
+    return () => false;
+  }
   const regexp = new RegExp(
     patterns.map((pattern) => Micromatch.makeRe(pattern).source).join('|'),
   );

--- a/website/docs/api/plugins/plugin-sitemap.md
+++ b/website/docs/api/plugins/plugin-sitemap.md
@@ -39,6 +39,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `changefreq` | `string` | `'weekly'` | See [sitemap docs](https://www.sitemaps.org/protocol.html#xmlTagDefinitions) |
 | `priority` | `number` | `0.5` | See [sitemap docs](https://www.sitemaps.org/protocol.html#xmlTagDefinitions) |
+| `ignorePatterns` | `string[]` | `[]` | A list of glob patterns; matching route paths will be filtered from the sitemap. Note that you may need to include the base URL in here. |
 
 </APITable>
 
@@ -68,6 +69,7 @@ Most Docusaurus users configure this plugin through the preset options.
 const config = {
   changefreq: 'weekly',
   priority: 0.5,
+  ignorePatterns: ['/tags/**'],
 };
 ```
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -338,6 +338,9 @@ const config = {
               trackingID: 'UA-141789564-1',
             }
           : undefined,
+        sitemap: {
+          ignorePatterns: ['/tests/**'],
+        },
       }),
     ],
   ],


### PR DESCRIPTION
## Motivation

When I generate a sitemap, I want to ignore some paths, such as the path starting with `/tags`, so I add an option named `ignorePatterns` to `plugin-sitemap`, which accepts an array of regular expressions and allows users to ignore some paths that do not need to appear in the sitemap.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've added several test cases in the following files.

- `packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts`
- `packages/docusaurus-plugin-sitemap/src/__tests__/options.test.ts`.

## Related PRs

No other PRs related to this request as far as I could find.
