### PR TITLE
chore: remove baseUrl from tsconfig

### DIFF
--- a/packages/docusaurus-plugin-ideal-image/tsconfig.json
+++ b/packages/docusaurus-plugin-ideal-image/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "lib": ["DOM", "ES2019"],
     "rootDir": "src",
-    "baseUrl": "src",
     "outDir": "lib"
   }
 }

--- a/packages/docusaurus-plugin-pwa/tsconfig.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "lib": ["DOM", "ES2019"],
     "rootDir": "src",
-    "baseUrl": "src",
     "outDir": "lib"
   }
 }

--- a/packages/docusaurus-theme-classic/tsconfig.json
+++ b/packages/docusaurus-theme-classic/tsconfig.json
@@ -4,8 +4,7 @@
     "lib": ["DOM", "ES2019"],
     "module": "esnext",
     "noEmit": true,
-    "jsx": "react-native",
-    "baseUrl": "src"
+    "jsx": "react-native"
   },
   "include": ["src/"]
 }

--- a/packages/docusaurus-theme-search-algolia/tsconfig.json
+++ b/packages/docusaurus-theme-search-algolia/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "lib": ["DOM", "ES2019"],
     "rootDir": "src",
-    "baseUrl": "src",
     "outDir": "lib"
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md

If this PR adds or changes functionality, please take some time to update the docs.

Happy contributing!

-->

## Motivation

The `baseUrl` is actually a config option that informs TS about path-mapping. Because we don't have any path-mapping, this is useless and leads to problems if you try to import something in node_modules, because it will import the file with the same name in `src` in priority.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
