### PR TITLE
fix(theme-classic): do not add caret for non-collapsible categories

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category.tsx
@@ -163,7 +163,7 @@ export default function DocSidebarItemCategory({
         <Link
           className={clsx('menu__link', {
             'menu__link--sublist': collapsible,
-            'menu__link--sublist-caret': !href,
+            'menu__link--sublist-caret': !href && collapsible,
             'menu__link--active': isActive,
           })}
           onClick={


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

A caret is added for even non-collapsible categories:

<img width="289" alt="image" src="https://user-images.githubusercontent.com/55398995/160231524-678e5255-9744-403c-818a-fbfdf7d6bfa2.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

## Related PRs

https://github.com/facebook/docusaurus/pull/6983