### PR TITLE
fix(theme-classic): avoid rendering empty search box container

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -74,7 +74,6 @@ declare module '@theme/AnnouncementBar/CloseButton' {
 declare module '@theme/BackToTopButton' {
   export default function BackToTopButton(): JSX.Element;
 }
-
 declare module '@theme/BlogListPaginator' {
   import type {BlogPaginatedMetadata} from '@docusaurus/plugin-content-blog';
 
@@ -900,7 +899,7 @@ declare module '@theme/Navbar/Search' {
     readonly className?: string;
   }
 
-  export default function NavbarSearch(props: Props): JSX.Element;
+  export default function NavbarSearch(props: Props): JSX.Element | null;
 }
 
 declare module '@theme/NavbarItem/DefaultNavbarItem' {

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -1117,7 +1117,7 @@ declare module '@theme/PaginatorNavLink' {
 }
 
 declare module '@theme/SearchBar' {
-  export default function SearchBar(): JSX.Element;
+  export default function SearchBar(): JSX.Element | null;
 }
 
 declare module '@theme/TabItem' {

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -74,6 +74,7 @@ declare module '@theme/AnnouncementBar/CloseButton' {
 declare module '@theme/BackToTopButton' {
   export default function BackToTopButton(): JSX.Element;
 }
+
 declare module '@theme/BlogListPaginator' {
   import type {BlogPaginatedMetadata} from '@docusaurus/plugin-content-blog';
 

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -15,5 +15,6 @@ export default function NavbarSearch({
   children,
   className,
 }: Props): JSX.Element {
+  if (!children) return <></>;
   return <div className={clsx(className, styles.searchBox)}>{children}</div>;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import type {Props} from '@theme/Navbar/Search';
 
 import styles from './styles.module.css';
@@ -15,7 +16,8 @@ export default function NavbarSearch({
   children,
   className,
 }: Props): JSX.Element | null {
-  if (!children) {
+  const {siteConfig} = useDocusaurusContext();
+  if (!siteConfig.themeConfig?.algolia) {
     return null;
   }
   return <div className={clsx(className, styles.searchBox)}>{children}</div>;

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import type {Props} from '@theme/Navbar/Search';
 
 import styles from './styles.module.css';
@@ -16,8 +15,7 @@ export default function NavbarSearch({
   children,
   className,
 }: Props): JSX.Element | null {
-  const {siteConfig} = useDocusaurusContext();
-  if (!siteConfig.themeConfig?.algolia) {
+  if ((children as any)?.type?.() === null) {
     return null;
   }
   return <div className={clsx(className, styles.searchBox)}>{children}</div>;

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -14,7 +14,7 @@ import styles from './styles.module.css';
 export default function NavbarSearch({
   children,
   className,
-}: Props): JSX.Element {
+}: Props): JSX.Element | null {
   if (!children) {
     return null;
   }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -15,6 +15,8 @@ export default function NavbarSearch({
   children,
   className,
 }: Props): JSX.Element {
-  if (!children) return <></>;
+  if (!children) {
+    return null;
+  }
   return <div className={clsx(className, styles.searchBox)}>{children}</div>;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

<img width="309" alt="image" src="https://user-images.githubusercontent.com/69514654/186157736-89c5a689-c471-403a-843d-395620835ea2.png">

https://stackblitz.com/github/facebook/docusaurus/tree/starter

The search box should not be displayed when the search function is not enabled.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
