### PR TITLE
bug: fixes docs sidebar to display without overlapping elements

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
@@ -20,7 +20,6 @@
     display: block !important;
     background-color: var(--docusaurus-collapse-button-bg);
     height: 40px;
-    position: sticky;
     bottom: 0;
     border-radius: 0;
     border: 1px solid var(--ifm-toc-border-color);


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
> tests were not written as changes were to CSS only.

## Motivation

[Issue #8370](https://github.com/facebook/docusaurus/issues/8370) indicates there is a layout issue when the anouncementBar is present.  After investigation, it appears the button with `title` `Collapse Sidebar` is causing the issue.  The `position` for this element is set to `sticky`.  When adjusting screen size this causes the button to start seeping into the `Sidebar Ad` element.

This PR removes the `sticky` positioning from the CSS file related to the `Collapse Sidebar` button.  This allows both the `SideBar Ad` and `Collapse Sidebar` button to display in all view ports without overlapping.
## Test Plan
**Verify the problem:**

1. navigate to https://docusaurus.io/tests/docs
2. using your browser developer tools in a responsive view, resize the window until you see the `Collapse Sidebar` button start overlapping with the `Sidebar Ad` element.

_image of problem:_
<img width="670" alt="Screenshot 2022-11-25 at 1 54 55 PM" src="https://user-images.githubusercontent.com/62929526/204054567-e64226fb-03e2-44a4-8275-3e9bfca6e9bc.png">

**verify the fix**

1. download this branch to your local or use the environment spun up to test changes.
2. navigate to `/tests/docs` <- start of URL will differ based on environment.  EX local would be - http://localhost:3000/tests/docs
4. using your browser developer tools in a responsive view, resize the height of the window again, this time notice that the `Collapse Sidebar` button does not start overlapping the `Sidebar Ad` element at any height.

_image of fix:_
![Screenshot 2022-11-25 at 1 57 02 PM](https://user-images.githubusercontent.com/62929526/204054677-583fb37f-919b-4447-8868-9467235964ac.png)

### Test links
Deploy preview: https://deploy-preview-8377--docusaurus-2.netlify.app/tests/docs

## Related issues/PRs
[Issue #8370](https://github.com/facebook/docusaurus/issues/8370)

