### PR TITLE
fix(theme-classic): add caret for dropdown on mobile

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
@@ -157,7 +157,7 @@ function DropdownNavbarItemMobile({
       })}>
       <NavbarNavLink
         role="button"
-        className={clsx('menu__link menu__link--sublist', className)}
+        className={clsx('menu__link menu__link--sublist menu__link--sublist-caret', className)}
         {...props}
         onClick={(e) => {
           e.preventDefault();

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
@@ -157,7 +157,10 @@ function DropdownNavbarItemMobile({
       })}>
       <NavbarNavLink
         role="button"
-        className={clsx('menu__link menu__link--sublist menu__link--sublist-caret', className)}
+        className={clsx(
+          'menu__link menu__link--sublist menu__link--sublist-caret',
+          className,
+        )}
         {...props}
         onClick={(e) => {
           e.preventDefault();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

After merging of #6983, the caret icon on collapsible dropdown is no longer displayed on mobiles

![image](https://user-images.githubusercontent.com/4408379/160495886-188d2f7e-4c3f-4102-bd65-97a66175c135.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

![image](https://user-images.githubusercontent.com/4408379/160496049-18fbaeef-2d21-46da-bd01-da72adee5886.png)


## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
