### PR TITLE
refactor(core): minor PendingNavigation refactor

### DIFF
--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -8,7 +8,9 @@
 import React from 'react';
 
 import routes from '@generated/routes';
-import renderRoutes from './exports/renderRoutes';
+import {useLocation} from '@docusaurus/router';
+import normalizeLocation from './normalizeLocation';
+import renderRoutes from '@docusaurus/renderRoutes';
 import {BrowserContextProvider} from './browserContext';
 import {DocusaurusContextProvider} from './docusaurusContext';
 import PendingNavigation from './PendingNavigation';
@@ -24,6 +26,8 @@ import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import Error from '@theme/Error';
 
 export default function App(): JSX.Element {
+  const routeElement = renderRoutes(routes);
+  const location = useLocation();
   return (
     <ErrorBoundary fallback={Error}>
       <DocusaurusContextProvider>
@@ -32,8 +36,10 @@ export default function App(): JSX.Element {
             <SiteMetadataDefaults />
             <SiteMetadata />
             <BaseUrlIssueBanner />
-            <PendingNavigation routes={routes} delay={1000}>
-              {renderRoutes(routes)}
+            <PendingNavigation
+              location={normalizeLocation(location)}
+              delay={1000}>
+              {routeElement}
             </PendingNavigation>
           </Root>
         </BrowserContextProvider>

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -44,7 +44,7 @@ class PendingNavigation extends React.Component<Props, State> {
   // Intercept location update and still show current route until next route
   // is done loading.
   override shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
-    if (nextProps.location !== this.props.location) {
+    if (nextProps.location === this.props.location) {
       // `nextRouteHasLoaded` is false means there's a pending route transition.
       // Don't update until it's done.
       return nextState.nextRouteHasLoaded;

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -6,21 +6,18 @@
  */
 
 import React from 'react';
-import {Route, withRouter, type RouteComponentProps} from 'react-router-dom';
-import type {RouteConfig} from 'react-router-config';
+import {Route} from 'react-router-dom';
 import nprogress from 'nprogress';
 
 import clientLifecyclesDispatcher from './clientLifecyclesDispatcher';
 import preload from './preload';
-import normalizeLocation from './normalizeLocation';
 import type {Location} from 'history';
 
 import './nprogress.css';
 
 nprogress.configure({showSpinner: false});
 
-type Props = RouteComponentProps & {
-  readonly routes: RouteConfig[];
+type Props = {
   readonly delay: number;
   readonly location: Location;
   readonly children: JSX.Element;
@@ -31,7 +28,7 @@ type State = {
 
 class PendingNavigation extends React.Component<Props, State> {
   private previousLocation: Location | null;
-  private progressBarTimeout: NodeJS.Timeout | null;
+  private progressBarTimeout: number | null;
 
   constructor(props: Props) {
     super(props);
@@ -46,67 +43,54 @@ class PendingNavigation extends React.Component<Props, State> {
 
   // Intercept location update and still show current route until next route
   // is done loading.
-  override shouldComponentUpdate(nextProps: Props, nextState: State) {
-    const routeDidChange = nextProps.location !== this.props.location;
-    const {routes, delay} = this.props;
-
-    // If `routeDidChange` is true, means the router is trying to navigate to a
-    // new route. We will preload the new route.
-    if (routeDidChange) {
-      const nextLocation = normalizeLocation(nextProps.location);
-      this.startProgressBar(delay);
-      // Save the location first.
-      this.previousLocation = normalizeLocation(this.props.location);
-      this.setState({
-        nextRouteHasLoaded: false,
-      });
-
-      // Load data while the old screen remains.
-      preload(routes, nextLocation.pathname)
-        .then(() => {
-          clientLifecyclesDispatcher.onRouteUpdate({
-            previousLocation: this.previousLocation,
-            location: nextLocation,
-          });
-          // Route has loaded, we can reset previousLocation.
-          this.previousLocation = null;
-          this.setState({nextRouteHasLoaded: true}, this.stopProgressBar);
-          const {hash} = nextLocation;
-          if (!hash) {
-            window.scrollTo(0, 0);
-          } else {
-            const id = decodeURIComponent(hash.substring(1));
-            const element = document.getElementById(id);
-            if (element) {
-              element.scrollIntoView();
-            }
-          }
-        })
-        .catch((e) => console.warn(e));
-      return false;
+  override shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
+    if (nextProps.location !== this.props.location) {
+      // `nextRouteHasLoaded` is false means there's a pending route transition.
+      // Don't update until it's done.
+      return nextState.nextRouteHasLoaded;
     }
 
-    // There's a pending route transition. Don't update until it's done.
-    if (!nextState.nextRouteHasLoaded) {
-      return false;
-    }
+    // props.location being different means the router is trying to navigate to
+    // a new route. We will preload the new route.
+    const nextLocation = nextProps.location;
+    // Save the location first.
+    this.previousLocation = this.props.location;
+    this.setState({nextRouteHasLoaded: false});
+    this.startProgressBar(this.props.delay);
 
-    // Route has loaded, we can update now.
-    return true;
+    // Load data while the old screen remains.
+    preload(nextLocation.pathname)
+      .then(() => {
+        clientLifecyclesDispatcher.onRouteUpdate({
+          previousLocation: this.previousLocation,
+          location: nextLocation,
+        });
+        this.setState({nextRouteHasLoaded: true}, this.stopProgressBar);
+        const {hash} = nextLocation;
+        if (!hash) {
+          window.scrollTo(0, 0);
+        } else {
+          const id = decodeURIComponent(hash.substring(1));
+          const element = document.getElementById(id);
+          element?.scrollIntoView();
+        }
+      })
+      .catch((e) => console.warn(e));
+    return false;
   }
 
   private clearProgressBarTimeout() {
     if (this.progressBarTimeout) {
-      clearTimeout(this.progressBarTimeout);
+      window.clearTimeout(this.progressBarTimeout);
       this.progressBarTimeout = null;
     }
   }
 
   private startProgressBar(delay: number) {
     this.clearProgressBarTimeout();
-    this.progressBarTimeout = setTimeout(() => {
+    this.progressBarTimeout = window.setTimeout(() => {
       clientLifecyclesDispatcher.onRouteUpdateDelayed({
-        location: normalizeLocation(this.props.location),
+        location: this.props.location,
       });
       nprogress.start();
     }, delay);
@@ -117,12 +101,12 @@ class PendingNavigation extends React.Component<Props, State> {
     nprogress.done();
   }
 
-  override render() {
+  override render(): JSX.Element {
     const {children, location} = this.props;
-    return (
-      <Route location={normalizeLocation(location)} render={() => children} />
-    );
+    // Use a controlled <Route> to trick all descendants into rendering the old
+    // location.
+    return <Route location={location} render={() => children} />;
   }
 }
 
-export default withRouter(PendingNavigation);
+export default PendingNavigation;

--- a/packages/docusaurus/src/client/clientEntry.tsx
+++ b/packages/docusaurus/src/client/clientEntry.tsx
@@ -10,7 +10,6 @@ import ReactDOM from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 import {HelmetProvider} from 'react-helmet-async';
 
-import routes from '@generated/routes';
 import ExecutionEnvironment from './exports/ExecutionEnvironment';
 import App from './App';
 import preload from './preload';
@@ -32,7 +31,7 @@ if (ExecutionEnvironment.canUseDOM) {
   // We also preload async component to avoid first-load loading screen.
   const renderMethod =
     process.env.NODE_ENV === 'production' ? ReactDOM.hydrate : ReactDOM.render;
-  preload(routes, window.location.pathname).then(() => {
+  preload(window.location.pathname).then(() => {
     renderMethod(
       // @ts-expect-error: https://github.com/staylor/react-helmet-async/pull/165
       <HelmetProvider>

--- a/packages/docusaurus/src/client/docusaurus.ts
+++ b/packages/docusaurus/src/client/docusaurus.ts
@@ -85,7 +85,7 @@ const docusaurus = {
     }
 
     loaded[routePath] = true;
-    preloadHelper(routes, routePath);
+    preloadHelper(routePath);
     return true;
   },
 };

--- a/packages/docusaurus/src/client/preload.ts
+++ b/packages/docusaurus/src/client/preload.ts
@@ -5,21 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {matchRoutes, type RouteConfig} from 'react-router-config';
+import routes from '@generated/routes';
+import {matchRoutes} from 'react-router-config';
 
 /**
  * Helper function to make sure all async components for that particular route
  * is preloaded before rendering. This is especially useful to avoid loading
  * screens.
  *
- * @param routes react-router-config
  * @param pathname the route pathname, example: /docs/installation
  * @returns Promise object represents whether pathname has been preloaded
  */
-export default function preload(
-  routes: RouteConfig[],
-  pathname: string,
-): Promise<void[]> {
+export default function preload(pathname: string): Promise<void[]> {
   const matches = matchRoutes(routes, pathname);
 
   return Promise.all(

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -16,7 +16,6 @@ import Loadable from 'react-loadable';
 import {minify} from 'html-minifier-terser';
 import path from 'path';
 import fs from 'fs-extra';
-import routes from '@generated/routes';
 import preload from './preload';
 import App from './App';
 import {
@@ -76,7 +75,7 @@ async function doRender(locals: Locals & {path: string}) {
     noIndex,
   } = locals;
   const location = routesLocation[locals.path]!;
-  await preload(routes, location);
+  await preload(location);
   const modules = new Set<string>();
   const routerContext = {};
   const helmetContext = {};


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

I was looking at React-router v6 migration again (#6037). Unsurprisingly, the `withRouter` HOC is gone in favor of `useLocation`. However, our `PendingNavigation` is quite hard to refactor into a functional component (due to comparing and setting states in `shouldComponentUpdate`), so to make it easier, I simply moved the fetching of location up to `App.tsx` and pass it into `PendingNavigation` as prop. This brings the additional benefit that `normalizeLocation` can now be called at the top instead of being scattered among the `PendingNavigation` code.

Furthermore, I decided to import `@generated/routes` within `preload`, so that we don't pass the route config object around. This should make the code clearer about which components actually make use of the route config object, which can prepare us for refactors in the future.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Should have no behavior change