### PR TITLE
feat(plugin-content-blog): add setGlobalData

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -196,7 +196,7 @@ export default async function pluginContentBlog(
         archiveBasePath,
       } = options;
 
-      const {addRoute, createData} = actions;
+      const {addRoute, createData, setGlobalData} = actions;
       const {
         blogSidebarTitle,
         blogPosts,
@@ -383,6 +383,12 @@ export default async function pluginContentBlog(
 
       await createTagsListPage();
       await Promise.all(Object.values(blogTags).map(createTagPostsListPage));
+
+      setGlobalData({
+        path: normalizeUrl([baseUrl, options.routeBasePath]),
+        blogs: blogPosts,
+        tags: blogTags,
+      });
     },
 
     translateContent({content, translationFiles}) {


### PR DESCRIPTION
When I use useGlobalData hook, I only get docusaurus-plugin-content-docs data, but I didn't see any data from docusaurus-plugin-content-blog, so I wanted to give it setGlobalData.

![image](https://user-images.githubusercontent.com/61005888/162977273-af388012-6825-4d05-8deb-4e65e8c77bd5.png)

But I think that's all there is to it.