### PR TITLE
refactor: remove long-deprecated routesLoaded lifecycle

### DIFF
--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -319,7 +319,6 @@ export type Plugin<Content = unknown> = {
     allContent: AllContent;
     actions: PluginContentLoadedActions;
   }) => Promise<void> | void;
-  routesLoaded?: (routes: RouteConfig[]) => void; // TODO remove soon, deprecated (alpha-60)
   postBuild?: (
     props: Props & {
       content: Content;

--- a/packages/docusaurus/src/server/plugins/index.ts
+++ b/packages/docusaurus/src/server/plugins/index.ts
@@ -19,7 +19,6 @@ import type {
 } from '@docusaurus/types';
 import {initPlugins} from './init';
 import {createBootstrapPlugin, createMDXFallbackPlugin} from './synthetic';
-import logger from '@docusaurus/logger';
 import _ from 'lodash';
 import {localizePluginTranslationFile} from '../translations/translations';
 import {applyRouteTrailingSlash, sortConfig} from './routeConfig';
@@ -144,21 +143,6 @@ export async function loadPlugins(context: LoadContext): Promise<{
       };
 
       await plugin.contentLoaded({content, actions, allContent});
-    }),
-  );
-
-  // 4. Plugin Lifecycle - routesLoaded.
-  await Promise.all(
-    loadedPlugins.map(async (plugin) => {
-      if (!plugin.routesLoaded) {
-        return;
-      }
-
-      // TODO alpha-60: remove this deprecated lifecycle soon
-      // 1 user reported usage of this lifecycle: https://github.com/facebook/docusaurus/issues/3918
-      logger.error`Plugin code=${'routesLoaded'} lifecycle is deprecated. If you think we should keep this lifecycle, please report here: url=${'https://github.com/facebook/docusaurus/issues/3918'}`;
-
-      await plugin.routesLoaded(pluginsRouteConfigs);
     }),
   );
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

Close #3918. After 1 year and a half, we only had one user complaining, and there's no follow-up. I can only assume that this is going to impact no-one.

#3918 mentioned search plugins as a use-case. We now have many successful search plugins that read the routes data through `postBuild`, so I believe there's no valid use-case of this lifecycle anymore.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
