### PR TITLE
fix(svgo): enable prefixIds by default

### DIFF
--- a/packages/docusaurus-utils/src/webpackUtils.ts
+++ b/packages/docusaurus-utils/src/webpackUtils.ts
@@ -124,6 +124,7 @@ export function getFileLoaderUtils(): FileLoaderUtils {
                         },
                       },
                     },
+                    'prefixIds'
                   ],
                 },
                 titleProp: true,


### PR DESCRIPTION
Hello guys,
with this PR I would like to activate by default the `prefixIds` plugin of `svgo`.

It is useful to avoid any kind of id collision that could happen when are defined different `linearGradient` for multiple svgs in the same page.