### PR TITLE
feat(theme-classiic, theme-translations): Added text selection option instead of breadcrumb icon

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/validateThemeConfig.test.ts
@@ -109,6 +109,7 @@ describe('themeConfig', () => {
         minHeadingLevel: 2,
         maxHeadingLevel: 5,
       },
+      breadcrumbsHomeText: true,
     };
     expect(testValidateThemeConfig(userConfig)).toEqual({
       ...DEFAULT_CONFIG,

--- a/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
@@ -11,6 +11,7 @@ import {
   ThemeClassNames,
   useSidebarBreadcrumbs,
   useHomePageRoute,
+  useThemeConfig,
 } from '@docusaurus/theme-common';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -79,8 +80,18 @@ function BreadcrumbsItem({
   );
 }
 
+function HomeBreadcrumbText() {
+  return translate({
+    id: 'theme.docs.breadcrumbs.home.text',
+    message: 'Home',
+    description: 'The ARIA label for the home page in the breadcrumbs',
+  });
+}
+
 function HomeBreadcrumbItem() {
   const homeHref = useBaseUrl('/');
+  const shouldBreadcrumbsHomeText =
+    useThemeConfig().breadcrumbsHomeText === true;
   return (
     <li className="breadcrumbs__item">
       <Link
@@ -91,7 +102,11 @@ function HomeBreadcrumbItem() {
         })}
         className={clsx('breadcrumbs__link', styles.breadcrumbsItemLink)}
         href={homeHref}>
-        <IconHome className={styles.breadcrumbHomeIcon} />
+        {shouldBreadcrumbsHomeText ? (
+          HomeBreadcrumbText()
+        ) : (
+          <IconHome className={styles.breadcrumbHomeIcon} />
+        )}
       </Link>
     </li>
   );

--- a/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
+++ b/packages/docusaurus-theme-classic/src/validateThemeConfig.ts
@@ -58,6 +58,7 @@ export const DEFAULT_CONFIG: ThemeConfig = {
     minHeadingLevel: 2,
     maxHeadingLevel: 3,
   },
+  breadcrumbsHomeText: false,
 };
 
 const NavbarItemPosition = Joi.string().equal('left', 'right').default('left');
@@ -438,6 +439,7 @@ export const ThemeConfigSchema = Joi.object<ThemeConfig>({
       .max(6)
       .default(DEFAULT_CONFIG.tableOfContents.maxHeadingLevel),
   }).default(DEFAULT_CONFIG.tableOfContents),
+  breadcrumbsHomeText: Joi.bool().default(false),
 });
 
 export function validateThemeConfig({

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -125,6 +125,7 @@ export type ThemeConfig = {
   image?: string;
   metadata: {[key: string]: string}[];
   tableOfContents: TableOfContents;
+  breadcrumbsHomeText: boolean;
 };
 
 // User-provided theme config, unnormalized

--- a/packages/docusaurus-theme-translations/locales/ar/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/ar/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "التنقل بين صفحات الددات",
   "theme.docs.paginator.next": "التالى",
   "theme.docs.paginator.previous": "السابق",

--- a/packages/docusaurus-theme-translations/locales/base/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/base/theme-common.json
@@ -71,6 +71,8 @@
   "theme.docs.breadcrumbs.home___DESCRIPTION": "The ARIA label for the home page in the breadcrumbs",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.breadcrumbs.navAriaLabel___DESCRIPTION": "The ARIA label for the breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
+  "theme.docs.breadcrumbs.home.text___DESCRIPTION": "The label used hometext instead of homeIcon in the breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Docs pages navigation",
   "theme.docs.paginator.navAriaLabel___DESCRIPTION": "The ARIA label for the docs pagination",
   "theme.docs.paginator.next": "Next",

--- a/packages/docusaurus-theme-translations/locales/bn/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/bn/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "ডক্স পৃষ্টাগুলির নেভিগেশন",
   "theme.docs.paginator.next": "পরবর্তী",
   "theme.docs.paginator.previous": "পূর্ববর্তী",

--- a/packages/docusaurus-theme-translations/locales/cs/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/cs/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Stránkování dokumentace",
   "theme.docs.paginator.next": "Další",
   "theme.docs.paginator.previous": "Předchozí",

--- a/packages/docusaurus-theme-translations/locales/da/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/da/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Dokumentside navigation",
   "theme.docs.paginator.next": "Næste",
   "theme.docs.paginator.previous": "Tidligere",

--- a/packages/docusaurus-theme-translations/locales/de/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/de/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} Einträge",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Dokumentation Seiten Navigation",
   "theme.docs.paginator.next": "Weiter",
   "theme.docs.paginator.previous": "Zurück",

--- a/packages/docusaurus-theme-translations/locales/es/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/es/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Navegación de páginas de documentos",
   "theme.docs.paginator.next": "Siguiente",
   "theme.docs.paginator.previous": "Anterior",

--- a/packages/docusaurus-theme-translations/locales/fa/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/fa/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} مورد",
   "theme.docs.breadcrumbs.home": "صفحه اصلی",
   "theme.docs.breadcrumbs.navAriaLabel": "نشانگر صفحات",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "کنترل صفحات مطالب",
   "theme.docs.paginator.next": "بعدی",
   "theme.docs.paginator.previous": "قبلی",

