### PR TITLE
feat(client-redirects): make plugin respect onDuplicateRoutes config

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/collectRedirects.ts
@@ -102,8 +102,10 @@ function filterUnwantedRedirects(
   Object.entries(_.groupBy(redirects, (redirect) => redirect.from)).forEach(
     ([from, groupedFromRedirects]) => {
       if (groupedFromRedirects.length > 1) {
-        logger.error`name=${'@docusaurus/plugin-client-redirects'}: multiple redirects are created with the same "from" pathname: path=${from}
-It is not possible to redirect the same pathname to multiple destinations: ${groupedFromRedirects.map(
+        logger.report(
+          pluginContext.siteConfig.onDuplicateRoutes,
+        )`name=${'@docusaurus/plugin-client-redirects'}: multiple redirects are created with the same "from" pathname: path=${from}
+It is not possible to redirect the same pathname to multiple destinations:${groupedFromRedirects.map(
           (r) => JSON.stringify(r),
         )}`;
       }
@@ -111,18 +113,18 @@ It is not possible to redirect the same pathname to multiple destinations: ${gro
   );
   const collectedRedirects = _.uniqBy(redirects, (redirect) => redirect.from);
 
-  // We don't want to override an already existing route with a redirect file!
-  const redirectsOverridingExistingPath = collectedRedirects.filter(
-    (redirect) => pluginContext.relativeRoutesPaths.includes(redirect.from),
-  );
+  const {false: newRedirects = [], true: redirectsOverridingExistingPath = []} =
+    _.groupBy(collectedRedirects, (redirect) =>
+      pluginContext.relativeRoutesPaths.includes(redirect.from),
+    );
   if (redirectsOverridingExistingPath.length > 0) {
-    logger.error`name=${'@docusaurus/plugin-client-redirects'}: some redirects would override existing paths, and will be ignored: ${redirectsOverridingExistingPath.map(
+    logger.report(
+      pluginContext.siteConfig.onDuplicateRoutes,
+    )`name=${'@docusaurus/plugin-client-redirects'}: some redirects would override existing paths, and will be ignored:${redirectsOverridingExistingPath.map(
       (r) => JSON.stringify(r),
     )}`;
   }
-  return collectedRedirects.filter(
-    (redirect) => !pluginContext.relativeRoutesPaths.includes(redirect.from),
-  );
+  return newRedirects;
 }
 
 function createRedirectsOptionRedirects(

--- a/packages/docusaurus-plugin-client-redirects/src/index.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/index.ts
@@ -31,6 +31,7 @@ export default function pluginClientRedirectsPages(
         baseUrl: props.baseUrl,
         outDir: props.outDir,
         options,
+        siteConfig: props.siteConfig,
       };
 
       const redirects: RedirectItem[] = collectRedirects(

--- a/packages/docusaurus-plugin-client-redirects/src/types.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/types.ts
@@ -11,7 +11,7 @@ import type {PluginOptions} from './options';
 /**
  * The minimal infos the plugin needs to work
  */
-export type PluginContext = Pick<Props, 'outDir' | 'baseUrl'> & {
+export type PluginContext = Pick<Props, 'outDir' | 'baseUrl' | 'siteConfig'> & {
   options: PluginOptions;
   relativeRoutesPaths: string[];
 };

--- a/website/docs/api/plugins/plugin-client-redirects.md
+++ b/website/docs/api/plugins/plugin-client-redirects.md
@@ -50,6 +50,12 @@ Accepted fields:
 </APITable>
 ```
 
+:::note
+
+This plugin will also read the [`siteConfig.onDuplicateRoutes`](../docusaurus.config.js.md#onDuplicateRoutes) config to adjust its logging level when multiple files will be emitted to the same location.
+
+:::
+
 ### Types {#types}
 
 #### `RedirectRule` {#RedirectRule}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #7615) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
