### PR TITLE
docs: update gtag docs to reflect what a GA4 tag looks like

### DIFF
--- a/website/docs/api/plugins/plugin-google-gtag.md
+++ b/website/docs/api/plugins/plugin-google-gtag.md
@@ -63,7 +63,7 @@ Most Docusaurus users configure this plugin through the preset options.
 // Plugin Options: @docusaurus/plugin-google-gtag
 
 const config = {
-  trackingID: '141789564',
+  trackingID: 'G-226F0LR9KE',
   anonymizeIP: true,
 };
 ```


### PR DESCRIPTION
## Motivation

This PR is a follow on from https://github.com/facebook/docusaurus/pull/6184 which I mean to improve the docs for GA4 but actually didn't.  This was discussed in https://github.com/facebook/docusaurus/issues/7221

The change made in this PR reflects the format required for GA4 properties which I'm successfully using here: https://github.com/johnnyreilly/blog.johnnyreilly.com/blob/4e824dc2172efca72c075f1dbc3a39a92fd22064/blog-website/docusaurus.config.js#L35

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No test - it's docs 

## Related PRs

See above