### PR TITLE
fix(website): remove skipLibCheck

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -57,7 +57,7 @@
     "raw-loader": "^4.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-medium-image-zoom": "^4.3.6",
+    "react-medium-image-zoom": "^4.3.7",
     "react-popper": "^2.2.5",
     "rehype-katex": "^6.0.2",
     "remark-math": "^3.0.1",

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -6,9 +6,10 @@
     "baseUrl": ".",
     "resolveJsonModule": true,
     "strict": true,
-    // Work around a type error in react-medium-image-zoom.
-    // https://github.com/rpearce/image-zoom/pull/303
-    "skipLibCheck": true,
+    // This is important. We run `yarn tsc` in website so we can catch issues
+    // with our declaration files (mostly name that are forgotten to be
+    // imported). Removing this would make things harder to catch.
+    "skipLibCheck": false,
     "types": ["@types/jest"]
   },
   "exclude": ["src/sw.js"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -15559,10 +15559,10 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
-react-medium-image-zoom@^4.3.6:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-4.3.6.tgz#75c874fa219ba1f29e23ae75f9a5affe74e9bc61"
-  integrity sha512-fIetmbdwshFahTX3WICIDZdJ+loxp/RGfax7z8ov2qdBzbBEqPveQn8U18oj+e1mQdnV2UjmY3YY035k2XPFZA==
+react-medium-image-zoom@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.npmmirror.com/react-medium-image-zoom/-/react-medium-image-zoom-4.3.7.tgz#06c0771401c6de312a85843d1feebd15641a969b"
+  integrity sha512-Vg1M8CIX1EfhfSsmNc2tHP+8KjPDo9e5/zEDaSsfeTBHI82wjEvW3Lgb4k3jdWILPZVOWhM+7QHyDaAzghlvaQ==
   dependencies:
     focus-options-polyfill "1.2.0"
     react-use "^17.2.1"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

I mistakenly enabled `skipLibCheck` in the website in #7138. This is dangerous because there's no E2E tests for the type declarations. This is a quickfix, after https://github.com/rpearce/image-zoom/pull/303 has been merged. Luckily no bugs have been introduced so far.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
