### PR TITLE
docs: fix mermaid theme options typo

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-diagrams.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-diagrams.mdx
@@ -68,13 +68,13 @@ See the [Mermaid theme documentation](https://mermaid-js.github.io/mermaid/#/the
 
 ## Mermaid Config {#configuration}
 
-Options in `mermaid.mermaidOptions` will be passed directly to `mermaid.initialize`:
+Options in `mermaid.options` will be passed directly to `mermaid.initialize`:
 
 ```js title="docusaurus.config.js"
 module.exports = {
   themeConfig: {
     mermaid: {
-      mermaidOptions: {
+      options: {
         maxTextSize: 50,
       },
     },

--- a/website/versioned_docs/version-2.2.0/guides/markdown-features/markdown-features-diagrams.mdx
+++ b/website/versioned_docs/version-2.2.0/guides/markdown-features/markdown-features-diagrams.mdx
@@ -68,13 +68,13 @@ See the [Mermaid theme documentation](https://mermaid-js.github.io/mermaid/#/the
 
 ## Mermaid Config {#configuration}
 
-Options in `mermaid.mermaidOptions` will be passed directly to `mermaid.initialize`:
+Options in `mermaid.options` will be passed directly to `mermaid.initialize`:
 
 ```js title="docusaurus.config.js"
 module.exports = {
   themeConfig: {
     mermaid: {
-      mermaidOptions: {
+      options: {
         maxTextSize: 50,
       },
     },


### PR DESCRIPTION
According to the types here https://github.com/facebook/docusaurus/blob/9c92a79d23533a61f3ad1bf3ea4d0889f0e2710f/packages/docusaurus-theme-mermaid/src/theme-mermaid.d.ts as well as runtime validation by myself - it should options not mermaidOptions.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Docs are misleading

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Set some options using this method and they applied
