### PR TITLE
fix(theme-translations): typo in vi locale

### DIFF
--- a/packages/docusaurus-theme-translations/locales/vi/plugin-ideal-image.json
+++ b/packages/docusaurus-theme-translations/locales/vi/plugin-ideal-image.json
@@ -2,6 +2,6 @@
   "theme.IdealImageMessage.404error": "404. Không tìm thấy ảnh",
   "theme.IdealImageMessage.error": "Có lỗi. Nhấn để tải lại",
   "theme.IdealImageMessage.load": "Nhấn để tải {sizeMessage}",
-  "theme.IdealImageMessage.loading": "Đang tái...",
+  "theme.IdealImageMessage.loading": "Đang tải...",
   "theme.IdealImageMessage.offline": "Hiện bạn đang ngoại tuyến. Không thể tải ảnh"
 }


### PR DESCRIPTION
Correct missing typo