### PR TITLE
fix(theme): do not show tab content when tabbing over it; show after selection only

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -104,7 +104,10 @@ function TabsComponent(props: Props): JSX.Element {
   }
 
   const handleTabChange = (
-    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement>,
+    event:
+      | React.FocusEvent<HTMLLIElement>
+      | React.MouseEvent<HTMLLIElement>
+      | React.KeyboardEvent<HTMLLIElement>,
   ) => {
     const newTab = event.currentTarget;
     const newTabIndex = tabRefs.indexOf(newTab);
@@ -124,6 +127,10 @@ function TabsComponent(props: Props): JSX.Element {
     let focusElement: HTMLLIElement | null = null;
 
     switch (event.key) {
+      case 'Enter': {
+        handleTabChange(event);
+        break;
+      }
       case 'ArrowRight': {
         const nextTab = tabRefs.indexOf(event.currentTarget) + 1;
         focusElement = tabRefs[nextTab] ?? tabRefs[0]!;
@@ -161,7 +168,6 @@ function TabsComponent(props: Props): JSX.Element {
             key={value}
             ref={(tabControl) => tabRefs.push(tabControl)}
             onKeyDown={handleKeydown}
-            onFocus={handleTabChange}
             onClick={handleTabChange}
             {...attributes}
             className={clsx(


### PR DESCRIPTION
## Motivation

Improve a11y for Tabs component.

## Test plan

manual - Voiceover on MacOS.

https://user-images.githubusercontent.com/64769322/193444240-0a71828b-c56c-4cc7-9fdc-f3e9191c8257.mov

Tab content is only shown after selection (hitting enter).

Compare:
- https://docusaurus.io/docs/markdown-features/tabs
- https://deploy-preview-8161--docusaurus-2.netlify.app/docs/markdown-features/tabs

## Related issues

Closes #8063