### PR TITLE
chore: fix site deployment Crowdin issue

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -282,9 +282,10 @@ Below, we will introduce how the magic comment system can be extended to define 
 
 You can declare custom magic comments through theme config. For example, you can register another magic comment that adds a `code-block-error-line` class name:
 
-`````mdx-code-block
+```mdx-code-block
 <Tabs>
 <TabItem value="docusaurus.config.js">
+```
 
 ```js
 module.exports = {
@@ -309,8 +310,10 @@ module.exports = {
 };
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="src/css/custom.css">
+```
 
 ```css
 .code-block-error-line {
@@ -322,8 +325,10 @@ module.exports = {
 }
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="myDoc.md">
+```
 
 ````md
 In JavaScript, trying to access properties on `null` will error.
@@ -336,10 +341,10 @@ console.log(name.toUpperCase());
 ```
 ````
 
+```mdx-code-block
 </TabItem>
-
 </Tabs>
-`````
+```
 
 ````mdx-code-block
 <BrowserWindow>


### PR DESCRIPTION

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

The site can't deploy due to MDX and too many code block backticks, messing up with Crowdin translations

Not sure it's the best way to fix it but it works better at least 🤷‍♂️ 

## Test Plan

local + preview

<img width="1021" alt="CleanShot 2022-05-04 at 17 39 14@2x" src="https://user-images.githubusercontent.com/749374/166718368-ff1600fe-8191-4953-b6f9-56a39ed85fbc.png">


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/pull/7307
