### PR TITLE
feat(core): allow opting out of HTML minification

### DIFF
--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -142,6 +142,10 @@ async function doRender(locals: Locals & {path: string}) {
   });
 
   try {
+    if (process.env.SKIP_HTML_MINIFICATION === 'true') {
+      return renderedHtml;
+    }
+
     // Minify html with https://github.com/DanielRuf/html-minifier-terser
     return await minify(renderedHtml, {
       removeComments: false,

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -94,6 +94,8 @@ Compiles your site for production.
 
 For advanced minification of CSS bundle, we use the [advanced cssnano preset](https://github.com/cssnano/cssnano/tree/master/packages/cssnano-preset-advanced) (along with additional several PostCSS plugins) and [level 2 optimization of clean-css](https://github.com/jakubpawlowicz/clean-css#level-2-optimizations). If as a result of this advanced CSS minification you find broken CSS, build your website with the environment variable `USE_SIMPLE_CSS_MINIFIER=true` to minify CSS with the [default cssnano preset](https://github.com/cssnano/cssnano/tree/master/packages/cssnano-preset-default). **Please [fill out an issue](https://github.com/facebook/docusaurus/issues/new?labels=bug%2C+needs+triage&template=bug.md) if you experience CSS minification bugs.**
 
+You can skip the HTML minification with the environment variable `SKIP_HTML_MINIFICATION=true`.
+
 :::
 
 ### `docusaurus swizzle [themeName] [componentName] [siteDir]` {#docusaurus-swizzle}


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

The current build process is "optimizing" the HTML in a way that breaks bootstrap. More specifically, it removes some "worthless" attributes (such as `type="text"` from `input` fields), which breaks Bootstrap's `[type="text"]` selectors (probably selectors of other css frameworks aswell).

This change will allow users to specify the exact options that they want to be passed to the minifier. It won't introduce any breaking changes since it's merging the existing opts with any user-provided opts.

## Test Plan

N/A

### Test links

* https://deploy-preview-7581--docusaurus-2.netlify.app/docs/api/docusaurus-config/#buildConfig

## Related issues/PRs

N/A
