### PR TITLE
refactor(theme-classic): make tag text visually certered

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
@@ -21,7 +21,7 @@
 
 .tagRegular {
   border-radius: 0.5rem;
-  padding: 0.3rem 0.5rem;
+  padding: 0.2rem 0.5rem 0.3rem 0.5rem;
   font-size: 90%;
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Tag/styles.module.css
@@ -21,7 +21,7 @@
 
 .tagRegular {
   border-radius: 0.5rem;
-  padding: 0.2rem 0.5rem 0.3rem 0.5rem;
+  padding: 0.2rem 0.5rem 0.3rem;
   font-size: 90%;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

The tag content was visually offset which looked out of place. This fixes it.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Manually verified.

| Before | After |
| --- | --- |
| ![Screenshot 2022-08-01 at 15 36 46](https://user-images.githubusercontent.com/6379824/182160364-267e96ac-4ff5-4023-814f-cc2dcabd0111.png) | ![Screenshot 2022-08-01 at 15 36 35](https://user-images.githubusercontent.com/6379824/182160402-24df2a3b-4260-4987-b953-52aad11b4658.png) |