### PR TITLE
feat(core): allow plugins to declare custom route context

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/normalization.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/normalization.test.ts
@@ -78,12 +78,13 @@ describe('normalization', () => {
       `"Invalid sidebar items collection [36m\`\\"bar\\"\`[39m in [36m\`items\`[39m of the category [34m[1mCategory[22m[39m: it must either be an array of sidebar items or a shorthand notation (which doesn't contain a [36m\`type\`[39m property). See [36m[4mhttps://docusaurus.io/docs/sidebar/items[24m[39m for all valid syntaxes."`,
     );
 
-    expect(() =>
-      normalizeSidebars({
-        sidebar: 'item',
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(
+    expect(
+      () =>
+        normalizeSidebars({
+          sidebar: 'item',
+        }),
       // cSpell:ignore msidebar
+    ).toThrowErrorMatchingInlineSnapshot(
       `"Invalid sidebar items collection [36m\`\\"item\\"\`[39m in sidebar [34m[1msidebar[22m[39m: it must either be an array of sidebar items or a shorthand notation (which doesn't contain a [36m\`type\`[39m property). See [36m[4mhttps://docusaurus.io/docs/sidebar/items[24m[39m for all valid syntaxes."`,
     );
   });

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/normalization.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/normalization.test.ts
@@ -78,13 +78,12 @@ describe('normalization', () => {
       `"Invalid sidebar items collection [36m\`\\"bar\\"\`[39m in [36m\`items\`[39m of the category [34m[1mCategory[22m[39m: it must either be an array of sidebar items or a shorthand notation (which doesn't contain a [36m\`type\`[39m property). See [36m[4mhttps://docusaurus.io/docs/sidebar/items[24m[39m for all valid syntaxes."`,
     );
 
-    expect(
-      () =>
-        normalizeSidebars({
-          sidebar: 'item',
-        }),
-      // cSpell:ignore msidebar
+    expect(() =>
+      normalizeSidebars({
+        sidebar: 'item',
+      }),
     ).toThrowErrorMatchingInlineSnapshot(
+      // cSpell:ignore msidebar
       `"Invalid sidebar items collection [36m\`\\"item\\"\`[39m in sidebar [34m[1msidebar[22m[39m: it must either be an array of sidebar items or a shorthand notation (which doesn't contain a [36m\`type\`[39m property). See [36m[4mhttps://docusaurus.io/docs/sidebar/items[24m[39m for all valid syntaxes."`,
     );
   });

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -487,6 +487,12 @@ export type RouteConfig = {
    * `createData`)
    */
   modules?: RouteModules;
+  /**
+   * The route context will wrap the `component`. Use `useRouteContext` to
+   * retrieve what's declared here. Note that all custom route context declared
+   * here will be namespaced under {@link RouteContext.data}.
+   */
+  context?: RouteModules;
   /** Nested routes config. */
   routes?: RouteConfig[];
   /** React router config option: `exact` routes would not match subroutes. */

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
@@ -20,7 +20,6 @@ exports[`loadRoutes loads flat route config 1`] = `
   "routesChunkNames": {
     "/blog-599": {
       "__comp": "__comp---theme-blog-list-pagea-6-a-7ba",
-      "__context": {},
       "items": [
         {
           "content": "content---blog-0-b-4-09e",
@@ -80,7 +79,6 @@ exports[`loadRoutes loads nested route config 1`] = `
     },
     "/docs:route-502": {
       "__comp": "__comp---theme-doc-page-1-be-9be",
-      "__context": {},
       "docsMetadata": "docsMetadata---docs-routef-34-881",
     },
     "docs/foo/baz-eb2": {
@@ -140,7 +138,6 @@ exports[`loadRoutes loads route config with empty (but valid) path string 1`] = 
   "routesChunkNames": {
     "-b2a": {
       "__comp": "__comp---hello-world-jse-0-f-b6c",
-      "__context": {},
     },
   },
   "routesConfig": "import React from 'react';

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
@@ -20,6 +20,7 @@ exports[`loadRoutes loads flat route config 1`] = `
   "routesChunkNames": {
     "/blog-599": {
       "__comp": "__comp---theme-blog-list-pagea-6-a-7ba",
+      "__context": {},
       "items": [
         {
           "content": "content---blog-0-b-4-09e",
@@ -66,19 +67,27 @@ exports[`loadRoutes loads nested route config 1`] = `
     "docsMetadata---docs-routef-34-881": "docs-b5f.json",
     "metadata---docs-foo-baz-2-cf-fa7": "docs-foo-baz-dd9.json",
     "metadata---docs-hello-956-741": "docs-hello-da2.json",
+    "plugin---docs-hello-665-3ca": "pluginRouteContextModule-100.json",
   },
   "routesChunkNames": {
-    "/docs/hello-44b": {
+    "/docs/hello-fcc": {
       "__comp": "__comp---theme-doc-item-178-a40",
+      "__context": {
+        "plugin": "plugin---docs-hello-665-3ca",
+      },
       "content": "content---docs-helloaff-811",
       "metadata": "metadata---docs-hello-956-741",
     },
-    "/docs:route-52d": {
+    "/docs:route-502": {
       "__comp": "__comp---theme-doc-page-1-be-9be",
+      "__context": {},
       "docsMetadata": "docsMetadata---docs-routef-34-881",
     },
-    "docs/foo/baz-070": {
+    "docs/foo/baz-eb2": {
       "__comp": "__comp---theme-doc-item-178-a40",
+      "__context": {
+        "plugin": "plugin---docs-hello-665-3ca",
+      },
       "content": "content---docs-foo-baz-8-ce-61e",
       "metadata": "metadata---docs-foo-baz-2-cf-fa7",
     },
@@ -89,17 +98,17 @@ import ComponentCreator from '@docusaurus/ComponentCreator';
 export default [
   {
     path: '/docs:route',
-    component: ComponentCreator('/docs:route', '52d'),
+    component: ComponentCreator('/docs:route', '502'),
     routes: [
       {
         path: '/docs/hello',
-        component: ComponentCreator('/docs/hello', '44b'),
+        component: ComponentCreator('/docs/hello', 'fcc'),
         exact: true,
         sidebar: \\"main\\"
       },
       {
         path: 'docs/foo/baz',
-        component: ComponentCreator('docs/foo/baz', '070'),
+        component: ComponentCreator('docs/foo/baz', 'eb2'),
         sidebar: \\"secondary\\",
         \\"key:a\\": \\"containing colon\\",
         \\"key'b\\": \\"containing quote\\",
@@ -131,6 +140,7 @@ exports[`loadRoutes loads route config with empty (but valid) path string 1`] = 
   "routesChunkNames": {
     "-b2a": {
       "__comp": "__comp---hello-world-jse-0-f-b6c",
+      "__context": {},
     },
   },
   "routesConfig": "import React from 'react';

--- a/packages/docusaurus/src/server/__tests__/routes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/routes.test.ts
@@ -117,6 +117,9 @@ describe('loadRoutes', () => {
             content: 'docs/hello.md',
             metadata: 'docs-hello-da2.json',
           },
+          context: {
+            plugin: 'pluginRouteContextModule-100.json',
+          },
           sidebar: 'main',
         },
         {
@@ -125,6 +128,9 @@ describe('loadRoutes', () => {
           modules: {
             content: 'docs/foo/baz.md',
             metadata: 'docs-foo-baz-dd9.json',
+          },
+          context: {
+            plugin: 'pluginRouteContextModule-100.json',
           },
           sidebar: 'secondary',
           'key:a': 'containing colon',

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -15,6 +15,7 @@ import type {
   GlobalData,
   LoadedPlugin,
   InitializedPlugin,
+  PluginRouteContext,
 } from '@docusaurus/types';
 import {initPlugins} from './init';
 import {createBootstrapPlugin, createMDXFallbackPlugin} from './synthetic';
@@ -107,10 +108,14 @@ export async function loadPlugins(context: LoadContext): Promise<{
         dataDir,
         `${docuHash('pluginRouteContextModule')}.json`,
       );
+      const pluginRouteContext: PluginRouteContext['plugin'] = {
+        name: plugin.name,
+        id: pluginId,
+      };
       await generate(
         '/',
         pluginRouteContextModulePath,
-        JSON.stringify({name: plugin.name, id: pluginId}, null, 2),
+        JSON.stringify(pluginRouteContext, null, 2),
       );
       const actions: PluginContentLoadedActions = {
         addRoute(initialRouteConfig) {

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -250,7 +250,7 @@ function genRouteCode(routeConfig: RouteConfig, res: LoadedRoutes): string {
     path: routePath,
     component,
     modules = {},
-    context = {},
+    context,
     routes: subroutes,
     priority,
     exact,
@@ -272,7 +272,9 @@ ${JSON.stringify(routeConfig)}`,
   res.routesChunkNames[`${routePath}-${routeHash}`] = {
     // Avoid clash with a prop called "component"
     ...genChunkNames({__comp: component}, 'component', component, res),
-    ...genChunkNames({__context: context}, 'context', routePath, res),
+    ...(context
+      ? genChunkNames({__context: context}, 'context', routePath, res)
+      : {}),
     ...genChunkNames(modules, 'module', routePath, res),
   };
 

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -250,6 +250,7 @@ function genRouteCode(routeConfig: RouteConfig, res: LoadedRoutes): string {
     path: routePath,
     component,
     modules = {},
+    context = {},
     routes: subroutes,
     priority,
     exact,
@@ -271,6 +272,7 @@ ${JSON.stringify(routeConfig)}`,
   res.routesChunkNames[`${routePath}-${routeHash}`] = {
     // Avoid clash with a prop called "component"
     ...genChunkNames({__comp: component}, 'component', component, res),
+    ...genChunkNames({__context: context}, 'context', routePath, res),
     ...genChunkNames(modules, 'module', routePath, res),
   };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Complete the TODO. Honestly I'm not too sure what we should put here, so I didn't modify the content plugins yet. We already have front matter duplicated twice (once in `metadata.frontMatter`, once as separate `frontMatter` injected from MDX loader), I don't really want to duplicate it a third time as that would be disastrous for bundle size.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Builds same as before