### PR TITLE
feat(preset-classic): exclude debug plugin routes from sitemap

### DIFF
--- a/packages/docusaurus-plugin-debug/src/index.ts
+++ b/packages/docusaurus-plugin-debug/src/index.ts
@@ -9,6 +9,8 @@ import type {LoadContext, Plugin} from '@docusaurus/types';
 import {docuHash, normalizeUrl, posixPath} from '@docusaurus/utils';
 import path from 'path';
 
+export const routeBasePath = '__docusaurus/debug';
+
 export default function pluginDebug({
   siteConfig: {baseUrl},
   generatedFilesDir,
@@ -40,37 +42,37 @@ export default function pluginDebug({
 
       // Home is config (duplicate for now)
       addRoute({
-        path: normalizeUrl([baseUrl, '__docusaurus/debug']),
+        path: normalizeUrl([baseUrl, routeBasePath]),
         component: '@theme/DebugConfig',
         exact: true,
       });
 
       addRoute({
-        path: normalizeUrl([baseUrl, '__docusaurus/debug/config']),
+        path: normalizeUrl([baseUrl, routeBasePath, 'config']),
         component: '@theme/DebugConfig',
         exact: true,
       });
 
       addRoute({
-        path: normalizeUrl([baseUrl, '__docusaurus/debug/metadata']),
+        path: normalizeUrl([baseUrl, routeBasePath, 'metadata']),
         component: '@theme/DebugSiteMetadata',
         exact: true,
       });
 
       addRoute({
-        path: normalizeUrl([baseUrl, '__docusaurus/debug/registry']),
+        path: normalizeUrl([baseUrl, routeBasePath, 'registry']),
         component: '@theme/DebugRegistry',
         exact: true,
       });
 
       addRoute({
-        path: normalizeUrl([baseUrl, '__docusaurus/debug/routes']),
+        path: normalizeUrl([baseUrl, routeBasePath, 'routes']),
         component: '@theme/DebugRoutes',
         exact: true,
       });
 
       addRoute({
-        path: normalizeUrl([baseUrl, '__docusaurus/debug/content']),
+        path: normalizeUrl([baseUrl, routeBasePath, 'content']),
         component: '@theme/DebugContent',
         exact: true,
         modules: {
@@ -79,7 +81,7 @@ export default function pluginDebug({
       });
 
       addRoute({
-        path: normalizeUrl([baseUrl, '__docusaurus/debug/globalData']),
+        path: normalizeUrl([baseUrl, routeBasePath, 'globalData']),
         component: '@theme/DebugGlobalData',
         exact: true,
       });

--- a/packages/docusaurus-plugin-debug/src/plugin-debug.d.ts
+++ b/packages/docusaurus-plugin-debug/src/plugin-debug.d.ts
@@ -7,6 +7,10 @@
 
 /// <reference types="@docusaurus/module-type-aliases" />
 
+declare module '@docusaurus/plugin-debug' {
+  export const routeBasePath: string;
+}
+
 declare module '@theme/DebugConfig' {
   export default function DebugMetadata(): JSX.Element;
 }

--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -29,7 +29,7 @@ export default function preset(
   opts: Options = {},
 ): Preset {
   const {siteConfig} = context;
-  const {themeConfig} = siteConfig;
+  const {themeConfig, baseUrl} = siteConfig;
   const {algolia} = themeConfig as Partial<ThemeConfig>;
   const isProd = process.env.NODE_ENV === 'production';
   const {
@@ -84,7 +84,8 @@ export default function preset(
   }
   if (isProd && sitemap !== false) {
     if (isDebugEnabled) {
-      (sitemap.ignorePatterns ||= []).push(`/${debugPluginRouteBasePath}/**`);
+      sitemap.ignorePatterns ??= [];
+      sitemap.ignorePatterns.push(`${baseUrl}${debugPluginRouteBasePath}/**`);
     }
     plugins.push(makePluginConfig('@docusaurus/plugin-sitemap', sitemap));
   }

--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -37,7 +37,7 @@ export default function preset(
     docs,
     blog,
     pages,
-    sitemap,
+    sitemap = {},
     theme,
     googleAnalytics,
     gtag,
@@ -84,7 +84,7 @@ export default function preset(
   }
   if (isProd && sitemap !== false) {
     if (isDebugEnabled) {
-      sitemap?.ignorePatterns?.push(`/${debugPluginRouteBasePath}/**`);
+      (sitemap.ignorePatterns ||= []).push(`/${debugPluginRouteBasePath}/**`);
     }
     plugins.push(makePluginConfig('@docusaurus/plugin-sitemap', sitemap));
   }

--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {routeBasePath as debugPluginRouteBasePath} from '@docusaurus/plugin-debug';
 import type {
   Preset,
   LoadContext,
@@ -42,6 +43,7 @@ export default function preset(
     gtag,
     ...rest
   } = opts;
+  const isDebugEnabled = debug || (debug === undefined && !isProd);
 
   const themes: PluginConfig[] = [];
   themes.push(makePluginConfig('@docusaurus/theme-classic', theme));
@@ -74,13 +76,16 @@ export default function preset(
       makePluginConfig('@docusaurus/plugin-google-analytics', googleAnalytics),
     );
   }
-  if (debug || (debug === undefined && !isProd)) {
+  if (isDebugEnabled) {
     plugins.push(require.resolve('@docusaurus/plugin-debug'));
   }
   if (gtag) {
     plugins.push(makePluginConfig('@docusaurus/plugin-google-gtag', gtag));
   }
   if (isProd && sitemap !== false) {
+    if (isDebugEnabled) {
+      sitemap?.ignorePatterns?.push(`/${debugPluginRouteBasePath}/**`);
+    }
     plugins.push(makePluginConfig('@docusaurus/plugin-sitemap', sitemap));
   }
   if (Object.keys(rest).length > 0) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

If it is now possible to exclude certain pages from generated sitemap file, let's remove the pages related with debugging. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See sitemap file on preview site.

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
