### PR TITLE
refactor: extract MDX components

### DIFF
--- a/packages/docusaurus-theme-classic/src/getSwizzleConfig.ts
+++ b/packages/docusaurus-theme-classic/src/getSwizzleConfig.ts
@@ -136,6 +136,68 @@ export default function getSwizzleConfig(): SwizzleConfig {
         description:
           'The MDX components to use for rendering MDX files. Meant to be ejected.',
       },
+      'MDXComponents/A': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description:
+          'The component used to render <a> tags and Markdown links in MDX',
+      },
+      'MDXComponents/Code': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description:
+          'The component used to render <code> tags and Markdown code blocks in MDX',
+      },
+      'MDXComponents/Details': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description: 'The component used to render <details> tags in MDX',
+      },
+      'MDXComponents/Head': {
+        actions: {
+          eject: 'forbidden',
+          wrap: 'forbidden',
+        },
+        description:
+          'Technical component used to assign metadata (generally for SEO purpose) to the current MDX document',
+      },
+      'MDXComponents/Heading': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description:
+          'The component used to render heading tags (<h1>, <h2>...) and Markdown headings in MDX',
+      },
+      'MDXComponents/Img': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description:
+          'The component used to render <img> tags and Markdown images in MDX',
+      },
+      'MDXComponents/Pre': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description: 'The component used to render <pre> tags in MDX',
+      },
+      'MDXComponents/Ul': {
+        actions: {
+          eject: 'safe',
+          wrap: 'safe',
+        },
+        description:
+          'The component used to render <ul> tags and Markdown unordered lists in MDX',
+      },
       MDXContent: {
         actions: {
           eject: 'safe',

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -417,24 +417,85 @@ declare module '@theme/SkipToContent' {
   export default function SkipToContent(): JSX.Element;
 }
 
-declare module '@theme/MDXComponents' {
+declare module '@theme/MDXComponents/A' {
   import type {ComponentProps} from 'react';
-  import type CodeBlock from '@theme/CodeBlock';
-  import type Head from '@docusaurus/Head';
+
+  export interface Props extends ComponentProps<'a'> {}
+
+  export default function MDXA(props: Props): JSX.Element;
+}
+
+declare module '@theme/MDXComponents/Code' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'code'> {}
+
+  export default function MDXCode(props: Props): JSX.Element;
+}
+
+declare module '@theme/MDXComponents/Details' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'details'> {}
+
+  export default function MDXDetails(props: Props): JSX.Element;
+}
+
+declare module '@theme/MDXComponents/Ul' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'ul'> {}
+
+  export default function MDXUl(props: Props): JSX.Element;
+}
+
+declare module '@theme/MDXComponents/Head' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'head'> {}
+
+  export default function MDXHead(props: Props): JSX.Element;
+}
+
+declare module '@theme/MDXComponents/Heading' {
+  import type {ComponentProps} from 'react';
+  import type Heading from '@theme/Heading';
+
+  export interface Props extends ComponentProps<typeof Heading> {}
+
+  export default function MDXHeading(props: Props): JSX.Element;
+}
+
+declare module '@theme/MDXComponents/Pre' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'pre'> {}
+
+  export default function MDXPre(props: Props): JSX.Element;
+}
+
+declare module '@theme/MDXComponents' {
+  import type {ComponentType, ComponentProps} from 'react';
+
+  import type MDXHead from '@theme/MDXComponents/Head';
+  import type MDXCode from '@theme/MDXComponents/Code';
+  import type MDXA from '@theme/MDXComponents/A';
+  import type MDXPre from '@theme/MDXComponents/Pre';
+  import type MDXDetails from '@theme/MDXComponents/Details';
 
   export type MDXComponentsObject = {
-    readonly head: typeof Head;
-    readonly code: typeof CodeBlock;
-    readonly a: (props: ComponentProps<'a'>) => JSX.Element;
-    readonly pre: typeof CodeBlock;
-    readonly details: (props: ComponentProps<'details'>) => JSX.Element;
+    readonly head: typeof MDXHead;
+    readonly code: typeof MDXCode;
+    readonly a: typeof MDXA;
+    readonly pre: typeof MDXPre;
+    readonly details: typeof MDXDetails;
     readonly h1: (props: ComponentProps<'h1'>) => JSX.Element;
     readonly h2: (props: ComponentProps<'h2'>) => JSX.Element;
     readonly h3: (props: ComponentProps<'h3'>) => JSX.Element;
     readonly h4: (props: ComponentProps<'h4'>) => JSX.Element;
     readonly h5: (props: ComponentProps<'h5'>) => JSX.Element;
     readonly h6: (props: ComponentProps<'h6'>) => JSX.Element;
-  };
+  } & Record<string, ComponentType<unknown>>;
 
   const MDXComponents: MDXComponentsObject;
   export default MDXComponents;

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -449,6 +449,14 @@ declare module '@theme/MDXComponents/Ul' {
   export default function MDXUl(props: Props): JSX.Element;
 }
 
