### PR TITLE
feat(logger): new "url" format, add double quotes around paths

### DIFF
--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -318,7 +318,7 @@ export default async function init(
   logger.info('Creating new Docusaurus project...');
 
   if (isValidGitRepoUrl(template)) {
-    logger.info`Cloning Git template name=${template}...`;
+    logger.info`Cloning Git template url=${template}...`;
     if (!gitStrategies.includes(gitStrategy)) {
       logger.error`Invalid git strategy: name=${gitStrategy}. Value must be one of ${gitStrategies.join(
         ', ',

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -271,7 +271,7 @@ export default async function init(
         return logger.red('Invalid repository URL');
       },
       message: logger.interpolate`Enter a repository URL from GitHub, Bitbucket, GitLab, or any other public repo.
-(e.g: path=${'https://github.com/ownerName/repoName.git'})`,
+(e.g: url=${'https://github.com/ownerName/repoName.git'})`,
     });
     ({gitStrategy} = await prompts({
       type: 'select',
@@ -318,7 +318,7 @@ export default async function init(
   logger.info('Creating new Docusaurus project...');
 
   if (isValidGitRepoUrl(template)) {
-    logger.info`Cloning Git template path=${template}...`;
+    logger.info`Cloning Git template name=${template}...`;
     if (!gitStrategies.includes(gitStrategy)) {
       logger.error`Invalid git strategy: name=${gitStrategy}. Value must be one of ${gitStrategies.join(
         ', ',
@@ -416,7 +416,7 @@ export default async function init(
   }
 
   const useNpm = pkgManager === 'npm';
-  logger.success`Created path=${cdpath}.`;
+  logger.success`Created name=${cdpath}.`;
   logger.info`Inside that directory, you can run several commands:
 
   code=${`${pkgManager} start`}

--- a/packages/docusaurus-logger/README.md
+++ b/packages/docusaurus-logger/README.md
@@ -8,7 +8,8 @@ It exports a single object as default export: `logger`. `logger` has the followi
 
 - Some useful colors.
 - Formatters. These functions have the same signature as the formatters of `picocolors`. Note that their implementations are not guaranteed. You should only care about their semantics.
-  - `path`: formats a file path or URL.
+  - `path`: formats a file path.
+  - `url`: formats a URL.
   - `id`: formats an identifier.
   - `code`: formats a code snippet.
   - `subdue`: subdues the text.
@@ -34,6 +35,7 @@ To buy anything, enter code=${'buy x'} where code=${'x'} is the item's name; to 
 An embedded expression is optionally preceded by a flag in the form `%[a-z]+` (a percentage sign followed by a few lowercase letters). If it's not preceded by any flag, it's printed out as-is. Otherwise, it's formatted with one of the formatters:
 
 - `path=`: `path`
+- `url=`: `url`
 - `name=`: `id`
 - `code=`: `code`
 - `subdue=`: `subdue`

--- a/packages/docusaurus-logger/src/__tests__/index.test.ts
+++ b/packages/docusaurus-logger/src/__tests__/index.test.ts
@@ -12,8 +12,9 @@ describe('formatters', () => {
   it('path', () => {
     // cSpell:ignore mhey
     expect(logger.path('hey')).toMatchInlineSnapshot(`"[36m[4m\\"hey\\"[24m[39m"`);
-
-    expect(logger.path('https://docusaurus.io/')).toMatchInlineSnapshot(
+  });
+  it('url', () => {
+    expect(logger.url('https://docusaurus.io/')).toMatchInlineSnapshot(
       `"[36m[4mhttps://docusaurus.io/[24m[39m"`,
     );
   });

--- a/packages/docusaurus-logger/src/__tests__/index.test.ts
+++ b/packages/docusaurus-logger/src/__tests__/index.test.ts
@@ -11,7 +11,11 @@ import logger from '../index';
 describe('formatters', () => {
   it('path', () => {
     // cSpell:ignore mhey
-    expect(logger.path('hey')).toMatchInlineSnapshot(`"[36m[4mhey[24m[39m"`);
+    expect(logger.path('hey')).toMatchInlineSnapshot(`"[36m[4m\\"hey\\"[24m[39m"`);
+
+    expect(logger.path('https://docusaurus.io/')).toMatchInlineSnapshot(
+      `"[36m[4mhttps://docusaurus.io/[24m[39m"`,
+    );
   });
   it('id', () => {
     expect(logger.name('hey')).toMatchInlineSnapshot(`"[34m[1mhey[22m[39m"`);
@@ -40,8 +44,7 @@ describe('interpolate', () => {
     expect(
       logger.interpolate`The package at path=${'packages/docusaurus'} has number=${10} files. name=${'Babel'} is exported here subdue=${'(as a preset)'} that you can with code=${"require.resolve('@docusaurus/core/lib/babel/preset')"}`,
     ).toMatchInlineSnapshot(
-      // cSpell:ignore mpackages
-      `"The package at [36m[4mpackages/docusaurus[24m[39m has [33m10[39m files. [34m[1mBabel[22m[39m is exported here [90m(as a preset)[39m that you can with [36m\`require.resolve('@docusaurus/core/lib/babel/preset')\`[39m"`,
+      `"The package at [36m[4m\\"packages/docusaurus\\"[24m[39m has [33m10[39m files. [34m[1mBabel[22m[39m is exported here [90m(as a preset)[39m that you can with [36m\`require.resolve('@docusaurus/core/lib/babel/preset')\`[39m"`,
     );
   });
   it('interpolates arrays with flags', () => {

--- a/packages/docusaurus-logger/src/index.ts
+++ b/packages/docusaurus-logger/src/index.ts
@@ -9,7 +9,10 @@ import chalk, {type Chalk} from 'chalk';
 
 type InterpolatableValue = string | number | (string | number)[];
 
-const path = (msg: unknown): string => chalk.cyan(chalk.underline(msg));
+const path = (msg: unknown): string => {
+  const isUrl = /^https?:\/\//.test(msg as string);
+  return chalk.cyan(chalk.underline(isUrl ? msg : `"${msg}"`));
+};
 const name = (msg: unknown): string => chalk.blue(chalk.bold(msg));
 const code = (msg: unknown): string => chalk.cyan(`\`${msg}\``);
 const subdue: Chalk = chalk.gray;

--- a/packages/docusaurus-logger/src/index.ts
+++ b/packages/docusaurus-logger/src/index.ts
@@ -9,10 +9,8 @@ import chalk, {type Chalk} from 'chalk';
 
 type InterpolatableValue = string | number | (string | number)[];
 
-const path = (msg: unknown): string => {
-  const isUrl = /^https?:\/\//.test(msg as string);
-  return chalk.cyan(chalk.underline(isUrl ? msg : `"${msg}"`));
-};
+const path = (msg: unknown): string => chalk.cyan(chalk.underline(`"${msg}"`));
+const url = (msg: unknown): string => chalk.cyan(chalk.underline(msg));
 const name = (msg: unknown): string => chalk.blue(chalk.bold(msg));
 const code = (msg: unknown): string => chalk.cyan(`\`${msg}\``);
 const subdue: Chalk = chalk.gray;
@@ -33,6 +31,8 @@ function interpolate(
       switch (flag[0]) {
         case 'path=':
           return path;
+        case 'url=':
+          return url;
         case 'number=':
           return num;
         case 'name=':
@@ -134,6 +134,7 @@ const logger = {
   bold: chalk.bold,
   dim: chalk.dim,
   path,
+  url,
   name,
   code,
   subdue,

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/normalization.ts
@@ -65,7 +65,7 @@ function normalizeSidebar(
     throw new Error(
       logger.interpolate`Invalid sidebar items collection code=${JSON.stringify(
         sidebar,
-      )} in ${place}: it must either be an array of sidebar items or a shorthand notation (which doesn't contain a code=${'type'} property). See path=${'https://docusaurus.io/docs/sidebar/items'} for all valid syntaxes.`,
+      )} in ${place}: it must either be an array of sidebar items or a shorthand notation (which doesn't contain a code=${'type'} property). See url=${'https://docusaurus.io/docs/sidebar/items'} for all valid syntaxes.`,
     );
   }
 

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -55,7 +55,7 @@ export default async function render(
 
     if (isNotDefinedErrorRegex.test((err as Error).message)) {
       logger.info`It looks like you are using code that should run on the client-side only.
-To get around it, try using code=${'<BrowserOnly>'} (path=${'https://docusaurus.io/docs/docusaurus-core/#browseronly'}) or code=${'ExecutionEnvironment'} (path=${'https://docusaurus.io/docs/docusaurus-core/#executionenvironment'}).
+To get around it, try using code=${'<BrowserOnly>'} (url=${'https://docusaurus.io/docs/docusaurus-core/#browseronly'}) or code=${'ExecutionEnvironment'} (url=${'https://docusaurus.io/docs/docusaurus-core/#executionenvironment'}).
 It might also require to wrap your client code in code=${'useEffect'} hook and/or import a third-party library dynamically (if any).`;
     }
 

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -230,7 +230,7 @@ export async function loadPlugins({
       // TODO remove this deprecated lifecycle soon
       // deprecated since alpha-60
       // TODO, 1 user reported usage of this lifecycle! https://github.com/facebook/docusaurus/issues/3918
-      logger.error`Plugin code=${'routesLoaded'} lifecycle is deprecated. If you think we should keep this lifecycle, please report here: path=${'https://github.com/facebook/docusaurus/issues/3918'}`;
+      logger.error`Plugin code=${'routesLoaded'} lifecycle is deprecated. If you think we should keep this lifecycle, please report here: url=${'https://github.com/facebook/docusaurus/issues/3918'}`;
 
       await plugin.routesLoaded(pluginsRouteConfigs);
     }),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

The paths in a command output are better placed in quotes, they were correctly identified as paths. For example, if there is a "dot" at the end of line with path, VS Code will not find that path if you click by it from output:

```
[INFO] 158 translations will be written at i18n/fr/code.json.
[INFO] 6 translations will be written at i18n/fr/docusaurus-theme-classic/navbar.json.
```

![image](https://user-images.githubusercontent.com/4408379/160239212-93709a94-fb14-4cb4-8c3e-54326625c050.png)

Also, quoted paths  make it easier to copy-pasting from terminal, for example currently when trying to copy the path below, a "dot" char will also be selected:

![image](https://user-images.githubusercontent.com/4408379/160239318-a887d44f-3dc3-44a4-907b-8a0b5df08bf2.png)

After:

![image](https://user-images.githubusercontent.com/4408379/160239332-b0caeab0-f30d-4667-b1f4-dbb25236303e.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

<!-- Write your answer here. -->

## Test Plan

Try to run cli command contains paths in the output, eg `yarn run write-translations -- --locale fr`

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
