### PR TITLE
fix: avoid flash of page scrolling to top on refresh

### DIFF
--- a/packages/docusaurus/src/client/ClientLifecyclesDispatcher.tsx
+++ b/packages/docusaurus/src/client/ClientLifecyclesDispatcher.tsx
@@ -27,6 +27,17 @@ export function dispatchLifecycleAction<K extends keyof ClientModule>(
   return () => callbacks.forEach((cb) => cb?.());
 }
 
+function scrollAfterNavigation(location: Location) {
+  const {hash} = location;
+  if (!hash) {
+    window.scrollTo(0, 0);
+  } else {
+    const id = decodeURIComponent(hash.substring(1));
+    const element = document.getElementById(id);
+    element?.scrollIntoView();
+  }
+}
+
 function ClientLifecyclesDispatcher({
   children,
   location,
@@ -38,13 +49,8 @@ function ClientLifecyclesDispatcher({
 }): JSX.Element {
   useLayoutEffect(() => {
     if (previousLocation !== location) {
-      const {hash} = location;
-      if (!hash) {
-        window.scrollTo(0, 0);
-      } else {
-        const id = decodeURIComponent(hash.substring(1));
-        const element = document.getElementById(id);
-        element?.scrollIntoView();
+      if (previousLocation) {
+        scrollAfterNavigation(location);
       }
       dispatchLifecycleAction('onRouteDidUpdate', {previousLocation, location});
     }


### PR DESCRIPTION

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fix regression of https://github.com/facebook/docusaurus/pull/6732

On page refresh, we scroll to top for a while instead of keeping previous scroll position

The code that scrolls to top/anchor after a navigation should not be executed on first page load (like it used to be)

## Test Plan

preview does not

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/pull/6732