### PR TITLE
fix(theme-classic): admonition title: disable text-transform on inline code blocks

### DIFF
--- a/packages/docusaurus-theme-classic/src/admonitions.css
+++ b/packages/docusaurus-theme-classic/src/admonitions.css
@@ -11,6 +11,10 @@
   text-transform: uppercase;
 }
 
+.admonition h5 code {
+  text-transform: none;
+}
+
 .admonition-icon {
   display: inline-block;
   vertical-align: middle;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

<!-- Write your motivation here. -->

Currently `text-transform: uppercase` is set for `.admonition h5`. This makes all texts uppercased even when wrapped by `<code />`.

```mdx
:::tip This is a `code`
:::
```

![](https://user-images.githubusercontent.com/45363260/163401269-547885bc-a821-4ba4-bec7-c8ed5d2c1cc4.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

<!-- Write your answer here. -->

Yes

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

After changes are made, codes are no longer uppercased as shown in the screenshot below.

![](https://user-images.githubusercontent.com/45363260/163401911-3453b949-02e7-4e1f-9c04-85c586e17f8f.png)
