### PR TITLE
fix(utils): allow partially backticked markdown h1 contentTitles

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -195,7 +195,7 @@ describe('parseMarkdownContentTitle', () => {
     });
   });
 
-  it('parses markdown h1 title at the top and unwrap inline code block', () => {
+  it('parses markdown h1 title inside backticks at the top and unwrap inline code block', () => {
     const markdown = dedent`
 
           # \`Markdown Title\`
@@ -206,6 +206,20 @@ describe('parseMarkdownContentTitle', () => {
     expect(parseMarkdownContentTitle(markdown)).toEqual({
       content: markdown,
       contentTitle: 'Markdown Title',
+    });
+  });
+
+  it('parses markdown h1 title with interspersed backticks at the top and unwrap inline code block', () => {
+    const markdown = dedent`
+
+          # Markdown \`Title\` With \`Many\` Backticks!
+
+          Lorem Ipsum
+
+        `;
+    expect(parseMarkdownContentTitle(markdown)).toEqual({
+      content: markdown,
+      contentTitle: 'Markdown Title With Many Backticks!',
     });
   });
 

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -155,10 +155,7 @@ export function parseFrontMatter(markdownFileContent: string): {
 }
 
 function toTextContentTitle(contentTitle: string): string {
-  if (contentTitle.startsWith('`') && contentTitle.endsWith('`')) {
-    return contentTitle.substring(1, contentTitle.length - 1);
-  }
-  return contentTitle;
+  return contentTitle.replace(/`(?<text>[^`]*)`/g, '$<text>');
 }
 
 type ParseMarkdownContentTitleOptions = {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.


## Motivation

See https://github.com/facebook/docusaurus/discussions/8294 - I want h1s with inline code please 😄 

## Test Plan

I ... don't have one beyond unit tests.

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/discussions/8294 - would you like me to file an issue? Or can someone convert that to one?