### PR TITLE
feat(theme-classic): store selected tab in query string.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint:spelling": "cspell \"**\" --no-progress",
     "lint:style": "stylelint \"**/*.css\"",
     "lerna": "lerna",
-    "test": "jest",
+    "test": "cross-env TEST=true jest",
     "test:build:website": "./admin/scripts/test-release.sh",
     "watch": "yarn lerna run --parallel watch",
     "clear": "(yarn workspace website clear || echo 'Failure while running docusaurus clear') && yarn lerna exec --ignore docusaurus yarn rimraf lib",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint:spelling": "cspell \"**\" --no-progress",
     "lint:style": "stylelint \"**/*.css\"",
     "lerna": "lerna",
-    "test": "cross-env TEST=true jest",
+    "test": "jest",
     "test:build:website": "./admin/scripts/test-release.sh",
     "watch": "yarn lerna run --parallel watch",
     "clear": "(yarn workspace website clear || echo 'Failure while running docusaurus clear') && yarn lerna exec --ignore docusaurus yarn rimraf lib",

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -1263,7 +1263,7 @@ declare module '@theme/Tabs' {
     }[];
     readonly groupId?: string;
     readonly className?: string;
-    readonly queryString: string | boolean;
+    readonly queryString?: string | boolean;
   }
 
   export default function Tabs(props: Props): JSX.Element;

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -1263,6 +1263,7 @@ declare module '@theme/Tabs' {
     }[];
     readonly groupId?: string;
     readonly className?: string;
+    readonly queryString: string | boolean;
   }
 
   export default function Tabs(props: Props): JSX.Element;

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -11,17 +11,21 @@ import {
   TabGroupChoiceProvider,
   ScrollControllerProvider,
 } from '@docusaurus/theme-common/internal';
+import {StaticRouter} from 'react-router-dom';
 import Tabs from '../index';
 import TabItem from '../../TabItem';
 
