### PR TITLE
fix(theme-classic): resolve customCss from site dir

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import path from 'path';
 import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {ThemeConfig} from '@docusaurus/theme-common';
 import {getTranslationFiles, translateThemeConfig} from './translations';
@@ -142,11 +143,11 @@ export default function themeClassic(
       ];
 
       if (customCss) {
-        if (Array.isArray(customCss)) {
-          modules.push(...customCss);
-        } else {
-          modules.push(customCss);
-        }
+        modules.push(
+          ...(Array.isArray(customCss) ? customCss : [customCss]).map((p) =>
+            path.resolve(context.siteDir, p),
+          ),
+        );
       }
 
       return modules;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -337,7 +337,8 @@ const config = {
         theme: {
           customCss: [
             require.resolve('./src/css/custom.css'),
-            require.resolve('./_dogfooding/dogfooding.css'),
+            // relative paths are relative to site dir
+            './_dogfooding/dogfooding.css',
           ],
         },
         gtag: !isDeployPreview


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Because after #6921, relative paths from plugins are resolved relative to the plugin entry point, specifying relative CSS paths no longer works. (I don't know if it worked before; never tried. It's highly possible that it didn't either.) Anyways, `./src/css/custom.css` should definitely work.

## Test Plan

Used a relative path in our own config.