### PR TITLE
refactor(pwa): remove reloadPopup option in favor of swizzling

### DIFF
--- a/packages/docusaurus-plugin-pwa/src/index.ts
+++ b/packages/docusaurus-plugin-pwa/src/index.ts
@@ -52,7 +52,6 @@ export default function pluginPWA(
     debug,
     offlineModeActivationStrategies,
     injectManifestConfig,
-    reloadPopup,
     pwaHead,
     swCustom,
     swRegister,
@@ -94,7 +93,6 @@ export default function pluginPWA(
             ),
             PWA_OFFLINE_MODE_ACTIVATION_STRATEGIES:
               offlineModeActivationStrategies,
-            PWA_RELOAD_POPUP: reloadPopup,
           }),
         ],
       };

--- a/packages/docusaurus-plugin-pwa/src/options.ts
+++ b/packages/docusaurus-plugin-pwa/src/options.ts
@@ -20,7 +20,6 @@ const DEFAULT_OPTIONS = {
   pwaHead: [],
   swCustom: undefined,
   swRegister: './registerSw.js',
-  reloadPopup: '@theme/PwaReloadPopup',
 };
 
 const optionsSchema = Joi.object<PluginOptions>({
@@ -49,9 +48,6 @@ const optionsSchema = Joi.object<PluginOptions>({
   swRegister: Joi.alternatives()
     .try(Joi.string(), Joi.bool().valid(false))
     .default(DEFAULT_OPTIONS.swRegister),
-  reloadPopup: Joi.alternatives()
-    .try(Joi.string(), Joi.bool().valid(false))
-    .default(DEFAULT_OPTIONS.reloadPopup),
 });
 
 export function validateOptions({

--- a/packages/docusaurus-plugin-pwa/src/options.ts
+++ b/packages/docusaurus-plugin-pwa/src/options.ts
@@ -48,6 +48,11 @@ const optionsSchema = Joi.object<PluginOptions>({
   swRegister: Joi.alternatives()
     .try(Joi.string(), Joi.bool().valid(false))
     .default(DEFAULT_OPTIONS.swRegister),
+  // @ts-expect-error: forbidden
+  reloadPopup: Joi.any().forbidden().messages({
+    'any.unknown':
+      'The reloadPopup option is removed in favor of swizzling. See https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-pwa#customizing-reload-popup for how to customize the reload popup using swizzling.',
+  }),
 });
 
 export function validateOptions({

--- a/packages/docusaurus-plugin-pwa/src/plugin-pwa.d.ts
+++ b/packages/docusaurus-plugin-pwa/src/plugin-pwa.d.ts
@@ -47,16 +47,6 @@ declare module '@docusaurus/plugin-pwa' {
      */
     injectManifestConfig: InjectManifestOptions;
     /**
-     * Module path to reload popup component. This popup is rendered when a new
-     * service worker is waiting to be installed, and we suggest a reload to
-     * the user.
-     *
-     * Passing `false` will disable the popup, but this is not recommended:
-     * users won't have a way to get up-to-date content.
-     * @see {@link @theme/PwaReloadPopup}
-     */
-    reloadPopup: string | false;
-    /**
      * Array of objects containing `tagName` and key-value pairs for attributes
      * to inject into the `<head>` tag. Technically you can inject any head tag
      * through this, but it's ideally used for tags to make your site PWA-

--- a/packages/docusaurus-plugin-pwa/src/registerSw.ts
+++ b/packages/docusaurus-plugin-pwa/src/registerSw.ts
@@ -6,11 +6,11 @@
  */
 
 import {createStorageSlot} from '@docusaurus/theme-common';
+import renderReloadPopup from './renderReloadPopup';
 
 // First: read the env variables (provided by Webpack)
 /* eslint-disable prefer-destructuring */
 const PWA_SERVICE_WORKER_URL = process.env.PWA_SERVICE_WORKER_URL!;
-const PWA_RELOAD_POPUP = process.env.PWA_RELOAD_POPUP;
 const PWA_OFFLINE_MODE_ACTIVATION_STRATEGIES = process.env
   .PWA_OFFLINE_MODE_ACTIVATION_STRATEGIES as unknown as (keyof typeof OfflineModeActivationStrategiesImplementations)[];
 const PWA_DEBUG = process.env.PWA_DEBUG;
@@ -170,9 +170,8 @@ async function registerSW() {
     // Immediately load new service worker when files aren't cached
     if (!offlineMode) {
       sendSkipWaiting();
-    } else if (PWA_RELOAD_POPUP) {
-      const renderReloadPopup = (await import('./renderReloadPopup')).default;
-      await renderReloadPopup({
+    } else {
+      renderReloadPopup({
         onReload() {
           wb.addEventListener('controlling', () => {
             window.location.reload();

--- a/packages/docusaurus-plugin-pwa/src/registerSw.ts
+++ b/packages/docusaurus-plugin-pwa/src/registerSw.ts
@@ -6,7 +6,6 @@
  */
 
 import {createStorageSlot} from '@docusaurus/theme-common';
-import renderReloadPopup from './renderReloadPopup';
 
 // First: read the env variables (provided by Webpack)
 /* eslint-disable prefer-destructuring */
@@ -171,7 +170,8 @@ async function registerSW() {
     if (!offlineMode) {
       sendSkipWaiting();
     } else {
-      renderReloadPopup({
+      const renderReloadPopup = (await import('./renderReloadPopup')).default;
+      await renderReloadPopup({
         onReload() {
           wb.addEventListener('controlling', () => {
             window.location.reload();

--- a/packages/docusaurus-plugin-pwa/src/renderReloadPopup.tsx
+++ b/packages/docusaurus-plugin-pwa/src/renderReloadPopup.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReloadPopup, {type Props} from '@theme/PwaReloadPopup';
+import type {Props} from '@theme/PwaReloadPopup';
 
 const POPUP_CONTAINER_ID = 'pwa-popup-container';
 
@@ -20,7 +20,8 @@ const createContainer = () => {
   return container;
 };
 
-export default function renderReloadPopup(props: Props): void {
+export default async function renderReloadPopup(props: Props): Promise<void> {
   const container = getContainer() || createContainer();
+  const ReloadPopup = (await import('@theme/PwaReloadPopup')).default;
   ReactDOM.render(<ReloadPopup {...props} />, container);
 }

--- a/packages/docusaurus-plugin-pwa/src/renderReloadPopup.tsx
+++ b/packages/docusaurus-plugin-pwa/src/renderReloadPopup.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import ReloadPopup, {type Props} from '@theme/PwaReloadPopup';
 
 const POPUP_CONTAINER_ID = 'pwa-popup-container';
 
@@ -19,10 +20,7 @@ const createContainer = () => {
   return container;
 };
 
-export default async function renderReloadPopup(props: {
-  onReload: () => void;
-}): Promise<void> {
+export default function renderReloadPopup(props: Props): void {
   const container = getContainer() || createContainer();
-  const {default: ReloadPopup} = await import(process.env.PWA_RELOAD_POPUP!);
   ReactDOM.render(<ReloadPopup {...props} />, container);
 }

--- a/website/docs/api/plugins/plugin-pwa.md
+++ b/website/docs/api/plugins/plugin-pwa.md
@@ -171,27 +171,6 @@ module.exports = {
 };
 ```
 
-### `reloadPopup` {#reloadpopup}
-
-- Type: `string | false`
-- Default: `'@theme/PwaReloadPopup'`
-
-Module path to reload popup component. This popup is rendered when a new service worker is waiting to be installed, and we suggest a reload to the user.
-
-Passing `false` will disable the popup, but this is not recommended: users won't have a way to get up-to-date content.
-
-A custom component can be used, as long as it accepts `onReload` as a prop. The `onReload` callback should be called when the `reload` button is clicked. This will tell the service worker to install the waiting service worker and reload the page.
-
-```ts
-interface PwaReloadPopupProps {
-  onReload: () => void;
-}
-```
-
-The default theme includes an implementation for the reload popup and uses [Infima Alerts](https://infima.dev/docs/components/alert).
-
-![pwa_reload.gif](/img/pwa_reload.gif)
-
 ### `pwaHead` {#pwahead}
 
 - Type: `Array<{ tagName: string } & Record<string,string>>`
@@ -312,3 +291,13 @@ import CodeBlock from '@theme/CodeBlock';
   {JSON.stringify(require("@site/static/manifest.json"),null,2)}
 </CodeBlock>
 ```
+
+## Customizing reload popup {#customizing-reload-popup}
+
+The `@theme/PwaReloadPopup` component is rendered when a new service worker is waiting to be installed, and we suggest a reload to the user. You can [swizzle](../../swizzling.md) this component and implement your own UI. It will receive an `onReload` callback as props, which should be called when the `reload` button is clicked. This will tell the service worker to install the waiting service worker and reload the page.
+
+The default theme includes an implementation for the reload popup and uses [Infima Alerts](https://infima.dev/docs/components/alert).
+
+![pwa_reload.gif](/img/pwa_reload.gif)
+
+Your component can render `null`, but this is not recommended: users won't have a way to get up-to-date content.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Breaking change

The `reloadPopup` option of the PWA plugin is removed. If you are using a custom component, consider swizzling `@theme/PwaReloadPopup` instead. If you set it to `false`, consider returning `null` from your component.

## Motivation

The dynamic import used to import the reload popup component has caused problems with server-side rendering due to how Babel/SWC compiles it. See https://github.com/facebook/docusaurus/pull/3742 and https://github.com/facebook/docusaurus/pull/7329 for some struggles. I propose to simply remove this option, because we can leverage swizzling to achieve the same effect.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
