### PR TITLE
docs: remove extraneous line break tags

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -367,8 +367,6 @@ import MyComponentSource from '!!raw-loader!@site/src/pages/examples/_myComponen
 <CodeBlock language="jsx">{MyComponentSource}</CodeBlock>
 
 </BrowserWindow>
-
-<br />
 ```
 
 See [using code blocks in JSX](./markdown-features-code-blocks.mdx#usage-in-jsx) for more details of the `<CodeBlock>` component.
@@ -409,15 +407,13 @@ import PartialExample from './_markdown-partial-example.mdx';
 <BrowserWindow>
   <PartialExample name="Sebastien" />
 </BrowserWindow>
-
-<br />
 ```
 
 This way, you can reuse content among multiple pages and avoid duplicating materials.
 
 :::caution
 
-The table of contents does not currently contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
+Currently, the table of contents does not contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
 
 :::
 

--- a/website/docs/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-tabs.mdx
@@ -75,7 +75,6 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
     <TabItem value="banana">This is a banana 🍌</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 <details>
@@ -163,7 +162,6 @@ You may want choices of the same kind of tabs to sync with each other. For examp
     <TabItem value="mac" label="macOS">Use Command + V to paste.</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 For all tab groups that have the same `groupId`, the possible values do not need to be the same. If one tab group is chosen a value that does not exist in another tab group with the same `groupId`, the tab group with the missing value won't change its tab. You can see that from the following example. Try to select Linux, and the above tab groups don't change.

--- a/website/versioned_docs/version-2.0.0-beta.17/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.17/guides/markdown-features/markdown-features-react.mdx
@@ -365,8 +365,6 @@ import MyComponentSource from '!!raw-loader!@site/src/pages/examples/_myComponen
 <CodeBlock className="language-jsx">{MyComponentSource}</CodeBlock>
 
 </BrowserWindow>
-
-<br />
 ```
 
 See [using code blocks in JSX](./markdown-features-code-blocks.mdx#usage-in-jsx) for more details of the `<CodeBlock>` component.
@@ -407,8 +405,6 @@ import PartialExample from './_markdown-partial-example.mdx';
 <BrowserWindow>
   <PartialExample name="Sebastien" />
 </BrowserWindow>
-
-<br />
 ```
 
 This way, you can reuse content among multiple pages and avoid duplicating materials.

--- a/website/versioned_docs/version-2.0.0-beta.17/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.17/guides/markdown-features/markdown-features-tabs.mdx
@@ -75,7 +75,6 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
     <TabItem value="banana">This is a banana 🍌</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 <details>
@@ -115,7 +114,6 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
     <TabItem value="banana" label="Banana 2" default>This is a banana 🍌</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 </details>
@@ -164,7 +162,6 @@ You may want choices of the same kind of tabs to sync with each other. For examp
     <TabItem value="mac" label="macOS">Use Command + V to paste.</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 For all tab groups that have the same `groupId`, the possible values do not need to be the same. If one tab group is chosen a value that does not exist in another tab group with the same `groupId`, the tab group with the missing value won't change its tab. You can see that from the following example. Try to select Linux, and the above tab groups don't change.

--- a/website/versioned_docs/version-2.0.0-beta.18/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.18/guides/markdown-features/markdown-features-react.mdx
@@ -365,8 +365,6 @@ import MyComponentSource from '!!raw-loader!@site/src/pages/examples/_myComponen
 <CodeBlock language="jsx">{MyComponentSource}</CodeBlock>
 
 </BrowserWindow>
-
-<br />
 ```
 
 See [using code blocks in JSX](./markdown-features-code-blocks.mdx#usage-in-jsx) for more details of the `<CodeBlock>` component.
@@ -407,8 +405,6 @@ import PartialExample from './_markdown-partial-example.mdx';
 <BrowserWindow>
   <PartialExample name="Sebastien" />
 </BrowserWindow>
-
-<br />
 ```
 
 This way, you can reuse content among multiple pages and avoid duplicating materials.

--- a/website/versioned_docs/version-2.0.0-beta.18/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/versioned_docs/version-2.0.0-beta.18/guides/markdown-features/markdown-features-tabs.mdx
@@ -75,7 +75,6 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
     <TabItem value="banana">This is a banana 🍌</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 <details>
@@ -115,7 +114,6 @@ It is also possible to provide `values` and `defaultValue` props to `Tabs`:
     <TabItem value="banana" label="Banana 2" default>This is a banana 🍌</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 </details>
@@ -164,7 +162,6 @@ You may want choices of the same kind of tabs to sync with each other. For examp
     <TabItem value="mac" label="macOS">Use Command + V to paste.</TabItem>
   </Tabs>
 </BrowserWindow>
-<br/>
 ```
 
 For all tab groups that have the same `groupId`, the possible values do not need to be the same. If one tab group is chosen a value that does not exist in another tab group with the same `groupId`, the tab group with the missing value won't change its tab. You can see that from the following example. Try to select Linux, and the above tab groups don't change.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

These tags were there because the browser window didn't have good margins. After #7119, this is no longer necessary.