### PR TITLE
docs: update workbox doc link

### DIFF
--- a/website/docs/api/plugins/plugin-pwa.md
+++ b/website/docs/api/plugins/plugin-pwa.md
@@ -142,7 +142,7 @@ The [`standalone` strategy](https://petelepage.com/blog/2019/07/is-my-pwa-instal
 
 ### `injectManifestConfig` {#injectmanifestconfig}
 
-[Workbox options](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest) to pass to `workbox.injectManifest()`. This gives you control over which assets will be precached, and be available offline.
+[Workbox options]( https://developer.chrome.com/docs/workbox/reference/workbox-build/#type-InjectManifestOptions) to pass to `workbox.injectManifest()`. This gives you control over which assets will be precached, and be available offline.
 
 - Type: `InjectManifestOptions`
 - Default: `{}`

--- a/website/docs/api/plugins/plugin-pwa.md
+++ b/website/docs/api/plugins/plugin-pwa.md
@@ -142,7 +142,7 @@ The [`standalone` strategy](https://petelepage.com/blog/2019/07/is-my-pwa-instal
 
 ### `injectManifestConfig` {#injectmanifestconfig}
 
-[Workbox options]( https://developer.chrome.com/docs/workbox/reference/workbox-build/#type-InjectManifestOptions) to pass to `workbox.injectManifest()`. This gives you control over which assets will be precached, and be available offline.
+[Workbox options](https://developer.chrome.com/docs/workbox/reference/workbox-build/#type-InjectManifestOptions) to pass to `workbox.injectManifest()`. This gives you control over which assets will be precached, and be available offline.
 
 - Type: `InjectManifestOptions`
 - Default: `{}`

--- a/website/versioned_docs/version-2.0.0-beta.22/api/plugins/plugin-pwa.md
+++ b/website/versioned_docs/version-2.0.0-beta.22/api/plugins/plugin-pwa.md
@@ -142,7 +142,7 @@ The [`standalone` strategy](https://petelepage.com/blog/2019/07/is-my-pwa-instal
 
 ### `injectManifestConfig` {#injectmanifestconfig}
 
-[Workbox options](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest) to pass to `workbox.injectManifest()`. This gives you control over which assets will be precached, and be available offline.
+[Workbox options](https://developer.chrome.com/docs/workbox/reference/workbox-build/#type-InjectManifestOptions) to pass to `workbox.injectManifest()`. This gives you control over which assets will be precached, and be available offline.
 
 - Type: `InjectManifestOptions`
 - Default: `{}`


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Issue

updated link does not show reference to workbox

## Links
Old Link: https://developer.chrome.com/docs/workbox/reference/#.injectManifest
New Link: https://developer.chrome.com/docs/workbox/reference/workbox-webpack-plugin/#type-InjectManifest
