### PR TITLE
docs(website): fix code block Crowdin issue

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -54,31 +54,37 @@ npx create-docusaurus@latest my-website facebook
 
 You can also initialize a new project using your preferred project manager:
 
-````mdx-code-block
+```mdx-code-block
 <Tabs>
 <TabItem value="npm">
+```
 
 ```bash
 npm init docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="yarn">
+```
 
 ```bash
 yarn create docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="pnpm">
+```
 
 ```bash
 pnpm create docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 </Tabs>
-````
+```
 
 </details>
 

--- a/website/versioned_docs/version-2.0.0-beta.18/installation.md
+++ b/website/versioned_docs/version-2.0.0-beta.18/installation.md
@@ -64,31 +64,37 @@ npx create-docusaurus@latest my-website facebook
 
 You can also initialize a new project using your preferred project manager:
 
-````mdx-code-block
+```mdx-code-block
 <Tabs>
 <TabItem value="npm">
+```
 
 ```bash
 npm init docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="yarn">
+```
 
 ```bash
 yarn create docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="pnpm">
+```
 
 ```bash
 pnpm create docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 </Tabs>
-````
+```
 
 </details>
 

--- a/website/versioned_docs/version-2.0.0-beta.19/installation.md
+++ b/website/versioned_docs/version-2.0.0-beta.19/installation.md
@@ -64,31 +64,37 @@ npx create-docusaurus@latest my-website facebook
 
 You can also initialize a new project using your preferred project manager:
 
-````mdx-code-block
+```mdx-code-block
 <Tabs>
 <TabItem value="npm">
+```
 
 ```bash
 npm init docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="yarn">
+```
 
 ```bash
 yarn create docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 <TabItem value="pnpm">
+```
 
 ```bash
 pnpm create docusaurus
 ```
 
+```mdx-code-block
 </TabItem>
 </Tabs>
-````
+```
 
 </details>
 


### PR DESCRIPTION
Fix site can't deploy because Crowdin download badly formatted markdown with bad code block backticks

https://app.netlify.com/sites/docusaurus-2/deploys/6273b760dc5aaf0008442f3b

This leads to Docusaurus thinking some links are inside a code block, leading to broken links (unresolved md paths)

https://app.netlify.com/sites/docusaurus-2/deploys/6273b760dc5aaf0008442f3b


Also prod website for FR:

<img width="977" alt="CleanShot 2022-05-05 at 15 19 33@2x" src="https://user-images.githubusercontent.com/749374/166931532-ec278606-cc88-4fdd-b731-f13008b1a047.png">

https://docusaurus.io/fr/docs/next/installation

---

Solution is to apply `mdx-code-block` only around JSX tags so that it doesn't mess up with Crowdin



