### PR TITLE
docs(swizzling): add useBlogPost to guide

### DIFF
--- a/website/docs/swizzling.md
+++ b/website/docs/swizzling.md
@@ -207,12 +207,16 @@ Wrapping a theme is a great way to **add extra components around existing one** 
 import React from 'react';
 import BlogPostItem from '@theme-original/BlogPostItem';
 import MyCustomCommentSystem from '@site/src/MyCustomCommentSystem';
+import { useBlogPost } from '@docusaurus/theme-common/internal':
 
 export default function BlogPostItemWrapper(props) {
+  // use this hook to determine that it is currently in blog posts or blog page
+  const { isBlogPostPage } = useBlogPost();
+  
   return (
     <>
       <BlogPostItem {...props} />
-      <MyCustomCommentSystem />
+      {isBlogPostPage && <MyCustomCommentSystem />}
     </>
   );
 }


### PR DESCRIPTION
In my experience, we need `useBlogPost` to guide how to add comment to `BlogPostItemWrapper`, this hook can determine that it is currently in blog post list or blog page.

## Test Plan
don't need test.


