### PR TITLE
refactor(theme-classic): split CodeBlock

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -148,10 +148,10 @@ declare module '@theme/BlogLayout' {
 }
 
 declare module '@theme/CodeBlock' {
-  import type {ReactElement} from 'react';
+  import type {ReactNode} from 'react';
 
   export interface Props {
-    readonly children: string | ReactElement;
+    readonly children: ReactNode;
     readonly className?: string;
     readonly metastring?: string;
     readonly title?: string;

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -170,6 +170,56 @@ declare module '@theme/CodeBlock/CopyButton' {
   export default function CopyButton(props: Props): JSX.Element;
 }
 
+declare module '@theme/CodeBlock/Container' {
+  import type {ComponentProps} from 'react';
+
+  export default function CodeBlockContainer<T extends 'div' | 'pre'>({
+    as: As,
+    ...props
+  }: {as: T} & ComponentProps<T>): JSX.Element;
+}
+
+declare module '@theme/CodeBlock/Content/Element' {
+  import type {Props} from '@theme/CodeBlock';
+
+  export type {Props};
+
+  export default function CodeBlockElementContent(props: Props): JSX.Element;
+}
+
+declare module '@theme/CodeBlock/Content/String' {
+  import type {Props as CodeBlockProps} from '@theme/CodeBlock';
+
+  export interface Props extends Omit<CodeBlockProps, 'children'> {
+    readonly children: string;
+  }
+
+  export default function CodeBlockStringContent(props: Props): JSX.Element;
+}
+
+declare module '@theme/CodeBlock/Line' {
+  import type {ComponentProps} from 'react';
+  import type Highlight from 'prism-react-renderer';
+
+  // Lib does not make this easy
+  type RenderProps = Parameters<
+    ComponentProps<typeof Highlight>['children']
+  >[0];
+  type GetLineProps = RenderProps['getLineProps'];
+  type GetTokenProps = RenderProps['getTokenProps'];
+  type Token = RenderProps['tokens'][number][number];
+
+  export interface Props {
+    readonly line: Token[];
+    readonly highlight: boolean;
+    readonly showLineNumbers: boolean;
+    readonly getLineProps: GetLineProps;
+    readonly getTokenProps: GetTokenProps;
+  }
+
+  export default function CodeBlockLine(props: Props): JSX.Element;
+}
+
 declare module '@theme/DocCard' {
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ComponentProps} from 'react';
+import clsx from 'clsx';
+import {
+  usePrismTheme,
+  getPrismCssVariables,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import styles from './styles.module.css';
+
+export default function CodeBlockContainer<T extends 'div' | 'pre'>({
+  as: As,
+  ...props
+}: {as: T} & ComponentProps<T>): JSX.Element {
+  const prismTheme = usePrismTheme();
+  const prismCssVariables = getPrismCssVariables(prismTheme);
+  return (
+    <As
+      // Polymorphic components are hard to type, without `oneOf` generics
+      {...(props as never)}
+      style={prismCssVariables}
+      className={clsx(
+        props.className,
+        styles.codeBlockContainer,
+        ThemeClassNames.common.codeBlock,
+      )}
+    />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/styles.module.css
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.codeBlockContainer {
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  margin-bottom: var(--ifm-leading);
+  box-shadow: var(--ifm-global-shadow-lw);
+  border-radius: var(--ifm-code-border-radius);
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/Element.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/Element.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Container from '@theme/CodeBlock/Container';
+import clsx from 'clsx';
+import type {Props} from '@theme/CodeBlock/Content/Element';
+
+import styles from './styles.module.css';
+
+// <pre> tags in markdown map to CodeBlocks. They may contain JSX children. When
+// the children is not a simple string, we just return a styled block without
+// actually highlighting.
+export default function CodeBlockJSX({
+  children,
+  className,
+}: Props): JSX.Element {
+  return (
+    <Container
+      as="pre"
+      tabIndex={0}
+      className={clsx(styles.codeBlockStandalone, 'thin-scrollbar', className)}>
+      <code className={styles.codeBlockLines}>{children}</code>
+    </Container>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import {
+  useThemeConfig,
+  parseCodeBlockTitle,
+  parseLanguage,
+  parseLines,
+  containsLineNumbers,
+  usePrismTheme,
+} from '@docusaurus/theme-common';
+import clsx from 'clsx';
+import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
+import Line from '@theme/CodeBlock/Line';
+import CopyButton from '@theme/CodeBlock/CopyButton';
+import Container from '@theme/CodeBlock/Container';
+import type {Props} from '@theme/CodeBlock/Content/String';
+
+import styles from './styles.module.css';
+
+export default function CodeBlockString({
+  children,
+  className: blockClassName = '',
+  metastring,
+  title: titleProp,
+  showLineNumbers: showLineNumbersProp,
+  language: languageProp,
+}: Props): JSX.Element {
+  const {
+    prism: {defaultLanguage},
+  } = useThemeConfig();
+  const language =
+    languageProp ?? parseLanguage(blockClassName) ?? defaultLanguage;
+  const prismTheme = usePrismTheme();
+
+  // We still parse the metastring in case we want to support more syntax in the
+  // future. Note that MDX doesn't strip quotes when parsing metastring:
+  // "title=\"xyz\"" => title: "\"xyz\""
+  const title = parseCodeBlockTitle(metastring) || titleProp;
+
+  const {highlightLines, code} = parseLines(children, metastring, language);
+  const showLineNumbers =
+    showLineNumbersProp || containsLineNumbers(metastring);
+
+  return (
+    <Container
+      as="div"
+      className={clsx(
+        blockClassName,
+        language &&
+          !blockClassName.includes(`language-${language}`) &&
+          `language-${language}`,
+      )}>
+      {title && <div className={styles.codeBlockTitle}>{title}</div>}
+      <div className={styles.codeBlockContent}>
+        <Highlight
+          {...defaultProps}
+          theme={prismTheme}
+          code={code}
+          language={(language ?? 'text') as Language}>
+          {({className, tokens, getLineProps, getTokenProps}) => (
+            <pre
+              /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+              tabIndex={0}
+              className={clsx(className, styles.codeBlock, 'thin-scrollbar')}>
+              <code
+                className={clsx(
+                  styles.codeBlockLines,
+                  showLineNumbers && styles.codeBlockLinesWithNumbering,
+                )}>
+                {tokens.map((line, i) => (
+                  <Line
+                    key={i}
+                    line={line}
+                    getLineProps={getLineProps}
+                    getTokenProps={getTokenProps}
+                    highlight={highlightLines.includes(i)}
+                    showLineNumbers={showLineNumbers}
+                  />
+                ))}
+              </code>
+            </pre>
+          )}
+        </Highlight>
+        <CopyButton code={code} />
+      </div>
+    </Container>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/styles.module.css
@@ -5,14 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.codeBlockContainer {
-  background: var(--prism-background-color);
-  color: var(--prism-color);
-  margin-bottom: var(--ifm-leading);
-  box-shadow: var(--ifm-global-shadow-lw);
-  border-radius: var(--ifm-code-border-radius);
-}
-
 .codeBlockContent {
   position: relative;
   /* rtl:ignore */
@@ -61,32 +53,4 @@
   .codeBlockLines {
     white-space: pre-wrap;
   }
-}
-
-.codeLine {
-  display: table-row;
-  counter-increment: line-count;
-}
-
-.codeLineNumber {
-  display: table-cell;
-  text-align: right;
-  width: 1%;
-  position: sticky;
-  left: 0;
-  padding: 0 var(--ifm-pre-padding);
-  background: var(--ifm-pre-background);
-}
-
-.codeLineNumber::before {
-  content: counter(line-count);
-  opacity: 0.4;
-}
-
-:global(.docusaurus-highlight-code-line) .codeLineNumber::before {
-  opacity: 0.8;
-}
-
-.codeLineContent {
-  padding-right: var(--ifm-pre-padding);
 }

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/CodeBlock/Line';
+import styles from './styles.module.css';
+
+export default function CodeBlockLine({
+  line,
+  highlight,
+  showLineNumbers,
+  getLineProps,
+  getTokenProps,
+}: Props): JSX.Element {
+  if (line.length === 1 && line[0]!.content === '\n') {
+    line[0]!.content = '';
+  }
+
+  const lineProps = getLineProps({
+    line,
+    ...(showLineNumbers && {className: styles.codeLine}),
+  });
+
+  if (highlight) {
+    lineProps.className += ' docusaurus-highlight-code-line';
+  }
+
+  const lineTokens = line.map((token, key) => (
+    <span key={key} {...getTokenProps({token, key})} />
+  ));
+
+  return (
+    <span {...lineProps}>
+      {showLineNumbers ? (
+        <>
+          <span className={styles.codeLineNumber} />
+          <span className={styles.codeLineContent}>{lineTokens}</span>
+        </>
+      ) : (
+        <>
+          {lineTokens}
+          <br />
+        </>
+      )}
+    </span>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/styles.module.css
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.codeLine {
+  display: table-row;
+  counter-increment: line-count;
+}
+
+.codeLineNumber {
+  display: table-cell;
+  text-align: right;
+  width: 1%;
+  position: sticky;
+  left: 0;
+  padding: 0 var(--ifm-pre-padding);
+  background: var(--ifm-pre-background);
+}
+
+.codeLineNumber::before {
+  content: counter(line-count);
+  opacity: 0.4;
+}
+
+:global(.docusaurus-highlight-code-line) .codeLineNumber::before {
+  opacity: 0.8;
+}
+
+.codeLineContent {
+  padding-right: var(--ifm-pre-padding);
+}

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -7,13 +7,12 @@
 
 import React, {
   isValidElement,
-  useEffect,
-  useState,
   type ComponentProps,
-  type ReactElement,
+  type ReactNode,
 } from 'react';
 import clsx from 'clsx';
 import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import {
   useThemeConfig,
   parseCodeBlockTitle,
@@ -82,51 +81,47 @@ function CodeBlockLine({
   );
 }
 
-function childrenToString(children: string | ReactElement): string | null {
+/**
+ * Best attempt to make the children a plain string so it is copyable. If there
+ * are react elements, we will not be able to copy the content, and it will
+ * return `children` as-is; otherwise, it concatenates the string children
+ * together.
+ */
+function maybeStringifyChildren(children: ReactNode): ReactNode {
   if (React.Children.toArray(children).some((el) => isValidElement(el))) {
-    return null;
+    return children;
   }
   // The children is now guaranteed to be one/more plain strings
   return Array.isArray(children) ? children.join('') : (children as string);
 }
 
-// The Prism theme on SSR is always the default theme but the site theme
-// can be in a different mode. React hydration doesn't update DOM styles
-// that come from SSR. Hence force a re-render after mounting to apply the
-// current relevant styles. There will be a flash seen of the original
-// styles seen using this current approach but that's probably ok. Fixing
-// the flash will require changing the theming approach and is not worth it
-// at this point.
-function useCodeBlockKey(): string {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-  return String(mounted);
-}
-
-export default function CodeBlock({children, ...props}: Props): JSX.Element {
-  const key = useCodeBlockKey();
-  const childrenString = childrenToString(children);
-  return childrenString ? (
-    <CodeBlockString key={key} {...props}>
-      {childrenString}
-    </CodeBlockString>
-  ) : (
-    <CodeBlockJSX key={key} {...props}>
-      {children}
-    </CodeBlockJSX>
+export default function CodeBlock({
+  children: rawChildren,
+  ...props
+}: Props): JSX.Element {
+  // The Prism theme on SSR is always the default theme but the site theme can
+  // be in a different mode. React hydration doesn't update DOM styles that come
+  // from SSR. Hence force a re-render after mounting to apply the current
+  // relevant styles.
+  const isBrowser = useIsBrowser();
+  const children = maybeStringifyChildren(rawChildren);
+  const CodeBlockComp =
+    typeof children === 'string' ? CodeBlockString : CodeBlockJSX;
+  return (
+    <CodeBlockComp key={String(isBrowser)} {...props}>
+      {children as string}
+    </CodeBlockComp>
   );
 }
 
-function CodeBlockContainer<As extends 'div' | 'pre'>({
-  as: Wrapper,
+function CodeBlockContainer<T extends 'div' | 'pre'>({
+  as: As,
   ...props
-}: {as: As} & ComponentProps<As>) {
+}: {as: T} & ComponentProps<T>) {
   return (
-    // @ts-expect-error: TODO bad typing here
-    <Wrapper
-      {...props}
+    <As
+      // Polymorphic components are hard to type, without `oneOf` generics
+      {...(props as never)}
       className={clsx(
         props.className,
         styles.codeBlockContainer,
@@ -145,7 +140,6 @@ function CodeBlockJSX({children, className}: Props): JSX.Element {
   return (
     <CodeBlockContainer
       as="pre"
-       
       tabIndex={0}
       className={clsx(styles.codeBlockStandalone, 'thin-scrollbar', className)}
       style={prismCssVariables}>

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -107,21 +107,16 @@ function useCodeBlockKey(): string {
 
 export default function CodeBlock({children, ...props}: Props): JSX.Element {
   const key = useCodeBlockKey();
-
   const childrenString = childrenToString(children);
-  if (childrenString) {
-    return (
-      <CodeBlockString {...defaultProps} key={key} {...props}>
-        {childrenString}
-      </CodeBlockString>
-    );
-  } 
-    return (
-      <CodeBlockJSX key={key} {...props}>
-        {children}
-      </CodeBlockJSX>
-    );
-  
+  return childrenString ? (
+    <CodeBlockString key={key} {...props}>
+      {childrenString}
+    </CodeBlockString>
+  ) : (
+    <CodeBlockJSX key={key} {...props}>
+      {children}
+    </CodeBlockJSX>
+  );
 }
 
 // <pre> tags in markdown map to CodeBlocks. They may contain JSX children.

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -119,29 +119,38 @@ export default function CodeBlock({children, ...props}: Props): JSX.Element {
   );
 }
 
+function CodeBlockContainer<As extends 'div' | 'pre'>({
+  as: Wrapper,
+  ...props
+}: {as: As} & ComponentProps<As>) {
+  return (
+    // @ts-expect-error: TODO bad typing here
+    <Wrapper
+      {...props}
+      className={clsx(
+        props.className,
+        styles.codeBlockContainer,
+        ThemeClassNames.common.codeBlock,
+      )}
+    />
+  );
+}
+
 // <pre> tags in markdown map to CodeBlocks. They may contain JSX children.
 // When the children is not a simple string, we just return a styled block
 // without actually highlighting.
-function CodeBlockJSX({
-  children,
-  className: blockClassName,
-}: Props): JSX.Element {
+function CodeBlockJSX({children, className}: Props): JSX.Element {
   const prismTheme = usePrismTheme();
   const prismCssVariables = getPrismCssVariables(prismTheme);
   return (
-    <pre
-      /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+    <CodeBlockContainer
+      as="pre"
+       
       tabIndex={0}
-      className={clsx(
-        styles.codeBlockStandalone,
-        'thin-scrollbar',
-        styles.codeBlockContainer,
-        blockClassName,
-        ThemeClassNames.common.codeBlock,
-      )}
+      className={clsx(styles.codeBlockStandalone, 'thin-scrollbar', className)}
       style={prismCssVariables}>
       <code className={styles.codeBlockLines}>{children}</code>
-    </pre>
+    </CodeBlockContainer>
   );
 }
 
@@ -177,16 +186,12 @@ function CodeBlockString({
       code={code}
       language={(language ?? 'text') as Language}>
       {({className, tokens, getLineProps, getTokenProps}) => (
-        <div
-          className={clsx(
-            styles.codeBlockContainer,
-            blockClassName,
-            {
-              [`language-${language}`]:
-                language && !blockClassName.includes(`language-${language}`),
-            },
-            ThemeClassNames.common.codeBlock,
-          )}
+        <CodeBlockContainer
+          as="div"
+          className={clsx(blockClassName, {
+            [`language-${language}`]:
+              language && !blockClassName.includes(`language-${language}`),
+          })}
           style={prismCssVariables}>
           {codeBlockTitle && (
             <div className={styles.codeBlockTitle}>{codeBlockTitle}</div>
@@ -216,7 +221,7 @@ function CodeBlockString({
 
             <CopyButton code={code} />
           </div>
-        </div>
+        </CodeBlockContainer>
       )}
     </Highlight>
   );

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -182,11 +182,10 @@ export function getPrismCssVariables(prismTheme: PrismTheme): CSSProperties {
     backgroundColor: '--prism-background-color',
   };
 
-  const properties: CSSProperties = {};
+  const properties: {[key: string]: string} = {};
   Object.entries(prismTheme.plain).forEach(([key, value]) => {
     const varName = mapping[key];
     if (varName && typeof value === 'string') {
-      // @ts-expect-error: why css variables not in inline style type?
       properties[varName] = value;
     }
   });


### PR DESCRIPTION
## Motivation

Preliminary refactor before extracting new theme components meant to be swizzled

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Preview tests should be exactly as before

- https://docusaurus.io/tests/pages/code-block-tests
- https://deploy-preview-7175--docusaurus-2.netlify.app/tests/pages/code-block-tests

