### PR TITLE
docs(content-docs): updates typo in lifecycle-apis.md

### DIFF
--- a/website/docs/api/plugin-methods/lifecycle-apis.md
+++ b/website/docs/api/plugin-methods/lifecycle-apis.md
@@ -11,7 +11,7 @@ During the build, plugins are loaded in parallel to fetch their own contents and
 
 Plugins should use this lifecycle to fetch from data sources (filesystem, remote API, headless CMS, etc.) or do some server processing. The return value is the content it needs.
 
-For example, this plugin below return a random integer between 1 to 10 as content.
+For example, this plugin below returns a random integer between 1 and 10 as content.
 
 ```js title="docusaurus-plugin/src/index.js"
 module.exports = function (context, options) {


### PR DESCRIPTION
Grammatical change on line 14

`For example, this plugin below returns a random integer between 1 and 10 as content.`

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I wanted to fix a small typo while reading through the docusaurus documentation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

N/A

### Test links

Link to documentation:
https://docusaurus.io/docs/api/plugin-methods/lifecycle-apis#loadContent

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8055--docusaurus-2.netlify.app/docs/api/plugin-methods/lifecycle-apis#loadContent

## Related issues/PRs

N/A 
<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
