### PR TITLE
chore: fix pnpm E2E test to work on pnpm v7

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -166,7 +166,7 @@ jobs:
         env:
           npm_config_registry: http://localhost:4873
       - name: Start test-website project
-        run: pnpm run start -- --no-open
+        run: pnpm start --no-open
         working-directory: ../test-website
         env:
           E2E_TEST: true

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - packages/**
       - tsconfig.json
+      - .github/workflows/tests-e2e.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -116,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
       - name: Use Node.js 16
         uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # v3
         with:
@@ -146,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
       - name: Use Node.js 16
         uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # v3
         with:
@@ -158,8 +159,9 @@ jobs:
         run: yarn test:build:website -s
       - name: Install test-website project with pnpm
         run: |
-          curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
-          pnpm install
+          npm install -g pnpm
+          # Fix some peer dependencies errors
+          pnpm add @algolia/client-search @types/react@17 typescript
         working-directory: ../test-website
         env:
           npm_config_registry: http://localhost:4873


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Due to https://github.com/pnpm/pnpm/pull/4427, our pnpm action has been failing. I hope this is sufficient to fix it. I'm curious why the Yarn one works, even with `pnpFallbackMode none`, though!

## Test Plan

The E2E test is now triggered when the action file changes, so we can preview the effect.