### PR TITLE
fix(content-docs): make category index text translatable

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/globalData.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/globalData.test.ts.snap
@@ -18,6 +18,11 @@ exports[`toGlobalDataVersion generates the right docs, sidebars, and metadata 1`
       "path": "/current/generated",
       "sidebar": "tutorial",
     },
+    {
+      "id": "/current/generated-2",
+      "path": "/current/generated-2",
+      "sidebar": "another",
+    },
   ],
   "draftIds": [
     "some-draft-id",
@@ -31,7 +36,7 @@ exports[`toGlobalDataVersion generates the right docs, sidebars, and metadata 1`
     "another": {
       "link": {
         "label": "Generated",
-        "path": "/current/generated",
+        "path": "/current/generated-2",
       },
     },
     "links": {},

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/globalData.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/globalData.test.ts
@@ -6,9 +6,79 @@
  */
 
 import {toGlobalDataVersion} from '../globalData';
+import {createSidebarsUtils} from '../sidebars/utils';
+import {getCategoryGeneratedIndexMetadataList} from '../categoryGeneratedIndex';
+import type {Sidebars} from '../sidebars/types';
 
 describe('toGlobalDataVersion', () => {
   it('generates the right docs, sidebars, and metadata', () => {
+    const docs = [
+      {
+        unversionedId: 'main',
+        permalink: '/current/main',
+        sidebar: 'tutorial',
+        frontMatter: {},
+      },
+      {
+        unversionedId: 'doc',
+        permalink: '/current/doc',
+        sidebar: 'tutorial',
+        frontMatter: {},
+      },
+    ];
+    const sidebars: Sidebars = {
+      tutorial: [
+        {
+          type: 'doc',
+          id: 'main',
+        },
+        {
+          type: 'category',
+          label: 'Generated',
+          link: {
+            type: 'generated-index',
+            permalink: '/current/generated',
+            slug: '/current/generated',
+          },
+          items: [
+            {
+              type: 'doc',
+              id: 'doc',
+            },
+          ],
+        },
+      ],
+      links: [
+        {
+          type: 'link',
+          href: 'foo',
+          label: 'Foo',
+        },
+        {
+          type: 'link',
+          href: 'bar',
+          label: 'Bar',
+        },
+      ],
+      another: [
+        {
+          type: 'category',
+          label: 'Generated',
+          link: {
+            type: 'generated-index',
+            permalink: '/current/generated-2',
+            slug: '/current/generated-2',
+          },
+          items: [
+            {
+              type: 'doc',
+              id: 'doc',
+            },
+          ],
+        },
+      ],
+    };
+    const sidebarsUtils = createSidebarsUtils(sidebars);
     expect(
       toGlobalDataVersion({
         versionName: 'current',
@@ -16,18 +86,7 @@ describe('toGlobalDataVersion', () => {
         isLast: true,
         path: '/current',
         mainDocId: 'main',
-        docs: [
-          {
-            unversionedId: 'main',
-            permalink: '/current/main',
-            sidebar: 'tutorial',
-          },
-          {
-            unversionedId: 'doc',
-            permalink: '/current/doc',
-            sidebar: 'tutorial',
-          },
-        ],
+        docs,
         drafts: [
           {
             unversionedId: 'some-draft-id',
@@ -35,64 +94,12 @@ describe('toGlobalDataVersion', () => {
             sidebar: undefined,
           },
         ],
-        sidebars: {
-          another: [
-            {
-              type: 'category',
-              label: 'Generated',
-              link: {
-                type: 'generated-index',
-                permalink: '/current/generated',
-              },
-              items: [
-                {
-                  type: 'doc',
-                  id: 'doc',
-                },
-              ],
-            },
-          ],
-          tutorial: [
-            {
-              type: 'doc',
-              id: 'main',
-            },
-            {
-              type: 'category',
-              label: 'Generated',
-              link: {
-                type: 'generated-index',
-                permalink: '/current/generated',
-              },
-              items: [
-                {
-                  type: 'doc',
-                  id: 'doc',
-                },
-              ],
-            },
-          ],
-          links: [
-            {
-              type: 'link',
-              href: 'foo',
-              label: 'Foo',
-            },
-            {
-              type: 'link',
-              href: 'bar',
-              label: 'Bar',
-            },
-          ],
-        },
-        categoryGeneratedIndices: [
-          {
-            title: 'Generated',
-            slug: '/current/generated',
-            permalink: '/current/generated',
-            sidebar: 'tutorial',
-          },
-        ],
+        sidebars,
+        categoryGeneratedIndices: getCategoryGeneratedIndexMetadataList({
+          docs,
+          sidebarsUtils,
+        }),
+        sidebarsUtils,
         banner: 'unreleased',
         badge: true,
         className: 'current-cls',

--- a/packages/docusaurus-plugin-content-docs/src/globalData.ts
+++ b/packages/docusaurus-plugin-content-docs/src/globalData.ts
@@ -7,8 +7,8 @@
 
 import _ from 'lodash';
 import type {Sidebars} from './sidebars/types';
-import {createSidebarsUtils} from './sidebars/utils';
-import type {LoadedVersion} from './types';
+import {getMainDocId} from './docs';
+import type {FullVersion} from './types';
 import type {
   CategoryGeneratedIndexMetadata,
   DocMetadata,
@@ -39,11 +39,10 @@ function toGlobalDataGeneratedIndex(
 
 function toGlobalSidebars(
   sidebars: Sidebars,
-  version: LoadedVersion,
+  version: FullVersion,
 ): {[sidebarId: string]: GlobalSidebar} {
-  const {getFirstLink} = createSidebarsUtils(sidebars);
   return _.mapValues(sidebars, (sidebar, sidebarId) => {
-    const firstLink = getFirstLink(sidebarId);
+    const firstLink = version.sidebarsUtils.getFirstLink(sidebarId);
     if (!firstLink) {
       return {};
     }
@@ -62,13 +61,13 @@ function toGlobalSidebars(
   });
 }
 
-export function toGlobalDataVersion(version: LoadedVersion): GlobalVersion {
+export function toGlobalDataVersion(version: FullVersion): GlobalVersion {
   return {
     name: version.versionName,
     label: version.label,
     isLast: version.isLast,
     path: version.path,
-    mainDocId: version.mainDocId,
+    mainDocId: getMainDocId(version),
     docs: version.docs
       .map(toGlobalDataDoc)
       .concat(version.categoryGeneratedIndices.map(toGlobalDataGeneratedIndex)),

--- a/packages/docusaurus-plugin-content-docs/src/routes.ts
+++ b/packages/docusaurus-plugin-content-docs/src/routes.ts
@@ -7,7 +7,7 @@
 
 import type {PluginContentLoadedActions, RouteConfig} from '@docusaurus/types';
 import {docuHash, createSlugger} from '@docusaurus/utils';
-import type {LoadedVersion} from './types';
+import type {FullVersion} from './types';
 import type {
   CategoryGeneratedIndexMetadata,
   DocMetadata,
@@ -21,7 +21,7 @@ export async function createCategoryGeneratedIndexRoutes({
   docCategoryGeneratedIndexComponent,
   aliasedSource,
 }: {
-  version: LoadedVersion;
+  version: FullVersion;
   actions: PluginContentLoadedActions;
   docCategoryGeneratedIndexComponent: string;
   aliasedSource: (str: string) => string;
@@ -99,7 +99,7 @@ export async function createDocRoutes({
 }
 
 export async function createVersionRoutes({
-  loadedVersion,
+  version,
   actions,
   docItemComponent,
   docLayoutComponent,
@@ -107,7 +107,7 @@ export async function createVersionRoutes({
   pluginId,
   aliasedSource,
 }: {
-  loadedVersion: LoadedVersion;
+  version: FullVersion;
   actions: PluginContentLoadedActions;
   docLayoutComponent: string;
   docItemComponent: string;
@@ -115,7 +115,7 @@ export async function createVersionRoutes({
   pluginId: string;
   aliasedSource: (str: string) => string;
 }): Promise<void> {
-  async function doCreateVersionRoutes(version: LoadedVersion): Promise<void> {
+  async function doCreateVersionRoutes(): Promise<void> {
     const versionMetadata = toVersionMetadataProp(pluginId, version);
     const versionMetadataPropPath = await actions.createData(
       `${docuHash(`version-${version.versionName}-metadata-prop`)}.json`,
@@ -151,9 +151,9 @@ export async function createVersionRoutes({
   }
 
   try {
-    return await doCreateVersionRoutes(loadedVersion);
+    return await doCreateVersionRoutes();
   } catch (err) {
-    logger.error`Can't create version routes for version name=${loadedVersion.versionName}`;
+    logger.error`Can't create version routes for version name=${version.versionName}`;
     throw err;
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/types.ts
@@ -16,6 +16,7 @@ import type {
   CategoryGeneratedIndexMetadata,
 } from '@docusaurus/plugin-content-docs';
 import type {Tag} from '@docusaurus/types';
+import type {SidebarsUtils} from './sidebars/utils';
 
 export type DocFile = {
   contentPath: string; // /!\ may be localized
@@ -38,15 +39,18 @@ export type VersionTags = {
 };
 
 export type LoadedVersion = VersionMetadata & {
-  mainDocId: string;
   docs: DocMetadata[];
   drafts: DocMetadata[];
   sidebars: Sidebars;
-  categoryGeneratedIndices: CategoryGeneratedIndexMetadata[];
 };
 
 export type LoadedContent = {
   loadedVersions: LoadedVersion[];
+};
+
+export type FullVersion = LoadedVersion & {
+  sidebarsUtils: SidebarsUtils;
+  categoryGeneratedIndices: CategoryGeneratedIndexMetadata[];
 };
 
 export type DocBrokenMarkdownLink = BrokenMarkdownLink<VersionMetadata>;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Reported in https://github.com/facebook/docusaurus/issues/4542#issuecomment-1107411164

This PR enforces single source of truth for the docs content. We no longer derive some content fields from other content fields, so that we don't accidentally forget some translations.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally with `yarn write-translations -l zh-CN` and translating some descriptions.

<img width="492" alt="image" src="https://user-images.githubusercontent.com/55398995/164888501-67904304-eb4b-4c91-8e6e-b85a0741ff35.png">
