### PR TITLE
refactor: mitigate FOUC when applying Prism theme

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
@@ -7,24 +7,17 @@
 
 import React, {type ComponentProps} from 'react';
 import clsx from 'clsx';
-import {
-  usePrismTheme,
-  getPrismCssVariables,
-  ThemeClassNames,
-} from '@docusaurus/theme-common';
+import {ThemeClassNames} from '@docusaurus/theme-common';
 import styles from './styles.module.css';
 
 export default function CodeBlockContainer<T extends 'div' | 'pre'>({
   as: As,
   ...props
 }: {as: T} & ComponentProps<T>): JSX.Element {
-  const prismTheme = usePrismTheme();
-  const prismCssVariables = getPrismCssVariables(prismTheme);
   return (
     <As
       // Polymorphic components are hard to type, without `oneOf` generics
       {...(props as never)}
-      style={prismCssVariables}
       className={clsx(
         props.className,
         styles.codeBlockContainer,

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/CodeBlock/Line';
 import styles from './styles.module.css';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 export default function CodeBlockLine({
   line,
@@ -17,6 +18,8 @@ export default function CodeBlockLine({
   getLineProps,
   getTokenProps,
 }: Props): JSX.Element {
+  const isBrowser = useIsBrowser();
+
   if (line.length === 1 && line[0]!.content === '\n') {
     line[0]!.content = '';
   }
@@ -27,11 +30,15 @@ export default function CodeBlockLine({
   });
 
   const lineTokens = line.map((token, key) => (
-    <span key={key} {...getTokenProps({token, key})} />
+    <span
+      key={key}
+      {...getTokenProps({token, key})}
+      {...(!isBrowser && {style: undefined})}
+    />
   ));
 
   return (
-    <span {...lineProps}>
+    <span {...lineProps} {...(!isBrowser && {style: undefined})}>
       {showLineNumbers ? (
         <>
           <span className={styles.codeLineNumber} />

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, {isValidElement, type ReactNode} from 'react';
-import useIsBrowser from '@docusaurus/useIsBrowser';
 import type {Props} from '@theme/CodeBlock';
 import ElementContent from '@theme/CodeBlock/Content/Element';
 import StringContent from '@theme/CodeBlock/Content/String';
@@ -29,17 +28,8 @@ export default function CodeBlock({
   children: rawChildren,
   ...props
 }: Props): JSX.Element {
-  // The Prism theme on SSR is always the default theme but the site theme can
-  // be in a different mode. React hydration doesn't update DOM styles that come
-  // from SSR. Hence force a re-render after mounting to apply the current
-  // relevant styles.
-  const isBrowser = useIsBrowser();
   const children = maybeStringifyChildren(rawChildren);
   const CodeBlockComp =
     typeof children === 'string' ? StringContent : ElementContent;
-  return (
-    <CodeBlockComp key={String(isBrowser)} {...props}>
-      {children as string}
-    </CodeBlockComp>
-  );
+  return <CodeBlockComp {...props}>{children as string}</CodeBlockComp>;
 }

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -44,6 +44,7 @@ export const DEFAULT_CONFIG = {
   prism: {
     additionalLanguages: [],
     theme: defaultPrismTheme,
+    darkTheme: defaultPrismTheme,
     magicComments: [
       {
         className: 'theme-code-block-highlighted-line',

--- a/packages/docusaurus-theme-common/src/hooks/usePrismTheme.ts
+++ b/packages/docusaurus-theme-common/src/hooks/usePrismTheme.ts
@@ -16,9 +16,7 @@ import {useThemeConfig} from '../utils/useThemeConfig';
 export function usePrismTheme(): PrismTheme {
   const {prism} = useThemeConfig();
   const {colorMode} = useColorMode();
-  const lightModeTheme = prism.theme;
-  const darkModeTheme = prism.darkTheme || lightModeTheme;
-  const prismTheme = colorMode === 'dark' ? darkModeTheme : lightModeTheme;
+  const prismTheme = colorMode === 'dark' ? prism.darkTheme : prism.theme;
 
   return prismTheme;
 }

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -35,7 +35,6 @@ export {
   parseLanguage,
   parseLines,
   containsLineNumbers,
-  getPrismCssVariables,
 } from './utils/codeBlockUtils';
 
 export {

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -6,8 +6,6 @@
  */
 
 import rangeParser from 'parse-numeric-range';
-import type {PrismTheme} from 'prism-react-renderer';
-import type {CSSProperties} from 'react';
 
 const codeBlockTitleRegex = /title=(?<quote>["'])(?<title>.*?)\1/;
 const metastringLinesRangeRegex = /\{(?<range>[\d,-]+)\}/;
@@ -230,20 +228,4 @@ export function parseLines(
     });
   });
   return {lineClassNames, code};
-}
-
-export function getPrismCssVariables(prismTheme: PrismTheme): CSSProperties {
-  const mapping: {[name: keyof PrismTheme['plain']]: string} = {
-    color: '--prism-color',
-    backgroundColor: '--prism-background-color',
-  };
-
-  const properties: {[key: string]: string} = {};
-  Object.entries(prismTheme.plain).forEach(([key, value]) => {
-    const varName = mapping[key];
-    if (varName && typeof value === 'string') {
-      properties[varName] = value;
-    }
-  });
-  return properties;
 }

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -55,7 +55,7 @@ export type AnnouncementBarConfig = {
 
 export type PrismConfig = {
   theme: PrismTheme;
-  darkTheme?: PrismTheme;
+  darkTheme: PrismTheme;
   defaultLanguage?: string;
   additionalLanguages: string[];
   magicComments: MagicCommentConfig[];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

This is an attempt to eliminate the flickering background of code blocks when dark mode is on, as well as the duplication of the Prism-related CSS vars. As you can see below, this does not completely fix FOUC, but the result is better than earlier.

Before

![ezgif com-gif-maker](https://user-images.githubusercontent.com/4408379/167293234-393d2980-b57b-4e86-bd75-e23bf847d7ad.gif)


After

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/4408379/167293326-7b71be5e-ada4-4374-a8c7-9a132a0ec2d0.gif)


## Test Plan

Preview


<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->



## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
