### PR TITLE
docs: docusaurus-plugin-sass need npm install sass-loader

### DIFF
--- a/website/docs/styling-layout.md
+++ b/website/docs/styling-layout.md
@@ -191,7 +191,7 @@ To use Sass/SCSS as your CSS preprocessor, install the unofficial Docusaurus 2 p
 1. Install [`docusaurus-plugin-sass`](https://github.com/rlamana/docusaurus-plugin-sass):
 
 ```bash npm2yarn
-npm install --save docusaurus-plugin-sass sass
+npm install --save docusaurus-plugin-sass sass sass-loader
 ```
 
 2. Include the plugin in your `docusaurus.config.js` file:


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

`sass-loader` has to be installed, otherwise docusaurus will fail to run with the following error:

```
Compiled with problems:

ERROR in ./.docusaurus/client-modules.js 1:492-548

Module not found: Error: Can't resolve 'sass-loader'
```