### PR TITLE
test(logger): use `jest-serializer-ansi-escapes`

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -80,6 +80,7 @@ export default {
   },
   snapshotSerializers: [
     '<rootDir>/jest/snapshotPathNormalizer.ts',
+    'jest-serializer-ansi-escapes',
     'jest-serializer-react-helmet-async',
   ],
   snapshotFormat: {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "image-size": "^1.0.1",
     "jest": "^28.1.1",
     "jest-environment-jsdom": "^28.1.1",
+    "jest-serializer-ansi-escapes": "^2.0.1",
     "jest-serializer-react-helmet-async": "^1.0.21",
     "lerna": "^5.1.4",
     "lerna-changelog": "^2.2.0",

--- a/packages/docusaurus-logger/package.json
+++ b/packages/docusaurus-logger/package.json
@@ -27,7 +27,6 @@
     "node": ">=16.14"
   },
   "devDependencies": {
-    "@types/supports-color": "^8.1.1",
-    "jest-serializer-ansi-escapes": "^2.0.1"
+    "@types/supports-color": "^8.1.1"
   }
 }

--- a/packages/docusaurus-logger/package.json
+++ b/packages/docusaurus-logger/package.json
@@ -27,6 +27,7 @@
     "node": ">=16.14"
   },
   "devDependencies": {
-    "@types/supports-color": "^8.1.1"
+    "@types/supports-color": "^8.1.1",
+    "jest-serializer-ansi-escapes": "^2.0.1"
   }
 }

--- a/packages/docusaurus-logger/src/__tests__/index.test.ts
+++ b/packages/docusaurus-logger/src/__tests__/index.test.ts
@@ -6,27 +6,36 @@
  */
 
 import {jest} from '@jest/globals';
+import ansiEscapesSerializer from 'jest-serializer-ansi-escapes';
 import logger from '../index';
 
-// cSpell:ignore mkeep
+expect.addSnapshotSerializer(ansiEscapesSerializer);
 
 describe('formatters', () => {
   it('path', () => {
-    expect(logger.path('keepAnsi')).toMatchInlineSnapshot(`"[36m[4m"keepAnsi"[24m[39m"`);
+    expect(logger.path('keepAnsi')).toMatchInlineSnapshot(
+      `"<cyan><underline>"keepAnsi"</underline></color>"`,
+    );
   });
   it('url', () => {
     expect(logger.url('https://docusaurus.io/keepAnsi')).toMatchInlineSnapshot(
-      `"[36m[4mhttps://docusaurus.io/keepAnsi[24m[39m"`,
+      `"<cyan><underline>https://docusaurus.io/keepAnsi</underline></color>"`,
     );
   });
   it('id', () => {
-    expect(logger.name('keepAnsi')).toMatchInlineSnapshot(`"[34m[1mkeepAnsi[22m[39m"`);
+    expect(logger.name('keepAnsi')).toMatchInlineSnapshot(
+      `"<blue><bold>keepAnsi</intensity></color>"`,
+    );
   });
   it('code', () => {
-    expect(logger.code('keepAnsi')).toMatchInlineSnapshot(`"[36m\`keepAnsi\`[39m"`);
+    expect(logger.code('keepAnsi')).toMatchInlineSnapshot(
+      `"<cyan>\`keepAnsi\`</color>"`,
+    );
   });
   it('subdue', () => {
-    expect(logger.subdue('keepAnsi')).toMatchInlineSnapshot(`"[90mkeepAnsi[39m"`);
+    expect(logger.subdue('keepAnsi')).toMatchInlineSnapshot(
+      `"<gray>keepAnsi</color>"`,
+    );
   });
 });
 
