### PR TITLE
refactor: mark a few client-side packages as side-effect-free

### DIFF
--- a/packages/docusaurus-plugin-content-docs/package.json
+++ b/packages/docusaurus-plugin-content-docs/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-beta.18",
   "description": "Docs plugin for Docusaurus.",
   "main": "lib/index.js",
+  "sideEffects": false,
   "exports": {
     "./client": "./lib/client/index.js",
     "./server": "./lib/server-export.js",

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -4,10 +4,6 @@
   "description": "Classic theme for Docusaurus",
   "main": "lib/index.js",
   "types": "src/theme-classic.d.ts",
-  "sideEffects": [
-    "*.css",
-    "lib/prism-include-languages.js"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -4,6 +4,10 @@
   "description": "Classic theme for Docusaurus",
   "main": "lib/index.js",
   "types": "src/theme-classic.d.ts",
+  "sideEffects": [
+    "*.css",
+    "lib/prism-include-languages.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -857,7 +857,7 @@ declare module '@theme/ThemedImage' {
 }
 
 declare module '@theme/Details' {
-  import {Details, type DetailsProps} from '@docusaurus/theme-common';
+  import {Details, type DetailsProps} from '@docusaurus/theme-common/Details';
 
   export interface Props extends DetailsProps {}
   export default Details;

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -7,10 +7,8 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import {Details as DetailsGeneric} from '@docusaurus/theme-common';
+import {Details as DetailsGeneric} from '@docusaurus/theme-common/Details';
 import type {Props} from '@theme/Details';
-// Ensure that the default details style is properly overridden
-import '@docusaurus/theme-common/lib/components/Details/styles.module.css';
 import styles from './styles.module.css';
 
 // Should we have a custom details/summary comp in Infima instead of reusing

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 import clsx from 'clsx';
 import {Details as DetailsGeneric} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Details';
-// Ensure that the default details style is properly overridden
-import '@docusaurus/theme-common/lib/components/Details/styles.module.css';
 import styles from './styles.module.css';
 
 // Should we have a custom details/summary comp in Infima instead of reusing

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 import clsx from 'clsx';
 import {Details as DetailsGeneric} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Details';
+// Ensure that the default details style is properly overridden
+import '@docusaurus/theme-common/lib/components/Details/styles.module.css';
 import styles from './styles.module.css';
 
 // Should we have a custom details/summary comp in Infima instead of reusing

--- a/packages/docusaurus-theme-common/Details.d.ts
+++ b/packages/docusaurus-theme-common/Details.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// `Details` is a separate export entry because of side-effects messing with CSS
+// insertion order. See https://github.com/facebook/docusaurus/pull/7085.
+// However, because TS doesn't recognize `exports` (also a problem in
+// `content-docs`), we have to manually create a stub.
+
+// eslint-disable-next-line import/named
+export {Details, type DetailsProps} from './lib/components/Details';

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -4,6 +4,7 @@
   "description": "Common code for Docusaurus themes.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "node copyUntypedFiles.mjs && tsc",
     "watch": "node copyUntypedFiles.mjs && tsc --watch"

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -4,7 +4,9 @@
   "description": "Common code for Docusaurus themes.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "scripts": {
     "build": "node copyUntypedFiles.mjs && tsc",
     "watch": "node copyUntypedFiles.mjs && tsc --watch"

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -5,8 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "sideEffects": [
-    "lib/components/Details/*",
-    "lib/index.js"
+    "lib/components/Details/*"
   ],
   "scripts": {
     "build": "node copyUntypedFiles.mjs && tsc",

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -5,7 +5,8 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "sideEffects": [
-    "lib/components/Details/*"
+    "lib/components/Details/*",
+    "lib/index.js"
   ],
   "scripts": {
     "build": "node copyUntypedFiles.mjs && tsc",

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "sideEffects": [
-    "*.css"
+    "lib/components/Details/*"
   ],
   "scripts": {
     "build": "node copyUntypedFiles.mjs && tsc",

--- a/packages/docusaurus-theme-common/package.json
+++ b/packages/docusaurus-theme-common/package.json
@@ -5,8 +5,13 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "sideEffects": [
-    "lib/components/Details/*"
+    "lib/components/Details/*",
+    "*.css"
   ],
+  "exports": {
+    ".": "./lib/index.js",
+    "./Details": "./lib/components/Details/index.js"
+  },
   "scripts": {
     "build": "node copyUntypedFiles.mjs && tsc",
     "watch": "node copyUntypedFiles.mjs && tsc --watch"

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -63,8 +63,6 @@ export {useLocationChange} from './utils/useLocationChange';
 
 export {useCollapsible, Collapsible} from './components/Collapsible';
 
-export {Details, type DetailsProps} from './components/Details';
-
 export {
   useDocsPreferredVersion,
   useDocsPreferredVersionByPluginId,

--- a/packages/docusaurus-theme-common/tsconfig.json
+++ b/packages/docusaurus-theme-common/tsconfig.json
@@ -8,5 +8,6 @@
     "declarationMap": true,
     "rootDir": "src",
     "outDir": "lib"
-  }
+  },
+  "include": ["src"]
 }

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -4,7 +4,9 @@
   "description": "Docusaurus live code block component.",
   "main": "lib/index.js",
   "types": "src/theme-live-codeblock.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -4,6 +4,7 @@
   "description": "Docusaurus live code block component.",
   "main": "lib/index.js",
   "types": "src/theme-live-codeblock.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/docusaurus-theme-live-codeblock/package.json
+++ b/packages/docusaurus-theme-live-codeblock/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "src/theme-live-codeblock.d.ts",
   "sideEffects": [
-    "*.css"
+    "lib/theme/Playground/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-beta.18",
   "description": "Algolia search component for Docusaurus.",
   "main": "lib/index.js",
+  "sideEffects": false,
   "exports": {
     "./client": "./lib/client/index.js",
     ".": "./lib/index.js"

--- a/packages/docusaurus-theme-search-algolia/package.json
+++ b/packages/docusaurus-theme-search-algolia/package.json
@@ -3,7 +3,9 @@
   "version": "2.0.0-beta.18",
   "description": "Algolia search component for Docusaurus.",
   "main": "lib/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "exports": {
     "./client": "./lib/client/index.js",
     ".": "./lib/index.js"

--- a/packages/docusaurus-utils-common/package.json
+++ b/packages/docusaurus-utils-common/package.json
@@ -4,6 +4,7 @@
   "description": "Common (Node/Browser) utility functions for Docusaurus packages.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Instant bundle size optimization⚡️

I did not mark core as side-effect-free, though, because there are a few side-effects there (mostly importing non-module CSS), and it's quite tedious trying to filter out everything.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Page builds fine