### PR TITLE
feat(theme-classic): show blog sidebar on mobile

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
@@ -8,17 +8,21 @@
 import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
+import {translate} from '@docusaurus/Translate';
+import {
+  NavbarSecondaryMenuFiller,
+  useWindowSize,
+} from '@docusaurus/theme-common';
 import type {Props} from '@theme/BlogSidebar';
 import styles from './styles.module.css';
-import {translate} from '@docusaurus/Translate';
 
-export default function BlogSidebar({sidebar}: Props): JSX.Element | null {
-  if (sidebar.items.length === 0) {
-    return null;
-  }
+function BlogSidebarContent({
+  sidebar,
+  className,
+}: Props & {className?: string}): JSX.Element {
   return (
     <nav
-      className={clsx(styles.sidebar, 'thin-scrollbar')}
+      className={clsx(styles.sidebar, 'thin-scrollbar', className)}
       aria-label={translate({
         id: 'theme.blog.sidebar.navAriaLabel',
         message: 'Blog recent posts navigation',
@@ -42,4 +46,18 @@ export default function BlogSidebar({sidebar}: Props): JSX.Element | null {
       </ul>
     </nav>
   );
+}
+
+export default function BlogSidebar(props: Props): JSX.Element | null {
+  const windowSize = useWindowSize();
+  if (props.sidebar.items.length === 0) {
+    return null;
+  }
+  // Mobile sidebar doesn't need to be server-rendered
+  if (windowSize === 'mobile') {
+    return (
+      <NavbarSecondaryMenuFiller component={BlogSidebarContent} props={props} />
+    );
+  }
+  return <BlogSidebarContent {...props} className={styles.sidebarDesktop} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/styles.module.css
@@ -40,7 +40,11 @@
 }
 
 @media (max-width: 996px) {
-  .sidebar {
+  .sidebarDesktop {
     display: none;
+  }
+
+  .sidebar {
+    top: 0;
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

The blog had been a little hard to navigate on mobile because there's no sidebar. I figured that implementing one is extremely easy. This would also be a POC that multiple plugins can fill the same secondary menu.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

