### PR TITLE
fix(core): allow empty static directories

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -124,7 +124,11 @@ async function buildLocale({
     outDir,
     generatedFilesDir,
     plugins,
-    siteConfig: {baseUrl, onBrokenLinks, staticDirectories},
+    siteConfig: {
+      baseUrl,
+      onBrokenLinks,
+      staticDirectories: staticDirectoriesOption,
+    },
     routes,
   } = props;
 
@@ -162,15 +166,29 @@ async function buildLocale({
     },
   });
 
-  if (staticDirectories.length > 0) {
-    await Promise.all(staticDirectories.map((dir) => fs.ensureDir(dir)));
+  // The staticDirectories option can contain empty directories, or non-existent
+  // directories (e.g. user deleted `static`). Instead of issuing an error, we
+  // just silently filter then out.
+  const staticDirectories = (
+    await Promise.all(
+      staticDirectoriesOption.map(async (dir) => {
+        const staticDir = path.resolve(siteDir, dir);
+        if (
+          (await fs.pathExists(staticDir)) &&
+          (await fs.readdir(staticDir)).length > 0
+        ) {
+          return staticDir;
+        }
+        return '';
+      }),
+    )
+  ).filter(Boolean);
 
+  if (staticDirectories.length > 0) {
     serverConfig = merge(serverConfig, {
       plugins: [
         new CopyWebpackPlugin({
-          patterns: staticDirectories
-            .map((dir) => path.resolve(siteDir, dir))
-            .map((dir) => ({from: dir, to: outDir})),
+          patterns: staticDirectories.map((dir) => ({from: dir, to: outDir})),
         }),
       ],
     });

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -168,7 +168,8 @@ async function buildLocale({
 
   // The staticDirectories option can contain empty directories, or non-existent
   // directories (e.g. user deleted `static`). Instead of issuing an error, we
-  // just silently filter then out.
+  // just silently filter them out, because user could have never configured it
+  // in the first place (the default option should always "work").
   const staticDirectories = (
     await Promise.all(
       staticDirectoriesOption.map(async (dir) => {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -120,6 +120,9 @@ const config = {
   staticDirectories: [
     'static',
     path.join(__dirname, '_dogfooding/_asset-tests'),
+    // Adding a non-existent static directory. If user deleted `static` without
+    // specifying `staticDirectories: []`, build should still work
+    path.join(__dirname, '_dogfooding/non-existent'),
   ],
   themes: ['live-codeblock', ...dogfoodingThemeInstances],
   plugins: [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
  - I _really_ want to add tests but I don't know how to persist it, so see test plan below
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

It turns out that simply `ensureDir` is not sufficient to make build succeed with an empty static folder. To reproduce, do `mkdir website/_dogfooding/emptyStaticDir`, and add `_dogfooding/emptyStaticDir` to the `staticDirectories` list, then run `yarn build -l en`. Server build errors with:

```
unable to locate '/.../docusaurus/website/_dogfooding/emptyStaticDir/**/*' glob
```

This seems to be a bad thing to happen for a glob pattern, but just in case, I've simply filtered out all non-existent directories instead of creating empty ones. This also means the user doesn't magically have a static folder created after every build.

## Test Plan

Tested locally with the above reproduction. I don't really know how to add a dogfooding test—my suspicion is it's impossible to do it in a simple way, because empty dirs aren't checked in to git... I just added a directory that doesn't exist, which should do half the job.

## Related issues/PRs

https://github.com/facebook/docusaurus/issues/6311