### PR TITLE
fix: collapse siblings when first category is selected

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
@@ -136,7 +136,7 @@ export default function DocSidebarItemCategory({
   useEffect(() => {
     if (
       collapsible &&
-      expandedItem &&
+      expandedItem != null &&
       expandedItem !== index &&
       autoCollapseCategories
     ) {


### PR DESCRIPTION
## Motivation

When clicking on first section other section will not collapse.

## Test Plan

`expandedItem` when it is equal to `0` is a falsy value. Therefore that `useEffect` will not produce any effect. I've changed it to checking of `expandedItem != null` in order to ensure that effect will not happen only when expanded item is `null` or `undefined.` 


### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

There is none