### PR TITLE
fix(docs,theme): auto-generated category index should not display unlisted content

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -9,7 +9,7 @@ import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {
-  findFirstCategoryLink,
+  findFirstSidebarItemLink,
   useDocById,
 } from '@docusaurus/theme-common/internal';
 import isInternalUrl from '@docusaurus/isInternalUrl';
@@ -71,7 +71,7 @@ function CardCategory({
 }: {
   item: PropSidebarItemCategory;
 }): JSX.Element | null {
-  const href = findFirstCategoryLink(item);
+  const href = findFirstSidebarItemLink(item);
 
   // Unexpected: categories that don't have a link have been filtered upfront
   if (!href) {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '@docusaurus/theme-common';
 import {
   isActiveSidebarItem,
-  findFirstCategoryLink,
+  findFirstSidebarItemLink,
   useDocSidebarItemsExpandedState,
   isSamePath,
 } from '@docusaurus/theme-common/internal';
@@ -59,15 +59,12 @@ function useCategoryHrefWithSSRFallback(
 ): string | undefined {
   const isBrowser = useIsBrowser();
   return useMemo(() => {
-    if (item.href && !item.linkUnlisted) {
-      return item.href;
-    }
     // In these cases, it's not necessary to render a fallback
     // We skip the "findFirstCategoryLink" computation
     if (isBrowser || !item.collapsible) {
       return undefined;
     }
-    return findFirstCategoryLink(item);
+    return findFirstSidebarItemLink(item);
   }, [item, isBrowser]);
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
@@ -59,6 +59,9 @@ function useCategoryHrefWithSSRFallback(
 ): string | undefined {
   const isBrowser = useIsBrowser();
   return useMemo(() => {
+    if (item.href && !item.linkUnlisted) {
+      return item.href;
+    }
     // In these cases, it's not necessary to render a fallback
     // We skip the "findFirstCategoryLink" computation
     if (isBrowser || !item.collapsible) {

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -67,7 +67,7 @@ export {
   isDocsPluginEnabled,
   useDocById,
   findSidebarCategory,
-  findFirstCategoryLink,
+  findFirstSidebarItemLink,
   isActiveSidebarItem,
   isVisibleSidebarItem,
   useVisibleSidebarItems,

--- a/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
@@ -79,24 +79,35 @@ export function findSidebarCategory(
  * Best effort to assign a link to a sidebar category. If the category doesn't
  * have a link itself, we link to the first sub item with a link.
  */
-export function findFirstCategoryLink(
+export function findFirstSidebarItemCategoryLink(
   item: PropSidebarItemCategory,
 ): string | undefined {
-  if (item.href) {
+  if (item.href && !item.linkUnlisted) {
     return item.href;
   }
 
   for (const subItem of item.items) {
-    if (subItem.type === 'link') {
-      return subItem.href;
-    } else if (subItem.type === 'category') {
-      const categoryLink = findFirstCategoryLink(subItem);
-      if (categoryLink) {
-        return categoryLink;
-      }
+    const link = findFirstSidebarItemLink(subItem);
+    if (link) {
+      return link;
     }
-    // Could be "html" items
   }
+  return undefined;
+}
+
+/**
+ * Best effort to assign a link to a sidebar item.
+ */
+export function findFirstSidebarItemLink(
+  item: PropSidebarItem,
+): string | undefined {
+  if (item.type === 'link' && !item.unlisted) {
+    return item.href;
+  }
+  if (item.type === 'category') {
+    return findFirstSidebarItemCategoryLink(item);
+  }
+  // Other items types, like "html"
   return undefined;
 }
 
@@ -391,15 +402,16 @@ export function useDocRootMetadata({route}: DocRootProps): null | {
 }
 
 /**
- * Filter categories that don't have a link.
+ * Filter items we don't want to display on the doc card list view
  * @param items
  */
 export function filterDocCardListItems(
   items: PropSidebarItem[],
 ): PropSidebarItem[] {
   return items.filter((item) => {
-    if (item.type === 'category') {
-      return !!findFirstCategoryLink(item);
+    const canHaveLink = item.type === 'category' || item.type === 'link';
+    if (canHaveLink) {
+      return !!findFirstSidebarItemLink(item);
     }
     return true;
   });

--- a/website/_dogfooding/_docs tests/tests/visibility/index.md
+++ b/website/_dogfooding/_docs tests/tests/visibility/index.md
@@ -24,3 +24,11 @@ In production, unlisted items should remain accessible, but be hidden in the sid
 - [./some-unlisteds/unlisted1.md](./some-unlisteds/unlisted1.md)
 - [./some-unlisteds/unlisted2.md](./some-unlisteds/unlisted2.md)
 - [./some-unlisteds/unlisted-subcategory/unlisted3.md](./some-unlisteds/unlisted-subcategory/unlisted3.md)
+
+---
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/_dogfooding/_docs tests/tests/visibility/only-drafts/draft-subcategory/index.md
+++ b/website/_dogfooding/_docs tests/tests/visibility/only-drafts/draft-subcategory/index.md
@@ -6,3 +6,9 @@ tags: [visibility, draft]
 # Only Drafts - Subcategory index draft
 
 Doc with draft front matter
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/_dogfooding/_docs tests/tests/visibility/only-unlisteds/unlisted-subcategory/index.md
+++ b/website/_dogfooding/_docs tests/tests/visibility/only-unlisteds/unlisted-subcategory/index.md
@@ -6,3 +6,9 @@ tags: [visibility, unlisted]
 # Only Unlisteds - Subcategory index unlisted
 
 Doc with unlisted front matter
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/_dogfooding/_docs tests/tests/visibility/some-drafts/draft-subcategory/index.md
+++ b/website/_dogfooding/_docs tests/tests/visibility/some-drafts/draft-subcategory/index.md
@@ -6,3 +6,9 @@ tags: [visibility, draft]
 # Some Drafts - Subcategory index draft
 
 Doc with draft front matter
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/unlisted-subcategory/index.md
+++ b/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/unlisted-subcategory/index.md
@@ -6,3 +6,9 @@ tags: [visibility, unlisted]
 # Some Unlisteds - Subcategory index unlisted
 
 Doc with unlisted front matter
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/8301

The auto-generated category index should not present content with `unlisted: true` frontmatter in production mode.

## Test Plan

Unit tests

Dogfood: `SIMULATE_PRODUCTION_VISIBILITY=true yarn start:website`


### Test links

- https://deploy-preview-8319--docusaurus-2.netlify.app/tests/docs/tests/visibility => should show 2 subcategories instead of 4 (draft-only + unlisted-only categories are now both filtered)
- https://deploy-preview-8319--docusaurus-2.netlify.app/tests/docs/tests/visibility/some-unlisteds/unlisted-subcategory/ => should show a single listed doc instead of 2

## Related issues/PRs

Missing edge case from https://github.com/facebook/docusaurus/pull/8004
