### PR TITLE
fix: docs sidebar layout issue when announcementBar visible

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/styles.module.css
@@ -34,6 +34,13 @@
     top: 0;
     position: sticky;
     height: 100%;
-    max-height: 100vh;
+    /* stylelint-disable custom-property-pattern */
+    max-height: clamp(
+      calc(100vh - var(--docusaurus-announcement-bar-height)),
+      calc(
+        100vh - (var(--docusaurus-announcement-bar-height) - var(--scroll-Y))
+      ),
+      100vh
+    );
   }
 }

--- a/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
@@ -107,11 +107,15 @@ export function useScrollPosition(
   const dynamicEffect = useEvent(effect);
 
   useEffect(() => {
+    document.documentElement.style.setProperty('--scroll-Y', '0');
     const handleScroll = () => {
       if (!scrollEventsEnabledRef.current) {
         return;
       }
       const currentPosition = getScrollPosition()!;
+      const {scrollY} = currentPosition;
+      document.documentElement.style.setProperty('--scroll-Y', `${scrollY}px`);
+
       dynamicEffect(currentPosition, lastPositionRef.current);
       lastPositionRef.current = currentPosition;
     };


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

- Fix overlapping issue in docs sidebar (Sidebar Ad vs Collapse Button). Subtracted announcement bar height from sidebarViewport max-height 
- Not sure why `margin-bottom` for `DocSidebar` is set to `var(--docusaurus-announcement-bar-height)`

## Test Plan

Can easily be double-checked / manually tested on the specific breakpoint causing issue.

### Test links

N/A

## Related issues/PRs

Issues [8370](https://github.com/facebook/docusaurus/issues/8370) and [8374](https://github.com/facebook/docusaurus/issues/8374)

