### PR TITLE
chore: update changelog after 2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Docusaurus 2 Changelog
 
+## 2.0.1 (2022-08-01)
+
+Fix bad npm publish of 2.0.0
+
+#### Committers: 1
+
+- Sébastien Lorber ([@slorber](https://github.com/slorber))
+
+## 2.0.0 (2022-08-01)
+
+Bad npm publish, please use 2.0.1
+
 #### :nail_care: Polish
 
 - `docusaurus`

--- a/admin/scripts/test-release.sh
+++ b/admin/scripts/test-release.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 CUSTOM_REGISTRY_URL="http://localhost:4873"
-NEW_VERSION="$(node -p "require('./packages/docusaurus/package.json').version").NEW"
+NEW_VERSION="$(node -p "require('./packages/docusaurus/package.json').version")-NEW"
 CONTAINER_NAME="verdaccio"
 EXTRA_OPTS=""
 


### PR DESCRIPTION
- Missing title in 2.0.0
- Mention bad npm publish
- Add 2.0.1 entry