### PR TITLE
refactor: better external link icon positioning

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -250,6 +250,7 @@ function DocSidebarItemLink({
 }: Props & {item: PropSidebarItemLink}) {
   const {href, label, className} = item;
   const isActive = isActiveSidebarItem(item, activePath);
+  const isInternalLink = isInternalUrl(href);
   return (
     <li
       className={clsx(
@@ -260,17 +261,21 @@ function DocSidebarItemLink({
       )}
       key={label}>
       <Link
-        className={clsx('menu__link', {
-          'menu__link--active': isActive,
-        })}
+        className={clsx(
+          'menu__link',
+          !isInternalLink && styles.menuExternalLink,
+          {
+            'menu__link--active': isActive,
+          },
+        )}
         aria-current={isActive ? 'page' : undefined}
         to={href}
-        {...(isInternalUrl(href) && {
+        {...(isInternalLink && {
           onClick: onItemClick ? () => onItemClick(item) : undefined,
         })}
         {...props}>
         {label}
-        {!isInternalUrl(href) && <IconExternalLink />}
+        {!isInternalLink && <IconExternalLink />}
       </Link>
     </li>
   );

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/styles.module.css
@@ -11,3 +11,7 @@
       var(--ifm-menu-link-padding-horizontal);
   }
 }
+
+.menuExternalLink {
+  align-items: center;
+}

--- a/packages/docusaurus-theme-classic/src/theme/IconExternalLink/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/IconExternalLink/styles.module.css
@@ -7,6 +7,4 @@
 
 .iconExternalLink {
   margin-left: 0.3rem;
-  position: relative;
-  top: 1px;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

The relative positioning of external link icons was originally needed for sidebar items, but it has been applied inside other elements. Therefore, it is better to align that icon only within the doc sidebar items.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
