### PR TITLE
chore: bad remark-admonition readme link

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/admonitions/README.md
+++ b/packages/docusaurus-mdx-loader/src/remark/admonitions/README.md
@@ -1,3 +1,3 @@
 # Docusaurus admonitions
 
-Code from [remark-admonitions](https://github.com/remarkjs/remark-directive) (MIT license) has been copied to this folder, and highly customized for Docusaurus needs.
+Code from [remark-admonitions](https://github.com/elviswolcott/remark-admonitions) (MIT license) has been copied to this folder, and highly customized for Docusaurus needs.


### PR DESCRIPTION
readme link targets the wrong repo