### PR TITLE
fix(cli): always show error stack to unhandled rejection

### DIFF
--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -274,6 +274,6 @@ if (!process.argv.slice(2).length) {
 cli.parse(process.argv);
 
 process.on('unhandledRejection', (err) => {
-  logger.error(err);
+  logger.error(err instanceof Error ? err.stack : err);
   process.exit(1);
 });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Currently, all build-time errors don't show proper stack traces because we only log the error itself, which serializes to the message. We should log the full stack instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Throw an error from `lib/commands/build.js`.

Before:

<img width="950" alt="image" src="https://user-images.githubusercontent.com/55398995/164373666-d5a1339e-7a7b-4f34-ae11-6f36751db72d.png">

After:

<img width="950" alt="image" src="https://user-images.githubusercontent.com/55398995/164373691-eb6d6baf-478e-4b46-945e-67190d12f438.png">
