### PR TITLE
fix: make docs page wrapper take full height

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/index.tsx
@@ -14,13 +14,13 @@ import DocPageLayoutMain from '@theme/DocPage/Layout/Main';
 
 import styles from './styles.module.css';
 
-import {useDocsSidebar} from '@docusaurus/theme-common';
+import {useDocsSidebar, ThemeClassNames} from '@docusaurus/theme-common';
 
 export default function DocPageLayout({children}: Props): JSX.Element {
   const sidebar = useDocsSidebar();
   const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
   return (
-    <Layout>
+    <Layout wrapperClassName={ThemeClassNames.wrapper.docsPages}>
       <BackToTopButton />
       <div className={styles.docPage}>
         {sidebar && (

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/index.tsx
@@ -14,13 +14,13 @@ import DocPageLayoutMain from '@theme/DocPage/Layout/Main';
 
 import styles from './styles.module.css';
 
-import {useDocsSidebar, ThemeClassNames} from '@docusaurus/theme-common';
+import {useDocsSidebar} from '@docusaurus/theme-common';
 
 export default function DocPageLayout({children}: Props): JSX.Element {
   const sidebar = useDocsSidebar();
   const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
   return (
-    <Layout wrapperClassName={ThemeClassNames.wrapper.docsPages}>
+    <Layout wrapperClassName={styles.docsWrapper}>
       <BackToTopButton />
       <div className={styles.docPage}>
         {sidebar && (

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
@@ -10,14 +10,11 @@
   --doc-sidebar-hidden-width: 30px;
 }
 
-:global(.docs-wrapper) {
-  display: flex;
-}
-
 .docPage {
   width: 100%;
 }
 
+.docsWrapper,
 .docPage,
 .docMainContainer {
   display: flex;

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
@@ -10,10 +10,17 @@
   --doc-sidebar-hidden-width: 30px;
 }
 
+:global(.docs-wrapper) {
+  display: flex;
+}
+
+.docPage {
+  width: 100%;
+}
+
 .docPage,
 .docMainContainer {
   display: flex;
-  width: 100%;
 }
 
 .docSidebarContainer {

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -77,7 +77,6 @@ export default function DocPage(props: Props): JSX.Element {
       />
       <HtmlClassNameProvider
         className={clsx(
-          ThemeClassNames.wrapper.docsPages,
           ThemeClassNames.page.docsDocPage,
           props.versionMetadata.className,
         )}>

--- a/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/index.tsx
@@ -77,6 +77,8 @@ export default function DocPage(props: Props): JSX.Element {
       />
       <HtmlClassNameProvider
         className={clsx(
+          // TODO: it should be removed from here
+          ThemeClassNames.wrapper.docsPages,
           ThemeClassNames.page.docsDocPage,
           props.versionMetadata.className,
         )}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fixes #7018, broken as result changes in https://github.com/facebook/docusaurus/pull/6925/files#diff-efc286976b85125e3056044ed1ef259e5794477ab266e4c6207a68d795f76b4a

Note: this bug will be noticeable if the content area column on the right is smaller by height than the sidebar.

I had to add back the `docs-wrapper` class as it was before, since I guess that's the only available way to make things work. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Create empty Markdown page or via dev tools try to empty content area on any existent page -- the sidebar should be stretched to the footer.

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
