### PR TITLE
test: add docusaurus deploy CI tests

### DIFF
--- a/.github/workflows/tests-cli-deploy.yml
+++ b/.github/workflows/tests-cli-deploy.yml
@@ -1,0 +1,57 @@
+name: Tests CLI docusaurus deploy
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - packages/docusaurus/src/commands/deploy.ts
+
+# We queue those jobs on purpose to avoid race conditions
+# Using a single static deploy branch: good enough
+concurrency:
+  group: cli-deploy-singleton-group
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Tests
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['16.14', '16', '18']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+      - name: Installation
+        run: yarn
+
+      - name: Cleanup Deployment Git Branch
+        run: git push origin --delete ci-deploy-test-branch
+        # Normally that branch does not exist, but who knows what can happen
+        continue-on-error: true
+
+      # We only test the deployment script, not the website build process
+      - name: Create artificial build dir
+        run: |
+          mkdir website/build
+          echo "CI CLI Deployment tests" > website/build/README.md
+
+      # We run twice the same CLI deployment command
+      # The script has different code for new vs existing remote branch
+      - name: Test CLI deployment 1 (new branch)
+        run: DEPLOYMENT_BRANCH=ci-deploy-test-branch yarn workspace website deploy --skip-build
+      - name: Test CLI deployment 2 (existing branch)
+        run: DEPLOYMENT_BRANCH=ci-deploy-test-branch yarn workspace website deploy --skip-build
+
+      - name: Cleanup Deployment Git Branch
+        run: git push origin --delete ci-deploy-test-branch


### PR DESCRIPTION

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

As mentioned in https://github.com/facebook/docusaurus/pull/7702, we don't have any automated way to ensure our deploy CLI keeps working over time, and any modification usually requires manual tests to ensure nothing gets broken.

These CLI scripts are not really easy to test as they usually run multiple complex Git commands.

I suggest we run as part of our CI tests to deploy a build dir to a real Git repo branch, ensuring at least the "happy path" of that script keeps working over time.

## Test Plan

CI