### PR TITLE
fix(theme-classic): minor code copy button improvements

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState} from 'react';
+import React, {useCallback, useState, useRef, useEffect} from 'react';
 import clsx from 'clsx';
 import copy from 'copy-text-to-clipboard';
 import {translate} from '@docusaurus/Translate';
@@ -15,14 +15,16 @@ import styles from './styles.module.css';
 
 export default function CopyButton({code}: Props): JSX.Element {
   const [isCopied, setIsCopied] = useState(false);
-  const handleCopyCode = () => {
+  const copyTimeout = useRef<number | undefined>(undefined);
+  const handleCopyCode = useCallback(() => {
     copy(code);
     setIsCopied(true);
-
-    setTimeout(() => {
+    copyTimeout.current = window.setTimeout(() => {
       setIsCopied(false);
-    }, 2000);
-  };
+    }, 1000);
+  }, [code]);
+
+  useEffect(() => () => window.clearTimeout(copyTimeout.current), []);
 
   return (
     <button


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

- Reduced the timeout to 1s which seems more sensible
- Clean up the timeout before unmount because state is mutated in the timeout:

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/55398995/159950769-8fc7eced-5352-428c-8180-5212047df70b.png">

I also think that the button is only ever reset to the original state after the timeout, so even when the cursor leaves the code block, the button stays as a tick, which seems a little weird. But changing that requires moving state management up to `CodeBlock` which seems too much trouble.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

