### PR TITLE
fix(website): add website admonitions extendDefaults: true

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -305,6 +305,7 @@ const config = {
           },
           admonitions: {
             keywords: ['my-custom-admonition'],
+            extendDefaults: true,
           },
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,


### PR DESCRIPTION
## Motivation

I broke our website admonitions 😅 

<img width="655" alt="CleanShot 2022-09-07 at 19 00 07@2x" src="https://user-images.githubusercontent.com/749374/188937057-f9a9622c-ed76-45ce-b2de-761da5af8fbf.png">

## Test Plan

preview

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8060--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/pull/7945
