### PR TITLE
fix(content-blog): make RSS feed generation work with slugs with .html extension

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/__fixtures__/build-snap/htmlFile.html
+++ b/packages/docusaurus-utils/src/__tests__/__fixtures__/build-snap/htmlFile.html
@@ -1,0 +1,1 @@
+htmlFile.html

--- a/packages/docusaurus-utils/src/__tests__/__fixtures__/build-snap/weird.html.folder/nestedHtmlFile.html
+++ b/packages/docusaurus-utils/src/__tests__/__fixtures__/build-snap/weird.html.folder/nestedHtmlFile.html
@@ -1,0 +1,1 @@
+nestedHtmlFile.html

--- a/packages/docusaurus-utils/src/__tests__/emitUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/emitUtils.test.ts
@@ -89,6 +89,22 @@ describe('readOutputHTMLFile', () => {
       ).then(String),
     ).resolves.toBe('htmlFile.html\n');
   });
+  it('reads file ending in .html in folder containing .html', async () => {
+    await expect(
+      readOutputHTMLFile(
+        '/weird.html.folder/nestedHtmlFile.html',
+        path.join(__dirname, '__fixtures__/build-snap'),
+        undefined,
+      ).then(String),
+    ).resolves.toBe('nestedHtmlFile.html\n');
+    await expect(
+      readOutputHTMLFile(
+        '/weird.html.folder/nestedHtmlFile.html',
+        path.join(__dirname, '__fixtures__/build-snap'),
+        undefined,
+      ).then(String),
+    ).resolves.toBe('nestedHtmlFile.html\n');
+  });
   // Can it ever happen?
   it('throws if file does not exist', async () => {
     await expect(
@@ -98,7 +114,7 @@ describe('readOutputHTMLFile', () => {
         undefined,
       ).then(String),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Expected output HTML file to be found at <PROJECT_ROOT>/packages/docusaurus-utils/src/__tests__/__fixtures__/build-snap/nonExistent/index.html."`,
+      `"Expected output HTML file to be found at <PROJECT_ROOT>/packages/docusaurus-utils/src/__tests__/__fixtures__/build-snap/nonExistent/index.html for permalink /nonExistent."`,
     );
   });
 });

--- a/packages/docusaurus-utils/src/__tests__/emitUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/emitUtils.test.ts
@@ -73,6 +73,22 @@ describe('readOutputHTMLFile', () => {
       ).then(String),
     ).resolves.toBe('file\n');
   });
+  it('reads file ending in .html', async () => {
+    await expect(
+      readOutputHTMLFile(
+        '/htmlFile.html',
+        path.join(__dirname, '__fixtures__/build-snap'),
+        false,
+      ).then(String),
+    ).resolves.toBe('htmlFile.html\n');
+    await expect(
+      readOutputHTMLFile(
+        '/htmlFile.html',
+        path.join(__dirname, '__fixtures__/build-snap'),
+        undefined,
+      ).then(String),
+    ).resolves.toBe('htmlFile.html\n');
+  });
   // Can it ever happen?
   it('throws if file does not exist', async () => {
     await expect(

--- a/packages/docusaurus-utils/src/emitUtils.ts
+++ b/packages/docusaurus-utils/src/emitUtils.ts
@@ -79,20 +79,22 @@ export async function readOutputHTMLFile(
   trailingSlash: boolean | undefined,
 ): Promise<Buffer> {
   const withTrailingSlashPath = path.join(outDir, permalink, 'index.html');
-  const withoutTrailingSlashPath = path.join(
-    outDir,
-    `${permalink.replace(/\/$/, '').replace(/.html$/, '')}.html`,
-  );
-  const HTMLPath = await findAsyncSequential(
-    [
-      trailingSlash !== false && withTrailingSlashPath,
-      trailingSlash !== true && withoutTrailingSlashPath,
-    ].filter((p): p is string => Boolean(p)),
-    fs.pathExists,
-  );
+  const withoutTrailingSlashPath = (() => {
+    const basePath = path.join(outDir, permalink.replace(/\/$/, ''));
+    const htmlSuffix = /\.html?$/i.test(basePath) ? '' : '.html';
+    return `${basePath}${htmlSuffix}`;
+  })();
+
+  const possibleHtmlPaths = [
+    trailingSlash !== false && withTrailingSlashPath,
+    trailingSlash !== true && withoutTrailingSlashPath,
+  ].filter((p): p is string => Boolean(p));
+
+  const HTMLPath = await findAsyncSequential(possibleHtmlPaths, fs.pathExists);
+
   if (!HTMLPath) {
     throw new Error(
-      `Expected output HTML file to be found at ${withTrailingSlashPath}.`,
+      `Expected output HTML file to be found at ${withTrailingSlashPath} for permalink ${permalink}.`,
     );
   }
   return fs.readFile(HTMLPath);

--- a/packages/docusaurus-utils/src/emitUtils.ts
+++ b/packages/docusaurus-utils/src/emitUtils.ts
@@ -81,7 +81,7 @@ export async function readOutputHTMLFile(
   const withTrailingSlashPath = path.join(outDir, permalink, 'index.html');
   const withoutTrailingSlashPath = path.join(
     outDir,
-    `${permalink.replace(/\/$/, '')}.html`,
+    `${permalink.replace(/\/$/, '').replace(/.html$/, '')}.html`,
   );
   const HTMLPath = await findAsyncSequential(
     [

--- a/website/_dogfooding/_blog tests/2022-10-02-html-slug.md
+++ b/website/_dogfooding/_blog tests/2022-10-02-html-slug.md
@@ -1,0 +1,15 @@
+---
+title: A post with html slug
+tags: [paginated-tag]
+slug: /x/y/z.html
+---
+
+# Hmmm!
+
+This is a blog post with an html slug!
+
+```mdx-code-block
+import Partial from "./_partial.mdx"
+
+<Partial />
+```


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Before this commit, adding slugs ending in .html to the frontmatter blogs resulted in the build process breaking. This PR fixes this issue

## Test Plan

Added Tests for the emitUtils.readOutputHTMLFile function in which the changes were to be made. Sample file also has been added in website/_dogfooding

### Test links
Deploy preview: https://deploy-preview-8158--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8139 
