### PR TITLE
fix: expose empty string alt text in navbar logos

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -32,7 +32,7 @@ export default function Logo(props: Props): JSX.Element {
       sources={sources}
       height={logo.height}
       width={logo.width}
-      alt={logo.alt ?? navbarTitle ?? title}
+      alt={logo.alt ?? (navbarTitle || title)}
     />
   );
 

--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -32,7 +32,7 @@ export default function Logo(props: Props): JSX.Element {
       sources={sources}
       height={logo.height}
       width={logo.width}
-      alt={logo.alt || navbarTitle || title}
+      alt={logo.alt ?? navbarTitle ?? title}
     />
   );
 

--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -27,12 +27,21 @@ export default function Logo(props: Props): JSX.Element {
     light: useBaseUrl(logo.src),
     dark: useBaseUrl(logo.srcDark || logo.src),
   };
+
+  // If visible title is shown, fallback alt text should be
+  // an empty string to mark the logo as decorative.
+  const fallbackAlt = navbarTitle ? '' : title;
+
+  // Use logo alt text if provided (including empty string),
+  // and provide a sensible fallback otherwise.
+  const alt = logo.alt ?? fallbackAlt;
+
   const themedImage = (
     <ThemedImage
       sources={sources}
       height={logo.height}
       width={logo.width}
-      alt={logo.alt ?? (navbarTitle || title)}
+      alt={alt}
     />
   );
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -399,7 +399,7 @@ const config = {
         hideOnScroll: true,
         title: 'Docusaurus',
         logo: {
-          alt: 'Docusaurus Logo',
+          alt: '',
           src: 'img/docusaurus.svg',
           srcDark: 'img/docusaurus_keytar.svg',
           width: 32,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Resolves #7658

Allowing users to supply `alt=""` (distinct from _no_ alt/undefined alt) for their navbar brand link logos can enable users to reduce clutter in screenreader announcements. However, as it currently stands, when an empty string is provided for a logo alt, Docusaurus falls back to the provided navbar title or the site title.

This pull request ensures that if a Docusaurus config provides `alt: ''` for a logo, that empty string is respected, so Docusaurus users can confidently mark their logos as decorative and reduce duplicated announcements.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Create a fresh Docusaurus site. In the Docusaurus config, update the `navbar.logo.alt` config to be an empty string. Build the site. Verify that the logo element has `alt=""` (may show up as simply `alt` in some browser devtools).

Navigate to the brand link with a screenreader. Verify that the screenreader only announces the site title once (from the visible site title label)

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Choosing to dogfood on the main Docusaurus site's brand logo link:

Deploy preview: https://deploy-preview-7659--docusaurus-2.netlify.app/

<img width="1429" alt="Chrome DevTools inspecting Docusaurus brand link. The logo image element shows alt set to the empty string" src="https://user-images.githubusercontent.com/18060369/175091898-4b8f1150-8d1a-4fbd-bfcb-ee2155a6c9b8.png">

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

Resolves #7658

Prior art in #3352 (which addressed #3350) and #3817 (which addressed #3816)