### PR TITLE
fix(core): make generated files have unambiguous module types

### DIFF
--- a/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/routes.test.ts.snap
@@ -34,8 +34,7 @@ exports[`loadRoutes loads flat route config 1`] = `
       ],
     },
   },
-  "routesConfig": "import React from 'react';
-import ComponentCreator from '@docusaurus/ComponentCreator';
+  "routesConfig": "import ComponentCreator from '@docusaurus/ComponentCreator';
 
 export default [
   {
@@ -90,8 +89,7 @@ exports[`loadRoutes loads nested route config 1`] = `
       "metadata": "metadata---docs-foo-baz-2-cf-fa7",
     },
   },
-  "routesConfig": "import React from 'react';
-import ComponentCreator from '@docusaurus/ComponentCreator';
+  "routesConfig": "import ComponentCreator from '@docusaurus/ComponentCreator';
 
 export default [
   {
@@ -140,8 +138,7 @@ exports[`loadRoutes loads route config with empty (but valid) path string 1`] = 
       "__comp": "__comp---hello-world-jse-0-f-b6c",
     },
   },
-  "routesConfig": "import React from 'react';
-import ComponentCreator from '@docusaurus/ComponentCreator';
+  "routesConfig": "import ComponentCreator from '@docusaurus/ComponentCreator';
 
 export default [
   {

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -168,8 +168,8 @@ export default ${JSON.stringify(siteConfig, null, 2)};
 
   const genClientModules = generate(
     generatedFilesDir,
-    'client-modules.js',
-    `export default [
+    'client-modules.cjs',
+    `module.exports = [
 ${clientModules
   // Use `require()` because `import()` is async but client modules can have CSS
   // and the order matters for loading CSS.
@@ -181,8 +181,8 @@ ${clientModules
 
   const genRegistry = generate(
     generatedFilesDir,
-    'registry.js',
-    `export default {
+    'registry.cjs',
+    `module.exports = {
 ${Object.entries(registry)
   .sort((a, b) => a[0].localeCompare(b[0]))
   .map(

--- a/packages/docusaurus/src/server/index.ts
+++ b/packages/docusaurus/src/server/index.ts
@@ -199,7 +199,7 @@ ${Object.entries(registry)
     JSON.stringify(routesChunkNames, null, 2),
   );
 
-  const genRoutes = generate(generatedFilesDir, 'routes.js', routesConfig);
+  const genRoutes = generate(generatedFilesDir, 'routes.mjs', routesConfig);
 
   const genGlobalData = generate(
     generatedFilesDir,

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -314,8 +314,7 @@ export function loadRoutes(
     .map((r) => genRouteCode(r, res))
     .join(',\n');
 
-  res.routesConfig = `import React from 'react';
-import ComponentCreator from '@docusaurus/ComponentCreator';
+  res.routesConfig = `import ComponentCreator from '@docusaurus/ComponentCreator';
 
 export default [
 ${indent(routeConfigSerialized)},

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -129,6 +129,8 @@ export async function createBaseConfig(
         '.tsx',
         '.json',
       ],
+      // Allow omitting extension even when the current file is ESM
+      fullySpecified: false,
       symlinks: true, // See https://github.com/facebook/docusaurus/issues/3272
       roots: [
         // Allow resolution of url("/fonts/xyz.ttf") by webpack
@@ -205,7 +207,7 @@ export async function createBaseConfig(
         fileLoaderUtils.rules.svg(),
         fileLoaderUtils.rules.otherAssets(),
         {
-          test: /\.[jt]sx?$/i,
+          test: /\.[mc]?[jt]sx?$/i,
           exclude: excludeJS,
           use: [
             getCustomizableJSLoader(siteConfig.webpack?.jsLoader)({

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -119,7 +119,16 @@ export async function createBaseConfig(
     devtool: isProd ? undefined : 'eval-cheap-module-source-map',
     resolve: {
       unsafeCache: false, // Not enabled, does not seem to improve perf much
-      extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
+      extensions: [
+        '.wasm',
+        '.mjs',
+        '.cjs',
+        '.js',
+        '.jsx',
+        '.ts',
+        '.tsx',
+        '.json',
+      ],
       symlinks: true, // See https://github.com/facebook/docusaurus/issues/3272
       roots: [
         // Allow resolution of url("/fonts/xyz.ttf") by webpack


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Related: #6520

I set up a new website and added `"type": "module"` to the root package.json. Unsurprisingly, the build failed with a multitude of reasons. Some of them are related to `docusaurus.config.js` and `sidebars.js` being seen as ES modules, which will be fixed in #7371. However, there are some generated files that use `require` but are seen as ES modules, therefore triggering "require is not defined in ES module scope" error. To fix this, we simply need to make them `.cjs`, and use CJS-exclusive APIs instead. This is recommended practice because it makes the module type unambiguous.

In addition, I've added `.cjs` to the resolvable extensions list.

## Test Plan

I applied these changes to a locally set up site and it works. The same changes should be reflected in the deploy preview as well.

When locally serving a production build, I noticed a flash of "cannot find module" banner from the serve handler. We will need to check that.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
