### PR TITLE
refactor: control base styling of code blocks via CSS vars

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.ts
@@ -481,6 +481,7 @@ describe('themeConfig', () => {
     const prismConfig = {
       prism: {
         additionalLanguages: ['kotlin', 'java'],
+        theme: darkTheme,
       },
     };
     expect(testValidateThemeConfig(prismConfig)).toEqual({

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/styles.module.css
@@ -7,7 +7,9 @@
 
 .copyButton {
   display: flex;
-  background: inherit;
+  /* TODO: move to base button styling */
+  background: var(--prism-background-color);
+  color: var(--prism-color);
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: var(--ifm-global-radius);
   padding: 0.4rem;

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -16,6 +16,7 @@ import {
   containsLineNumbers,
   ThemeClassNames,
   usePrismTheme,
+  getPrismCssVariables,
 } from '@docusaurus/theme-common';
 import CopyButton from '@theme/CodeBlock/CopyButton';
 import type {Props} from '@theme/CodeBlock';
@@ -50,6 +51,8 @@ export default function CodeBlock({
   const codeBlockTitle = parseCodeBlockTitle(metastring) || title;
   const prismTheme = usePrismTheme();
 
+  const prismCssVariables = getPrismCssVariables(prismTheme);
+
   // <pre> tags in markdown map to CodeBlocks and they may contain JSX children.
   // When the children is not a simple string, we just return a styled block
   // without actually highlighting.
@@ -72,7 +75,8 @@ export default function CodeBlock({
               styles.codeBlockContainer,
               blockClassName,
               ThemeClassNames.common.codeBlock,
-            )}>
+            )}
+            style={prismCssVariables}>
             <code className={styles.codeBlockLines}>{children}</code>
           </pre>
         )}
@@ -108,7 +112,8 @@ export default function CodeBlock({
                 language && !blockClassName.includes(`language-${language}`),
             },
             ThemeClassNames.common.codeBlock,
-          )}>
+          )}
+          style={prismCssVariables}>
           {codeBlockTitle && (
             <div className={styles.codeBlockTitle}>{codeBlockTitle}</div>
           )}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -61,7 +61,7 @@ export default function CodeBlock({
         theme={prismTheme}
         code=""
         language={'text' as Language}>
-        {({className, style}) => (
+        {({className}) => (
           <pre
             /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
             tabIndex={0}
@@ -72,8 +72,7 @@ export default function CodeBlock({
               styles.codeBlockContainer,
               blockClassName,
               ThemeClassNames.common.codeBlock,
-            )}
-            style={style}>
+            )}>
             <code className={styles.codeBlockLines}>{children}</code>
           </pre>
         )}
@@ -99,7 +98,7 @@ export default function CodeBlock({
       theme={prismTheme}
       code={code}
       language={(language ?? 'text') as Language}>
-      {({className, style, tokens, getLineProps, getTokenProps}) => (
+      {({className, tokens, getLineProps, getTokenProps}) => (
         <div
           className={clsx(
             styles.codeBlockContainer,
@@ -111,11 +110,9 @@ export default function CodeBlock({
             ThemeClassNames.common.codeBlock,
           )}>
           {codeBlockTitle && (
-            <div style={style} className={styles.codeBlockTitle}>
-              {codeBlockTitle}
-            </div>
+            <div className={styles.codeBlockTitle}>{codeBlockTitle}</div>
           )}
-          <div className={styles.codeBlockContent} style={style}>
+          <div className={styles.codeBlockContent}>
             <pre
               /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
               tabIndex={0}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
@@ -6,6 +6,8 @@
  */
 
 .codeBlockContainer {
+  background: var(--prism-background-color);
+  color: var(--prism-color);
   margin-bottom: var(--ifm-leading);
   box-shadow: var(--ifm-global-shadow-lw);
   border-radius: var(--ifm-code-border-radius);
@@ -28,7 +30,7 @@
 }
 
 .codeBlock {
-  --ifm-pre-background: inherit;
+  --ifm-pre-background: var(--prism-background-color);
   margin: 0;
   padding: 0;
 }
@@ -44,7 +46,6 @@
 
 .codeBlockLines {
   font: inherit;
-  background: var(--ifm-pre-background);
   /* rtl:ignore */
   float: left;
   min-width: 100%;

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import defaultPrismTheme from 'prism-react-renderer/themes/palenight';
 import {Joi, URISchema} from '@docusaurus/utils-validation';
 import type {
   ThemeConfig,
@@ -32,6 +33,7 @@ export const DEFAULT_CONFIG = {
   metadata: [],
   prism: {
     additionalLanguages: [],
+    theme: defaultPrismTheme,
   },
   navbar: {
     hideOnScroll: false,
@@ -335,7 +337,7 @@ export const ThemeConfigSchema = Joi.object({
     theme: Joi.object({
       plain: Joi.alternatives().try(Joi.array(), Joi.object()).required(),
       styles: Joi.alternatives().try(Joi.array(), Joi.object()).required(),
-    }),
+    }).default(DEFAULT_CONFIG.prism.theme),
     darkTheme: Joi.object({
       plain: Joi.alternatives().try(Joi.array(), Joi.object()).required(),
       styles: Joi.alternatives().try(Joi.array(), Joi.object()).required(),

--- a/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
@@ -59,6 +59,7 @@ const storeColorMode = (newColorMode: ColorMode) => {
 
 function useContextValue(): ContextValue {
   const {
+    prism,
     colorMode: {defaultMode, disableSwitch, respectPrefersColorScheme},
   } = useThemeConfig();
   const [colorMode, setColorModeState] = useState(
@@ -75,7 +76,23 @@ function useContextValue(): ContextValue {
       'data-theme',
       coerceToColorMode(colorMode),
     );
-  }, [colorMode]);
+
+    // Add Prism's CSS variables
+    const root = window.document.documentElement;
+    const currentPrismTheme =
+      (colorMode === 'dark' ? prism.darkTheme : prism.theme) || prism.theme;
+
+    Object.entries(currentPrismTheme.plain).forEach(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ([name, color]: [string, any]) => {
+        const cssVarName = `--prism-${name.replace(
+          /[a-z][A-Z\d]/g,
+          (m) => `${m[0]}-${m[1]!.toLowerCase()}`,
+        )}`;
+        root.style.setProperty(cssVarName, color);
+      },
+    );
+  }, [colorMode, prism.theme, prism.darkTheme]);
 
   useEffect(() => {
     if (disableSwitch) {

--- a/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
@@ -59,7 +59,6 @@ const storeColorMode = (newColorMode: ColorMode) => {
 
 function useContextValue(): ContextValue {
   const {
-    prism,
     colorMode: {defaultMode, disableSwitch, respectPrefersColorScheme},
   } = useThemeConfig();
   const [colorMode, setColorModeState] = useState(
@@ -76,23 +75,7 @@ function useContextValue(): ContextValue {
       'data-theme',
       coerceToColorMode(colorMode),
     );
-
-    // Add Prism's CSS variables
-    const root = window.document.documentElement;
-    const currentPrismTheme =
-      (colorMode === 'dark' ? prism.darkTheme : prism.theme) || prism.theme;
-
-    Object.entries(currentPrismTheme.plain).forEach(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ([name, color]: [string, any]) => {
-        const cssVarName = `--prism-${name.replace(
-          /[a-z][A-Z\d]/g,
-          (m) => `${m[0]}-${m[1]!.toLowerCase()}`,
-        )}`;
-        root.style.setProperty(cssVarName, color);
-      },
-    );
-  }, [colorMode, prism.theme, prism.darkTheme]);
+  }, [colorMode]);
 
   useEffect(() => {
     if (disableSwitch) {

--- a/packages/docusaurus-theme-common/src/hooks/usePrismTheme.ts
+++ b/packages/docusaurus-theme-common/src/hooks/usePrismTheme.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import defaultTheme from 'prism-react-renderer/themes/palenight';
+import type {PrismTheme} from 'prism-react-renderer';
 import {useColorMode} from '../contexts/colorMode';
 import {useThemeConfig} from '../utils/useThemeConfig';
 
@@ -13,10 +13,10 @@ import {useThemeConfig} from '../utils/useThemeConfig';
  * Returns a color-mode-dependent Prism theme: whatever the user specified in
  * the config. Falls back to `palenight`.
  */
-export function usePrismTheme(): typeof defaultTheme {
+export function usePrismTheme(): PrismTheme {
   const {prism} = useThemeConfig();
   const {colorMode} = useColorMode();
-  const lightModeTheme = prism.theme || defaultTheme;
+  const lightModeTheme = prism.theme;
   const darkModeTheme = prism.darkTheme || lightModeTheme;
   const prismTheme = colorMode === 'dark' ? darkModeTheme : lightModeTheme;
 

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -35,6 +35,7 @@ export {
   parseLanguage,
   parseLines,
   containsLineNumbers,
+  getPrismCssVariables,
 } from './utils/codeBlockUtils';
 
 export {

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -6,6 +6,8 @@
  */
 
 import rangeParser from 'parse-numeric-range';
+import type {PrismTheme} from 'prism-react-renderer';
+import type {CSSProperties} from 'react';
 
 const codeBlockTitleRegex = /title=(?<quote>["'])(?<title>.*?)\1/;
 const highlightLinesRangeRegex = /\{(?<range>[\d,-]+)\}/;
@@ -172,4 +174,21 @@ export function parseLines(
   const highlightLines = rangeParser(highlightRange);
   code = lines.join('\n');
   return {highlightLines, code};
+}
+
+export function getPrismCssVariables(prismTheme: PrismTheme): CSSProperties {
+  const mapping: {[name: keyof PrismTheme['plain']]: string} = {
+    color: '--prism-color',
+    backgroundColor: '--prism-background-color',
+  };
+
+  const properties: CSSProperties = {};
+  Object.entries(prismTheme.plain).forEach(([key, value]) => {
+    const varName = mapping[key];
+    if (varName && typeof value === 'string') {
+      // @ts-expect-error: why css variables not in inline style type?
+      properties[varName] = value;
+    }
+  });
+  return properties;
 }

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -53,7 +53,7 @@ export type AnnouncementBarConfig = {
 };
 
 export type PrismConfig = {
-  theme?: PrismTheme;
+  theme: PrismTheme;
   darkTheme?: PrismTheme;
   defaultLanguage?: string;
   additionalLanguages: string[];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

My recent PR #7007 broke applying proper background of Prism theme to code blocks (it is especially noticeable when dark mode is on). Unfortunately, inheritance when used with CSS vars works unexpected from it way. Also, as I mentioned earlier https://github.com/facebook/docusaurus/pull/7036/files/ebb2d9e303eeb5978ffcf6573b0162b27868ba43#r845543297 to group the code buttons would require adding `style` attributes coming from Prism on each button.
Overall, the code complexity increases and with it,  increasingly difficult to ensure proper styling of block codes with all use cases in mind.
So I propose to dynamically create two CSS vars corresponding to the current Prism color theme. This way we can avoid overusing of `style` attribute on many elements and it is just a predictable way to control styling as opposed to many inherited values.

Ideally I would of course like to do away with inline styles completely when highlighting the code itself, maybe in the future it's worth thinking about how to do this (dynamically create CSS classes like `token-line` etc.).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Compare https://docusaurus.io/tests/pages/code-block-tests and respective page on preview site.

## Related PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
