### PR TITLE
feat: headTags API for tags rendered in the head

### DIFF
--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -193,6 +193,13 @@ export type DocusaurusConfig = {
    */
   staticDirectories: string[];
   /**
+   * An array of tags that will be inserted in the HTML `<head>`.
+   *
+   * @see https://docusaurus.io/docs/api/docusaurus-config#head
+   * @default []
+   */
+  headTags: HtmlTagObject[];
+  /**
    * An array of scripts to load. The values can be either strings or plain
    * objects of attribute-value maps. The `<script>` tags will be inserted in
    * the HTML `<head>`.

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -33,6 +33,7 @@ export const DEFAULT_CONFIG: Pick<
   | 'plugins'
   | 'themes'
   | 'presets'
+  | 'headTags'
   | 'stylesheets'
   | 'scripts'
   | 'clientModules'
@@ -51,6 +52,7 @@ export const DEFAULT_CONFIG: Pick<
   plugins: [],
   themes: [],
   presets: [],
+  headTags: [],
   stylesheets: [],
   scripts: [],
   clientModules: [],
@@ -214,6 +216,18 @@ export const ConfigSchema = Joi.object<DocusaurusConfig>({
     })
     .default(DEFAULT_CONFIG.scripts),
   ssrTemplate: Joi.string(),
+  headTags: Joi.array()
+    .items(
+      Joi.object({
+        tagName: Joi.string().required(),
+        attributes: Joi.object().required(),
+      }).unknown(),
+    )
+    .messages({
+      'array.includes':
+        '{#label} is invalid. A headTag must be an object with at least a "tagName" and an "attributes" property.',
+    })
+    .default(DEFAULT_CONFIG.headTags),
   stylesheets: Joi.array()
     .items(
       Joi.string(),

--- a/packages/docusaurus/src/server/plugins/synthetic.ts
+++ b/packages/docusaurus/src/server/plugins/synthetic.ts
@@ -21,6 +21,7 @@ export function createBootstrapPlugin({
   const {
     stylesheets,
     scripts,
+    headTags,
     clientModules: siteConfigClientModules,
   } = siteConfig;
   return {
@@ -58,7 +59,7 @@ export function createBootstrapPlugin({
             },
       );
       return {
-        headTags: [...stylesheetsTags, ...scriptsTags],
+        headTags: [...headTags, ...stylesheetsTags, ...scriptsTags],
       };
     },
   };

--- a/website/docs/api/docusaurus.config.js.md
+++ b/website/docs/api/docusaurus.config.js.md
@@ -429,6 +429,30 @@ module.exports = {
 };
 ```
 
+### `headTags` {#headTags}
+
+An array of tags that will be inserted in the HTML `<head>`. The values must be objects that contain two properties; `tagName` and `attributes`. `tagName` must be a string that determines the tag being created; eg `"link"`. `attributes` must be an attribute-value map.
+
+- Type: `{ tagName: string; attributes: Object; }[]`
+
+Example:
+
+```js title="docusaurus.config.js"
+module.exports = {
+  headTags: [
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'monetization',
+        href: 'https://ilp.uphold.com/LwQQhXdpwxeJ',
+      },
+    },
+  ],
+};
+```
+
+This would become `<link rel="monetization" href="https://ilp.uphold.com/LwQQhXdpwxeJ" />` in the generated HTML.
+
 ### `scripts` {#scripts}
 
 An array of scripts to load. The values can be either strings or plain objects of attribute-value maps. The `<script>` tags will be inserted in the HTML `<head>`. If you use a plain object, the only required attribute is `src`, and any other attributes are permitted (each one should have boolean/string values).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -82,6 +82,15 @@ const config = {
   // - force trailing slashes for deploy previews
   // - avoid trailing slashes in prod
   trailingSlash: isDeployPreview,
+  headTags: [
+    {
+      tagName: "link", 
+      attributes: {
+        rel: "monetization", 
+        href: "https://ilp.uphold.com/LwQQhXdpwxeJ"
+      }
+    },
+  ],
   stylesheets: [
     {
       href: '/katex/katex.min.css',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This is a follow on of https://github.com/facebook/docusaurus/pull/8077 - motivation copied from there:

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

I'm trying to add a custom link tag to the header of all the pages on my Docusaurus site. In my case I'm looking to render a web monetization link which looks like this:

```html
<link rel="monetization" content="https://ilp.uphold.com/LwQQhXdpwxeJ" />
```

It looks like there isn't a way to generically supply global link tags with Docusaurus. At least... until now!

## Test Plan

<img width="1560" alt="image" src="https://user-images.githubusercontent.com/1010525/193341698-098435eb-c7bb-4afd-9164-1b8edc844213.png">

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

https://github.com/facebook/docusaurus/pull/8077
