### PR TITLE
feat: allow activeBaseRegex for DocNavbarItem

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -7,7 +7,11 @@
 
 import React from 'react';
 import {useActiveDocContext} from '@docusaurus/plugin-content-docs/client';
-import {useLayoutDoc} from '@docusaurus/theme-common/internal';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import {
+  isRegexpStringMatch,
+  useLayoutDoc,
+} from '@docusaurus/theme-common/internal';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import type {Props} from '@theme/NavbarItem/DocNavbarItem';
 
@@ -15,10 +19,13 @@ export default function DocNavbarItem({
   docId,
   label: staticLabel,
   docsPluginId,
+  activeBasePath,
+  activeBaseRegex,
   ...props
 }: Props): JSX.Element | null {
   const {activeDoc} = useActiveDocContext(docsPluginId);
   const doc = useLayoutDoc(docId, docsPluginId);
+  const activeBaseUrl = useBaseUrl(activeBasePath);
 
   // Draft items are not displayed in the navbar.
   if (doc === null) {
@@ -29,10 +36,25 @@ export default function DocNavbarItem({
     <DefaultNavbarItem
       exact
       {...props}
-      isActive={() =>
-        activeDoc?.path === doc.path ||
-        (!!activeDoc?.sidebar && activeDoc.sidebar === doc.sidebar)
-      }
+      isActive={(_match, location) => {
+        if (activeBaseRegex) {
+          console.log('using activeBaseRegex', activeBaseRegex);
+          console.log('location', location.pathname);
+          const matched = isRegexpStringMatch(
+            activeBaseRegex,
+            location.pathname,
+          );
+          console.log('matched', matched);
+          return matched;
+        }
+        if (activeBasePath) {
+          return location.pathname.startsWith(activeBaseUrl);
+        }
+        return (
+          activeDoc?.path === doc.path ||
+          (!!activeDoc?.sidebar && activeDoc.sidebar === doc.sidebar)
+        );
+      }}
       label={staticLabel ?? doc.id}
       to={doc.path}
     />

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -431,6 +431,13 @@ const config = {
             label: 'Docs',
           },
           {
+            type: 'doc',
+            position: 'left',
+            docId: 'playground',
+            label: 'Playground',
+            activeBaseRegex: `/docs/playground`,
+          },
+          {
             type: 'docSidebar',
             position: 'left',
             sidebarId: 'api',


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

DocNavbarItem's currently aren't allowed being matched using `activeBasePath` or `activeBaseRegex` like other NavbarItems. This PR adds the ability to match these too.

For reference, on the [tRPC website](https://trpc.io), we have multiple DocItems in the navbar, and currently they are all being matched as active. By allowing them to be regex matched we would have more flexibility and could fix this issue.

## Test Plan

I don't think there is any need for tests. I have reused the same logic from `NavbarNavLink`. If you disagree, let me know and we can work it out.

### Test links

- NaN

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8018