### PR TITLE
fix(core): all plugin lifecycles should receive translated content

### DIFF
--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -125,10 +125,7 @@ export async function load(options: LoadContextOptions): Promise<Props> {
     ssrTemplate,
     codeTranslations: siteCodeTranslations,
   } = context;
-  const {plugins, pluginsRouteConfigs, globalData, themeConfigTranslated} =
-    await loadPlugins(context);
-  // Side-effect to replace the untranslated themeConfig by the translated one
-  context.siteConfig.themeConfig = themeConfigTranslated;
+  const {plugins, pluginsRouteConfigs, globalData} = await loadPlugins(context);
   const clientModules = loadClientModules(plugins);
   const {headTags, preBodyTags, postBodyTags} = loadHtmlTags(plugins);
   const {registry, routesChunkNames, routesConfig, routesPaths} =

--- a/packages/docusaurus/src/server/plugins/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus/src/server/plugins/__tests__/__snapshots__/index.test.ts.snap
@@ -64,6 +64,5 @@ exports[`loadPlugins loads plugins 1`] = `
     },
   ],
   "pluginsRouteConfigs": [],
-  "themeConfigTranslated": {},
 }
 `;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Just realized our later lifecycles like `configureWebpack` and `postBuild` don't receive the translated content. Probably doesn't matter much but would be cool to have anyways