### PR TITLE
fix(core): throw error for invalid URL in config file

### DIFF
--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {jest} from '@jest/globals';
 import {
   ConfigSchema,
   DEFAULT_CONFIG,
@@ -111,25 +110,20 @@ describe('normalizeConfig', () => {
   });
 
   it('normalizes various URLs', () => {
-    const consoleMock = jest
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {});
-
     expect(
       normalizeConfig({
         url: 'https://mysite.com/',
       }).url,
     ).toBe('https://mysite.com');
-    expect(
+    expect(() =>
       normalizeConfig({
         // This shouldn't happen
         url: 'https://mysite.com/foo/',
-      }).url,
-    ).toBe('https://mysite.com/foo');
-
-    expect(consoleMock.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"[WARNING] Docusaurus config validation warning. Field "url": The url is not supposed to contain a sub-path like '/foo/'. Please use the baseUrl field for sub-paths."`,
-    );
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "The url is not supposed to contain a sub-path like "". Please use the baseUrl field for sub-paths.
+      "
+    `);
   });
 
   it('throws for non-string base URLs', () => {
@@ -392,7 +386,7 @@ describe('normalizeConfig', () => {
   });
 });
 
-describe('config warnings', () => {
+describe('config warning and error', () => {
   function getWarning(config: unknown) {
     return ConfigSchema.validate(config).warning;
   }
@@ -402,15 +396,14 @@ describe('config warnings', () => {
     expect(warning).toBeUndefined();
   });
 
-  it('site url has warning when using subpath', () => {
-    const warning = getWarning({
+  it('site url fails validation when using subpath', () => {
+    const {error} = ConfigSchema.validate({
       ...baseConfig,
       url: 'https://mysite.com/someSubpath',
-    })!;
-    expect(warning).toBeDefined();
-    expect(warning.details).toHaveLength(1);
-    expect(warning.details[0]!.message).toMatchInlineSnapshot(
-      `"Docusaurus config validation warning. Field "url": The url is not supposed to contain a sub-path like '/someSubpath'. Please use the baseUrl field for sub-paths."`,
+    });
+    expect(error).toBeDefined();
+    expect(error.message).toBe(
+      'The url is not supposed to contain a sub-path like "". Please use the baseUrl field for sub-paths.',
     );
   });
 });

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -109,21 +109,12 @@ describe('normalizeConfig', () => {
     `);
   });
 
-  it('normalizes various URLs', () => {
+  it('normalizes URL', () => {
     expect(
       normalizeConfig({
         url: 'https://mysite.com/',
       }).url,
     ).toBe('https://mysite.com');
-    expect(() =>
-      normalizeConfig({
-        // This shouldn't happen
-        url: 'https://mysite.com/foo/',
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      "The url is not supposed to contain a sub-path like "". Please use the baseUrl field for sub-paths.
-      "
-    `);
   });
 
   it('throws for non-string base URLs', () => {
@@ -403,7 +394,7 @@ describe('config warning and error', () => {
     });
     expect(error).toBeDefined();
     expect(error.message).toBe(
-      'The url is not supposed to contain a sub-path like "". Please use the baseUrl field for sub-paths.',
+      'The url is not supposed to contain a sub-path like "/someSubpath". Please use the baseUrl field for sub-paths.',
     );
   });
 });

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -158,7 +158,7 @@ const SiteUrlSchema = Joi.string()
     try {
       const {pathname} = new URL(value);
       if (pathname !== '/') {
-        return helpers.error('docusaurus.configValidationWarning');
+        return helpers.error('docusaurus.subPathError', {pathname});
       }
     } catch {
       return helpers.error('any.invalid');
@@ -168,7 +168,7 @@ const SiteUrlSchema = Joi.string()
   .messages({
     'any.invalid':
       '"{#value}" does not look like a valid URL. Make sure it has a protocol; for example, "https://example.com".',
-    'docusaurus.configValidationWarning':
+    'docusaurus.subPathError':
       'The url is not supposed to contain a sub-path like "{#pathname}". Please use the baseUrl field for sub-paths.',
   });
 

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -158,9 +158,7 @@ const SiteUrlSchema = Joi.string()
     try {
       const {pathname} = new URL(value);
       if (pathname !== '/') {
-        helpers.warn('docusaurus.configValidationWarning', {
-          warningMessage: `The url is not supposed to contain a sub-path like '${pathname}'. Please use the baseUrl field for sub-paths.`,
-        });
+        return helpers.error('docusaurus.configValidationWarning');
       }
     } catch {
       return helpers.error('any.invalid');
@@ -170,6 +168,8 @@ const SiteUrlSchema = Joi.string()
   .messages({
     'any.invalid':
       '"{#value}" does not look like a valid URL. Make sure it has a protocol; for example, "https://example.com".',
+    'docusaurus.configValidationWarning':
+      'The url is not supposed to contain a sub-path like "{#pathname}". Please use the baseUrl field for sub-paths.',
   });
 
 // TODO move to @docusaurus/utils-validation


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Currently, a warning is displayed when the URL contains a sub-path but as mentioned at the end of #8159, it makes more sense to display an error. So, I updated the code to display an error instead of a warning. 

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

I updated unit tests to verify my code.

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

Related to https://github.com/facebook/docusaurus/pull/8159 and https://github.com/facebook/docusaurus/issues/8116
