### PR TITLE
test: improve e2e verdaccio configuration

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -12,10 +12,9 @@ on:
       - packages/**
       - tsconfig.json
   pull_request:
-    # force E2E on PR for this PR (test)
-    # branches:
-    #   - main
-    #   - docusaurus-v**
+    branches:
+      - main
+      - docusaurus-v**
     paths:
       - package.json
       - yarn.lock

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -12,15 +12,17 @@ on:
       - packages/**
       - tsconfig.json
   pull_request:
-    branches:
-      - main
-      - docusaurus-v**
+    # force E2E on PR for this PR (test)
+    # branches:
+    #   - main
+    #   - docusaurus-v**
     paths:
       - package.json
       - yarn.lock
       - jest.config.mjs
       - packages/**
       - tsconfig.json
+      - admin/verdaccio.yaml
       - .github/workflows/tests-e2e.yml
 
 concurrency:

--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -13,11 +13,21 @@
 
 storage: ../storage
 
+publish:
+  allow_offline: false
+
 # A list of other known repositories we can talk to
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
+  '@docusaurus/*':
+    access: $all
+    publish: $all
+  '@*/*':
+      access: $all
+      publish: $authenticated
+      proxy: npmjs    
   '**':
     # Allow all users (including non-authenticated users) to read and
     # publish all packages

--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -50,7 +50,7 @@ packages:
 
 # Log settings
 logs:
-  - {type: stdout, format: json, level: warn}
+  - {type: stdout, format: pretty, level: http}
 
 # Fix 413 errors in e2e CI
 max_body_size: 1000mb

--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -21,6 +21,10 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
+  '@docusaurus/react-loadable':
+    access: $all
+    publish: $all
+    proxy: npmjs  
   '@docusaurus/*':
     access: $all
     publish: $all

--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -13,9 +13,9 @@
 
 storage: ../storage
 
-## verdaccio does not allow to publish packages when the client is offline, to avoid
-## errors on publish it is disabled
-## https://verdaccio.org/docs/configuration#offline-publish
+# Verdaccio does not allow to publish packages when the client is offline, to avoid
+# errors on publish
+# https://verdaccio.org/docs/configuration#offline-publish
 publish:
   allow_offline: false
 
@@ -24,14 +24,12 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
-  # this package is hosted outside the monorepo
-  # https://github.com/slorber/react-loadable
-  # thus requires to be fetched from npmjs
+  # Forked packages need to be fetched from npm
   '@docusaurus/react-loadable':
     access: $all
     publish: $all
     proxy: npmjs
-  # group and isolate all local packages, avoid being proxy from outside
+  # Group and isolate all local packages, avoid being proxy from outside
   '@docusaurus/*':
     access: $all
     publish: $all

--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -13,6 +13,9 @@
 
 storage: ../storage
 
+## verdaccio does not allow to publish packages when the client is offline, to avoid
+## errors on publish it is disabled
+## https://verdaccio.org/docs/configuration#offline-publish
 publish:
   allow_offline: false
 
@@ -47,7 +50,7 @@ packages:
 
 # Log settings
 logs:
-  - {type: stdout, format: pretty, level: http}
+  - {type: stdout, format: json, level: warn}
 
 # Fix 413 errors in e2e CI
 max_body_size: 1000mb

--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -21,17 +21,21 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
+  # this package is hosted outside the monorepo
+  # https://github.com/slorber/react-loadable
+  # thus requires to be fetched from npmjs
   '@docusaurus/react-loadable':
     access: $all
     publish: $all
-    proxy: npmjs  
+    proxy: npmjs
+  # group and isolate all local packages, avoid being proxy from outside
   '@docusaurus/*':
     access: $all
     publish: $all
   '@*/*':
-      access: $all
-      publish: $authenticated
-      proxy: npmjs    
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
   '**':
     # Allow all users (including non-authenticated users) to read and
     # publish all packages


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I've notice master fails with `E503 one of the uplinks is down, refuse to publish`, this happens because on publish first check on internet if the version of this package exist, for E2E this should not be required. I'm trying to improve the master branch builds.

By adding a new block for `@docusaurus/*` avoid check any uplink and also the property `allow_offline` avoid any check with internet on publish (this is handy if the connection is dropped so avoid network issues)

> I had to add an additional block for `@docusaurus/react-loadable` because this package is not part of this monorepo, while the order in the `packages` section matters, should be on the top of `@docusaurus/*`.


The CI build: https://github.com/facebook/docusaurus/runs/7881520546?check_suite_focus=true
```
lerna notice total files:   64                                      
775
lerna notice 
776
lerna ERR! E503 one of the uplinks is down, refuse to publish
777
error Command failed with exit code 1.
778
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
779
Error: Process completed with exit code 1.
```

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

- E2E are green

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
