### PR TITLE
refactor(theme-common): move useDocsPreferredVersion() to public api

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -10,10 +10,8 @@ import {
   useVersions,
   useActiveDocContext,
 } from '@docusaurus/plugin-content-docs/client';
-import {
-  useDocsPreferredVersion,
-  useDocsVersionCandidates,
-} from '@docusaurus/theme-common/internal';
+import {useDocsPreferredVersion} from '@docusaurus/theme-common';
+import {useDocsVersionCandidates} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -73,3 +73,5 @@ export {isRegexpStringMatch} from './utils/regexpUtils';
 export {duplicates, uniq} from './utils/jsUtils';
 
 export {usePrismTheme} from './hooks/usePrismTheme';
+
+export {useDocsPreferredVersion} from './contexts/docsPreferredVersion';

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -27,7 +27,6 @@ export {DocsSidebarProvider, useDocsSidebar} from './contexts/docsSidebar';
 export {DocProvider, useDoc, type DocContextValue} from './contexts/doc';
 
 export {
-  useDocsPreferredVersion,
   useDocsPreferredVersionByPluginId,
   DocsPreferredVersionContextProvider,
 } from './contexts/docsPreferredVersion';

--- a/website/src/components/Versions.tsx
+++ b/website/src/components/Versions.tsx
@@ -12,7 +12,7 @@ import React, {
   useRef,
   type ReactNode,
 } from 'react';
-import {useDocsPreferredVersion} from '@docusaurus/theme-common/internal';
+import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 import {useVersions} from '@docusaurus/plugin-content-docs/client';
 import Translate from '@docusaurus/Translate';
 import CodeBlock from '@theme/CodeBlock';


### PR DESCRIPTION


## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.


## Motivation

`useDocsPreferredVersion()` is a useful hook to get the currently "selected" version (ie the one displayed in the navbar dropdown)

It is complicated to implement in userland and already used by some plugins (see also https://github.com/easyops-cn/docusaurus-search-local/pull/205#discussion_r914807848)

So let's move this to our public undocumented API: we maintain retro compatibility on all minor versions

## Test Plan

CI + preview

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
