### PR TITLE
fix(theme-classic): content container grow to take all the available space

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/styles.module.css
@@ -12,4 +12,5 @@
 
 .docsWrapper {
   display: flex;
+  flex: 1 0 auto;
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
@@ -43,4 +43,5 @@
 
 .collapseSidebarButton {
   display: none;
+  margin: 0;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.module.css
@@ -12,6 +12,8 @@ body {
 
 .mainWrapper {
   flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Docusaurus-specific utility class */


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

1. CollapseButton margin style set zero locally #8426 
2. docusaurus-theme-classic/Layout set flex style for grow #8369

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

## Related issues/PRs

fix #8369 
fix #8426  for CollapseButton