### PR TITLE
fix(core): preload should support encoded page links

### DIFF
--- a/packages/docusaurus/src/client/preload.ts
+++ b/packages/docusaurus/src/client/preload.ts
@@ -18,7 +18,7 @@ import {matchRoutes} from 'react-router-config';
  */
 export default function preload(pathname: string): Promise<void[]> {
   const matches = Array.from(new Set([pathname, decodeURI(pathname)]))
-    .map(p => matchRoutes(routes, p))
+    .map((p) => matchRoutes(routes, p))
     .flat();
 
   return Promise.all(matches.map((match) => match.route.component.preload?.()));

--- a/packages/docusaurus/src/client/preload.ts
+++ b/packages/docusaurus/src/client/preload.ts
@@ -17,7 +17,9 @@ import {matchRoutes} from 'react-router-config';
  * @returns Promise object represents whether pathname has been preloaded
  */
 export default function preload(pathname: string): Promise<void[]> {
-  const matches = matchRoutes(routes, pathname);
+  const matches = [pathname, decodeURI(pathname)]
+    .map(p => matchRoutes(routes, p))
+    .flat();
 
   return Promise.all(matches.map((match) => match.route.component.preload?.()));
 }

--- a/packages/docusaurus/src/client/preload.ts
+++ b/packages/docusaurus/src/client/preload.ts
@@ -17,7 +17,7 @@ import {matchRoutes} from 'react-router-config';
  * @returns Promise object represents whether pathname has been preloaded
  */
 export default function preload(pathname: string): Promise<void[]> {
-  const matches = [pathname, decodeURI(pathname)]
+  const matches = Array.from(new Set([pathname, decodeURI(pathname)]))
     .map(p => matchRoutes(routes, p))
     .flat();
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Similar to https://github.com/facebook/docusaurus/pull/4407, when containing encoded chars (like whitespace, cn) "preload" won't work, and thus the page will blink (first render as static html, then empty, then after js loaded async render page again), and break the behavior that jumping to doc content with url hash  `#`.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Wish to provide unit test, but stuck during initializing dev env. The code is simple, and is tested in my own repo.

A playground to show the problem: https://codesandbox.io/s/frosty-curran-rsoubc?file=/docs/%E5%85%A5%E9%97%A8%E4%BB%8B%E7%BB%8D.md. Visit `/docs/入门介绍` and debug `client/preload.js` file. `preload` func won't match the extract route.


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-7977--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
https://github.com/facebook/docusaurus/pull/4407