-describe.skip('Tabs', () => {
+describe('Tabs', () => {
   it('rejects bad Tabs child', () => {
     expect(() => {
       renderer.create(
-        <Tabs>
-          <div>Naughty</div>
-          <TabItem value="good">Good</TabItem>
-        </Tabs>,
+        <StaticRouter location={{pathname: '/'}}>
+          <Tabs>
+            <div>Naughty</div>
+            <TabItem value="good">Good</TabItem>
+          </Tabs>
+          ,
+        </StaticRouter>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
       `"Docusaurus error: Bad <Tabs> child <div>: all children of the <Tabs> component should be <TabItem>, and every <TabItem> should have a unique "value" prop."`,
@@ -30,10 +34,12 @@ describe.skip('Tabs', () => {
   it('rejects bad Tabs defaultValue', () => {
     expect(() => {
       renderer.create(
-        <Tabs defaultValue="bad">
-          <TabItem value="v1">Tab 1</TabItem>
-          <TabItem value="v2">Tab 2</TabItem>
-        </Tabs>,
+        <StaticRouter location={{pathname: '/'}}>
+          <Tabs defaultValue="bad">
+            <TabItem value="v1">Tab 1</TabItem>
+            <TabItem value="v2">Tab 2</TabItem>
+          </Tabs>
+        </StaticRouter>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
       `"Docusaurus error: The <Tabs> has a defaultValue "bad" but none of its children has the corresponding value. Available values are: v1, v2. If you intend to show no default tab, use defaultValue={null} instead."`,
@@ -42,14 +48,16 @@ describe.skip('Tabs', () => {
   it('rejects duplicate values', () => {
     expect(() => {
       renderer.create(
-        <Tabs>
-          <TabItem value="v1">Tab 1</TabItem>
-          <TabItem value="v2">Tab 2</TabItem>
-          <TabItem value="v3">Tab 3</TabItem>
-          <TabItem value="v4">Tab 4</TabItem>
-          <TabItem value="v1">Tab 5</TabItem>
-          <TabItem value="v2">Tab 6</TabItem>
-        </Tabs>,
+        <StaticRouter location={{pathname: '/'}}>
+          <Tabs>
+            <TabItem value="v1">Tab 1</TabItem>
+            <TabItem value="v2">Tab 2</TabItem>
+            <TabItem value="v3">Tab 3</TabItem>
+            <TabItem value="v4">Tab 4</TabItem>
+            <TabItem value="v1">Tab 5</TabItem>
+            <TabItem value="v2">Tab 6</TabItem>
+          </Tabs>
+        </StaticRouter>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
       `"Docusaurus error: Duplicate values "v1, v2" found in <Tabs>. Every value needs to be unique."`,
@@ -58,54 +66,56 @@ describe.skip('Tabs', () => {
   it('accepts valid Tabs config', () => {
     expect(() => {
       renderer.create(
-        <ScrollControllerProvider>
-          <TabGroupChoiceProvider>
-            <Tabs>
-              <TabItem value="v1">Tab 1</TabItem>
-              <TabItem value="v2">Tab 2</TabItem>
-            </Tabs>
-            <Tabs>
-              <TabItem value="v1">Tab 1</TabItem>
-              <TabItem value="v2" default>
-                Tab 2
-              </TabItem>
-            </Tabs>
-            <Tabs defaultValue="v1">
-              <TabItem value="v1" label="V1">
-                Tab 1
-              </TabItem>
-              <TabItem value="v2" label="V2">
-                Tab 2
-              </TabItem>
-            </Tabs>
-            <Tabs
-              defaultValue="v1"
-              values={[
-                {value: 'v1', label: 'V1'},
-                {value: 'v2', label: 'V2'},
-              ]}>
-              <TabItem value="v1">Tab 1</TabItem>
-              <TabItem value="v2">Tab 2</TabItem>
-            </Tabs>
-            <Tabs
-              defaultValue={null}
-              values={[
-                {value: 'v1', label: 'V1'},
-                {value: 'v2', label: 'V2'},
-              ]}>
-              <TabItem value="v1">Tab 1</TabItem>
-              <TabItem value="v2">Tab 2</TabItem>
-            </Tabs>
-            <Tabs defaultValue={null}>
-              <TabItem value="v1" label="V1">
-                Tab 1
-              </TabItem>
-              <TabItem value="v2" label="V2">
-                Tab 2
-              </TabItem>
-            </Tabs>
-          </TabGroupChoiceProvider>
-        </ScrollControllerProvider>,
+        <StaticRouter location={{pathname: '/'}}>
+          <ScrollControllerProvider>
+            <TabGroupChoiceProvider>
+              <Tabs>
+                <TabItem value="v1">Tab 1</TabItem>
+                <TabItem value="v2">Tab 2</TabItem>
+              </Tabs>
+              <Tabs>
+                <TabItem value="v1">Tab 1</TabItem>
+                <TabItem value="v2" default>
+                  Tab 2
+                </TabItem>
+              </Tabs>
+              <Tabs defaultValue="v1">
+                <TabItem value="v1" label="V1">
+                  Tab 1
+                </TabItem>
+                <TabItem value="v2" label="V2">
+                  Tab 2
+                </TabItem>
+              </Tabs>
+              <Tabs
+                defaultValue="v1"
+                values={[
+                  {value: 'v1', label: 'V1'},
+                  {value: 'v2', label: 'V2'},
+                ]}>
+                <TabItem value="v1">Tab 1</TabItem>
+                <TabItem value="v2">Tab 2</TabItem>
+              </Tabs>
+              <Tabs
+                defaultValue={null}
+                values={[
+                  {value: 'v1', label: 'V1'},
+                  {value: 'v2', label: 'V2'},
+                ]}>
+                <TabItem value="v1">Tab 1</TabItem>
+                <TabItem value="v2">Tab 2</TabItem>
+              </Tabs>
+              <Tabs defaultValue={null}>
+                <TabItem value="v1" label="V1">
+                  Tab 1
+                </TabItem>
+                <TabItem value="v2" label="V2">
+                  Tab 2
+                </TabItem>
+              </Tabs>
+            </TabGroupChoiceProvider>
+          </ScrollControllerProvider>
+        </StaticRouter>,
       );
     }).not.toThrow(); // TODO Better Jest infrastructure to mock the Layout
   });
@@ -114,22 +124,24 @@ describe.skip('Tabs', () => {
     expect(() => {
       const tabs = ['Apple', 'Banana', 'Carrot'];
       renderer.create(
-        <ScrollControllerProvider>
-          <TabGroupChoiceProvider>
-            <Tabs
-              // @ts-expect-error: for an edge-case that we didn't write types for
-              values={tabs.map((t, idx) => ({label: t, value: idx}))}
-              // @ts-expect-error: for an edge-case that we didn't write types for
-              defaultValue={0}>
-              {tabs.map((t, idx) => (
+        <StaticRouter location={{pathname: '/'}}>
+          <ScrollControllerProvider>
+            <TabGroupChoiceProvider>
+              <Tabs
                 // @ts-expect-error: for an edge-case that we didn't write types for
-                <TabItem key={idx} value={idx}>
-                  {t}
-                </TabItem>
-              ))}
-            </Tabs>
-          </TabGroupChoiceProvider>
-        </ScrollControllerProvider>,
+                values={tabs.map((t, idx) => ({label: t, value: idx}))}
+                // @ts-expect-error: for an edge-case that we didn't write types for
+                defaultValue={0}>
+                {tabs.map((t, idx) => (
+                  // @ts-expect-error: for an edge-case that we didn't write types for
+                  <TabItem key={idx} value={idx}>
+                    {t}
+                  </TabItem>
+                ))}
+              </Tabs>
+            </TabGroupChoiceProvider>
+          </ScrollControllerProvider>
+        </StaticRouter>,
       );
     }).not.toThrow();
   });

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -149,7 +149,8 @@ describe('Tabs', () => {
       renderer.create(
         <StaticRouter location={{pathname: '/'}}>
           <Tabs queryString>
-            <TabItem value="good">Good</TabItem>
+            <TabItem value="val1">Val1</TabItem>
+            <TabItem value="val2">Val2</TabItem>
           </Tabs>
         </StaticRouter>,
       );

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -24,7 +24,6 @@ describe('Tabs', () => {
             <div>Naughty</div>
             <TabItem value="good">Good</TabItem>
           </Tabs>
-          ,
         </StaticRouter>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
@@ -144,5 +143,18 @@ describe('Tabs', () => {
         </StaticRouter>,
       );
     }).not.toThrow();
+  });
+  it('rejects if querystring is true, but groupId falsy', () => {
+    expect(() => {
+      renderer.create(
+        <StaticRouter location={{pathname: '/'}}>
+          <Tabs queryString>
+            <TabItem value="good">Good</TabItem>
+          </Tabs>
+        </StaticRouter>,
+      );
+    }).toThrow(
+      'Docusaurus error: The <Tabs> component needs to have groupId specified if queryString is true.',
+    );
   });
 });

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import renderer from 'react-test-renderer';
 import {
   TabGroupChoiceProvider,
@@ -15,16 +15,32 @@ import {StaticRouter} from 'react-router-dom';
 import Tabs from '../index';
 import TabItem from '../../TabItem';
 
+function TestProviders({
+  children,
+  pathname = '/',
+}: {
+  children: ReactNode;
+  pathname?: string;
+}) {
+  return (
+    <StaticRouter location={{pathname}}>
+      <ScrollControllerProvider>
+        <TabGroupChoiceProvider>{children}</TabGroupChoiceProvider>
+      </ScrollControllerProvider>
+    </StaticRouter>
+  );
+}
+
 describe('Tabs', () => {
   it('rejects bad Tabs child', () => {
     expect(() => {
       renderer.create(
-        <StaticRouter location={{pathname: '/'}}>
+        <TestProviders>
           <Tabs>
             <div>Naughty</div>
             <TabItem value="good">Good</TabItem>
           </Tabs>
-        </StaticRouter>,
+        </TestProviders>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
       `"Docusaurus error: Bad <Tabs> child <div>: all children of the <Tabs> component should be <TabItem>, and every <TabItem> should have a unique "value" prop."`,
@@ -33,12 +49,12 @@ describe('Tabs', () => {
   it('rejects bad Tabs defaultValue', () => {
     expect(() => {
       renderer.create(
-        <StaticRouter location={{pathname: '/'}}>
+        <TestProviders>
           <Tabs defaultValue="bad">
             <TabItem value="v1">Tab 1</TabItem>
             <TabItem value="v2">Tab 2</TabItem>
           </Tabs>
-        </StaticRouter>,
+        </TestProviders>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
       `"Docusaurus error: The <Tabs> has a defaultValue "bad" but none of its children has the corresponding value. Available values are: v1, v2. If you intend to show no default tab, use defaultValue={null} instead."`,
@@ -47,7 +63,7 @@ describe('Tabs', () => {
   it('rejects duplicate values', () => {
     expect(() => {
       renderer.create(
-        <StaticRouter location={{pathname: '/'}}>
+        <TestProviders>
           <Tabs>
             <TabItem value="v1">Tab 1</TabItem>
             <TabItem value="v2">Tab 2</TabItem>
@@ -56,7 +72,7 @@ describe('Tabs', () => {
             <TabItem value="v1">Tab 5</TabItem>
             <TabItem value="v2">Tab 6</TabItem>
           </Tabs>
-        </StaticRouter>,
+        </TestProviders>,
       );
     }).toThrowErrorMatchingInlineSnapshot(
       `"Docusaurus error: Duplicate values "v1, v2" found in <Tabs>. Every value needs to be unique."`,
@@ -65,56 +81,52 @@ describe('Tabs', () => {
   it('accepts valid Tabs config', () => {
     expect(() => {
       renderer.create(
-        <StaticRouter location={{pathname: '/'}}>
-          <ScrollControllerProvider>
-            <TabGroupChoiceProvider>
-              <Tabs>
-                <TabItem value="v1">Tab 1</TabItem>
-                <TabItem value="v2">Tab 2</TabItem>
-              </Tabs>
-              <Tabs>
-                <TabItem value="v1">Tab 1</TabItem>
-                <TabItem value="v2" default>
-                  Tab 2
-                </TabItem>
-              </Tabs>
-              <Tabs defaultValue="v1">
-                <TabItem value="v1" label="V1">
-                  Tab 1
-                </TabItem>
-                <TabItem value="v2" label="V2">
-                  Tab 2
-                </TabItem>
-              </Tabs>
-              <Tabs
-                defaultValue="v1"
-                values={[
-                  {value: 'v1', label: 'V1'},
-                  {value: 'v2', label: 'V2'},
-                ]}>
-                <TabItem value="v1">Tab 1</TabItem>
-                <TabItem value="v2">Tab 2</TabItem>
-              </Tabs>
-              <Tabs
-                defaultValue={null}
-                values={[
-                  {value: 'v1', label: 'V1'},
-                  {value: 'v2', label: 'V2'},
-                ]}>
-                <TabItem value="v1">Tab 1</TabItem>
-                <TabItem value="v2">Tab 2</TabItem>
-              </Tabs>
-              <Tabs defaultValue={null}>
-                <TabItem value="v1" label="V1">
-                  Tab 1
-                </TabItem>
-                <TabItem value="v2" label="V2">
-                  Tab 2
-                </TabItem>
-              </Tabs>
-            </TabGroupChoiceProvider>
-          </ScrollControllerProvider>
-        </StaticRouter>,
+        <TestProviders>
+          <Tabs>
+            <TabItem value="v1">Tab 1</TabItem>
+            <TabItem value="v2">Tab 2</TabItem>
+          </Tabs>
+          <Tabs>
+            <TabItem value="v1">Tab 1</TabItem>
+            <TabItem value="v2" default>
+              Tab 2
+            </TabItem>
+          </Tabs>
+          <Tabs defaultValue="v1">
+            <TabItem value="v1" label="V1">
+              Tab 1
+            </TabItem>
+            <TabItem value="v2" label="V2">
+              Tab 2
+            </TabItem>
+          </Tabs>
+          <Tabs
+            defaultValue="v1"
+            values={[
+              {value: 'v1', label: 'V1'},
+              {value: 'v2', label: 'V2'},
+            ]}>
+            <TabItem value="v1">Tab 1</TabItem>
+            <TabItem value="v2">Tab 2</TabItem>
+          </Tabs>
+          <Tabs
+            defaultValue={null}
+            values={[
+              {value: 'v1', label: 'V1'},
+              {value: 'v2', label: 'V2'},
+            ]}>
+            <TabItem value="v1">Tab 1</TabItem>
+            <TabItem value="v2">Tab 2</TabItem>
+          </Tabs>
+          <Tabs defaultValue={null}>
+            <TabItem value="v1" label="V1">
+              Tab 1
+            </TabItem>
+            <TabItem value="v2" label="V2">
+              Tab 2
+            </TabItem>
+          </Tabs>
+        </TestProviders>,
       );
     }).not.toThrow(); // TODO Better Jest infrastructure to mock the Layout
   });
@@ -123,39 +135,61 @@ describe('Tabs', () => {
     expect(() => {
       const tabs = ['Apple', 'Banana', 'Carrot'];
       renderer.create(
-        <StaticRouter location={{pathname: '/'}}>
-          <ScrollControllerProvider>
-            <TabGroupChoiceProvider>
-              <Tabs
-                // @ts-expect-error: for an edge-case that we didn't write types for
-                values={tabs.map((t, idx) => ({label: t, value: idx}))}
-                // @ts-expect-error: for an edge-case that we didn't write types for
-                defaultValue={0}>
-                {tabs.map((t, idx) => (
-                  // @ts-expect-error: for an edge-case that we didn't write types for
-                  <TabItem key={idx} value={idx}>
-                    {t}
-                  </TabItem>
-                ))}
-              </Tabs>
-            </TabGroupChoiceProvider>
-          </ScrollControllerProvider>
-        </StaticRouter>,
+        <TestProviders>
+          <Tabs
+            // @ts-expect-error: for an edge-case that we didn't write types for
+            values={tabs.map((t, idx) => ({label: t, value: idx}))}
+            // @ts-expect-error: for an edge-case that we didn't write types for
+            defaultValue={0}>
+            {tabs.map((t, idx) => (
+              // @ts-expect-error: for an edge-case that we didn't write types for
+              <TabItem key={idx} value={idx}>
+                {t}
+              </TabItem>
+            ))}
+          </Tabs>
+        </TestProviders>,
       );
     }).not.toThrow();
   });
   it('rejects if querystring is true, but groupId falsy', () => {
     expect(() => {
       renderer.create(
-        <StaticRouter location={{pathname: '/'}}>
+        <TestProviders>
           <Tabs queryString>
             <TabItem value="val1">Val1</TabItem>
             <TabItem value="val2">Val2</TabItem>
           </Tabs>
-        </StaticRouter>,
+        </TestProviders>,
       );
     }).toThrow(
-      'Docusaurus error: The <Tabs> component needs to have groupId specified if queryString is true.',
+      'Docusaurus error: The <Tabs> component groupId prop is required if queryString=true, because this value is used as the search param name. You can also provide an explicit value such as queryString="my-search-param".',
     );
+  });
+
+  it('accept querystring=true when groupId is defined', () => {
+    expect(() => {
+      renderer.create(
+        <TestProviders>
+          <Tabs queryString groupId="my-group-id">
+            <TabItem value="val1">Val1</TabItem>
+            <TabItem value="val2">Val2</TabItem>
+          </Tabs>
+        </TestProviders>,
+      );
+    }).not.toThrow();
+  });
+
+  it('accept querystring as string, but groupId falsy', () => {
+    expect(() => {
+      renderer.create(
+        <TestProviders>
+          <Tabs queryString="qsKey">
+            <TabItem value="val1">Val1</TabItem>
+            <TabItem value="val2">Val2</TabItem>
+          </Tabs>
+        </TestProviders>,
+      );
+    }).not.toThrow();
   });
 });

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx
@@ -14,7 +14,7 @@ import {
 import Tabs from '../index';
 import TabItem from '../../TabItem';
 
-describe('Tabs', () => {
+describe.skip('Tabs', () => {
   it('rejects bad Tabs child', () => {
     expect(() => {
       renderer.create(

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -122,14 +122,11 @@ function TabsComponent(props: Props): JSX.Element {
   }
 
   const {tabGroupChoices, setTabGroupChoices} = useTabGroupChoice();
-  let defaultValue: string | null | undefined;
-  if (!defaultValue || !values.some((a) => a.value === defaultValue)) {
-    defaultValue =
-      defaultValueProp !== undefined
-        ? defaultValueProp
-        : children.find((child) => child.props.default)?.props.value ??
-          children[0]!.props.value;
-  }
+  const defaultValue =
+    defaultValueProp !== undefined
+      ? defaultValueProp
+      : children.find((child) => child.props.default)?.props.value ??
+        children[0]!.props.value;
 
   const [selectedValue, setSelectedValue] = useState(defaultValue);
   const tabRefs: (HTMLLIElement | null)[] = [];

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -122,13 +122,7 @@ function TabsComponent(props: Props): JSX.Element {
   }
 
   const {tabGroupChoices, setTabGroupChoices} = useTabGroupChoice();
-  // local storage >
-  // specified defaultValue >
-  // first child with "default" attr >
-  // first tab item.
   let defaultValue: string | null | undefined;
-  // If we didn't find the right value in search params or local storage,
-  // fallback to props > child with "default" specified > first tab.
   if (!defaultValue || !values.some((a) => a.value === defaultValue)) {
     defaultValue =
       defaultValueProp !== undefined

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -100,16 +100,6 @@ function TabsComponent(props: Props): JSX.Element {
       typeof queryString === 'string' ? queryString : groupId || '';
     defaultValue = new URLSearchParams(location.search).get(searchKey);
   }
-  if (!defaultValue && groupId != null) {
-    const relevantTabGroupChoice = tabGroupChoices[groupId];
-    if (
-      relevantTabGroupChoice != null &&
-      relevantTabGroupChoice !== defaultValue &&
-      values.some((value) => value.value === relevantTabGroupChoice)
-    ) {
-      defaultValue = relevantTabGroupChoice;
-    }
-  }
   // If we didn't find the right value in search params or local storage,
   // fallback to props > child with "default" specified > first tab.
   if (!defaultValue || !values.some((a) => a.value === defaultValue)) {
@@ -124,6 +114,17 @@ function TabsComponent(props: Props): JSX.Element {
   const tabRefs: (HTMLLIElement | null)[] = [];
   const {blockElementScrollPositionUntilNextRender} =
     useScrollPositionBlocker();
+
+  if (groupId != null) {
+    const relevantTabGroupChoice = tabGroupChoices[groupId];
+    if (
+      relevantTabGroupChoice != null &&
+      relevantTabGroupChoice !== selectedValue &&
+      values.some((value) => value.value === relevantTabGroupChoice)
+    ) {
+      setSelectedValue(relevantTabGroupChoice);
+    }
+  }
 
   const handleTabChange = (
     event:

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -88,6 +88,12 @@ function TabsComponent(props: Props): JSX.Element {
     );
   }
 
+  if (queryString === true && !groupId) {
+    throw new Error(
+      `Docusaurus error: The <Tabs> component needs to have groupId specified if queryString is true.`,
+    );
+  }
+
   const {tabGroupChoices, setTabGroupChoices} = useTabGroupChoice();
   // search params >
   // local storage >

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -33,6 +33,9 @@ function isTabItem(
 
 const NON_GROUP_TAB_KEY = '__noGroup__';
 function getValueFromSearchParams(groupId = NON_GROUP_TAB_KEY): string | null {
+  if (typeof window === 'undefined') {
+    return null; // Ignore during SSR.
+  }
   const searchParams = new URLSearchParams(window.location.search);
   const prevSearchParams = searchParams.get('tabs');
   return prevSearchParams ? JSON.parse(prevSearchParams)[groupId] : null;
@@ -77,6 +80,21 @@ function TabsComponent(props: Props): JSX.Element {
     );
   }
 
+  // Warn user about passing incorrect defaultValue as prop.
+  if (
+    defaultValueProp !== null &&
+    defaultValueProp !== undefined &&
+    !values.some((a) => a.value === defaultValueProp)
+  ) {
+    throw new Error(
+      `Docusaurus error: The <Tabs> has a defaultValue "${defaultValueProp}" but none of its children has the corresponding value. Available values are: ${values
+        .map((a) => a.value)
+        .join(
+          ', ',
+        )}. If you intend to show no default tab, use defaultValue={null} instead.`,
+    );
+  }
+
   const {tabGroupChoices, setTabGroupChoices} = useTabGroupChoice();
   // search params >
   // local storage >
@@ -103,21 +121,6 @@ function TabsComponent(props: Props): JSX.Element {
         ? defaultValueProp
         : children.find((child) => child.props.default)?.props.value ??
           children[0]!.props.value;
-  }
-
-  // Warn user about passing incorrect defaultValue as prop.
-  if (
-    defaultValueProp !== null &&
-    defaultValueProp !== undefined &&
-    !values.some((a) => a.value === defaultValueProp)
-  ) {
-    throw new Error(
-      `Docusaurus error: The <Tabs> has a defaultValue "${defaultValue}" but none of its children has the corresponding value. Available values are: ${values
-        .map((a) => a.value)
-        .join(
-          ', ',
-        )}. If you intend to show no default tab, use defaultValue={null} instead.`,
-    );
   }
 
   const [selectedValue, setSelectedValue] = useState(defaultValue);

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -140,7 +140,11 @@ function TabsComponent(props: Props): JSX.Element {
     );
   }
 
-  const {tabGroupChoices, setTabGroupChoices} = useTabGroupChoice();
+  const {
+    ready: tabGroupChoicesReady,
+    tabGroupChoices,
+    setTabGroupChoices,
+  } = useTabGroupChoice();
   const defaultValue =
     defaultValueProp !== undefined
       ? defaultValueProp
@@ -209,13 +213,17 @@ function TabsComponent(props: Props): JSX.Element {
   };
 
   useEffect(() => {
-    const queryValue = tabQueryString.get();
-    if (queryValue) {
-      setSelectedValue(queryValue);
+    // The querystring value should be used in priority over stored value
+    // so we need to execute effect after stored value restoration
+    if (tabGroupChoicesReady) {
+      const queryValue = tabQueryString.get();
+      if (queryValue) {
+        setSelectedValue(queryValue);
+      }
     }
     // TODO bad React code but should be ok for now
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [tabGroupChoicesReady]);
 
   return (
     <div className={clsx('tabs-container', styles.tabList)}>

--- a/packages/docusaurus-theme-common/src/contexts/tabGroupChoice.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/tabGroupChoice.tsx
@@ -19,6 +19,8 @@ import {ReactContextError} from '../utils/reactUtils';
 const TAB_CHOICE_PREFIX = 'docusaurus.tab.';
 
 type ContextValue = {
+  /** A boolean that tells if choices have already been restored from storage */
+  readonly ready: boolean;
   /** A map from `groupId` to the `value` of the saved choice. */
   readonly tabGroupChoices: {readonly [groupId: string]: string};
   /** Set the new choice value of a group. */
@@ -28,6 +30,7 @@ type ContextValue = {
 const Context = React.createContext<ContextValue | undefined>(undefined);
 
 function useContextValue(): ContextValue {
+  const [ready, setReady] = useState(false);
   const [tabGroupChoices, setChoices] = useState<{
     readonly [groupId: string]: string;
   }>({});
@@ -51,6 +54,7 @@ function useContextValue(): ContextValue {
     } catch (err) {
       console.error(err);
     }
+    setReady(true);
   }, []);
 
   const setTabGroupChoices = useCallback(
@@ -62,8 +66,8 @@ function useContextValue(): ContextValue {
   );
 
   return useMemo(
-    () => ({tabGroupChoices, setTabGroupChoices}),
-    [tabGroupChoices, setTabGroupChoices],
+    () => ({ready, tabGroupChoices, setTabGroupChoices}),
+    [ready, tabGroupChoices, setTabGroupChoices],
   );
 }
 

--- a/website/docs/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-tabs.mdx
@@ -319,32 +319,40 @@ li[role='tab'][data-value='apple'] {
 
 :::
 
-## Query string
+## Query string {#query-string}
 
-If you need to share a URL with some tabs already preselected (e.g. a specific programming language) you can use a `queryString`. It can be a string that represents the search query key for the corresponding tab.
+It is possible to persist the selected tab into the url search parameters. This enables deep linking: the ability to share or bookmark a link to a specific tab, that will be pre-selected when the page loads.
+
+Use the `queryString` prop to enable this feature and define the search param name to use.
+
+```tsx
+<Tabs queryString="current-os">
+  <TabItem value="android" label="Android">
+    Android content
+  </TabItem>
+  <TabItem value="ios" label="iOS">
+    iOS content
+  </TabItem>
+</Tabs>
+```
+
+As soon as a tab is clicked, a search parameter is added at the end of the url: `?current-os=android` or `?current-os=ios`.
 
 ```mdx-code-block
 <BrowserWindow>
-  <Tabs queryString='query1'>
+  <Tabs queryString='current-os'>
     <TabItem value="android" label="Android">Android content</TabItem>
     <TabItem value="ios" label="iOS">iOS content</TabItem>
   </Tabs>
 </BrowserWindow>
 ```
 
-Another option is to specify it as a boolean with a value of `true`. This configuration uses existing `groupId` as a search query key, thus the `groupId` attribute must be specified.
+:::tip
 
-```mdx-code-block
-<BrowserWindow>
-  <Tabs queryString={true} groupId='operating-systems'>
-    <TabItem value="android" label="Android">Android content</TabItem>
-    <TabItem value="ios" label="iOS">iOS content</TabItem>
-  </Tabs>
-  <Tabs queryString={true} groupId='operating-systems'>
-    <TabItem value="android" label="Android">Android content</TabItem>
-    <TabItem value="ios" label="iOS">iOS content</TabItem>
-  </Tabs>
-</BrowserWindow>
+When `groupId` is defined, its value is used as a default for `queryString`, and you can simply declare:
+
+```tsx
+<Tabs queryString groupId="current-os">
 ```
 
-The `queryString` param is `false` by default.
+:::

--- a/website/docs/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-tabs.mdx
@@ -318,3 +318,33 @@ li[role='tab'][data-value='apple'] {
 ```
 
 :::
+
+## Query string
+
+If you need to share a URL with some tabs already preselected (e.g. a specific programming language) you can use a `queryString`. It can be a string that represents the search query key for the corresponding tab.
+
+```mdx-code-block
+<BrowserWindow>
+  <Tabs queryString='query1'>
+    <TabItem value="android" label="Android">Android content</TabItem>
+    <TabItem value="ios" label="iOS">iOS content</TabItem>
+  </Tabs>
+</BrowserWindow>
+```
+
+Another option is to specify it as a boolean with a value of `true`. This configuration uses existing `groupId` as a search query key, thus the `groupId` attribute must be specified.
+
+```mdx-code-block
+<BrowserWindow>
+  <Tabs queryString={true} groupId='operating-systems'>
+    <TabItem value="android" label="Android">Android content</TabItem>
+    <TabItem value="ios" label="iOS">iOS content</TabItem>
+  </Tabs>
+  <Tabs queryString={true} groupId='operating-systems'>
+    <TabItem value="android" label="Android">Android content</TabItem>
+    <TabItem value="ios" label="iOS">iOS content</TabItem>
+  </Tabs>
+</BrowserWindow>
+```
+
+The `queryString` param is `false` by default.

--- a/website/docs/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-tabs.mdx
@@ -326,6 +326,7 @@ It is possible to persist the selected tab into the url search parameters. This 
 Use the `queryString` prop to enable this feature and define the search param name to use.
 
 ```tsx
+// highlight-next-line
 <Tabs queryString="current-os">
   <TabItem value="android" label="Android">
     Android
@@ -354,6 +355,7 @@ As soon as a tab is clicked, a search parameter is added at the end of the url: 
 For convenience, when the `queryString` prop is `true`, the `groupId` value will be used as a fallback.
 
 ```tsx
+// highlight-next-line
 <Tabs groupId="current-os" queryString>
   <TabItem value="android" label="Android">
     Android

--- a/website/docs/guides/markdown-features/markdown-features-tabs.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-tabs.mdx
@@ -328,31 +328,51 @@ Use the `queryString` prop to enable this feature and define the search param na
 ```tsx
 <Tabs queryString="current-os">
   <TabItem value="android" label="Android">
-    Android content
+    Android
   </TabItem>
   <TabItem value="ios" label="iOS">
-    iOS content
+    iOS
   </TabItem>
 </Tabs>
 ```
 
-As soon as a tab is clicked, a search parameter is added at the end of the url: `?current-os=android` or `?current-os=ios`.
-
 ```mdx-code-block
 <BrowserWindow>
   <Tabs queryString='current-os'>
-    <TabItem value="android" label="Android">Android content</TabItem>
-    <TabItem value="ios" label="iOS">iOS content</TabItem>
+    <TabItem value="android" label="Android">Android</TabItem>
+    <TabItem value="ios" label="iOS">iOS</TabItem>
   </Tabs>
 </BrowserWindow>
 ```
 
+As soon as a tab is clicked, a search parameter is added at the end of the url: `?current-os=android` or `?current-os=ios`.
+
 :::tip
 
-When `groupId` is defined, its value is used as a default for `queryString`, and you can simply declare:
+`queryString` can be used together with `groupId`.
+
+For convenience, when the `queryString` prop is `true`, the `groupId` value will be used as a fallback.
 
 ```tsx
-<Tabs queryString groupId="current-os">
+<Tabs groupId="current-os" queryString>
+  <TabItem value="android" label="Android">
+    Android
+  </TabItem>
+  <TabItem value="ios" label="iOS">
+    iOS
+  </TabItem>
+</Tabs>
 ```
+
+```mdx-code-block
+<BrowserWindow>
+  <Tabs queryString groupId="current-os">
+    <TabItem value="android" label="Android">Android</TabItem>
+    <TabItem value="ios" label="iOS">iOS</TabItem>
+  </Tabs>
+</BrowserWindow>
+```
+
+When the page loads, the tab query string choice will be restored in priority over the `groupId` choice (using `localStorage`).
 
 :::


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->
## Implementation description

* Selection stored according to [this comment](https://github.com/facebook/docusaurus/issues/7008#issuecomment-1152540679) - serialized JSON with group ids as keys and `__noGroup__` constant key for tabs that do not belong to any group. Downsides:
   * Ugly links - http://localhost:3000/docs/markdown-features/tabs?tabs=%7B%22__noGroup__%22%3A%22banana%22%2C%22operating-systems%22%3A%22win%22%7D
   * In case of multiple tabs that do not belong to any group and have different tab item keys, this solution would only work for the last selected tab.
* Selected key priority: search query > local storage > defaultValue prop > 1st tab with default specified > 1st tab.
* @slorber can you please provide further explanation for [this comment](https://github.com/facebook/docusaurus/issues/7008#issuecomment-1157484387) ? I identified the file that needs the changes as [this](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/index.ts), but it's not clear to me what is actually needed to be done. From my understanding, when you hydrate React components and build static HTML off it, you cannot know the search URL query params as they are only available during the actual request or am I missing something?

Let's use this PR as starting point for further discussion around UX/implementation.
## Motivation

Allows for sharing tabs selection via URL - better UX.

## Test Plan

Manual

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

- https://deploy-preview-8225--docusaurus-2.netlify.app/docs/markdown-features/tabs#query-string
- https://deploy-preview-8225--docusaurus-2.netlify.app/docs/markdown-features/tabs?current-os=ios#query-string
- https://deploy-preview-8225--docusaurus-2.netlify.app/docs/markdown-features/tabs?current-os=android#query-string

## Related issues/PRs

Closes #7008 
