### PR TITLE
fix(docs): Update link for tooljet website(broken)

### DIFF
--- a/website/src/data/users.tsx
+++ b/website/src/data/users.tsx
@@ -2269,7 +2269,7 @@ const Users: User[] = [
     description:
       'Open-source low-code platform to build & deploy internal tools with minimal engineering effort.',
     preview: require('./showcase/tooljet.png'),
-    website: 'https://docs.tooljet.com/docs/intro/',
+    website: 'https://docs.tooljet.com/docs/',
     source: 'https://github.com/ToolJet/ToolJet/tree/develop/docs',
     tags: ['opensource', 'design', 'large', 'product'],
   },


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I have been using Docusaurus a lot for a personal project(I also submitted an issue which was fixed recently) and I was going through a lot of design and code inspirations for software tools when I noticed tooljet website's intro section has been moved. 

## Test Plan

I ran the website locally and it worked fine. SInce it's just a URL swap, no further tests are required.

### Test links

Deploy preview: https://deploy-preview-8454--docusaurus-2.netlify.app

## Related issues/PRs

