### PR TITLE
fix: allow swizzling a component's parent folder

### DIFF
--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexComp1.css
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexComp1.css
@@ -1,0 +1,3 @@
+.testClass {
+  background: black;
+}

--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexComp1.tsx
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexComp1.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function NoIndexComp1() {
+  return <div>NoIndexComp1</div>;
+}

--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexComp2.tsx
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexComp2.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function NoIndexComp2() {
+  return <div>NoIndexComp2</div>;
+}

--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexSub/NoIndexSubComp.tsx
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/NoIndex/NoIndexSub/NoIndexSubComp.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function NoIndexSubComp() {
+  return <div>NoIndexSubComp</div>;
+}

--- a/packages/docusaurus/src/commands/swizzle/__tests__/components.test.ts
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/components.test.ts
@@ -19,10 +19,8 @@ describe('readComponentNames', () => {
       Components.ComponentInSubFolder,
       Components.Sibling,
       Components.FirstLevelComponent,
-      Components.NoIndex,
       Components.NoIndexComp1,
       Components.NoIndexComp2,
-      Components.NoIndexSub,
       Components.NoIndexSubComp,
     ]);
   });
@@ -164,6 +162,39 @@ describe('getThemeComponents', () => {
     ).toBe('unsafe');
     expect(
       themeComponents.getActionStatus(Components.FirstLevelComponent, 'eject'),
+    ).toBe('unsafe');
+
+    expect(
+      themeComponents.getActionStatus(Components.NoIndexComp1, 'wrap'),
+    ).toBe('unsafe');
+    expect(
+      themeComponents.getActionStatus(Components.NoIndexComp1, 'eject'),
+    ).toBe('unsafe');
+    expect(
+      themeComponents.getActionStatus(Components.NoIndexComp2, 'wrap'),
+    ).toBe('unsafe');
+    expect(
+      themeComponents.getActionStatus(Components.NoIndexComp2, 'eject'),
+    ).toBe('unsafe');
+    expect(
+      themeComponents.getActionStatus(Components.NoIndexSubComp, 'wrap'),
+    ).toBe('unsafe');
+    expect(
+      themeComponents.getActionStatus(Components.NoIndexSubComp, 'eject'),
+    ).toBe('unsafe');
+
+    // Intermediate folders are not real components: forbidden to wrap!
+    expect(themeComponents.getActionStatus(Components.NoIndex, 'wrap')).toBe(
+      'forbidden',
+    );
+    expect(themeComponents.getActionStatus(Components.NoIndex, 'eject')).toBe(
+      'unsafe',
+    );
+    expect(themeComponents.getActionStatus(Components.NoIndexSub, 'wrap')).toBe(
+      'forbidden',
+    );
+    expect(
+      themeComponents.getActionStatus(Components.NoIndexSub, 'eject'),
     ).toBe('unsafe');
   });
 

--- a/packages/docusaurus/src/commands/swizzle/__tests__/components.test.ts
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/components.test.ts
@@ -19,6 +19,11 @@ describe('readComponentNames', () => {
       Components.ComponentInSubFolder,
       Components.Sibling,
       Components.FirstLevelComponent,
+      Components.NoIndex,
+      Components.NoIndexComp1,
+      Components.NoIndexComp2,
+      Components.NoIndexSub,
+      Components.NoIndexSubComp,
     ]);
   });
 });
@@ -66,6 +71,11 @@ describe('getThemeComponents', () => {
       Components.ComponentInSubFolder,
       Components.Sibling,
       Components.FirstLevelComponent,
+      Components.NoIndex,
+      Components.NoIndexComp1,
+      Components.NoIndexComp2,
+      Components.NoIndexSub,
+      Components.NoIndexSubComp,
     ]);
   });
 

