### PR TITLE
fix(core): preserve Interpolate children semantics

### DIFF
--- a/packages/docusaurus/src/client/exports/Interpolate.tsx
+++ b/packages/docusaurus/src/client/exports/Interpolate.tsx
@@ -9,7 +9,6 @@ import React, {isValidElement, type ReactNode} from 'react';
 import type {
   InterpolateProps,
   InterpolateValues,
-  ExtractInterpolatePlaceholders,
 } from '@docusaurus/Interpolate';
 
 /*
@@ -17,8 +16,6 @@ Minimal implementation of a React interpolate component.
 We don't ship a markdown parser nor a feature-complete i18n library on purpose.
 More details here: https://github.com/facebook/docusaurus/pull/4295
 */
-
-const ValueFoundMarker = '{}'; // does not care much
 
 // If all the values are plain strings, then interpolate returns a simple string
 export function interpolate<Str extends string>(
@@ -36,46 +33,26 @@ export function interpolate<Str extends string, Value extends ReactNode>(
   text: Str,
   values?: InterpolateValues<Str, Value>,
 ): ReactNode {
-  const elements: (Value | string)[] = [];
-
-  const processedText = text.replace(
-    // eslint-disable-next-line prefer-named-capture-group
-    /\{(\w+)\}/g,
-    (match, key: ExtractInterpolatePlaceholders<Str>) => {
-      const value = values?.[key];
-
-      if (typeof value !== 'undefined') {
-        const element = isValidElement(value)
-          ? value
-          : // For non-React elements: basic primitive->string conversion
-            String(value);
-        elements.push(element);
-        return ValueFoundMarker;
+  // eslint-disable-next-line prefer-named-capture-group
+  const segments = text.split(/(\{\w+\})/).map((seg, index) => {
+    // Odd indices (1, 3, 5...) of the segments are (potentially) interpolatable
+    if (index % 2 === 1) {
+      const value = values?.[seg.slice(1, -1) as keyof typeof values];
+      if (value !== undefined) {
+        return value;
       }
-      return match; // no match? add warning?
-    },
-  );
-
-  // No interpolation to be done: just return the text
-  if (elements.length === 0) {
-    return text;
+      // No match: add warning? There's no way to "escape" interpolation though
+    }
+    return seg;
+  });
+  if (segments.some((seg) => isValidElement(seg))) {
+    return segments
+      .map((seg, index) =>
+        isValidElement(seg) ? React.cloneElement(seg, {key: index}) : seg,
+      )
+      .filter((seg) => seg !== '');
   }
-  // Basic string interpolation: returns interpolated string
-  if (elements.every((el): el is string => typeof el === 'string')) {
-    return processedText
-      .split(ValueFoundMarker)
-      .reduce<string>(
-        (str, value, index) => str.concat(value).concat(elements[index] ?? ''),
-        '',
-      );
-  }
-  // JSX interpolation: returns ReactNode
-  return processedText.split(ValueFoundMarker).map((value, index) => (
-    <React.Fragment key={index}>
-      {value}
-      {elements[index]}
-    </React.Fragment>
-  ));
+  return segments.join('');
 }
 
 export default function Interpolate<Str extends string>({
@@ -83,9 +60,10 @@ export default function Interpolate<Str extends string>({
   values,
 }: InterpolateProps<Str>): JSX.Element {
   if (typeof children !== 'string') {
-    console.warn('Illegal <Interpolate> children', children);
     throw new Error(
-      'The Docusaurus <Interpolate> component only accept simple string values',
+      `The Docusaurus <Interpolate> component only accept simple string values. Received: ${JSON.stringify(
+        children,
+      )}`,
     );
   }
   return <>{interpolate(children, values)}</>;

--- a/packages/docusaurus/src/client/exports/Interpolate.tsx
+++ b/packages/docusaurus/src/client/exports/Interpolate.tsx
@@ -61,9 +61,9 @@ export default function Interpolate<Str extends string>({
 }: InterpolateProps<Str>): JSX.Element {
   if (typeof children !== 'string') {
     throw new Error(
-      `The Docusaurus <Interpolate> component only accept simple string values. Received: ${JSON.stringify(
-        children,
-      )}`,
+      `The Docusaurus <Interpolate> component only accept simple string values. Received: ${
+        isValidElement(children) ? 'React element' : typeof children
+      }`,
     );
   }
   return <>{interpolate(children, values)}</>;

--- a/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
@@ -130,7 +130,7 @@ describe('<Interpolate>', () => {
         </Interpolate>,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"The Docusaurus <Interpolate> component only accept simple string values"`,
+      `"The Docusaurus <Interpolate> component only accept simple string values. Received: {\\"type\\":\\"span\\",\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"children\\":\\"aaa\\"},\\"_owner\\":null,\\"_store\\":{}}"`,
     );
   });
 });

--- a/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
+++ b/packages/docusaurus/src/client/exports/__tests__/Interpolate.test.tsx
@@ -130,7 +130,7 @@ describe('<Interpolate>', () => {
         </Interpolate>,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"The Docusaurus <Interpolate> component only accept simple string values. Received: {\\"type\\":\\"span\\",\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"children\\":\\"aaa\\"},\\"_owner\\":null,\\"_store\\":{}}"`,
+      `"The Docusaurus <Interpolate> component only accept simple string values. Received: React element"`,
     );
   });
 });

--- a/packages/docusaurus/src/client/exports/__tests__/__snapshots__/Interpolate.test.tsx.snap
+++ b/packages/docusaurus/src/client/exports/__tests__/__snapshots__/Interpolate.test.tsx.snap
@@ -8,62 +8,48 @@ exports[`<Interpolate> acceptance test 1`] = `
   <span>
     today
   </span>,
-  "? Another {unprovidedValue}!",
+  "? Another ",
+  "{unprovidedValue}",
+  "!",
 ]
 `;
 
 exports[`interpolate acceptance test 1`] = `
 [
-  <React.Fragment>
-    Hello 
-    Sébastien
-  </React.Fragment>,
-  <React.Fragment>
-     how are you 
-    <span>
-      today
-    </span>
-  </React.Fragment>,
-  <React.Fragment>
-    ? Another {unprovidedValue}!
-  </React.Fragment>,
+  "Hello ",
+  "Sébastien",
+  " how are you ",
+  <span>
+    today
+  </span>,
+  "? Another ",
+  "{unprovidedValue}",
+  "!",
 ]
 `;
 
 exports[`interpolate placeholders with JSX values 1`] = `
 [
-  <React.Fragment>
-    Hello 
-    <b>
-      Sébastien
-    </b>
-  </React.Fragment>,
-  <React.Fragment>
-     how are you 
-    <span>
-      today
-    </span>
-  </React.Fragment>,
-  <React.Fragment>
-    ?
-  </React.Fragment>,
+  "Hello ",
+  <b>
+    Sébastien
+  </b>,
+  " how are you ",
+  <span>
+    today
+  </span>,
+  "?",
 ]
 `;
 
 exports[`interpolate placeholders with mixed vales 1`] = `
 [
-  <React.Fragment>
-    Hello 
-    Sébastien
-  </React.Fragment>,
-  <React.Fragment>
-     how are you 
-    <span>
-      today
-    </span>
-  </React.Fragment>,
-  <React.Fragment>
-    ?
-  </React.Fragment>,
+  "Hello ",
+  "Sébastien",
+  " how are you ",
+  <span>
+    today
+  </span>,
+  "?",
 ]
 `;

--- a/website/_dogfooding/_pages tests/error-boundary-tests.tsx
+++ b/website/_dogfooding/_pages tests/error-boundary-tests.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import Layout from '@theme/Layout';
+import Interpolate from '@docusaurus/Interpolate';
 
 import ErrorBoundaryTestButton from '@site/src/components/ErrorBoundaryTestButton';
 
@@ -22,6 +23,9 @@ export default function ErrorBoundaryTests(): JSX.Element {
               Crash inside layout
             </ErrorBoundaryTestButton>
           </div>
+          <Interpolate values={{foo: <span>FooFoo</span>, bar: <b>BarBar</b>}}>
+            {'{foo} is {bar}'}
+          </Interpolate>
         </main>
       </Layout>
     </>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

While our `Interpolate` is "functionally" fine, it's semantically incorrect. Each element will be wrapped in a React fragment, and things like `null` will be converted to a literal `"null"` instead of an actual `null` children.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests