### PR TITLE
fix: button style margin set zero globally

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.module.css
@@ -10,6 +10,10 @@ body {
   height: 100%;
 }
 
+button {
+  margin: 0;
+}
+
 .mainWrapper {
   flex: 1 0 auto;
 }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

in safari, button element default margin left and right set 2px;
![스크린샷 2022-12-11 오후 10 04 21](https://user-images.githubusercontent.com/49237205/206915534-e4e6902f-c530-484d-836e-129ab019bfe6.png)

but Chrome and firefox were not set 2px;
![스크린샷 2022-12-11 오후 10 05 46](https://user-images.githubusercontent.com/49237205/206915686-5e2549ed-a613-4693-898c-06102dd924b3.png)
![스크린샷 2022-12-12 오전 1 27 39](https://user-images.githubusercontent.com/49237205/206915906-123e08d1-e92b-4e2a-9182-e96b71796e1b.png)

so i check how to use in facebook.

they are using static style sheet by cdn 
(https://static.xx.fbcdn.net/rsrc.php/v3/yC/l/0,cross/xv165oDvQLn.css?_nc_x=Ij3Wp8lg5Kz)

in there set
```css
button {
 margin: 0
}
```

if we set this, we can remove css that some of button set margin: 0

i set default value in theme/Layout/styles.module.css but i think it's not best.
could you advice about that?


## Related issues/PRs

none
<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
