### PR TITLE
feat(core): deploy CLI - add support for git url "insteadOf": use 'remote get-url' to determine source repo url

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -66,7 +66,7 @@ This behavior can have SEO impacts and create relative link issues.
 
   // Source repo is the repo from where the command is invoked
   const sourceRepoUrl = shell
-    .exec('git config --get remote.origin.url', {silent: true})
+    .exec('git remote get-url origin', {silent: true})
     .stdout.trim();
 
   // The source branch; defaults to the currently checked out branch


### PR DESCRIPTION
A minor simplification/optimization in the way the repo source url is determined during deployment.

Instead of directly extracting the raw value from config, use the more idiomatic, built-in command:

```
git remote get-url origin
```

It has the added benefit that a potential `insteadOf` configuration is also taken into account.

See [git remote man page](https://git-scm.com/docs/git-remote.html#Documentation/git-remote.txt-emget-urlem) for additional details.