### PR TITLE
feat(content-docs): make docs:version command work on localized docs

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -67,7 +67,7 @@ export default async function pluginContentDocs(
 
   const versionsMetadata = await readVersionsMetadata({context, options});
 
-  const pluginId = options.id ?? DEFAULT_PLUGIN_ID;
+  const pluginId = options.id;
 
   const pluginDataDirRoot = path.join(
     generatedFilesDir,
@@ -97,12 +97,7 @@ export default async function pluginContentDocs(
         .arguments('<version>')
         .description(commandDescription)
         .action((version) => {
-          cliDocsVersionCommand(version, siteDir, pluginId, {
-            path: options.path,
-            sidebarPath: options.sidebarPath,
-            sidebarCollapsed: options.sidebarCollapsed,
-            sidebarCollapsible: options.sidebarCollapsible,
-          });
+          cliDocsVersionCommand(version, options, context);
         });
     },
 

--- a/packages/docusaurus-plugin-content-docs/src/versions.ts
+++ b/packages/docusaurus-plugin-content-docs/src/versions.ts
@@ -133,7 +133,7 @@ export async function readVersionNames(
   return versions;
 }
 
-function getDocsDirPathLocalized({
+export function getDocsDirPathLocalized({
   siteDir,
   locale,
   pluginId,
@@ -143,7 +143,7 @@ function getDocsDirPathLocalized({
   locale: string;
   pluginId: string;
   versionName: string;
-}) {
+}): string {
   return getPluginI18nPath({
     siteDir,
     locale,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

See #7104

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally by creating `i18n/zh-CN/docusaurus-plugin-content-docs/current/foo.md` and running `yarn docusaurus docs:version foo`. Things work as expected.