### PR TITLE
fix(theme-classic): remove breadcrumb items without href from microdata

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
@@ -40,9 +40,12 @@ function BreadcrumbsItemLink({
       <span itemProp="name">{children}</span>
     </Link>
   ) : (
-    <span className={className} itemProp="item name">
-      {children}
-    </span>
+    // TODO Google search console doesn't like breadcrumb items without href.
+    // The schema doesn't seem to require `id` for each `item`, although Google
+    // insist to infer one, even if it's invalid. Removing `itemProp="item
+    // name"` for now, since I don't know how to properly fix it.
+    // See https://github.com/facebook/docusaurus/issues/7241
+    <span className={className}>{children}</span>
   );
 }
 
@@ -51,16 +54,20 @@ function BreadcrumbsItem({
   children,
   active,
   index,
+  addMicrodata,
 }: {
   children: ReactNode;
   active?: boolean;
   index: number;
+  addMicrodata: boolean;
 }): JSX.Element {
   return (
     <li
-      itemScope
-      itemProp="itemListElement"
-      itemType="https://schema.org/ListItem"
+      {...(addMicrodata && {
+        itemScope: true,
+        itemProp: 'itemListElement',
+        itemType: 'https://schema.org/ListItem',
+      })}
       className={clsx('breadcrumbs__item', {
         'breadcrumbs__item--active': active,
       })}>
@@ -106,7 +113,11 @@ export default function DocBreadcrumbs(): JSX.Element | null {
         {breadcrumbs.map((item, idx) => {
           const isLast = idx === breadcrumbs.length - 1;
           return (
-            <BreadcrumbsItem key={idx} active={isLast} index={idx}>
+            <BreadcrumbsItem
+              key={idx}
+              active={isLast}
+              index={idx}
+              addMicrodata={!!item.href}>
               <BreadcrumbsItemLink href={item.href} isLast={isLast}>
                 {item.label}
               </BreadcrumbsItemLink>

--- a/project-words.txt
+++ b/project-words.txt
@@ -158,6 +158,7 @@ mdxast
 mdxhast
 metadatum
 metastring
+microdata
 middlewares
 minifier
 mkcert


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This has caused too much confusion, both on Discord and on the issue tracker (#7303, #7241). Even when I tend to think it's working as intended, let's remove it from the default theme to conform to the one and only truth™ in search engines.

## Test Plan

Tested on rich results; it's valid now.