### PR TITLE
fix(theme): add bash style to Markdown comment styles

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -15,7 +15,7 @@ const commentPatterns = {
   js: {start: '\\/\\/', end: ''},
   jsBlock: {start: '\\/\\*', end: '\\*\\/'},
   jsx: {start: '\\{\\s*\\/\\*', end: '\\*\\/\\s*\\}'},
-  python: {start: '#', end: ''},
+  bash: {start: '#', end: ''},
   html: {start: '<!--', end: '-->'},
 };
 
@@ -59,11 +59,13 @@ function getAllMagicCommentDirectiveStyles(lang: string) {
 
     case 'python':
     case 'py':
-      return getCommentPattern(['python']);
+    case 'bash':
+      return getCommentPattern(['bash']);
 
     case 'markdown':
     case 'md':
-      return getCommentPattern(['html', 'jsx']);
+      // Text uses HTML, front matter uses bash
+      return getCommentPattern(['html', 'jsx', 'bash']);
 
     default:
       // all comment types

--- a/website/docs/guides/docs/sidebar/autogenerated.md
+++ b/website/docs/guides/docs/sidebar/autogenerated.md
@@ -311,11 +311,11 @@ For handwritten sidebar definitions, you would provide metadata to sidebar items
 
 ```md title="docs/tutorials/tutorial-easy.md"
 ---
-// highlight-start
+# highlight-start
 sidebar_position: 2
 sidebar_label: Easy
 sidebar_class_name: green
-// highlight-end
+# highlight-end
 ---
 
 # Easy Tutorial

--- a/website/docs/guides/docs/sidebar/autogenerated.md
+++ b/website/docs/guides/docs/sidebar/autogenerated.md
@@ -311,11 +311,11 @@ For handwritten sidebar definitions, you would provide metadata to sidebar items
 
 ```md title="docs/tutorials/tutorial-easy.md"
 ---
-# highlight-start
+// highlight-start
 sidebar_position: 2
 sidebar_label: Easy
 sidebar_class_name: green
-# highlight-end
+// highlight-end
 ---
 
 # Easy Tutorial


### PR DESCRIPTION
## Motivation

Currently the code block in https://docusaurus.io/docs/sidebar/autogenerated#autogenerated-sidebar-metadata uses the wrong comment delimiter (`#`) for code highlighting - while it is highlighting YAML frontmatter, the code block language is `md`, which is used to determine the valid comment delimiters for highlighting (https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts). This changes those comments to use `//` instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

edit and check the website
