### PR TITLE
fix(preset-classic): broken link in "unrecognized keys" error message

### DIFF
--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -87,7 +87,7 @@ export default function preset(
     throw new Error(
       `Unrecognized keys ${Object.keys(rest).join(
         ', ',
-      )} found in preset-classic configuration. The allowed keys are debug, docs, blog, pages, sitemap, theme, googleAnalytics, gtag. Check the documentation: https://docusaurus.io/docs/presets#docusauruspreset-classic for more information on how to configure individual plugins.`,
+      )} found in preset-classic configuration. The allowed keys are debug, docs, blog, pages, sitemap, theme, googleAnalytics, gtag. Check the documentation: https://docusaurus.io/docs/using-plugins#docusauruspreset-classic for more information on how to configure individual plugins.`,
     );
   }
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

By running docusaurus with unrecognized keys inside the preset classic configuration, an error is displayed with a link to the documentation:
<img width="709" alt="Capture d’écran 2022-08-31 à 10 52 19" src="https://user-images.githubusercontent.com/30866152/187640976-d6855a4c-49b1-4f0c-a872-6b3abb5f7f57.png">

The provided link ([https://docusaurus.io/docs/presets#docusauruspreset-classic](https://docusaurus.io/docs/presets#docusauruspreset-classic)) leads to a `Page not Found` on the documentation: 

<img width="722" alt="Capture d’écran 2022-08-31 à 11 02 15" src="https://user-images.githubusercontent.com/30866152/187641528-a9bb7854-0d1f-421e-a33a-2d3d77a86c2e.png">

As the `preset` page doesn't exist anymore, it would make sense to replace the previous link with this one: [https://docusaurus.io/docs/using-plugins#docusauruspreset-classic](https://docusaurus.io/docs/using-plugins#docusauruspreset-classic)


### Test links

Deploy preview: https://deploy-preview-8029--docusaurus-2.netlify.app/

