### PR TITLE
fix(theme-classic): fix docs sidebar layout shifts when expanding categories

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -8,7 +8,8 @@
 @media (min-width: 997px) {
   .menu {
     flex-grow: 1;
-    padding: 0.5rem;
+    padding: 0.5rem 0 0.5rem 0.5rem;
+    scrollbar-gutter: stable;
   }
 
   .menuWithAnnouncementBar {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -8,8 +8,13 @@
 @media (min-width: 997px) {
   .menu {
     flex-grow: 1;
-    padding: 0.5rem 0 0.5rem 0.5rem;
-    scrollbar-gutter: stable;
+    padding: 0.5rem;
+  }
+  @supports (scrollbar-gutter: stable) {
+    .menu {
+      padding: 0.5rem 0 0.5rem 0.5rem;
+      scrollbar-gutter: stable;
+    }
   }
 
   .menuWithAnnouncementBar {


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/5254

`scrollbar-gutter` property support has significantly increased since last time we checked: https://caniuse.com/mdn-css_properties_scrollbar-gutter

Even if support is not perfect, it can already be used as a progressive enhancement thanks to `@supports` mediaquery


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

preview layout shifts are fixed in all browsers supporting `scrollbar-gutter`

other browsers (Safari) should keep working the same

---

Other related issue: https://github.com/facebook/docusaurus/issues/7130

