### PR TITLE
fix(core): prevent useBaseUrl returning /base/base when on /base

### DIFF
--- a/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/useBaseUrl.test.tsx
@@ -77,6 +77,7 @@ describe('useBaseUrl', () => {
     expect(mockUseBaseUrl('/hello/foo', {absolute: true})).toBe(
       'https://docusaurus.io/docusaurus/hello/foo',
     );
+    expect(mockUseBaseUrl('/docusaurus')).toBe('/docusaurus/');
     expect(mockUseBaseUrl('/docusaurus/')).toBe('/docusaurus/');
     expect(mockUseBaseUrl('/docusaurus/hello')).toBe('/docusaurus/hello');
     expect(mockUseBaseUrl('#hello')).toBe('#hello');
@@ -143,6 +144,7 @@ describe('useBaseUrlUtils().withBaseUrl()', () => {
     expect(withBaseUrl('/hello/foo', {absolute: true})).toBe(
       'https://docusaurus.io/docusaurus/hello/foo',
     );
+    expect(withBaseUrl('/docusaurus')).toBe('/docusaurus/');
     expect(withBaseUrl('/docusaurus/')).toBe('/docusaurus/');
     expect(withBaseUrl('/docusaurus/hello')).toBe('/docusaurus/hello');
     expect(withBaseUrl('#hello')).toBe('#hello');

--- a/packages/docusaurus/src/client/exports/useBaseUrl.ts
+++ b/packages/docusaurus/src/client/exports/useBaseUrl.ts
@@ -33,6 +33,12 @@ function addBaseUrl(
     return baseUrl + url.replace(/^\//, '');
   }
 
+  // /baseUrl -> /baseUrl/
+  // https://github.com/facebook/docusaurus/issues/6315
+  if (url === baseUrl.replace(/\/$/, '')) {
+    return baseUrl;
+  }
+
   // We should avoid adding the baseurl twice if it's already there
   const shouldAddBaseUrl = !url.startsWith(baseUrl);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix #6315. It's a pretty trivial fix; not sure if a better solution exists. Since we have this duplicate base URL detection anyways, this fix only exists to make the behavior more consistent. Related to #6294

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added two tests