### PR TITLE
docs: Added more directions for Blog-Only Mode

### DIFF
--- a/website/docs/blog.mdx
+++ b/website/docs/blog.mdx
@@ -568,7 +568,22 @@ https://example.com/blog/feed.json
 
 ### Blog-only mode {#blog-only-mode}
 
-You can run your Docusaurus 2 site without a dedicated landing page and instead have your blog's post list page as the index page. Set the `routeBasePath` to be `'/'` to serve the blog through the root route `example.com/` instead of the subroute `example.com/blog/`.
+You can run your Docusaurus 2 site without a dedicated landing page and instead have your blog's post list page as the index page. Set the `routeBasePath` to be `'/'` to serve the blog through the root route `example.com/` instead of the subroute `example.com/blog/`. Ensure that all links pointing to `/blog` are changed to `/` as well.
+
+:::caution
+
+You should only set the `routeBasePath` to be `'/'` if you do not want a homepage. It is possible to remove the docs functionality while still having a separate homepage.
+
+If you do chose to forego a landing page by setting `routeBasePath` to `'/'`, don't forget to delete the existing homepage at `./src/pages/index.js` or else there will be two files mapping to the same route! If this is the case, you will see a warning in your terminal that says something like:
+
+```
+[WARNING] Duplicate routes found!
+Attempting to create page at /, but a page already exists at this route.
+This could lead to non-deterministic routing behavior.
+```
+
+and you will not be able to reach your blog.
+:::
 
 ```js title="docusaurus.config.js"
 module.exports = {
@@ -587,12 +602,34 @@ module.exports = {
       },
     ],
   ],
+  // ...
+  themeConfig:
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    ({
+      navbar: {
+        items: [
+        // highlight-next-line
+          { to: "/", label: "Blog", position: "left" }, // Change link to match routeBasePath
+        ],
+        },
+         footer: {
+        {
+            title: "More",
+            items: [
+              {
+                label: "Blog",
+          // highlight-next-line
+                to: "/", // Change link to match routeBasePath
+              },
+            ],
+          },
+     });
 };
 ```
 
-:::caution
+:::tip
 
-Don't forget to delete the existing homepage at `./src/pages/index.js` or else there will be two files mapping to the same route!
+You can set `routeBasePath` to something completely different (eg. `/articles` or `/thoughts` or `/ramblings`). Be sure to change any links that point to `/blog` as well to match `routeBasePath`, like in the navbar/footer components.
 
 :::
 


### PR DESCRIPTION
The original docs did not explicitly explain that it is possible to keep a homepage and alter the name of the route for the blog. There was also no recommendations to adjust the default links in the navbar/footer. I also added in some behavior that is expected if they do not delete their home index.js and duplicate routes are found.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
