### PR TITLE
refactor(cli): make the CLI an even thinner wrapper around command functions

### DIFF
--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -8,7 +8,6 @@
 
 // @ts-check
 
-import fs from 'fs-extra';
 import logger from '@docusaurus/logger';
 import cli from 'commander';
 import {DOCUSAURUS_VERSION} from '@docusaurus/utils';
@@ -26,8 +25,6 @@ import {
 import beforeCli from './beforeCli.mjs';
 
 await beforeCli();
-
-const resolveDir = (dir = '.') => fs.realpath(dir);
 
 cli.version(DOCUSAURUS_VERSION).usage('<command> [options]');
 
@@ -54,9 +51,9 @@ cli
     '--no-minify',
     'build website without minimizing JS bundles (default: false)',
   )
-  .action(async (siteDir, options) => {
-    await build(await resolveDir(siteDir), options);
-  });
+  // @ts-expect-error: Promise<string> is not assignable to Promise<void>... but
+  // good enough here.
+  .action(build);
 
 cli
   .command('swizzle [themeName] [componentName] [siteDir]')
@@ -80,9 +77,7 @@ cli
     'copy TypeScript theme files when possible (default: false)',
   )
   .option('--danger', 'enable swizzle for unsafe component of themes')
-  .action(async (themeName, componentName, siteDir, options) =>
-    swizzle(await resolveDir(siteDir), themeName, componentName, options),
-  );
+  .action(swizzle);
 
 cli
   .command('deploy [siteDir]')
@@ -103,9 +98,7 @@ cli
     '--skip-build',
     'skip building website before deploy it (default: false)',
   )
-  .action(async (siteDir, options) =>
-    deploy(await resolveDir(siteDir), options),
-  );
+  .action(deploy);
 
 cli
   .command('start [siteDir]')
@@ -130,9 +123,7 @@ cli
     '--no-minify',
     'build website without minimizing JS bundles (default: false)',
   )
-  .action(async (siteDir, options) =>
-    start(await resolveDir(siteDir), options),
-  );
+  .action(start);
 
 cli
   .command('serve [siteDir]')
@@ -152,14 +143,12 @@ cli
     '--no-open',
     'do not open page in the browser (default: false, or true in CI)',
   )
-  .action(async (siteDir, options) =>
-    serve(await resolveDir(siteDir), options),
-  );
+  .action(serve);
 
 cli
   .command('clear [siteDir]')
   .description('Remove build artifacts.')
-  .action(async (siteDir) => clear(await resolveDir(siteDir)));
+  .action(clear);
 
 cli
   .command('write-translations [siteDir]')
@@ -180,9 +169,7 @@ cli
     '--messagePrefix <messagePrefix>',
     'Allows to init new written messages with a given prefix. This might help you to highlight untranslated message by making them stand out in the UI (default: "")',
   )
-  .action(async (siteDir, options) =>
-    writeTranslations(await resolveDir(siteDir), options),
-  );
+  .action(writeTranslations);
 
 cli
   .command('write-heading-ids [siteDir] [files...]')
@@ -192,9 +179,7 @@ cli
     "keep the headings' casing, otherwise make all lowercase (default: false)",
   )
   .option('--overwrite', 'overwrite existing heading IDs (default: false)')
