### PR TITLE
fix(utils): remove non-ASCII limitation for path normalization

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/pathUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/pathUtils.test.ts
@@ -156,7 +156,7 @@ describe('posixPath', () => {
   it('works', () => {
     const asserts: {[key: string]: string} = {
       'c:/aaaa\\bbbb': 'c:/aaaa/bbbb',
-      'c:\\aaaa\\bbbb\\★': 'c:\\aaaa\\bbbb\\★',
+      'c:\\aaaa\\bbbb\\★': 'c:/aaaa/bbbb/★',
       '\\\\?\\c:\\aaaa\\bbbb': '\\\\?\\c:\\aaaa\\bbbb',
       'c:\\aaaa\\bbbb': 'c:/aaaa/bbbb',
       'foo\\bar': 'foo/bar',

--- a/packages/docusaurus-utils/src/pathUtils.ts
+++ b/packages/docusaurus-utils/src/pathUtils.ts
@@ -58,12 +58,7 @@ export function shortName(str: string): string {
 export function posixPath(str: string): string {
   const isExtendedLengthPath = str.startsWith('\\\\?\\');
 
-  // Forward slashes are only valid Windows paths when they don't contain non-
-  // ascii characters.
-  // eslint-disable-next-line no-control-regex
-  const hasNonAscii = /[^\u0000-\u0080]+/.test(str);
-
-  if (isExtendedLengthPath || hasNonAscii) {
+  if (isExtendedLengthPath) {
     return str;
   }
   return str.replace(/\\/g, '/');

--- a/website/_dogfooding/_docs tests/tests/ascii/folder/æøå.md
+++ b/website/_dogfooding/_docs tests/tests/ascii/folder/æøå.md
@@ -1,0 +1,1 @@
+Dogfood test for https://github.com/facebook/docusaurus/pull/8137

--- a/website/_dogfooding/_docs tests/tests/ascii/æøå/index.md
+++ b/website/_dogfooding/_docs tests/tests/ascii/æøå/index.md
@@ -1,0 +1,1 @@
+Dogfood test for https://github.com/facebook/docusaurus/pull/8137


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Fixes https://github.com/facebook/docusaurus/issues/8124

The issue specifically pertains to index file detection for paths that contain non-ASCII letters (e.g. "æ"). This failed previously, due to a test for non-ASCII characters when normalizing file paths. This test originated in the sindresorhus/slash package, and was copied over when the code was integrated into docusaurus - but doesn't appear to match how Windows works.

See that issue for further discussion, or https://github.com/sindresorhus/slash/issues/19 for discussion on limitation in the originating package. The limitation was removed in the originating package in https://github.com/sindresorhus/slash/pull/20

## Test Plan

Updated tests in this repo, and verified by modifying `node_modules` directly in https://github.com/birjj/docusaurus-repro-8124 that it works for the specific issue encountered:

<p align="center"><img alt="Image comparing a Docusaurus sidebar before and after the change, show an expandable "æøå" category in the before image, versus a simple "ÆØÅ" link in the after" src="https://user-images.githubusercontent.com/4542461/192495271-4d1e3a3b-648c-49d7-bf47-f8325a868c8f.png" />

For the file structure

```
docs
 ├─ abc
 │  └─ index.md
 └─ æøå
    └─ index.md
```

### Test links

Deploy preview: https://deploy-preview-8137--docusaurus-2.netlify.app/ (note that this isn't relevant, as the issue is Windows-specific)

## Related issues/PRs

https://github.com/facebook/docusaurus/issues/8124
https://github.com/sindresorhus/slash/issues/19
https://github.com/sindresorhus/slash/pull/20