### PR TITLE
chore: remove dependabot from upgrading npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,3 @@ updates:
     open-pull-requests-limit: 99
     labels:
       - 'tag: dependencies'
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 99
-    labels:
-      - 'tag: dependencies'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I'm now doing weekly dependency upgrades myself, there's no need to continue using dependabot. It's still nice to upgrade GitHub actions, but for npm it's too much noise.
