### PR TITLE
refactor: unify how MDX content types are represented

### DIFF
--- a/packages/docusaurus-mdx-loader/src/mdx-loader.d.ts
+++ b/packages/docusaurus-mdx-loader/src/mdx-loader.d.ts
@@ -6,6 +6,7 @@
  */
 
 import type {Plugin} from 'unified';
+import type {TOCItem} from '@docusaurus/types';
 
 export type MDXPlugin =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/docusaurus-mdx-loader/src/mdx-loader.d.ts
+++ b/packages/docusaurus-mdx-loader/src/mdx-loader.d.ts
@@ -16,3 +16,21 @@ export type MDXOptions = {
   beforeDefaultRemarkPlugins: MDXPlugin[];
   beforeDefaultRehypePlugins: MDXPlugin[];
 };
+
+export type LoadedMDXContent<FrontMatter, Metadata, Assets = undefined> = {
+  /** As verbatim declared in the MDX document. */
+  readonly frontMatter: FrontMatter;
+  /** As provided by the content plugin. */
+  readonly metadata: Metadata;
+  /** A list of TOC items (headings). */
+  readonly toc: readonly TOCItem[];
+  /** First h1 title before any content. */
+  readonly contentTitle: string | undefined;
+  /**
+   * Usually image assets that may be collocated like `./img/thumbnail.png`.
+   * The loader would also bundle these assets and the client should use these
+   * in priority.
+   */
+  readonly assets: Assets;
+  (): JSX.Element;
+};

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -414,7 +414,7 @@ declare module '@docusaurus/plugin-content-blog' {
 }
 
 declare module '@theme/BlogPostPage' {
-  import type {TOCItem} from '@docusaurus/types';
+  import type {LoadedMDXContent} from '@docusaurus/mdx-loader';
   import type {
     BlogPostFrontMatter,
     BlogPostMetadata,
@@ -433,22 +433,11 @@ declare module '@theme/BlogPostPage' {
     }
   >;
 
-  export type Content = {
-    /** Same as `metadata.frontMatter` */
-    readonly frontMatter: FrontMatter;
-    /**
-     * Usually image assets that may be collocated like `./img/thumbnail.png`.
-     * The loader would also bundle these assets and the client should use these
-     * in priority.
-     */
-    readonly assets: Assets;
-    /** Metadata of the post. */
-    readonly metadata: Metadata;
-    /** A list of TOC items (headings). */
-    readonly toc: readonly TOCItem[];
-    /** Renders the actual MDX content. */
-    (): JSX.Element;
-  };
+  export type Content = LoadedMDXContent<
+    BlogPostFrontMatter,
+    BlogPostMetadata,
+    Assets
+  >;
 
   export interface Props {
     /** Blog sidebar. */

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -433,11 +433,7 @@ declare module '@theme/BlogPostPage' {
     }
   >;
 
-  export type Content = LoadedMDXContent<
-    BlogPostFrontMatter,
-    BlogPostMetadata,
-    Assets
-  >;
+  export type Content = LoadedMDXContent<FrontMatter, Metadata, Assets>;
 
   export interface Props {
     /** Blog sidebar. */

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -496,7 +496,7 @@ declare module '@docusaurus/plugin-content-docs' {
 }
 
 declare module '@theme/DocItem' {
-  import type {TOCItem} from '@docusaurus/types';
+  import type {LoadedMDXContent} from '@docusaurus/mdx-loader';
   import type {
     PropVersionMetadata,
     Assets,
@@ -514,14 +514,7 @@ declare module '@theme/DocItem' {
   export interface Props {
     readonly route: DocumentRoute;
     readonly versionMetadata: PropVersionMetadata;
-    readonly content: {
-      readonly frontMatter: DocFrontMatter;
-      readonly metadata: DocMetadata;
-      readonly toc: readonly TOCItem[];
-      readonly contentTitle: string | undefined;
-      readonly assets: Assets;
-      (): JSX.Element;
-    };
+    readonly content: LoadedMDXContent<DocFrontMatter, DocMetadata, Assets>;
   }
 
   export default function DocItem(props: Props): JSX.Element;

--- a/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
+++ b/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
@@ -48,19 +48,14 @@ declare module '@docusaurus/plugin-content-pages' {
 }
 
 declare module '@theme/MDXPage' {
-  import type {TOCItem} from '@docusaurus/types';
+  import type {LoadedMDXContent} from '@docusaurus/mdx-loader';
   import type {
     MDXPageMetadata,
     FrontMatter,
   } from '@docusaurus/plugin-content-pages';
 
   export interface Props {
-    readonly content: {
-      readonly frontMatter: FrontMatter;
-      readonly metadata: MDXPageMetadata;
-      readonly toc: readonly TOCItem[];
-      (): JSX.Element;
-    };
+    readonly content: LoadedMDXContent<FrontMatter, MDXPageMetadata>;
   }
 
   export default function MDXPage(props: Props): JSX.Element;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

The MDX content shape is defined by the MDX loader, so the type should also be exported from there. This makes the types less duplicated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
