### PR TITLE
fix(theme-translations): always try all possible locale resolutions

### DIFF
--- a/packages/docusaurus-theme-translations/src/__tests__/index.test.ts
+++ b/packages/docusaurus-theme-translations/src/__tests__/index.test.ts
@@ -18,21 +18,45 @@ describe('codeTranslationLocalesToTry', () => {
       'fr',
       'fr-FR',
       'fr-Latn',
+      'fr',
     ]);
-    expect(codeTranslationLocalesToTry('fr-FR')).toEqual(['fr-FR', 'fr']);
+    expect(codeTranslationLocalesToTry('fr-FR')).toEqual([
+      'fr-FR',
+      'fr-FR',
+      'fr-Latn',
+      'fr',
+    ]);
     // Note: "pt" is expanded into "pt-BR", not "pt-PT", as "pt-BR" is more
     // widely used! See https://github.com/facebook/docusaurus/pull/4536#issuecomment-810088783
     expect(codeTranslationLocalesToTry('pt')).toEqual([
       'pt',
       'pt-BR',
       'pt-Latn',
+      'pt',
     ]);
-    expect(codeTranslationLocalesToTry('pt-BR')).toEqual(['pt-BR', 'pt']);
-    expect(codeTranslationLocalesToTry('pt-PT')).toEqual(['pt-PT', 'pt']);
+    expect(codeTranslationLocalesToTry('pt-BR')).toEqual([
+      'pt-BR',
+      'pt-BR',
+      'pt-Latn',
+      'pt',
+    ]);
+    expect(codeTranslationLocalesToTry('pt-PT')).toEqual([
+      'pt-PT',
+      'pt-PT',
+      'pt-Latn',
+      'pt',
+    ]);
     expect(codeTranslationLocalesToTry('zh')).toEqual([
       'zh',
       'zh-CN',
       'zh-Hans',
+      'zh',
+    ]);
+    expect(codeTranslationLocalesToTry('zh-cn')).toEqual([
+      'zh-cn',
+      'zh-CN',
+      'zh-Hans',
+      'zh',
     ]);
   });
 });
@@ -48,12 +72,7 @@ describe('readDefaultCodeTranslationMessages', () => {
   async function readAsJSON(locale: string, filename: string = name) {
     console.log(path.resolve(dirPath, locale, `${filename}.json`));
 
-    return JSON.parse(
-      await fs.readFile(
-        path.resolve(dirPath, locale, `${filename}.json`),
-        'utf8',
-      ),
-    );
+    return fs.readJSON(path.resolve(dirPath, locale, `${filename}.json`));
   }
 
   it('for empty locale', async () => {

--- a/packages/docusaurus-theme-translations/src/index.ts
+++ b/packages/docusaurus-theme-translations/src/index.ts
@@ -18,17 +18,18 @@ export function codeTranslationLocalesToTry(locale: string): string[] {
   const intlLocale = new Intl.Locale(locale);
   // if locale is just a simple language like "pt", we want to fallback to pt-BR
   // (not pt-PT!) See https://github.com/facebook/docusaurus/pull/4536#issuecomment-810088783
-  if (intlLocale.language === locale) {
-    const maximizedLocale = intlLocale.maximize(); // pt-Latn-BR`
-    // ["pt","pt-BR"]; ["zh", "zh-Hans"]
-    return [
-      locale,
-      `${maximizedLocale.language}-${maximizedLocale.region}`,
-      `${maximizedLocale.language}-${maximizedLocale.script}`,
-    ];
-  }
-  // if locale is like "pt-BR", we want to fallback to "pt"
-  return [locale, intlLocale.language!];
+  const maximizedLocale = intlLocale.maximize(); // pt-Latn-BR
+  return [
+    // May be "zh", "zh-CN", "zh-Hans", "zh-cn", or anything: very likely to be
+    // unresolved except for simply locales
+    locale,
+    // zh-CN / pt-BR
+    `${maximizedLocale.language}-${maximizedLocale.region}`,
+    // zh-Hans / pt-Latn
+    `${maximizedLocale.language}-${maximizedLocale.script}`,
+    // zh / pt
+    maximizedLocale.language!,
+  ];
 }
 
 // Useful to implement getDefaultCodeTranslationMessages() in themes


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

I've seen people trying to use `zh-cn` as locale name, but resolution fails, because `localesToTry` would be `["zh-cn", "zh"]` in this case, neither of which are existent.

I think this is a perfectly valid use-case, so we should try all of {original locale, locale-by-region, locale-by-script, bare language}.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test