### PR TITLE
refactor(cli): normalize default value application

### DIFF
--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -56,14 +56,8 @@ cli
     '--no-minify',
     'build website without minimizing JS bundles (default: false)',
   )
-  .action(async (siteDir, {bundleAnalyzer, config, outDir, locale, minify}) => {
-    build(await resolveDir(siteDir), {
-      bundleAnalyzer,
-      outDir,
-      config,
-      locale,
-      minify,
-    });
+  .action(async (siteDir, options) => {
+    build(await resolveDir(siteDir), options);
   });
 
 cli
@@ -88,9 +82,9 @@ cli
     'copy TypeScript theme files when possible (default: false)',
   )
   .option('--danger', 'enable swizzle for unsafe component of themes')
-  .action(async (themeName, componentName, siteDir, options) => {
-    swizzle(await resolveDir(siteDir), themeName, componentName, options);
-  });
+  .action(async (themeName, componentName, siteDir, options) =>
+    swizzle(await resolveDir(siteDir), themeName, componentName, options),
+  );
 
 cli
   .command('deploy [siteDir]')
@@ -111,13 +105,9 @@ cli
     '--skip-build',
     'skip building website before deploy it (default: false)',
   )
-  .action(async (siteDir, {outDir, skipBuild, config}) => {
-    deploy(await resolveDir(siteDir), {
-      outDir,
-      config,
-      skipBuild,
-    });
-  });
+  .action(async (siteDir, options) =>
+    deploy(await resolveDir(siteDir), options),
+  );
 
 cli
   .command('start [siteDir]')
@@ -138,18 +128,8 @@ cli
     '--poll [interval]',
     'use polling rather than watching for reload (default: false). Can specify a poll interval in milliseconds',
   )
