### PR TITLE
refactor(theme-classic): split AnnouncementBar, increase z-index, use shadow

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -55,6 +55,22 @@ declare module '@theme/AnnouncementBar' {
   export default function AnnouncementBar(): JSX.Element | null;
 }
 
+declare module '@theme/AnnouncementBar/Content' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'div'> {}
+
+  export default function AnnouncementBarContent(props: Props): JSX.Element;
+}
+
+declare module '@theme/AnnouncementBar/CloseButton' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'button'> {}
+
+  export default function AnnouncementBarCloseButton(props: Props): JSX.Element;
+}
+
 declare module '@theme/BackToTopButton' {
   export default function BackToTopButton(): JSX.Element;
 }

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/CloseButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/CloseButton/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import IconClose from '@theme/Icon/Close';
+import type {Props} from '@theme/AnnouncementBar/CloseButton';
+import styles from './styles.module.css';
+
+export default function AnnouncementBarCloseButton(
+  props: Props,
+): JSX.Element | null {
+  return (
+    <button
+      type="button"
+      aria-label={translate({
+        id: 'theme.AnnouncementBar.closeButtonAriaLabel',
+        message: 'Close',
+        description: 'The ARIA label for close button of announcement bar',
+      })}
+      {...props}
+      className={clsx('clean-btn close', styles.closeButton, props.className)}>
+      <IconClose width={14} height={14} strokeWidth={3.1} />
+    </button>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/CloseButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/CloseButton/styles.module.css
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.closeButton {
+  padding: 0;
+  line-height: 0;
+}

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/Content/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import type {Props} from '@theme/AnnouncementBar/Content';
+import styles from './styles.module.css';
+
+export default function AnnouncementBarContent(
+  props: Props,
+): JSX.Element | null {
+  const {announcementBar} = useThemeConfig();
+  const {content} = announcementBar!;
+  return (
+    <div
+      {...props}
+      className={clsx(styles.content, props.className)}
+      // Developer provided the HTML, so assume it's safe.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{__html: content}}
+    />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/Content/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/Content/styles.module.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.content {
+  font-size: 85%;
+  text-align: center;
+  padding: 5px 0;
+}
+
+.content a {
+  color: inherit;
+  text-decoration: underline;
+}

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
@@ -6,49 +6,33 @@
  */
 
 import React from 'react';
-import clsx from 'clsx';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import {useAnnouncementBar} from '@docusaurus/theme-common/internal';
-import {translate} from '@docusaurus/Translate';
-import IconClose from '@theme/Icon/Close';
+import AnnouncementBarCloseButton from '@theme/AnnouncementBar/CloseButton';
+import AnnouncementBarContent from '@theme/AnnouncementBar/Content';
 
 import styles from './styles.module.css';
 
 export default function AnnouncementBar(): JSX.Element | null {
-  const {isActive, close} = useAnnouncementBar();
   const {announcementBar} = useThemeConfig();
-
+  const {isActive, close} = useAnnouncementBar();
   if (!isActive) {
     return null;
   }
-
-  const {content, backgroundColor, textColor, isCloseable} = announcementBar!;
-
+  const {backgroundColor, textColor, isCloseable} = announcementBar!;
   return (
     <div
       className={styles.announcementBar}
       style={{backgroundColor, color: textColor}}
       role="banner">
       {isCloseable && <div className={styles.announcementBarPlaceholder} />}
-      <div
-        className={styles.announcementBarContent}
-        // Developer provided the HTML, so assume it's safe.
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{__html: content}}
-      />
-      {isCloseable ? (
-        <button
-          type="button"
-          className={clsx('clean-btn close', styles.announcementBarClose)}
+      <AnnouncementBarContent className={styles.announcementBarContent} />
+      {isCloseable && (
+        <AnnouncementBarCloseButton
           onClick={close}
-          aria-label={translate({
-            id: 'theme.AnnouncementBar.closeButtonAriaLabel',
-            message: 'Close',
-            description: 'The ARIA label for close button of announcement bar',
-          })}>
-          <IconClose width={14} height={14} strokeWidth={3.1} />
-        </button>
-      ) : null}
+          className={styles.announcementBarClose}
+        />
+      )}
     </div>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -15,7 +15,8 @@
   height: var(--docusaurus-announcement-bar-height);
   background-color: var(--ifm-color-white);
   color: var(--ifm-color-black);
-  border-bottom: 1px solid var(--ifm-color-emphasis-100);
+  box-shadow: var(--ifm-global-shadow-lw);
+  z-index: calc(var(--ifm-z-index-fixed) + 1); /* just above the navbar */
 }
 
 html[data-announcement-bar-initially-dismissed='true'] .announcementBar {

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/styles.module.css
@@ -29,26 +29,16 @@ html[data-announcement-bar-initially-dismissed='true'] .announcementBar {
 .announcementBarClose {
   flex: 0 0 30px;
   align-self: stretch;
-  padding: 0;
-  line-height: 0;
 }
 
 .announcementBarContent {
   flex: 1 1 auto;
-  font-size: 85%;
-  text-align: center;
-  padding: 5px 0;
 }
 
 @media print {
   .announcementBar {
     display: none;
   }
-}
-
-.announcementBarContent a {
-  color: inherit;
-  text-decoration: underline;
 }
 
 @media (min-width: 997px) {


### PR DESCRIPTION
## Motivation

- Split theme AnnouncementBar component: extract CloseButton + Content.
- Use z-index to make it render just above the navbar
- Use shadow instead of border-bottom (requiring the z-index change to work)

Note: I didn't extract a Layout/Container component as it wasn't very easy to design those properly without introducing some extra dom nodes. 

## Test Plan

preview vs prod (almost not visible in dark mode), subtle changes only: shadow instead of border + 1px additional space.

Before:

<img width="402" alt="CleanShot 2022-08-11 at 12 23 57@2x" src="https://user-images.githubusercontent.com/749374/184113823-cd3d8d30-1479-4f5b-ae91-731b921f6f74.png">


After:

<img width="372" alt="CleanShot 2022-08-11 at 12 23 33@2x" src="https://user-images.githubusercontent.com/749374/184113766-e258a73d-679d-47c8-abf9-af421df5db69.png">


### Test links


Deploy preview: https://deploy-preview-7940--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/discussions/7827