### PR TITLE
feat(theme-classic): new DocLink component

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/client/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/index.ts
@@ -36,6 +36,7 @@ export type GlobalDoc = {
    * there won't be clashes.
    */
   id: string;
+  title: string;
   path: string;
   sidebar: string | undefined;
 };

--- a/packages/docusaurus-plugin-content-docs/src/globalData.ts
+++ b/packages/docusaurus-plugin-content-docs/src/globalData.ts
@@ -22,6 +22,7 @@ import type {Sidebars} from './sidebars/types';
 function toGlobalDataDoc(doc: DocMetadata): GlobalDoc {
   return {
     id: doc.unversionedId,
+    title: doc.title,
     path: doc.permalink,
     sidebar: doc.sidebar,
   };
@@ -32,6 +33,7 @@ function toGlobalDataGeneratedIndex(
 ): GlobalDoc {
   return {
     id: doc.slug,
+    title: doc.title,
     path: doc.permalink,
     sidebar: doc.sidebar,
   };

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -363,6 +363,18 @@ declare module '@theme/DocItem/Footer' {
   export default function DocItemFooter(): JSX.Element;
 }
 
+declare module '@theme/DocLink' {
+  import type {Props as LinkProps} from '@docusaurus/Link';
+
+  export interface Props extends LinkProps {
+    readonly docId: string;
+    readonly label: string;
+    readonly docsPluginId?: string;
+  }
+
+  export default function DocLink(props: Props): JSX.Element | null;
+}
+
 declare module '@theme/DocPage/Layout' {
   import type {ReactNode} from 'react';
 

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -40,7 +40,7 @@ declare module '@docusaurus/theme-classic' {
 }
 
 declare module '@theme/Admonition' {
-  import type {ReactNode, ReactNode} from 'react';
+  import type {ReactNode} from 'react';
 
   export interface Props {
     readonly children: ReactNode;
@@ -364,6 +364,7 @@ declare module '@theme/DocItem/Footer' {
 }
 
 declare module '@theme/DocLink' {
+  import type {ReactNode} from 'react';
   import type {Props as LinkProps} from '@docusaurus/Link';
 
   export interface Props extends LinkProps {

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -40,7 +40,7 @@ declare module '@docusaurus/theme-classic' {
 }
 
 declare module '@theme/Admonition' {
-  import type {ReactNode} from 'react';
+  import type {ReactNode, ReactNode} from 'react';
 
   export interface Props {
     readonly children: ReactNode;
@@ -368,7 +368,7 @@ declare module '@theme/DocLink' {
 
   export interface Props extends LinkProps {
     readonly docId: string;
-    readonly label: string;
+    readonly children?: ReactNode;
     readonly docsPluginId?: string;
   }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import {useLayoutDoc} from '@docusaurus/theme-common/internal';
 import Link from '@docusaurus/Link';
-import type {Props} from '@theme/NavbarItem/DocNavbarItem';
+import type {Props} from '@theme/DocLink';
 
 export default function DocLink({
   docId,
@@ -24,11 +24,8 @@ export default function DocLink({
   }
 
   return (
-    <Link
-      exact
-      {...props}
-      // label={staticLabel ?? doc.id}
-      to={doc.path}
-    />
+    <Link exact {...props} to={doc.path}>
+      {staticLabel ?? doc.id}
+    </Link>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import {useLayoutDoc} from '@docusaurus/theme-common/internal';
+import Link from '@docusaurus/Link';
+import type {Props} from '@theme/NavbarItem/DocNavbarItem';
+
+export default function DocLink({
+  docId,
+  label: staticLabel,
+  docsPluginId,
+  ...props
+}: Props): JSX.Element | null {
+  const doc = useLayoutDoc(docId, docsPluginId);
+
+  // Draft items are not displayed in the navbar.
+  if (doc === null) {
+    return null;
+  }
+
+  return (
+    <Link
+      exact
+      {...props}
+      // label={staticLabel ?? doc.id}
+      to={doc.path}
+    />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
@@ -18,14 +18,14 @@ export default function DocLink({
 }: Props): JSX.Element | null {
   const doc = useLayoutDoc(docId, docsPluginId);
 
-  // Draft items are not displayed in the navbar.
+  // Will error out if the doc doesn't exist
   if (doc === null) {
     return null;
   }
 
   return (
     <Link exact {...props} to={doc.path}>
-      {children ?? doc.id}
+      {children ?? doc.title}
     </Link>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocLink/index.tsx
@@ -12,8 +12,8 @@ import type {Props} from '@theme/DocLink';
 
 export default function DocLink({
   docId,
-  label: staticLabel,
   docsPluginId,
+  children,
   ...props
 }: Props): JSX.Element | null {
   const doc = useLayoutDoc(docId, docsPluginId);
@@ -25,7 +25,7 @@ export default function DocLink({
 
   return (
     <Link exact {...props} to={doc.path}>
-      {staticLabel ?? doc.id}
+      {children ?? doc.id}
     </Link>
   );
 }

--- a/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
@@ -273,7 +273,7 @@ export function useLayoutDoc(
         return null;
       }
       throw new Error(
-        `DocNavbarItem: couldn't find any doc with id "${docId}" in version${
+        `DocLink: couldn't find any doc with id "${docId}" in version${
           versions.length > 1 ? 's' : ''
         } ${versions.map((version) => version.name).join(', ')}".
 Available doc ids are:

--- a/website/blog/2022-08-01-announcing-docusaurus-2.0/index.mdx
+++ b/website/blog/2022-08-01-announcing-docusaurus-2.0/index.mdx
@@ -22,6 +22,7 @@ import ColorModeToggle from '@theme/Navbar/ColorModeToggle';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import ThemedImage from '@theme/ThemedImage';
 import {ShowcaseCarouselV1, ShowcaseCarouselV2, ShowcaseCarouselV2Theming} from './ShowcaseCarousel';
+import DocLink from '@theme/DocLink';
 ```
 
 Today we are extremely happy to finally **announce Docusaurus 2.0**! 🥳️
@@ -310,7 +311,7 @@ Docusaurus theming gives a lot of **flexibility** on multiple levels:
 - Customize CSS variables to adjust colors, fonts, and more
 - Provide your own CSS stylesheets
 - Implement your own theme from scratch
-- **Override any React component** provided by our default theme: we call this [swizzling](https://docusaurus.io/docs/swizzling)
+- **Override any React component** provided by our default theme: we call this <DocLink docId="swizzling"/>
 
 <TweetQuote
   url="https://twitter.com/hung_dev/status/1546918275065741312"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -89,7 +89,7 @@ function MigrationAnnouncement() {
               </Link>
             ),
             migrationGuideLink: (
-              <DocLink docId="migration/migration-overview" label="Test">
+              <DocLink docId="migration/migration-overview">
                 <Translate>v1 to v2 migration guide</Translate>
               </DocLink>
             ),

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -15,6 +15,7 @@ import useBaseUrl, {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
 
 import Image from '@theme/IdealImage';
 import Layout from '@theme/Layout';
+import DocLink from '@theme/DocLink';
 
 import Tweet from '@site/src/components/Tweet';
 import Tweets, {type TweetItem} from '@site/src/data/tweets';
@@ -88,9 +89,9 @@ function MigrationAnnouncement() {
               </Link>
             ),
             migrationGuideLink: (
-              <Link to="/docs/migration">
+              <DocLink docId="migration/migration-overview" label="Test">
                 <Translate>v1 to v2 migration guide</Translate>
-              </Link>
+              </DocLink>
             ),
           }}>
           {`Coming from {docusaurusV1Link}? Check out our {migrationGuideLink}.`}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

This is related to #7402 to implement the `<DocLink>` component. I would like a way to link to docs from non-doc pages and with the custom versioning we have set up (not using `current` as our docs base url) then I had to use `import { useLatestVersion } from "@docusaurus/plugin-content-docs/client";` as @Josh-Cena suggested.

I am admittedly very green to development within Docusaurus and React in general, so please feel free to give me guidance on any changes needed. Figured it would be better to get this minimal bit out there and get feedback than struggling to make it "perfect" myself ;) 

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I have added a (admittedly minimal) test to the Docusaurus website for the "v1 to v2 migration guide" link.

<img width="865" alt="Screenshot 2022-08-11 at 14 04 42" src="https://user-images.githubusercontent.com/15347255/184139826-0e4c4cd1-f889-40c6-9979-7f74a3341396.png">

Also added a this to the latest blog post page in the theming section (swizzling link):

<img width="778" alt="Screenshot 2022-08-11 at 19 47 56" src="https://user-images.githubusercontent.com/15347255/184216272-7a8d875c-2573-40b6-8b91-bdfb769b329f.png">


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-7943--docusaurus-2.netlify.app
Test on blog post: https://deploy-preview-7943--docusaurus-2.netlify.app/blog/2022/08/01/announcing-docusaurus-2.0/#theming (swizzling bullet point under theming)

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

https://github.com/facebook/docusaurus/issues/7402

## Additional Items

- [x] If there's a way to dynamically get the doc title (I'm thinking the H1 and not the sidebar label) then it would be nice to be able to automatically retrieve it
- [ ] Doesn't respect if anything other than `error` is used for `onBrokenLink` since `useLayoutDoc` throws an error and will only ignore if the doc is marked as a draft. Could also look at having a separate function since it seems `useLayoutDoc` is meant exclusively for generating navbar-type links (which should throw an error if broken I guess)
