### PR TITLE
fix(gtag): send the newly rendered page's title instead of the old one's

### DIFF
--- a/packages/docusaurus-plugin-google-gtag/src/gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.ts
@@ -16,10 +16,9 @@ const clientModule: ClientModule = {
   onRouteDidUpdate({location, previousLocation}) {
     if (previousLocation && location.pathname !== previousLocation.pathname) {
       // Normally, the document title is updated in the next tick due to how
-      // `react-helmet-async` updates it.
-      // We want to send to gtag the current document title so we use 
-      // setTimeout to put the function on the callback stack to be executed
-      // on the next tick.
+      // `react-helmet-async` updates it. We want to send the current document's
+      // title to gtag instead of the old one's, so we use `setTimeout` to defer
+      // execution to the next tick.
       // See: https://github.com/facebook/docusaurus/issues/7420
       setTimeout(() => {
         // Always refer to the variable on window in case it gets overridden

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.ts
@@ -27,7 +27,7 @@ const clientModule: ClientModule = {
           page_location: window.location.href,
           page_path: location.pathname,
         });
-      };
+      });
     }
   },
 };

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.ts
@@ -15,9 +15,15 @@ const {trackingID} = globalData['docusaurus-plugin-google-gtag']!
 const clientModule: ClientModule = {
   onRouteDidUpdate({location, previousLocation}) {
     if (previousLocation && location.pathname !== previousLocation.pathname) {
-      // Always refer to the variable on window in case it gets overridden
-      // elsewhere.
+      // Normally, the document title is updated in the next tick due to how
+      // `react-helmet-async` updates it.
+      // We want to send to gtag the current document title so we use 
+      // setTimeout to put the function on the callback stack to be executed
+      // on the next tick.
+      // See: https://github.com/facebook/docusaurus/issues/7420
       setTimeout(() => {
+        // Always refer to the variable on window in case it gets overridden
+        // elsewhere.
         window.gtag('config', trackingID, {
           page_path: location.pathname,
           page_title: document.title,

--- a/packages/docusaurus-plugin-google-gtag/src/gtag.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/gtag.ts
@@ -17,15 +17,17 @@ const clientModule: ClientModule = {
     if (previousLocation && location.pathname !== previousLocation.pathname) {
       // Always refer to the variable on window in case it gets overridden
       // elsewhere.
-      window.gtag('config', trackingID, {
-        page_path: location.pathname,
-        page_title: document.title,
-      });
-      window.gtag('event', 'page_view', {
-        page_title: document.title,
-        page_location: window.location.href,
-        page_path: location.pathname,
-      });
+      setTimeout(() => {
+        window.gtag('config', trackingID, {
+          page_path: location.pathname,
+          page_title: document.title,
+        });
+        window.gtag('event', 'page_view', {
+          page_title: document.title,
+          page_location: window.location.href,
+          page_path: location.pathname,
+        });
+      };
     }
   },
 };

--- a/website/_dogfooding/clientModuleExample.ts
+++ b/website/_dogfooding/clientModuleExample.ts
@@ -13,10 +13,16 @@ function logPage(
   location: Location,
   previousLocation: Location | null,
 ): void {
-  console.log(`${event}
-Previous location: ${previousLocation?.pathname}
-Current location: ${location.pathname}
-Current heading: ${document.getElementsByTagName('h1')[0]?.innerText}`);
+  console.log(event, location.pathname, {
+    location,
+    prevLocation: previousLocation,
+    heading: document.getElementsByTagName('h1')[0]?.innerText,
+    title: document.title,
+    description: (
+      document.querySelector('meta[name="description"]') as HTMLMetaElement
+    )?.content,
+    htmlClassName: document.getElementsByTagName('html')[0]?.className,
+  });
 }
 
 export function onRouteUpdate({


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

## Motivation

Fix https://github.com/facebook/docusaurus/issues/7420

## Test Plan

I manually tested it with the [reproduction environment on stackblitz](https://stackblitz.com/edit/github-fab3de?file=plugin%2Fclient-module.js).
I also have on my private project repo this implementation fix of the gtag plugin that I deployed and debuged using GA debug tools.
It can be clearly seen in the logs and in GA debug panel that the correct title is used now.

### Test links

https://stackblitz.com/edit/github-fab3de?file=plugin%2Fclient-module.js

Deploy preview: https://deploy-preview-7424--docusaurus-2.netlify.app/

