### PR TITLE
fix(utils): parse Markdown headings with CRLF line break

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -253,6 +253,22 @@ Lorem Ipsum
     });
   });
 
+  it('parses markdown h1 title with CRLF break', () => {
+    const markdown = `# Markdown Title\r\n\r\nLorem Ipsum`;
+    expect(parseMarkdownContentTitle(markdown)).toEqual({
+      content: markdown,
+      contentTitle: 'Markdown Title',
+    });
+  });
+
+  it('parses markdown h1 setext title with CRLF break', () => {
+    const markdown = `Markdown Title\r\n=====\r\n\r\nLorem Ipsum`;
+    expect(parseMarkdownContentTitle(markdown)).toEqual({
+      content: markdown,
+      contentTitle: 'Markdown Title',
+    });
+  });
+
   it('parses markdown h1 title at the top (atx style with closing #)', () => {
     const markdown = dedent`
 

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -198,13 +198,13 @@ export function parseMarkdownContentTitle(
   // `import` nodes, as broken syntax can't render anyways. That means any block
   // that has `import` at the very beginning and surrounded by empty lines.
   const contentWithoutImport = content
-    .replace(/^(?:import\s(?:.|\n(?!\n))*\n{2,})*/, '')
+    .replace(/^(?:import\s(?:.|\r?\n(?!\r?\n))*(?:\r?\n){2,})*/, '')
     .trim();
 
-  const regularTitleMatch = /^#[ \t]+(?<title>[^ \t].*)(?:\n|$)/.exec(
+  const regularTitleMatch = /^#[ \t]+(?<title>[^ \t].*)(?:\r?\n|$)/.exec(
     contentWithoutImport,
   );
-  const alternateTitleMatch = /^(?<title>.*)\n=+(?:\n|$)/.exec(
+  const alternateTitleMatch = /^(?<title>.*)\r?\n=+(?:\r?\n|$)/.exec(
     contentWithoutImport,
   );
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix #7044

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added two tests