--- a/packages/docusaurus-theme-translations/locales/fil/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/fil/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Nabegasyón para sa mga pahinang docs.",
   "theme.docs.paginator.next": "Sumunod",
   "theme.docs.paginator.previous": "Naraaan",

--- a/packages/docusaurus-theme-translations/locales/fr/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/fr/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} éléments",
   "theme.docs.breadcrumbs.home": "Page d'accueil",
   "theme.docs.breadcrumbs.navAriaLabel": "Fil d'Ariane",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Pagination des documents",
   "theme.docs.paginator.next": "Suivant",
   "theme.docs.paginator.previous": "Précédent",

--- a/packages/docusaurus-theme-translations/locales/he/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/he/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "רשימת דוקומנטאציה",
   "theme.docs.paginator.next": "הבא",
   "theme.docs.paginator.previous": "הקודם",

--- a/packages/docusaurus-theme-translations/locales/hi/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/hi/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "डॉक्स पेज नेविगेशन",
   "theme.docs.paginator.next": "अगला",
   "theme.docs.paginator.previous": "पिछ्ला",

--- a/packages/docusaurus-theme-translations/locales/it/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/it/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Navigazione delle pagine dei documenti",
   "theme.docs.paginator.next": "Successivo",
   "theme.docs.paginator.previous": "Precedente",

--- a/packages/docusaurus-theme-translations/locales/ja/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/ja/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "ホーム",
   "theme.docs.paginator.navAriaLabel": "ドキュメントのナビゲーション",
   "theme.docs.paginator.next": "次へ",
   "theme.docs.paginator.previous": "前へ",

--- a/packages/docusaurus-theme-translations/locales/ko/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/ko/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} 항목",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "문서 탐색",
   "theme.docs.paginator.next": "다음",
   "theme.docs.paginator.previous": "이전",

--- a/packages/docusaurus-theme-translations/locales/pl/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/pl/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} elementów",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Nawigacja na stronie dokumentacji",
   "theme.docs.paginator.next": "Następna strona",
   "theme.docs.paginator.previous": "Poprzednia strona",

--- a/packages/docusaurus-theme-translations/locales/pt-BR/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/pt-BR/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Navigação das páginas de documentação",
   "theme.docs.paginator.next": "Próxima",
   "theme.docs.paginator.previous": "Anterior",

--- a/packages/docusaurus-theme-translations/locales/pt-PT/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/pt-PT/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Navigação das páginas de documentação",
   "theme.docs.paginator.next": "Próxima",
   "theme.docs.paginator.previous": "Anterior",

--- a/packages/docusaurus-theme-translations/locales/ru/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/ru/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} элемент|{count} элемента|{count} элементов",
   "theme.docs.breadcrumbs.home": "Главная страница",
   "theme.docs.breadcrumbs.navAriaLabel": "Навигационная цепочка текущей страницы",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Навигация по странице документации",
   "theme.docs.paginator.next": "Следующая страница",
   "theme.docs.paginator.previous": "Предыдущая страница",

