### PR TITLE
docs: add hyperlink to swizzling in Search page

### DIFF
--- a/website/docs/search.md
+++ b/website/docs/search.md
@@ -260,7 +260,7 @@ module.exports = {
 
 ### Editing the Algolia search component {#editing-the-algolia-search-component}
 
-If you prefer to edit the Algolia search React component, swizzle the `SearchBar` component in `@docusaurus/theme-search-algolia`:
+If you prefer to edit the Algolia search React component, [swizzle](swizzling.md) the `SearchBar` component in `@docusaurus/theme-search-algolia`:
 
 ```bash npm2yarn
 npm run swizzle @docusaurus/theme-search-algolia SearchBar

--- a/website/versioned_docs/version-2.2.0/search.md
+++ b/website/versioned_docs/version-2.2.0/search.md
@@ -260,7 +260,7 @@ module.exports = {
 
 ### Editing the Algolia search component {#editing-the-algolia-search-component}
 
-If you prefer to edit the Algolia search React component, [swizzle](swizzling) the `SearchBar` component in `@docusaurus/theme-search-algolia`:
+If you prefer to edit the Algolia search React component, [swizzle](swizzling.md) the `SearchBar` component in `@docusaurus/theme-search-algolia`:
 
 ```bash npm2yarn
 npm run swizzle @docusaurus/theme-search-algolia SearchBar

--- a/website/versioned_docs/version-2.2.0/search.md
+++ b/website/versioned_docs/version-2.2.0/search.md
@@ -260,7 +260,7 @@ module.exports = {
 
 ### Editing the Algolia search component {#editing-the-algolia-search-component}
 
-If you prefer to edit the Algolia search React component, swizzle the `SearchBar` component in `@docusaurus/theme-search-algolia`:
+If you prefer to edit the Algolia search React component, [swizzle](swizzling) the `SearchBar` component in `@docusaurus/theme-search-algolia`:
 
 ```bash npm2yarn
 npm run swizzle @docusaurus/theme-search-algolia SearchBar


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Those looking to evaluate Docusaurus's [search capabilities](https://docusaurus.io/docs/search), won't be familiar with swizzling.