### PR TITLE
fix(theme-common): use native scrolling when smooth behavior set in CSS

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
@@ -253,10 +253,7 @@ function smoothScrollPolyfill(top: number): CancelScrollTop {
       (!isUpScroll && currentScroll < top)
     ) {
       raf = requestAnimationFrame(rafRecursion);
-      window.scrollTo(
-        0,
-        Math.floor(Math.abs(currentScroll - top) * 0.85) + top,
-      );
+      window.scrollTo(0, Math.floor((currentScroll - top) * 0.85) + top);
     }
   }
   rafRecursion();

--- a/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
@@ -306,6 +306,6 @@ export function useSmoothScrollTo(): {
         ? smoothScrollNative(top)
         : smoothScrollPolyfill(top);
     },
-    cancelScroll: () => cancelRef?.current,
+    cancelScroll: () => cancelRef.current?.(),
   };
 }

--- a/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
@@ -16,6 +16,7 @@ import React, {
 } from 'react';
 import {useDynamicCallback, ReactContextError} from './reactUtils';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 type ScrollController = {
   /** A boolean ref tracking whether scroll events are enabled. */
@@ -233,16 +234,6 @@ export function useScrollPositionBlocker(): {
   };
 }
 
-// Not all have support for smooth scrolling (particularly Safari mobile iOS)
-// TODO proper detection is currently unreliable!
-// see https://github.com/wessberg/scroll-behavior-polyfill/issues/16
-// For now, we only use native scroll behavior if smooth is already set, because
-// otherwise the polyfill produces a weird UX when both CSS and JS try to scroll
-// a page, and they cancel each other.
-const supportsNativeSmoothScrolling =
-  ExecutionEnvironment.canUseDOM &&
-  getComputedStyle(document.documentElement).scrollBehavior === 'smooth';
-
 type CancelScrollTop = () => void;
 
 function smoothScrollNative(top: number): CancelScrollTop {
@@ -299,6 +290,16 @@ export function useSmoothScrollTo(): {
   cancelScroll: CancelScrollTop;
 } {
   const cancelRef = useRef<CancelScrollTop | null>(null);
+  const isBrowser = useIsBrowser();
+  // Not all have support for smooth scrolling (particularly Safari mobile iOS)
+  // TODO proper detection is currently unreliable!
+  // see https://github.com/wessberg/scroll-behavior-polyfill/issues/16
+  // For now, we only use native scroll behavior if smooth is already set,
+  // because otherwise the polyfill produces a weird UX when both CSS and JS try
+  // to scroll a page, and they cancel each other.
+  const supportsNativeSmoothScrolling =
+    isBrowser &&
+    getComputedStyle(document.documentElement).scrollBehavior === 'smooth';
   return {
     startScroll: (top: number) => {
       cancelRef.current = supportsNativeSmoothScrolling


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Part of the changes in #6666 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add `scroll-behavior: smooth` to the root selector

| Before | After |
|--------|-------|
| ![Test](https://user-images.githubusercontent.com/55398995/160586672-9eedd2de-6e18-4f70-9898-31663a1eb7ec.gif) | ![Test2](https://user-images.githubusercontent.com/55398995/160586707-545b5023-a8a8-459d-a47a-600c8d555dc8.gif) |

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