-  .action(
-    async (siteDir, {port, host, locale, config, hotOnly, open, poll}) => {
-      start(await resolveDir(siteDir), {
-        port,
-        host,
-        locale,
-        config,
-        hotOnly,
-        open,
-        poll,
-      });
-    },
+  .action(async (siteDir, options) =>
+    start(await resolveDir(siteDir), options),
   );
 
 cli
@@ -166,33 +146,14 @@ cli
   .option('-p, --port <port>', 'use specified port (default: 3000)')
   .option('--build', 'build website before serving (default: false)')
   .option('-h, --host <host>', 'use specified host (default: localhost)')
-  .action(
-    async (
-      siteDir,
-      {
-        dir = 'build',
-        port = 3000,
-        host = 'localhost',
-        build: buildSite = false,
-        config,
-      },
-    ) => {
-      serve(await resolveDir(siteDir), {
-        dir,
-        port,
-        build: buildSite,
-        config,
-        host,
-      });
-    },
+  .action(async (siteDir, options) =>
+    serve(await resolveDir(siteDir), options),
   );
 
 cli
   .command('clear [siteDir]')
   .description('Remove build artifacts.')
-  .action(async (siteDir) => {
-    clear(await resolveDir(siteDir));
-  });
+  .action(async (siteDir) => clear(await resolveDir(siteDir)));
 
 cli
   .command('write-translations [siteDir]')
@@ -213,18 +174,8 @@ cli
     '--messagePrefix <messagePrefix>',
     'allows to init new written messages with a given prefix. This might help you to highlight untranslated message to make them stand out in the UI',
   )
-  .action(
-    async (
-      siteDir,
-      {locale = undefined, override = false, messagePrefix = '', config},
-    ) => {
-      writeTranslations(await resolveDir(siteDir), {
-        locale,
-        override,
-        config,
-        messagePrefix,
-      });
-    },
+  .action(async (siteDir, options) =>
+    writeTranslations(await resolveDir(siteDir), options),
   );
 
 cli

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -31,7 +31,7 @@ import type {HelmetServerState} from 'react-helmet-async';
 
 export async function build(
   siteDir: string,
-  cliOptions: Partial<BuildCLIOptions> = {},
+  cliOptions: Partial<BuildCLIOptions>,
   // When running build, we force terminate the process to prevent async
   // operations from never returning. However, if run as part of docusaurus
   // deploy, we have to let deploy finish.

--- a/packages/docusaurus/src/commands/clear.ts
+++ b/packages/docusaurus/src/commands/clear.ts
@@ -26,7 +26,7 @@ async function removePath(entry: {path: string; description: string}) {
   }
 }
 
-export async function clear(siteDir: string): Promise<unknown> {
+export async function clear(siteDir: string): Promise<void> {
   const generatedFolder = {
     path: path.join(siteDir, GENERATED_FILES_DIR_NAME),
     description: 'generated folder',
@@ -40,7 +40,7 @@ export async function clear(siteDir: string): Promise<unknown> {
     path: path.join(siteDir, p, '.cache'),
     description: 'Webpack persistent cache folder',
   }));
-  return Promise.all(
+  await Promise.all(
     [generatedFolder, buildFolder, ...cacheFolders].map(removePath),
   );
 }

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -36,7 +36,7 @@ function shellExecLog(cmd: string) {
 
 export async function deploy(
   siteDir: string,
-  cliOptions: Partial<BuildCLIOptions> = {},
+  cliOptions: Partial<BuildCLIOptions>,
 ): Promise<void> {
   const {outDir, siteConfig, siteConfigPath} = await loadContext({
     siteDir,

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -12,13 +12,15 @@ import path from 'path';
 import {loadSiteConfig} from '../server/config';
 import {build} from './build';
 import {getCLIOptionHost, getCLIOptionPort} from './commandUtils';
+import {DEFAULT_BUILD_DIR_NAME} from '@docusaurus/utils';
 import type {ServeCLIOptions} from '@docusaurus/types';
 
 export async function serve(
   siteDir: string,
-  cliOptions: ServeCLIOptions,
+  cliOptions: Partial<ServeCLIOptions>,
 ): Promise<void> {
-  let dir = path.resolve(siteDir, cliOptions.dir);
+  const buildDir = cliOptions.dir ?? DEFAULT_BUILD_DIR_NAME;
+  let dir = path.resolve(siteDir, buildDir);
 
   if (cliOptions.build) {
     dir = await build(
@@ -69,7 +71,7 @@ export async function serve(
     });
   });
 
-  logger.success`Serving path=${cliOptions.dir} directory at url=${
+  logger.success`Serving path=${buildDir} directory at url=${
     servingUrl + baseUrl
   }.`;
   server.listen(port);

--- a/packages/docusaurus/src/commands/writeHeadingIds.ts
+++ b/packages/docusaurus/src/commands/writeHeadingIds.ts
@@ -42,8 +42,8 @@ async function getPathsToWatch(siteDir: string): Promise<string[]> {
 
 export async function writeHeadingIds(
   siteDir: string,
-  files?: string[],
-  options?: WriteHeadingIDOptions,
+  files: string[],
+  options: WriteHeadingIDOptions,
 ): Promise<void> {
   const markdownFiles = await safeGlobby(
     files ?? (await getPathsToWatch(siteDir)),

--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -74,7 +74,9 @@ async function writePluginTranslationFiles({
 
 export async function writeTranslations(
   siteDir: string,
-  options: WriteTranslationsOptions & ConfigOptions & {locale?: string},
+  options: Partial<
+    WriteTranslationsOptions & ConfigOptions & {locale?: string}
+  >,
 ): Promise<void> {
   const context = await loadContext({
     siteDir,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Right now, our CLI code is a bit messy, because default values are applied at different stages. Sometimes we apply default values directly in the command `action`; sometimes we pretend an argument of a function is optional while in practice it always exists... I decided to decouple the CLI implementation from the actual command interface, i.e. the CLI only passes the arguments down, without caring what's inside it. This should make the code much cleaner.

A big pain point of commander, though, is that its typings are quite loose. I can't find a great way to work around it at the moment.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

All commands work the same as before.