### PR TITLE
fix(core): make error boundary fallback a component instead of a callback

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -75,10 +75,14 @@ declare module '@theme-original/*';
 declare module '@theme-init/*';
 
 declare module '@theme/Error' {
-  export interface Props {
-    readonly error: Error;
-    readonly tryAgain: () => void;
-  }
+  import type {ComponentProps} from 'react';
+  import type ErrorBoundary from '@docusaurus/ErrorBoundary';
+
+  type ErrorProps = ComponentProps<
+    NonNullable<ComponentProps<typeof ErrorBoundary>['fallback']>
+  >;
+
+  export interface Props extends ErrorProps {}
   export default function Error(props: Props): JSX.Element;
 }
 
@@ -119,11 +123,13 @@ declare module '@docusaurus/constants' {
 }
 
 declare module '@docusaurus/ErrorBoundary' {
-  import type {ReactNode} from 'react';
-  import type ErrorComponent from '@theme/Error';
+  import type {ReactNode, ComponentType} from 'react';
 
   export interface Props {
-    readonly fallback?: typeof ErrorComponent;
+    readonly fallback?: ComponentType<{
+      readonly error: Error;
+      readonly tryAgain: () => void;
+    }>;
     readonly children: ReactNode;
   }
   export default function ErrorBoundary(props: Props): JSX.Element;

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -33,17 +33,13 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     const {error} = this.state;
 
     if (error) {
-      const fallback = this.props.fallback ?? DefaultFallback;
-      return fallback({
-        error,
-        tryAgain: () => this.setState({error: null}),
-      });
+      const Fallback = this.props.fallback ?? DefaultFallback;
+      return (
+        <Fallback error={error} tryAgain={() => this.setState({error: null})} />
+      );
     }
 
-    return (
-      children ??
-      // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647
-      null
-    );
+    // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647
+    return children ?? null;
   }
 }

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -55,7 +55,7 @@ This component doesn't catch build-time errors and only protects against client-
 
 #### Props {#errorboundary-props}
 
-- `fallback`: an optional callback returning a JSX element. It will receive two props: `error`, the error that was caught, and `tryAgain`, a function (`() => void`) callback to reset the error in the component and try rendering it again.
+- `fallback`: a React component. The error boundary will render the component with two props: `error`, the error that was caught, and `tryAgain`, a function (`() => void`) callback to reset the error in the component and try rendering it again.
 
 ### `<Head/>` {#head}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I realized we made a wild mistake: we should _render_ the component instead of _call_ it. The semantics of this prop is very unclear: we said in the docs that it's a callback and we also call it like `fallback({...})`, but the `DefaultFallback` and what's actually passed in in our internal usage are both components.

As a general principle, components should not be called directly, because (a) it may be a class and (b) it may contain hooks. This aims to make the semantics of this prop clearer by making it receive an actual component.

## Test Plan

Testing is a bit hard :(