### PR TITLE
docs: fix example admonition syntax

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -87,14 +87,14 @@ If you use [Prettier](https://prettier.io) to format your Markdown files, Pretti
 <!-- prettier-ignore -->
 ```md
 <!-- Prettier doesn't change this -->
-::: note
+:::note
 
 Hello world
 
 :::
 
 <!-- Prettier changes this -->
-::: note
+:::note
 Hello world
 :::
 


### PR DESCRIPTION
`::: info` should be `:::info` or else Docusaurus does not render it as an admonition.
