### PR TITLE
refactor(admonitions): admonition options breaking changes

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/admonitions/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-mdx-loader/src/remark/admonitions/__tests__/__snapshots__/index.test.ts.snap
@@ -38,9 +38,7 @@ exports[`admonitions remark plugin custom tag 1`] = `
 
 exports[`admonitions remark plugin default behavior for custom keyword 1`] = `
 "<p>The blog feature enables you to deploy in no time a full-featured blog.</p>
-<p>:::info Sample Title</p>
-<p>Check the <a href="./api/plugins/plugin-content-blog.md">Blog Plugin API Reference documentation</a> for an exhaustive list of options.</p>
-<p>:::</p>
+<admonition title="Sample Title" type="info"><p>Check the <a href="./api/plugins/plugin-content-blog.md">Blog Plugin API Reference documentation</a> for an exhaustive list of options.</p></admonition>
 <h2>Initial setup {#initial-setup}</h2>
 <p>To set up your site's blog, start by creating a <code>blog</code> directory.</p>
 <admonition type="tip"><p>Use the <strong><a href="introduction.md#fast-track">Fast Track</a></strong> to understand Docusaurus in <strong>5 minutes ⏱</strong>!</p><p>Use <strong><a href="https://docusaurus.new">docusaurus.new</a></strong> to test Docusaurus immediately in your browser!</p></admonition>

--- a/packages/docusaurus-mdx-loader/src/remark/admonitions/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/admonitions/index.ts
@@ -34,7 +34,7 @@ export const DefaultAdmonitionOptions: AdmonitionOptions = {
     'important',
     'caution',
   ],
-  extendDefaults: false, // TODO make it true by default: breaking change
+  extendDefaults: true,
 };
 
 function escapeRegExp(s: string): string {

--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -253,7 +253,7 @@ The plugin accepts the following options:
 
 - `tag`: The tag that encloses the admonition. Defaults to `:::`.
 - `keywords`: An array of keywords that can be used as the type for the admonition.
-- `extendDefaults`: Should the provided options (such as `keywords`) be merged into the existing defaults. Defaults to `false`.
+- `extendDefaults`: Should the provided options (such as `keywords`) be merged into the existing defaults. Defaults to `true`.
 
 The `keyword` will be passed as the `type` prop of the `Admonition` component.
 


### PR DESCRIPTION
## Breaking change

- By default: `admonition.keywords` are appended to the default list of keywords instead of replacing the default list of keywords


## Motivation

Let's use this PR to discuss / implement all the admonition API breaking changes we want to do.

Some pending questions:
- Do we want to give the ability to use custom tags per keyword? `:::note, +++tip`....
- Do we wait for `siteConfig.markdown.admonitions` config before merging this?

## Test Plan

unit tests

### Test links


Deploy preview: https://deploy-preview-8058--docusaurus-2.netlify.app/

## Related issues/PRs

Follow-up of https://github.com/facebook/docusaurus/pull/7945
