### PR TITLE
chore: fix CSS import order ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -263,8 +263,19 @@ module.exports = {
           {pattern: '@site/**', group: 'internal'},
           {pattern: '@theme-init/**', group: 'internal'},
           {pattern: '@theme-original/**', group: 'internal'},
+          // always put css import to the last
+          // see more: https://github.com/import-js/eslint-plugin-import/issues/1239
+          {
+            pattern: '*.+(css|sass|less|scss|pcss|styl)',
+            group: 'unknown',
+            patternOptions: {matchBase: true},
+            position: 'after',
+          },
         ],
         pathGroupsExcludedImportTypes: [],
+        // it's even better for understanding import layers at first glance
+        // see more: https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/order.md#newlines-between-ignorealwaysalways-and-inside-groupsnever
+        //  {"newlines-between": "always-and-inside-groups"}
       },
     ],
     'import/prefer-default-export': OFF,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -249,6 +249,14 @@ module.exports = {
           'type',
         ],
         pathGroups: [
+          // always put css import to the last, ref:
+          // https://github.com/import-js/eslint-plugin-import/issues/1239
+          {
+            pattern: '*.+(css|sass|less|scss|pcss|styl)',
+            group: 'unknown',
+            patternOptions: {matchBase: true},
+            position: 'after',
+          },
           {pattern: '@jest/globals', group: 'builtin', position: 'before'},
           {pattern: 'react', group: 'builtin', position: 'before'},
           {pattern: 'fs-extra', group: 'builtin'},
@@ -263,19 +271,12 @@ module.exports = {
           {pattern: '@site/**', group: 'internal'},
           {pattern: '@theme-init/**', group: 'internal'},
           {pattern: '@theme-original/**', group: 'internal'},
-          // always put css import to the last
-          // see more: https://github.com/import-js/eslint-plugin-import/issues/1239
-          {
-            pattern: '*.+(css|sass|less|scss|pcss|styl)',
-            group: 'unknown',
-            patternOptions: {matchBase: true},
-            position: 'after',
-          },
         ],
         pathGroupsExcludedImportTypes: [],
-        // it's even better for understanding import layers at first glance
-        // see more: https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/order.md#newlines-between-ignorealwaysalways-and-inside-groupsnever
-        //  {"newlines-between": "always-and-inside-groups"}
+        // example: let `import './nprogress.css';` after importing others
+        // in `packages/docusaurus-theme-classic/src/nprogress.ts`
+        // see more: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#warnonunassignedimports-truefalse
+        warnOnUnassignedImports: true,
       },
     ],
     'import/prefer-default-export': OFF,

--- a/packages/docusaurus-theme-classic/src/nprogress.ts
+++ b/packages/docusaurus-theme-classic/src/nprogress.ts
@@ -6,8 +6,9 @@
  */
 
 import nprogress from 'nprogress';
-import './nprogress.css';
 import type {ClientModule} from '@docusaurus/types';
+
+import './nprogress.css';
 
 nprogress.configure({showSpinner: false});
 

--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -14,13 +14,14 @@ import {
 } from '@docusaurus/theme-common/internal';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import {translate} from '@docusaurus/Translate';
-import type {Props} from '@theme/DocCard';
 
-import styles from './styles.module.css';
+import type {Props} from '@theme/DocCard';
 import type {
   PropSidebarItemCategory,
   PropSidebarItemLink,
 } from '@docusaurus/plugin-content-docs';
