### PR TITLE
fix: avoid printing period after localhost URL

### DIFF
--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -76,8 +76,8 @@ export async function serve(
     });
   });
 
-  logger.success`Serving path=${buildDir} directory at url=${
+  logger.success`Serving path=${buildDir} directory at: url=${
     servingUrl + baseUrl
-  }.`;
+  }`;
   server.listen(port);
 }

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -67,7 +67,7 @@ export async function start(
   const urls = prepareUrls(protocol, host, port);
   const openUrl = normalizeUrl([urls.localUrlForBrowser, baseUrl]);
 
-  logger.success`Docusaurus website is running at url=${openUrl}.`;
+  logger.success`Docusaurus website is running at: url=${openUrl}`;
 
   // Reload files processing.
   const reload = _.debounce(() => {
@@ -75,7 +75,7 @@ export async function start(
       .then(({baseUrl: newBaseUrl}) => {
         const newOpenUrl = normalizeUrl([urls.localUrlForBrowser, newBaseUrl]);
         if (newOpenUrl !== openUrl) {
-          logger.success`Docusaurus website is running at url=${newOpenUrl}.`;
+          logger.success`Docusaurus website is running at: url=${newOpenUrl}`;
         }
       })
       .catch((err: Error) => {


### PR DESCRIPTION
When you type `npm run serve`, Docusaurus will output the following text to your terminal:

```
[SUCCESS] Serving "docs" directory at http://localhost:3000/.
```

The next step at this point is to copy the text from the terminal, and then paste it into your browser.
However, the trailing period interferes with this, as it is not part of the URL. and makes it difficult to properly copy the intended text. Thus, this PR.

Related:
When doing `npm run start`, the page automatically opens in your browser, which is helpful.
Why doesn't this behavior also apply to `npm run serve`?