### PR TITLE
chore: fix flaky tests

### DIFF
--- a/packages/docusaurus-logger/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-logger/src/__tests__/__snapshots__/index.test.ts.snap
@@ -12,7 +12,7 @@ exports[`error prints objects 1`] = `
     "[ERROR] 1,2,3",
   ],
   [
-    "[ERROR] Sat Nov 13 2021 00:00:00 GMT+0000 (Coordinated Universal Time)",
+    "[ERROR] Sat, 13 Nov 2021 00:00:00 GMT",
   ],
 ]
 `;
@@ -29,7 +29,7 @@ exports[`info prints objects 1`] = `
     "[INFO] 1,2,3",
   ],
   [
-    "[INFO] Sat Nov 13 2021 00:00:00 GMT+0000 (Coordinated Universal Time)",
+    "[INFO] Sat, 13 Nov 2021 00:00:00 GMT",
   ],
 ]
 `;
@@ -46,7 +46,7 @@ exports[`success prints objects 1`] = `
     "[SUCCESS] 1,2,3",
   ],
   [
-    "[SUCCESS] Sat Nov 13 2021 00:00:00 GMT+0000 (Coordinated Universal Time)",
+    "[SUCCESS] Sat, 13 Nov 2021 00:00:00 GMT",
   ],
 ]
 `;
@@ -63,7 +63,7 @@ exports[`warn prints objects 1`] = `
     "[WARNING] 1,2,3",
   ],
   [
-    "[WARNING] Sat Nov 13 2021 00:00:00 GMT+0000 (Coordinated Universal Time)",
+    "[WARNING] Sat, 13 Nov 2021 00:00:00 GMT",
   ],
 ]
 `;

--- a/packages/docusaurus-logger/src/index.ts
+++ b/packages/docusaurus-logger/src/index.ts
@@ -60,6 +60,9 @@ function stringify(msg: unknown): string {
   if (String(msg) === '[object Object]') {
     return JSON.stringify(msg);
   }
+  if (msg instanceof Date) {
+    return msg.toUTCString();
+  }
   return String(msg);
 }
 

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/lastUpdate.test.ts
@@ -13,6 +13,10 @@ import {createTempRepo} from '@testing-utils/git';
 
 import {getFileLastUpdate} from '../lastUpdate';
 
+// The 5s default timeout fails sometimes fail on Windows?
+// https://github.com/facebook/docusaurus/actions/runs/3335697149/jobs/5519968190
+jest.setTimeout(15000);
+
 describe('getFileLastUpdate', () => {
   const existingFilePath = path.join(
     __dirname,


### PR DESCRIPTION
Some tests fail randomly:


## LastUpdate

timeout on windows, likely due to executing git commands, see https://github.com/facebook/docusaurus/actions/runs/3335697149/jobs/5519968190

## logger 

printing localized date locally (on my computer):

<img width="698" alt="CleanShot 2022-10-27 at 19 36 43@2x" src="https://user-images.githubusercontent.com/749374/198359973-1081e884-ae84-4cc5-ae35-287949ded6b8.png">

I updated the logged date format, I guess it shouldn't be a problem and it's not localized anymore on my computer. 