+
+import styles from './styles.module.css';
 
 function CardContainer({
   href,

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
@@ -13,10 +13,11 @@ import Translate from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import {usePrismTheme} from '@docusaurus/theme-common';
+
 import type {Props} from '@theme/Playground';
+import type {ThemeConfig} from '@docusaurus/theme-live-codeblock';
 
 import styles from './styles.module.css';
-import type {ThemeConfig} from '@docusaurus/theme-live-codeblock';
 
 function Header({children}: {children: React.ReactNode}) {
   return <div className={clsx(styles.playgroundHeader)}>{children}</div>;

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
@@ -31,8 +31,9 @@ import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 import Translate, {translate} from '@docusaurus/Translate';
 import Layout from '@theme/Layout';
 
-import styles from './styles.module.css';
 import type {ThemeConfig} from '@docusaurus/theme-search-algolia';
+
+import styles from './styles.module.css';
 
 // Very simple pluralization: probably good enough for now
 function useDocumentsFoundPlural() {

--- a/packages/stylelint-copyright/src/index.ts
+++ b/packages/stylelint-copyright/src/index.ts
@@ -12,16 +12,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: 'Missing copyright in the header comment',
 });
 
-type SecondaryOption =
-  | {header?: string}
-  // FIX: the SecondOption is potential to be undefined in the following files:
-  // - examples/facebook/src/pages/styles.module.css
-  // - examples/facebook/src/css/custom.css
-  // - packages/create-docusaurus/templates/facebook/src/css/custom.css
-  // - packages/create-docusaurus/templates/facebook/src/pages/styles.module.css
-  //
-  // And the file info can be derived from `result.opts.from`
-  | undefined;
+type SecondaryOption = {header?: string};
 
 const plugin = stylelint.createPlugin(
   ruleName,
@@ -47,12 +38,12 @@ const plugin = stylelint.createPlugin(
         root.first.source?.start?.column === 1
       ) {
         const {text} = root.first;
-        if (text === secondaryOption?.header) {
+        if (text === secondaryOption.header) {
           return;
         }
       }
       if (context.fix) {
-        root.first?.before(`/*${secondaryOption?.header}\n */`);
+        root.first?.before(`/*${secondaryOption.header!}\n */`);
         return;
       }
 

--- a/packages/stylelint-copyright/src/index.ts
+++ b/packages/stylelint-copyright/src/index.ts
@@ -12,7 +12,16 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: 'Missing copyright in the header comment',
 });
 
-type SecondaryOption = {header?: string};
+type SecondaryOption =
+  | {header?: string}
+  // FIX: the SecondOption is potential to be undefined in the following files:
+  // - examples/facebook/src/pages/styles.module.css
+  // - examples/facebook/src/css/custom.css
+  // - packages/create-docusaurus/templates/facebook/src/css/custom.css
+  // - packages/create-docusaurus/templates/facebook/src/pages/styles.module.css
+  //
+  // And the file info can be derived from `result.opts.from`
+  | undefined;
 
 const plugin = stylelint.createPlugin(
   ruleName,
@@ -38,12 +47,12 @@ const plugin = stylelint.createPlugin(
         root.first.source?.start?.column === 1
       ) {
         const {text} = root.first;
-        if (text === secondaryOption.header) {
+        if (text === secondaryOption?.header) {
           return;
         }
       }
       if (context.fix) {
-        root.first?.before(`/*${secondaryOption.header!}\n */`);
+        root.first?.before(`/*${secondaryOption?.header}\n */`);
         return;
       }
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -212,6 +212,7 @@ paraiso
 pathinfo
 pathnames
 pbcopy
+pcss
 peaceiris
 philpl
 photoshop
@@ -307,6 +308,7 @@ subsubsubfolder
 sucipto
 supabase
 svgr
+styl
 swizzlable
 teik
 templating

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import clsx from 'clsx';
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
-import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import Link from '@docusaurus/Link';
 import Translate, {translate} from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -23,6 +22,7 @@ import Quotes from '@site/src/data/quotes';
 import Features, {type FeatureItem} from '@site/src/data/features';
 
 import styles from './styles.module.css';
+import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 
 function HeroBanner() {
   return (


### PR DESCRIPTION
# enhance: added ESLint ruler for CSS import

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

In previous PR #7849, I found there is a bug when importing a `CSS` file after importing a type from `@docusaurus/type`.

At first, we (with the maintainer) are guessing the problem is caused by my system environment. But later I did a lot of checks, and came to realize that it's not.

## Best Solution (potential)

Just adding one extra ruler in order to force CSS to be imported at last:

```js
// .eslintrc.js
{
  pattern: '*.css', // or '*.+(css|sass|less|scss|pcss|styl)' for general match
  patternOptions: {matchBase: true},
  group: 'unknown',
  position: 'after',
}
```

## Other Solutions

I'd think it unnecessary although it may work well using an extra plugin of [`eslint-plugin-css-import-order`](https://www.npmjs.com/package/eslint-plugin-css-import-order).

## Test (tested both in WebStorm and VSCode)

As mentioned from #7849, we can do a simple test.

TIPS:

- `grep -irE "import.*\.css" packages | cut -d ':' -f 1 | uniq` can list all the files with css files imported.
- the target type file is at `packages/docusaurus-types/src/index.d.ts`

Take the `packages/docusaurus-theme-common/src/components/Details/index.tsx` as an example, we can easily get the warning if we import types from `@docusaurus/types` before css file. 

![picture 2](https://mark-vue-oss.oss-cn-hangzhou.aliyuncs.com/pr-eslint-1659195319887-8770459de59c7347cb5845f23368115d7be11115ef6c6aa5aaa99d726a26612c.png)  

However, if we omitted the imported default variable, then the warning would go away immediately (but would cause the later reference problems):

![picture 3](https://mark-vue-oss.oss-cn-hangzhou.aliyuncs.com/pr-eslint-1659195545529-b436263301a97afed1c705136cdcfe6a14ffce1e3f1b224b09304eb973ee688a.png)  

## Essential

The plugin of `eslint-plugin-import` has no default type check for file extensions, so:

| grammar | group interpreated |
| --- | --- | 
| `import css from 'xx.css'` | `internal` |
| `import css from './xx.css'` | `sibling` |
| `import css from '../xx.css'` | `parent`|
| `import '../xx.css'` | `unknown`(maybe) |

Hence, in normal situation, those `internal | sibling | parent` would be ranked in front of `type`, except we explictly declaring the module order, just like what the former work has been done:

```js
// .eslintrc.js
...
{pattern: '@theme/**', group: 'internal'},
{pattern: '@site/**', group: 'internal'},
{pattern: '@theme-init/**', group: 'internal'},
{pattern: '@theme-original/**', group: 'internal'},
...
```

All those variables, as well as types, would be intepreted before any css-like imports.

But then, not so lucky for those types imported from `@docusaurus/types`.

## Other Problems

Also, if we do not rectify this problem, each time when we commited, the eslint fix would force the local files changed into like this, which is not expected:

```ts
import styles from './styles.module.css';

import type { Config } from "@docusaurus/types";
```

## Related issues/PRs

#7849

## References

You can get more info from the following references:

- official documentation of `eslint-plugin-import`: https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/order.md
- a discussion on how to import css at last (source of the potential best solution): https://github.com/import-js/eslint-plugin-import/issues/1239