### PR TITLE
Remove `@mdx-js/react` from templates

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/package.json
+++ b/packages/create-docusaurus/templates/classic-typescript/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-rc.1",
     "@docusaurus/preset-classic": "2.0.0-rc.1",
-    "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/packages/create-docusaurus/templates/classic/package.json
+++ b/packages/create-docusaurus/templates/classic/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-rc.1",
     "@docusaurus/preset-classic": "2.0.0-rc.1",
-    "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/packages/create-docusaurus/templates/facebook/package.json
+++ b/packages/create-docusaurus/templates/facebook/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-rc.1",
     "@docusaurus/preset-classic": "2.0.0-rc.1",
-    "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
This shouldn't need to be an explicit dependency. The preset is already
depending on it.

## Motivation

Cleaner dependencies! There are a couple reasons
1. The classic typescript starter template is 200MB of dependencies.
2. This is explicitly required anywhere in the website so it shouldn't be a dependency.

## Test Plan

Used the TS starter to create a website. Removed this dependency. Site still works in development mode. Included MDX blog post still works correctly.
