### PR TITLE
docs: fix anchor link

### DIFF
--- a/website/community/5-release-process.md
+++ b/website/community/5-release-process.md
@@ -38,7 +38,7 @@ Whenever a new major version is released, we publish:
 
 :::tip
 
-Read our [public API surface](##public-api-surface) section to clearly understand what we consider as a breaking change.
+Read our [public API surface](#public-api-surface) section to clearly understand what we consider as a breaking change.
 
 :::
 

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -327,7 +327,7 @@ cmd /C "set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy"
 
 ```powershell
 cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
-````
+```
 
 ```mdx-code-block
 </TabItem>


### PR DESCRIPTION
The link to the public API surface had an erroneous extra # in the link
preventing it from linking correctly.

## Pre-flight checklist

- [/] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [/] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [/] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fix a bug in the docs

## Test Plan

View /community/release-process#major-versions and attempt to follow the link in the first admonition to the "Public API surface"

### Test links

- https://docusaurus.io/community/release-process#major-versions
- Deploy preview: https://deploy-preview-7813--docusaurus-2.netlify.app/community/release-process#major-versions

## Related issues/PRs

None