### PR TITLE
adding docsPluginId parameter for  navbar

### DIFF
--- a/website/docs/guides/docs/docs-multi-instance.mdx
+++ b/website/docs/guides/docs/docs-multi-instance.mdx
@@ -211,3 +211,29 @@ module.exports = {
   },
 };
 ```
+
+In case of the examples given in https://docusaurus.io/docs/docs-multi-instance#setup the configuration would looks as below:
+
+```js title="docusaurus.config.js"
+module.exports = {
+  themeConfig: {
+    navbar: {
+      items: [
+          {
+            type: 'doc',
+            docId: 'intro',    //assuming there is a website/docs/intro.md
+            position: 'left',
+            label: 'Product Docs',
+          },
+          {
+            type: 'doc',
+            position: 'left',
+            docId: 'intro',   //assuming there is a website/docs/intro.md
+            docsPluginId: 'community',
+            label: 'Community Docs',
+          }
+      ],
+    },
+  },
+};
+```


### PR DESCRIPTION
show how to use the docsPluginId parameter to show multiple instances of  Docs in navbar items

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [-] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [-] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

improve docs as I need help with it through Discourse which could have been avoided by this little bit
