### PR TITLE
fix(types): declare missing peerDependencies

### DIFF
--- a/packages/docusaurus-types/package.json
+++ b/packages/docusaurus-types/package.json
@@ -23,5 +23,9 @@
     "utility-types": "^3.10.0",
     "webpack": "^5.72.0",
     "webpack-merge": "^5.8.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.4 || ^17.0.0",
+    "react-dom": "^16.8.4 || ^17.0.0"
   }
 }


### PR DESCRIPTION
I added some missing dependencies requested by react-helmet-async in @docusaurus/types. The missing dependencies are react and react-dom.

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Installing @docusaurus/types triggers warnings about peer dependencies that are not provided. To fix these warnings, I added the peerDependencies to the @docusaurus/types package.

## Test Plan

No code change, no test.

### Test links

No test link.

## Related issues/PRs

No known related issues/PRs.
