### PR TITLE
fix: proper spacing between generated card items on mobiles

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
@@ -9,6 +9,10 @@
   .generatedIndexPage {
     max-width: 75% !important;
   }
+
+  .list article:nth-last-child(-n + 2) {
+    margin-bottom: 0 !important;
+  }
 }
 
 /* Duplicated from .markdown h1 */
@@ -17,6 +21,6 @@
   margin-bottom: calc(1.25 * var(--ifm-leading));
 }
 
-.list article:nth-last-child(-n + 2) {
+.list article:last-child {
   margin-bottom: 0 !important;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

In #7129 I forgot to take into account that on mobile  margin of generated card items needs to be reset a little differently.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Preview

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