-  .action(async (siteDir, files, options) =>
-    writeHeadingIds(await resolveDir(siteDir), files, options),
-  );
+  .action(writeHeadingIds);
 
 cli.arguments('<command>').action((cmd) => {
   cli.outputHelp();
@@ -221,14 +206,14 @@ function isInternalCommand(command) {
 }
 
 if (!isInternalCommand(process.argv.slice(2)[0])) {
-  await externalCommand(cli, await resolveDir('.'));
+  await externalCommand(cli);
 }
 
 if (!process.argv.slice(2).length) {
   cli.outputHelp();
 }
 
-cli.parse(process.argv);
+await cli.parseAsync(process.argv);
 
 process.on('unhandledRejection', (err) => {
   logger.error(err instanceof Error ? err.stack : err);

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -213,7 +213,7 @@ if (!process.argv.slice(2).length) {
   cli.outputHelp();
 }
 
-await cli.parseAsync(process.argv);
+cli.parse(process.argv);
 
 process.on('unhandledRejection', (err) => {
   logger.error(err instanceof Error ? err.stack : err);

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -38,14 +38,16 @@ export type BuildCLIOptions = Pick<
 };
 
 export async function build(
-  siteDir: string,
-  cliOptions: Partial<BuildCLIOptions>,
+  siteDirParam: string = '.',
+  cliOptions: Partial<BuildCLIOptions> = {},
   // When running build, we force terminate the process to prevent async
   // operations from never returning. However, if run as part of docusaurus
   // deploy, we have to let deploy finish.
   // See https://github.com/facebook/docusaurus/pull/2496
   forceTerminate: boolean = true,
 ): Promise<string> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   ['SIGINT', 'SIGTERM'].forEach((sig) => {
     process.on(sig, () => process.exit());
   });

--- a/packages/docusaurus/src/commands/clear.ts
+++ b/packages/docusaurus/src/commands/clear.ts
@@ -26,7 +26,9 @@ async function removePath(entry: {path: string; description: string}) {
   }
 }
 
-export async function clear(siteDir: string): Promise<void> {
+export async function clear(siteDirParam: string = '.'): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   const generatedFolder = {
     path: path.join(siteDir, GENERATED_FILES_DIR_NAME),
     description: 'generated folder',

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -41,9 +41,11 @@ function shellExecLog(cmd: string) {
 }
 
 export async function deploy(
-  siteDir: string,
-  cliOptions: Partial<DeployCLIOptions>,
+  siteDirParam: string = '.',
+  cliOptions: Partial<DeployCLIOptions> = {},
 ): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   const {outDir, siteConfig, siteConfigPath} = await loadContext({
     siteDir,
     config: cliOptions.config,

--- a/packages/docusaurus/src/commands/external.ts
+++ b/packages/docusaurus/src/commands/external.ts
@@ -5,14 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs-extra';
 import {loadContext} from '../server';
 import {initPlugins} from '../server/plugins/init';
 import type {CommanderStatic} from 'commander';
 
-export async function externalCommand(
-  cli: CommanderStatic,
-  siteDir: string,
-): Promise<void> {
+export async function externalCommand(cli: CommanderStatic): Promise<void> {
+  const siteDir = await fs.realpath('.');
   const context = await loadContext({siteDir});
   const plugins = await initPlugins(context);
 

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs-extra';
 import http from 'http';
 import path from 'path';
 import logger from '@docusaurus/logger';
@@ -24,9 +25,11 @@ export type ServeCLIOptions = HostPortOptions &
   };
 
 export async function serve(
-  siteDir: string,
-  cliOptions: Partial<ServeCLIOptions>,
+  siteDirParam: string = '.',
+  cliOptions: Partial<ServeCLIOptions> = {},
 ): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   const buildDir = cliOptions.dir ?? DEFAULT_BUILD_DIR_NAME;
   let dir = path.resolve(siteDir, buildDir);
 

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs-extra';
 import path from 'path';
 import _ from 'lodash';
 import logger from '@docusaurus/logger';
@@ -35,9 +36,11 @@ export type StartCLIOptions = HostPortOptions &
   };
 
 export async function start(
-  siteDir: string,
-  cliOptions: Partial<StartCLIOptions>,
+  siteDirParam: string = '.',
+  cliOptions: Partial<StartCLIOptions> = {},
 ): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   process.env.NODE_ENV = 'development';
   process.env.BABEL_ENV = 'development';
   logger.info('Starting the development server...');

--- a/packages/docusaurus/src/commands/swizzle/__tests__/index.test.ts
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/index.test.ts
@@ -111,7 +111,7 @@ async function createTestSite() {
     component: string;
     typescript?: boolean;
   }) {
-    return swizzleWithExit(siteDir, FixtureThemeName, component, {
+    return swizzleWithExit(FixtureThemeName, component, siteDir, {
       wrap: true,
       danger: true,
       typescript,
@@ -125,7 +125,7 @@ async function createTestSite() {
     component: string;
     typescript?: boolean;
   }) {
-    return swizzleWithExit(siteDir, FixtureThemeName, component, {
+    return swizzleWithExit(FixtureThemeName, component, siteDir, {
       eject: true,
       danger: true,
       typescript,

--- a/packages/docusaurus/src/commands/swizzle/index.ts
+++ b/packages/docusaurus/src/commands/swizzle/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs-extra';
 import logger from '@docusaurus/logger';
 import {getThemeName, getThemePath, getThemeNames} from './themes';
 import {getThemeComponents, getComponentName} from './components';
@@ -87,11 +88,13 @@ If you want to swizzle it, use the code=${'--danger'} flag, or confirm that you 
 }
 
 export async function swizzle(
-  siteDir: string,
-  themeNameParam: string | undefined,
-  componentNameParam: string | undefined,
-  optionsParam: Partial<SwizzleCLIOptions>,
+  themeNameParam: string | undefined = undefined,
+  componentNameParam: string | undefined = undefined,
+  siteDirParam: string = '.',
+  optionsParam: Partial<SwizzleCLIOptions> = {},
 ): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   const options = normalizeOptions(optionsParam);
   const {list, danger, typescript} = options;
 

--- a/packages/docusaurus/src/commands/writeHeadingIds.ts
+++ b/packages/docusaurus/src/commands/writeHeadingIds.ts
@@ -41,10 +41,12 @@ async function getPathsToWatch(siteDir: string): Promise<string[]> {
 }
 
 export async function writeHeadingIds(
-  siteDir: string,
-  files: string[] | undefined,
-  options: WriteHeadingIDOptions,
+  siteDirParam: string = '.',
+  files: string[] = [],
+  options: WriteHeadingIDOptions = {},
 ): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   const markdownFiles = await safeGlobby(
     files ?? (await getPathsToWatch(siteDir)),
     {

--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs-extra';
 import path from 'path';
 import {loadContext, type LoadContextOptions} from '../server';
 import {initPlugins} from '../server/plugins/init';
@@ -75,9 +76,11 @@ async function writePluginTranslationFiles({
 }
 
 export async function writeTranslations(
-  siteDir: string,
-  options: Partial<WriteTranslationsCLIOptions>,
+  siteDirParam: string = '.',
+  options: Partial<WriteTranslationsCLIOptions> = {},
 ): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
+
   const context = await loadContext({
     siteDir,
     config: options.config,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

The reason is because the commander functions are very weakly typed: basically `action(fn: (...args: any[]) => void | Promise<void>)`. This makes TS-ESLint whine about unsafe arguments when we pass these `any` into our actual function, even when it's actually safe.

This also means people who try to use these functions on Node side do not immediately get feature parity with the CLI: they have to resolve site directory, they have to apply default values (see also #7220), they have to even change the order of parameters.

We should just handle these ourselves. The CLI is just a very thin wrapper that automatically invokes these functions. Now users can do `await docusaurus.build();` without passing any arguments.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
