### PR TITLE
fix: expand doc main container to full width on mobiles

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
@@ -10,7 +10,8 @@
   --doc-sidebar-hidden-width: 30px;
 }
 
-.docPage {
+.docPage,
+.docMainContainer {
   width: 100%;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

In  #7025  I forgot to check the doc layout for mobiles, which resulted in horizontal scrolling on small screens.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