--- a/packages/docusaurus-theme-translations/locales/sr/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/sr/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Навигација по документима",
   "theme.docs.paginator.next": "Даље",
   "theme.docs.paginator.previous": "Назад",

--- a/packages/docusaurus-theme-translations/locales/tr/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/tr/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Dokümanlar sayfası navigasyonu",
   "theme.docs.paginator.next": "Sonraki",
   "theme.docs.paginator.previous": "Önceki",

--- a/packages/docusaurus-theme-translations/locales/vi/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/vi/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} mục",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "Thanh điều hướng của trang tài liệu",
   "theme.docs.paginator.next": "Kế tiếp",
   "theme.docs.paginator.previous": "Trước",

--- a/packages/docusaurus-theme-translations/locales/zh-Hans/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/zh-Hans/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} 个项目",
   "theme.docs.breadcrumbs.home": "主页面",
   "theme.docs.breadcrumbs.navAriaLabel": "页面路径",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "文档分页导航",
   "theme.docs.paginator.next": "下一页",
   "theme.docs.paginator.previous": "上一页",

--- a/packages/docusaurus-theme-translations/locales/zh-Hant/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/zh-Hant/theme-common.json
@@ -35,6 +35,7 @@
   "theme.docs.DocCard.categoryDescription": "{count} 個項目",
   "theme.docs.breadcrumbs.home": "主頁面",
   "theme.docs.breadcrumbs.navAriaLabel": "頁面路徑",
+  "theme.docs.breadcrumbs.home.text": "Home",
   "theme.docs.paginator.navAriaLabel": "文件分頁導覽",
   "theme.docs.paginator.next": "下一頁",
   "theme.docs.paginator.previous": "上一頁",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -359,6 +359,7 @@ const config = {
       liveCodeBlock: {
         playgroundPosition: 'bottom',
       },
+      breadcrumbsHomeText: false,
       docs: {
         sidebar: {
           hideable: true,


### PR DESCRIPTION
First, I'm sorry. I'm not good at English skill. so, I may use miss expression and have a wrong understanding. If you point out any mistake, I appreciate.

I added the `breadcrumbsHomeText` option to the `themeConfig`.

Added it to:
```ts
const config = {
  themeConfig: {
    breadcrumbsHomeText: false,
  },
};
```
if set false or if not set (breadcrumbs icon case):
![breadcrumbs icon](https://user-images.githubusercontent.com/44361433/171855416-6e941f25-6c0b-450b-8c65-89cb02c488c0.png)

if set true (breadcrumbs text case):
![breadcrumbs text](https://user-images.githubusercontent.com/44361433/171855505-b2374ede-3a86-4d9f-924c-13b0ccfe30a0.png)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

I don't want to use breadcrumb icon. I want to use substitute text for icon.
There may be other people besides me who want to use the text.

so, I added an option to make it text instead of icon.

I was wondering if I should set the option to `themeConfig`.　Because `@docusaurus/preset-classic` have breadcrumbs options. but, I chose to add option in `themeConfig`.  I thought it was appearance option.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

case 1)
1. Add `breadcrumbsHomeText` option to `themeConfig` of `docusaurus.config.js` with false

If `breadcrumb icon` is displayed in breadcrumb, it's OK

case 2)
1. Add `breadcrumbsHomeText` option to `themeConfig` of `docusaurus.config.js` with true

If `Home` is displayed in breadcrumb, it's OK

case 3)
1. Do not add `breadcrumbsHomeText` option to `themeConfig` of `docusaurus.config.js`

If `breadcrumb icon` is displayed in breadcrumb, it's OK

case 4) 
1. Change `theme.docs.breadcrumbs.home.text` of one language of `theme-translations` from `Home` to any string
2. Add `breadcrumbsHomeText` option to `themeConfig` of `docusaurus.config.js` with true

If the written string is displayed in breadcrumb, it's OK

case 5) 
1. Change `theme.docs.breadcrumbs.home.text` of one language of `theme-translations`  from `Home` to any string. but language different from case4
2. Add `breadcrumbsHomeText` option to `themeConfig` of `docusaurus.config.js` with true

If the written string is displayed in breadcrumb, it's OK
