### PR TITLE
refactor: use export = syntax for Node utility packages

### DIFF
--- a/packages/docusaurus-logger/src/index.ts
+++ b/packages/docusaurus-logger/src/index.ts
@@ -149,7 +149,4 @@ const logger = {
 
 // TODO remove when migrating to ESM
 // logger can only be default-imported in ESM with this
-module.exports = logger;
-module.exports.default = logger;
-
-export default logger;
+export = logger;

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.ts
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.ts
@@ -6,9 +6,7 @@
  */
 
 import remark from 'remark';
-// Import from the transpiled lib because Babel can't transpile `export =`
-// TODO change to `../index` after migrating to ESM
-import npm2yarn from '../../lib/index';
+import npm2yarn from '../index';
 import vfile from 'to-vfile';
 import path from 'path';
 import mdx from 'remark-mdx';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

We previously had some hack around `module.exports` to support importing these packages in both ESM and CJS, because `export default` will be compiled to `module.exports.default = `, which will work in neither ESM nor CJS (only in TypeScript, where it knows how to handle `default`). This turns out to be no longer necessary now, because we use SWC instead of Babel, which supports `export = ` OOTB, without bringing some extra plugins.

## Test Plan

Everything still works