### PR TITLE
refactor: remove "error" reporting level, move reportMessage to logger

### DIFF
--- a/packages/docusaurus-logger/README.md
+++ b/packages/docusaurus-logger/README.md
@@ -25,6 +25,7 @@ It exports a single object as default export: `logger`. `logger` has the followi
   - `warn`: prints a warning that should be payed attention to.
   - `error`: prints an error (not necessarily halting the program) that signals significant problems.
   - `success`: prints a success message.
+- The `report` function. It takes a `ReportingSeverity` value (`ignore`, `log`, `warn`, `throw`) and reports a message according to the severity.
 
 ### A word on the `error` formatter
 

--- a/packages/docusaurus-logger/src/__tests__/index.test.ts
+++ b/packages/docusaurus-logger/src/__tests__/index.test.ts
@@ -124,3 +124,33 @@ describe('success', () => {
     expect(consoleMock.mock.calls).toMatchSnapshot();
   });
 });
+
+describe('report', () => {
+  beforeAll(() => jest.clearAllMocks());
+  it('works with all severities', () => {
+    const consoleLog = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    logger.report('ignore')('hey');
+    logger.report('log')('hey');
+    logger.report('warn')('hey');
+    expect(() =>
+      logger.report('throw')('hey'),
+    ).toThrowErrorMatchingInlineSnapshot(`"hey"`);
+    expect(() =>
+      // @ts-expect-error: for test
+      logger.report('foo')('hey'),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected "reportingSeverity" value: foo."`,
+    );
+    expect(consoleLog).toBeCalledTimes(1);
+    expect(consoleLog).toBeCalledWith(
+      expect.stringMatching(/.*\[INFO\].* hey/),
+    );
+    expect(consoleWarn).toBeCalledTimes(1);
+    expect(consoleWarn).toBeCalledWith(
+      expect.stringMatching(/.*\[WARNING\].* hey/),
+    );
+  });
+});

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -6,12 +6,12 @@
  */
 
 import path from 'path';
