### PR TITLE
fix(website): fix multiple accessibility issues around color contrast

### DIFF
--- a/admin/scripts/format-lighthouse-score.mjs
+++ b/admin/scripts/format-lighthouse-score.mjs
@@ -18,12 +18,12 @@ const summaryKeys = {
   pwa: 'PWA',
 };
 
-/** @param {number} score */
-const scoreEntry = (score) => {
-  const normalizedScore = Math.round(score * 100);
+/** @param {number} rawScore */
+const scoreEntry = (rawScore) => {
+  const score = Math.round(rawScore * 100);
   // eslint-disable-next-line no-nested-ternary
   const scoreIcon = score >= 90 ? '🟢' : score >= 50 ? '🟠' : '🔴';
-  return `${scoreIcon} ${normalizedScore}`;
+  return `${scoreIcon} ${score}`;
 };
 
 /**

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -19,6 +19,8 @@
   --site-color-checkbox-checked-bg: hsl(167deg 56% 73% / 25%);
   --site-color-feedback-background: #fff;
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 10%);
+  /* Use a darker color to ensure contrast, ideally we don't need important */
+  --ifm-breadcrumb-color-active: var(--ifm-color-primary-darker) !important;
 }
 
 html[data-theme='dark'] {
@@ -28,6 +30,10 @@ html[data-theme='dark'] {
   --docusaurus-highlighted-code-line-bg: rgb(66 66 66 / 35%);
 }
 
+/*
+ * This selector will be dynamically replaced by the color generator. Don't put
+ * other properties here.
+ */
 [data-theme='light'] {
   --ifm-color-primary: hsl(var(--site-primary-hue-saturation) 30%);
   --ifm-color-primary-dark: hsl(var(--site-primary-hue-saturation) 26%);
@@ -41,10 +47,12 @@ html[data-theme='dark'] {
   --ifm-color-primary-lightest: hsl(
     var(--site-primary-hue-saturation-light) 58%
   );
-  /* Use a darker color to ensure contrast */
-  --ifm-breadcrumb-color-active: var(--ifm-color-primary-darker);
 }
 
+/*
+ * This selector will be dynamically replaced by the color generator. Don't put
+ * other properties here.
+ */
 [data-theme='dark'] {
   --ifm-color-primary: hsl(var(--site-primary-hue-saturation) 45%);
   --ifm-color-primary-dark: hsl(var(--site-primary-hue-saturation) 41%);

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -21,6 +21,7 @@
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 10%);
   /* Use a darker color to ensure contrast, ideally we don't need important */
   --ifm-breadcrumb-color-active: var(--ifm-color-primary-darker) !important;
+  --ifm-menu-color-active: var(--ifm-color-primary-darker) !important;
 }
 
 html[data-theme='dark'] {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -41,6 +41,8 @@ html[data-theme='dark'] {
   --ifm-color-primary-lightest: hsl(
     var(--site-primary-hue-saturation-light) 58%
   );
+  /* Use a darker color to ensure contrast */
+  --ifm-breadcrumb-color-active: var(--ifm-color-primary-darker);
 }
 
 [data-theme='dark'] {

--- a/website/src/utils/prismLight.mjs
+++ b/website/src/utils/prismLight.mjs
@@ -90,5 +90,11 @@ export default {
         color: '#E36209',
       },
     },
+    {
+      types: ['comment'],
+      style: {
+        color: '#6B6B6B',
+      },
+    },
   ],
 };

--- a/website/src/utils/prismLight.mjs
+++ b/website/src/utils/prismLight.mjs
@@ -51,7 +51,7 @@ export default {
     {
       types: ['font-matter', 'string', 'attr-value'],
       style: {
-        color: '#E3116C',
+        color: '#C6105F',
       },
     },
     {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

The lighthouse report is reporting a11y problems on the doc page because the breadcrumb active item doesn't have enough contrast. I've darkened it a bit.

## Test Plan

No more a11y warnings.