### PR TITLE
feat(core): plugin postCompile lifecycle

### DIFF
--- a/packages/docusaurus-types/src/plugin.d.ts
+++ b/packages/docusaurus-types/src/plugin.d.ts
@@ -116,6 +116,7 @@ export type Plugin<Content = unknown> = {
     allContent: AllContent;
     actions: PluginContentLoadedActions;
   }) => Promise<void> | void;
+  postCompile?: () => Promise<void> | void;
   postBuild?: (
     props: Props & {
       content: Content;

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -167,6 +167,19 @@ export async function start(
   });
 
   const compiler = webpack(config);
+
+  compiler.hooks.done.tap('done', async () => {
+    // Plugin Lifecycle - postCompile.
+    await Promise.all(
+      plugins.map(async (plugin) => {
+        if (!plugin.postCompile) {
+          return;
+        }
+        await plugin.postCompile();
+      }),
+    );
+  });
+
   if (process.env.E2E_TEST) {
     compiler.hooks.done.tap('done', (stats) => {
       if (stats.hasErrors()) {

--- a/website/docs/api/plugin-methods/README.md
+++ b/website/docs/api/plugin-methods/README.md
@@ -66,6 +66,10 @@ async function myPlugin(context, opts) {
       // `actions` are set of functional API provided by Docusaurus (e.g. addRoute)
     },
 
+    async postCompile(props) {
+      // After docusaurus webpack finishes compiling.
+    },
+
     async postBuild(props) {
       // After docusaurus <build> finish.
     },

--- a/website/docs/api/plugin-methods/lifecycle-apis.md
+++ b/website/docs/api/plugin-methods/lifecycle-apis.md
@@ -286,6 +286,26 @@ module.exports = function (context, options) {
 };
 ```
 
+## `postCompile()` {#postCompile}
+
+Called when a build compiles.
+
+Example:
+
+```js title="docusaurus-plugin/src/index.js"
+module.exports = function (context, options) {
+  return {
+    name: 'docusaurus-plugin',
+    // highlight-start
+    async postCompile() {
+      // Creates index of all built output used for search
+      await createSearchIndex();
+    },
+    // highlight-end
+  };
+};
+```
+
 ## `postBuild(props)` {#postBuild}
 
 Called when a (production) build finishes.


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #5616) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Adds the ability for plugins to decide when to do additional steps during a dev build, since there is no postStart just postBuild. This enables plugins to do more with dev builds.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I didn't see a strategy for testing plugin life cycle events, this is a TBD before we merge it needs to have a test for sure.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

#5616 
