### PR TITLE
chore: ci tests should run on version branches "docusaurus-vX"

### DIFF
--- a/.github/workflows/build-blog-only.yml
+++ b/.github/workflows/build-blog-only.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - packages/**
 

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - package.json
       - yarn.lock

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - packages/**
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - docusaurus-v**
   pull_request:
     branches:
       - main
+      - docusaurus-v**
   schedule:
     - cron: 25 22 * * 3
 

--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - main
+      - docusaurus-v**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/showcase-test.yml
+++ b/.github/workflows/showcase-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - website/src/data/**
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - package.json
       - yarn.lock
@@ -13,6 +14,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - package.json
       - yarn.lock

--- a/.github/workflows/tests-swizzle.yml
+++ b/.github/workflows/tests-swizzle.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - packages/**
 

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - package.json
       - yarn.lock

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - docusaurus-v**
     paths:
       - package.json
       - yarn.lock


### PR DESCRIPTION
chore: ci tests should run on version branches "docusaurus-vX"