--- a/packages/docusaurus/src/commands/swizzle/__tests__/testUtils.ts
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/testUtils.ts
@@ -16,6 +16,11 @@ export const Components = {
   Sibling: 'ComponentInFolder/Sibling',
   ComponentInFolder: 'ComponentInFolder',
   FirstLevelComponent: 'FirstLevelComponent',
+  NoIndex: 'NoIndex',
+  NoIndexComp1: 'NoIndex/NoIndexComp1',
+  NoIndexComp2: 'NoIndex/NoIndexComp2',
+  NoIndexSub: 'NoIndex/NoIndexSub',
+  NoIndexSubComp: 'NoIndex/NoIndexSub/NoIndexSubComp',
 };
 
 export async function createTempSiteDir(): Promise<string> {

--- a/packages/docusaurus/src/commands/swizzle/components.ts
+++ b/packages/docusaurus/src/commands/swizzle/components.ts
@@ -42,9 +42,14 @@ function sortComponentNames(componentNames: string[]): string[] {
   return componentNames.sort(); // Algo may change?
 }
 
-// Even if a folder is not directly a component,
-// we still want to be able to swizzle parent folders of any component
-// See https://github.com/facebook/docusaurus/pull/7175#issuecomment-1103757218
+/**
+ * Expand a list of components to include and return parent folders.
+ * If a folder is not directly a component (no Folder/index.tsx file),
+ * we still want to be able to swizzle --eject that folder.
+ * See https://github.com/facebook/docusaurus/pull/7175#issuecomment-1103757218
+ *
+ * @param componentNames the original list of component names
+ */
 function getMissingIntermediateComponentFolderNames(
   componentNames: string[],
 ): string[] {

--- a/packages/docusaurus/src/commands/swizzle/config.ts
+++ b/packages/docusaurus/src/commands/swizzle/config.ts
@@ -48,33 +48,35 @@ function getModuleSwizzleConfig(
   return undefined;
 }
 
-export function normalizeSwizzleConfig(
-  unsafeSwizzleConfig: unknown,
-): SwizzleConfig {
-  const schema = Joi.object<SwizzleConfig>({
-    components: Joi.object()
-      .pattern(
-        Joi.string(),
-        Joi.object({
-          actions: Joi.object().pattern(
-            Joi.string().valid(...SwizzleActions),
-            Joi.string().valid(...SwizzleActionsStatuses),
-          ),
-          description: Joi.string(),
-        }),
-      )
-      .required(),
-  });
+const SwizzleConfigSchema = Joi.object<SwizzleConfig>({
+  components: Joi.object()
+    .pattern(
+      Joi.string(),
+      Joi.object({
+        actions: Joi.object().pattern(
+          Joi.string().valid(...SwizzleActions),
+          Joi.string().valid(...SwizzleActionsStatuses),
+        ),
+        description: Joi.string(),
+      }),
+    )
+    .required(),
+});
 
-  const result = schema.validate(unsafeSwizzleConfig);
-
+function validateSwizzleConfig(unsafeSwizzleConfig: unknown): SwizzleConfig {
+  const result = SwizzleConfigSchema.validate(unsafeSwizzleConfig);
   if (result.error) {
     throw new Error(
       `Swizzle config does not match expected schema: ${result.error.message}`,
     );
   }
+  return result.value;
+}
 
-  const swizzleConfig: SwizzleConfig = result.value;
+export function normalizeSwizzleConfig(
+  unsafeSwizzleConfig: unknown,
+): SwizzleConfig {
+  const swizzleConfig = validateSwizzleConfig(unsafeSwizzleConfig);
 
   // Ensure all components always declare all actions
   Object.values(swizzleConfig.components).forEach((componentConfig) => {


### PR DESCRIPTION
## Motivation

We should be able to swizzle a parent folder of any component to be able to eject the whole folder at once

See also https://github.com/facebook/docusaurus/pull/7175#issuecomment-1103757218

It's currently not possible to eject `CodeBlock/Content` because it has no index and is not appearing in the list:

<img width="606" alt="CleanShot 2022-04-21 at 20 16 05@2x" src="https://user-images.githubusercontent.com/749374/164526821-6aa83ef3-07ff-4eba-a9f0-6dca255b0a30.png">

This now works:

```bash
yarn workspace website docusaurus swizzle @docusaurus/theme-classic CodeBlock/Content --eject --danger
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tests


