### PR TITLE
fix(core): allow githubPort in config validation

### DIFF
--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -37,6 +37,7 @@ describe('normalizeConfig', () => {
       organizationName: 'facebook',
       projectName: 'docusaurus',
       githubHost: 'github.com',
+      githubPort: '8000',
       customFields: {
         myCustomField: '42',
       },

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -185,6 +185,7 @@ export const ConfigSchema = Joi.object({
   deploymentBranch: Joi.string().optional(),
   customFields: Joi.object().unknown().default(DEFAULT_CONFIG.customFields),
   githubHost: Joi.string(),
+  githubPort: Joi.string(),
   plugins: Joi.array().items(PluginSchema).default(DEFAULT_CONFIG.plugins),
   themes: Joi.array().items(ThemeSchema).default(DEFAULT_CONFIG.themes),
   presets: Joi.array().items(PresetSchema).default(DEFAULT_CONFIG.presets),


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #7359) and the maintainers have approved on my working plan.

## Motivation
This fixes a tiny configuration setting validation bug #7359

## Test Plan
Set the githubPort config in a docusaurus.config.js and run deploy command


