### PR TITLE
fix(core): TypeError: Invalid URL while trying to build with sitemap not set to false #8116

### DIFF
--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -94,7 +94,19 @@ describe('normalizeConfig', () => {
         url: 1,
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
-      ""url" contains an invalid value
+      ""url" must be a string
+      "
+    `);
+  });
+
+  it('throws for URLs missing protocol', () => {
+    expect(() =>
+      normalizeConfig({
+        url: 'docusaurus.io',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Field "url" must be a valid URL, (value='docusaurus.io'). Ensure you are not missing the protocol in the URL e.g. https://docusaurus.io.
+      "url" contains an invalid value
       "
     `);
   });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation
The `url` field in `docusaurus.config.js` currently accepts URLs without a preceding protocol causing the downstream sitemap builder to fail when calling `new URL()` with said invalid URLs.

This PR updates the Joi validation of the field to reject URLs that would cause `new URL()` to error out.

## Implementation
The current validation schema `URISchema` used in the validation of the `url` field in `docusaurus.config.js` allows relative URLs with the `{allowRelative: true}` config option. 
https://github.com/facebook/docusaurus/blob/c6f5cf9ac75f9942203d1570697d928098abcaeb/packages/docusaurus-utils-validation/src/validationSchemas.ts#L67-L68

This lets URLs without protocols pass validation and cause errors when constructing URLs. Disabling that option would fix this but `URISchema` is used in a number of other places, changing it could have unintended consequences. 

This PR removes the dependency on `URISchema` and directly adds Joi `.url()` validation to the `url` field without the `allowRelative` config option. It also adds `new URL()` construction validation as a fallback to ensure invalid URLs that aren't caught by Joi but error out on `new URL()` don't make it past validation.

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->


## Test Plan
A `'throws for URLs missing protocol'` test is added to validate URLs like "docusaurus.io" don't pass config validation.

The inline snapshot for an existing test on the same `url` field is also updated. Providing a number to the URL field throws a ```"url" must be a string``` error instead of a `invalid value`error.

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Preview of Changes
![Descriptive error when invalid URL is provided](https://user-images.githubusercontent.com/87580113/193450181-9103b944-6297-46f1-803b-62afd34ac4e3.png)


## Related issues/PRs
Fixes #8116 

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
