### PR TITLE
Typo metadata+s in docusaurus-config in SEO page

### DIFF
--- a/website/docs/seo.md
+++ b/website/docs/seo.md
@@ -19,7 +19,7 @@ Provide global meta attributes for the entire site through the [site configurati
 ```js title="docusaurus.config.js"
 module.exports = {
   themeConfig: {
-    metadata: [{name: 'keywords', content: 'cooking, blog'}],
+    metadatas: [{name: 'keywords', content: 'cooking, blog'}],
     // This would become <meta name="keywords" content="cooking, blog"> in the generated HTML
   },
 };


### PR DESCRIPTION
## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

It seems the "metadata" key should have been "metadatas". Following the current docs didn't work for me but the IDE's Type suggestion made things work.

