### PR TITLE
docs: update Hacker News + Product Hunt links

### DIFF
--- a/website/blog/2022-08-01-announcing-docusaurus-2.0/index.mdx
+++ b/website/blog/2022-08-01-announcing-docusaurus-2.0/index.mdx
@@ -34,7 +34,7 @@ After **4 years of work, [75 alphas](https://github.com/facebook/docusaurus/rele
 
 <!--truncate-->
 
-:::info We are on [ProductHunt](https://www.producthunt.com/) and [Hacker News](https://news.ycombinator.com/)!
+:::info We are on [ProductHunt](https://www.producthunt.com/posts/docusaurus-2-0) and [Hacker News](https://news.ycombinator.com/item?id=32303052)!
 
 **Now** is the best time to show your love for Docusaurus!
 
@@ -432,7 +432,7 @@ At [Meta Open Source](https://opensource.fb.com/), Docusaurus is one of our **mo
 
 — Slash
 
-:::info We are on [ProductHunt](https://www.producthunt.com/) and [Hacker News](https://news.ycombinator.com/)!
+:::info We are on [ProductHunt](https://www.producthunt.com/posts/docusaurus-2-0) and [Hacker News](https://news.ycombinator.com/item?id=32303052)!
 
 🙏 Share your experience using Docusaurus with the community!
 

--- a/website/src/components/HackerNewsIcon.tsx
+++ b/website/src/components/HackerNewsIcon.tsx
@@ -14,7 +14,7 @@ export default function HackerNewsIcon({
 }): JSX.Element {
   return (
     <a
-      href="https://news.ycombinator.com/"
+      href="https://news.ycombinator.com/item?id=32303052"
       target="_blank"
       rel="noreferrer"
       style={{display: 'block', width: size, height: size}}>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -274,8 +274,14 @@ function TopBanner() {
           <div className={styles.topBannerDescription}>
             We are on{' '}
             <b>
-              <Link to="https://www.producthunt.com/">ProductHunt</Link> and{' '}
-              <Link to="https://news.ycombinator.com/">Hacker News</Link> today!
+              <Link to="https://www.producthunt.com/posts/docusaurus-2-0">
+                ProductHunt
+              </Link>{' '}
+              and{' '}
+              <Link to="https://news.ycombinator.com/item?id=32303052">
+                Hacker News
+              </Link>{' '}
+              today!
             </b>
           </div>
         </div>


### PR DESCRIPTION
Update links for the launch

Linking to index page gives a better scoring per upvote but we are already underperforming on HN so let's link directly to the item otherwise users won't find the entry.