### PR TITLE
misc: add links section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,14 @@ Happy contributing!
 
 <!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
 
-## Related PRs
+## Links
 
-<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. -->
+<!--
+🙏 Please add an exhaustive list of links relevant to this pull-request.
+⏱ This saves maintainers a lot of time during reviews.
+
+Example:
+- 🔗 link to new and updated documentation pages, using the deploy preview
+- 🔗 link to test pages: you can add tests to docusaurus/website/_dogfooding, those are deployed at https://docusaurus.io/tests
+- 🔗 link to related pull-requests and issues
+-->


### PR DESCRIPTION
This is really helpful in PR to have links to:
- all docs pages
- all dogfood tests

This saves me a ton of time, and when it's not done, I generally do this even just for myself.

Sometimes it takes a long time to read diff, find relevant doc changes, infer URLs mentally and navigate to relevant doc pages, and a doc page may require multiple reviews before merging so it's really a time saver to include links ahead of time.