### PR TITLE
feat: allow using pure HTML as label in navbar links

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.ts
@@ -112,10 +112,24 @@ describe('themeConfig', () => {
             docId: 'intro',
             label: 'Introduction',
           },
+          // Doc link with HTML as label
+          {
+            type: 'doc',
+            position: 'left',
+            docId: 'intro',
+            html: '<b>Introduction</b>',
+          },
           // Regular link
           {
             to: '/guide/',
             label: 'Guide',
+            position: 'left',
+            activeBaseRegex: '/guide/',
+          },
+          // Regular link with HTML as label
+          {
+            to: '/guide/',
+            html: '<b>Guide</b>',
             position: 'left',
             activeBaseRegex: '/guide/',
           },
@@ -136,10 +150,10 @@ describe('themeConfig', () => {
               },
             ],
           },
-          // Dropdown with name
+          // Dropdown with label as HTML
           {
             type: 'dropdown',
-            label: 'Tools',
+            label: 'Tools <sup>new</sup>',
             position: 'left',
             items: [
               {

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -651,6 +651,7 @@ declare module '@theme/NavbarItem/NavbarNavLink' {
     readonly activeBaseRegex?: string;
     readonly exact?: boolean;
     readonly label?: ReactNode;
+    readonly html?: string;
     readonly prependBaseUrlToHref?: string;
   }
 

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -21,6 +21,7 @@ export default function NavbarNavLink({
   to,
   href,
   label,
+  html,
   activeClassName = '',
   prependBaseUrlToHref,
   ...props
@@ -54,11 +55,21 @@ export default function NavbarNavLink({
                 }
               : null),
           })}
-      {...props}>
-      {label}
-      {isExternalLink && (
-        <IconExternalLink {...(isDropdownLink && {width: 12, height: 12})} />
-      )}
-    </Link>
+      {...props}
+      {...(html
+        ? {dangerouslySetInnerHTML: {__html: html}}
+        : {
+            children: (
+              <>
+                {label}
+                {isExternalLink && (
+                  <IconExternalLink
+                    {...(isDropdownLink && {width: 12, height: 12})}
+                  />
+                )}
+              </>
+            ),
+          })}
+    />
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -34,42 +34,47 @@ export default function NavbarNavLink({
   const isExternalLink = label && href && !isInternalUrl(href);
   const isDropdownLink = activeClassName === dropdownLinkActiveClass;
 
+  // Link content is set through html XOR label
+  const linkContentProps = html
+    ? {dangerouslySetInnerHTML: {__html: html}}
+    : {
+        children: (
+          <>
+            {label}
+            {isExternalLink && (
+              <IconExternalLink
+                {...(isDropdownLink && {width: 12, height: 12})}
+              />
+            )}
+          </>
+        ),
+      };
+
+  if (href) {
+    return (
+      <Link
+        href={prependBaseUrlToHref ? normalizedHref : href}
+        {...props}
+        {...linkContentProps}
+      />
+    );
+  }
+
   return (
     <Link
-      {...(href
-        ? {
-            href: prependBaseUrlToHref ? normalizedHref : href,
-          }
-        : {
-            isNavLink: true,
-            activeClassName: !props.className?.includes(activeClassName)
-              ? activeClassName
-              : '',
-            to: toUrl,
-            ...(activeBasePath || activeBaseRegex
-              ? {
-                  isActive: (_match, location) =>
-                    activeBaseRegex
-                      ? isRegexpStringMatch(activeBaseRegex, location.pathname)
-                      : location.pathname.startsWith(activeBaseUrl),
-                }
-              : null),
-          })}
+      to={toUrl}
+      isNavLink
+      activeClassName={
+        !props.className?.includes(activeClassName) ? activeClassName : ''
+      }
+      {...((activeBasePath || activeBaseRegex) && {
+        isActive: (_match, location) =>
+          activeBaseRegex
+            ? isRegexpStringMatch(activeBaseRegex, location.pathname)
+            : location.pathname.startsWith(activeBaseUrl),
+      })}
       {...props}
-      {...(html
-        ? {dangerouslySetInnerHTML: {__html: html}}
-        : {
-            children: (
-              <>
-                {label}
-                {isExternalLink && (
-                  <IconExternalLink
-                    {...(isDropdownLink && {width: 12, height: 12})}
-                  />
-                )}
-              </>
-            ),
-          })}
+      {...linkContentProps}
     />
   );
 }

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -49,8 +49,10 @@ const NavbarItemPosition = Joi.string().equal('left', 'right').default('left');
 
 const NavbarItemBaseSchema = Joi.object({
   label: Joi.string(),
+  html: Joi.string(),
   className: Joi.string(),
 })
+  .nand('html', 'label')
   // We allow any unknown attributes on the links (users may need additional
   // attributes like target, aria-role, data-customAttribute...)
   .unknown();

--- a/website/docs/api/themes/theme-configuration.md
+++ b/website/docs/api/themes/theme-configuration.md
@@ -259,6 +259,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `type` | `'default'` | Optional | Sets the type of this item to a link. |
 | `label` | `string` | **Required** | The name to be shown for this item. |
+| `html` | `string` | Optional | Same as `label`, but renders pure HTML instead of text content. |
 | `to` | `string` | **Required** | Client-side routing, used for navigating within the website. The baseUrl will be automatically prepended to this value. |
 | `href` | `string` | **Required** | A full-page navigation, used for navigating outside of the website. **Only one of `to` or `href` should be used.** |
 | `prependBaseUrlToHref` | `boolean` | `false` | Prepends the baseUrl to `href` values. |
@@ -288,6 +289,8 @@ module.exports = {
           // Only one of "to" or "href" should be used
           // href: 'https://www.facebook.com',
           label: 'Introduction',
+          // Only one of "label" or "html" should be used
+          // html: '<b>Introduction</b>'
           position: 'left',
           activeBaseRegex: 'docs/(next|v8)',
           target: '_blank',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Although a new `html` type for navbar items is coming soon, it does not solve the issue of having to use HTML as label for a navbar link. It can be useful to style text content of a link or add an SVG icon inside it without using custom CSS. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See tests as examples. Is it worth to use the option on the website as applying of dogfooding approach?

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
