### PR TITLE
fix(live-codeblock): add err boundary to live code block

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/CodeBlock/index.tsx
@@ -6,15 +6,21 @@
  */
 
 import React from 'react';
+import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import Playground from '@theme/Playground';
 import ReactLiveScope from '@theme/ReactLiveScope';
 import CodeBlock, {type Props} from '@theme-init/CodeBlock';
+import ErrorPageContent from '@theme/ErrorPageContent';
 
 const withLiveEditor = (Component: typeof CodeBlock) => {
   function WrappedComponent(props: Props) {
     if (props.live) {
-      // @ts-expect-error: we have deliberately widened the type of language prop
-      return <Playground scope={ReactLiveScope} {...props} />;
+      return (
+        <ErrorBoundary fallback={(params) => <ErrorPageContent {...params} />}>
+          {/* @ts-expect-error: we have deliberately widened the type of language prop */}
+          <Playground scope={ReactLiveScope} {...props} />
+        </ErrorBoundary>
+      );
     }
 
     return <Component {...props} />;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Invalid code in live code block should not crash the whole page, but just editor.

## Test Plan

Manual.

https://user-images.githubusercontent.com/64769322/195175398-a4a2d32e-3950-43d0-b438-298853b3b25d.mov

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Closes #8009
