### PR TITLE
refactor: remove copyright comment from swizzled components

### DIFF
--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/ComponentInFolder/index.css
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/ComponentInFolder/index.css
@@ -1,3 +1,11 @@
-.testClass {
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ .testClass {
   background: black;
 }

--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/ComponentInFolder/index.tsx
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/ComponentInFolder/index.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 
 export default function ComponentInFolder() {

--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/FirstLevelComponent.css
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/FirstLevelComponent.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .testClass {
   background: black;
 }

--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/FirstLevelComponent.tsx
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/FirstLevelComponent.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 
 export default function FirstLevelComponent() {

--- a/packages/docusaurus/src/commands/swizzle/actions.ts
+++ b/packages/docusaurus/src/commands/swizzle/actions.ts
@@ -84,7 +84,7 @@ export async function eject({
         const fileContents = await fs.readFile(sourceFile, 'utf-8');
         await fs.outputFile(
           targetFile,
-          fileContents.trimStart().replace(/(?<!\n)\/\*[\s\S]+?\*\/\s*/, ''),
+          fileContents.trimStart().replace(/^\/\*.+?\*\/\s*/ms, ''),
         );
       } catch (err) {
         throw new Error(

--- a/packages/docusaurus/src/commands/swizzle/actions.ts
+++ b/packages/docusaurus/src/commands/swizzle/actions.ts
@@ -81,7 +81,11 @@ export async function eject({
       const fileName = path.basename(sourceFile);
       const targetFile = path.join(toPath, fileName);
       try {
-        await fs.copy(sourceFile, targetFile, {overwrite: true});
+        const fileContents = await fs.readFile(sourceFile, 'utf-8');
+        await fs.outputFile(
+          targetFile,
+          fileContents.trimStart().replace(/(?<!\n)\/\*[\s\S]+?\*\/\s*/, ''),
+        );
       } catch (err) {
         throw new Error(
           logger.interpolate`Could not copy file from ${sourceFile} to ${targetFile}`,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

The standard Facebook copyright comment in completely swizzled components would be nice to remove (just like they are not in swizzled wrappers), as users often have to do this manually. Similar to how init site templates do not have any copyright comments, they should not appear after swizzling of components. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Snapshots are same after adding copyright comment in fixtures.

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