@@ -47,7 +56,7 @@ describe('interpolate', () => {
     expect(
       logger.interpolate`(keepAnsi) The package at path=${'packages/docusaurus'} has number=${10} files. name=${'Babel'} is exported here subdue=${'(as a preset)'} that you can with code=${"require.resolve('@docusaurus/core/lib/babel/preset')"}`,
     ).toMatchInlineSnapshot(
-      `"(keepAnsi) The package at [36m[4m"packages/docusaurus"[24m[39m has [33m10[39m files. [34m[1mBabel[22m[39m is exported here [90m(as a preset)[39m that you can with [36m\`require.resolve('@docusaurus/core/lib/babel/preset')\`[39m"`,
+      `"(keepAnsi) The package at <cyan><underline>"packages/docusaurus"</underline></color> has <yellow>10</color> files. <blue><bold>Babel</intensity></color> is exported here <gray>(as a preset)</color> that you can with <cyan>\`require.resolve('@docusaurus/core/lib/babel/preset')\`</color>"`,
     );
   });
   it('interpolates arrays with flags', () => {
@@ -59,9 +68,9 @@ describe('interpolate', () => {
       ]}`,
     ).toMatchInlineSnapshot(`
       "(keepAnsi) The following commands are available:
-      - [36m\`docusaurus start\`[39m
-      - [36m\`docusaurus build\`[39m
-      - [36m\`docusaurus deploy\`[39m"
+      - <cyan>\`docusaurus start\`</color>
+      - <cyan>\`docusaurus build\`</color>
+      - <cyan>\`docusaurus deploy\`</color>"
     `);
   });
   it('prints detached flags as-is', () => {

--- a/packages/docusaurus-logger/src/__tests__/index.test.ts
+++ b/packages/docusaurus-logger/src/__tests__/index.test.ts
@@ -6,10 +6,7 @@
  */
 
 import {jest} from '@jest/globals';
-import ansiEscapesSerializer from 'jest-serializer-ansi-escapes';
 import logger from '../index';
-
-expect.addSnapshotSerializer(ansiEscapesSerializer);
 
 describe('formatters', () => {
   it('path', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9470,6 +9470,11 @@ jest-runtime@^28.1.1:
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
+jest-serializer-ansi-escapes@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer-ansi-escapes/-/jest-serializer-ansi-escapes-2.0.1.tgz#053fc7f2d8629ad127afb6a31e542b65c6ad7806"
+  integrity sha512-+BuVKZQutcejSuODTleG/CV+8OVONZSOSrtrQRG8isTLu367JVKK+/yaG2jGs5O6MPBZ88WNy5jg8hqhd/p6pw==
+
 jest-serializer-react-helmet-async@^1.0.21:
   version "1.0.21"
   resolved "https://registry.yarnpkg.com/jest-serializer-react-helmet-async/-/jest-serializer-react-helmet-async-1.0.21.tgz#bf2aee7522909bc4c933a0911db236b92db4685c"


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

I noticed that ansi escape sequences are included in snapshots of `@docusaurus/logger` tests. Recently I wrote a [snapshot serializer](https://github.com/mrazauskas/jest-serializer-ansi-escapes) which is replacing the sequences with human readable strings. For example, `'\u001b[3;32mSuccess!\u001b[0m'` gets snapshotted as `'<italic, green>Success!</>'`.

Just though – perhaps you will find it useful? After using the plugin in a couple of projects, it felt to me that the improved readability helps to maintain snapshots. Of course, in the end the same output is snapshotted.

---

`jest-serializer-ansi-escapes` is inspired by [`ConvertAnsi`](https://github.com/facebook/jest/blob/main/packages/pretty-format/src/plugins/ConvertAnsi.ts) plugin which ships with `pretty-format` and is bundled with Jest as well. Currently `ConvertAnsi` does not support `blue` or `underline`. Also its implementation is based on `ansi-styles` (which does not work for vanilla sequences with more than one arguments: `\u001b[3;32m`).

These and similar limitations was the reason why I created `jest-serializer-ansi-escapes`. It supports vanilla escape sequences as well as the ones produced by libraries like `chalk` and it replaces color, style and cursor control escape sequences.

## Test Plan

Snapshots are updated. All current tests should pass.

### Test links

N/A

## Related issues/PRs

N/A