### PR TITLE
fix(core): explicitly define CopyWebpackPlugin toType: 'dir'

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -199,7 +199,11 @@ async function buildLocale({
     serverConfig = merge(serverConfig, {
       plugins: [
         new CopyWebpackPlugin({
-          patterns: staticDirectories.map((dir) => ({from: dir, to: outDir})),
+          patterns: staticDirectories.map((dir) => ({
+            from: dir,
+            to: outDir,
+            toType: 'dir',
+          })),
         }),
       ],
     });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Note

Since it's my first PR here, I am not sure about the process.
And we be pleased to have some guidance.

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #8480, closes #8135) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation
I have a project where the convention is using bracket [] in folder name.
The actual version of docusaurus if failing at build stage when there is a folder with bracket in the name.

## What I did
After some investigation, I found that the issue is coming from the `copy-webpack-plugin`.
It actually report the folder has a file.

### Here the actual config
> /packages/docusaurus/src/commands/build.ts line 199
```ts
    serverConfig = merge(serverConfig, {
      plugins: [
        new CopyWebpackPlugin({
          patterns: staticDirectories.map((dir) => ({from: dir, to: outDir})),
        }),
      ],
    });
```
### Proposed change
Since outDir is of course always a dir we can set the `toType` option to `dir` to solve this issue, this actually solve the false report of the outdir has a file by `copy-webpack-plugin`

```ts
    serverConfig = merge(serverConfig, {
      plugins: [
        new CopyWebpackPlugin({
          patterns: staticDirectories.map((dir) => ({from: dir, to: outDir, toType: 'dir'})),
        }),
      ],
    });
```

## Test Plan
I will need some guidance for this part as I am not sure how to test this change.
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

Bug reproduction: https://github.com/Thomascogez/docusaurus-bracket-in-path-bug-repro
<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs
https://github.com/facebook/docusaurus/issues/8480
<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
