### PR TITLE
fix(create-docusaurus): tutorial and init template improvements

### DIFF
--- a/packages/create-docusaurus/templates/facebook/sidebars.js
+++ b/packages/create-docusaurus/templates/facebook/sidebars.js
@@ -25,10 +25,12 @@ module.exports = {
   // But you can create a sidebar manually
   /*
   tutorialSidebar: [
+    'intro',
+    'hello',
     {
       type: 'category',
       label: 'Tutorial',
-      items: ['hello'],
+      items: ['tutorial-basics/create-a-document'],
     },
   ],
    */

--- a/packages/create-docusaurus/templates/shared/docs/tutorial-basics/create-a-document.md
+++ b/packages/create-docusaurus/templates/shared/docs/tutorial-basics/create-a-document.md
@@ -44,11 +44,13 @@ It is also possible to create your sidebar explicitly in `sidebars.js`:
 ```js title="sidebars.js"
 module.exports = {
   tutorialSidebar: [
+    'intro',
+    // highlight-next-line
+    'hello',
     {
       type: 'category',
       label: 'Tutorial',
-      // highlight-next-line
-      items: ['hello'],
+      items: ['tutorial-basics/create-a-document'],
     },
   ],
 };

--- a/packages/create-docusaurus/templates/shared/sidebars.js
+++ b/packages/create-docusaurus/templates/shared/sidebars.js
@@ -19,10 +19,12 @@ const sidebars = {
   // But you can create a sidebar manually
   /*
   tutorialSidebar: [
+    'intro',
+    'hello',
     {
       type: 'category',
       label: 'Tutorial',
-      items: ['hello'],
+      items: ['tutorial-basics/create-a-document'],
     },
   ],
    */


### PR DESCRIPTION


## Motivation


The tutorial explicit sidebar must contain the `tutorial-basics/create-a-document` doc, so that the sidebar remains visible while browsing the doc suggesting to create that manual sidebar in the first place. See also feedback https://github.com/facebook/docusaurus/discussions/4610#discussioncomment-3525088
