### PR TITLE
misc: avoid using fs.realpathSync in website

### DIFF
--- a/website/_dogfooding/README.md
+++ b/website/_dogfooding/README.md
@@ -11,7 +11,6 @@ Eventually, we could move these tests later so another test site? Note there is 
 Fancy things we can test for here:
 
 - Plugin Multi-instance
-- Symlinks support
 - Webpack configs
 - \_ prefix convention
 - Huge sidebars impact

--- a/website/_dogfooding/docs-tests-symlink
+++ b/website/_dogfooding/docs-tests-symlink
@@ -1,1 +1,0 @@
-_docs tests

--- a/website/_dogfooding/dogfooding.config.js
+++ b/website/_dogfooding/dogfooding.config.js
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const fs = require('fs');
-
 /** @type {import('@docusaurus/types').PluginConfig[]} */
 const dogfoodingThemeInstances = [
   /** @type {import('@docusaurus/types').PluginModule} */
@@ -31,8 +29,7 @@ const dogfoodingPluginInstances = [
 
       // Using a symlinked folder as source, test for use-case https://github.com/facebook/docusaurus/issues/3272
       // The target folder uses a _ prefix to test against an edge case regarding MDX partials: https://github.com/facebook/docusaurus/discussions/5181#discussioncomment-1018079
-      // eslint-disable-next-line no-restricted-properties
-      path: fs.realpathSync('_dogfooding/docs-tests-symlink'),
+      path: '_dogfooding/_docs tests',
       showLastUpdateTime: true,
       sidebarItemsGenerator(args) {
         return args.defaultSidebarItemsGenerator({

--- a/website/_dogfooding/dogfooding.config.js
+++ b/website/_dogfooding/dogfooding.config.js
@@ -27,8 +27,7 @@ const dogfoodingPluginInstances = [
       routeBasePath: '/tests/docs',
       sidebarPath: '_dogfooding/docs-tests-sidebars.js',
 
-      // Using a symlinked folder as source, test for use-case https://github.com/facebook/docusaurus/issues/3272
-      // The target folder uses a _ prefix to test against an edge case regarding MDX partials: https://github.com/facebook/docusaurus/discussions/5181#discussioncomment-1018079
+      // Using a _ prefix to test against an edge case regarding MDX partials: https://github.com/facebook/docusaurus/discussions/5181#discussioncomment-1018079
       path: '_dogfooding/_docs tests',
       showLastUpdateTime: true,
       sidebarItemsGenerator(args) {


### PR DESCRIPTION
fixes `yarn start`, from @Josh-Cena