### PR TITLE
feat(core): add new Webpack file-loader extensions: avif, mov, mkv, mpg, avi...

### DIFF
--- a/packages/docusaurus-utils/src/webpackUtils.ts
+++ b/packages/docusaurus-utils/src/webpackUtils.ts
@@ -100,7 +100,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
      */
     media: () => ({
       use: [loaders.url({folder: 'medias'})],
-      test: /\.(?:mp4|webm|ogv|wav|mp3|m4a|aac|oga|flac)$/i,
+      test: /\.(?:mp4|avi|mov|mkv|mpg|mpeg|vob|wmv|m4v|webm|ogv|wav|mp3|m4a|aac|oga|flac)$/i,
     }),
 
     svg: () => ({

--- a/packages/docusaurus-utils/src/webpackUtils.ts
+++ b/packages/docusaurus-utils/src/webpackUtils.ts
@@ -86,7 +86,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
      */
     images: () => ({
       use: [loaders.url({folder: 'images'})],
-      test: /\.(?:ico|jpe?g|png|gif|webp)(?:\?.*)?$/i,
+      test: /\.(?:ico|jpe?g|png|gif|webp|avif)(?:\?.*)?$/i,
     }),
 
     fonts: () => ({


### PR DESCRIPTION
## Motivation

Some users get confused, as some media extensions are not supported by default by Webpack file-loader

Example with `.mov` here: https://twitter.com/remitbri/status/1555216969699409920

I added some extra extensions, but it's hard to be exhaustive. Feel free to add more if you have any ideas

## Test Plan

none, that doesn't seem too risky 🤪 



