### PR TITLE
refactor(core): lower timeout before rendering progress bar to 200ms

### DIFF
--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -38,7 +38,7 @@ export default function App(): JSX.Element {
             <BaseUrlIssueBanner />
             <PendingNavigation
               location={normalizeLocation(location)}
-              delay={1000}>
+              delay={200}>
               {routeElement}
             </PendingNavigation>
           </Root>

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -56,7 +56,7 @@ class PendingNavigation extends React.Component<Props, State> {
     // Save the location first.
     this.previousLocation = this.props.location;
     this.setState({nextRouteHasLoaded: false});
-    this.startProgressBar(this.props.delay);
+    this.startProgressBar();
 
     // Load data while the old screen remains.
     preload(nextLocation.pathname)
@@ -86,14 +86,14 @@ class PendingNavigation extends React.Component<Props, State> {
     }
   }
 
-  private startProgressBar(delay: number) {
+  private startProgressBar() {
     this.clearProgressBarTimeout();
     this.progressBarTimeout = window.setTimeout(() => {
       clientLifecyclesDispatcher.onRouteUpdateDelayed({
         location: this.props.location,
       });
       nprogress.start();
-    }, delay);
+    }, this.props.delay);
   }
 
   private stopProgressBar() {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Close #6290. Because `react-loadable` sets a default timeout of 200ms, I think this makes more sense. I would agree that `1s` sometimes looks like the page is lagging.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

