### PR TITLE
fix(core): handle case where package.json is not available at CWD

### DIFF
--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -16,15 +16,23 @@ import boxen from 'boxen';
 import {createRequire} from 'module';
 
 const packageJson = createRequire(import.meta.url)('../package.json');
-const sitePkg = createRequire(path.join(process.cwd(), 'package.json'))(
-  './package.json',
-);
+/** @type {Record<string, any>} */
+let sitePkg;
+try {
+  sitePkg = createRequire(path.resolve('package.json'))('./package.json');
+} catch {
+  logger.warn`path=${'package.json'} file not found at CWD: path=${process.cwd()}.`;
+  logger.info`This is non-critical, but could lead to non-deterministic behavior downstream. Docusaurus assumes that path=${'package.json'} exists at CWD, because it's where the package manager looks up the script at. A common reason is because you have changed directory in the script. Instead of writing code=${'"start": "cd website && docusaurus start"'}, consider using the code=${'[siteDir]'} argument: code=${'"start": "docusaurus start website"'}.`;
+  sitePkg = {};
+}
 
 const {
   name,
   version,
   engines: {node: requiredVersion},
 } = packageJson;
+
+process.env.DOCUSAURUS_VERSION = version;
 
 /**
  * Notify user if `@docusaurus` packages are outdated

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -11,7 +11,6 @@
 import logger from '@docusaurus/logger';
 import fs from 'fs-extra';
 import cli from 'commander';
-import {createRequire} from 'module';
 import {
   build,
   swizzle,
@@ -29,9 +28,7 @@ await beforeCli();
 
 const resolveDir = (dir = '.') => fs.realpath(dir);
 
-cli
-  .version(createRequire(import.meta.url)('../package.json').version)
-  .usage('<command> [options]');
+cli.version(process.env.DOCUSAURUS_VERSION).usage('<command> [options]');
 
 cli
   .command('build [siteDir]')

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -27,9 +27,6 @@ import logger from '@docusaurus/logger';
 import _ from 'lodash';
 import type {Locals} from '@slorber/static-site-generator-webpack-plugin';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const packageJson = require('../../package.json');
-
 const getCompiledSSRTemplate = _.memoize((template: string) =>
   eta.compile(template.trim(), {
     rmWhitespace: true,
@@ -132,7 +129,7 @@ async function doRender(locals: Locals & {path: string}) {
     scripts,
     stylesheets,
     noIndex,
-    version: packageJson.version,
+    version: process.env.DOCUSAURUS_VERSION,
   });
 
   try {

--- a/packages/docusaurus/src/server/siteMetadata.ts
+++ b/packages/docusaurus/src/server/siteMetadata.ts
@@ -98,9 +98,7 @@ export async function loadSiteMetadata({
   siteDir: string;
 }): Promise<SiteMetadata> {
   const siteMetadata: SiteMetadata = {
-    docusaurusVersion: (await getPackageJsonVersion(
-      path.join(__dirname, '../../package.json'),
-    ))!,
+    docusaurusVersion: process.env.DOCUSAURUS_VERSION!,
     siteVersion: await getPackageJsonVersion(
       path.join(siteDir, 'package.json'),
     ),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Fix #7161. Moreover, this PR adds a `DOCUSAURUS_VERSION` env so that different environments can read this version without re-importing the package.json file.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Delete `website/package.json`, and add `"dev": "cd website && docusaurus start",` to the root package.json. The site starts gracefully:

<img width="1005" alt="image" src="https://user-images.githubusercontent.com/55398995/163701599-8df8988b-0aea-4e66-930d-0bbe7dbc969d.png">