### PR TITLE
feat: improve syncing of user preferred theme

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -384,7 +384,6 @@ const config = {
         },
       },
       colorMode: {
-        defaultMode: 'light',
         disableSwitch: false,
         respectPrefersColorScheme: true,
       },


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

As mentioned in #8074, I believe that if I change my preferred theme between sessions, I probably want it to update if my preferred theme has changed.

I implemented a feature that stores the user's preferred theme in localStorage (if `respectPrefersColorScheme` is used). That way, we can check when the user visits the site the next time, if their preferred theme has changed.

This is needed because the `theme` key (set when toggling using the switch) takes precedence over the media-matched `prefers-color-scheme` entry. This means that if I use the switch, the site no longer respects my system preferences. This is good when navigating the page to keep it from switching themes when navigating. But if I come back later at night, and my system preference has changed, this change would previously not be recognized.

Let me explain the new behavior with some examples (examples goes both ways for light/dark mode):

1. The user browses the site during the day and uses light mode. When they come back at night, their system preferences has changed to dark mode. This change will be registered so the site will use dark mode too.

2. The user browses the site using light mode, because they don't like the dark mode of that site. The user always uses dark mode for their system preferences, so when coming back it won't have changed so the site will keep running in light mode. 

3. The user navigates the site and uses the toggle to select light mode. They switch page. The dark mode system preference does not take precedence so we keep using light mode.

## Test Plan

I have not yet added any tests, if you feel like it's required let me know and we can plan a test plan together.

### Test links

- NaN

Deploy preview: https://deploy-preview-8078--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8074 
