### PR TITLE
fix(core): always treat error boundary fallback as a callback

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -77,14 +77,9 @@ declare module '@theme-original/*';
 declare module '@theme-init/*';
 
 declare module '@theme/Error' {
-  import type {ComponentProps} from 'react';
-  import type ErrorBoundary from '@docusaurus/ErrorBoundary';
+  import type {FallbackParams} from '@docusaurus/ErrorBoundary';
 
-  type ErrorProps = Parameters<
-    NonNullable<ComponentProps<typeof ErrorBoundary>['fallback']>
-  >[0];
-
-  export interface Props extends ErrorProps {}
+  export interface Props extends FallbackParams {}
   export default function Error(props: Props): JSX.Element;
 }
 
@@ -127,11 +122,15 @@ declare module '@docusaurus/constants' {
 declare module '@docusaurus/ErrorBoundary' {
   import type {ReactNode} from 'react';
 
+  export type FallbackParams = {
+    readonly error: Error;
+    readonly tryAgain: () => void;
+  };
+
+  export type FallbackFunction = (params: FallbackParams) => JSX.Element;
+
   export interface Props {
-    readonly fallback?: (props: {
-      readonly error: Error;
-      readonly tryAgain: () => void;
-    }) => JSX.Element;
+    readonly fallback?: FallbackFunction;
     readonly children: ReactNode;
   }
   export default function ErrorBoundary(props: Props): JSX.Element;

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -80,9 +80,9 @@ declare module '@theme/Error' {
   import type {ComponentProps} from 'react';
   import type ErrorBoundary from '@docusaurus/ErrorBoundary';
 
-  type ErrorProps = ComponentProps<
+  type ErrorProps = Parameters<
     NonNullable<ComponentProps<typeof ErrorBoundary>['fallback']>
-  >;
+  >[0];
 
   export interface Props extends ErrorProps {}
   export default function Error(props: Props): JSX.Element;
@@ -125,13 +125,13 @@ declare module '@docusaurus/constants' {
 }
 
 declare module '@docusaurus/ErrorBoundary' {
-  import type {ReactNode, ComponentType} from 'react';
+  import type {ReactNode} from 'react';
 
   export interface Props {
-    readonly fallback?: ComponentType<{
+    readonly fallback?: (props: {
       readonly error: Error;
       readonly tryAgain: () => void;
-    }>;
+    }) => JSX.Element;
     readonly children: ReactNode;
   }
   export default function ErrorBoundary(props: Props): JSX.Element;

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -45,7 +45,7 @@ export default function Layout(props: Props): JSX.Element {
       <Navbar />
 
       <div className={clsx(ThemeClassNames.wrapper.main, wrapperClassName)}>
-        <ErrorBoundary fallback={(p) => <ErrorPageContent {...p} />}>
+        <ErrorBoundary fallback={(params) => <ErrorPageContent {...params} />}>
           {children}
         </ErrorBoundary>
       </div>

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -45,7 +45,9 @@ export default function Layout(props: Props): JSX.Element {
       <Navbar />
 
       <div className={clsx(ThemeClassNames.wrapper.main, wrapperClassName)}>
-        <ErrorBoundary fallback={ErrorPageContent}>{children}</ErrorBoundary>
+        <ErrorBoundary fallback={(p) => <ErrorPageContent {...p} />}>
+          {children}
+        </ErrorBoundary>
       </div>
 
       {!noFooter && <Footer />}

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -23,14 +23,12 @@ import SiteMetadataDefaults from './SiteMetadataDefaults';
 // TODO, quick fix for CSS insertion order
 // eslint-disable-next-line import/order
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
-// eslint-disable-next-line import/order
-import Error from '@theme/Error';
 
 export default function App(): JSX.Element {
   const routeElement = renderRoutes(routes);
   const location = useLocation();
   return (
-    <ErrorBoundary fallback={Error}>
+    <ErrorBoundary>
       <DocusaurusContextProvider>
         <BrowserContextProvider>
           <Root>

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -44,7 +44,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
         error,
         tryAgain: () => this.setState({error: null}),
       };
-      const fallback: FallbackFunction = this.props.fallback || DefaultFallback;
+      const fallback: FallbackFunction = this.props.fallback ?? DefaultFallback;
       return fallback(fallbackParams);
     }
 

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -32,10 +32,12 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     const {error} = this.state;
 
     if (error) {
-      const Fallback = this.props.fallback ?? DefaultFallback;
-      return (
-        <Fallback error={error} tryAgain={() => this.setState({error: null})} />
-      );
+      const fallback =
+        this.props.fallback ?? ((props) => <DefaultFallback {...props} />);
+      return fallback({
+        error,
+        tryAgain: () => this.setState({error: null}),
+      });
     }
 
     // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -7,12 +7,20 @@
 
 import React, {type ReactNode} from 'react';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
-import DefaultFallback from '@theme/Error';
-import type {Props} from '@docusaurus/ErrorBoundary';
+import ThemeError from '@theme/Error';
+import type {
+  FallbackFunction,
+  FallbackParams,
+  Props,
+} from '@docusaurus/ErrorBoundary';
 
 type State = {
   error: Error | null;
 };
+
+const DefaultFallback: FallbackFunction = (params) => (
+  <ThemeError {...params} />
+);
 
 export default class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -32,14 +40,12 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     const {error} = this.state;
 
     if (error) {
-      const fallbackProps = {
+      const fallbackParams: FallbackParams = {
         error,
         tryAgain: () => this.setState({error: null}),
       };
-      if (this.props.fallback) {
-        return this.props.fallback(fallbackProps);
-      }
-      return <DefaultFallback {...fallbackProps} />;
+      const fallback: FallbackFunction = this.props.fallback || DefaultFallback;
+      return fallback(fallbackParams);
     }
 
     // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647

--- a/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
+++ b/packages/docusaurus/src/client/exports/ErrorBoundary.tsx
@@ -32,12 +32,14 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     const {error} = this.state;
 
     if (error) {
-      const fallback =
-        this.props.fallback ?? ((props) => <DefaultFallback {...props} />);
-      return fallback({
+      const fallbackProps = {
         error,
         tryAgain: () => this.setState({error: null}),
-      });
+      };
+      if (this.props.fallback) {
+        return this.props.fallback(fallbackProps);
+      }
+      return <DefaultFallback {...fallbackProps} />;
     }
 
     // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -55,7 +55,13 @@ This component doesn't catch build-time errors and only protects against client-
 
 #### Props {#errorboundary-props}
 
-- `fallback`: an optional callback returning a JSX element. It will receive two props: `error`, the error that was caught, and `tryAgain`, a function (`() => void`) callback to reset the error in the component and try rendering it again. If not present, `@theme/Error` will be rendered instead. `@theme/Error` is used for the error boundaries wrapping the site, above the layout.
+- `fallback`: an optional render callback returning a JSX element. It will receive an object with 2 attributes: `error`, the error that was caught, and `tryAgain`, a function (`() => void`) callback to reset the error in the component and try rendering it again. If not present, `@theme/Error` will be rendered instead. `@theme/Error` is used for the error boundaries wrapping the site, above the layout.
+
+:::caution
+
+The `fallback` prop is a callback, and **not a React functional component**. You can't use React hooks inside this callback.
+
+:::
 
 ### `<Head/>` {#head}
 

--- a/website/docs/docusaurus-core.md
+++ b/website/docs/docusaurus-core.md
@@ -55,7 +55,7 @@ This component doesn't catch build-time errors and only protects against client-
 
 #### Props {#errorboundary-props}
 
-- `fallback`: a React component. The error boundary will render the component with two props: `error`, the error that was caught, and `tryAgain`, a function (`() => void`) callback to reset the error in the component and try rendering it again.
+- `fallback`: an optional callback returning a JSX element. It will receive two props: `error`, the error that was caught, and `tryAgain`, a function (`() => void`) callback to reset the error in the component and try rendering it again. If not present, `@theme/Error` will be rendered instead. `@theme/Error` is used for the error boundaries wrapping the site, above the layout.
 
 ### `<Head/>` {#head}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Re-do #7368, after @slorber pointed out about performance issues.

The problem still stands: we needs to be clear whether the prop is a callback to be called, or a component to be rendered with JSX. We cannot have a mix of both.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