+declare module '@theme/MDXComponents/Img' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'img'> {}
+
+  export default function MDXImg(props: Props): JSX.Element;
+}
+
 declare module '@theme/MDXComponents/Head' {
   import type {ComponentProps} from 'react';
 
@@ -482,6 +490,8 @@ declare module '@theme/MDXComponents' {
   import type MDXA from '@theme/MDXComponents/A';
   import type MDXPre from '@theme/MDXComponents/Pre';
   import type MDXDetails from '@theme/MDXComponents/Details';
+  import type MDXUl from '@theme/MDXComponents/Ul';
+  import type MDXImg from '@theme/MDXComponents/Img';
 
   export type MDXComponentsObject = {
     readonly head: typeof MDXHead;
@@ -489,6 +499,8 @@ declare module '@theme/MDXComponents' {
     readonly a: typeof MDXA;
     readonly pre: typeof MDXPre;
     readonly details: typeof MDXDetails;
+    readonly ul: typeof MDXUl;
+    readonly img: typeof MDXImg;
     readonly h1: (props: ComponentProps<'h1'>) => JSX.Element;
     readonly h2: (props: ComponentProps<'h2'>) => JSX.Element;
     readonly h3: (props: ComponentProps<'h3'>) => JSX.Element;

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/A.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/A.tsx
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Link from '@docusaurus/Link';
+import type {Props} from '@theme/MDXComponents/A';
+
+export default function MDXA(props: Props): JSX.Element {
+  return <Link {...props} />;
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
@@ -6,7 +6,7 @@
  */
 
 import type {ComponentProps} from 'react';
-import React, { isValidElement} from 'react';
+import React, {isValidElement} from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import type {Props} from '@theme/MDXComponents/Code';
 

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {ComponentProps} from 'react';
+import React, { isValidElement} from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import type {Props} from '@theme/MDXComponents/Code';
+
+export default function MDXCode(props: Props): JSX.Element {
+  const inlineElements = [
+    'a',
+    'b',
+    'big',
+    'i',
+    'span',
+    'em',
+    'strong',
+    'sup',
+    'sub',
+    'small',
+  ];
+  const shouldBeInline = React.Children.toArray(props.children).every(
+    (el) =>
+      (typeof el === 'string' && !el.includes('\n')) ||
+      (isValidElement(el) && inlineElements.includes(el.props.mdxType)),
+  );
+
+  return shouldBeInline ? (
+    <code {...props} />
+  ) : (
+    <CodeBlock {...(props as ComponentProps<typeof CodeBlock>)} />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Details.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Details.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ComponentProps, type ReactElement} from 'react';
+import Details from '@theme/Details';
+import type {Props} from '@theme/MDXComponents/Details';
+
+export default function MDXDetails(props: Props): JSX.Element {
+  const items = React.Children.toArray(props.children) as ReactElement[];
+  // Split summary item from the rest to pass it as a separate prop to the
+  // Details theme component
+  const summary: ReactElement<ComponentProps<'summary'>> = items.find(
+    (item) => item?.props?.mdxType === 'summary',
+  )!;
+  const children = <>{items.filter((item) => item !== summary)}</>;
+
+  return (
+    <Details {...props} summary={summary}>
+      {children}
+    </Details>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Head.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Head.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactElement, type ComponentProps} from 'react';
+import Head from '@docusaurus/Head';
+import type {Props} from '@theme/MDXComponents/Head';
+
+// MDX elements are wrapped through the MDX pragma. In some cases (notably usage
+// with Head/Helmet) we need to unwrap those elements.
+function unwrapMDXElement(element: ReactElement) {
+  if (element?.props?.mdxType && element?.props?.originalType) {
+    const {mdxType, originalType, ...newProps} = element.props;
+    return React.createElement(element.props.originalType, newProps);
+  }
+  return element;
+}
+
+export default function MDXHead(props: Props): JSX.Element {
+  const unwrappedChildren = React.Children.map(props.children, (child) =>
+    unwrapMDXElement(child as ReactElement),
+  );
+  return (
+    <Head {...(props as ComponentProps<typeof Head>)}>{unwrappedChildren}</Head>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Heading.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Heading.tsx
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Heading from '@theme/Heading';
+import type {Props} from '@theme/MDXComponents/Heading';
+
+export default function MDXHeading(props: Props): JSX.Element {
+  return <Heading {...props} />;
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img.module.css
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.contains-task-list {
-  padding-left: 0;
-  list-style: none;
+.img {
+  height: auto;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/MDXComponents/Img';
+import styles from './Img.module.css';
+import clsx from 'clsx';
+
+export default function MDXImg(props: Props): JSX.Element {
+  return (
+    // eslint-disable-next-line jsx-a11y/alt-text
+    <img {...props} className={clsx(props.className, styles.img)} />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img.tsx
@@ -10,9 +10,11 @@ import type {Props} from '@theme/MDXComponents/Img';
 import styles from './Img.module.css';
 import clsx from 'clsx';
 
+function transformImgClassName(className?: string): string {
+  return clsx(className, styles.img);
+}
+
 export default function MDXImg(props: Props): JSX.Element {
-  return (
-    // eslint-disable-next-line jsx-a11y/alt-text
-    <img {...props} className={clsx(props.className, styles.img)} />
-  );
+  // eslint-disable-next-line jsx-a11y/alt-text
+  return <img {...props} className={transformImgClassName(props.className)} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Pre.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Pre.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {isValidElement} from 'react';
+import CodeBlock from '@theme/CodeBlock';
+
+export default function MDXPre(props: any) {
+  return (
+    <CodeBlock
+      // If this pre is created by a ``` fenced codeblock, unwrap the children
+      {...(isValidElement(props.children) &&
+      props.children.props.originalType === 'code'
+        ? props.children?.props
+        : {...props})}
+    />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.module.css
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-ul.contains-task-list {
+.contains-task-list {
   padding-left: 0;
   list-style: none;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/MDXComponents/Ul';
+
+export default function MDXUl(props: Props): JSX.Element {
+  return <ul {...props} />;
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
@@ -19,6 +19,9 @@ export default function MDXUl(props: Props): JSX.Element {
       {...props}
       className={clsx(
         props.className,
+
+        // This class is set globally by GitHub/MDX
+        // See https://github.com/syntax-tree/mdast-util-to-hast/issues/28
         props.className?.includes('contains-task-list') &&
           containsClassListLocalClass,
       )}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
@@ -6,8 +6,22 @@
  */
 
 import React from 'react';
+import clsx from 'clsx';
 import type {Props} from '@theme/MDXComponents/Ul';
 
+import styles from './Ul.module.css';
+
+const containsClassListLocalClass = styles['contains-task-list'];
+
 export default function MDXUl(props: Props): JSX.Element {
-  return <ul {...props} />;
+  return (
+    <ul
+      {...props}
+      className={clsx(
+        props.className,
+        props.className?.includes('contains-task-list') &&
+          containsClassListLocalClass,
+      )}
+    />
+  );
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul.tsx
@@ -13,18 +13,16 @@ import styles from './Ul.module.css';
 
 const containsClassListLocalClass = styles['contains-task-list'];
 
-export default function MDXUl(props: Props): JSX.Element {
-  return (
-    <ul
-      {...props}
-      className={clsx(
-        props.className,
-
-        // This class is set globally by GitHub/MDX
-        // See https://github.com/syntax-tree/mdast-util-to-hast/issues/28
-        props.className?.includes('contains-task-list') &&
-          containsClassListLocalClass,
-      )}
-    />
+function transformUlClassName(className?: string): string {
+  return clsx(
+    className,
+    // This class is set globally by GitHub/MDX
+    // We keep the global class, but apply scoped CSS
+    // See https://github.com/syntax-tree/mdast-util-to-hast/issues/28
+    className?.includes('contains-task-list') && containsClassListLocalClass,
   );
+}
+
+export default function MDXUl(props: Props): JSX.Element {
+  return <ul {...props} className={transformUlClassName(props.className)} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -16,8 +16,6 @@ import MDXUl from '@theme/MDXComponents/Ul';
 
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 
-import './styles.css';
-
 const MDXComponents: MDXComponentsObject = {
   head: MDXHead,
   code: MDXCode,

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -5,89 +5,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {
-  isValidElement,
-  type ComponentProps,
-  type ReactElement,
-} from 'react';
-import Head from '@docusaurus/Head';
-import Link from '@docusaurus/Link';
-import CodeBlock from '@theme/CodeBlock';
-import Heading from '@theme/Heading';
-import Details from '@theme/Details';
+import React from 'react';
+import MDXHead from '@theme/MDXComponents/Head';
+import MDXCode from '@theme/MDXComponents/Code';
+import MDXA from '@theme/MDXComponents/A';
+import MDXPre from '@theme/MDXComponents/Pre';
+import MDXDetails from '@theme/MDXComponents/Details';
+import MDXHeading from '@theme/MDXComponents/Heading';
+import MDXUl from '@theme/MDXComponents/Ul';
+
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 
 import './styles.css';
 
-// MDX elements are wrapped through the MDX pragma. In some cases (notably usage
-// with Head/Helmet) we need to unwrap those elements.
-function unwrapMDXElement(element: ReactElement) {
-  if (element?.props?.mdxType && element?.props?.originalType) {
-    const {mdxType, originalType, ...newProps} = element.props;
-    return React.createElement(element.props.originalType, newProps);
-  }
-  return element;
-}
-
 const MDXComponents: MDXComponentsObject = {
-  head: (props) => {
-    const unwrappedChildren = React.Children.map(props.children, (child) =>
-      unwrapMDXElement(child as ReactElement),
-    );
-    return <Head {...props}>{unwrappedChildren}</Head>;
-  },
-  code: (props) => {
-    const inlineElements = [
-      'a',
-      'b',
-      'big',
-      'i',
-      'span',
-      'em',
-      'strong',
-      'sup',
-      'sub',
-      'small',
-    ];
-    const shouldBeInline = React.Children.toArray(props.children).every(
-      (el) =>
-        (typeof el === 'string' && !el.includes('\n')) ||
-        (isValidElement(el) && inlineElements.includes(el.props.mdxType)),
-    );
-
-    return shouldBeInline ? <code {...props} /> : <CodeBlock {...props} />;
-  },
-  a: (props) => <Link {...props} />,
-  pre: (props) => (
-    <CodeBlock
-      // If this pre is created by a ``` fenced codeblock, unwrap the children
-      {...(isValidElement(props.children) &&
-      props.children.props.originalType === 'code'
-        ? props.children?.props
-        : {...props})}
-    />
-  ),
-  details: (props): JSX.Element => {
-    const items = React.Children.toArray(props.children) as ReactElement[];
-    // Split summary item from the rest to pass it as a separate prop to the
-    // Details theme component
-    const summary: ReactElement<ComponentProps<'summary'>> = items.find(
-      (item) => item?.props?.mdxType === 'summary',
-    )!;
-    const children = <>{items.filter((item) => item !== summary)}</>;
-
-    return (
-      <Details {...props} summary={summary}>
-        {children}
-      </Details>
-    );
-  },
-  h1: (props) => <Heading as="h1" {...props} />,
-  h2: (props) => <Heading as="h2" {...props} />,
-  h3: (props) => <Heading as="h3" {...props} />,
-  h4: (props) => <Heading as="h4" {...props} />,
-  h5: (props) => <Heading as="h5" {...props} />,
-  h6: (props) => <Heading as="h6" {...props} />,
+  head: MDXHead,
+  code: MDXCode,
+  a: MDXA,
+  pre: MDXPre,
+  details: MDXDetails,
+  ul: MDXUl,
+  h1: (props) => <MDXHeading as="h1" {...props} />,
+  h2: (props) => <MDXHeading as="h2" {...props} />,
+  h3: (props) => <MDXHeading as="h3" {...props} />,
+  h4: (props) => <MDXHeading as="h4" {...props} />,
+  h5: (props) => <MDXHeading as="h5" {...props} />,
+  h6: (props) => <MDXHeading as="h6" {...props} />,
 };
 
 export default MDXComponents;

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -13,6 +13,7 @@ import MDXPre from '@theme/MDXComponents/Pre';
 import MDXDetails from '@theme/MDXComponents/Details';
 import MDXHeading from '@theme/MDXComponents/Heading';
 import MDXUl from '@theme/MDXComponents/Ul';
+import MDXImg from '@theme/MDXComponents/Img';
 
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 
@@ -23,6 +24,7 @@ const MDXComponents: MDXComponentsObject = {
   pre: MDXPre,
   details: MDXDetails,
   ul: MDXUl,
+  img: MDXImg,
   h1: (props) => <MDXHeading as="h1" {...props} />,
   h2: (props) => <MDXHeading as="h2" {...props} />,
   h3: (props) => <MDXHeading as="h3" {...props} />,

--- a/project-words.txt
+++ b/project-words.txt
@@ -152,6 +152,7 @@ mathjax
 mdast
 mdxast
 mdxhast
+MDXA
 metadatum
 metastring
 middlewares

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -5,6 +5,17 @@ description: Docusaurus was designed from the ground up to be easily installed a
 slug: /
 ---
 
+- [x] I'm using the latest version of Docusaurus.
+- [x] I have tried the `npm run clear` or `yarn clear` command.
+- [x] I have tried `rm -rf node_modules yarn.lock package-lock.json` and re-installing packages.
+- [x] I have tried creating a repro with https://new.docusaurus.io.
+- [x] I have read the console error message carefully (if applicable).
+
+Hey
+
+- x
+- y
+
 ⚡️ Docusaurus will help you ship a **beautiful documentation site in no time**.
 
 💸 Building a custom tech stack is expensive. Instead, **focus on your content** and just write Markdown files.

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -5,17 +5,6 @@ description: Docusaurus was designed from the ground up to be easily installed a
 slug: /
 ---
 
-- [x] I'm using the latest version of Docusaurus.
-- [x] I have tried the `npm run clear` or `yarn clear` command.
-- [x] I have tried `rm -rf node_modules yarn.lock package-lock.json` and re-installing packages.
-- [x] I have tried creating a repro with https://new.docusaurus.io.
-- [x] I have read the console error message carefully (if applicable).
-
-Hey
-
-- x
-- y
-
 ⚡️ Docusaurus will help you ship a **beautiful documentation site in no time**.
 
 💸 Building a custom tech stack is expensive. Instead, **focus on your content** and just write Markdown files.


### PR DESCRIPTION
## Motivation

Breaking change:
- `ul.contains-task-list` CSS is now locally scoped instead of applied globally
- `<img>` outside of markdown documents won't be auto-applied with `height: auto`: it is your responsibility to apply this in images of your Docusaurus pages if you want that CSS rule again, or to apply it back with a global CSS rule

## Motivation

Make it easy to swizzle one specific component used to render MDX elements

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview

