### PR TITLE
fix(theme-classic): code block wrap mode should allow wrapping in the middle of a word

### DIFF
--- a/packages/docusaurus-theme-common/src/hooks/useCodeWordWrap.ts
+++ b/packages/docusaurus-theme-common/src/hooks/useCodeWordWrap.ts
@@ -69,6 +69,9 @@ export function useCodeWordWrap(): {
       codeElement.removeAttribute('style');
     } else {
       codeElement.style.whiteSpace = 'pre-wrap';
+      // When code wrap is enabled, we want to avoid a scrollbar in any case
+      // Ensure that very very long words/strings/tokens still wrap
+      codeElement.style.overflowWrap = 'anywhere';
     }
 
     setIsEnabled((value) => !value);


### PR DESCRIPTION


## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

When code block wrap mode is enabled, we should avoid displaying a vertical scrollbar at all cost and anways wrap (even if it's in a middle of a very long word that can't fit on the screen)

restore behavior from https://github.com/facebook/docusaurus/pull/7485#discussion_r887908925
