### PR TITLE
refactor(core): prefetch/preload refactor

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -346,3 +346,10 @@ declare module '*.css' {
   const src: string;
   export default src;
 }
+
+interface Window {
+  docusaurus: {
+    prefetch: (url: string) => false | Promise<void[]>;
+    preload: (url: string) => false | Promise<void[]>;
+  };
+}

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -62,7 +62,9 @@ class PendingNavigation extends React.Component<Props, State> {
       location: nextLocation,
     })!;
 
-    // Load data while the old screen remains.
+    // Load data while the old screen remains. Force preload instead of using
+    // `window.docusaurus`, because we want to avoid loading screen even when
+    // user is on saveData
     preload(nextLocation.pathname)
       .then(() => {
         this.routeUpdateCleanupCb?.();

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -21,13 +21,6 @@ import {useBaseUrlUtils} from './useBaseUrl';
 import {applyTrailingSlash} from '@docusaurus/utils-common';
 
 import type {Props} from '@docusaurus/Link';
-import type docusaurus from '../docusaurus';
-
-declare global {
-  interface Window {
-    docusaurus: typeof docusaurus;
-  }
-}
 
 // TODO all this wouldn't be necessary if we used ReactRouter basename feature
 // We don't automatically add base urls to all links,

--- a/packages/docusaurus/src/client/flat.ts
+++ b/packages/docusaurus/src/client/flat.ts
@@ -25,18 +25,18 @@ export default function flat(target: ChunkNames): {[keyPath: string]: string} {
   const delimiter = '.';
   const output: {[keyPath: string]: string} = {};
 
-  function step(object: Tree, prefix?: string | number) {
+  function dfs(object: Tree, prefix?: string | number) {
     Object.entries(object).forEach(([key, value]) => {
       const newKey = prefix ? `${prefix}${delimiter}${key}` : key;
 
       if (isTree(value)) {
-        step(value, newKey);
+        dfs(value, newKey);
       } else {
         output[newKey] = value;
       }
     });
   }
 
-  step(target);
+  dfs(target);
   return output;
 }

--- a/packages/docusaurus/src/client/prefetch.ts
+++ b/packages/docusaurus/src/client/prefetch.ts
@@ -14,7 +14,7 @@ function supports(feature: string) {
   }
 }
 
-function linkPrefetchStrategy(url: string) {
+function linkPrefetchStrategy(url: string): Promise<void> {
   return new Promise((resolve, reject) => {
     if (typeof document === 'undefined') {
       reject();
@@ -25,8 +25,8 @@ function linkPrefetchStrategy(url: string) {
     link.setAttribute('rel', 'prefetch');
     link.setAttribute('href', url);
 
-    link.onload = resolve;
-    link.onerror = reject;
+    link.onload = () => resolve();
+    link.onerror = () => reject();
 
     const parentElement =
       document.getElementsByTagName('head')[0] ??
@@ -57,20 +57,6 @@ const supportedPrefetchStrategy = supports('prefetch')
   ? linkPrefetchStrategy
   : xhrPrefetchStrategy;
 
-const preFetched: {[url: string]: boolean} = {};
-
 export default function prefetch(url: string): Promise<void> {
-  return new Promise((resolve) => {
-    if (preFetched[url]) {
-      resolve();
-      return;
-    }
-
-    supportedPrefetchStrategy(url)
-      .then(() => {
-        resolve();
-        preFetched[url] = true;
-      })
-      .catch(() => {}); // 404s are logged to the console anyway.
-  });
+  return supportedPrefetchStrategy(url).catch(() => {}); // 404s are logged to the console anyway.
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

With this change:

- We are using `Set` instead of an object as the memoization layer, which should be more performant & has better semantics.
- The duplicated `prefetch` memoization has been deduplicated. `prefetchHelper` now does not memoize on itself; only `window.docusaurus.prefetch` does. This is fine, because we don't call `prefetchHelper` directly anywhere else.
- `window.docusaurus.preload` and `window.docusaurus.prefetch` now return `Promise<void[]>` instead of `true`, which can allow external callers to wait for them instead of having floating promises.

## Test Plan

Prefetching work the same. You can confirm by scrolling down a page and see the network cascade expanding whenever a new link is in viewport.