### PR TITLE
fix(cli): output correct path when swizzling bare-file component in subfolder

### DIFF
--- a/packages/docusaurus/src/commands/swizzle/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__snapshots__/index.test.ts.snap
@@ -162,14 +162,14 @@ exports[`swizzle eject ComponentInFolder/ComponentInSubFolder TS: theme dir tree
         └── styles.module.css"
 `;
 
-exports[`swizzle eject ComponentInFolder/Sibling JS: Sibling.css 1`] = `
+exports[`swizzle eject ComponentInFolder/Sibling JS: ComponentInFolder/Sibling.css 1`] = `
 ".testClass {
   background: black;
 }
 "
 `;
 
-exports[`swizzle eject ComponentInFolder/Sibling JS: Sibling.tsx 1`] = `
+exports[`swizzle eject ComponentInFolder/Sibling JS: ComponentInFolder/Sibling.tsx 1`] = `
 "import React from 'react';
 
 export default function Sibling() {
@@ -180,18 +180,19 @@ export default function Sibling() {
 
 exports[`swizzle eject ComponentInFolder/Sibling JS: theme dir tree 1`] = `
 "theme
-├── Sibling.css
-└── Sibling.tsx"
+└── ComponentInFolder
+    ├── Sibling.css
+    └── Sibling.tsx"
 `;
 
-exports[`swizzle eject ComponentInFolder/Sibling TS: Sibling.css 1`] = `
+exports[`swizzle eject ComponentInFolder/Sibling TS: ComponentInFolder/Sibling.css 1`] = `
 ".testClass {
   background: black;
 }
 "
 `;
 
-exports[`swizzle eject ComponentInFolder/Sibling TS: Sibling.tsx 1`] = `
+exports[`swizzle eject ComponentInFolder/Sibling TS: ComponentInFolder/Sibling.tsx 1`] = `
 "import React from 'react';
 
 export default function Sibling() {
@@ -202,8 +203,9 @@ export default function Sibling() {
 
 exports[`swizzle eject ComponentInFolder/Sibling TS: theme dir tree 1`] = `
 "theme
-├── Sibling.css
-└── Sibling.tsx"
+└── ComponentInFolder
+    ├── Sibling.css
+    └── Sibling.tsx"
 `;
 
 exports[`swizzle eject FirstLevelComponent JS: FirstLevelComponent.css 1`] = `

--- a/packages/docusaurus/src/commands/swizzle/__tests__/actions.test.ts
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/actions.test.ts
@@ -72,6 +72,20 @@ describe('eject', () => {
     `);
   });
 
+  it(`eject ${Components.Sibling}`, async () => {
+    const result = await testEject('eject', Components.Sibling);
+    expect(result.createdFiles).toEqual([
+      'ComponentInFolder/Sibling.css',
+      'ComponentInFolder/Sibling.tsx',
+    ]);
+    expect(result.tree).toMatchInlineSnapshot(`
+      "theme
+      └── ComponentInFolder
+          ├── Sibling.css
+          └── Sibling.tsx"
+    `);
+  });
+
   it(`eject ${Components.ComponentInFolder}`, async () => {
     const result = await testEject('eject', Components.ComponentInFolder);
     expect(result.createdFiles).toEqual([

--- a/packages/docusaurus/src/commands/swizzle/actions.ts
+++ b/packages/docusaurus/src/commands/swizzle/actions.ts
@@ -70,16 +70,16 @@ export async function eject({
     );
   }
 
-  const toPath = isDirectory
-    ? path.join(siteDir, THEME_PATH, componentName)
-    : path.join(siteDir, THEME_PATH);
+  const toPath = path.join(siteDir, THEME_PATH);
 
   await fs.ensureDir(toPath);
 
   const createdFiles = await Promise.all(
     filesToCopy.map(async (sourceFile: string) => {
-      const fileName = path.basename(sourceFile);
-      const targetFile = path.join(toPath, fileName);
+      const targetFile = path.join(
+        toPath,
+        path.relative(themePath, sourceFile),
+      );
       try {
         const fileContents = await fs.readFile(sourceFile, 'utf-8');
         await fs.outputFile(
@@ -87,9 +87,8 @@ export async function eject({
           fileContents.trimStart().replace(/^\/\*.+?\*\/\s*/ms, ''),
         );
       } catch (err) {
-        throw new Error(
-          logger.interpolate`Could not copy file from path=${sourceFile} to path=${targetFile}`,
-        );
+        logger.error`Could not copy file from path=${sourceFile} to path=${targetFile}`;
+        throw err;
       }
       return targetFile;
     }),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Currently, when running `yarn swizzle @docusaurus/theme-classic NavbarItem/DropdownNavbarItem --eject --danger`, it outputs `src/theme/DropdownNavbarItem.js` without the `NavbarItem` folder. This PR fixes it.

## Test Plan

Added a test case

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
