### PR TITLE
fix(theme-classic): adjust shadow on code block

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -8,13 +8,14 @@
 .codeBlockContainer {
   margin-bottom: var(--ifm-leading);
   box-shadow: var(--ifm-global-shadow-lw);
+  border-radius: var(--ifm-code-border-radius);
 }
 
 .codeBlockContent {
   position: relative;
   /* rtl:ignore */
   direction: ltr;
-  border-radius: var(--ifm-global-radius);
+  border-radius: inherit;
 }
 
 .codeBlockTitle {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -23,8 +23,8 @@
   font-size: var(--ifm-code-font-size);
   font-weight: 500;
   padding: 0.75rem var(--ifm-pre-padding);
-  border-top-left-radius: var(--ifm-global-radius);
-  border-top-right-radius: var(--ifm-global-radius);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
 }
 
 .codeBlock {


### PR DESCRIPTION
Changed a `border-radius` on code-block container in order for it to match the inner code element, this way `box-shadow` outlines the code-block properly.

## Motivation

The code-block looked broken
<img width="657" alt="image" src="https://user-images.githubusercontent.com/37013688/160224772-50e61dfb-ba8b-4abd-8330-09293e47a72e.png">

Now it's fine
<img width="666" alt="image" src="https://user-images.githubusercontent.com/37013688/160224855-b17abf8f-8559-460b-b400-493d4233edde.png">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Served the app locally and checked it manually

