### PR TITLE
fix(create-docusaurus): add missing dependencies to templates

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -89,25 +89,21 @@ jobs:
           # https://yarnpkg.com/features/pnp#fallback-mode
           yarn config set pnpFallbackMode none
 
+          # This has been fixed in unified@10 / will be set automatically in the next Yarn release.
+          # TODO: Remove when updating unified or after the next Yarn release.
+          yarn config set packageExtensions --json '{ "unified@<10": { "dependencies": { "@types/unist": "^2.0.6" } } }'
+
           yarn install
         working-directory: ../test-website
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false # Yarn berry should create the lockfile, despite CI env
-      - name: Install missing dependencies
-        if: matrix.variant == '-st' && matrix.nodeLinker == 'pnp'
-        run: |
-          # These dependencies are referenced in the init project, not by our packages
-          yarn add @docusaurus/theme-classic @docusaurus/types @types/node
-          yarn config set packageExtensions --json '{ "unified@^9.2.2": { "dependencies": { "@types/unist": "^2.0.6" } } }'
-        working-directory: ../test-website
       - name: Start test-website project
         run: yarn start --no-open
         working-directory: ../test-website
         env:
           E2E_TEST: true
       - name: Type check
-        # TODO: there're some lingering issues with PnP + tsc. Enable tsc in PnP later.
-        if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'
+        if: matrix.variant == '-st'
         run: yarn typecheck
         working-directory: ../test-website
       - name: Build test-website project

--- a/packages/create-docusaurus/templates/classic-typescript/package.json
+++ b/packages/create-docusaurus/templates/classic-typescript/package.json
@@ -25,8 +25,15 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.0.0-beta.21",
+    "@docusaurus/theme-classic": "2.0.0-beta.21",
+    "@docusaurus/types": "2.0.0-beta.21",
     "@tsconfig/docusaurus": "^1.0.5",
+    "@types/node": "^16",
+    "@types/react": "^17",
     "typescript": "^4.6.4"
+  },
+  "resolutions": {
+    "@types/react": "^17"
   },
   "browserslist": {
     "production": [

--- a/packages/create-docusaurus/templates/classic/package.json
+++ b/packages/create-docusaurus/templates/classic/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.0.0-beta.21"
+    "@docusaurus/module-type-aliases": "2.0.0-beta.21",
+    "@docusaurus/types": "2.0.0-beta.21"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #6157) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Resolve the type checking errors in the templates by adding undeclared dependencies.

Motivations for the changes made:
- JS and TS templates must depend on `@docusaurus/types` since they try to 
import from it in `docusaurus.config.js`.

- The TS template must depend on `@docusaurus/theme-classic` and `@types/node` 
since `@tsconfig/docusaurus` specifies that they need to be loaded.

- The TS template must depend on `@types/react` since it imports from `react`
and also needs to provide it to `@docusaurus/theme-classic` for its types.

- The `@types/react` `resolutions` entry is needed because other `@types`
packages depend on `@types/react@*` which causes duplicated/incompatible types.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

e2e test should pass.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

https://github.com/facebook/docusaurus/pull/7521
https://github.com/facebook/docusaurus/issues/6157#issuecomment-1140293297