### PR TITLE
fix(content-docs): add trailing slash to contentDirs, before passing it to isMDXPartial

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -249,12 +249,13 @@ export default async function pluginContentDocs(
       };
 
       function createMDXLoaderRule(): RuleSetRule {
-        const contentDirs = versionsMetadata.flatMap(getContentPathList);
+        const contentDirs = versionsMetadata
+          .flatMap(getContentPathList)
+          // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
+          .map(addTrailingPathSeparator);
         return {
           test: /\.mdx?$/i,
-          include: contentDirs
-            // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
-            .map(addTrailingPathSeparator),
+          include: contentDirs,
           use: [
             getJSLoader({isServer}),
             {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

If you have multi-instances and versioning and you're trying to import partial MDX to a file from cut version, you'll get console error. This happens because a paths to the directory with the next version docs and directory with docs for some version starts with the same, i.e "\*\*/instance" and "\*\*/instance_versioned_docs/\*\*". So, isMDXPartial() uses wrong directory as a root directory as a root. We need to append slashes to contentDirs, so that "\*\*/instance/\*\*"(slash added) will not mix up with "\*\*/instance_versioned_docs/\*\*"

Example:

In my docs folder I have a folder "_includes" with MDX partials. I use multi-instances, "instance" is a name of one of the instances. I import partials like that:
`import Partial from '@site/instance/_includes/_partial.mdx'; `
Then I cut a new version and want to update the imports to "versioned_docs" path, so I use: 
`import Partial from '@site/instance_versioned_docs/version-1.0.0/_includes/_partial.mdx'; `

```
That's the error I get:
[ERROR] MDX loader can't read MDX metadata file "path-to-my-repo\.docusaurus\docusaurus-plugin-content-docs\instance\site-instance-versioned-docs-version-1-0-0-includes-partial-mdx-d57.json". Maybe the isMDXPartial option function was not provided?
[ERROR] Error: ENOENT: no such file or directory, open 'path-to-my-repo\.docusaurus\docusaurus-plugin-content-docs\instance\site-instance-versioned-docs-version-1-0-0-includes-partial-mdx-d57.json'
[INFO] Docusaurus version: 2.2.0
Node version: v16.14.0
error Command failed with exit code 1.
```

The same thing when I use relative paths.
