### PR TITLE
fix(theme-classic): layout shift when scrollbar (dis)appears

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -18,6 +18,9 @@ body {
 
 .main-wrapper {
   flex: 1 0 auto;
+  
+  /* fix layout shift from scrollbar */
+  padding-left: calc(100vw - 100%);
 }
 
 /* Docusaurus-specific utility classes */

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.css
@@ -18,7 +18,7 @@ body {
 
 .main-wrapper {
   flex: 1 0 auto;
-  
+
   /* fix layout shift from scrollbar */
   padding-left: calc(100vw - 100%);
 }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Since static pages are fast, it is more common to click around at a few links.

When switching between pages that fit on the screen and pages that do not, the scrollbar appears and disappears.

This is causing the layout to shift (potentially) every time you click a link. 

The combination of shifting layouts and faster clicking may cause users to miss-click.

## Solution:

Add a padding on the left-hand side that is exactly as big as the scrollbar.

Source: https://stackoverflow.com/a/30293718/3593896

## Test Plan

See before and after in this vid:

https://user-images.githubusercontent.com/20756439/170068259-da6251bf-5e9e-4ffc-bfb6-c5c6888479ef.mp4

## Other thoughts

Since it's using padding and not margin, this will not affect backgrounds.

Since this is by far the most accepted answer and nobody on StackOverflow points out specific browsers that this doesn't work for I believe this is a valid cross browser and responsive solution, that can be applied without any downsides.

Please let me know if you have any feedback or would like to see any changes.