+import logger from '@docusaurus/logger';
 import {
   normalizeUrl,
   docuHash,
   aliasedSitePath,
   getPluginI18nPath,
-  reportMessage,
   posixPath,
   addTrailingPathSeparator,
   createAbsoluteFilePathMatcher,
@@ -391,10 +391,9 @@ export default async function pluginContentBlog(
           if (onBrokenMarkdownLinks === 'ignore') {
             return;
           }
-          reportMessage(
-            `Blog markdown link couldn't be resolved: (${brokenMarkdownLink.link}) in ${brokenMarkdownLink.filePath}`,
+          logger.report(
             onBrokenMarkdownLinks,
-          );
+          )`Blog markdown link couldn't be resolved: (url=${brokenMarkdownLink.link}) in path=${brokenMarkdownLink.filePath}`;
         },
       };
 

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -13,7 +13,6 @@ import {
   docuHash,
   aliasedSitePath,
   getContentPathList,
-  reportMessage,
   posixPath,
   addTrailingPathSeparator,
   createAbsoluteFilePathMatcher,
@@ -330,13 +329,9 @@ export default async function pluginContentDocs(
         sourceToPermalink: getSourceToPermalink(),
         versionsMetadata,
         onBrokenMarkdownLink: (brokenMarkdownLink) => {
-          if (siteConfig.onBrokenMarkdownLinks === 'ignore') {
-            return;
-          }
-          reportMessage(
-            `Docs markdown link couldn't be resolved: (${brokenMarkdownLink.link}) in ${brokenMarkdownLink.filePath} for version ${brokenMarkdownLink.contentPaths.versionName}`,
+          logger.report(
             siteConfig.onBrokenMarkdownLinks,
-          );
+          )`Docs markdown link couldn't be resolved: (url=${brokenMarkdownLink.link}) in path=${brokenMarkdownLink.filePath} for version number=${brokenMarkdownLink.contentPaths.versionName}`;
         },
       };
 

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -21,7 +21,7 @@ import type {Location} from 'history';
 
 // === Configuration ===
 
-export type ReportingSeverity = 'ignore' | 'log' | 'warn' | 'error' | 'throw';
+export type ReportingSeverity = 'ignore' | 'log' | 'warn' | 'throw';
 
 export type PluginOptions = {id?: string} & {[key: string]: unknown};
 

--- a/packages/docusaurus-utils/src/__tests__/jsUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/jsUtils.test.ts
@@ -12,7 +12,6 @@ import {
   removePrefix,
   mapAsyncSequential,
   findAsyncSequential,
-  reportMessage,
 } from '../jsUtils';
 
 describe('removeSuffix', () => {
@@ -106,42 +105,5 @@ describe('findAsyncSequential', () => {
     const timeTotal = timeAfter - timeBefore;
     expect(timeTotal).toBeGreaterThanOrEqual(600);
     expect(timeTotal).toBeLessThan(1000);
-  });
-});
-
-describe('reportMessage', () => {
-  it('works with all severities', () => {
-    const consoleLog = jest.spyOn(console, 'info').mockImplementation(() => {});
-    const consoleWarn = jest
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {});
-    const consoleError = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-    reportMessage('hey', 'ignore');
-    reportMessage('hey', 'log');
-    reportMessage('hey', 'warn');
-    reportMessage('hey', 'error');
-    expect(() =>
-      reportMessage('hey', 'throw'),
-    ).toThrowErrorMatchingInlineSnapshot(`"hey"`);
-    expect(() =>
-      // @ts-expect-error: for test
-      reportMessage('hey', 'foo'),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Unexpected "reportingSeverity" value: foo."`,
-    );
-    expect(consoleLog).toBeCalledTimes(1);
-    expect(consoleLog).toBeCalledWith(
-      expect.stringMatching(/.*\[INFO\].* hey/),
-    );
-    expect(consoleWarn).toBeCalledTimes(1);
-    expect(consoleWarn).toBeCalledWith(
-      expect.stringMatching(/.*\[WARNING\].* hey/),
-    );
-    expect(consoleError).toBeCalledTimes(1);
-    expect(consoleError).toBeCalledWith(
-      expect.stringMatching(/.*\[ERROR\].* hey/),
-    );
   });
 });

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -40,7 +40,6 @@ export {
   removePrefix,
   mapAsyncSequential,
   findAsyncSequential,
-  reportMessage,
 } from './jsUtils';
 export {
   normalizeUrl,

--- a/packages/docusaurus-utils/src/jsUtils.ts
+++ b/packages/docusaurus-utils/src/jsUtils.ts
@@ -5,9 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import logger from '@docusaurus/logger';
-import type {ReportingSeverity} from '@docusaurus/types';
-
 /** Removes a given string suffix from `str`. */
 export function removeSuffix(str: string, suffix: string): string {
   if (suffix === '') {
@@ -59,44 +56,4 @@ export async function findAsyncSequential<T>(
     }
   }
   return undefined;
-}
-
-/**
- * Takes a message and reports it according to the severity that the user wants.
- *
- * - `ignore`: completely no-op
- * - `log`: uses the `INFO` log level
- * - `warn`: uses the `WARN` log level
- * - `error`: uses the `ERROR` log level
- * - `throw`: aborts the process, throws the error.
- *
- * Since the logger doesn't have logging level filters yet, these severities
- * mostly just differ by their colors.
- *
- * @throws In addition to throwing when `reportingSeverity === "throw"`, this
- * function also throws if `reportingSeverity` is not one of the above.
- */
-export function reportMessage(
-  message: string,
-  reportingSeverity: ReportingSeverity,
-): void {
-  switch (reportingSeverity) {
-    case 'ignore':
-      break;
-    case 'log':
-      logger.info(message);
-      break;
-    case 'warn':
-      logger.warn(message);
-      break;
-    case 'error':
-      logger.error(message);
-      break;
-    case 'throw':
-      throw new Error(message);
-    default:
-      throw new Error(
-        `Unexpected "reportingSeverity" value: ${reportingSeverity}.`,
-      );
-  }
 }

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/configValidation.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/configValidation.test.ts.snap
@@ -161,3 +161,8 @@ exports[`normalizeConfig throws error for unknown field 1`] = `
 If you still want these fields to be in your configuration, put them in the "customFields" field.
 See https://docusaurus.io/docs/api/docusaurus-config/#customfields"
 `;
+
+exports[`normalizeConfig throws for "error" reporting severity 1`] = `
+""onBrokenLinks" must be one of [ignore, log, warn, throw]
+"
+`;

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -308,6 +308,20 @@ describe('normalizeConfig', () => {
       ),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  it('throws for "error" reporting severity', () => {
+    expect(() =>
+      validateConfig(
+        {
+          title: 'Site',
+          url: 'https://example.com',
+          baseUrl: '/',
+          onBrokenLinks: 'error',
+        },
+        'docusaurus.config.js',
+      ),
+    ).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('config warnings', () => {

--- a/packages/docusaurus/src/server/brokenLinks.ts
+++ b/packages/docusaurus/src/server/brokenLinks.ts
@@ -11,12 +11,7 @@ import _ from 'lodash';
 import logger from '@docusaurus/logger';
 import combinePromises from 'combine-promises';
 import {matchRoutes} from 'react-router-config';
-import {
-  removePrefix,
-  removeSuffix,
-  reportMessage,
-  resolvePathname,
-} from '@docusaurus/utils';
+import {removePrefix, removeSuffix, resolvePathname} from '@docusaurus/utils';
 import {getAllFinalRoutes} from './utils';
 import type {RouteConfig, ReportingSeverity} from '@docusaurus/types';
 
@@ -247,6 +242,6 @@ export async function handleBrokenLinks({
 
   const errorMessage = getBrokenLinksErrorMessage(allBrokenLinks);
   if (errorMessage) {
-    reportMessage(errorMessage, onBrokenLinks);
+    logger.report(onBrokenLinks)(errorMessage);
   }
 }

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -173,13 +173,13 @@ export const ConfigSchema = Joi.object<DocusaurusConfig>({
   trailingSlash: Joi.boolean(), // No default value! undefined = retrocompatible legacy behavior!
   i18n: I18N_CONFIG_SCHEMA,
   onBrokenLinks: Joi.string()
-    .equal('ignore', 'log', 'warn', 'error', 'throw')
+    .equal('ignore', 'log', 'warn', 'throw')
     .default(DEFAULT_CONFIG.onBrokenLinks),
   onBrokenMarkdownLinks: Joi.string()
-    .equal('ignore', 'log', 'warn', 'error', 'throw')
+    .equal('ignore', 'log', 'warn', 'throw')
     .default(DEFAULT_CONFIG.onBrokenMarkdownLinks),
   onDuplicateRoutes: Joi.string()
-    .equal('ignore', 'log', 'warn', 'error', 'throw')
+    .equal('ignore', 'log', 'warn', 'throw')
     .default(DEFAULT_CONFIG.onDuplicateRoutes),
   organizationName: Joi.string().allow(''),
   staticDirectories: Joi.array()

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -7,12 +7,12 @@
 
 import query from 'querystring';
 import _ from 'lodash';
+import logger from '@docusaurus/logger';
 import {
   docuHash,
   normalizeUrl,
   simpleHash,
   escapePath,
-  reportMessage,
 } from '@docusaurus/utils';
 import {getAllFinalRoutes} from './utils';
 import type {
@@ -228,15 +228,13 @@ export function handleDuplicateRoutes(
     return false;
   });
   if (duplicatePaths.length > 0) {
-    const finalMessage = `Duplicate routes found!
-${duplicatePaths
-  .map(
-    (duplicateRoute) =>
-      `- Attempting to create page at ${duplicateRoute}, but a page already exists at this route.`,
-  )
-  .join('\n')}
+    logger.report(
+      onDuplicateRoutes,
+    )`Duplicate routes found!${duplicatePaths.map(
+      (duplicateRoute) =>
+        logger.interpolate`Attempting to create page at url=${duplicateRoute}, but a page already exists at this route.`,
+    )}
 This could lead to non-deterministic routing behavior.`;
-    reportMessage(finalMessage, onDuplicateRoutes);
   }
 }
 

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -172,7 +172,7 @@ module.exports = {
 
 ### `onBrokenLinks` {#onBrokenLinks}
 
-- Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`
+- Type: `'ignore' | 'log' | 'warn' | 'throw'`
 
 The behavior of Docusaurus when it detects any broken link.
 
@@ -186,7 +186,7 @@ The broken links detection is only available for a production build (`docusaurus
 
 ### `onBrokenMarkdownLinks` {#onBrokenMarkdownLinks}
 
-- Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`
+- Type: `'ignore' | 'log' | 'warn' | 'throw'`
 
 The behavior of Docusaurus when it detects any broken Markdown link.
 
@@ -194,7 +194,7 @@ By default, it prints a warning, to let you know about your broken Markdown link
 
 ### `onDuplicateRoutes` {#onDuplicateRoutes}
 
-- Type: `'ignore' | 'log' | 'warn' | 'error' | 'throw'`
+- Type: `'ignore' | 'log' | 'warn' | 'throw'`
 
 The behavior of Docusaurus when it detects any [duplicate routes](/guides/creating-pages.md#duplicate-routes).
 

--- a/website/docs/api/misc/logger/logger.md
+++ b/website/docs/api/misc/logger/logger.md
@@ -32,6 +32,7 @@ It exports a single object as default export: `logger`. `logger` has the followi
   - `warn`: prints a warning that should be payed attention to.
   - `error`: prints an error (not necessarily halting the program) that signals significant problems.
   - `success`: prints a success message.
+- The `report` function. It takes a `ReportingSeverity` value (`ignore`, `log`, `warn`, `throw`) and reports a message according to the severity.
 
 :::caution A word on the `error` formatter
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Breaking Change

- "error" reporting level is removed in favor of "throw"
- the `reportMessage` API (internal but maybe used by some?) has been moved/renamed

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

As discussed in https://github.com/facebook/docusaurus/issues/7615, removing the "error" reporting severity to avoid confusion for the users. I've actually been asked similar questions on Discord...

I took this chance to move `reportMessage` to `logger`, to make it appear more uniform, and also to take advantage of the interpolate function.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
