### PR TITLE
chore: vendor MDX deps for Jest and the MDX 2 upgrade

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,7 +31,8 @@
     "*.xyz",
     "*.docx",
     "versioned_docs",
-    "*.min.*"
+    "*.min.*",
+    "jest/vendor"
   ],
   "ignoreRegExpList": ["Email", "Urls", "#[\\w-]*"]
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@ build
 coverage
 jest.config.js
 jest.transform.js
+jest/vendor
 examples/
 
 packages/lqip-loader/lib/

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,9 @@ node_modules
 build
 coverage
 .docusaurus
+
+jest/vendor
+
 packages/lqip-loader/lib/
 packages/docusaurus/lib/
 packages/docusaurus-*/lib/*

--- a/jest/vendor/@mdx-js__mdx@2.1.5.js
+++ b/jest/vendor/@mdx-js__mdx@2.1.5.js
@@ -1,0 +1,25696 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all4) => {
+  for (var name2 in all4)
+    __defProp(target, name2, { get: all4[name2], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/is-buffer/index.js
+var require_is_buffer = __commonJS({
+  "node_modules/is-buffer/index.js"(exports, module2) {
+    module2.exports = function isBuffer2(obj) {
+      return obj != null && obj.constructor != null && typeof obj.constructor.isBuffer === "function" && obj.constructor.isBuffer(obj);
+    };
+  }
+});
+
+// node_modules/extend/index.js
+var require_extend = __commonJS({
+  "node_modules/extend/index.js"(exports, module2) {
+    "use strict";
+    var hasOwn2 = Object.prototype.hasOwnProperty;
+    var toStr = Object.prototype.toString;
+    var defineProperty = Object.defineProperty;
+    var gOPD = Object.getOwnPropertyDescriptor;
+    var isArray2 = function isArray3(arr) {
+      if (typeof Array.isArray === "function") {
+        return Array.isArray(arr);
+      }
+      return toStr.call(arr) === "[object Array]";
+    };
+    var isPlainObject2 = function isPlainObject3(obj) {
+      if (!obj || toStr.call(obj) !== "[object Object]") {
+        return false;
+      }
+      var hasOwnConstructor = hasOwn2.call(obj, "constructor");
+      var hasIsPrototypeOf = obj.constructor && obj.constructor.prototype && hasOwn2.call(obj.constructor.prototype, "isPrototypeOf");
+      if (obj.constructor && !hasOwnConstructor && !hasIsPrototypeOf) {
+        return false;
+      }
+      var key;
+      for (key in obj) {
+      }
+      return typeof key === "undefined" || hasOwn2.call(obj, key);
+    };
+    var setProperty = function setProperty2(target, options) {
+      if (defineProperty && options.name === "__proto__") {
+        defineProperty(target, options.name, {
+          enumerable: true,
+          configurable: true,
+          value: options.newValue,
+          writable: true
+        });
+      } else {
+        target[options.name] = options.newValue;
+      }
+    };
+    var getProperty = function getProperty2(obj, name2) {
+      if (name2 === "__proto__") {
+        if (!hasOwn2.call(obj, name2)) {
+          return void 0;
+        } else if (gOPD) {
+          return gOPD(obj, name2).value;
+        }
+      }
+      return obj[name2];
+    };
+    module2.exports = function extend3() {
+      var options, name2, src, copy, copyIsArray, clone;
+      var target = arguments[0];
+      var i = 1;
+      var length = arguments.length;
+      var deep = false;
+      if (typeof target === "boolean") {
+        deep = target;
+        target = arguments[1] || {};
+        i = 2;
+      }
+      if (target == null || typeof target !== "object" && typeof target !== "function") {
+        target = {};
+      }
+      for (; i < length; ++i) {
+        options = arguments[i];
+        if (options != null) {
+          for (name2 in options) {
+            src = getProperty(target, name2);
+            copy = getProperty(options, name2);
+            if (target !== copy) {
+              if (deep && copy && (isPlainObject2(copy) || (copyIsArray = isArray2(copy)))) {
+                if (copyIsArray) {
+                  copyIsArray = false;
+                  clone = src && isArray2(src) ? src : [];
+                } else {
+                  clone = src && isPlainObject2(src) ? src : {};
+                }
+                setProperty(target, { name: name2, newValue: extend3(deep, clone, copy) });
+              } else if (typeof copy !== "undefined") {
+                setProperty(target, { name: name2, newValue: copy });
+              }
+            }
+          }
+        }
+      }
+      return target;
+    };
+  }
+});
+
+// node_modules/acorn-jsx/xhtml.js
+var require_xhtml = __commonJS({
+  "node_modules/acorn-jsx/xhtml.js"(exports, module2) {
+    module2.exports = {
+      quot: '"',
+      amp: "&",
+      apos: "'",
+      lt: "<",
+      gt: ">",
+      nbsp: "\xA0",
+      iexcl: "\xA1",
+      cent: "\xA2",
+      pound: "\xA3",
+      curren: "\xA4",
+      yen: "\xA5",
+      brvbar: "\xA6",
+      sect: "\xA7",
+      uml: "\xA8",
+      copy: "\xA9",
+      ordf: "\xAA",
+      laquo: "\xAB",
+      not: "\xAC",
+      shy: "\xAD",
+      reg: "\xAE",
+      macr: "\xAF",
+      deg: "\xB0",
+      plusmn: "\xB1",
+      sup2: "\xB2",
+      sup3: "\xB3",
+      acute: "\xB4",
+      micro: "\xB5",
+      para: "\xB6",
+      middot: "\xB7",
+      cedil: "\xB8",
+      sup1: "\xB9",
+      ordm: "\xBA",
+      raquo: "\xBB",
+      frac14: "\xBC",
+      frac12: "\xBD",
+      frac34: "\xBE",
+      iquest: "\xBF",
+      Agrave: "\xC0",
+      Aacute: "\xC1",
+      Acirc: "\xC2",
+      Atilde: "\xC3",
+      Auml: "\xC4",
+      Aring: "\xC5",
+      AElig: "\xC6",
+      Ccedil: "\xC7",
+      Egrave: "\xC8",
+      Eacute: "\xC9",
+      Ecirc: "\xCA",
+      Euml: "\xCB",
+      Igrave: "\xCC",
+      Iacute: "\xCD",
+      Icirc: "\xCE",
+      Iuml: "\xCF",
+      ETH: "\xD0",
+      Ntilde: "\xD1",
+      Ograve: "\xD2",
+      Oacute: "\xD3",
+      Ocirc: "\xD4",
+      Otilde: "\xD5",
+      Ouml: "\xD6",
+      times: "\xD7",
+      Oslash: "\xD8",
+      Ugrave: "\xD9",
+      Uacute: "\xDA",
+      Ucirc: "\xDB",
+      Uuml: "\xDC",
+      Yacute: "\xDD",
+      THORN: "\xDE",
+      szlig: "\xDF",
+      agrave: "\xE0",
+      aacute: "\xE1",
+      acirc: "\xE2",
+      atilde: "\xE3",
+      auml: "\xE4",
+      aring: "\xE5",
+      aelig: "\xE6",
+      ccedil: "\xE7",
+      egrave: "\xE8",
+      eacute: "\xE9",
+      ecirc: "\xEA",
+      euml: "\xEB",
+      igrave: "\xEC",
+      iacute: "\xED",
+      icirc: "\xEE",
+      iuml: "\xEF",
+      eth: "\xF0",
+      ntilde: "\xF1",
+      ograve: "\xF2",
+      oacute: "\xF3",
+      ocirc: "\xF4",
+      otilde: "\xF5",
+      ouml: "\xF6",
+      divide: "\xF7",
+      oslash: "\xF8",
+      ugrave: "\xF9",
+      uacute: "\xFA",
+      ucirc: "\xFB",
+      uuml: "\xFC",
+      yacute: "\xFD",
+      thorn: "\xFE",
+      yuml: "\xFF",
+      OElig: "\u0152",
+      oelig: "\u0153",
+      Scaron: "\u0160",
+      scaron: "\u0161",
+      Yuml: "\u0178",
+      fnof: "\u0192",
+      circ: "\u02C6",
+      tilde: "\u02DC",
+      Alpha: "\u0391",
+      Beta: "\u0392",
+      Gamma: "\u0393",
+      Delta: "\u0394",
+      Epsilon: "\u0395",
+      Zeta: "\u0396",
+      Eta: "\u0397",
+      Theta: "\u0398",
+      Iota: "\u0399",
+      Kappa: "\u039A",
+      Lambda: "\u039B",
+      Mu: "\u039C",
+      Nu: "\u039D",
+      Xi: "\u039E",
+      Omicron: "\u039F",
+      Pi: "\u03A0",
+      Rho: "\u03A1",
+      Sigma: "\u03A3",
+      Tau: "\u03A4",
+      Upsilon: "\u03A5",
+      Phi: "\u03A6",
+      Chi: "\u03A7",
+      Psi: "\u03A8",
+      Omega: "\u03A9",
+      alpha: "\u03B1",
+      beta: "\u03B2",
+      gamma: "\u03B3",
+      delta: "\u03B4",
+      epsilon: "\u03B5",
+      zeta: "\u03B6",
+      eta: "\u03B7",
+      theta: "\u03B8",
+      iota: "\u03B9",
+      kappa: "\u03BA",
+      lambda: "\u03BB",
+      mu: "\u03BC",
+      nu: "\u03BD",
+      xi: "\u03BE",
+      omicron: "\u03BF",
+      pi: "\u03C0",
+      rho: "\u03C1",
+      sigmaf: "\u03C2",
+      sigma: "\u03C3",
+      tau: "\u03C4",
+      upsilon: "\u03C5",
+      phi: "\u03C6",
+      chi: "\u03C7",
+      psi: "\u03C8",
+      omega: "\u03C9",
+      thetasym: "\u03D1",
+      upsih: "\u03D2",
+      piv: "\u03D6",
+      ensp: "\u2002",
+      emsp: "\u2003",
+      thinsp: "\u2009",
+      zwnj: "\u200C",
+      zwj: "\u200D",
+      lrm: "\u200E",
+      rlm: "\u200F",
+      ndash: "\u2013",
+      mdash: "\u2014",
+      lsquo: "\u2018",
+      rsquo: "\u2019",
+      sbquo: "\u201A",
+      ldquo: "\u201C",
+      rdquo: "\u201D",
+      bdquo: "\u201E",
+      dagger: "\u2020",
+      Dagger: "\u2021",
+      bull: "\u2022",
+      hellip: "\u2026",
+      permil: "\u2030",
+      prime: "\u2032",
+      Prime: "\u2033",
+      lsaquo: "\u2039",
+      rsaquo: "\u203A",
+      oline: "\u203E",
+      frasl: "\u2044",
+      euro: "\u20AC",
+      image: "\u2111",
+      weierp: "\u2118",
+      real: "\u211C",
+      trade: "\u2122",
+      alefsym: "\u2135",
+      larr: "\u2190",
+      uarr: "\u2191",
+      rarr: "\u2192",
+      darr: "\u2193",
+      harr: "\u2194",
+      crarr: "\u21B5",
+      lArr: "\u21D0",
+      uArr: "\u21D1",
+      rArr: "\u21D2",
+      dArr: "\u21D3",
+      hArr: "\u21D4",
+      forall: "\u2200",
+      part: "\u2202",
+      exist: "\u2203",
+      empty: "\u2205",
+      nabla: "\u2207",
+      isin: "\u2208",
+      notin: "\u2209",
+      ni: "\u220B",
+      prod: "\u220F",
+      sum: "\u2211",
+      minus: "\u2212",
+      lowast: "\u2217",
+      radic: "\u221A",
+      prop: "\u221D",
+      infin: "\u221E",
+      ang: "\u2220",
+      and: "\u2227",
+      or: "\u2228",
+      cap: "\u2229",
+      cup: "\u222A",
+      "int": "\u222B",
+      there4: "\u2234",
+      sim: "\u223C",
+      cong: "\u2245",
+      asymp: "\u2248",
+      ne: "\u2260",
+      equiv: "\u2261",
+      le: "\u2264",
+      ge: "\u2265",
+      sub: "\u2282",
+      sup: "\u2283",
+      nsub: "\u2284",
+      sube: "\u2286",
+      supe: "\u2287",
+      oplus: "\u2295",
+      otimes: "\u2297",
+      perp: "\u22A5",
+      sdot: "\u22C5",
+      lceil: "\u2308",
+      rceil: "\u2309",
+      lfloor: "\u230A",
+      rfloor: "\u230B",
+      lang: "\u2329",
+      rang: "\u232A",
+      loz: "\u25CA",
+      spades: "\u2660",
+      clubs: "\u2663",
+      hearts: "\u2665",
+      diams: "\u2666"
+    };
+  }
+});
+
+// node_modules/acorn/dist/acorn.js
+var require_acorn = __commonJS({
+  "node_modules/acorn/dist/acorn.js"(exports, module2) {
+    (function(global, factory2) {
+      typeof exports === "object" && typeof module2 !== "undefined" ? factory2(exports) : typeof define === "function" && define.amd ? define(["exports"], factory2) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory2(global.acorn = {}));
+    })(exports, function(exports2) {
+      "use strict";
+      var astralIdentifierCodes2 = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 370, 1, 154, 10, 50, 3, 123, 2, 54, 14, 32, 10, 3, 1, 11, 3, 46, 10, 8, 0, 46, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 161, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 193, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 84, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 406, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 19306, 9, 87, 9, 39, 4, 60, 6, 26, 9, 1014, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 4706, 45, 3, 22, 543, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 262, 6, 10, 9, 357, 0, 62, 13, 1495, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
+      var astralIdentifierStartCodes2 = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 13, 10, 2, 14, 2, 6, 2, 1, 2, 10, 2, 14, 2, 6, 2, 1, 68, 310, 10, 21, 11, 7, 25, 5, 2, 41, 2, 8, 70, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 349, 41, 7, 1, 79, 28, 11, 0, 9, 21, 43, 17, 47, 20, 28, 22, 13, 52, 58, 1, 3, 0, 14, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 85, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 159, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 38, 6, 186, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 19, 72, 264, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 190, 0, 80, 921, 103, 110, 18, 195, 2637, 96, 16, 1070, 4050, 582, 8634, 568, 8, 30, 18, 78, 18, 29, 19, 47, 17, 3, 32, 20, 6, 18, 689, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 43, 8, 8936, 3, 2, 6, 2, 1, 2, 290, 46, 2, 18, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 1845, 30, 482, 44, 11, 6, 17, 0, 322, 29, 19, 43, 1269, 6, 2, 3, 2, 1, 2, 14, 2, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42719, 33, 4152, 8, 221, 3, 5761, 15, 7472, 3104, 541, 1507, 4938];
+      var nonASCIIidentifierChars2 = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u0898-\u089F\u08CA-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3C\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1715\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u180F-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF-\u1ACE\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DFF\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F";
+      var nonASCIIidentifierStartChars2 = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u0870-\u0887\u0889-\u088E\u08A0-\u08C9\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C5D\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u1711\u171F-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4C\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7CA\uA7D0\uA7D1\uA7D3\uA7D5-\uA7D9\uA7F2-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
+      var reservedWords2 = {
+        3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
+        5: "class enum extends super const export import",
+        6: "enum",
+        strict: "implements interface let package private protected public static yield",
+        strictBind: "eval arguments"
+      };
+      var ecma5AndLessKeywords2 = "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this";
+      var keywords$12 = {
+        5: ecma5AndLessKeywords2,
+        "5module": ecma5AndLessKeywords2 + " export import",
+        6: ecma5AndLessKeywords2 + " const class extends export import super"
+      };
+      var keywordRelationalOperator2 = /^in(stanceof)?$/;
+      var nonASCIIidentifierStart2 = new RegExp("[" + nonASCIIidentifierStartChars2 + "]");
+      var nonASCIIidentifier2 = new RegExp("[" + nonASCIIidentifierStartChars2 + nonASCIIidentifierChars2 + "]");
+      function isInAstralSet2(code2, set) {
+        var pos = 65536;
+        for (var i2 = 0; i2 < set.length; i2 += 2) {
+          pos += set[i2];
+          if (pos > code2) {
+            return false;
+          }
+          pos += set[i2 + 1];
+          if (pos >= code2) {
+            return true;
+          }
+        }
+      }
+      function isIdentifierStart2(code2, astral) {
+        if (code2 < 65) {
+          return code2 === 36;
+        }
+        if (code2 < 91) {
+          return true;
+        }
+        if (code2 < 97) {
+          return code2 === 95;
+        }
+        if (code2 < 123) {
+          return true;
+        }
+        if (code2 <= 65535) {
+          return code2 >= 170 && nonASCIIidentifierStart2.test(String.fromCharCode(code2));
+        }
+        if (astral === false) {
+          return false;
+        }
+        return isInAstralSet2(code2, astralIdentifierStartCodes2);
+      }
+      function isIdentifierChar2(code2, astral) {
+        if (code2 < 48) {
+          return code2 === 36;
+        }
+        if (code2 < 58) {
+          return true;
+        }
+        if (code2 < 65) {
+          return false;
+        }
+        if (code2 < 91) {
+          return true;
+        }
+        if (code2 < 97) {
+          return code2 === 95;
+        }
+        if (code2 < 123) {
+          return true;
+        }
+        if (code2 <= 65535) {
+          return code2 >= 170 && nonASCIIidentifier2.test(String.fromCharCode(code2));
+        }
+        if (astral === false) {
+          return false;
+        }
+        return isInAstralSet2(code2, astralIdentifierStartCodes2) || isInAstralSet2(code2, astralIdentifierCodes2);
+      }
+      var TokenType3 = function TokenType4(label, conf) {
+        if (conf === void 0)
+          conf = {};
+        this.label = label;
+        this.keyword = conf.keyword;
+        this.beforeExpr = !!conf.beforeExpr;
+        this.startsExpr = !!conf.startsExpr;
+        this.isLoop = !!conf.isLoop;
+        this.isAssign = !!conf.isAssign;
+        this.prefix = !!conf.prefix;
+        this.postfix = !!conf.postfix;
+        this.binop = conf.binop || null;
+        this.updateContext = null;
+      };
+      function binop2(name2, prec) {
+        return new TokenType3(name2, { beforeExpr: true, binop: prec });
+      }
+      var beforeExpr2 = { beforeExpr: true }, startsExpr2 = { startsExpr: true };
+      var keywords2 = {};
+      function kw2(name2, options) {
+        if (options === void 0)
+          options = {};
+        options.keyword = name2;
+        return keywords2[name2] = new TokenType3(name2, options);
+      }
+      var types$12 = {
+        num: new TokenType3("num", startsExpr2),
+        regexp: new TokenType3("regexp", startsExpr2),
+        string: new TokenType3("string", startsExpr2),
+        name: new TokenType3("name", startsExpr2),
+        privateId: new TokenType3("privateId", startsExpr2),
+        eof: new TokenType3("eof"),
+        bracketL: new TokenType3("[", { beforeExpr: true, startsExpr: true }),
+        bracketR: new TokenType3("]"),
+        braceL: new TokenType3("{", { beforeExpr: true, startsExpr: true }),
+        braceR: new TokenType3("}"),
+        parenL: new TokenType3("(", { beforeExpr: true, startsExpr: true }),
+        parenR: new TokenType3(")"),
+        comma: new TokenType3(",", beforeExpr2),
+        semi: new TokenType3(";", beforeExpr2),
+        colon: new TokenType3(":", beforeExpr2),
+        dot: new TokenType3("."),
+        question: new TokenType3("?", beforeExpr2),
+        questionDot: new TokenType3("?."),
+        arrow: new TokenType3("=>", beforeExpr2),
+        template: new TokenType3("template"),
+        invalidTemplate: new TokenType3("invalidTemplate"),
+        ellipsis: new TokenType3("...", beforeExpr2),
+        backQuote: new TokenType3("`", startsExpr2),
+        dollarBraceL: new TokenType3("${", { beforeExpr: true, startsExpr: true }),
+        eq: new TokenType3("=", { beforeExpr: true, isAssign: true }),
+        assign: new TokenType3("_=", { beforeExpr: true, isAssign: true }),
+        incDec: new TokenType3("++/--", { prefix: true, postfix: true, startsExpr: true }),
+        prefix: new TokenType3("!/~", { beforeExpr: true, prefix: true, startsExpr: true }),
+        logicalOR: binop2("||", 1),
+        logicalAND: binop2("&&", 2),
+        bitwiseOR: binop2("|", 3),
+        bitwiseXOR: binop2("^", 4),
+        bitwiseAND: binop2("&", 5),
+        equality: binop2("==/!=/===/!==", 6),
+        relational: binop2("</>/<=/>=", 7),
+        bitShift: binop2("<</>>/>>>", 8),
+        plusMin: new TokenType3("+/-", { beforeExpr: true, binop: 9, prefix: true, startsExpr: true }),
+        modulo: binop2("%", 10),
+        star: binop2("*", 10),
+        slash: binop2("/", 10),
+        starstar: new TokenType3("**", { beforeExpr: true }),
+        coalesce: binop2("??", 1),
+        _break: kw2("break"),
+        _case: kw2("case", beforeExpr2),
+        _catch: kw2("catch"),
+        _continue: kw2("continue"),
+        _debugger: kw2("debugger"),
+        _default: kw2("default", beforeExpr2),
+        _do: kw2("do", { isLoop: true, beforeExpr: true }),
+        _else: kw2("else", beforeExpr2),
+        _finally: kw2("finally"),
+        _for: kw2("for", { isLoop: true }),
+        _function: kw2("function", startsExpr2),
+        _if: kw2("if"),
+        _return: kw2("return", beforeExpr2),
+        _switch: kw2("switch"),
+        _throw: kw2("throw", beforeExpr2),
+        _try: kw2("try"),
+        _var: kw2("var"),
+        _const: kw2("const"),
+        _while: kw2("while", { isLoop: true }),
+        _with: kw2("with"),
+        _new: kw2("new", { beforeExpr: true, startsExpr: true }),
+        _this: kw2("this", startsExpr2),
+        _super: kw2("super", startsExpr2),
+        _class: kw2("class", startsExpr2),
+        _extends: kw2("extends", beforeExpr2),
+        _export: kw2("export"),
+        _import: kw2("import", startsExpr2),
+        _null: kw2("null", startsExpr2),
+        _true: kw2("true", startsExpr2),
+        _false: kw2("false", startsExpr2),
+        _in: kw2("in", { beforeExpr: true, binop: 7 }),
+        _instanceof: kw2("instanceof", { beforeExpr: true, binop: 7 }),
+        _typeof: kw2("typeof", { beforeExpr: true, prefix: true, startsExpr: true }),
+        _void: kw2("void", { beforeExpr: true, prefix: true, startsExpr: true }),
+        _delete: kw2("delete", { beforeExpr: true, prefix: true, startsExpr: true })
+      };
+      var lineBreak2 = /\r\n?|\n|\u2028|\u2029/;
+      var lineBreakG2 = new RegExp(lineBreak2.source, "g");
+      function isNewLine2(code2) {
+        return code2 === 10 || code2 === 13 || code2 === 8232 || code2 === 8233;
+      }
+      function nextLineBreak2(code2, from, end) {
+        if (end === void 0)
+          end = code2.length;
+        for (var i2 = from; i2 < end; i2++) {
+          var next = code2.charCodeAt(i2);
+          if (isNewLine2(next)) {
+            return i2 < end - 1 && next === 13 && code2.charCodeAt(i2 + 1) === 10 ? i2 + 2 : i2 + 1;
+          }
+        }
+        return -1;
+      }
+      var nonASCIIwhitespace2 = /[\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
+      var skipWhiteSpace2 = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
+      var ref2 = Object.prototype;
+      var hasOwnProperty3 = ref2.hasOwnProperty;
+      var toString3 = ref2.toString;
+      var hasOwn2 = Object.hasOwn || function(obj, propName) {
+        return hasOwnProperty3.call(obj, propName);
+      };
+      var isArray2 = Array.isArray || function(obj) {
+        return toString3.call(obj) === "[object Array]";
+      };
+      function wordsRegexp2(words) {
+        return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+      }
+      function codePointToString2(code2) {
+        if (code2 <= 65535) {
+          return String.fromCharCode(code2);
+        }
+        code2 -= 65536;
+        return String.fromCharCode((code2 >> 10) + 55296, (code2 & 1023) + 56320);
+      }
+      var loneSurrogate2 = /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/;
+      var Position3 = function Position4(line, col) {
+        this.line = line;
+        this.column = col;
+      };
+      Position3.prototype.offset = function offset2(n) {
+        return new Position3(this.line, this.column + n);
+      };
+      var SourceLocation3 = function SourceLocation4(p, start3, end) {
+        this.start = start3;
+        this.end = end;
+        if (p.sourceFile !== null) {
+          this.source = p.sourceFile;
+        }
+      };
+      function getLineInfo2(input, offset2) {
+        for (var line = 1, cur = 0; ; ) {
+          var nextBreak = nextLineBreak2(input, cur, offset2);
+          if (nextBreak < 0) {
+            return new Position3(line, offset2 - cur);
+          }
+          ++line;
+          cur = nextBreak;
+        }
+      }
+      var defaultOptions2 = {
+        ecmaVersion: null,
+        sourceType: "script",
+        onInsertedSemicolon: null,
+        onTrailingComma: null,
+        allowReserved: null,
+        allowReturnOutsideFunction: false,
+        allowImportExportEverywhere: false,
+        allowAwaitOutsideFunction: null,
+        allowSuperOutsideMethod: null,
+        allowHashBang: false,
+        locations: false,
+        onToken: null,
+        onComment: null,
+        ranges: false,
+        program: null,
+        sourceFile: null,
+        directSourceFile: null,
+        preserveParens: false
+      };
+      var warnedAboutEcmaVersion2 = false;
+      function getOptions2(opts) {
+        var options = {};
+        for (var opt in defaultOptions2) {
+          options[opt] = opts && hasOwn2(opts, opt) ? opts[opt] : defaultOptions2[opt];
+        }
+        if (options.ecmaVersion === "latest") {
+          options.ecmaVersion = 1e8;
+        } else if (options.ecmaVersion == null) {
+          if (!warnedAboutEcmaVersion2 && typeof console === "object" && console.warn) {
+            warnedAboutEcmaVersion2 = true;
+            console.warn("Since Acorn 8.0.0, options.ecmaVersion is required.\nDefaulting to 2020, but this will stop working in the future.");
+          }
+          options.ecmaVersion = 11;
+        } else if (options.ecmaVersion >= 2015) {
+          options.ecmaVersion -= 2009;
+        }
+        if (options.allowReserved == null) {
+          options.allowReserved = options.ecmaVersion < 5;
+        }
+        if (opts.allowHashBang == null) {
+          options.allowHashBang = options.ecmaVersion >= 14;
+        }
+        if (isArray2(options.onToken)) {
+          var tokens = options.onToken;
+          options.onToken = function(token) {
+            return tokens.push(token);
+          };
+        }
+        if (isArray2(options.onComment)) {
+          options.onComment = pushComment2(options, options.onComment);
+        }
+        return options;
+      }
+      function pushComment2(options, array) {
+        return function(block, text5, start3, end, startLoc, endLoc) {
+          var comment2 = {
+            type: block ? "Block" : "Line",
+            value: text5,
+            start: start3,
+            end
+          };
+          if (options.locations) {
+            comment2.loc = new SourceLocation3(this, startLoc, endLoc);
+          }
+          if (options.ranges) {
+            comment2.range = [start3, end];
+          }
+          array.push(comment2);
+        };
+      }
+      var SCOPE_TOP2 = 1, SCOPE_FUNCTION2 = 2, SCOPE_ASYNC2 = 4, SCOPE_GENERATOR2 = 8, SCOPE_ARROW2 = 16, SCOPE_SIMPLE_CATCH2 = 32, SCOPE_SUPER2 = 64, SCOPE_DIRECT_SUPER2 = 128, SCOPE_CLASS_STATIC_BLOCK2 = 256, SCOPE_VAR2 = SCOPE_TOP2 | SCOPE_FUNCTION2 | SCOPE_CLASS_STATIC_BLOCK2;
+      function functionFlags2(async, generator) {
+        return SCOPE_FUNCTION2 | (async ? SCOPE_ASYNC2 : 0) | (generator ? SCOPE_GENERATOR2 : 0);
+      }
+      var BIND_NONE2 = 0, BIND_VAR2 = 1, BIND_LEXICAL2 = 2, BIND_FUNCTION2 = 3, BIND_SIMPLE_CATCH2 = 4, BIND_OUTSIDE2 = 5;
+      var Parser3 = function Parser4(options, input, startPos) {
+        this.options = options = getOptions2(options);
+        this.sourceFile = options.sourceFile;
+        this.keywords = wordsRegexp2(keywords$12[options.ecmaVersion >= 6 ? 6 : options.sourceType === "module" ? "5module" : 5]);
+        var reserved = "";
+        if (options.allowReserved !== true) {
+          reserved = reservedWords2[options.ecmaVersion >= 6 ? 6 : options.ecmaVersion === 5 ? 5 : 3];
+          if (options.sourceType === "module") {
+            reserved += " await";
+          }
+        }
+        this.reservedWords = wordsRegexp2(reserved);
+        var reservedStrict = (reserved ? reserved + " " : "") + reservedWords2.strict;
+        this.reservedWordsStrict = wordsRegexp2(reservedStrict);
+        this.reservedWordsStrictBind = wordsRegexp2(reservedStrict + " " + reservedWords2.strictBind);
+        this.input = String(input);
+        this.containsEsc = false;
+        if (startPos) {
+          this.pos = startPos;
+          this.lineStart = this.input.lastIndexOf("\n", startPos - 1) + 1;
+          this.curLine = this.input.slice(0, this.lineStart).split(lineBreak2).length;
+        } else {
+          this.pos = this.lineStart = 0;
+          this.curLine = 1;
+        }
+        this.type = types$12.eof;
+        this.value = null;
+        this.start = this.end = this.pos;
+        this.startLoc = this.endLoc = this.curPosition();
+        this.lastTokEndLoc = this.lastTokStartLoc = null;
+        this.lastTokStart = this.lastTokEnd = this.pos;
+        this.context = this.initialContext();
+        this.exprAllowed = true;
+        this.inModule = options.sourceType === "module";
+        this.strict = this.inModule || this.strictDirective(this.pos);
+        this.potentialArrowAt = -1;
+        this.potentialArrowInForAwait = false;
+        this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
+        this.labels = [];
+        this.undefinedExports = /* @__PURE__ */ Object.create(null);
+        if (this.pos === 0 && options.allowHashBang && this.input.slice(0, 2) === "#!") {
+          this.skipLineComment(2);
+        }
+        this.scopeStack = [];
+        this.enterScope(SCOPE_TOP2);
+        this.regexpState = null;
+        this.privateNameStack = [];
+      };
+      var prototypeAccessors2 = { inFunction: { configurable: true }, inGenerator: { configurable: true }, inAsync: { configurable: true }, canAwait: { configurable: true }, allowSuper: { configurable: true }, allowDirectSuper: { configurable: true }, treatFunctionsAsVar: { configurable: true }, allowNewDotTarget: { configurable: true }, inClassStaticBlock: { configurable: true } };
+      Parser3.prototype.parse = function parse5() {
+        var node = this.options.program || this.startNode();
+        this.nextToken();
+        return this.parseTopLevel(node);
+      };
+      prototypeAccessors2.inFunction.get = function() {
+        return (this.currentVarScope().flags & SCOPE_FUNCTION2) > 0;
+      };
+      prototypeAccessors2.inGenerator.get = function() {
+        return (this.currentVarScope().flags & SCOPE_GENERATOR2) > 0 && !this.currentVarScope().inClassFieldInit;
+      };
+      prototypeAccessors2.inAsync.get = function() {
+        return (this.currentVarScope().flags & SCOPE_ASYNC2) > 0 && !this.currentVarScope().inClassFieldInit;
+      };
+      prototypeAccessors2.canAwait.get = function() {
+        for (var i2 = this.scopeStack.length - 1; i2 >= 0; i2--) {
+          var scope = this.scopeStack[i2];
+          if (scope.inClassFieldInit || scope.flags & SCOPE_CLASS_STATIC_BLOCK2) {
+            return false;
+          }
+          if (scope.flags & SCOPE_FUNCTION2) {
+            return (scope.flags & SCOPE_ASYNC2) > 0;
+          }
+        }
+        return this.inModule && this.options.ecmaVersion >= 13 || this.options.allowAwaitOutsideFunction;
+      };
+      prototypeAccessors2.allowSuper.get = function() {
+        var ref3 = this.currentThisScope();
+        var flags = ref3.flags;
+        var inClassFieldInit = ref3.inClassFieldInit;
+        return (flags & SCOPE_SUPER2) > 0 || inClassFieldInit || this.options.allowSuperOutsideMethod;
+      };
+      prototypeAccessors2.allowDirectSuper.get = function() {
+        return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER2) > 0;
+      };
+      prototypeAccessors2.treatFunctionsAsVar.get = function() {
+        return this.treatFunctionsAsVarInScope(this.currentScope());
+      };
+      prototypeAccessors2.allowNewDotTarget.get = function() {
+        var ref3 = this.currentThisScope();
+        var flags = ref3.flags;
+        var inClassFieldInit = ref3.inClassFieldInit;
+        return (flags & (SCOPE_FUNCTION2 | SCOPE_CLASS_STATIC_BLOCK2)) > 0 || inClassFieldInit;
+      };
+      prototypeAccessors2.inClassStaticBlock.get = function() {
+        return (this.currentVarScope().flags & SCOPE_CLASS_STATIC_BLOCK2) > 0;
+      };
+      Parser3.extend = function extend3() {
+        var plugins = [], len = arguments.length;
+        while (len--)
+          plugins[len] = arguments[len];
+        var cls = this;
+        for (var i2 = 0; i2 < plugins.length; i2++) {
+          cls = plugins[i2](cls);
+        }
+        return cls;
+      };
+      Parser3.parse = function parse5(input, options) {
+        return new this(options, input).parse();
+      };
+      Parser3.parseExpressionAt = function parseExpressionAt3(input, pos, options) {
+        var parser = new this(options, input, pos);
+        parser.nextToken();
+        return parser.parseExpression();
+      };
+      Parser3.tokenizer = function tokenizer3(input, options) {
+        return new this(options, input);
+      };
+      Object.defineProperties(Parser3.prototype, prototypeAccessors2);
+      var pp$92 = Parser3.prototype;
+      var literal2 = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/;
+      pp$92.strictDirective = function(start3) {
+        if (this.options.ecmaVersion < 5) {
+          return false;
+        }
+        for (; ; ) {
+          skipWhiteSpace2.lastIndex = start3;
+          start3 += skipWhiteSpace2.exec(this.input)[0].length;
+          var match = literal2.exec(this.input.slice(start3));
+          if (!match) {
+            return false;
+          }
+          if ((match[1] || match[2]) === "use strict") {
+            skipWhiteSpace2.lastIndex = start3 + match[0].length;
+            var spaceAfter = skipWhiteSpace2.exec(this.input), end = spaceAfter.index + spaceAfter[0].length;
+            var next = this.input.charAt(end);
+            return next === ";" || next === "}" || lineBreak2.test(spaceAfter[0]) && !(/[(`.[+\-/*%<>=,?^&]/.test(next) || next === "!" && this.input.charAt(end + 1) === "=");
+          }
+          start3 += match[0].length;
+          skipWhiteSpace2.lastIndex = start3;
+          start3 += skipWhiteSpace2.exec(this.input)[0].length;
+          if (this.input[start3] === ";") {
+            start3++;
+          }
+        }
+      };
+      pp$92.eat = function(type) {
+        if (this.type === type) {
+          this.next();
+          return true;
+        } else {
+          return false;
+        }
+      };
+      pp$92.isContextual = function(name2) {
+        return this.type === types$12.name && this.value === name2 && !this.containsEsc;
+      };
+      pp$92.eatContextual = function(name2) {
+        if (!this.isContextual(name2)) {
+          return false;
+        }
+        this.next();
+        return true;
+      };
+      pp$92.expectContextual = function(name2) {
+        if (!this.eatContextual(name2)) {
+          this.unexpected();
+        }
+      };
+      pp$92.canInsertSemicolon = function() {
+        return this.type === types$12.eof || this.type === types$12.braceR || lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+      };
+      pp$92.insertSemicolon = function() {
+        if (this.canInsertSemicolon()) {
+          if (this.options.onInsertedSemicolon) {
+            this.options.onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+          }
+          return true;
+        }
+      };
+      pp$92.semicolon = function() {
+        if (!this.eat(types$12.semi) && !this.insertSemicolon()) {
+          this.unexpected();
+        }
+      };
+      pp$92.afterTrailingComma = function(tokType, notNext) {
+        if (this.type === tokType) {
+          if (this.options.onTrailingComma) {
+            this.options.onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+          }
+          if (!notNext) {
+            this.next();
+          }
+          return true;
+        }
+      };
+      pp$92.expect = function(type) {
+        this.eat(type) || this.unexpected();
+      };
+      pp$92.unexpected = function(pos) {
+        this.raise(pos != null ? pos : this.start, "Unexpected token");
+      };
+      var DestructuringErrors3 = function DestructuringErrors4() {
+        this.shorthandAssign = this.trailingComma = this.parenthesizedAssign = this.parenthesizedBind = this.doubleProto = -1;
+      };
+      pp$92.checkPatternErrors = function(refDestructuringErrors, isAssign) {
+        if (!refDestructuringErrors) {
+          return;
+        }
+        if (refDestructuringErrors.trailingComma > -1) {
+          this.raiseRecoverable(refDestructuringErrors.trailingComma, "Comma is not permitted after the rest element");
+        }
+        var parens = isAssign ? refDestructuringErrors.parenthesizedAssign : refDestructuringErrors.parenthesizedBind;
+        if (parens > -1) {
+          this.raiseRecoverable(parens, isAssign ? "Assigning to rvalue" : "Parenthesized pattern");
+        }
+      };
+      pp$92.checkExpressionErrors = function(refDestructuringErrors, andThrow) {
+        if (!refDestructuringErrors) {
+          return false;
+        }
+        var shorthandAssign = refDestructuringErrors.shorthandAssign;
+        var doubleProto = refDestructuringErrors.doubleProto;
+        if (!andThrow) {
+          return shorthandAssign >= 0 || doubleProto >= 0;
+        }
+        if (shorthandAssign >= 0) {
+          this.raise(shorthandAssign, "Shorthand property assignments are valid only in destructuring patterns");
+        }
+        if (doubleProto >= 0) {
+          this.raiseRecoverable(doubleProto, "Redefinition of __proto__ property");
+        }
+      };
+      pp$92.checkYieldAwaitInDefaultParams = function() {
+        if (this.yieldPos && (!this.awaitPos || this.yieldPos < this.awaitPos)) {
+          this.raise(this.yieldPos, "Yield expression cannot be a default value");
+        }
+        if (this.awaitPos) {
+          this.raise(this.awaitPos, "Await expression cannot be a default value");
+        }
+      };
+      pp$92.isSimpleAssignTarget = function(expr) {
+        if (expr.type === "ParenthesizedExpression") {
+          return this.isSimpleAssignTarget(expr.expression);
+        }
+        return expr.type === "Identifier" || expr.type === "MemberExpression";
+      };
+      var pp$82 = Parser3.prototype;
+      pp$82.parseTopLevel = function(node) {
+        var exports3 = /* @__PURE__ */ Object.create(null);
+        if (!node.body) {
+          node.body = [];
+        }
+        while (this.type !== types$12.eof) {
+          var stmt = this.parseStatement(null, true, exports3);
+          node.body.push(stmt);
+        }
+        if (this.inModule) {
+          for (var i2 = 0, list4 = Object.keys(this.undefinedExports); i2 < list4.length; i2 += 1) {
+            var name2 = list4[i2];
+            this.raiseRecoverable(this.undefinedExports[name2].start, "Export '" + name2 + "' is not defined");
+          }
+        }
+        this.adaptDirectivePrologue(node.body);
+        this.next();
+        node.sourceType = this.options.sourceType;
+        return this.finishNode(node, "Program");
+      };
+      var loopLabel2 = { kind: "loop" }, switchLabel2 = { kind: "switch" };
+      pp$82.isLet = function(context) {
+        if (this.options.ecmaVersion < 6 || !this.isContextual("let")) {
+          return false;
+        }
+        skipWhiteSpace2.lastIndex = this.pos;
+        var skip = skipWhiteSpace2.exec(this.input);
+        var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+        if (nextCh === 91 || nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+          return true;
+        }
+        if (context) {
+          return false;
+        }
+        if (nextCh === 123) {
+          return true;
+        }
+        if (isIdentifierStart2(nextCh, true)) {
+          var pos = next + 1;
+          while (isIdentifierChar2(nextCh = this.input.charCodeAt(pos), true)) {
+            ++pos;
+          }
+          if (nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+            return true;
+          }
+          var ident = this.input.slice(next, pos);
+          if (!keywordRelationalOperator2.test(ident)) {
+            return true;
+          }
+        }
+        return false;
+      };
+      pp$82.isAsyncFunction = function() {
+        if (this.options.ecmaVersion < 8 || !this.isContextual("async")) {
+          return false;
+        }
+        skipWhiteSpace2.lastIndex = this.pos;
+        var skip = skipWhiteSpace2.exec(this.input);
+        var next = this.pos + skip[0].length, after;
+        return !lineBreak2.test(this.input.slice(this.pos, next)) && this.input.slice(next, next + 8) === "function" && (next + 8 === this.input.length || !(isIdentifierChar2(after = this.input.charCodeAt(next + 8)) || after > 55295 && after < 56320));
+      };
+      pp$82.parseStatement = function(context, topLevel, exports3) {
+        var starttype = this.type, node = this.startNode(), kind;
+        if (this.isLet(context)) {
+          starttype = types$12._var;
+          kind = "let";
+        }
+        switch (starttype) {
+          case types$12._break:
+          case types$12._continue:
+            return this.parseBreakContinueStatement(node, starttype.keyword);
+          case types$12._debugger:
+            return this.parseDebuggerStatement(node);
+          case types$12._do:
+            return this.parseDoStatement(node);
+          case types$12._for:
+            return this.parseForStatement(node);
+          case types$12._function:
+            if (context && (this.strict || context !== "if" && context !== "label") && this.options.ecmaVersion >= 6) {
+              this.unexpected();
+            }
+            return this.parseFunctionStatement(node, false, !context);
+          case types$12._class:
+            if (context) {
+              this.unexpected();
+            }
+            return this.parseClass(node, true);
+          case types$12._if:
+            return this.parseIfStatement(node);
+          case types$12._return:
+            return this.parseReturnStatement(node);
+          case types$12._switch:
+            return this.parseSwitchStatement(node);
+          case types$12._throw:
+            return this.parseThrowStatement(node);
+          case types$12._try:
+            return this.parseTryStatement(node);
+          case types$12._const:
+          case types$12._var:
+            kind = kind || this.value;
+            if (context && kind !== "var") {
+              this.unexpected();
+            }
+            return this.parseVarStatement(node, kind);
+          case types$12._while:
+            return this.parseWhileStatement(node);
+          case types$12._with:
+            return this.parseWithStatement(node);
+          case types$12.braceL:
+            return this.parseBlock(true, node);
+          case types$12.semi:
+            return this.parseEmptyStatement(node);
+          case types$12._export:
+          case types$12._import:
+            if (this.options.ecmaVersion > 10 && starttype === types$12._import) {
+              skipWhiteSpace2.lastIndex = this.pos;
+              var skip = skipWhiteSpace2.exec(this.input);
+              var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+              if (nextCh === 40 || nextCh === 46) {
+                return this.parseExpressionStatement(node, this.parseExpression());
+              }
+            }
+            if (!this.options.allowImportExportEverywhere) {
+              if (!topLevel) {
+                this.raise(this.start, "'import' and 'export' may only appear at the top level");
+              }
+              if (!this.inModule) {
+                this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'");
+              }
+            }
+            return starttype === types$12._import ? this.parseImport(node) : this.parseExport(node, exports3);
+          default:
+            if (this.isAsyncFunction()) {
+              if (context) {
+                this.unexpected();
+              }
+              this.next();
+              return this.parseFunctionStatement(node, true, !context);
+            }
+            var maybeName = this.value, expr = this.parseExpression();
+            if (starttype === types$12.name && expr.type === "Identifier" && this.eat(types$12.colon)) {
+              return this.parseLabeledStatement(node, maybeName, expr, context);
+            } else {
+              return this.parseExpressionStatement(node, expr);
+            }
+        }
+      };
+      pp$82.parseBreakContinueStatement = function(node, keyword) {
+        var isBreak = keyword === "break";
+        this.next();
+        if (this.eat(types$12.semi) || this.insertSemicolon()) {
+          node.label = null;
+        } else if (this.type !== types$12.name) {
+          this.unexpected();
+        } else {
+          node.label = this.parseIdent();
+          this.semicolon();
+        }
+        var i2 = 0;
+        for (; i2 < this.labels.length; ++i2) {
+          var lab = this.labels[i2];
+          if (node.label == null || lab.name === node.label.name) {
+            if (lab.kind != null && (isBreak || lab.kind === "loop")) {
+              break;
+            }
+            if (node.label && isBreak) {
+              break;
+            }
+          }
+        }
+        if (i2 === this.labels.length) {
+          this.raise(node.start, "Unsyntactic " + keyword);
+        }
+        return this.finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+      };
+      pp$82.parseDebuggerStatement = function(node) {
+        this.next();
+        this.semicolon();
+        return this.finishNode(node, "DebuggerStatement");
+      };
+      pp$82.parseDoStatement = function(node) {
+        this.next();
+        this.labels.push(loopLabel2);
+        node.body = this.parseStatement("do");
+        this.labels.pop();
+        this.expect(types$12._while);
+        node.test = this.parseParenExpression();
+        if (this.options.ecmaVersion >= 6) {
+          this.eat(types$12.semi);
+        } else {
+          this.semicolon();
+        }
+        return this.finishNode(node, "DoWhileStatement");
+      };
+      pp$82.parseForStatement = function(node) {
+        this.next();
+        var awaitAt = this.options.ecmaVersion >= 9 && this.canAwait && this.eatContextual("await") ? this.lastTokStart : -1;
+        this.labels.push(loopLabel2);
+        this.enterScope(0);
+        this.expect(types$12.parenL);
+        if (this.type === types$12.semi) {
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+          return this.parseFor(node, null);
+        }
+        var isLet = this.isLet();
+        if (this.type === types$12._var || this.type === types$12._const || isLet) {
+          var init$1 = this.startNode(), kind = isLet ? "let" : this.value;
+          this.next();
+          this.parseVar(init$1, true, kind);
+          this.finishNode(init$1, "VariableDeclaration");
+          if ((this.type === types$12._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) && init$1.declarations.length === 1) {
+            if (this.options.ecmaVersion >= 9) {
+              if (this.type === types$12._in) {
+                if (awaitAt > -1) {
+                  this.unexpected(awaitAt);
+                }
+              } else {
+                node.await = awaitAt > -1;
+              }
+            }
+            return this.parseForIn(node, init$1);
+          }
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+          return this.parseFor(node, init$1);
+        }
+        var startsWithLet = this.isContextual("let"), isForOf = false;
+        var refDestructuringErrors = new DestructuringErrors3();
+        var init = this.parseExpression(awaitAt > -1 ? "await" : true, refDestructuringErrors);
+        if (this.type === types$12._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+          if (this.options.ecmaVersion >= 9) {
+            if (this.type === types$12._in) {
+              if (awaitAt > -1) {
+                this.unexpected(awaitAt);
+              }
+            } else {
+              node.await = awaitAt > -1;
+            }
+          }
+          if (startsWithLet && isForOf) {
+            this.raise(init.start, "The left-hand side of a for-of loop may not start with 'let'.");
+          }
+          this.toAssignable(init, false, refDestructuringErrors);
+          this.checkLValPattern(init);
+          return this.parseForIn(node, init);
+        } else {
+          this.checkExpressionErrors(refDestructuringErrors, true);
+        }
+        if (awaitAt > -1) {
+          this.unexpected(awaitAt);
+        }
+        return this.parseFor(node, init);
+      };
+      pp$82.parseFunctionStatement = function(node, isAsync, declarationPosition) {
+        this.next();
+        return this.parseFunction(node, FUNC_STATEMENT2 | (declarationPosition ? 0 : FUNC_HANGING_STATEMENT2), false, isAsync);
+      };
+      pp$82.parseIfStatement = function(node) {
+        this.next();
+        node.test = this.parseParenExpression();
+        node.consequent = this.parseStatement("if");
+        node.alternate = this.eat(types$12._else) ? this.parseStatement("if") : null;
+        return this.finishNode(node, "IfStatement");
+      };
+      pp$82.parseReturnStatement = function(node) {
+        if (!this.inFunction && !this.options.allowReturnOutsideFunction) {
+          this.raise(this.start, "'return' outside of function");
+        }
+        this.next();
+        if (this.eat(types$12.semi) || this.insertSemicolon()) {
+          node.argument = null;
+        } else {
+          node.argument = this.parseExpression();
+          this.semicolon();
+        }
+        return this.finishNode(node, "ReturnStatement");
+      };
+      pp$82.parseSwitchStatement = function(node) {
+        this.next();
+        node.discriminant = this.parseParenExpression();
+        node.cases = [];
+        this.expect(types$12.braceL);
+        this.labels.push(switchLabel2);
+        this.enterScope(0);
+        var cur;
+        for (var sawDefault = false; this.type !== types$12.braceR; ) {
+          if (this.type === types$12._case || this.type === types$12._default) {
+            var isCase = this.type === types$12._case;
+            if (cur) {
+              this.finishNode(cur, "SwitchCase");
+            }
+            node.cases.push(cur = this.startNode());
+            cur.consequent = [];
+            this.next();
+            if (isCase) {
+              cur.test = this.parseExpression();
+            } else {
+              if (sawDefault) {
+                this.raiseRecoverable(this.lastTokStart, "Multiple default clauses");
+              }
+              sawDefault = true;
+              cur.test = null;
+            }
+            this.expect(types$12.colon);
+          } else {
+            if (!cur) {
+              this.unexpected();
+            }
+            cur.consequent.push(this.parseStatement(null));
+          }
+        }
+        this.exitScope();
+        if (cur) {
+          this.finishNode(cur, "SwitchCase");
+        }
+        this.next();
+        this.labels.pop();
+        return this.finishNode(node, "SwitchStatement");
+      };
+      pp$82.parseThrowStatement = function(node) {
+        this.next();
+        if (lineBreak2.test(this.input.slice(this.lastTokEnd, this.start))) {
+          this.raise(this.lastTokEnd, "Illegal newline after throw");
+        }
+        node.argument = this.parseExpression();
+        this.semicolon();
+        return this.finishNode(node, "ThrowStatement");
+      };
+      var empty$12 = [];
+      pp$82.parseTryStatement = function(node) {
+        this.next();
+        node.block = this.parseBlock();
+        node.handler = null;
+        if (this.type === types$12._catch) {
+          var clause = this.startNode();
+          this.next();
+          if (this.eat(types$12.parenL)) {
+            clause.param = this.parseBindingAtom();
+            var simple = clause.param.type === "Identifier";
+            this.enterScope(simple ? SCOPE_SIMPLE_CATCH2 : 0);
+            this.checkLValPattern(clause.param, simple ? BIND_SIMPLE_CATCH2 : BIND_LEXICAL2);
+            this.expect(types$12.parenR);
+          } else {
+            if (this.options.ecmaVersion < 10) {
+              this.unexpected();
+            }
+            clause.param = null;
+            this.enterScope(0);
+          }
+          clause.body = this.parseBlock(false);
+          this.exitScope();
+          node.handler = this.finishNode(clause, "CatchClause");
+        }
+        node.finalizer = this.eat(types$12._finally) ? this.parseBlock() : null;
+        if (!node.handler && !node.finalizer) {
+          this.raise(node.start, "Missing catch or finally clause");
+        }
+        return this.finishNode(node, "TryStatement");
+      };
+      pp$82.parseVarStatement = function(node, kind) {
+        this.next();
+        this.parseVar(node, false, kind);
+        this.semicolon();
+        return this.finishNode(node, "VariableDeclaration");
+      };
+      pp$82.parseWhileStatement = function(node) {
+        this.next();
+        node.test = this.parseParenExpression();
+        this.labels.push(loopLabel2);
+        node.body = this.parseStatement("while");
+        this.labels.pop();
+        return this.finishNode(node, "WhileStatement");
+      };
+      pp$82.parseWithStatement = function(node) {
+        if (this.strict) {
+          this.raise(this.start, "'with' in strict mode");
+        }
+        this.next();
+        node.object = this.parseParenExpression();
+        node.body = this.parseStatement("with");
+        return this.finishNode(node, "WithStatement");
+      };
+      pp$82.parseEmptyStatement = function(node) {
+        this.next();
+        return this.finishNode(node, "EmptyStatement");
+      };
+      pp$82.parseLabeledStatement = function(node, maybeName, expr, context) {
+        for (var i$1 = 0, list4 = this.labels; i$1 < list4.length; i$1 += 1) {
+          var label = list4[i$1];
+          if (label.name === maybeName) {
+            this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+          }
+        }
+        var kind = this.type.isLoop ? "loop" : this.type === types$12._switch ? "switch" : null;
+        for (var i2 = this.labels.length - 1; i2 >= 0; i2--) {
+          var label$1 = this.labels[i2];
+          if (label$1.statementStart === node.start) {
+            label$1.statementStart = this.start;
+            label$1.kind = kind;
+          } else {
+            break;
+          }
+        }
+        this.labels.push({ name: maybeName, kind, statementStart: this.start });
+        node.body = this.parseStatement(context ? context.indexOf("label") === -1 ? context + "label" : context : "label");
+        this.labels.pop();
+        node.label = expr;
+        return this.finishNode(node, "LabeledStatement");
+      };
+      pp$82.parseExpressionStatement = function(node, expr) {
+        node.expression = expr;
+        this.semicolon();
+        return this.finishNode(node, "ExpressionStatement");
+      };
+      pp$82.parseBlock = function(createNewLexicalScope, node, exitStrict) {
+        if (createNewLexicalScope === void 0)
+          createNewLexicalScope = true;
+        if (node === void 0)
+          node = this.startNode();
+        node.body = [];
+        this.expect(types$12.braceL);
+        if (createNewLexicalScope) {
+          this.enterScope(0);
+        }
+        while (this.type !== types$12.braceR) {
+          var stmt = this.parseStatement(null);
+          node.body.push(stmt);
+        }
+        if (exitStrict) {
+          this.strict = false;
+        }
+        this.next();
+        if (createNewLexicalScope) {
+          this.exitScope();
+        }
+        return this.finishNode(node, "BlockStatement");
+      };
+      pp$82.parseFor = function(node, init) {
+        node.init = init;
+        this.expect(types$12.semi);
+        node.test = this.type === types$12.semi ? null : this.parseExpression();
+        this.expect(types$12.semi);
+        node.update = this.type === types$12.parenR ? null : this.parseExpression();
+        this.expect(types$12.parenR);
+        node.body = this.parseStatement("for");
+        this.exitScope();
+        this.labels.pop();
+        return this.finishNode(node, "ForStatement");
+      };
+      pp$82.parseForIn = function(node, init) {
+        var isForIn = this.type === types$12._in;
+        this.next();
+        if (init.type === "VariableDeclaration" && init.declarations[0].init != null && (!isForIn || this.options.ecmaVersion < 8 || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")) {
+          this.raise(
+            init.start,
+            (isForIn ? "for-in" : "for-of") + " loop variable declaration may not have an initializer"
+          );
+        }
+        node.left = init;
+        node.right = isForIn ? this.parseExpression() : this.parseMaybeAssign();
+        this.expect(types$12.parenR);
+        node.body = this.parseStatement("for");
+        this.exitScope();
+        this.labels.pop();
+        return this.finishNode(node, isForIn ? "ForInStatement" : "ForOfStatement");
+      };
+      pp$82.parseVar = function(node, isFor, kind) {
+        node.declarations = [];
+        node.kind = kind;
+        for (; ; ) {
+          var decl = this.startNode();
+          this.parseVarId(decl, kind);
+          if (this.eat(types$12.eq)) {
+            decl.init = this.parseMaybeAssign(isFor);
+          } else if (kind === "const" && !(this.type === types$12._in || this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+            this.unexpected();
+          } else if (decl.id.type !== "Identifier" && !(isFor && (this.type === types$12._in || this.isContextual("of")))) {
+            this.raise(this.lastTokEnd, "Complex binding patterns require an initialization value");
+          } else {
+            decl.init = null;
+          }
+          node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+          if (!this.eat(types$12.comma)) {
+            break;
+          }
+        }
+        return node;
+      };
+      pp$82.parseVarId = function(decl, kind) {
+        decl.id = this.parseBindingAtom();
+        this.checkLValPattern(decl.id, kind === "var" ? BIND_VAR2 : BIND_LEXICAL2, false);
+      };
+      var FUNC_STATEMENT2 = 1, FUNC_HANGING_STATEMENT2 = 2, FUNC_NULLABLE_ID2 = 4;
+      pp$82.parseFunction = function(node, statement, allowExpressionBody, isAsync, forInit) {
+        this.initFunction(node);
+        if (this.options.ecmaVersion >= 9 || this.options.ecmaVersion >= 6 && !isAsync) {
+          if (this.type === types$12.star && statement & FUNC_HANGING_STATEMENT2) {
+            this.unexpected();
+          }
+          node.generator = this.eat(types$12.star);
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node.async = !!isAsync;
+        }
+        if (statement & FUNC_STATEMENT2) {
+          node.id = statement & FUNC_NULLABLE_ID2 && this.type !== types$12.name ? null : this.parseIdent();
+          if (node.id && !(statement & FUNC_HANGING_STATEMENT2)) {
+            this.checkLValSimple(node.id, this.strict || node.generator || node.async ? this.treatFunctionsAsVar ? BIND_VAR2 : BIND_LEXICAL2 : BIND_FUNCTION2);
+          }
+        }
+        var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        this.enterScope(functionFlags2(node.async, node.generator));
+        if (!(statement & FUNC_STATEMENT2)) {
+          node.id = this.type === types$12.name ? this.parseIdent() : null;
+        }
+        this.parseFunctionParams(node);
+        this.parseFunctionBody(node, allowExpressionBody, false, forInit);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node, statement & FUNC_STATEMENT2 ? "FunctionDeclaration" : "FunctionExpression");
+      };
+      pp$82.parseFunctionParams = function(node) {
+        this.expect(types$12.parenL);
+        node.params = this.parseBindingList(types$12.parenR, false, this.options.ecmaVersion >= 8);
+        this.checkYieldAwaitInDefaultParams();
+      };
+      pp$82.parseClass = function(node, isStatement) {
+        this.next();
+        var oldStrict = this.strict;
+        this.strict = true;
+        this.parseClassId(node, isStatement);
+        this.parseClassSuper(node);
+        var privateNameMap = this.enterClassBody();
+        var classBody = this.startNode();
+        var hadConstructor = false;
+        classBody.body = [];
+        this.expect(types$12.braceL);
+        while (this.type !== types$12.braceR) {
+          var element2 = this.parseClassElement(node.superClass !== null);
+          if (element2) {
+            classBody.body.push(element2);
+            if (element2.type === "MethodDefinition" && element2.kind === "constructor") {
+              if (hadConstructor) {
+                this.raise(element2.start, "Duplicate constructor in the same class");
+              }
+              hadConstructor = true;
+            } else if (element2.key && element2.key.type === "PrivateIdentifier" && isPrivateNameConflicted2(privateNameMap, element2)) {
+              this.raiseRecoverable(element2.key.start, "Identifier '#" + element2.key.name + "' has already been declared");
+            }
+          }
+        }
+        this.strict = oldStrict;
+        this.next();
+        node.body = this.finishNode(classBody, "ClassBody");
+        this.exitClassBody();
+        return this.finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
+      };
+      pp$82.parseClassElement = function(constructorAllowsSuper) {
+        if (this.eat(types$12.semi)) {
+          return null;
+        }
+        var ecmaVersion2 = this.options.ecmaVersion;
+        var node = this.startNode();
+        var keyName = "";
+        var isGenerator = false;
+        var isAsync = false;
+        var kind = "method";
+        var isStatic = false;
+        if (this.eatContextual("static")) {
+          if (ecmaVersion2 >= 13 && this.eat(types$12.braceL)) {
+            this.parseClassStaticBlock(node);
+            return node;
+          }
+          if (this.isClassElementNameStart() || this.type === types$12.star) {
+            isStatic = true;
+          } else {
+            keyName = "static";
+          }
+        }
+        node.static = isStatic;
+        if (!keyName && ecmaVersion2 >= 8 && this.eatContextual("async")) {
+          if ((this.isClassElementNameStart() || this.type === types$12.star) && !this.canInsertSemicolon()) {
+            isAsync = true;
+          } else {
+            keyName = "async";
+          }
+        }
+        if (!keyName && (ecmaVersion2 >= 9 || !isAsync) && this.eat(types$12.star)) {
+          isGenerator = true;
+        }
+        if (!keyName && !isAsync && !isGenerator) {
+          var lastValue = this.value;
+          if (this.eatContextual("get") || this.eatContextual("set")) {
+            if (this.isClassElementNameStart()) {
+              kind = lastValue;
+            } else {
+              keyName = lastValue;
+            }
+          }
+        }
+        if (keyName) {
+          node.computed = false;
+          node.key = this.startNodeAt(this.lastTokStart, this.lastTokStartLoc);
+          node.key.name = keyName;
+          this.finishNode(node.key, "Identifier");
+        } else {
+          this.parseClassElementName(node);
+        }
+        if (ecmaVersion2 < 13 || this.type === types$12.parenL || kind !== "method" || isGenerator || isAsync) {
+          var isConstructor = !node.static && checkKeyName2(node, "constructor");
+          var allowsDirectSuper = isConstructor && constructorAllowsSuper;
+          if (isConstructor && kind !== "method") {
+            this.raise(node.key.start, "Constructor can't have get/set modifier");
+          }
+          node.kind = isConstructor ? "constructor" : kind;
+          this.parseClassMethod(node, isGenerator, isAsync, allowsDirectSuper);
+        } else {
+          this.parseClassField(node);
+        }
+        return node;
+      };
+      pp$82.isClassElementNameStart = function() {
+        return this.type === types$12.name || this.type === types$12.privateId || this.type === types$12.num || this.type === types$12.string || this.type === types$12.bracketL || this.type.keyword;
+      };
+      pp$82.parseClassElementName = function(element2) {
+        if (this.type === types$12.privateId) {
+          if (this.value === "constructor") {
+            this.raise(this.start, "Classes can't have an element named '#constructor'");
+          }
+          element2.computed = false;
+          element2.key = this.parsePrivateIdent();
+        } else {
+          this.parsePropertyName(element2);
+        }
+      };
+      pp$82.parseClassMethod = function(method, isGenerator, isAsync, allowsDirectSuper) {
+        var key = method.key;
+        if (method.kind === "constructor") {
+          if (isGenerator) {
+            this.raise(key.start, "Constructor can't be a generator");
+          }
+          if (isAsync) {
+            this.raise(key.start, "Constructor can't be an async method");
+          }
+        } else if (method.static && checkKeyName2(method, "prototype")) {
+          this.raise(key.start, "Classes may not have a static property named prototype");
+        }
+        var value = method.value = this.parseMethod(isGenerator, isAsync, allowsDirectSuper);
+        if (method.kind === "get" && value.params.length !== 0) {
+          this.raiseRecoverable(value.start, "getter should have no params");
+        }
+        if (method.kind === "set" && value.params.length !== 1) {
+          this.raiseRecoverable(value.start, "setter should have exactly one param");
+        }
+        if (method.kind === "set" && value.params[0].type === "RestElement") {
+          this.raiseRecoverable(value.params[0].start, "Setter cannot use rest params");
+        }
+        return this.finishNode(method, "MethodDefinition");
+      };
+      pp$82.parseClassField = function(field) {
+        if (checkKeyName2(field, "constructor")) {
+          this.raise(field.key.start, "Classes can't have a field named 'constructor'");
+        } else if (field.static && checkKeyName2(field, "prototype")) {
+          this.raise(field.key.start, "Classes can't have a static field named 'prototype'");
+        }
+        if (this.eat(types$12.eq)) {
+          var scope = this.currentThisScope();
+          var inClassFieldInit = scope.inClassFieldInit;
+          scope.inClassFieldInit = true;
+          field.value = this.parseMaybeAssign();
+          scope.inClassFieldInit = inClassFieldInit;
+        } else {
+          field.value = null;
+        }
+        this.semicolon();
+        return this.finishNode(field, "PropertyDefinition");
+      };
+      pp$82.parseClassStaticBlock = function(node) {
+        node.body = [];
+        var oldLabels = this.labels;
+        this.labels = [];
+        this.enterScope(SCOPE_CLASS_STATIC_BLOCK2 | SCOPE_SUPER2);
+        while (this.type !== types$12.braceR) {
+          var stmt = this.parseStatement(null);
+          node.body.push(stmt);
+        }
+        this.next();
+        this.exitScope();
+        this.labels = oldLabels;
+        return this.finishNode(node, "StaticBlock");
+      };
+      pp$82.parseClassId = function(node, isStatement) {
+        if (this.type === types$12.name) {
+          node.id = this.parseIdent();
+          if (isStatement) {
+            this.checkLValSimple(node.id, BIND_LEXICAL2, false);
+          }
+        } else {
+          if (isStatement === true) {
+            this.unexpected();
+          }
+          node.id = null;
+        }
+      };
+      pp$82.parseClassSuper = function(node) {
+        node.superClass = this.eat(types$12._extends) ? this.parseExprSubscripts(false) : null;
+      };
+      pp$82.enterClassBody = function() {
+        var element2 = { declared: /* @__PURE__ */ Object.create(null), used: [] };
+        this.privateNameStack.push(element2);
+        return element2.declared;
+      };
+      pp$82.exitClassBody = function() {
+        var ref3 = this.privateNameStack.pop();
+        var declared = ref3.declared;
+        var used = ref3.used;
+        var len = this.privateNameStack.length;
+        var parent = len === 0 ? null : this.privateNameStack[len - 1];
+        for (var i2 = 0; i2 < used.length; ++i2) {
+          var id = used[i2];
+          if (!hasOwn2(declared, id.name)) {
+            if (parent) {
+              parent.used.push(id);
+            } else {
+              this.raiseRecoverable(id.start, "Private field '#" + id.name + "' must be declared in an enclosing class");
+            }
+          }
+        }
+      };
+      function isPrivateNameConflicted2(privateNameMap, element2) {
+        var name2 = element2.key.name;
+        var curr = privateNameMap[name2];
+        var next = "true";
+        if (element2.type === "MethodDefinition" && (element2.kind === "get" || element2.kind === "set")) {
+          next = (element2.static ? "s" : "i") + element2.kind;
+        }
+        if (curr === "iget" && next === "iset" || curr === "iset" && next === "iget" || curr === "sget" && next === "sset" || curr === "sset" && next === "sget") {
+          privateNameMap[name2] = "true";
+          return false;
+        } else if (!curr) {
+          privateNameMap[name2] = next;
+          return false;
+        } else {
+          return true;
+        }
+      }
+      function checkKeyName2(node, name2) {
+        var computed = node.computed;
+        var key = node.key;
+        return !computed && (key.type === "Identifier" && key.name === name2 || key.type === "Literal" && key.value === name2);
+      }
+      pp$82.parseExport = function(node, exports3) {
+        this.next();
+        if (this.eat(types$12.star)) {
+          if (this.options.ecmaVersion >= 11) {
+            if (this.eatContextual("as")) {
+              node.exported = this.parseModuleExportName();
+              this.checkExport(exports3, node.exported, this.lastTokStart);
+            } else {
+              node.exported = null;
+            }
+          }
+          this.expectContextual("from");
+          if (this.type !== types$12.string) {
+            this.unexpected();
+          }
+          node.source = this.parseExprAtom();
+          this.semicolon();
+          return this.finishNode(node, "ExportAllDeclaration");
+        }
+        if (this.eat(types$12._default)) {
+          this.checkExport(exports3, "default", this.lastTokStart);
+          var isAsync;
+          if (this.type === types$12._function || (isAsync = this.isAsyncFunction())) {
+            var fNode = this.startNode();
+            this.next();
+            if (isAsync) {
+              this.next();
+            }
+            node.declaration = this.parseFunction(fNode, FUNC_STATEMENT2 | FUNC_NULLABLE_ID2, false, isAsync);
+          } else if (this.type === types$12._class) {
+            var cNode = this.startNode();
+            node.declaration = this.parseClass(cNode, "nullableID");
+          } else {
+            node.declaration = this.parseMaybeAssign();
+            this.semicolon();
+          }
+          return this.finishNode(node, "ExportDefaultDeclaration");
+        }
+        if (this.shouldParseExportStatement()) {
+          node.declaration = this.parseStatement(null);
+          if (node.declaration.type === "VariableDeclaration") {
+            this.checkVariableExport(exports3, node.declaration.declarations);
+          } else {
+            this.checkExport(exports3, node.declaration.id, node.declaration.id.start);
+          }
+          node.specifiers = [];
+          node.source = null;
+        } else {
+          node.declaration = null;
+          node.specifiers = this.parseExportSpecifiers(exports3);
+          if (this.eatContextual("from")) {
+            if (this.type !== types$12.string) {
+              this.unexpected();
+            }
+            node.source = this.parseExprAtom();
+          } else {
+            for (var i2 = 0, list4 = node.specifiers; i2 < list4.length; i2 += 1) {
+              var spec = list4[i2];
+              this.checkUnreserved(spec.local);
+              this.checkLocalExport(spec.local);
+              if (spec.local.type === "Literal") {
+                this.raise(spec.local.start, "A string literal cannot be used as an exported binding without `from`.");
+              }
+            }
+            node.source = null;
+          }
+          this.semicolon();
+        }
+        return this.finishNode(node, "ExportNamedDeclaration");
+      };
+      pp$82.checkExport = function(exports3, name2, pos) {
+        if (!exports3) {
+          return;
+        }
+        if (typeof name2 !== "string") {
+          name2 = name2.type === "Identifier" ? name2.name : name2.value;
+        }
+        if (hasOwn2(exports3, name2)) {
+          this.raiseRecoverable(pos, "Duplicate export '" + name2 + "'");
+        }
+        exports3[name2] = true;
+      };
+      pp$82.checkPatternExport = function(exports3, pat) {
+        var type = pat.type;
+        if (type === "Identifier") {
+          this.checkExport(exports3, pat, pat.start);
+        } else if (type === "ObjectPattern") {
+          for (var i2 = 0, list4 = pat.properties; i2 < list4.length; i2 += 1) {
+            var prop = list4[i2];
+            this.checkPatternExport(exports3, prop);
+          }
+        } else if (type === "ArrayPattern") {
+          for (var i$1 = 0, list$1 = pat.elements; i$1 < list$1.length; i$1 += 1) {
+            var elt = list$1[i$1];
+            if (elt) {
+              this.checkPatternExport(exports3, elt);
+            }
+          }
+        } else if (type === "Property") {
+          this.checkPatternExport(exports3, pat.value);
+        } else if (type === "AssignmentPattern") {
+          this.checkPatternExport(exports3, pat.left);
+        } else if (type === "RestElement") {
+          this.checkPatternExport(exports3, pat.argument);
+        } else if (type === "ParenthesizedExpression") {
+          this.checkPatternExport(exports3, pat.expression);
+        }
+      };
+      pp$82.checkVariableExport = function(exports3, decls) {
+        if (!exports3) {
+          return;
+        }
+        for (var i2 = 0, list4 = decls; i2 < list4.length; i2 += 1) {
+          var decl = list4[i2];
+          this.checkPatternExport(exports3, decl.id);
+        }
+      };
+      pp$82.shouldParseExportStatement = function() {
+        return this.type.keyword === "var" || this.type.keyword === "const" || this.type.keyword === "class" || this.type.keyword === "function" || this.isLet() || this.isAsyncFunction();
+      };
+      pp$82.parseExportSpecifiers = function(exports3) {
+        var nodes = [], first = true;
+        this.expect(types$12.braceL);
+        while (!this.eat(types$12.braceR)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (this.afterTrailingComma(types$12.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var node = this.startNode();
+          node.local = this.parseModuleExportName();
+          node.exported = this.eatContextual("as") ? this.parseModuleExportName() : node.local;
+          this.checkExport(
+            exports3,
+            node.exported,
+            node.exported.start
+          );
+          nodes.push(this.finishNode(node, "ExportSpecifier"));
+        }
+        return nodes;
+      };
+      pp$82.parseImport = function(node) {
+        this.next();
+        if (this.type === types$12.string) {
+          node.specifiers = empty$12;
+          node.source = this.parseExprAtom();
+        } else {
+          node.specifiers = this.parseImportSpecifiers();
+          this.expectContextual("from");
+          node.source = this.type === types$12.string ? this.parseExprAtom() : this.unexpected();
+        }
+        this.semicolon();
+        return this.finishNode(node, "ImportDeclaration");
+      };
+      pp$82.parseImportSpecifiers = function() {
+        var nodes = [], first = true;
+        if (this.type === types$12.name) {
+          var node = this.startNode();
+          node.local = this.parseIdent();
+          this.checkLValSimple(node.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node, "ImportDefaultSpecifier"));
+          if (!this.eat(types$12.comma)) {
+            return nodes;
+          }
+        }
+        if (this.type === types$12.star) {
+          var node$1 = this.startNode();
+          this.next();
+          this.expectContextual("as");
+          node$1.local = this.parseIdent();
+          this.checkLValSimple(node$1.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node$1, "ImportNamespaceSpecifier"));
+          return nodes;
+        }
+        this.expect(types$12.braceL);
+        while (!this.eat(types$12.braceR)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (this.afterTrailingComma(types$12.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var node$2 = this.startNode();
+          node$2.imported = this.parseModuleExportName();
+          if (this.eatContextual("as")) {
+            node$2.local = this.parseIdent();
+          } else {
+            this.checkUnreserved(node$2.imported);
+            node$2.local = node$2.imported;
+          }
+          this.checkLValSimple(node$2.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node$2, "ImportSpecifier"));
+        }
+        return nodes;
+      };
+      pp$82.parseModuleExportName = function() {
+        if (this.options.ecmaVersion >= 13 && this.type === types$12.string) {
+          var stringLiteral = this.parseLiteral(this.value);
+          if (loneSurrogate2.test(stringLiteral.value)) {
+            this.raise(stringLiteral.start, "An export name cannot include a lone surrogate.");
+          }
+          return stringLiteral;
+        }
+        return this.parseIdent(true);
+      };
+      pp$82.adaptDirectivePrologue = function(statements) {
+        for (var i2 = 0; i2 < statements.length && this.isDirectiveCandidate(statements[i2]); ++i2) {
+          statements[i2].directive = statements[i2].expression.raw.slice(1, -1);
+        }
+      };
+      pp$82.isDirectiveCandidate = function(statement) {
+        return this.options.ecmaVersion >= 5 && statement.type === "ExpressionStatement" && statement.expression.type === "Literal" && typeof statement.expression.value === "string" && (this.input[statement.start] === '"' || this.input[statement.start] === "'");
+      };
+      var pp$72 = Parser3.prototype;
+      pp$72.toAssignable = function(node, isBinding, refDestructuringErrors) {
+        if (this.options.ecmaVersion >= 6 && node) {
+          switch (node.type) {
+            case "Identifier":
+              if (this.inAsync && node.name === "await") {
+                this.raise(node.start, "Cannot use 'await' as identifier inside an async function");
+              }
+              break;
+            case "ObjectPattern":
+            case "ArrayPattern":
+            case "AssignmentPattern":
+            case "RestElement":
+              break;
+            case "ObjectExpression":
+              node.type = "ObjectPattern";
+              if (refDestructuringErrors) {
+                this.checkPatternErrors(refDestructuringErrors, true);
+              }
+              for (var i2 = 0, list4 = node.properties; i2 < list4.length; i2 += 1) {
+                var prop = list4[i2];
+                this.toAssignable(prop, isBinding);
+                if (prop.type === "RestElement" && (prop.argument.type === "ArrayPattern" || prop.argument.type === "ObjectPattern")) {
+                  this.raise(prop.argument.start, "Unexpected token");
+                }
+              }
+              break;
+            case "Property":
+              if (node.kind !== "init") {
+                this.raise(node.key.start, "Object pattern can't contain getter or setter");
+              }
+              this.toAssignable(node.value, isBinding);
+              break;
+            case "ArrayExpression":
+              node.type = "ArrayPattern";
+              if (refDestructuringErrors) {
+                this.checkPatternErrors(refDestructuringErrors, true);
+              }
+              this.toAssignableList(node.elements, isBinding);
+              break;
+            case "SpreadElement":
+              node.type = "RestElement";
+              this.toAssignable(node.argument, isBinding);
+              if (node.argument.type === "AssignmentPattern") {
+                this.raise(node.argument.start, "Rest elements cannot have a default value");
+              }
+              break;
+            case "AssignmentExpression":
+              if (node.operator !== "=") {
+                this.raise(node.left.end, "Only '=' operator can be used for specifying default value.");
+              }
+              node.type = "AssignmentPattern";
+              delete node.operator;
+              this.toAssignable(node.left, isBinding);
+              break;
+            case "ParenthesizedExpression":
+              this.toAssignable(node.expression, isBinding, refDestructuringErrors);
+              break;
+            case "ChainExpression":
+              this.raiseRecoverable(node.start, "Optional chaining cannot appear in left-hand side");
+              break;
+            case "MemberExpression":
+              if (!isBinding) {
+                break;
+              }
+            default:
+              this.raise(node.start, "Assigning to rvalue");
+          }
+        } else if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        return node;
+      };
+      pp$72.toAssignableList = function(exprList, isBinding) {
+        var end = exprList.length;
+        for (var i2 = 0; i2 < end; i2++) {
+          var elt = exprList[i2];
+          if (elt) {
+            this.toAssignable(elt, isBinding);
+          }
+        }
+        if (end) {
+          var last = exprList[end - 1];
+          if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier") {
+            this.unexpected(last.argument.start);
+          }
+        }
+        return exprList;
+      };
+      pp$72.parseSpread = function(refDestructuringErrors) {
+        var node = this.startNode();
+        this.next();
+        node.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+        return this.finishNode(node, "SpreadElement");
+      };
+      pp$72.parseRestBinding = function() {
+        var node = this.startNode();
+        this.next();
+        if (this.options.ecmaVersion === 6 && this.type !== types$12.name) {
+          this.unexpected();
+        }
+        node.argument = this.parseBindingAtom();
+        return this.finishNode(node, "RestElement");
+      };
+      pp$72.parseBindingAtom = function() {
+        if (this.options.ecmaVersion >= 6) {
+          switch (this.type) {
+            case types$12.bracketL:
+              var node = this.startNode();
+              this.next();
+              node.elements = this.parseBindingList(types$12.bracketR, true, true);
+              return this.finishNode(node, "ArrayPattern");
+            case types$12.braceL:
+              return this.parseObj(true);
+          }
+        }
+        return this.parseIdent();
+      };
+      pp$72.parseBindingList = function(close, allowEmpty, allowTrailingComma) {
+        var elts = [], first = true;
+        while (!this.eat(close)) {
+          if (first) {
+            first = false;
+          } else {
+            this.expect(types$12.comma);
+          }
+          if (allowEmpty && this.type === types$12.comma) {
+            elts.push(null);
+          } else if (allowTrailingComma && this.afterTrailingComma(close)) {
+            break;
+          } else if (this.type === types$12.ellipsis) {
+            var rest = this.parseRestBinding();
+            this.parseBindingListItem(rest);
+            elts.push(rest);
+            if (this.type === types$12.comma) {
+              this.raise(this.start, "Comma is not permitted after the rest element");
+            }
+            this.expect(close);
+            break;
+          } else {
+            var elem = this.parseMaybeDefault(this.start, this.startLoc);
+            this.parseBindingListItem(elem);
+            elts.push(elem);
+          }
+        }
+        return elts;
+      };
+      pp$72.parseBindingListItem = function(param) {
+        return param;
+      };
+      pp$72.parseMaybeDefault = function(startPos, startLoc, left) {
+        left = left || this.parseBindingAtom();
+        if (this.options.ecmaVersion < 6 || !this.eat(types$12.eq)) {
+          return left;
+        }
+        var node = this.startNodeAt(startPos, startLoc);
+        node.left = left;
+        node.right = this.parseMaybeAssign();
+        return this.finishNode(node, "AssignmentPattern");
+      };
+      pp$72.checkLValSimple = function(expr, bindingType, checkClashes) {
+        if (bindingType === void 0)
+          bindingType = BIND_NONE2;
+        var isBind = bindingType !== BIND_NONE2;
+        switch (expr.type) {
+          case "Identifier":
+            if (this.strict && this.reservedWordsStrictBind.test(expr.name)) {
+              this.raiseRecoverable(expr.start, (isBind ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+            }
+            if (isBind) {
+              if (bindingType === BIND_LEXICAL2 && expr.name === "let") {
+                this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name");
+              }
+              if (checkClashes) {
+                if (hasOwn2(checkClashes, expr.name)) {
+                  this.raiseRecoverable(expr.start, "Argument name clash");
+                }
+                checkClashes[expr.name] = true;
+              }
+              if (bindingType !== BIND_OUTSIDE2) {
+                this.declareName(expr.name, bindingType, expr.start);
+              }
+            }
+            break;
+          case "ChainExpression":
+            this.raiseRecoverable(expr.start, "Optional chaining cannot appear in left-hand side");
+            break;
+          case "MemberExpression":
+            if (isBind) {
+              this.raiseRecoverable(expr.start, "Binding member expression");
+            }
+            break;
+          case "ParenthesizedExpression":
+            if (isBind) {
+              this.raiseRecoverable(expr.start, "Binding parenthesized expression");
+            }
+            return this.checkLValSimple(expr.expression, bindingType, checkClashes);
+          default:
+            this.raise(expr.start, (isBind ? "Binding" : "Assigning to") + " rvalue");
+        }
+      };
+      pp$72.checkLValPattern = function(expr, bindingType, checkClashes) {
+        if (bindingType === void 0)
+          bindingType = BIND_NONE2;
+        switch (expr.type) {
+          case "ObjectPattern":
+            for (var i2 = 0, list4 = expr.properties; i2 < list4.length; i2 += 1) {
+              var prop = list4[i2];
+              this.checkLValInnerPattern(prop, bindingType, checkClashes);
+            }
+            break;
+          case "ArrayPattern":
+            for (var i$1 = 0, list$1 = expr.elements; i$1 < list$1.length; i$1 += 1) {
+              var elem = list$1[i$1];
+              if (elem) {
+                this.checkLValInnerPattern(elem, bindingType, checkClashes);
+              }
+            }
+            break;
+          default:
+            this.checkLValSimple(expr, bindingType, checkClashes);
+        }
+      };
+      pp$72.checkLValInnerPattern = function(expr, bindingType, checkClashes) {
+        if (bindingType === void 0)
+          bindingType = BIND_NONE2;
+        switch (expr.type) {
+          case "Property":
+            this.checkLValInnerPattern(expr.value, bindingType, checkClashes);
+            break;
+          case "AssignmentPattern":
+            this.checkLValPattern(expr.left, bindingType, checkClashes);
+            break;
+          case "RestElement":
+            this.checkLValPattern(expr.argument, bindingType, checkClashes);
+            break;
+          default:
+            this.checkLValPattern(expr, bindingType, checkClashes);
+        }
+      };
+      var TokContext3 = function TokContext4(token, isExpr, preserveSpace, override, generator) {
+        this.token = token;
+        this.isExpr = !!isExpr;
+        this.preserveSpace = !!preserveSpace;
+        this.override = override;
+        this.generator = !!generator;
+      };
+      var types2 = {
+        b_stat: new TokContext3("{", false),
+        b_expr: new TokContext3("{", true),
+        b_tmpl: new TokContext3("${", false),
+        p_stat: new TokContext3("(", false),
+        p_expr: new TokContext3("(", true),
+        q_tmpl: new TokContext3("`", true, true, function(p) {
+          return p.tryReadTemplateToken();
+        }),
+        f_stat: new TokContext3("function", false),
+        f_expr: new TokContext3("function", true),
+        f_expr_gen: new TokContext3("function", true, false, null, true),
+        f_gen: new TokContext3("function", false, false, null, true)
+      };
+      var pp$62 = Parser3.prototype;
+      pp$62.initialContext = function() {
+        return [types2.b_stat];
+      };
+      pp$62.curContext = function() {
+        return this.context[this.context.length - 1];
+      };
+      pp$62.braceIsBlock = function(prevType) {
+        var parent = this.curContext();
+        if (parent === types2.f_expr || parent === types2.f_stat) {
+          return true;
+        }
+        if (prevType === types$12.colon && (parent === types2.b_stat || parent === types2.b_expr)) {
+          return !parent.isExpr;
+        }
+        if (prevType === types$12._return || prevType === types$12.name && this.exprAllowed) {
+          return lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+        }
+        if (prevType === types$12._else || prevType === types$12.semi || prevType === types$12.eof || prevType === types$12.parenR || prevType === types$12.arrow) {
+          return true;
+        }
+        if (prevType === types$12.braceL) {
+          return parent === types2.b_stat;
+        }
+        if (prevType === types$12._var || prevType === types$12._const || prevType === types$12.name) {
+          return false;
+        }
+        return !this.exprAllowed;
+      };
+      pp$62.inGeneratorContext = function() {
+        for (var i2 = this.context.length - 1; i2 >= 1; i2--) {
+          var context = this.context[i2];
+          if (context.token === "function") {
+            return context.generator;
+          }
+        }
+        return false;
+      };
+      pp$62.updateContext = function(prevType) {
+        var update, type = this.type;
+        if (type.keyword && prevType === types$12.dot) {
+          this.exprAllowed = false;
+        } else if (update = type.updateContext) {
+          update.call(this, prevType);
+        } else {
+          this.exprAllowed = type.beforeExpr;
+        }
+      };
+      pp$62.overrideContext = function(tokenCtx) {
+        if (this.curContext() !== tokenCtx) {
+          this.context[this.context.length - 1] = tokenCtx;
+        }
+      };
+      types$12.parenR.updateContext = types$12.braceR.updateContext = function() {
+        if (this.context.length === 1) {
+          this.exprAllowed = true;
+          return;
+        }
+        var out = this.context.pop();
+        if (out === types2.b_stat && this.curContext().token === "function") {
+          out = this.context.pop();
+        }
+        this.exprAllowed = !out.isExpr;
+      };
+      types$12.braceL.updateContext = function(prevType) {
+        this.context.push(this.braceIsBlock(prevType) ? types2.b_stat : types2.b_expr);
+        this.exprAllowed = true;
+      };
+      types$12.dollarBraceL.updateContext = function() {
+        this.context.push(types2.b_tmpl);
+        this.exprAllowed = true;
+      };
+      types$12.parenL.updateContext = function(prevType) {
+        var statementParens = prevType === types$12._if || prevType === types$12._for || prevType === types$12._with || prevType === types$12._while;
+        this.context.push(statementParens ? types2.p_stat : types2.p_expr);
+        this.exprAllowed = true;
+      };
+      types$12.incDec.updateContext = function() {
+      };
+      types$12._function.updateContext = types$12._class.updateContext = function(prevType) {
+        if (prevType.beforeExpr && prevType !== types$12._else && !(prevType === types$12.semi && this.curContext() !== types2.p_stat) && !(prevType === types$12._return && lineBreak2.test(this.input.slice(this.lastTokEnd, this.start))) && !((prevType === types$12.colon || prevType === types$12.braceL) && this.curContext() === types2.b_stat)) {
+          this.context.push(types2.f_expr);
+        } else {
+          this.context.push(types2.f_stat);
+        }
+        this.exprAllowed = false;
+      };
+      types$12.backQuote.updateContext = function() {
+        if (this.curContext() === types2.q_tmpl) {
+          this.context.pop();
+        } else {
+          this.context.push(types2.q_tmpl);
+        }
+        this.exprAllowed = false;
+      };
+      types$12.star.updateContext = function(prevType) {
+        if (prevType === types$12._function) {
+          var index2 = this.context.length - 1;
+          if (this.context[index2] === types2.f_expr) {
+            this.context[index2] = types2.f_expr_gen;
+          } else {
+            this.context[index2] = types2.f_gen;
+          }
+        }
+        this.exprAllowed = true;
+      };
+      types$12.name.updateContext = function(prevType) {
+        var allowed = false;
+        if (this.options.ecmaVersion >= 6 && prevType !== types$12.dot) {
+          if (this.value === "of" && !this.exprAllowed || this.value === "yield" && this.inGeneratorContext()) {
+            allowed = true;
+          }
+        }
+        this.exprAllowed = allowed;
+      };
+      var pp$52 = Parser3.prototype;
+      pp$52.checkPropClash = function(prop, propHash, refDestructuringErrors) {
+        if (this.options.ecmaVersion >= 9 && prop.type === "SpreadElement") {
+          return;
+        }
+        if (this.options.ecmaVersion >= 6 && (prop.computed || prop.method || prop.shorthand)) {
+          return;
+        }
+        var key = prop.key;
+        var name2;
+        switch (key.type) {
+          case "Identifier":
+            name2 = key.name;
+            break;
+          case "Literal":
+            name2 = String(key.value);
+            break;
+          default:
+            return;
+        }
+        var kind = prop.kind;
+        if (this.options.ecmaVersion >= 6) {
+          if (name2 === "__proto__" && kind === "init") {
+            if (propHash.proto) {
+              if (refDestructuringErrors) {
+                if (refDestructuringErrors.doubleProto < 0) {
+                  refDestructuringErrors.doubleProto = key.start;
+                }
+              } else {
+                this.raiseRecoverable(key.start, "Redefinition of __proto__ property");
+              }
+            }
+            propHash.proto = true;
+          }
+          return;
+        }
+        name2 = "$" + name2;
+        var other = propHash[name2];
+        if (other) {
+          var redefinition;
+          if (kind === "init") {
+            redefinition = this.strict && other.init || other.get || other.set;
+          } else {
+            redefinition = other.init || other[kind];
+          }
+          if (redefinition) {
+            this.raiseRecoverable(key.start, "Redefinition of property");
+          }
+        } else {
+          other = propHash[name2] = {
+            init: false,
+            get: false,
+            set: false
+          };
+        }
+        other[kind] = true;
+      };
+      pp$52.parseExpression = function(forInit, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseMaybeAssign(forInit, refDestructuringErrors);
+        if (this.type === types$12.comma) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.expressions = [expr];
+          while (this.eat(types$12.comma)) {
+            node.expressions.push(this.parseMaybeAssign(forInit, refDestructuringErrors));
+          }
+          return this.finishNode(node, "SequenceExpression");
+        }
+        return expr;
+      };
+      pp$52.parseMaybeAssign = function(forInit, refDestructuringErrors, afterLeftParse) {
+        if (this.isContextual("yield")) {
+          if (this.inGenerator) {
+            return this.parseYield(forInit);
+          } else {
+            this.exprAllowed = false;
+          }
+        }
+        var ownDestructuringErrors = false, oldParenAssign = -1, oldTrailingComma = -1, oldDoubleProto = -1;
+        if (refDestructuringErrors) {
+          oldParenAssign = refDestructuringErrors.parenthesizedAssign;
+          oldTrailingComma = refDestructuringErrors.trailingComma;
+          oldDoubleProto = refDestructuringErrors.doubleProto;
+          refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = -1;
+        } else {
+          refDestructuringErrors = new DestructuringErrors3();
+          ownDestructuringErrors = true;
+        }
+        var startPos = this.start, startLoc = this.startLoc;
+        if (this.type === types$12.parenL || this.type === types$12.name) {
+          this.potentialArrowAt = this.start;
+          this.potentialArrowInForAwait = forInit === "await";
+        }
+        var left = this.parseMaybeConditional(forInit, refDestructuringErrors);
+        if (afterLeftParse) {
+          left = afterLeftParse.call(this, left, startPos, startLoc);
+        }
+        if (this.type.isAssign) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.operator = this.value;
+          if (this.type === types$12.eq) {
+            left = this.toAssignable(left, false, refDestructuringErrors);
+          }
+          if (!ownDestructuringErrors) {
+            refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = refDestructuringErrors.doubleProto = -1;
+          }
+          if (refDestructuringErrors.shorthandAssign >= left.start) {
+            refDestructuringErrors.shorthandAssign = -1;
+          }
+          if (this.type === types$12.eq) {
+            this.checkLValPattern(left);
+          } else {
+            this.checkLValSimple(left);
+          }
+          node.left = left;
+          this.next();
+          node.right = this.parseMaybeAssign(forInit);
+          if (oldDoubleProto > -1) {
+            refDestructuringErrors.doubleProto = oldDoubleProto;
+          }
+          return this.finishNode(node, "AssignmentExpression");
+        } else {
+          if (ownDestructuringErrors) {
+            this.checkExpressionErrors(refDestructuringErrors, true);
+          }
+        }
+        if (oldParenAssign > -1) {
+          refDestructuringErrors.parenthesizedAssign = oldParenAssign;
+        }
+        if (oldTrailingComma > -1) {
+          refDestructuringErrors.trailingComma = oldTrailingComma;
+        }
+        return left;
+      };
+      pp$52.parseMaybeConditional = function(forInit, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseExprOps(forInit, refDestructuringErrors);
+        if (this.checkExpressionErrors(refDestructuringErrors)) {
+          return expr;
+        }
+        if (this.eat(types$12.question)) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.test = expr;
+          node.consequent = this.parseMaybeAssign();
+          this.expect(types$12.colon);
+          node.alternate = this.parseMaybeAssign(forInit);
+          return this.finishNode(node, "ConditionalExpression");
+        }
+        return expr;
+      };
+      pp$52.parseExprOps = function(forInit, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseMaybeUnary(refDestructuringErrors, false, false, forInit);
+        if (this.checkExpressionErrors(refDestructuringErrors)) {
+          return expr;
+        }
+        return expr.start === startPos && expr.type === "ArrowFunctionExpression" ? expr : this.parseExprOp(expr, startPos, startLoc, -1, forInit);
+      };
+      pp$52.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, forInit) {
+        var prec = this.type.binop;
+        if (prec != null && (!forInit || this.type !== types$12._in)) {
+          if (prec > minPrec) {
+            var logical = this.type === types$12.logicalOR || this.type === types$12.logicalAND;
+            var coalesce = this.type === types$12.coalesce;
+            if (coalesce) {
+              prec = types$12.logicalAND.binop;
+            }
+            var op = this.value;
+            this.next();
+            var startPos = this.start, startLoc = this.startLoc;
+            var right = this.parseExprOp(this.parseMaybeUnary(null, false, false, forInit), startPos, startLoc, prec, forInit);
+            var node = this.buildBinary(leftStartPos, leftStartLoc, left, right, op, logical || coalesce);
+            if (logical && this.type === types$12.coalesce || coalesce && (this.type === types$12.logicalOR || this.type === types$12.logicalAND)) {
+              this.raiseRecoverable(this.start, "Logical expressions and coalesce expressions cannot be mixed. Wrap either by parentheses");
+            }
+            return this.parseExprOp(node, leftStartPos, leftStartLoc, minPrec, forInit);
+          }
+        }
+        return left;
+      };
+      pp$52.buildBinary = function(startPos, startLoc, left, right, op, logical) {
+        if (right.type === "PrivateIdentifier") {
+          this.raise(right.start, "Private identifier can only be left side of binary expression");
+        }
+        var node = this.startNodeAt(startPos, startLoc);
+        node.left = left;
+        node.operator = op;
+        node.right = right;
+        return this.finishNode(node, logical ? "LogicalExpression" : "BinaryExpression");
+      };
+      pp$52.parseMaybeUnary = function(refDestructuringErrors, sawUnary, incDec, forInit) {
+        var startPos = this.start, startLoc = this.startLoc, expr;
+        if (this.isContextual("await") && this.canAwait) {
+          expr = this.parseAwait(forInit);
+          sawUnary = true;
+        } else if (this.type.prefix) {
+          var node = this.startNode(), update = this.type === types$12.incDec;
+          node.operator = this.value;
+          node.prefix = true;
+          this.next();
+          node.argument = this.parseMaybeUnary(null, true, update, forInit);
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          if (update) {
+            this.checkLValSimple(node.argument);
+          } else if (this.strict && node.operator === "delete" && node.argument.type === "Identifier") {
+            this.raiseRecoverable(node.start, "Deleting local variable in strict mode");
+          } else if (node.operator === "delete" && isPrivateFieldAccess2(node.argument)) {
+            this.raiseRecoverable(node.start, "Private fields can not be deleted");
+          } else {
+            sawUnary = true;
+          }
+          expr = this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
+        } else if (!sawUnary && this.type === types$12.privateId) {
+          if (forInit || this.privateNameStack.length === 0) {
+            this.unexpected();
+          }
+          expr = this.parsePrivateIdent();
+          if (this.type !== types$12._in) {
+            this.unexpected();
+          }
+        } else {
+          expr = this.parseExprSubscripts(refDestructuringErrors, forInit);
+          if (this.checkExpressionErrors(refDestructuringErrors)) {
+            return expr;
+          }
+          while (this.type.postfix && !this.canInsertSemicolon()) {
+            var node$1 = this.startNodeAt(startPos, startLoc);
+            node$1.operator = this.value;
+            node$1.prefix = false;
+            node$1.argument = expr;
+            this.checkLValSimple(expr);
+            this.next();
+            expr = this.finishNode(node$1, "UpdateExpression");
+          }
+        }
+        if (!incDec && this.eat(types$12.starstar)) {
+          if (sawUnary) {
+            this.unexpected(this.lastTokStart);
+          } else {
+            return this.buildBinary(startPos, startLoc, expr, this.parseMaybeUnary(null, false, false, forInit), "**", false);
+          }
+        } else {
+          return expr;
+        }
+      };
+      function isPrivateFieldAccess2(node) {
+        return node.type === "MemberExpression" && node.property.type === "PrivateIdentifier" || node.type === "ChainExpression" && isPrivateFieldAccess2(node.expression);
+      }
+      pp$52.parseExprSubscripts = function(refDestructuringErrors, forInit) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseExprAtom(refDestructuringErrors, forInit);
+        if (expr.type === "ArrowFunctionExpression" && this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")") {
+          return expr;
+        }
+        var result = this.parseSubscripts(expr, startPos, startLoc, false, forInit);
+        if (refDestructuringErrors && result.type === "MemberExpression") {
+          if (refDestructuringErrors.parenthesizedAssign >= result.start) {
+            refDestructuringErrors.parenthesizedAssign = -1;
+          }
+          if (refDestructuringErrors.parenthesizedBind >= result.start) {
+            refDestructuringErrors.parenthesizedBind = -1;
+          }
+          if (refDestructuringErrors.trailingComma >= result.start) {
+            refDestructuringErrors.trailingComma = -1;
+          }
+        }
+        return result;
+      };
+      pp$52.parseSubscripts = function(base2, startPos, startLoc, noCalls, forInit) {
+        var maybeAsyncArrow = this.options.ecmaVersion >= 8 && base2.type === "Identifier" && base2.name === "async" && this.lastTokEnd === base2.end && !this.canInsertSemicolon() && base2.end - base2.start === 5 && this.potentialArrowAt === base2.start;
+        var optionalChained = false;
+        while (true) {
+          var element2 = this.parseSubscript(base2, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit);
+          if (element2.optional) {
+            optionalChained = true;
+          }
+          if (element2 === base2 || element2.type === "ArrowFunctionExpression") {
+            if (optionalChained) {
+              var chainNode = this.startNodeAt(startPos, startLoc);
+              chainNode.expression = element2;
+              element2 = this.finishNode(chainNode, "ChainExpression");
+            }
+            return element2;
+          }
+          base2 = element2;
+        }
+      };
+      pp$52.parseSubscript = function(base2, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
+        var optionalSupported = this.options.ecmaVersion >= 11;
+        var optional = optionalSupported && this.eat(types$12.questionDot);
+        if (noCalls && optional) {
+          this.raise(this.lastTokStart, "Optional chaining cannot appear in the callee of new expressions");
+        }
+        var computed = this.eat(types$12.bracketL);
+        if (computed || optional && this.type !== types$12.parenL && this.type !== types$12.backQuote || this.eat(types$12.dot)) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.object = base2;
+          if (computed) {
+            node.property = this.parseExpression();
+            this.expect(types$12.bracketR);
+          } else if (this.type === types$12.privateId && base2.type !== "Super") {
+            node.property = this.parsePrivateIdent();
+          } else {
+            node.property = this.parseIdent(this.options.allowReserved !== "never");
+          }
+          node.computed = !!computed;
+          if (optionalSupported) {
+            node.optional = optional;
+          }
+          base2 = this.finishNode(node, "MemberExpression");
+        } else if (!noCalls && this.eat(types$12.parenL)) {
+          var refDestructuringErrors = new DestructuringErrors3(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+          this.yieldPos = 0;
+          this.awaitPos = 0;
+          this.awaitIdentPos = 0;
+          var exprList = this.parseExprList(types$12.parenR, this.options.ecmaVersion >= 8, false, refDestructuringErrors);
+          if (maybeAsyncArrow && !optional && !this.canInsertSemicolon() && this.eat(types$12.arrow)) {
+            this.checkPatternErrors(refDestructuringErrors, false);
+            this.checkYieldAwaitInDefaultParams();
+            if (this.awaitIdentPos > 0) {
+              this.raise(this.awaitIdentPos, "Cannot use 'await' as identifier inside an async function");
+            }
+            this.yieldPos = oldYieldPos;
+            this.awaitPos = oldAwaitPos;
+            this.awaitIdentPos = oldAwaitIdentPos;
+            return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, true, forInit);
+          }
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          this.yieldPos = oldYieldPos || this.yieldPos;
+          this.awaitPos = oldAwaitPos || this.awaitPos;
+          this.awaitIdentPos = oldAwaitIdentPos || this.awaitIdentPos;
+          var node$1 = this.startNodeAt(startPos, startLoc);
+          node$1.callee = base2;
+          node$1.arguments = exprList;
+          if (optionalSupported) {
+            node$1.optional = optional;
+          }
+          base2 = this.finishNode(node$1, "CallExpression");
+        } else if (this.type === types$12.backQuote) {
+          if (optional || optionalChained) {
+            this.raise(this.start, "Optional chaining cannot appear in the tag of tagged template expressions");
+          }
+          var node$2 = this.startNodeAt(startPos, startLoc);
+          node$2.tag = base2;
+          node$2.quasi = this.parseTemplate({ isTagged: true });
+          base2 = this.finishNode(node$2, "TaggedTemplateExpression");
+        }
+        return base2;
+      };
+      pp$52.parseExprAtom = function(refDestructuringErrors, forInit) {
+        if (this.type === types$12.slash) {
+          this.readRegexp();
+        }
+        var node, canBeArrow = this.potentialArrowAt === this.start;
+        switch (this.type) {
+          case types$12._super:
+            if (!this.allowSuper) {
+              this.raise(this.start, "'super' keyword outside a method");
+            }
+            node = this.startNode();
+            this.next();
+            if (this.type === types$12.parenL && !this.allowDirectSuper) {
+              this.raise(node.start, "super() call outside constructor of a subclass");
+            }
+            if (this.type !== types$12.dot && this.type !== types$12.bracketL && this.type !== types$12.parenL) {
+              this.unexpected();
+            }
+            return this.finishNode(node, "Super");
+          case types$12._this:
+            node = this.startNode();
+            this.next();
+            return this.finishNode(node, "ThisExpression");
+          case types$12.name:
+            var startPos = this.start, startLoc = this.startLoc, containsEsc = this.containsEsc;
+            var id = this.parseIdent(false);
+            if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === "async" && !this.canInsertSemicolon() && this.eat(types$12._function)) {
+              this.overrideContext(types2.f_expr);
+              return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true, forInit);
+            }
+            if (canBeArrow && !this.canInsertSemicolon()) {
+              if (this.eat(types$12.arrow)) {
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false, forInit);
+              }
+              if (this.options.ecmaVersion >= 8 && id.name === "async" && this.type === types$12.name && !containsEsc && (!this.potentialArrowInForAwait || this.value !== "of" || this.containsEsc)) {
+                id = this.parseIdent(false);
+                if (this.canInsertSemicolon() || !this.eat(types$12.arrow)) {
+                  this.unexpected();
+                }
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true, forInit);
+              }
+            }
+            return id;
+          case types$12.regexp:
+            var value = this.value;
+            node = this.parseLiteral(value.value);
+            node.regex = { pattern: value.pattern, flags: value.flags };
+            return node;
+          case types$12.num:
+          case types$12.string:
+            return this.parseLiteral(this.value);
+          case types$12._null:
+          case types$12._true:
+          case types$12._false:
+            node = this.startNode();
+            node.value = this.type === types$12._null ? null : this.type === types$12._true;
+            node.raw = this.type.keyword;
+            this.next();
+            return this.finishNode(node, "Literal");
+          case types$12.parenL:
+            var start3 = this.start, expr = this.parseParenAndDistinguishExpression(canBeArrow, forInit);
+            if (refDestructuringErrors) {
+              if (refDestructuringErrors.parenthesizedAssign < 0 && !this.isSimpleAssignTarget(expr)) {
+                refDestructuringErrors.parenthesizedAssign = start3;
+              }
+              if (refDestructuringErrors.parenthesizedBind < 0) {
+                refDestructuringErrors.parenthesizedBind = start3;
+              }
+            }
+            return expr;
+          case types$12.bracketL:
+            node = this.startNode();
+            this.next();
+            node.elements = this.parseExprList(types$12.bracketR, true, true, refDestructuringErrors);
+            return this.finishNode(node, "ArrayExpression");
+          case types$12.braceL:
+            this.overrideContext(types2.b_expr);
+            return this.parseObj(false, refDestructuringErrors);
+          case types$12._function:
+            node = this.startNode();
+            this.next();
+            return this.parseFunction(node, 0);
+          case types$12._class:
+            return this.parseClass(this.startNode(), false);
+          case types$12._new:
+            return this.parseNew();
+          case types$12.backQuote:
+            return this.parseTemplate();
+          case types$12._import:
+            if (this.options.ecmaVersion >= 11) {
+              return this.parseExprImport();
+            } else {
+              return this.unexpected();
+            }
+          default:
+            this.unexpected();
+        }
+      };
+      pp$52.parseExprImport = function() {
+        var node = this.startNode();
+        if (this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword import");
+        }
+        var meta = this.parseIdent(true);
+        switch (this.type) {
+          case types$12.parenL:
+            return this.parseDynamicImport(node);
+          case types$12.dot:
+            node.meta = meta;
+            return this.parseImportMeta(node);
+          default:
+            this.unexpected();
+        }
+      };
+      pp$52.parseDynamicImport = function(node) {
+        this.next();
+        node.source = this.parseMaybeAssign();
+        if (!this.eat(types$12.parenR)) {
+          var errorPos = this.start;
+          if (this.eat(types$12.comma) && this.eat(types$12.parenR)) {
+            this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+          } else {
+            this.unexpected(errorPos);
+          }
+        }
+        return this.finishNode(node, "ImportExpression");
+      };
+      pp$52.parseImportMeta = function(node) {
+        this.next();
+        var containsEsc = this.containsEsc;
+        node.property = this.parseIdent(true);
+        if (node.property.name !== "meta") {
+          this.raiseRecoverable(node.property.start, "The only valid meta property for import is 'import.meta'");
+        }
+        if (containsEsc) {
+          this.raiseRecoverable(node.start, "'import.meta' must not contain escaped characters");
+        }
+        if (this.options.sourceType !== "module" && !this.options.allowImportExportEverywhere) {
+          this.raiseRecoverable(node.start, "Cannot use 'import.meta' outside a module");
+        }
+        return this.finishNode(node, "MetaProperty");
+      };
+      pp$52.parseLiteral = function(value) {
+        var node = this.startNode();
+        node.value = value;
+        node.raw = this.input.slice(this.start, this.end);
+        if (node.raw.charCodeAt(node.raw.length - 1) === 110) {
+          node.bigint = node.raw.slice(0, -1).replace(/_/g, "");
+        }
+        this.next();
+        return this.finishNode(node, "Literal");
+      };
+      pp$52.parseParenExpression = function() {
+        this.expect(types$12.parenL);
+        var val = this.parseExpression();
+        this.expect(types$12.parenR);
+        return val;
+      };
+      pp$52.parseParenAndDistinguishExpression = function(canBeArrow, forInit) {
+        var startPos = this.start, startLoc = this.startLoc, val, allowTrailingComma = this.options.ecmaVersion >= 8;
+        if (this.options.ecmaVersion >= 6) {
+          this.next();
+          var innerStartPos = this.start, innerStartLoc = this.startLoc;
+          var exprList = [], first = true, lastIsComma = false;
+          var refDestructuringErrors = new DestructuringErrors3(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, spreadStart;
+          this.yieldPos = 0;
+          this.awaitPos = 0;
+          while (this.type !== types$12.parenR) {
+            first ? first = false : this.expect(types$12.comma);
+            if (allowTrailingComma && this.afterTrailingComma(types$12.parenR, true)) {
+              lastIsComma = true;
+              break;
+            } else if (this.type === types$12.ellipsis) {
+              spreadStart = this.start;
+              exprList.push(this.parseParenItem(this.parseRestBinding()));
+              if (this.type === types$12.comma) {
+                this.raise(this.start, "Comma is not permitted after the rest element");
+              }
+              break;
+            } else {
+              exprList.push(this.parseMaybeAssign(false, refDestructuringErrors, this.parseParenItem));
+            }
+          }
+          var innerEndPos = this.lastTokEnd, innerEndLoc = this.lastTokEndLoc;
+          this.expect(types$12.parenR);
+          if (canBeArrow && !this.canInsertSemicolon() && this.eat(types$12.arrow)) {
+            this.checkPatternErrors(refDestructuringErrors, false);
+            this.checkYieldAwaitInDefaultParams();
+            this.yieldPos = oldYieldPos;
+            this.awaitPos = oldAwaitPos;
+            return this.parseParenArrowList(startPos, startLoc, exprList, forInit);
+          }
+          if (!exprList.length || lastIsComma) {
+            this.unexpected(this.lastTokStart);
+          }
+          if (spreadStart) {
+            this.unexpected(spreadStart);
+          }
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          this.yieldPos = oldYieldPos || this.yieldPos;
+          this.awaitPos = oldAwaitPos || this.awaitPos;
+          if (exprList.length > 1) {
+            val = this.startNodeAt(innerStartPos, innerStartLoc);
+            val.expressions = exprList;
+            this.finishNodeAt(val, "SequenceExpression", innerEndPos, innerEndLoc);
+          } else {
+            val = exprList[0];
+          }
+        } else {
+          val = this.parseParenExpression();
+        }
+        if (this.options.preserveParens) {
+          var par = this.startNodeAt(startPos, startLoc);
+          par.expression = val;
+          return this.finishNode(par, "ParenthesizedExpression");
+        } else {
+          return val;
+        }
+      };
+      pp$52.parseParenItem = function(item) {
+        return item;
+      };
+      pp$52.parseParenArrowList = function(startPos, startLoc, exprList, forInit) {
+        return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, false, forInit);
+      };
+      var empty3 = [];
+      pp$52.parseNew = function() {
+        if (this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword new");
+        }
+        var node = this.startNode();
+        var meta = this.parseIdent(true);
+        if (this.options.ecmaVersion >= 6 && this.eat(types$12.dot)) {
+          node.meta = meta;
+          var containsEsc = this.containsEsc;
+          node.property = this.parseIdent(true);
+          if (node.property.name !== "target") {
+            this.raiseRecoverable(node.property.start, "The only valid meta property for new is 'new.target'");
+          }
+          if (containsEsc) {
+            this.raiseRecoverable(node.start, "'new.target' must not contain escaped characters");
+          }
+          if (!this.allowNewDotTarget) {
+            this.raiseRecoverable(node.start, "'new.target' can only be used in functions and class static block");
+          }
+          return this.finishNode(node, "MetaProperty");
+        }
+        var startPos = this.start, startLoc = this.startLoc, isImport = this.type === types$12._import;
+        node.callee = this.parseSubscripts(this.parseExprAtom(), startPos, startLoc, true, false);
+        if (isImport && node.callee.type === "ImportExpression") {
+          this.raise(startPos, "Cannot use new with import()");
+        }
+        if (this.eat(types$12.parenL)) {
+          node.arguments = this.parseExprList(types$12.parenR, this.options.ecmaVersion >= 8, false);
+        } else {
+          node.arguments = empty3;
+        }
+        return this.finishNode(node, "NewExpression");
+      };
+      pp$52.parseTemplateElement = function(ref3) {
+        var isTagged = ref3.isTagged;
+        var elem = this.startNode();
+        if (this.type === types$12.invalidTemplate) {
+          if (!isTagged) {
+            this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal");
+          }
+          elem.value = {
+            raw: this.value,
+            cooked: null
+          };
+        } else {
+          elem.value = {
+            raw: this.input.slice(this.start, this.end).replace(/\r\n?/g, "\n"),
+            cooked: this.value
+          };
+        }
+        this.next();
+        elem.tail = this.type === types$12.backQuote;
+        return this.finishNode(elem, "TemplateElement");
+      };
+      pp$52.parseTemplate = function(ref3) {
+        if (ref3 === void 0)
+          ref3 = {};
+        var isTagged = ref3.isTagged;
+        if (isTagged === void 0)
+          isTagged = false;
+        var node = this.startNode();
+        this.next();
+        node.expressions = [];
+        var curElt = this.parseTemplateElement({ isTagged });
+        node.quasis = [curElt];
+        while (!curElt.tail) {
+          if (this.type === types$12.eof) {
+            this.raise(this.pos, "Unterminated template literal");
+          }
+          this.expect(types$12.dollarBraceL);
+          node.expressions.push(this.parseExpression());
+          this.expect(types$12.braceR);
+          node.quasis.push(curElt = this.parseTemplateElement({ isTagged }));
+        }
+        this.next();
+        return this.finishNode(node, "TemplateLiteral");
+      };
+      pp$52.isAsyncProp = function(prop) {
+        return !prop.computed && prop.key.type === "Identifier" && prop.key.name === "async" && (this.type === types$12.name || this.type === types$12.num || this.type === types$12.string || this.type === types$12.bracketL || this.type.keyword || this.options.ecmaVersion >= 9 && this.type === types$12.star) && !lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+      };
+      pp$52.parseObj = function(isPattern, refDestructuringErrors) {
+        var node = this.startNode(), first = true, propHash = {};
+        node.properties = [];
+        this.next();
+        while (!this.eat(types$12.braceR)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (this.options.ecmaVersion >= 5 && this.afterTrailingComma(types$12.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var prop = this.parseProperty(isPattern, refDestructuringErrors);
+          if (!isPattern) {
+            this.checkPropClash(prop, propHash, refDestructuringErrors);
+          }
+          node.properties.push(prop);
+        }
+        return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
+      };
+      pp$52.parseProperty = function(isPattern, refDestructuringErrors) {
+        var prop = this.startNode(), isGenerator, isAsync, startPos, startLoc;
+        if (this.options.ecmaVersion >= 9 && this.eat(types$12.ellipsis)) {
+          if (isPattern) {
+            prop.argument = this.parseIdent(false);
+            if (this.type === types$12.comma) {
+              this.raise(this.start, "Comma is not permitted after the rest element");
+            }
+            return this.finishNode(prop, "RestElement");
+          }
+          prop.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+          if (this.type === types$12.comma && refDestructuringErrors && refDestructuringErrors.trailingComma < 0) {
+            refDestructuringErrors.trailingComma = this.start;
+          }
+          return this.finishNode(prop, "SpreadElement");
+        }
+        if (this.options.ecmaVersion >= 6) {
+          prop.method = false;
+          prop.shorthand = false;
+          if (isPattern || refDestructuringErrors) {
+            startPos = this.start;
+            startLoc = this.startLoc;
+          }
+          if (!isPattern) {
+            isGenerator = this.eat(types$12.star);
+          }
+        }
+        var containsEsc = this.containsEsc;
+        this.parsePropertyName(prop);
+        if (!isPattern && !containsEsc && this.options.ecmaVersion >= 8 && !isGenerator && this.isAsyncProp(prop)) {
+          isAsync = true;
+          isGenerator = this.options.ecmaVersion >= 9 && this.eat(types$12.star);
+          this.parsePropertyName(prop, refDestructuringErrors);
+        } else {
+          isAsync = false;
+        }
+        this.parsePropertyValue(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc);
+        return this.finishNode(prop, "Property");
+      };
+      pp$52.parsePropertyValue = function(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc) {
+        if ((isGenerator || isAsync) && this.type === types$12.colon) {
+          this.unexpected();
+        }
+        if (this.eat(types$12.colon)) {
+          prop.value = isPattern ? this.parseMaybeDefault(this.start, this.startLoc) : this.parseMaybeAssign(false, refDestructuringErrors);
+          prop.kind = "init";
+        } else if (this.options.ecmaVersion >= 6 && this.type === types$12.parenL) {
+          if (isPattern) {
+            this.unexpected();
+          }
+          prop.kind = "init";
+          prop.method = true;
+          prop.value = this.parseMethod(isGenerator, isAsync);
+        } else if (!isPattern && !containsEsc && this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type !== types$12.comma && this.type !== types$12.braceR && this.type !== types$12.eq)) {
+          if (isGenerator || isAsync) {
+            this.unexpected();
+          }
+          prop.kind = prop.key.name;
+          this.parsePropertyName(prop);
+          prop.value = this.parseMethod(false);
+          var paramCount = prop.kind === "get" ? 0 : 1;
+          if (prop.value.params.length !== paramCount) {
+            var start3 = prop.value.start;
+            if (prop.kind === "get") {
+              this.raiseRecoverable(start3, "getter should have no params");
+            } else {
+              this.raiseRecoverable(start3, "setter should have exactly one param");
+            }
+          } else {
+            if (prop.kind === "set" && prop.value.params[0].type === "RestElement") {
+              this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params");
+            }
+          }
+        } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+          if (isGenerator || isAsync) {
+            this.unexpected();
+          }
+          this.checkUnreserved(prop.key);
+          if (prop.key.name === "await" && !this.awaitIdentPos) {
+            this.awaitIdentPos = startPos;
+          }
+          prop.kind = "init";
+          if (isPattern) {
+            prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+          } else if (this.type === types$12.eq && refDestructuringErrors) {
+            if (refDestructuringErrors.shorthandAssign < 0) {
+              refDestructuringErrors.shorthandAssign = this.start;
+            }
+            prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+          } else {
+            prop.value = this.copyNode(prop.key);
+          }
+          prop.shorthand = true;
+        } else {
+          this.unexpected();
+        }
+      };
+      pp$52.parsePropertyName = function(prop) {
+        if (this.options.ecmaVersion >= 6) {
+          if (this.eat(types$12.bracketL)) {
+            prop.computed = true;
+            prop.key = this.parseMaybeAssign();
+            this.expect(types$12.bracketR);
+            return prop.key;
+          } else {
+            prop.computed = false;
+          }
+        }
+        return prop.key = this.type === types$12.num || this.type === types$12.string ? this.parseExprAtom() : this.parseIdent(this.options.allowReserved !== "never");
+      };
+      pp$52.initFunction = function(node) {
+        node.id = null;
+        if (this.options.ecmaVersion >= 6) {
+          node.generator = node.expression = false;
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node.async = false;
+        }
+      };
+      pp$52.parseMethod = function(isGenerator, isAsync, allowDirectSuper) {
+        var node = this.startNode(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.initFunction(node);
+        if (this.options.ecmaVersion >= 6) {
+          node.generator = isGenerator;
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node.async = !!isAsync;
+        }
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        this.enterScope(functionFlags2(isAsync, node.generator) | SCOPE_SUPER2 | (allowDirectSuper ? SCOPE_DIRECT_SUPER2 : 0));
+        this.expect(types$12.parenL);
+        node.params = this.parseBindingList(types$12.parenR, false, this.options.ecmaVersion >= 8);
+        this.checkYieldAwaitInDefaultParams();
+        this.parseFunctionBody(node, false, true, false);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node, "FunctionExpression");
+      };
+      pp$52.parseArrowExpression = function(node, params, isAsync, forInit) {
+        var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.enterScope(functionFlags2(isAsync, false) | SCOPE_ARROW2);
+        this.initFunction(node);
+        if (this.options.ecmaVersion >= 8) {
+          node.async = !!isAsync;
+        }
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        node.params = this.toAssignableList(params, true);
+        this.parseFunctionBody(node, true, false, forInit);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node, "ArrowFunctionExpression");
+      };
+      pp$52.parseFunctionBody = function(node, isArrowFunction, isMethod, forInit) {
+        var isExpression = isArrowFunction && this.type !== types$12.braceL;
+        var oldStrict = this.strict, useStrict = false;
+        if (isExpression) {
+          node.body = this.parseMaybeAssign(forInit);
+          node.expression = true;
+          this.checkParams(node, false);
+        } else {
+          var nonSimple = this.options.ecmaVersion >= 7 && !this.isSimpleParamList(node.params);
+          if (!oldStrict || nonSimple) {
+            useStrict = this.strictDirective(this.end);
+            if (useStrict && nonSimple) {
+              this.raiseRecoverable(node.start, "Illegal 'use strict' directive in function with non-simple parameter list");
+            }
+          }
+          var oldLabels = this.labels;
+          this.labels = [];
+          if (useStrict) {
+            this.strict = true;
+          }
+          this.checkParams(node, !oldStrict && !useStrict && !isArrowFunction && !isMethod && this.isSimpleParamList(node.params));
+          if (this.strict && node.id) {
+            this.checkLValSimple(node.id, BIND_OUTSIDE2);
+          }
+          node.body = this.parseBlock(false, void 0, useStrict && !oldStrict);
+          node.expression = false;
+          this.adaptDirectivePrologue(node.body.body);
+          this.labels = oldLabels;
+        }
+        this.exitScope();
+      };
+      pp$52.isSimpleParamList = function(params) {
+        for (var i2 = 0, list4 = params; i2 < list4.length; i2 += 1) {
+          var param = list4[i2];
+          if (param.type !== "Identifier") {
+            return false;
+          }
+        }
+        return true;
+      };
+      pp$52.checkParams = function(node, allowDuplicates) {
+        var nameHash = /* @__PURE__ */ Object.create(null);
+        for (var i2 = 0, list4 = node.params; i2 < list4.length; i2 += 1) {
+          var param = list4[i2];
+          this.checkLValInnerPattern(param, BIND_VAR2, allowDuplicates ? null : nameHash);
+        }
+      };
+      pp$52.parseExprList = function(close, allowTrailingComma, allowEmpty, refDestructuringErrors) {
+        var elts = [], first = true;
+        while (!this.eat(close)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (allowTrailingComma && this.afterTrailingComma(close)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var elt = void 0;
+          if (allowEmpty && this.type === types$12.comma) {
+            elt = null;
+          } else if (this.type === types$12.ellipsis) {
+            elt = this.parseSpread(refDestructuringErrors);
+            if (refDestructuringErrors && this.type === types$12.comma && refDestructuringErrors.trailingComma < 0) {
+              refDestructuringErrors.trailingComma = this.start;
+            }
+          } else {
+            elt = this.parseMaybeAssign(false, refDestructuringErrors);
+          }
+          elts.push(elt);
+        }
+        return elts;
+      };
+      pp$52.checkUnreserved = function(ref3) {
+        var start3 = ref3.start;
+        var end = ref3.end;
+        var name2 = ref3.name;
+        if (this.inGenerator && name2 === "yield") {
+          this.raiseRecoverable(start3, "Cannot use 'yield' as identifier inside a generator");
+        }
+        if (this.inAsync && name2 === "await") {
+          this.raiseRecoverable(start3, "Cannot use 'await' as identifier inside an async function");
+        }
+        if (this.currentThisScope().inClassFieldInit && name2 === "arguments") {
+          this.raiseRecoverable(start3, "Cannot use 'arguments' in class field initializer");
+        }
+        if (this.inClassStaticBlock && (name2 === "arguments" || name2 === "await")) {
+          this.raise(start3, "Cannot use " + name2 + " in class static initialization block");
+        }
+        if (this.keywords.test(name2)) {
+          this.raise(start3, "Unexpected keyword '" + name2 + "'");
+        }
+        if (this.options.ecmaVersion < 6 && this.input.slice(start3, end).indexOf("\\") !== -1) {
+          return;
+        }
+        var re = this.strict ? this.reservedWordsStrict : this.reservedWords;
+        if (re.test(name2)) {
+          if (!this.inAsync && name2 === "await") {
+            this.raiseRecoverable(start3, "Cannot use keyword 'await' outside an async function");
+          }
+          this.raiseRecoverable(start3, "The keyword '" + name2 + "' is reserved");
+        }
+      };
+      pp$52.parseIdent = function(liberal, isBinding) {
+        var node = this.startNode();
+        if (this.type === types$12.name) {
+          node.name = this.value;
+        } else if (this.type.keyword) {
+          node.name = this.type.keyword;
+          if ((node.name === "class" || node.name === "function") && (this.lastTokEnd !== this.lastTokStart + 1 || this.input.charCodeAt(this.lastTokStart) !== 46)) {
+            this.context.pop();
+          }
+        } else {
+          this.unexpected();
+        }
+        this.next(!!liberal);
+        this.finishNode(node, "Identifier");
+        if (!liberal) {
+          this.checkUnreserved(node);
+          if (node.name === "await" && !this.awaitIdentPos) {
+            this.awaitIdentPos = node.start;
+          }
+        }
+        return node;
+      };
+      pp$52.parsePrivateIdent = function() {
+        var node = this.startNode();
+        if (this.type === types$12.privateId) {
+          node.name = this.value;
+        } else {
+          this.unexpected();
+        }
+        this.next();
+        this.finishNode(node, "PrivateIdentifier");
+        if (this.privateNameStack.length === 0) {
+          this.raise(node.start, "Private field '#" + node.name + "' must be declared in an enclosing class");
+        } else {
+          this.privateNameStack[this.privateNameStack.length - 1].used.push(node);
+        }
+        return node;
+      };
+      pp$52.parseYield = function(forInit) {
+        if (!this.yieldPos) {
+          this.yieldPos = this.start;
+        }
+        var node = this.startNode();
+        this.next();
+        if (this.type === types$12.semi || this.canInsertSemicolon() || this.type !== types$12.star && !this.type.startsExpr) {
+          node.delegate = false;
+          node.argument = null;
+        } else {
+          node.delegate = this.eat(types$12.star);
+          node.argument = this.parseMaybeAssign(forInit);
+        }
+        return this.finishNode(node, "YieldExpression");
+      };
+      pp$52.parseAwait = function(forInit) {
+        if (!this.awaitPos) {
+          this.awaitPos = this.start;
+        }
+        var node = this.startNode();
+        this.next();
+        node.argument = this.parseMaybeUnary(null, true, false, forInit);
+        return this.finishNode(node, "AwaitExpression");
+      };
+      var pp$42 = Parser3.prototype;
+      pp$42.raise = function(pos, message) {
+        var loc = getLineInfo2(this.input, pos);
+        message += " (" + loc.line + ":" + loc.column + ")";
+        var err = new SyntaxError(message);
+        err.pos = pos;
+        err.loc = loc;
+        err.raisedAt = this.pos;
+        throw err;
+      };
+      pp$42.raiseRecoverable = pp$42.raise;
+      pp$42.curPosition = function() {
+        if (this.options.locations) {
+          return new Position3(this.curLine, this.pos - this.lineStart);
+        }
+      };
+      var pp$32 = Parser3.prototype;
+      var Scope4 = function Scope5(flags) {
+        this.flags = flags;
+        this.var = [];
+        this.lexical = [];
+        this.functions = [];
+        this.inClassFieldInit = false;
+      };
+      pp$32.enterScope = function(flags) {
+        this.scopeStack.push(new Scope4(flags));
+      };
+      pp$32.exitScope = function() {
+        this.scopeStack.pop();
+      };
+      pp$32.treatFunctionsAsVarInScope = function(scope) {
+        return scope.flags & SCOPE_FUNCTION2 || !this.inModule && scope.flags & SCOPE_TOP2;
+      };
+      pp$32.declareName = function(name2, bindingType, pos) {
+        var redeclared = false;
+        if (bindingType === BIND_LEXICAL2) {
+          var scope = this.currentScope();
+          redeclared = scope.lexical.indexOf(name2) > -1 || scope.functions.indexOf(name2) > -1 || scope.var.indexOf(name2) > -1;
+          scope.lexical.push(name2);
+          if (this.inModule && scope.flags & SCOPE_TOP2) {
+            delete this.undefinedExports[name2];
+          }
+        } else if (bindingType === BIND_SIMPLE_CATCH2) {
+          var scope$1 = this.currentScope();
+          scope$1.lexical.push(name2);
+        } else if (bindingType === BIND_FUNCTION2) {
+          var scope$2 = this.currentScope();
+          if (this.treatFunctionsAsVar) {
+            redeclared = scope$2.lexical.indexOf(name2) > -1;
+          } else {
+            redeclared = scope$2.lexical.indexOf(name2) > -1 || scope$2.var.indexOf(name2) > -1;
+          }
+          scope$2.functions.push(name2);
+        } else {
+          for (var i2 = this.scopeStack.length - 1; i2 >= 0; --i2) {
+            var scope$3 = this.scopeStack[i2];
+            if (scope$3.lexical.indexOf(name2) > -1 && !(scope$3.flags & SCOPE_SIMPLE_CATCH2 && scope$3.lexical[0] === name2) || !this.treatFunctionsAsVarInScope(scope$3) && scope$3.functions.indexOf(name2) > -1) {
+              redeclared = true;
+              break;
+            }
+            scope$3.var.push(name2);
+            if (this.inModule && scope$3.flags & SCOPE_TOP2) {
+              delete this.undefinedExports[name2];
+            }
+            if (scope$3.flags & SCOPE_VAR2) {
+              break;
+            }
+          }
+        }
+        if (redeclared) {
+          this.raiseRecoverable(pos, "Identifier '" + name2 + "' has already been declared");
+        }
+      };
+      pp$32.checkLocalExport = function(id) {
+        if (this.scopeStack[0].lexical.indexOf(id.name) === -1 && this.scopeStack[0].var.indexOf(id.name) === -1) {
+          this.undefinedExports[id.name] = id;
+        }
+      };
+      pp$32.currentScope = function() {
+        return this.scopeStack[this.scopeStack.length - 1];
+      };
+      pp$32.currentVarScope = function() {
+        for (var i2 = this.scopeStack.length - 1; ; i2--) {
+          var scope = this.scopeStack[i2];
+          if (scope.flags & SCOPE_VAR2) {
+            return scope;
+          }
+        }
+      };
+      pp$32.currentThisScope = function() {
+        for (var i2 = this.scopeStack.length - 1; ; i2--) {
+          var scope = this.scopeStack[i2];
+          if (scope.flags & SCOPE_VAR2 && !(scope.flags & SCOPE_ARROW2)) {
+            return scope;
+          }
+        }
+      };
+      var Node3 = function Node4(parser, pos, loc) {
+        this.type = "";
+        this.start = pos;
+        this.end = 0;
+        if (parser.options.locations) {
+          this.loc = new SourceLocation3(parser, loc);
+        }
+        if (parser.options.directSourceFile) {
+          this.sourceFile = parser.options.directSourceFile;
+        }
+        if (parser.options.ranges) {
+          this.range = [pos, 0];
+        }
+      };
+      var pp$22 = Parser3.prototype;
+      pp$22.startNode = function() {
+        return new Node3(this, this.start, this.startLoc);
+      };
+      pp$22.startNodeAt = function(pos, loc) {
+        return new Node3(this, pos, loc);
+      };
+      function finishNodeAt2(node, type, pos, loc) {
+        node.type = type;
+        node.end = pos;
+        if (this.options.locations) {
+          node.loc.end = loc;
+        }
+        if (this.options.ranges) {
+          node.range[1] = pos;
+        }
+        return node;
+      }
+      pp$22.finishNode = function(node, type) {
+        return finishNodeAt2.call(this, node, type, this.lastTokEnd, this.lastTokEndLoc);
+      };
+      pp$22.finishNodeAt = function(node, type, pos, loc) {
+        return finishNodeAt2.call(this, node, type, pos, loc);
+      };
+      pp$22.copyNode = function(node) {
+        var newNode = new Node3(this, node.start, this.startLoc);
+        for (var prop in node) {
+          newNode[prop] = node[prop];
+        }
+        return newNode;
+      };
+      var ecma9BinaryProperties2 = "ASCII ASCII_Hex_Digit AHex Alphabetic Alpha Any Assigned Bidi_Control Bidi_C Bidi_Mirrored Bidi_M Case_Ignorable CI Cased Changes_When_Casefolded CWCF Changes_When_Casemapped CWCM Changes_When_Lowercased CWL Changes_When_NFKC_Casefolded CWKCF Changes_When_Titlecased CWT Changes_When_Uppercased CWU Dash Default_Ignorable_Code_Point DI Deprecated Dep Diacritic Dia Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Extender Ext Grapheme_Base Gr_Base Grapheme_Extend Gr_Ext Hex_Digit Hex IDS_Binary_Operator IDSB IDS_Trinary_Operator IDST ID_Continue IDC ID_Start IDS Ideographic Ideo Join_Control Join_C Logical_Order_Exception LOE Lowercase Lower Math Noncharacter_Code_Point NChar Pattern_Syntax Pat_Syn Pattern_White_Space Pat_WS Quotation_Mark QMark Radical Regional_Indicator RI Sentence_Terminal STerm Soft_Dotted SD Terminal_Punctuation Term Unified_Ideograph UIdeo Uppercase Upper Variation_Selector VS White_Space space XID_Continue XIDC XID_Start XIDS";
+      var ecma10BinaryProperties2 = ecma9BinaryProperties2 + " Extended_Pictographic";
+      var ecma11BinaryProperties2 = ecma10BinaryProperties2;
+      var ecma12BinaryProperties2 = ecma11BinaryProperties2 + " EBase EComp EMod EPres ExtPict";
+      var ecma13BinaryProperties2 = ecma12BinaryProperties2;
+      var unicodeBinaryProperties2 = {
+        9: ecma9BinaryProperties2,
+        10: ecma10BinaryProperties2,
+        11: ecma11BinaryProperties2,
+        12: ecma12BinaryProperties2,
+        13: ecma13BinaryProperties2
+      };
+      var unicodeGeneralCategoryValues2 = "Cased_Letter LC Close_Punctuation Pe Connector_Punctuation Pc Control Cc cntrl Currency_Symbol Sc Dash_Punctuation Pd Decimal_Number Nd digit Enclosing_Mark Me Final_Punctuation Pf Format Cf Initial_Punctuation Pi Letter L Letter_Number Nl Line_Separator Zl Lowercase_Letter Ll Mark M Combining_Mark Math_Symbol Sm Modifier_Letter Lm Modifier_Symbol Sk Nonspacing_Mark Mn Number N Open_Punctuation Ps Other C Other_Letter Lo Other_Number No Other_Punctuation Po Other_Symbol So Paragraph_Separator Zp Private_Use Co Punctuation P punct Separator Z Space_Separator Zs Spacing_Mark Mc Surrogate Cs Symbol S Titlecase_Letter Lt Unassigned Cn Uppercase_Letter Lu";
+      var ecma9ScriptValues2 = "Adlam Adlm Ahom Anatolian_Hieroglyphs Hluw Arabic Arab Armenian Armn Avestan Avst Balinese Bali Bamum Bamu Bassa_Vah Bass Batak Batk Bengali Beng Bhaiksuki Bhks Bopomofo Bopo Brahmi Brah Braille Brai Buginese Bugi Buhid Buhd Canadian_Aboriginal Cans Carian Cari Caucasian_Albanian Aghb Chakma Cakm Cham Cham Cherokee Cher Common Zyyy Coptic Copt Qaac Cuneiform Xsux Cypriot Cprt Cyrillic Cyrl Deseret Dsrt Devanagari Deva Duployan Dupl Egyptian_Hieroglyphs Egyp Elbasan Elba Ethiopic Ethi Georgian Geor Glagolitic Glag Gothic Goth Grantha Gran Greek Grek Gujarati Gujr Gurmukhi Guru Han Hani Hangul Hang Hanunoo Hano Hatran Hatr Hebrew Hebr Hiragana Hira Imperial_Aramaic Armi Inherited Zinh Qaai Inscriptional_Pahlavi Phli Inscriptional_Parthian Prti Javanese Java Kaithi Kthi Kannada Knda Katakana Kana Kayah_Li Kali Kharoshthi Khar Khmer Khmr Khojki Khoj Khudawadi Sind Lao Laoo Latin Latn Lepcha Lepc Limbu Limb Linear_A Lina Linear_B Linb Lisu Lisu Lycian Lyci Lydian Lydi Mahajani Mahj Malayalam Mlym Mandaic Mand Manichaean Mani Marchen Marc Masaram_Gondi Gonm Meetei_Mayek Mtei Mende_Kikakui Mend Meroitic_Cursive Merc Meroitic_Hieroglyphs Mero Miao Plrd Modi Mongolian Mong Mro Mroo Multani Mult Myanmar Mymr Nabataean Nbat New_Tai_Lue Talu Newa Newa Nko Nkoo Nushu Nshu Ogham Ogam Ol_Chiki Olck Old_Hungarian Hung Old_Italic Ital Old_North_Arabian Narb Old_Permic Perm Old_Persian Xpeo Old_South_Arabian Sarb Old_Turkic Orkh Oriya Orya Osage Osge Osmanya Osma Pahawh_Hmong Hmng Palmyrene Palm Pau_Cin_Hau Pauc Phags_Pa Phag Phoenician Phnx Psalter_Pahlavi Phlp Rejang Rjng Runic Runr Samaritan Samr Saurashtra Saur Sharada Shrd Shavian Shaw Siddham Sidd SignWriting Sgnw Sinhala Sinh Sora_Sompeng Sora Soyombo Soyo Sundanese Sund Syloti_Nagri Sylo Syriac Syrc Tagalog Tglg Tagbanwa Tagb Tai_Le Tale Tai_Tham Lana Tai_Viet Tavt Takri Takr Tamil Taml Tangut Tang Telugu Telu Thaana Thaa Thai Thai Tibetan Tibt Tifinagh Tfng Tirhuta Tirh Ugaritic Ugar Vai Vaii Warang_Citi Wara Yi Yiii Zanabazar_Square Zanb";
+      var ecma10ScriptValues2 = ecma9ScriptValues2 + " Dogra Dogr Gunjala_Gondi Gong Hanifi_Rohingya Rohg Makasar Maka Medefaidrin Medf Old_Sogdian Sogo Sogdian Sogd";
+      var ecma11ScriptValues2 = ecma10ScriptValues2 + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho";
+      var ecma12ScriptValues2 = ecma11ScriptValues2 + " Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi";
+      var ecma13ScriptValues2 = ecma12ScriptValues2 + " Cypro_Minoan Cpmn Old_Uyghur Ougr Tangsa Tnsa Toto Vithkuqi Vith";
+      var unicodeScriptValues2 = {
+        9: ecma9ScriptValues2,
+        10: ecma10ScriptValues2,
+        11: ecma11ScriptValues2,
+        12: ecma12ScriptValues2,
+        13: ecma13ScriptValues2
+      };
+      var data2 = {};
+      function buildUnicodeData2(ecmaVersion2) {
+        var d = data2[ecmaVersion2] = {
+          binary: wordsRegexp2(unicodeBinaryProperties2[ecmaVersion2] + " " + unicodeGeneralCategoryValues2),
+          nonBinary: {
+            General_Category: wordsRegexp2(unicodeGeneralCategoryValues2),
+            Script: wordsRegexp2(unicodeScriptValues2[ecmaVersion2])
+          }
+        };
+        d.nonBinary.Script_Extensions = d.nonBinary.Script;
+        d.nonBinary.gc = d.nonBinary.General_Category;
+        d.nonBinary.sc = d.nonBinary.Script;
+        d.nonBinary.scx = d.nonBinary.Script_Extensions;
+      }
+      for (var i = 0, list3 = [9, 10, 11, 12, 13]; i < list3.length; i += 1) {
+        var ecmaVersion = list3[i];
+        buildUnicodeData2(ecmaVersion);
+      }
+      var pp$12 = Parser3.prototype;
+      var RegExpValidationState3 = function RegExpValidationState4(parser) {
+        this.parser = parser;
+        this.validFlags = "gim" + (parser.options.ecmaVersion >= 6 ? "uy" : "") + (parser.options.ecmaVersion >= 9 ? "s" : "") + (parser.options.ecmaVersion >= 13 ? "d" : "");
+        this.unicodeProperties = data2[parser.options.ecmaVersion >= 13 ? 13 : parser.options.ecmaVersion];
+        this.source = "";
+        this.flags = "";
+        this.start = 0;
+        this.switchU = false;
+        this.switchN = false;
+        this.pos = 0;
+        this.lastIntValue = 0;
+        this.lastStringValue = "";
+        this.lastAssertionIsQuantifiable = false;
+        this.numCapturingParens = 0;
+        this.maxBackReference = 0;
+        this.groupNames = [];
+        this.backReferenceNames = [];
+      };
+      RegExpValidationState3.prototype.reset = function reset2(start3, pattern, flags) {
+        var unicode = flags.indexOf("u") !== -1;
+        this.start = start3 | 0;
+        this.source = pattern + "";
+        this.flags = flags;
+        this.switchU = unicode && this.parser.options.ecmaVersion >= 6;
+        this.switchN = unicode && this.parser.options.ecmaVersion >= 9;
+      };
+      RegExpValidationState3.prototype.raise = function raise2(message) {
+        this.parser.raiseRecoverable(this.start, "Invalid regular expression: /" + this.source + "/: " + message);
+      };
+      RegExpValidationState3.prototype.at = function at2(i2, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        var s = this.source;
+        var l = s.length;
+        if (i2 >= l) {
+          return -1;
+        }
+        var c = s.charCodeAt(i2);
+        if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i2 + 1 >= l) {
+          return c;
+        }
+        var next = s.charCodeAt(i2 + 1);
+        return next >= 56320 && next <= 57343 ? (c << 10) + next - 56613888 : c;
+      };
+      RegExpValidationState3.prototype.nextIndex = function nextIndex2(i2, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        var s = this.source;
+        var l = s.length;
+        if (i2 >= l) {
+          return l;
+        }
+        var c = s.charCodeAt(i2), next;
+        if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i2 + 1 >= l || (next = s.charCodeAt(i2 + 1)) < 56320 || next > 57343) {
+          return i2 + 1;
+        }
+        return i2 + 2;
+      };
+      RegExpValidationState3.prototype.current = function current2(forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        return this.at(this.pos, forceU);
+      };
+      RegExpValidationState3.prototype.lookahead = function lookahead2(forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        return this.at(this.nextIndex(this.pos, forceU), forceU);
+      };
+      RegExpValidationState3.prototype.advance = function advance2(forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        this.pos = this.nextIndex(this.pos, forceU);
+      };
+      RegExpValidationState3.prototype.eat = function eat2(ch, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        if (this.current(forceU) === ch) {
+          this.advance(forceU);
+          return true;
+        }
+        return false;
+      };
+      pp$12.validateRegExpFlags = function(state) {
+        var validFlags = state.validFlags;
+        var flags = state.flags;
+        for (var i2 = 0; i2 < flags.length; i2++) {
+          var flag = flags.charAt(i2);
+          if (validFlags.indexOf(flag) === -1) {
+            this.raise(state.start, "Invalid regular expression flag");
+          }
+          if (flags.indexOf(flag, i2 + 1) > -1) {
+            this.raise(state.start, "Duplicate regular expression flag");
+          }
+        }
+      };
+      pp$12.validateRegExpPattern = function(state) {
+        this.regexp_pattern(state);
+        if (!state.switchN && this.options.ecmaVersion >= 9 && state.groupNames.length > 0) {
+          state.switchN = true;
+          this.regexp_pattern(state);
+        }
+      };
+      pp$12.regexp_pattern = function(state) {
+        state.pos = 0;
+        state.lastIntValue = 0;
+        state.lastStringValue = "";
+        state.lastAssertionIsQuantifiable = false;
+        state.numCapturingParens = 0;
+        state.maxBackReference = 0;
+        state.groupNames.length = 0;
+        state.backReferenceNames.length = 0;
+        this.regexp_disjunction(state);
+        if (state.pos !== state.source.length) {
+          if (state.eat(41)) {
+            state.raise("Unmatched ')'");
+          }
+          if (state.eat(93) || state.eat(125)) {
+            state.raise("Lone quantifier brackets");
+          }
+        }
+        if (state.maxBackReference > state.numCapturingParens) {
+          state.raise("Invalid escape");
+        }
+        for (var i2 = 0, list4 = state.backReferenceNames; i2 < list4.length; i2 += 1) {
+          var name2 = list4[i2];
+          if (state.groupNames.indexOf(name2) === -1) {
+            state.raise("Invalid named capture referenced");
+          }
+        }
+      };
+      pp$12.regexp_disjunction = function(state) {
+        this.regexp_alternative(state);
+        while (state.eat(124)) {
+          this.regexp_alternative(state);
+        }
+        if (this.regexp_eatQuantifier(state, true)) {
+          state.raise("Nothing to repeat");
+        }
+        if (state.eat(123)) {
+          state.raise("Lone quantifier brackets");
+        }
+      };
+      pp$12.regexp_alternative = function(state) {
+        while (state.pos < state.source.length && this.regexp_eatTerm(state)) {
+        }
+      };
+      pp$12.regexp_eatTerm = function(state) {
+        if (this.regexp_eatAssertion(state)) {
+          if (state.lastAssertionIsQuantifiable && this.regexp_eatQuantifier(state)) {
+            if (state.switchU) {
+              state.raise("Invalid quantifier");
+            }
+          }
+          return true;
+        }
+        if (state.switchU ? this.regexp_eatAtom(state) : this.regexp_eatExtendedAtom(state)) {
+          this.regexp_eatQuantifier(state);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatAssertion = function(state) {
+        var start3 = state.pos;
+        state.lastAssertionIsQuantifiable = false;
+        if (state.eat(94) || state.eat(36)) {
+          return true;
+        }
+        if (state.eat(92)) {
+          if (state.eat(66) || state.eat(98)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        if (state.eat(40) && state.eat(63)) {
+          var lookbehind = false;
+          if (this.options.ecmaVersion >= 9) {
+            lookbehind = state.eat(60);
+          }
+          if (state.eat(61) || state.eat(33)) {
+            this.regexp_disjunction(state);
+            if (!state.eat(41)) {
+              state.raise("Unterminated group");
+            }
+            state.lastAssertionIsQuantifiable = !lookbehind;
+            return true;
+          }
+        }
+        state.pos = start3;
+        return false;
+      };
+      pp$12.regexp_eatQuantifier = function(state, noError) {
+        if (noError === void 0)
+          noError = false;
+        if (this.regexp_eatQuantifierPrefix(state, noError)) {
+          state.eat(63);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatQuantifierPrefix = function(state, noError) {
+        return state.eat(42) || state.eat(43) || state.eat(63) || this.regexp_eatBracedQuantifier(state, noError);
+      };
+      pp$12.regexp_eatBracedQuantifier = function(state, noError) {
+        var start3 = state.pos;
+        if (state.eat(123)) {
+          var min = 0, max = -1;
+          if (this.regexp_eatDecimalDigits(state)) {
+            min = state.lastIntValue;
+            if (state.eat(44) && this.regexp_eatDecimalDigits(state)) {
+              max = state.lastIntValue;
+            }
+            if (state.eat(125)) {
+              if (max !== -1 && max < min && !noError) {
+                state.raise("numbers out of order in {} quantifier");
+              }
+              return true;
+            }
+          }
+          if (state.switchU && !noError) {
+            state.raise("Incomplete quantifier");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatAtom = function(state) {
+        return this.regexp_eatPatternCharacters(state) || state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state);
+      };
+      pp$12.regexp_eatReverseSolidusAtomEscape = function(state) {
+        var start3 = state.pos;
+        if (state.eat(92)) {
+          if (this.regexp_eatAtomEscape(state)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatUncapturingGroup = function(state) {
+        var start3 = state.pos;
+        if (state.eat(40)) {
+          if (state.eat(63) && state.eat(58)) {
+            this.regexp_disjunction(state);
+            if (state.eat(41)) {
+              return true;
+            }
+            state.raise("Unterminated group");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatCapturingGroup = function(state) {
+        if (state.eat(40)) {
+          if (this.options.ecmaVersion >= 9) {
+            this.regexp_groupSpecifier(state);
+          } else if (state.current() === 63) {
+            state.raise("Invalid group");
+          }
+          this.regexp_disjunction(state);
+          if (state.eat(41)) {
+            state.numCapturingParens += 1;
+            return true;
+          }
+          state.raise("Unterminated group");
+        }
+        return false;
+      };
+      pp$12.regexp_eatExtendedAtom = function(state) {
+        return state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state) || this.regexp_eatInvalidBracedQuantifier(state) || this.regexp_eatExtendedPatternCharacter(state);
+      };
+      pp$12.regexp_eatInvalidBracedQuantifier = function(state) {
+        if (this.regexp_eatBracedQuantifier(state, true)) {
+          state.raise("Nothing to repeat");
+        }
+        return false;
+      };
+      pp$12.regexp_eatSyntaxCharacter = function(state) {
+        var ch = state.current();
+        if (isSyntaxCharacter2(ch)) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      function isSyntaxCharacter2(ch) {
+        return ch === 36 || ch >= 40 && ch <= 43 || ch === 46 || ch === 63 || ch >= 91 && ch <= 94 || ch >= 123 && ch <= 125;
+      }
+      pp$12.regexp_eatPatternCharacters = function(state) {
+        var start3 = state.pos;
+        var ch = 0;
+        while ((ch = state.current()) !== -1 && !isSyntaxCharacter2(ch)) {
+          state.advance();
+        }
+        return state.pos !== start3;
+      };
+      pp$12.regexp_eatExtendedPatternCharacter = function(state) {
+        var ch = state.current();
+        if (ch !== -1 && ch !== 36 && !(ch >= 40 && ch <= 43) && ch !== 46 && ch !== 63 && ch !== 91 && ch !== 94 && ch !== 124) {
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_groupSpecifier = function(state) {
+        if (state.eat(63)) {
+          if (this.regexp_eatGroupName(state)) {
+            if (state.groupNames.indexOf(state.lastStringValue) !== -1) {
+              state.raise("Duplicate capture group name");
+            }
+            state.groupNames.push(state.lastStringValue);
+            return;
+          }
+          state.raise("Invalid group");
+        }
+      };
+      pp$12.regexp_eatGroupName = function(state) {
+        state.lastStringValue = "";
+        if (state.eat(60)) {
+          if (this.regexp_eatRegExpIdentifierName(state) && state.eat(62)) {
+            return true;
+          }
+          state.raise("Invalid capture group name");
+        }
+        return false;
+      };
+      pp$12.regexp_eatRegExpIdentifierName = function(state) {
+        state.lastStringValue = "";
+        if (this.regexp_eatRegExpIdentifierStart(state)) {
+          state.lastStringValue += codePointToString2(state.lastIntValue);
+          while (this.regexp_eatRegExpIdentifierPart(state)) {
+            state.lastStringValue += codePointToString2(state.lastIntValue);
+          }
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatRegExpIdentifierStart = function(state) {
+        var start3 = state.pos;
+        var forceU = this.options.ecmaVersion >= 11;
+        var ch = state.current(forceU);
+        state.advance(forceU);
+        if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+          ch = state.lastIntValue;
+        }
+        if (isRegExpIdentifierStart2(ch)) {
+          state.lastIntValue = ch;
+          return true;
+        }
+        state.pos = start3;
+        return false;
+      };
+      function isRegExpIdentifierStart2(ch) {
+        return isIdentifierStart2(ch, true) || ch === 36 || ch === 95;
+      }
+      pp$12.regexp_eatRegExpIdentifierPart = function(state) {
+        var start3 = state.pos;
+        var forceU = this.options.ecmaVersion >= 11;
+        var ch = state.current(forceU);
+        state.advance(forceU);
+        if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+          ch = state.lastIntValue;
+        }
+        if (isRegExpIdentifierPart2(ch)) {
+          state.lastIntValue = ch;
+          return true;
+        }
+        state.pos = start3;
+        return false;
+      };
+      function isRegExpIdentifierPart2(ch) {
+        return isIdentifierChar2(ch, true) || ch === 36 || ch === 95 || ch === 8204 || ch === 8205;
+      }
+      pp$12.regexp_eatAtomEscape = function(state) {
+        if (this.regexp_eatBackReference(state) || this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state) || state.switchN && this.regexp_eatKGroupName(state)) {
+          return true;
+        }
+        if (state.switchU) {
+          if (state.current() === 99) {
+            state.raise("Invalid unicode escape");
+          }
+          state.raise("Invalid escape");
+        }
+        return false;
+      };
+      pp$12.regexp_eatBackReference = function(state) {
+        var start3 = state.pos;
+        if (this.regexp_eatDecimalEscape(state)) {
+          var n = state.lastIntValue;
+          if (state.switchU) {
+            if (n > state.maxBackReference) {
+              state.maxBackReference = n;
+            }
+            return true;
+          }
+          if (n <= state.numCapturingParens) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatKGroupName = function(state) {
+        if (state.eat(107)) {
+          if (this.regexp_eatGroupName(state)) {
+            state.backReferenceNames.push(state.lastStringValue);
+            return true;
+          }
+          state.raise("Invalid named reference");
+        }
+        return false;
+      };
+      pp$12.regexp_eatCharacterEscape = function(state) {
+        return this.regexp_eatControlEscape(state) || this.regexp_eatCControlLetter(state) || this.regexp_eatZero(state) || this.regexp_eatHexEscapeSequence(state) || this.regexp_eatRegExpUnicodeEscapeSequence(state, false) || !state.switchU && this.regexp_eatLegacyOctalEscapeSequence(state) || this.regexp_eatIdentityEscape(state);
+      };
+      pp$12.regexp_eatCControlLetter = function(state) {
+        var start3 = state.pos;
+        if (state.eat(99)) {
+          if (this.regexp_eatControlLetter(state)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatZero = function(state) {
+        if (state.current() === 48 && !isDecimalDigit2(state.lookahead())) {
+          state.lastIntValue = 0;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatControlEscape = function(state) {
+        var ch = state.current();
+        if (ch === 116) {
+          state.lastIntValue = 9;
+          state.advance();
+          return true;
+        }
+        if (ch === 110) {
+          state.lastIntValue = 10;
+          state.advance();
+          return true;
+        }
+        if (ch === 118) {
+          state.lastIntValue = 11;
+          state.advance();
+          return true;
+        }
+        if (ch === 102) {
+          state.lastIntValue = 12;
+          state.advance();
+          return true;
+        }
+        if (ch === 114) {
+          state.lastIntValue = 13;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatControlLetter = function(state) {
+        var ch = state.current();
+        if (isControlLetter2(ch)) {
+          state.lastIntValue = ch % 32;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      function isControlLetter2(ch) {
+        return ch >= 65 && ch <= 90 || ch >= 97 && ch <= 122;
+      }
+      pp$12.regexp_eatRegExpUnicodeEscapeSequence = function(state, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        var start3 = state.pos;
+        var switchU = forceU || state.switchU;
+        if (state.eat(117)) {
+          if (this.regexp_eatFixedHexDigits(state, 4)) {
+            var lead = state.lastIntValue;
+            if (switchU && lead >= 55296 && lead <= 56319) {
+              var leadSurrogateEnd = state.pos;
+              if (state.eat(92) && state.eat(117) && this.regexp_eatFixedHexDigits(state, 4)) {
+                var trail = state.lastIntValue;
+                if (trail >= 56320 && trail <= 57343) {
+                  state.lastIntValue = (lead - 55296) * 1024 + (trail - 56320) + 65536;
+                  return true;
+                }
+              }
+              state.pos = leadSurrogateEnd;
+              state.lastIntValue = lead;
+            }
+            return true;
+          }
+          if (switchU && state.eat(123) && this.regexp_eatHexDigits(state) && state.eat(125) && isValidUnicode2(state.lastIntValue)) {
+            return true;
+          }
+          if (switchU) {
+            state.raise("Invalid unicode escape");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      function isValidUnicode2(ch) {
+        return ch >= 0 && ch <= 1114111;
+      }
+      pp$12.regexp_eatIdentityEscape = function(state) {
+        if (state.switchU) {
+          if (this.regexp_eatSyntaxCharacter(state)) {
+            return true;
+          }
+          if (state.eat(47)) {
+            state.lastIntValue = 47;
+            return true;
+          }
+          return false;
+        }
+        var ch = state.current();
+        if (ch !== 99 && (!state.switchN || ch !== 107)) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatDecimalEscape = function(state) {
+        state.lastIntValue = 0;
+        var ch = state.current();
+        if (ch >= 49 && ch <= 57) {
+          do {
+            state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+            state.advance();
+          } while ((ch = state.current()) >= 48 && ch <= 57);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatCharacterClassEscape = function(state) {
+        var ch = state.current();
+        if (isCharacterClassEscape2(ch)) {
+          state.lastIntValue = -1;
+          state.advance();
+          return true;
+        }
+        if (state.switchU && this.options.ecmaVersion >= 9 && (ch === 80 || ch === 112)) {
+          state.lastIntValue = -1;
+          state.advance();
+          if (state.eat(123) && this.regexp_eatUnicodePropertyValueExpression(state) && state.eat(125)) {
+            return true;
+          }
+          state.raise("Invalid property name");
+        }
+        return false;
+      };
+      function isCharacterClassEscape2(ch) {
+        return ch === 100 || ch === 68 || ch === 115 || ch === 83 || ch === 119 || ch === 87;
+      }
+      pp$12.regexp_eatUnicodePropertyValueExpression = function(state) {
+        var start3 = state.pos;
+        if (this.regexp_eatUnicodePropertyName(state) && state.eat(61)) {
+          var name2 = state.lastStringValue;
+          if (this.regexp_eatUnicodePropertyValue(state)) {
+            var value = state.lastStringValue;
+            this.regexp_validateUnicodePropertyNameAndValue(state, name2, value);
+            return true;
+          }
+        }
+        state.pos = start3;
+        if (this.regexp_eatLoneUnicodePropertyNameOrValue(state)) {
+          var nameOrValue = state.lastStringValue;
+          this.regexp_validateUnicodePropertyNameOrValue(state, nameOrValue);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_validateUnicodePropertyNameAndValue = function(state, name2, value) {
+        if (!hasOwn2(state.unicodeProperties.nonBinary, name2)) {
+          state.raise("Invalid property name");
+        }
+        if (!state.unicodeProperties.nonBinary[name2].test(value)) {
+          state.raise("Invalid property value");
+        }
+      };
+      pp$12.regexp_validateUnicodePropertyNameOrValue = function(state, nameOrValue) {
+        if (!state.unicodeProperties.binary.test(nameOrValue)) {
+          state.raise("Invalid property name");
+        }
+      };
+      pp$12.regexp_eatUnicodePropertyName = function(state) {
+        var ch = 0;
+        state.lastStringValue = "";
+        while (isUnicodePropertyNameCharacter2(ch = state.current())) {
+          state.lastStringValue += codePointToString2(ch);
+          state.advance();
+        }
+        return state.lastStringValue !== "";
+      };
+      function isUnicodePropertyNameCharacter2(ch) {
+        return isControlLetter2(ch) || ch === 95;
+      }
+      pp$12.regexp_eatUnicodePropertyValue = function(state) {
+        var ch = 0;
+        state.lastStringValue = "";
+        while (isUnicodePropertyValueCharacter2(ch = state.current())) {
+          state.lastStringValue += codePointToString2(ch);
+          state.advance();
+        }
+        return state.lastStringValue !== "";
+      };
+      function isUnicodePropertyValueCharacter2(ch) {
+        return isUnicodePropertyNameCharacter2(ch) || isDecimalDigit2(ch);
+      }
+      pp$12.regexp_eatLoneUnicodePropertyNameOrValue = function(state) {
+        return this.regexp_eatUnicodePropertyValue(state);
+      };
+      pp$12.regexp_eatCharacterClass = function(state) {
+        if (state.eat(91)) {
+          state.eat(94);
+          this.regexp_classRanges(state);
+          if (state.eat(93)) {
+            return true;
+          }
+          state.raise("Unterminated character class");
+        }
+        return false;
+      };
+      pp$12.regexp_classRanges = function(state) {
+        while (this.regexp_eatClassAtom(state)) {
+          var left = state.lastIntValue;
+          if (state.eat(45) && this.regexp_eatClassAtom(state)) {
+            var right = state.lastIntValue;
+            if (state.switchU && (left === -1 || right === -1)) {
+              state.raise("Invalid character class");
+            }
+            if (left !== -1 && right !== -1 && left > right) {
+              state.raise("Range out of order in character class");
+            }
+          }
+        }
+      };
+      pp$12.regexp_eatClassAtom = function(state) {
+        var start3 = state.pos;
+        if (state.eat(92)) {
+          if (this.regexp_eatClassEscape(state)) {
+            return true;
+          }
+          if (state.switchU) {
+            var ch$1 = state.current();
+            if (ch$1 === 99 || isOctalDigit2(ch$1)) {
+              state.raise("Invalid class escape");
+            }
+            state.raise("Invalid escape");
+          }
+          state.pos = start3;
+        }
+        var ch = state.current();
+        if (ch !== 93) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatClassEscape = function(state) {
+        var start3 = state.pos;
+        if (state.eat(98)) {
+          state.lastIntValue = 8;
+          return true;
+        }
+        if (state.switchU && state.eat(45)) {
+          state.lastIntValue = 45;
+          return true;
+        }
+        if (!state.switchU && state.eat(99)) {
+          if (this.regexp_eatClassControlLetter(state)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state);
+      };
+      pp$12.regexp_eatClassControlLetter = function(state) {
+        var ch = state.current();
+        if (isDecimalDigit2(ch) || ch === 95) {
+          state.lastIntValue = ch % 32;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatHexEscapeSequence = function(state) {
+        var start3 = state.pos;
+        if (state.eat(120)) {
+          if (this.regexp_eatFixedHexDigits(state, 2)) {
+            return true;
+          }
+          if (state.switchU) {
+            state.raise("Invalid escape");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatDecimalDigits = function(state) {
+        var start3 = state.pos;
+        var ch = 0;
+        state.lastIntValue = 0;
+        while (isDecimalDigit2(ch = state.current())) {
+          state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+          state.advance();
+        }
+        return state.pos !== start3;
+      };
+      function isDecimalDigit2(ch) {
+        return ch >= 48 && ch <= 57;
+      }
+      pp$12.regexp_eatHexDigits = function(state) {
+        var start3 = state.pos;
+        var ch = 0;
+        state.lastIntValue = 0;
+        while (isHexDigit2(ch = state.current())) {
+          state.lastIntValue = 16 * state.lastIntValue + hexToInt2(ch);
+          state.advance();
+        }
+        return state.pos !== start3;
+      };
+      function isHexDigit2(ch) {
+        return ch >= 48 && ch <= 57 || ch >= 65 && ch <= 70 || ch >= 97 && ch <= 102;
+      }
+      function hexToInt2(ch) {
+        if (ch >= 65 && ch <= 70) {
+          return 10 + (ch - 65);
+        }
+        if (ch >= 97 && ch <= 102) {
+          return 10 + (ch - 97);
+        }
+        return ch - 48;
+      }
+      pp$12.regexp_eatLegacyOctalEscapeSequence = function(state) {
+        if (this.regexp_eatOctalDigit(state)) {
+          var n1 = state.lastIntValue;
+          if (this.regexp_eatOctalDigit(state)) {
+            var n2 = state.lastIntValue;
+            if (n1 <= 3 && this.regexp_eatOctalDigit(state)) {
+              state.lastIntValue = n1 * 64 + n2 * 8 + state.lastIntValue;
+            } else {
+              state.lastIntValue = n1 * 8 + n2;
+            }
+          } else {
+            state.lastIntValue = n1;
+          }
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatOctalDigit = function(state) {
+        var ch = state.current();
+        if (isOctalDigit2(ch)) {
+          state.lastIntValue = ch - 48;
+          state.advance();
+          return true;
+        }
+        state.lastIntValue = 0;
+        return false;
+      };
+      function isOctalDigit2(ch) {
+        return ch >= 48 && ch <= 55;
+      }
+      pp$12.regexp_eatFixedHexDigits = function(state, length) {
+        var start3 = state.pos;
+        state.lastIntValue = 0;
+        for (var i2 = 0; i2 < length; ++i2) {
+          var ch = state.current();
+          if (!isHexDigit2(ch)) {
+            state.pos = start3;
+            return false;
+          }
+          state.lastIntValue = 16 * state.lastIntValue + hexToInt2(ch);
+          state.advance();
+        }
+        return true;
+      };
+      var Token3 = function Token4(p) {
+        this.type = p.type;
+        this.value = p.value;
+        this.start = p.start;
+        this.end = p.end;
+        if (p.options.locations) {
+          this.loc = new SourceLocation3(p, p.startLoc, p.endLoc);
+        }
+        if (p.options.ranges) {
+          this.range = [p.start, p.end];
+        }
+      };
+      var pp2 = Parser3.prototype;
+      pp2.next = function(ignoreEscapeSequenceInKeyword) {
+        if (!ignoreEscapeSequenceInKeyword && this.type.keyword && this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword " + this.type.keyword);
+        }
+        if (this.options.onToken) {
+          this.options.onToken(new Token3(this));
+        }
+        this.lastTokEnd = this.end;
+        this.lastTokStart = this.start;
+        this.lastTokEndLoc = this.endLoc;
+        this.lastTokStartLoc = this.startLoc;
+        this.nextToken();
+      };
+      pp2.getToken = function() {
+        this.next();
+        return new Token3(this);
+      };
+      if (typeof Symbol !== "undefined") {
+        pp2[Symbol.iterator] = function() {
+          var this$1$1 = this;
+          return {
+            next: function() {
+              var token = this$1$1.getToken();
+              return {
+                done: token.type === types$12.eof,
+                value: token
+              };
+            }
+          };
+        };
+      }
+      pp2.nextToken = function() {
+        var curContext = this.curContext();
+        if (!curContext || !curContext.preserveSpace) {
+          this.skipSpace();
+        }
+        this.start = this.pos;
+        if (this.options.locations) {
+          this.startLoc = this.curPosition();
+        }
+        if (this.pos >= this.input.length) {
+          return this.finishToken(types$12.eof);
+        }
+        if (curContext.override) {
+          return curContext.override(this);
+        } else {
+          this.readToken(this.fullCharCodeAtPos());
+        }
+      };
+      pp2.readToken = function(code2) {
+        if (isIdentifierStart2(code2, this.options.ecmaVersion >= 6) || code2 === 92) {
+          return this.readWord();
+        }
+        return this.getTokenFromCode(code2);
+      };
+      pp2.fullCharCodeAtPos = function() {
+        var code2 = this.input.charCodeAt(this.pos);
+        if (code2 <= 55295 || code2 >= 56320) {
+          return code2;
+        }
+        var next = this.input.charCodeAt(this.pos + 1);
+        return next <= 56319 || next >= 57344 ? code2 : (code2 << 10) + next - 56613888;
+      };
+      pp2.skipBlockComment = function() {
+        var startLoc = this.options.onComment && this.curPosition();
+        var start3 = this.pos, end = this.input.indexOf("*/", this.pos += 2);
+        if (end === -1) {
+          this.raise(this.pos - 2, "Unterminated comment");
+        }
+        this.pos = end + 2;
+        if (this.options.locations) {
+          for (var nextBreak = void 0, pos = start3; (nextBreak = nextLineBreak2(this.input, pos, this.pos)) > -1; ) {
+            ++this.curLine;
+            pos = this.lineStart = nextBreak;
+          }
+        }
+        if (this.options.onComment) {
+          this.options.onComment(
+            true,
+            this.input.slice(start3 + 2, end),
+            start3,
+            this.pos,
+            startLoc,
+            this.curPosition()
+          );
+        }
+      };
+      pp2.skipLineComment = function(startSkip) {
+        var start3 = this.pos;
+        var startLoc = this.options.onComment && this.curPosition();
+        var ch = this.input.charCodeAt(this.pos += startSkip);
+        while (this.pos < this.input.length && !isNewLine2(ch)) {
+          ch = this.input.charCodeAt(++this.pos);
+        }
+        if (this.options.onComment) {
+          this.options.onComment(
+            false,
+            this.input.slice(start3 + startSkip, this.pos),
+            start3,
+            this.pos,
+            startLoc,
+            this.curPosition()
+          );
+        }
+      };
+      pp2.skipSpace = function() {
+        loop:
+          while (this.pos < this.input.length) {
+            var ch = this.input.charCodeAt(this.pos);
+            switch (ch) {
+              case 32:
+              case 160:
+                ++this.pos;
+                break;
+              case 13:
+                if (this.input.charCodeAt(this.pos + 1) === 10) {
+                  ++this.pos;
+                }
+              case 10:
+              case 8232:
+              case 8233:
+                ++this.pos;
+                if (this.options.locations) {
+                  ++this.curLine;
+                  this.lineStart = this.pos;
+                }
+                break;
+              case 47:
+                switch (this.input.charCodeAt(this.pos + 1)) {
+                  case 42:
+                    this.skipBlockComment();
+                    break;
+                  case 47:
+                    this.skipLineComment(2);
+                    break;
+                  default:
+                    break loop;
+                }
+                break;
+              default:
+                if (ch > 8 && ch < 14 || ch >= 5760 && nonASCIIwhitespace2.test(String.fromCharCode(ch))) {
+                  ++this.pos;
+                } else {
+                  break loop;
+                }
+            }
+          }
+      };
+      pp2.finishToken = function(type, val) {
+        this.end = this.pos;
+        if (this.options.locations) {
+          this.endLoc = this.curPosition();
+        }
+        var prevType = this.type;
+        this.type = type;
+        this.value = val;
+        this.updateContext(prevType);
+      };
+      pp2.readToken_dot = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next >= 48 && next <= 57) {
+          return this.readNumber(true);
+        }
+        var next2 = this.input.charCodeAt(this.pos + 2);
+        if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) {
+          this.pos += 3;
+          return this.finishToken(types$12.ellipsis);
+        } else {
+          ++this.pos;
+          return this.finishToken(types$12.dot);
+        }
+      };
+      pp2.readToken_slash = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (this.exprAllowed) {
+          ++this.pos;
+          return this.readRegexp();
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(types$12.slash, 1);
+      };
+      pp2.readToken_mult_modulo_exp = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        var size = 1;
+        var tokentype = code2 === 42 ? types$12.star : types$12.modulo;
+        if (this.options.ecmaVersion >= 7 && code2 === 42 && next === 42) {
+          ++size;
+          tokentype = types$12.starstar;
+          next = this.input.charCodeAt(this.pos + 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, size + 1);
+        }
+        return this.finishOp(tokentype, size);
+      };
+      pp2.readToken_pipe_amp = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === code2) {
+          if (this.options.ecmaVersion >= 12) {
+            var next2 = this.input.charCodeAt(this.pos + 2);
+            if (next2 === 61) {
+              return this.finishOp(types$12.assign, 3);
+            }
+          }
+          return this.finishOp(code2 === 124 ? types$12.logicalOR : types$12.logicalAND, 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(code2 === 124 ? types$12.bitwiseOR : types$12.bitwiseAND, 1);
+      };
+      pp2.readToken_caret = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(types$12.bitwiseXOR, 1);
+      };
+      pp2.readToken_plus_min = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === code2) {
+          if (next === 45 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 62 && (this.lastTokEnd === 0 || lineBreak2.test(this.input.slice(this.lastTokEnd, this.pos)))) {
+            this.skipLineComment(3);
+            this.skipSpace();
+            return this.nextToken();
+          }
+          return this.finishOp(types$12.incDec, 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(types$12.plusMin, 1);
+      };
+      pp2.readToken_lt_gt = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        var size = 1;
+        if (next === code2) {
+          size = code2 === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+          if (this.input.charCodeAt(this.pos + size) === 61) {
+            return this.finishOp(types$12.assign, size + 1);
+          }
+          return this.finishOp(types$12.bitShift, size);
+        }
+        if (next === 33 && code2 === 60 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 45 && this.input.charCodeAt(this.pos + 3) === 45) {
+          this.skipLineComment(4);
+          this.skipSpace();
+          return this.nextToken();
+        }
+        if (next === 61) {
+          size = 2;
+        }
+        return this.finishOp(types$12.relational, size);
+      };
+      pp2.readToken_eq_excl = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === 61) {
+          return this.finishOp(types$12.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+        }
+        if (code2 === 61 && next === 62 && this.options.ecmaVersion >= 6) {
+          this.pos += 2;
+          return this.finishToken(types$12.arrow);
+        }
+        return this.finishOp(code2 === 61 ? types$12.eq : types$12.prefix, 1);
+      };
+      pp2.readToken_question = function() {
+        var ecmaVersion2 = this.options.ecmaVersion;
+        if (ecmaVersion2 >= 11) {
+          var next = this.input.charCodeAt(this.pos + 1);
+          if (next === 46) {
+            var next2 = this.input.charCodeAt(this.pos + 2);
+            if (next2 < 48 || next2 > 57) {
+              return this.finishOp(types$12.questionDot, 2);
+            }
+          }
+          if (next === 63) {
+            if (ecmaVersion2 >= 12) {
+              var next2$1 = this.input.charCodeAt(this.pos + 2);
+              if (next2$1 === 61) {
+                return this.finishOp(types$12.assign, 3);
+              }
+            }
+            return this.finishOp(types$12.coalesce, 2);
+          }
+        }
+        return this.finishOp(types$12.question, 1);
+      };
+      pp2.readToken_numberSign = function() {
+        var ecmaVersion2 = this.options.ecmaVersion;
+        var code2 = 35;
+        if (ecmaVersion2 >= 13) {
+          ++this.pos;
+          code2 = this.fullCharCodeAtPos();
+          if (isIdentifierStart2(code2, true) || code2 === 92) {
+            return this.finishToken(types$12.privateId, this.readWord1());
+          }
+        }
+        this.raise(this.pos, "Unexpected character '" + codePointToString2(code2) + "'");
+      };
+      pp2.getTokenFromCode = function(code2) {
+        switch (code2) {
+          case 46:
+            return this.readToken_dot();
+          case 40:
+            ++this.pos;
+            return this.finishToken(types$12.parenL);
+          case 41:
+            ++this.pos;
+            return this.finishToken(types$12.parenR);
+          case 59:
+            ++this.pos;
+            return this.finishToken(types$12.semi);
+          case 44:
+            ++this.pos;
+            return this.finishToken(types$12.comma);
+          case 91:
+            ++this.pos;
+            return this.finishToken(types$12.bracketL);
+          case 93:
+            ++this.pos;
+            return this.finishToken(types$12.bracketR);
+          case 123:
+            ++this.pos;
+            return this.finishToken(types$12.braceL);
+          case 125:
+            ++this.pos;
+            return this.finishToken(types$12.braceR);
+          case 58:
+            ++this.pos;
+            return this.finishToken(types$12.colon);
+          case 96:
+            if (this.options.ecmaVersion < 6) {
+              break;
+            }
+            ++this.pos;
+            return this.finishToken(types$12.backQuote);
+          case 48:
+            var next = this.input.charCodeAt(this.pos + 1);
+            if (next === 120 || next === 88) {
+              return this.readRadixNumber(16);
+            }
+            if (this.options.ecmaVersion >= 6) {
+              if (next === 111 || next === 79) {
+                return this.readRadixNumber(8);
+              }
+              if (next === 98 || next === 66) {
+                return this.readRadixNumber(2);
+              }
+            }
+          case 49:
+          case 50:
+          case 51:
+          case 52:
+          case 53:
+          case 54:
+          case 55:
+          case 56:
+          case 57:
+            return this.readNumber(false);
+          case 34:
+          case 39:
+            return this.readString(code2);
+          case 47:
+            return this.readToken_slash();
+          case 37:
+          case 42:
+            return this.readToken_mult_modulo_exp(code2);
+          case 124:
+          case 38:
+            return this.readToken_pipe_amp(code2);
+          case 94:
+            return this.readToken_caret();
+          case 43:
+          case 45:
+            return this.readToken_plus_min(code2);
+          case 60:
+          case 62:
+            return this.readToken_lt_gt(code2);
+          case 61:
+          case 33:
+            return this.readToken_eq_excl(code2);
+          case 63:
+            return this.readToken_question();
+          case 126:
+            return this.finishOp(types$12.prefix, 1);
+          case 35:
+            return this.readToken_numberSign();
+        }
+        this.raise(this.pos, "Unexpected character '" + codePointToString2(code2) + "'");
+      };
+      pp2.finishOp = function(type, size) {
+        var str = this.input.slice(this.pos, this.pos + size);
+        this.pos += size;
+        return this.finishToken(type, str);
+      };
+      pp2.readRegexp = function() {
+        var escaped, inClass, start3 = this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(start3, "Unterminated regular expression");
+          }
+          var ch = this.input.charAt(this.pos);
+          if (lineBreak2.test(ch)) {
+            this.raise(start3, "Unterminated regular expression");
+          }
+          if (!escaped) {
+            if (ch === "[") {
+              inClass = true;
+            } else if (ch === "]" && inClass) {
+              inClass = false;
+            } else if (ch === "/" && !inClass) {
+              break;
+            }
+            escaped = ch === "\\";
+          } else {
+            escaped = false;
+          }
+          ++this.pos;
+        }
+        var pattern = this.input.slice(start3, this.pos);
+        ++this.pos;
+        var flagsStart = this.pos;
+        var flags = this.readWord1();
+        if (this.containsEsc) {
+          this.unexpected(flagsStart);
+        }
+        var state = this.regexpState || (this.regexpState = new RegExpValidationState3(this));
+        state.reset(start3, pattern, flags);
+        this.validateRegExpFlags(state);
+        this.validateRegExpPattern(state);
+        var value = null;
+        try {
+          value = new RegExp(pattern, flags);
+        } catch (e) {
+        }
+        return this.finishToken(types$12.regexp, { pattern, flags, value });
+      };
+      pp2.readInt = function(radix, len, maybeLegacyOctalNumericLiteral) {
+        var allowSeparators = this.options.ecmaVersion >= 12 && len === void 0;
+        var isLegacyOctalNumericLiteral = maybeLegacyOctalNumericLiteral && this.input.charCodeAt(this.pos) === 48;
+        var start3 = this.pos, total = 0, lastCode = 0;
+        for (var i2 = 0, e = len == null ? Infinity : len; i2 < e; ++i2, ++this.pos) {
+          var code2 = this.input.charCodeAt(this.pos), val = void 0;
+          if (allowSeparators && code2 === 95) {
+            if (isLegacyOctalNumericLiteral) {
+              this.raiseRecoverable(this.pos, "Numeric separator is not allowed in legacy octal numeric literals");
+            }
+            if (lastCode === 95) {
+              this.raiseRecoverable(this.pos, "Numeric separator must be exactly one underscore");
+            }
+            if (i2 === 0) {
+              this.raiseRecoverable(this.pos, "Numeric separator is not allowed at the first of digits");
+            }
+            lastCode = code2;
+            continue;
+          }
+          if (code2 >= 97) {
+            val = code2 - 97 + 10;
+          } else if (code2 >= 65) {
+            val = code2 - 65 + 10;
+          } else if (code2 >= 48 && code2 <= 57) {
+            val = code2 - 48;
+          } else {
+            val = Infinity;
+          }
+          if (val >= radix) {
+            break;
+          }
+          lastCode = code2;
+          total = total * radix + val;
+        }
+        if (allowSeparators && lastCode === 95) {
+          this.raiseRecoverable(this.pos - 1, "Numeric separator is not allowed at the last of digits");
+        }
+        if (this.pos === start3 || len != null && this.pos - start3 !== len) {
+          return null;
+        }
+        return total;
+      };
+      function stringToNumber2(str, isLegacyOctalNumericLiteral) {
+        if (isLegacyOctalNumericLiteral) {
+          return parseInt(str, 8);
+        }
+        return parseFloat(str.replace(/_/g, ""));
+      }
+      function stringToBigInt2(str) {
+        if (typeof BigInt !== "function") {
+          return null;
+        }
+        return BigInt(str.replace(/_/g, ""));
+      }
+      pp2.readRadixNumber = function(radix) {
+        var start3 = this.pos;
+        this.pos += 2;
+        var val = this.readInt(radix);
+        if (val == null) {
+          this.raise(this.start + 2, "Expected number in radix " + radix);
+        }
+        if (this.options.ecmaVersion >= 11 && this.input.charCodeAt(this.pos) === 110) {
+          val = stringToBigInt2(this.input.slice(start3, this.pos));
+          ++this.pos;
+        } else if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+          this.raise(this.pos, "Identifier directly after number");
+        }
+        return this.finishToken(types$12.num, val);
+      };
+      pp2.readNumber = function(startsWithDot) {
+        var start3 = this.pos;
+        if (!startsWithDot && this.readInt(10, void 0, true) === null) {
+          this.raise(start3, "Invalid number");
+        }
+        var octal = this.pos - start3 >= 2 && this.input.charCodeAt(start3) === 48;
+        if (octal && this.strict) {
+          this.raise(start3, "Invalid number");
+        }
+        var next = this.input.charCodeAt(this.pos);
+        if (!octal && !startsWithDot && this.options.ecmaVersion >= 11 && next === 110) {
+          var val$1 = stringToBigInt2(this.input.slice(start3, this.pos));
+          ++this.pos;
+          if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+            this.raise(this.pos, "Identifier directly after number");
+          }
+          return this.finishToken(types$12.num, val$1);
+        }
+        if (octal && /[89]/.test(this.input.slice(start3, this.pos))) {
+          octal = false;
+        }
+        if (next === 46 && !octal) {
+          ++this.pos;
+          this.readInt(10);
+          next = this.input.charCodeAt(this.pos);
+        }
+        if ((next === 69 || next === 101) && !octal) {
+          next = this.input.charCodeAt(++this.pos);
+          if (next === 43 || next === 45) {
+            ++this.pos;
+          }
+          if (this.readInt(10) === null) {
+            this.raise(start3, "Invalid number");
+          }
+        }
+        if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+          this.raise(this.pos, "Identifier directly after number");
+        }
+        var val = stringToNumber2(this.input.slice(start3, this.pos), octal);
+        return this.finishToken(types$12.num, val);
+      };
+      pp2.readCodePoint = function() {
+        var ch = this.input.charCodeAt(this.pos), code2;
+        if (ch === 123) {
+          if (this.options.ecmaVersion < 6) {
+            this.unexpected();
+          }
+          var codePos = ++this.pos;
+          code2 = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos);
+          ++this.pos;
+          if (code2 > 1114111) {
+            this.invalidStringToken(codePos, "Code point out of bounds");
+          }
+        } else {
+          code2 = this.readHexChar(4);
+        }
+        return code2;
+      };
+      pp2.readString = function(quote) {
+        var out = "", chunkStart = ++this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(this.start, "Unterminated string constant");
+          }
+          var ch = this.input.charCodeAt(this.pos);
+          if (ch === quote) {
+            break;
+          }
+          if (ch === 92) {
+            out += this.input.slice(chunkStart, this.pos);
+            out += this.readEscapedChar(false);
+            chunkStart = this.pos;
+          } else if (ch === 8232 || ch === 8233) {
+            if (this.options.ecmaVersion < 10) {
+              this.raise(this.start, "Unterminated string constant");
+            }
+            ++this.pos;
+            if (this.options.locations) {
+              this.curLine++;
+              this.lineStart = this.pos;
+            }
+          } else {
+            if (isNewLine2(ch)) {
+              this.raise(this.start, "Unterminated string constant");
+            }
+            ++this.pos;
+          }
+        }
+        out += this.input.slice(chunkStart, this.pos++);
+        return this.finishToken(types$12.string, out);
+      };
+      var INVALID_TEMPLATE_ESCAPE_ERROR2 = {};
+      pp2.tryReadTemplateToken = function() {
+        this.inTemplateElement = true;
+        try {
+          this.readTmplToken();
+        } catch (err) {
+          if (err === INVALID_TEMPLATE_ESCAPE_ERROR2) {
+            this.readInvalidTemplateToken();
+          } else {
+            throw err;
+          }
+        }
+        this.inTemplateElement = false;
+      };
+      pp2.invalidStringToken = function(position3, message) {
+        if (this.inTemplateElement && this.options.ecmaVersion >= 9) {
+          throw INVALID_TEMPLATE_ESCAPE_ERROR2;
+        } else {
+          this.raise(position3, message);
+        }
+      };
+      pp2.readTmplToken = function() {
+        var out = "", chunkStart = this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(this.start, "Unterminated template");
+          }
+          var ch = this.input.charCodeAt(this.pos);
+          if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) {
+            if (this.pos === this.start && (this.type === types$12.template || this.type === types$12.invalidTemplate)) {
+              if (ch === 36) {
+                this.pos += 2;
+                return this.finishToken(types$12.dollarBraceL);
+              } else {
+                ++this.pos;
+                return this.finishToken(types$12.backQuote);
+              }
+            }
+            out += this.input.slice(chunkStart, this.pos);
+            return this.finishToken(types$12.template, out);
+          }
+          if (ch === 92) {
+            out += this.input.slice(chunkStart, this.pos);
+            out += this.readEscapedChar(true);
+            chunkStart = this.pos;
+          } else if (isNewLine2(ch)) {
+            out += this.input.slice(chunkStart, this.pos);
+            ++this.pos;
+            switch (ch) {
+              case 13:
+                if (this.input.charCodeAt(this.pos) === 10) {
+                  ++this.pos;
+                }
+              case 10:
+                out += "\n";
+                break;
+              default:
+                out += String.fromCharCode(ch);
+                break;
+            }
+            if (this.options.locations) {
+              ++this.curLine;
+              this.lineStart = this.pos;
+            }
+            chunkStart = this.pos;
+          } else {
+            ++this.pos;
+          }
+        }
+      };
+      pp2.readInvalidTemplateToken = function() {
+        for (; this.pos < this.input.length; this.pos++) {
+          switch (this.input[this.pos]) {
+            case "\\":
+              ++this.pos;
+              break;
+            case "$":
+              if (this.input[this.pos + 1] !== "{") {
+                break;
+              }
+            case "`":
+              return this.finishToken(types$12.invalidTemplate, this.input.slice(this.start, this.pos));
+          }
+        }
+        this.raise(this.start, "Unterminated template");
+      };
+      pp2.readEscapedChar = function(inTemplate) {
+        var ch = this.input.charCodeAt(++this.pos);
+        ++this.pos;
+        switch (ch) {
+          case 110:
+            return "\n";
+          case 114:
+            return "\r";
+          case 120:
+            return String.fromCharCode(this.readHexChar(2));
+          case 117:
+            return codePointToString2(this.readCodePoint());
+          case 116:
+            return "	";
+          case 98:
+            return "\b";
+          case 118:
+            return "\v";
+          case 102:
+            return "\f";
+          case 13:
+            if (this.input.charCodeAt(this.pos) === 10) {
+              ++this.pos;
+            }
+          case 10:
+            if (this.options.locations) {
+              this.lineStart = this.pos;
+              ++this.curLine;
+            }
+            return "";
+          case 56:
+          case 57:
+            if (this.strict) {
+              this.invalidStringToken(
+                this.pos - 1,
+                "Invalid escape sequence"
+              );
+            }
+            if (inTemplate) {
+              var codePos = this.pos - 1;
+              this.invalidStringToken(
+                codePos,
+                "Invalid escape sequence in template string"
+              );
+              return null;
+            }
+          default:
+            if (ch >= 48 && ch <= 55) {
+              var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+              var octal = parseInt(octalStr, 8);
+              if (octal > 255) {
+                octalStr = octalStr.slice(0, -1);
+                octal = parseInt(octalStr, 8);
+              }
+              this.pos += octalStr.length - 1;
+              ch = this.input.charCodeAt(this.pos);
+              if ((octalStr !== "0" || ch === 56 || ch === 57) && (this.strict || inTemplate)) {
+                this.invalidStringToken(
+                  this.pos - 1 - octalStr.length,
+                  inTemplate ? "Octal literal in template string" : "Octal literal in strict mode"
+                );
+              }
+              return String.fromCharCode(octal);
+            }
+            if (isNewLine2(ch)) {
+              return "";
+            }
+            return String.fromCharCode(ch);
+        }
+      };
+      pp2.readHexChar = function(len) {
+        var codePos = this.pos;
+        var n = this.readInt(16, len);
+        if (n === null) {
+          this.invalidStringToken(codePos, "Bad character escape sequence");
+        }
+        return n;
+      };
+      pp2.readWord1 = function() {
+        this.containsEsc = false;
+        var word = "", first = true, chunkStart = this.pos;
+        var astral = this.options.ecmaVersion >= 6;
+        while (this.pos < this.input.length) {
+          var ch = this.fullCharCodeAtPos();
+          if (isIdentifierChar2(ch, astral)) {
+            this.pos += ch <= 65535 ? 1 : 2;
+          } else if (ch === 92) {
+            this.containsEsc = true;
+            word += this.input.slice(chunkStart, this.pos);
+            var escStart = this.pos;
+            if (this.input.charCodeAt(++this.pos) !== 117) {
+              this.invalidStringToken(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+            }
+            ++this.pos;
+            var esc = this.readCodePoint();
+            if (!(first ? isIdentifierStart2 : isIdentifierChar2)(esc, astral)) {
+              this.invalidStringToken(escStart, "Invalid Unicode escape");
+            }
+            word += codePointToString2(esc);
+            chunkStart = this.pos;
+          } else {
+            break;
+          }
+          first = false;
+        }
+        return word + this.input.slice(chunkStart, this.pos);
+      };
+      pp2.readWord = function() {
+        var word = this.readWord1();
+        var type = types$12.name;
+        if (this.keywords.test(word)) {
+          type = keywords2[word];
+        }
+        return this.finishToken(type, word);
+      };
+      var version2 = "8.8.1";
+      Parser3.acorn = {
+        Parser: Parser3,
+        version: version2,
+        defaultOptions: defaultOptions2,
+        Position: Position3,
+        SourceLocation: SourceLocation3,
+        getLineInfo: getLineInfo2,
+        Node: Node3,
+        TokenType: TokenType3,
+        tokTypes: types$12,
+        keywordTypes: keywords2,
+        TokContext: TokContext3,
+        tokContexts: types2,
+        isIdentifierChar: isIdentifierChar2,
+        isIdentifierStart: isIdentifierStart2,
+        Token: Token3,
+        isNewLine: isNewLine2,
+        lineBreak: lineBreak2,
+        lineBreakG: lineBreakG2,
+        nonASCIIwhitespace: nonASCIIwhitespace2
+      };
+      function parse4(input, options) {
+        return Parser3.parse(input, options);
+      }
+      function parseExpressionAt2(input, pos, options) {
+        return Parser3.parseExpressionAt(input, pos, options);
+      }
+      function tokenizer2(input, options) {
+        return Parser3.tokenizer(input, options);
+      }
+      exports2.Node = Node3;
+      exports2.Parser = Parser3;
+      exports2.Position = Position3;
+      exports2.SourceLocation = SourceLocation3;
+      exports2.TokContext = TokContext3;
+      exports2.Token = Token3;
+      exports2.TokenType = TokenType3;
+      exports2.defaultOptions = defaultOptions2;
+      exports2.getLineInfo = getLineInfo2;
+      exports2.isIdentifierChar = isIdentifierChar2;
+      exports2.isIdentifierStart = isIdentifierStart2;
+      exports2.isNewLine = isNewLine2;
+      exports2.keywordTypes = keywords2;
+      exports2.lineBreak = lineBreak2;
+      exports2.lineBreakG = lineBreakG2;
+      exports2.nonASCIIwhitespace = nonASCIIwhitespace2;
+      exports2.parse = parse4;
+      exports2.parseExpressionAt = parseExpressionAt2;
+      exports2.tokContexts = types2;
+      exports2.tokTypes = types$12;
+      exports2.tokenizer = tokenizer2;
+      exports2.version = version2;
+      Object.defineProperty(exports2, "__esModule", { value: true });
+    });
+  }
+});
+
+// node_modules/acorn-jsx/index.js
+var require_acorn_jsx = __commonJS({
+  "node_modules/acorn-jsx/index.js"(exports, module2) {
+    "use strict";
+    var XHTMLEntities = require_xhtml();
+    var hexNumber = /^[\da-fA-F]+$/;
+    var decimalNumber = /^\d+$/;
+    var acornJsxMap = /* @__PURE__ */ new WeakMap();
+    function getJsxTokens(acorn) {
+      acorn = acorn.Parser.acorn || acorn;
+      let acornJsx2 = acornJsxMap.get(acorn);
+      if (!acornJsx2) {
+        const tt = acorn.tokTypes;
+        const TokContext3 = acorn.TokContext;
+        const TokenType3 = acorn.TokenType;
+        const tc_oTag = new TokContext3("<tag", false);
+        const tc_cTag = new TokContext3("</tag", false);
+        const tc_expr = new TokContext3("<tag>...</tag>", true, true);
+        const tokContexts = {
+          tc_oTag,
+          tc_cTag,
+          tc_expr
+        };
+        const tokTypes = {
+          jsxName: new TokenType3("jsxName"),
+          jsxText: new TokenType3("jsxText", { beforeExpr: true }),
+          jsxTagStart: new TokenType3("jsxTagStart", { startsExpr: true }),
+          jsxTagEnd: new TokenType3("jsxTagEnd")
+        };
+        tokTypes.jsxTagStart.updateContext = function() {
+          this.context.push(tc_expr);
+          this.context.push(tc_oTag);
+          this.exprAllowed = false;
+        };
+        tokTypes.jsxTagEnd.updateContext = function(prevType) {
+          let out = this.context.pop();
+          if (out === tc_oTag && prevType === tt.slash || out === tc_cTag) {
+            this.context.pop();
+            this.exprAllowed = this.curContext() === tc_expr;
+          } else {
+            this.exprAllowed = true;
+          }
+        };
+        acornJsx2 = { tokContexts, tokTypes };
+        acornJsxMap.set(acorn, acornJsx2);
+      }
+      return acornJsx2;
+    }
+    function getQualifiedJSXName(object) {
+      if (!object)
+        return object;
+      if (object.type === "JSXIdentifier")
+        return object.name;
+      if (object.type === "JSXNamespacedName")
+        return object.namespace.name + ":" + object.name.name;
+      if (object.type === "JSXMemberExpression")
+        return getQualifiedJSXName(object.object) + "." + getQualifiedJSXName(object.property);
+    }
+    module2.exports = function(options) {
+      options = options || {};
+      return function(Parser3) {
+        return plugin({
+          allowNamespaces: options.allowNamespaces !== false,
+          allowNamespacedObjects: !!options.allowNamespacedObjects
+        }, Parser3);
+      };
+    };
+    Object.defineProperty(module2.exports, "tokTypes", {
+      get: function get_tokTypes() {
+        return getJsxTokens(require_acorn()).tokTypes;
+      },
+      configurable: true,
+      enumerable: true
+    });
+    function plugin(options, Parser3) {
+      const acorn = Parser3.acorn || require_acorn();
+      const acornJsx2 = getJsxTokens(acorn);
+      const tt = acorn.tokTypes;
+      const tok = acornJsx2.tokTypes;
+      const tokContexts = acorn.tokContexts;
+      const tc_oTag = acornJsx2.tokContexts.tc_oTag;
+      const tc_cTag = acornJsx2.tokContexts.tc_cTag;
+      const tc_expr = acornJsx2.tokContexts.tc_expr;
+      const isNewLine2 = acorn.isNewLine;
+      const isIdentifierStart2 = acorn.isIdentifierStart;
+      const isIdentifierChar2 = acorn.isIdentifierChar;
+      return class extends Parser3 {
+        static get acornJsx() {
+          return acornJsx2;
+        }
+        jsx_readToken() {
+          let out = "", chunkStart = this.pos;
+          for (; ; ) {
+            if (this.pos >= this.input.length)
+              this.raise(this.start, "Unterminated JSX contents");
+            let ch = this.input.charCodeAt(this.pos);
+            switch (ch) {
+              case 60:
+              case 123:
+                if (this.pos === this.start) {
+                  if (ch === 60 && this.exprAllowed) {
+                    ++this.pos;
+                    return this.finishToken(tok.jsxTagStart);
+                  }
+                  return this.getTokenFromCode(ch);
+                }
+                out += this.input.slice(chunkStart, this.pos);
+                return this.finishToken(tok.jsxText, out);
+              case 38:
+                out += this.input.slice(chunkStart, this.pos);
+                out += this.jsx_readEntity();
+                chunkStart = this.pos;
+                break;
+              case 62:
+              case 125:
+                this.raise(
+                  this.pos,
+                  "Unexpected token `" + this.input[this.pos] + "`. Did you mean `" + (ch === 62 ? "&gt;" : "&rbrace;") + '` or `{"' + this.input[this.pos] + '"}`?'
+                );
+              default:
+                if (isNewLine2(ch)) {
+                  out += this.input.slice(chunkStart, this.pos);
+                  out += this.jsx_readNewLine(true);
+                  chunkStart = this.pos;
+                } else {
+                  ++this.pos;
+                }
+            }
+          }
+        }
+        jsx_readNewLine(normalizeCRLF) {
+          let ch = this.input.charCodeAt(this.pos);
+          let out;
+          ++this.pos;
+          if (ch === 13 && this.input.charCodeAt(this.pos) === 10) {
+            ++this.pos;
+            out = normalizeCRLF ? "\n" : "\r\n";
+          } else {
+            out = String.fromCharCode(ch);
+          }
+          if (this.options.locations) {
+            ++this.curLine;
+            this.lineStart = this.pos;
+          }
+          return out;
+        }
+        jsx_readString(quote) {
+          let out = "", chunkStart = ++this.pos;
+          for (; ; ) {
+            if (this.pos >= this.input.length)
+              this.raise(this.start, "Unterminated string constant");
+            let ch = this.input.charCodeAt(this.pos);
+            if (ch === quote)
+              break;
+            if (ch === 38) {
+              out += this.input.slice(chunkStart, this.pos);
+              out += this.jsx_readEntity();
+              chunkStart = this.pos;
+            } else if (isNewLine2(ch)) {
+              out += this.input.slice(chunkStart, this.pos);
+              out += this.jsx_readNewLine(false);
+              chunkStart = this.pos;
+            } else {
+              ++this.pos;
+            }
+          }
+          out += this.input.slice(chunkStart, this.pos++);
+          return this.finishToken(tt.string, out);
+        }
+        jsx_readEntity() {
+          let str = "", count = 0, entity;
+          let ch = this.input[this.pos];
+          if (ch !== "&")
+            this.raise(this.pos, "Entity must start with an ampersand");
+          let startPos = ++this.pos;
+          while (this.pos < this.input.length && count++ < 10) {
+            ch = this.input[this.pos++];
+            if (ch === ";") {
+              if (str[0] === "#") {
+                if (str[1] === "x") {
+                  str = str.substr(2);
+                  if (hexNumber.test(str))
+                    entity = String.fromCharCode(parseInt(str, 16));
+                } else {
+                  str = str.substr(1);
+                  if (decimalNumber.test(str))
+                    entity = String.fromCharCode(parseInt(str, 10));
+                }
+              } else {
+                entity = XHTMLEntities[str];
+              }
+              break;
+            }
+            str += ch;
+          }
+          if (!entity) {
+            this.pos = startPos;
+            return "&";
+          }
+          return entity;
+        }
+        jsx_readWord() {
+          let ch, start3 = this.pos;
+          do {
+            ch = this.input.charCodeAt(++this.pos);
+          } while (isIdentifierChar2(ch) || ch === 45);
+          return this.finishToken(tok.jsxName, this.input.slice(start3, this.pos));
+        }
+        jsx_parseIdentifier() {
+          let node = this.startNode();
+          if (this.type === tok.jsxName)
+            node.name = this.value;
+          else if (this.type.keyword)
+            node.name = this.type.keyword;
+          else
+            this.unexpected();
+          this.next();
+          return this.finishNode(node, "JSXIdentifier");
+        }
+        jsx_parseNamespacedName() {
+          let startPos = this.start, startLoc = this.startLoc;
+          let name2 = this.jsx_parseIdentifier();
+          if (!options.allowNamespaces || !this.eat(tt.colon))
+            return name2;
+          var node = this.startNodeAt(startPos, startLoc);
+          node.namespace = name2;
+          node.name = this.jsx_parseIdentifier();
+          return this.finishNode(node, "JSXNamespacedName");
+        }
+        jsx_parseElementName() {
+          if (this.type === tok.jsxTagEnd)
+            return "";
+          let startPos = this.start, startLoc = this.startLoc;
+          let node = this.jsx_parseNamespacedName();
+          if (this.type === tt.dot && node.type === "JSXNamespacedName" && !options.allowNamespacedObjects) {
+            this.unexpected();
+          }
+          while (this.eat(tt.dot)) {
+            let newNode = this.startNodeAt(startPos, startLoc);
+            newNode.object = node;
+            newNode.property = this.jsx_parseIdentifier();
+            node = this.finishNode(newNode, "JSXMemberExpression");
+          }
+          return node;
+        }
+        jsx_parseAttributeValue() {
+          switch (this.type) {
+            case tt.braceL:
+              let node = this.jsx_parseExpressionContainer();
+              if (node.expression.type === "JSXEmptyExpression")
+                this.raise(node.start, "JSX attributes must only be assigned a non-empty expression");
+              return node;
+            case tok.jsxTagStart:
+            case tt.string:
+              return this.parseExprAtom();
+            default:
+              this.raise(this.start, "JSX value should be either an expression or a quoted JSX text");
+          }
+        }
+        jsx_parseEmptyExpression() {
+          let node = this.startNodeAt(this.lastTokEnd, this.lastTokEndLoc);
+          return this.finishNodeAt(node, "JSXEmptyExpression", this.start, this.startLoc);
+        }
+        jsx_parseExpressionContainer() {
+          let node = this.startNode();
+          this.next();
+          node.expression = this.type === tt.braceR ? this.jsx_parseEmptyExpression() : this.parseExpression();
+          this.expect(tt.braceR);
+          return this.finishNode(node, "JSXExpressionContainer");
+        }
+        jsx_parseAttribute() {
+          let node = this.startNode();
+          if (this.eat(tt.braceL)) {
+            this.expect(tt.ellipsis);
+            node.argument = this.parseMaybeAssign();
+            this.expect(tt.braceR);
+            return this.finishNode(node, "JSXSpreadAttribute");
+          }
+          node.name = this.jsx_parseNamespacedName();
+          node.value = this.eat(tt.eq) ? this.jsx_parseAttributeValue() : null;
+          return this.finishNode(node, "JSXAttribute");
+        }
+        jsx_parseOpeningElementAt(startPos, startLoc) {
+          let node = this.startNodeAt(startPos, startLoc);
+          node.attributes = [];
+          let nodeName = this.jsx_parseElementName();
+          if (nodeName)
+            node.name = nodeName;
+          while (this.type !== tt.slash && this.type !== tok.jsxTagEnd)
+            node.attributes.push(this.jsx_parseAttribute());
+          node.selfClosing = this.eat(tt.slash);
+          this.expect(tok.jsxTagEnd);
+          return this.finishNode(node, nodeName ? "JSXOpeningElement" : "JSXOpeningFragment");
+        }
+        jsx_parseClosingElementAt(startPos, startLoc) {
+          let node = this.startNodeAt(startPos, startLoc);
+          let nodeName = this.jsx_parseElementName();
+          if (nodeName)
+            node.name = nodeName;
+          this.expect(tok.jsxTagEnd);
+          return this.finishNode(node, nodeName ? "JSXClosingElement" : "JSXClosingFragment");
+        }
+        jsx_parseElementAt(startPos, startLoc) {
+          let node = this.startNodeAt(startPos, startLoc);
+          let children = [];
+          let openingElement = this.jsx_parseOpeningElementAt(startPos, startLoc);
+          let closingElement = null;
+          if (!openingElement.selfClosing) {
+            contents:
+              for (; ; ) {
+                switch (this.type) {
+                  case tok.jsxTagStart:
+                    startPos = this.start;
+                    startLoc = this.startLoc;
+                    this.next();
+                    if (this.eat(tt.slash)) {
+                      closingElement = this.jsx_parseClosingElementAt(startPos, startLoc);
+                      break contents;
+                    }
+                    children.push(this.jsx_parseElementAt(startPos, startLoc));
+                    break;
+                  case tok.jsxText:
+                    children.push(this.parseExprAtom());
+                    break;
+                  case tt.braceL:
+                    children.push(this.jsx_parseExpressionContainer());
+                    break;
+                  default:
+                    this.unexpected();
+                }
+              }
+            if (getQualifiedJSXName(closingElement.name) !== getQualifiedJSXName(openingElement.name)) {
+              this.raise(
+                closingElement.start,
+                "Expected corresponding JSX closing tag for <" + getQualifiedJSXName(openingElement.name) + ">"
+              );
+            }
+          }
+          let fragmentOrElement = openingElement.name ? "Element" : "Fragment";
+          node["opening" + fragmentOrElement] = openingElement;
+          node["closing" + fragmentOrElement] = closingElement;
+          node.children = children;
+          if (this.type === tt.relational && this.value === "<") {
+            this.raise(this.start, "Adjacent JSX elements must be wrapped in an enclosing tag");
+          }
+          return this.finishNode(node, "JSX" + fragmentOrElement);
+        }
+        jsx_parseText() {
+          let node = this.parseLiteral(this.value);
+          node.type = "JSXText";
+          return node;
+        }
+        jsx_parseElement() {
+          let startPos = this.start, startLoc = this.startLoc;
+          this.next();
+          return this.jsx_parseElementAt(startPos, startLoc);
+        }
+        parseExprAtom(refShortHandDefaultPos) {
+          if (this.type === tok.jsxText)
+            return this.jsx_parseText();
+          else if (this.type === tok.jsxTagStart)
+            return this.jsx_parseElement();
+          else
+            return super.parseExprAtom(refShortHandDefaultPos);
+        }
+        readToken(code2) {
+          let context = this.curContext();
+          if (context === tc_expr)
+            return this.jsx_readToken();
+          if (context === tc_oTag || context === tc_cTag) {
+            if (isIdentifierStart2(code2))
+              return this.jsx_readWord();
+            if (code2 == 62) {
+              ++this.pos;
+              return this.finishToken(tok.jsxTagEnd);
+            }
+            if ((code2 === 34 || code2 === 39) && context == tc_oTag)
+              return this.jsx_readString(code2);
+          }
+          if (code2 === 60 && this.exprAllowed && this.input.charCodeAt(this.pos + 1) !== 33) {
+            ++this.pos;
+            return this.finishToken(tok.jsxTagStart);
+          }
+          return super.readToken(code2);
+        }
+        updateContext(prevType) {
+          if (this.type == tt.braceL) {
+            var curContext = this.curContext();
+            if (curContext == tc_oTag)
+              this.context.push(tokContexts.b_expr);
+            else if (curContext == tc_expr)
+              this.context.push(tokContexts.b_tmpl);
+            else
+              super.updateContext(prevType);
+            this.exprAllowed = true;
+          } else if (this.type === tt.slash && prevType === tok.jsxTagStart) {
+            this.context.length -= 2;
+            this.context.push(tc_cTag);
+            this.exprAllowed = false;
+          } else {
+            return super.updateContext(prevType);
+          }
+        }
+      };
+    }
+  }
+});
+
+// node_modules/inline-style-parser/index.js
+var require_inline_style_parser = __commonJS({
+  "node_modules/inline-style-parser/index.js"(exports, module2) {
+    var COMMENT_REGEX = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
+    var NEWLINE_REGEX = /\n/g;
+    var WHITESPACE_REGEX = /^\s*/;
+    var PROPERTY_REGEX = /^(\*?[-#/*\\\w]+(\[[0-9a-z_-]+\])?)\s*/;
+    var COLON_REGEX = /^:\s*/;
+    var VALUE_REGEX = /^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^)]*?\)|[^};])+)/;
+    var SEMICOLON_REGEX = /^[;\s]*/;
+    var TRIM_REGEX = /^\s+|\s+$/g;
+    var NEWLINE = "\n";
+    var FORWARD_SLASH = "/";
+    var ASTERISK = "*";
+    var EMPTY_STRING = "";
+    var TYPE_COMMENT = "comment";
+    var TYPE_DECLARATION = "declaration";
+    module2.exports = function(style2, options) {
+      if (typeof style2 !== "string") {
+        throw new TypeError("First argument must be a string");
+      }
+      if (!style2)
+        return [];
+      options = options || {};
+      var lineno = 1;
+      var column = 1;
+      function updatePosition(str) {
+        var lines = str.match(NEWLINE_REGEX);
+        if (lines)
+          lineno += lines.length;
+        var i = str.lastIndexOf(NEWLINE);
+        column = ~i ? str.length - i : column + str.length;
+      }
+      function position3() {
+        var start3 = { line: lineno, column };
+        return function(node) {
+          node.position = new Position3(start3);
+          whitespace2();
+          return node;
+        };
+      }
+      function Position3(start3) {
+        this.start = start3;
+        this.end = { line: lineno, column };
+        this.source = options.source;
+      }
+      Position3.prototype.content = style2;
+      var errorsList = [];
+      function error(msg) {
+        var err = new Error(
+          options.source + ":" + lineno + ":" + column + ": " + msg
+        );
+        err.reason = msg;
+        err.filename = options.source;
+        err.line = lineno;
+        err.column = column;
+        err.source = style2;
+        if (options.silent) {
+          errorsList.push(err);
+        } else {
+          throw err;
+        }
+      }
+      function match(re) {
+        var m = re.exec(style2);
+        if (!m)
+          return;
+        var str = m[0];
+        updatePosition(str);
+        style2 = style2.slice(str.length);
+        return m;
+      }
+      function whitespace2() {
+        match(WHITESPACE_REGEX);
+      }
+      function comments(rules) {
+        var c;
+        rules = rules || [];
+        while (c = comment2()) {
+          if (c !== false) {
+            rules.push(c);
+          }
+        }
+        return rules;
+      }
+      function comment2() {
+        var pos = position3();
+        if (FORWARD_SLASH != style2.charAt(0) || ASTERISK != style2.charAt(1))
+          return;
+        var i = 2;
+        while (EMPTY_STRING != style2.charAt(i) && (ASTERISK != style2.charAt(i) || FORWARD_SLASH != style2.charAt(i + 1))) {
+          ++i;
+        }
+        i += 2;
+        if (EMPTY_STRING === style2.charAt(i - 1)) {
+          return error("End of comment missing");
+        }
+        var str = style2.slice(2, i - 2);
+        column += 2;
+        updatePosition(str);
+        style2 = style2.slice(i);
+        column += 2;
+        return pos({
+          type: TYPE_COMMENT,
+          comment: str
+        });
+      }
+      function declaration() {
+        var pos = position3();
+        var prop = match(PROPERTY_REGEX);
+        if (!prop)
+          return;
+        comment2();
+        if (!match(COLON_REGEX))
+          return error("property missing ':'");
+        var val = match(VALUE_REGEX);
+        var ret = pos({
+          type: TYPE_DECLARATION,
+          property: trim(prop[0].replace(COMMENT_REGEX, EMPTY_STRING)),
+          value: val ? trim(val[0].replace(COMMENT_REGEX, EMPTY_STRING)) : EMPTY_STRING
+        });
+        match(SEMICOLON_REGEX);
+        return ret;
+      }
+      function declarations() {
+        var decls = [];
+        comments(decls);
+        var decl;
+        while (decl = declaration()) {
+          if (decl !== false) {
+            decls.push(decl);
+            comments(decls);
+          }
+        }
+        return decls;
+      }
+      whitespace2();
+      return declarations();
+    };
+    function trim(str) {
+      return str ? str.replace(TRIM_REGEX, EMPTY_STRING) : EMPTY_STRING;
+    }
+  }
+});
+
+// node_modules/style-to-object/index.js
+var require_style_to_object = __commonJS({
+  "node_modules/style-to-object/index.js"(exports, module2) {
+    var parse4 = require_inline_style_parser();
+    function StyleToObject(style2, iterator) {
+      var output = null;
+      if (!style2 || typeof style2 !== "string") {
+        return output;
+      }
+      var declaration;
+      var declarations = parse4(style2);
+      var hasIterator = typeof iterator === "function";
+      var property;
+      var value;
+      for (var i = 0, len = declarations.length; i < len; i++) {
+        declaration = declarations[i];
+        property = declaration.property;
+        value = declaration.value;
+        if (hasIterator) {
+          iterator(property, value, declaration);
+        } else if (value) {
+          output || (output = {});
+          output[property] = value;
+        }
+      }
+      return output;
+    }
+    module2.exports = StyleToObject;
+  }
+});
+
+// node_modules/markdown-extensions/markdown-extensions.json
+var require_markdown_extensions = __commonJS({
+  "node_modules/markdown-extensions/markdown-extensions.json"(exports, module2) {
+    module2.exports = [
+      "md",
+      "markdown",
+      "mdown",
+      "mkdn",
+      "mkd",
+      "mdwn",
+      "mkdown",
+      "ron"
+    ];
+  }
+});
+
+// node_modules/markdown-extensions/index.js
+var require_markdown_extensions2 = __commonJS({
+  "node_modules/markdown-extensions/index.js"(exports, module2) {
+    "use strict";
+    module2.exports = require_markdown_extensions();
+  }
+});
+
+// node_modules/@mdx-js/mdx/index.js
+var mdx_exports = {};
+__export(mdx_exports, {
+  compile: () => compile,
+  compileSync: () => compileSync,
+  createProcessor: () => createProcessor,
+  evaluate: () => evaluate,
+  evaluateSync: () => evaluateSync,
+  nodeTypes: () => nodeTypes,
+  run: () => run,
+  runSync: () => runSync
+});
+module.exports = __toCommonJS(mdx_exports);
+
+// node_modules/@mdx-js/mdx/node_modules/bail/index.js
+function bail(error) {
+  if (error) {
+    throw error;
+  }
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unified/lib/index.js
+var import_is_buffer2 = __toESM(require_is_buffer(), 1);
+var import_extend = __toESM(require_extend(), 1);
+
+// node_modules/@mdx-js/mdx/node_modules/is-plain-obj/index.js
+function isPlainObject(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in value) && !(Symbol.iterator in value);
+}
+
+// node_modules/@mdx-js/mdx/node_modules/trough/index.js
+function trough() {
+  const fns = [];
+  const pipeline = { run: run2, use };
+  return pipeline;
+  function run2(...values) {
+    let middlewareIndex = -1;
+    const callback = values.pop();
+    if (typeof callback !== "function") {
+      throw new TypeError("Expected function as last argument, not " + callback);
+    }
+    next(null, ...values);
+    function next(error, ...output) {
+      const fn = fns[++middlewareIndex];
+      let index2 = -1;
+      if (error) {
+        callback(error);
+        return;
+      }
+      while (++index2 < values.length) {
+        if (output[index2] === null || output[index2] === void 0) {
+          output[index2] = values[index2];
+        }
+      }
+      values = output;
+      if (fn) {
+        wrap(fn, next)(...output);
+      } else {
+        callback(null, ...output);
+      }
+    }
+  }
+  function use(middelware) {
+    if (typeof middelware !== "function") {
+      throw new TypeError(
+        "Expected `middelware` to be a function, not " + middelware
+      );
+    }
+    fns.push(middelware);
+    return pipeline;
+  }
+}
+function wrap(middleware, callback) {
+  let called;
+  return wrapped;
+  function wrapped(...parameters) {
+    const fnExpectsCallback = middleware.length > parameters.length;
+    let result;
+    if (fnExpectsCallback) {
+      parameters.push(done);
+    }
+    try {
+      result = middleware.apply(this, parameters);
+    } catch (error) {
+      const exception = error;
+      if (fnExpectsCallback && called) {
+        throw exception;
+      }
+      return done(exception);
+    }
+    if (!fnExpectsCallback) {
+      if (result instanceof Promise) {
+        result.then(then, done);
+      } else if (result instanceof Error) {
+        done(result);
+      } else {
+        then(result);
+      }
+    }
+  }
+  function done(error, ...output) {
+    if (!called) {
+      called = true;
+      callback(error, ...output);
+    }
+  }
+  function then(value) {
+    done(null, value);
+  }
+}
+
+// node_modules/vfile/lib/index.js
+var import_is_buffer = __toESM(require_is_buffer(), 1);
+
+// node_modules/unist-util-stringify-position/index.js
+function stringifyPosition(value) {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  if ("position" in value || "type" in value) {
+    return position(value.position);
+  }
+  if ("start" in value || "end" in value) {
+    return position(value);
+  }
+  if ("line" in value || "column" in value) {
+    return point(value);
+  }
+  return "";
+}
+function point(point3) {
+  return index(point3 && point3.line) + ":" + index(point3 && point3.column);
+}
+function position(pos) {
+  return point(pos && pos.start) + "-" + point(pos && pos.end);
+}
+function index(value) {
+  return value && typeof value === "number" ? value : 1;
+}
+
+// node_modules/vfile-message/index.js
+var VFileMessage = class extends Error {
+  constructor(reason, place, origin) {
+    const parts = [null, null];
+    let position3 = {
+      start: { line: null, column: null },
+      end: { line: null, column: null }
+    };
+    super();
+    if (typeof place === "string") {
+      origin = place;
+      place = void 0;
+    }
+    if (typeof origin === "string") {
+      const index2 = origin.indexOf(":");
+      if (index2 === -1) {
+        parts[1] = origin;
+      } else {
+        parts[0] = origin.slice(0, index2);
+        parts[1] = origin.slice(index2 + 1);
+      }
+    }
+    if (place) {
+      if ("type" in place || "position" in place) {
+        if (place.position) {
+          position3 = place.position;
+        }
+      } else if ("start" in place || "end" in place) {
+        position3 = place;
+      } else if ("line" in place || "column" in place) {
+        position3.start = place;
+      }
+    }
+    this.name = stringifyPosition(place) || "1:1";
+    this.message = typeof reason === "object" ? reason.message : reason;
+    this.stack = typeof reason === "object" ? reason.stack : "";
+    this.reason = this.message;
+    this.fatal;
+    this.line = position3.start.line;
+    this.column = position3.start.column;
+    this.source = parts[0];
+    this.ruleId = parts[1];
+    this.position = position3;
+    this.actual;
+    this.expected;
+    this.file;
+    this.url;
+    this.note;
+  }
+};
+VFileMessage.prototype.file = "";
+VFileMessage.prototype.name = "";
+VFileMessage.prototype.reason = "";
+VFileMessage.prototype.message = "";
+VFileMessage.prototype.stack = "";
+VFileMessage.prototype.fatal = null;
+VFileMessage.prototype.column = null;
+VFileMessage.prototype.line = null;
+VFileMessage.prototype.source = null;
+VFileMessage.prototype.ruleId = null;
+VFileMessage.prototype.position = null;
+
+// node_modules/vfile/lib/minpath.js
+var import_path = __toESM(require("path"), 1);
+
+// node_modules/vfile/lib/minproc.js
+var import_process = __toESM(require("process"), 1);
+
+// node_modules/vfile/lib/minurl.js
+var import_url = require("url");
+
+// node_modules/vfile/lib/minurl.shared.js
+function isUrl(fileURLOrPath) {
+  return fileURLOrPath !== null && typeof fileURLOrPath === "object" && fileURLOrPath.href && fileURLOrPath.origin;
+}
+
+// node_modules/vfile/lib/index.js
+var order = ["history", "path", "basename", "stem", "extname", "dirname"];
+var VFile = class {
+  constructor(value) {
+    let options;
+    if (!value) {
+      options = {};
+    } else if (typeof value === "string" || (0, import_is_buffer.default)(value)) {
+      options = { value };
+    } else if (isUrl(value)) {
+      options = { path: value };
+    } else {
+      options = value;
+    }
+    this.data = {};
+    this.messages = [];
+    this.history = [];
+    this.cwd = import_process.default.cwd();
+    this.value;
+    this.stored;
+    this.result;
+    this.map;
+    let index2 = -1;
+    while (++index2 < order.length) {
+      const prop2 = order[index2];
+      if (prop2 in options && options[prop2] !== void 0) {
+        this[prop2] = prop2 === "history" ? [...options[prop2]] : options[prop2];
+      }
+    }
+    let prop;
+    for (prop in options) {
+      if (!order.includes(prop))
+        this[prop] = options[prop];
+    }
+  }
+  get path() {
+    return this.history[this.history.length - 1];
+  }
+  set path(path) {
+    if (isUrl(path)) {
+      path = (0, import_url.fileURLToPath)(path);
+    }
+    assertNonEmpty(path, "path");
+    if (this.path !== path) {
+      this.history.push(path);
+    }
+  }
+  get dirname() {
+    return typeof this.path === "string" ? import_path.default.dirname(this.path) : void 0;
+  }
+  set dirname(dirname) {
+    assertPath(this.basename, "dirname");
+    this.path = import_path.default.join(dirname || "", this.basename);
+  }
+  get basename() {
+    return typeof this.path === "string" ? import_path.default.basename(this.path) : void 0;
+  }
+  set basename(basename) {
+    assertNonEmpty(basename, "basename");
+    assertPart(basename, "basename");
+    this.path = import_path.default.join(this.dirname || "", basename);
+  }
+  get extname() {
+    return typeof this.path === "string" ? import_path.default.extname(this.path) : void 0;
+  }
+  set extname(extname) {
+    assertPart(extname, "extname");
+    assertPath(this.dirname, "extname");
+    if (extname) {
+      if (extname.charCodeAt(0) !== 46) {
+        throw new Error("`extname` must start with `.`");
+      }
+      if (extname.includes(".", 1)) {
+        throw new Error("`extname` cannot contain multiple dots");
+      }
+    }
+    this.path = import_path.default.join(this.dirname, this.stem + (extname || ""));
+  }
+  get stem() {
+    return typeof this.path === "string" ? import_path.default.basename(this.path, this.extname) : void 0;
+  }
+  set stem(stem) {
+    assertNonEmpty(stem, "stem");
+    assertPart(stem, "stem");
+    this.path = import_path.default.join(this.dirname || "", stem + (this.extname || ""));
+  }
+  toString(encoding) {
+    return (this.value || "").toString(encoding);
+  }
+  message(reason, place, origin) {
+    const message = new VFileMessage(reason, place, origin);
+    if (this.path) {
+      message.name = this.path + ":" + message.name;
+      message.file = this.path;
+    }
+    message.fatal = false;
+    this.messages.push(message);
+    return message;
+  }
+  info(reason, place, origin) {
+    const message = this.message(reason, place, origin);
+    message.fatal = null;
+    return message;
+  }
+  fail(reason, place, origin) {
+    const message = this.message(reason, place, origin);
+    message.fatal = true;
+    throw message;
+  }
+};
+function assertPart(part, name2) {
+  if (part && part.includes(import_path.default.sep)) {
+    throw new Error(
+      "`" + name2 + "` cannot be a path: did not expect `" + import_path.default.sep + "`"
+    );
+  }
+}
+function assertNonEmpty(part, name2) {
+  if (!part) {
+    throw new Error("`" + name2 + "` cannot be empty");
+  }
+}
+function assertPath(path, name2) {
+  if (!path) {
+    throw new Error("Setting `" + name2 + "` requires `path` to be set too");
+  }
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unified/lib/index.js
+var unified = base().freeze();
+var own = {}.hasOwnProperty;
+function base() {
+  const transformers = trough();
+  const attachers = [];
+  let namespace = {};
+  let frozen;
+  let freezeIndex = -1;
+  processor.data = data2;
+  processor.Parser = void 0;
+  processor.Compiler = void 0;
+  processor.freeze = freeze;
+  processor.attachers = attachers;
+  processor.use = use;
+  processor.parse = parse4;
+  processor.stringify = stringify4;
+  processor.run = run2;
+  processor.runSync = runSync2;
+  processor.process = process2;
+  processor.processSync = processSync;
+  return processor;
+  function processor() {
+    const destination = base();
+    let index2 = -1;
+    while (++index2 < attachers.length) {
+      destination.use(...attachers[index2]);
+    }
+    destination.data((0, import_extend.default)(true, {}, namespace));
+    return destination;
+  }
+  function data2(key, value) {
+    if (typeof key === "string") {
+      if (arguments.length === 2) {
+        assertUnfrozen("data", frozen);
+        namespace[key] = value;
+        return processor;
+      }
+      return own.call(namespace, key) && namespace[key] || null;
+    }
+    if (key) {
+      assertUnfrozen("data", frozen);
+      namespace = key;
+      return processor;
+    }
+    return namespace;
+  }
+  function freeze() {
+    if (frozen) {
+      return processor;
+    }
+    while (++freezeIndex < attachers.length) {
+      const [attacher, ...options] = attachers[freezeIndex];
+      if (options[0] === false) {
+        continue;
+      }
+      if (options[0] === true) {
+        options[0] = void 0;
+      }
+      const transformer = attacher.call(processor, ...options);
+      if (typeof transformer === "function") {
+        transformers.use(transformer);
+      }
+    }
+    frozen = true;
+    freezeIndex = Number.POSITIVE_INFINITY;
+    return processor;
+  }
+  function use(value, ...options) {
+    let settings;
+    assertUnfrozen("use", frozen);
+    if (value === null || value === void 0) {
+    } else if (typeof value === "function") {
+      addPlugin(value, ...options);
+    } else if (typeof value === "object") {
+      if (Array.isArray(value)) {
+        addList(value);
+      } else {
+        addPreset(value);
+      }
+    } else {
+      throw new TypeError("Expected usable value, not `" + value + "`");
+    }
+    if (settings) {
+      namespace.settings = Object.assign(namespace.settings || {}, settings);
+    }
+    return processor;
+    function add(value2) {
+      if (typeof value2 === "function") {
+        addPlugin(value2);
+      } else if (typeof value2 === "object") {
+        if (Array.isArray(value2)) {
+          const [plugin, ...options2] = value2;
+          addPlugin(plugin, ...options2);
+        } else {
+          addPreset(value2);
+        }
+      } else {
+        throw new TypeError("Expected usable value, not `" + value2 + "`");
+      }
+    }
+    function addPreset(result) {
+      addList(result.plugins);
+      if (result.settings) {
+        settings = Object.assign(settings || {}, result.settings);
+      }
+    }
+    function addList(plugins) {
+      let index2 = -1;
+      if (plugins === null || plugins === void 0) {
+      } else if (Array.isArray(plugins)) {
+        while (++index2 < plugins.length) {
+          const thing = plugins[index2];
+          add(thing);
+        }
+      } else {
+        throw new TypeError("Expected a list of plugins, not `" + plugins + "`");
+      }
+    }
+    function addPlugin(plugin, value2) {
+      let index2 = -1;
+      let entry;
+      while (++index2 < attachers.length) {
+        if (attachers[index2][0] === plugin) {
+          entry = attachers[index2];
+          break;
+        }
+      }
+      if (entry) {
+        if (isPlainObject(entry[1]) && isPlainObject(value2)) {
+          value2 = (0, import_extend.default)(true, entry[1], value2);
+        }
+        entry[1] = value2;
+      } else {
+        attachers.push([...arguments]);
+      }
+    }
+  }
+  function parse4(doc) {
+    processor.freeze();
+    const file = vfile(doc);
+    const Parser3 = processor.Parser;
+    assertParser("parse", Parser3);
+    if (newable(Parser3, "parse")) {
+      return new Parser3(String(file), file).parse();
+    }
+    return Parser3(String(file), file);
+  }
+  function stringify4(node, doc) {
+    processor.freeze();
+    const file = vfile(doc);
+    const Compiler = processor.Compiler;
+    assertCompiler("stringify", Compiler);
+    assertNode(node);
+    if (newable(Compiler, "compile")) {
+      return new Compiler(node, file).compile();
+    }
+    return Compiler(node, file);
+  }
+  function run2(node, doc, callback) {
+    assertNode(node);
+    processor.freeze();
+    if (!callback && typeof doc === "function") {
+      callback = doc;
+      doc = void 0;
+    }
+    if (!callback) {
+      return new Promise(executor);
+    }
+    executor(null, callback);
+    function executor(resolve, reject) {
+      transformers.run(node, vfile(doc), done);
+      function done(error, tree, file) {
+        tree = tree || node;
+        if (error) {
+          reject(error);
+        } else if (resolve) {
+          resolve(tree);
+        } else {
+          callback(null, tree, file);
+        }
+      }
+    }
+  }
+  function runSync2(node, file) {
+    let result;
+    let complete;
+    processor.run(node, file, done);
+    assertDone("runSync", "run", complete);
+    return result;
+    function done(error, tree) {
+      bail(error);
+      result = tree;
+      complete = true;
+    }
+  }
+  function process2(doc, callback) {
+    processor.freeze();
+    assertParser("process", processor.Parser);
+    assertCompiler("process", processor.Compiler);
+    if (!callback) {
+      return new Promise(executor);
+    }
+    executor(null, callback);
+    function executor(resolve, reject) {
+      const file = vfile(doc);
+      processor.run(processor.parse(file), file, (error, tree, file2) => {
+        if (error || !tree || !file2) {
+          done(error);
+        } else {
+          const result = processor.stringify(tree, file2);
+          if (result === void 0 || result === null) {
+          } else if (looksLikeAVFileValue(result)) {
+            file2.value = result;
+          } else {
+            file2.result = result;
+          }
+          done(error, file2);
+        }
+      });
+      function done(error, file2) {
+        if (error || !file2) {
+          reject(error);
+        } else if (resolve) {
+          resolve(file2);
+        } else {
+          callback(null, file2);
+        }
+      }
+    }
+  }
+  function processSync(doc) {
+    let complete;
+    processor.freeze();
+    assertParser("processSync", processor.Parser);
+    assertCompiler("processSync", processor.Compiler);
+    const file = vfile(doc);
+    processor.process(file, done);
+    assertDone("processSync", "process", complete);
+    return file;
+    function done(error) {
+      complete = true;
+      bail(error);
+    }
+  }
+}
+function newable(value, name2) {
+  return typeof value === "function" && value.prototype && (keys(value.prototype) || name2 in value.prototype);
+}
+function keys(value) {
+  let key;
+  for (key in value) {
+    if (own.call(value, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+function assertParser(name2, value) {
+  if (typeof value !== "function") {
+    throw new TypeError("Cannot `" + name2 + "` without `Parser`");
+  }
+}
+function assertCompiler(name2, value) {
+  if (typeof value !== "function") {
+    throw new TypeError("Cannot `" + name2 + "` without `Compiler`");
+  }
+}
+function assertUnfrozen(name2, frozen) {
+  if (frozen) {
+    throw new Error(
+      "Cannot call `" + name2 + "` on a frozen processor.\nCreate a new processor first, by calling it: use `processor()` instead of `processor`."
+    );
+  }
+}
+function assertNode(node) {
+  if (!isPlainObject(node) || typeof node.type !== "string") {
+    throw new TypeError("Expected node, got `" + node + "`");
+  }
+}
+function assertDone(name2, asyncName, complete) {
+  if (!complete) {
+    throw new Error(
+      "`" + name2 + "` finished async. Use `" + asyncName + "` instead"
+    );
+  }
+}
+function vfile(value) {
+  return looksLikeAVFile(value) ? value : new VFile(value);
+}
+function looksLikeAVFile(value) {
+  return Boolean(
+    value && typeof value === "object" && "message" in value && "messages" in value
+  );
+}
+function looksLikeAVFileValue(value) {
+  return typeof value === "string" || (0, import_is_buffer2.default)(value);
+}
+
+// node_modules/acorn/dist/acorn.mjs
+var astralIdentifierCodes = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 370, 1, 154, 10, 50, 3, 123, 2, 54, 14, 32, 10, 3, 1, 11, 3, 46, 10, 8, 0, 46, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 161, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 193, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 84, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 406, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 19306, 9, 87, 9, 39, 4, 60, 6, 26, 9, 1014, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 4706, 45, 3, 22, 543, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 262, 6, 10, 9, 357, 0, 62, 13, 1495, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
+var astralIdentifierStartCodes = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 13, 10, 2, 14, 2, 6, 2, 1, 2, 10, 2, 14, 2, 6, 2, 1, 68, 310, 10, 21, 11, 7, 25, 5, 2, 41, 2, 8, 70, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 349, 41, 7, 1, 79, 28, 11, 0, 9, 21, 43, 17, 47, 20, 28, 22, 13, 52, 58, 1, 3, 0, 14, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 85, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 159, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 38, 6, 186, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 19, 72, 264, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 190, 0, 80, 921, 103, 110, 18, 195, 2637, 96, 16, 1070, 4050, 582, 8634, 568, 8, 30, 18, 78, 18, 29, 19, 47, 17, 3, 32, 20, 6, 18, 689, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 43, 8, 8936, 3, 2, 6, 2, 1, 2, 290, 46, 2, 18, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 1845, 30, 482, 44, 11, 6, 17, 0, 322, 29, 19, 43, 1269, 6, 2, 3, 2, 1, 2, 14, 2, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42719, 33, 4152, 8, 221, 3, 5761, 15, 7472, 3104, 541, 1507, 4938];
+var nonASCIIidentifierChars = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u0898-\u089F\u08CA-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3C\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1715\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u180F-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF-\u1ACE\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DFF\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F";
+var nonASCIIidentifierStartChars = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u0870-\u0887\u0889-\u088E\u08A0-\u08C9\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C5D\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u1711\u171F-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4C\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7CA\uA7D0\uA7D1\uA7D3\uA7D5-\uA7D9\uA7F2-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
+var reservedWords = {
+  3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
+  5: "class enum extends super const export import",
+  6: "enum",
+  strict: "implements interface let package private protected public static yield",
+  strictBind: "eval arguments"
+};
+var ecma5AndLessKeywords = "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this";
+var keywords$1 = {
+  5: ecma5AndLessKeywords,
+  "5module": ecma5AndLessKeywords + " export import",
+  6: ecma5AndLessKeywords + " const class extends export import super"
+};
+var keywordRelationalOperator = /^in(stanceof)?$/;
+var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
+var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
+function isInAstralSet(code2, set) {
+  var pos = 65536;
+  for (var i = 0; i < set.length; i += 2) {
+    pos += set[i];
+    if (pos > code2) {
+      return false;
+    }
+    pos += set[i + 1];
+    if (pos >= code2) {
+      return true;
+    }
+  }
+}
+function isIdentifierStart(code2, astral) {
+  if (code2 < 65) {
+    return code2 === 36;
+  }
+  if (code2 < 91) {
+    return true;
+  }
+  if (code2 < 97) {
+    return code2 === 95;
+  }
+  if (code2 < 123) {
+    return true;
+  }
+  if (code2 <= 65535) {
+    return code2 >= 170 && nonASCIIidentifierStart.test(String.fromCharCode(code2));
+  }
+  if (astral === false) {
+    return false;
+  }
+  return isInAstralSet(code2, astralIdentifierStartCodes);
+}
+function isIdentifierChar(code2, astral) {
+  if (code2 < 48) {
+    return code2 === 36;
+  }
+  if (code2 < 58) {
+    return true;
+  }
+  if (code2 < 65) {
+    return false;
+  }
+  if (code2 < 91) {
+    return true;
+  }
+  if (code2 < 97) {
+    return code2 === 95;
+  }
+  if (code2 < 123) {
+    return true;
+  }
+  if (code2 <= 65535) {
+    return code2 >= 170 && nonASCIIidentifier.test(String.fromCharCode(code2));
+  }
+  if (astral === false) {
+    return false;
+  }
+  return isInAstralSet(code2, astralIdentifierStartCodes) || isInAstralSet(code2, astralIdentifierCodes);
+}
+var TokenType = function TokenType2(label, conf) {
+  if (conf === void 0)
+    conf = {};
+  this.label = label;
+  this.keyword = conf.keyword;
+  this.beforeExpr = !!conf.beforeExpr;
+  this.startsExpr = !!conf.startsExpr;
+  this.isLoop = !!conf.isLoop;
+  this.isAssign = !!conf.isAssign;
+  this.prefix = !!conf.prefix;
+  this.postfix = !!conf.postfix;
+  this.binop = conf.binop || null;
+  this.updateContext = null;
+};
+function binop(name2, prec) {
+  return new TokenType(name2, { beforeExpr: true, binop: prec });
+}
+var beforeExpr = { beforeExpr: true };
+var startsExpr = { startsExpr: true };
+var keywords = {};
+function kw(name2, options) {
+  if (options === void 0)
+    options = {};
+  options.keyword = name2;
+  return keywords[name2] = new TokenType(name2, options);
+}
+var types$1 = {
+  num: new TokenType("num", startsExpr),
+  regexp: new TokenType("regexp", startsExpr),
+  string: new TokenType("string", startsExpr),
+  name: new TokenType("name", startsExpr),
+  privateId: new TokenType("privateId", startsExpr),
+  eof: new TokenType("eof"),
+  bracketL: new TokenType("[", { beforeExpr: true, startsExpr: true }),
+  bracketR: new TokenType("]"),
+  braceL: new TokenType("{", { beforeExpr: true, startsExpr: true }),
+  braceR: new TokenType("}"),
+  parenL: new TokenType("(", { beforeExpr: true, startsExpr: true }),
+  parenR: new TokenType(")"),
+  comma: new TokenType(",", beforeExpr),
+  semi: new TokenType(";", beforeExpr),
+  colon: new TokenType(":", beforeExpr),
+  dot: new TokenType("."),
+  question: new TokenType("?", beforeExpr),
+  questionDot: new TokenType("?."),
+  arrow: new TokenType("=>", beforeExpr),
+  template: new TokenType("template"),
+  invalidTemplate: new TokenType("invalidTemplate"),
+  ellipsis: new TokenType("...", beforeExpr),
+  backQuote: new TokenType("`", startsExpr),
+  dollarBraceL: new TokenType("${", { beforeExpr: true, startsExpr: true }),
+  eq: new TokenType("=", { beforeExpr: true, isAssign: true }),
+  assign: new TokenType("_=", { beforeExpr: true, isAssign: true }),
+  incDec: new TokenType("++/--", { prefix: true, postfix: true, startsExpr: true }),
+  prefix: new TokenType("!/~", { beforeExpr: true, prefix: true, startsExpr: true }),
+  logicalOR: binop("||", 1),
+  logicalAND: binop("&&", 2),
+  bitwiseOR: binop("|", 3),
+  bitwiseXOR: binop("^", 4),
+  bitwiseAND: binop("&", 5),
+  equality: binop("==/!=/===/!==", 6),
+  relational: binop("</>/<=/>=", 7),
+  bitShift: binop("<</>>/>>>", 8),
+  plusMin: new TokenType("+/-", { beforeExpr: true, binop: 9, prefix: true, startsExpr: true }),
+  modulo: binop("%", 10),
+  star: binop("*", 10),
+  slash: binop("/", 10),
+  starstar: new TokenType("**", { beforeExpr: true }),
+  coalesce: binop("??", 1),
+  _break: kw("break"),
+  _case: kw("case", beforeExpr),
+  _catch: kw("catch"),
+  _continue: kw("continue"),
+  _debugger: kw("debugger"),
+  _default: kw("default", beforeExpr),
+  _do: kw("do", { isLoop: true, beforeExpr: true }),
+  _else: kw("else", beforeExpr),
+  _finally: kw("finally"),
+  _for: kw("for", { isLoop: true }),
+  _function: kw("function", startsExpr),
+  _if: kw("if"),
+  _return: kw("return", beforeExpr),
+  _switch: kw("switch"),
+  _throw: kw("throw", beforeExpr),
+  _try: kw("try"),
+  _var: kw("var"),
+  _const: kw("const"),
+  _while: kw("while", { isLoop: true }),
+  _with: kw("with"),
+  _new: kw("new", { beforeExpr: true, startsExpr: true }),
+  _this: kw("this", startsExpr),
+  _super: kw("super", startsExpr),
+  _class: kw("class", startsExpr),
+  _extends: kw("extends", beforeExpr),
+  _export: kw("export"),
+  _import: kw("import", startsExpr),
+  _null: kw("null", startsExpr),
+  _true: kw("true", startsExpr),
+  _false: kw("false", startsExpr),
+  _in: kw("in", { beforeExpr: true, binop: 7 }),
+  _instanceof: kw("instanceof", { beforeExpr: true, binop: 7 }),
+  _typeof: kw("typeof", { beforeExpr: true, prefix: true, startsExpr: true }),
+  _void: kw("void", { beforeExpr: true, prefix: true, startsExpr: true }),
+  _delete: kw("delete", { beforeExpr: true, prefix: true, startsExpr: true })
+};
+var lineBreak = /\r\n?|\n|\u2028|\u2029/;
+var lineBreakG = new RegExp(lineBreak.source, "g");
+function isNewLine(code2) {
+  return code2 === 10 || code2 === 13 || code2 === 8232 || code2 === 8233;
+}
+function nextLineBreak(code2, from, end) {
+  if (end === void 0)
+    end = code2.length;
+  for (var i = from; i < end; i++) {
+    var next = code2.charCodeAt(i);
+    if (isNewLine(next)) {
+      return i < end - 1 && next === 13 && code2.charCodeAt(i + 1) === 10 ? i + 2 : i + 1;
+    }
+  }
+  return -1;
+}
+var nonASCIIwhitespace = /[\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
+var skipWhiteSpace = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
+var ref = Object.prototype;
+var hasOwnProperty = ref.hasOwnProperty;
+var toString = ref.toString;
+var hasOwn = Object.hasOwn || function(obj, propName) {
+  return hasOwnProperty.call(obj, propName);
+};
+var isArray = Array.isArray || function(obj) {
+  return toString.call(obj) === "[object Array]";
+};
+function wordsRegexp(words) {
+  return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+}
+function codePointToString(code2) {
+  if (code2 <= 65535) {
+    return String.fromCharCode(code2);
+  }
+  code2 -= 65536;
+  return String.fromCharCode((code2 >> 10) + 55296, (code2 & 1023) + 56320);
+}
+var loneSurrogate = /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/;
+var Position = function Position2(line, col) {
+  this.line = line;
+  this.column = col;
+};
+Position.prototype.offset = function offset(n) {
+  return new Position(this.line, this.column + n);
+};
+var SourceLocation = function SourceLocation2(p, start3, end) {
+  this.start = start3;
+  this.end = end;
+  if (p.sourceFile !== null) {
+    this.source = p.sourceFile;
+  }
+};
+function getLineInfo(input, offset2) {
+  for (var line = 1, cur = 0; ; ) {
+    var nextBreak = nextLineBreak(input, cur, offset2);
+    if (nextBreak < 0) {
+      return new Position(line, offset2 - cur);
+    }
+    ++line;
+    cur = nextBreak;
+  }
+}
+var defaultOptions = {
+  ecmaVersion: null,
+  sourceType: "script",
+  onInsertedSemicolon: null,
+  onTrailingComma: null,
+  allowReserved: null,
+  allowReturnOutsideFunction: false,
+  allowImportExportEverywhere: false,
+  allowAwaitOutsideFunction: null,
+  allowSuperOutsideMethod: null,
+  allowHashBang: false,
+  locations: false,
+  onToken: null,
+  onComment: null,
+  ranges: false,
+  program: null,
+  sourceFile: null,
+  directSourceFile: null,
+  preserveParens: false
+};
+var warnedAboutEcmaVersion = false;
+function getOptions(opts) {
+  var options = {};
+  for (var opt in defaultOptions) {
+    options[opt] = opts && hasOwn(opts, opt) ? opts[opt] : defaultOptions[opt];
+  }
+  if (options.ecmaVersion === "latest") {
+    options.ecmaVersion = 1e8;
+  } else if (options.ecmaVersion == null) {
+    if (!warnedAboutEcmaVersion && typeof console === "object" && console.warn) {
+      warnedAboutEcmaVersion = true;
+      console.warn("Since Acorn 8.0.0, options.ecmaVersion is required.\nDefaulting to 2020, but this will stop working in the future.");
+    }
+    options.ecmaVersion = 11;
+  } else if (options.ecmaVersion >= 2015) {
+    options.ecmaVersion -= 2009;
+  }
+  if (options.allowReserved == null) {
+    options.allowReserved = options.ecmaVersion < 5;
+  }
+  if (opts.allowHashBang == null) {
+    options.allowHashBang = options.ecmaVersion >= 14;
+  }
+  if (isArray(options.onToken)) {
+    var tokens = options.onToken;
+    options.onToken = function(token) {
+      return tokens.push(token);
+    };
+  }
+  if (isArray(options.onComment)) {
+    options.onComment = pushComment(options, options.onComment);
+  }
+  return options;
+}
+function pushComment(options, array) {
+  return function(block, text5, start3, end, startLoc, endLoc) {
+    var comment2 = {
+      type: block ? "Block" : "Line",
+      value: text5,
+      start: start3,
+      end
+    };
+    if (options.locations) {
+      comment2.loc = new SourceLocation(this, startLoc, endLoc);
+    }
+    if (options.ranges) {
+      comment2.range = [start3, end];
+    }
+    array.push(comment2);
+  };
+}
+var SCOPE_TOP = 1;
+var SCOPE_FUNCTION = 2;
+var SCOPE_ASYNC = 4;
+var SCOPE_GENERATOR = 8;
+var SCOPE_ARROW = 16;
+var SCOPE_SIMPLE_CATCH = 32;
+var SCOPE_SUPER = 64;
+var SCOPE_DIRECT_SUPER = 128;
+var SCOPE_CLASS_STATIC_BLOCK = 256;
+var SCOPE_VAR = SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK;
+function functionFlags(async, generator) {
+  return SCOPE_FUNCTION | (async ? SCOPE_ASYNC : 0) | (generator ? SCOPE_GENERATOR : 0);
+}
+var BIND_NONE = 0;
+var BIND_VAR = 1;
+var BIND_LEXICAL = 2;
+var BIND_FUNCTION = 3;
+var BIND_SIMPLE_CATCH = 4;
+var BIND_OUTSIDE = 5;
+var Parser = function Parser2(options, input, startPos) {
+  this.options = options = getOptions(options);
+  this.sourceFile = options.sourceFile;
+  this.keywords = wordsRegexp(keywords$1[options.ecmaVersion >= 6 ? 6 : options.sourceType === "module" ? "5module" : 5]);
+  var reserved = "";
+  if (options.allowReserved !== true) {
+    reserved = reservedWords[options.ecmaVersion >= 6 ? 6 : options.ecmaVersion === 5 ? 5 : 3];
+    if (options.sourceType === "module") {
+      reserved += " await";
+    }
+  }
+  this.reservedWords = wordsRegexp(reserved);
+  var reservedStrict = (reserved ? reserved + " " : "") + reservedWords.strict;
+  this.reservedWordsStrict = wordsRegexp(reservedStrict);
+  this.reservedWordsStrictBind = wordsRegexp(reservedStrict + " " + reservedWords.strictBind);
+  this.input = String(input);
+  this.containsEsc = false;
+  if (startPos) {
+    this.pos = startPos;
+    this.lineStart = this.input.lastIndexOf("\n", startPos - 1) + 1;
+    this.curLine = this.input.slice(0, this.lineStart).split(lineBreak).length;
+  } else {
+    this.pos = this.lineStart = 0;
+    this.curLine = 1;
+  }
+  this.type = types$1.eof;
+  this.value = null;
+  this.start = this.end = this.pos;
+  this.startLoc = this.endLoc = this.curPosition();
+  this.lastTokEndLoc = this.lastTokStartLoc = null;
+  this.lastTokStart = this.lastTokEnd = this.pos;
+  this.context = this.initialContext();
+  this.exprAllowed = true;
+  this.inModule = options.sourceType === "module";
+  this.strict = this.inModule || this.strictDirective(this.pos);
+  this.potentialArrowAt = -1;
+  this.potentialArrowInForAwait = false;
+  this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
+  this.labels = [];
+  this.undefinedExports = /* @__PURE__ */ Object.create(null);
+  if (this.pos === 0 && options.allowHashBang && this.input.slice(0, 2) === "#!") {
+    this.skipLineComment(2);
+  }
+  this.scopeStack = [];
+  this.enterScope(SCOPE_TOP);
+  this.regexpState = null;
+  this.privateNameStack = [];
+};
+var prototypeAccessors = { inFunction: { configurable: true }, inGenerator: { configurable: true }, inAsync: { configurable: true }, canAwait: { configurable: true }, allowSuper: { configurable: true }, allowDirectSuper: { configurable: true }, treatFunctionsAsVar: { configurable: true }, allowNewDotTarget: { configurable: true }, inClassStaticBlock: { configurable: true } };
+Parser.prototype.parse = function parse() {
+  var node = this.options.program || this.startNode();
+  this.nextToken();
+  return this.parseTopLevel(node);
+};
+prototypeAccessors.inFunction.get = function() {
+  return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
+};
+prototypeAccessors.inGenerator.get = function() {
+  return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0 && !this.currentVarScope().inClassFieldInit;
+};
+prototypeAccessors.inAsync.get = function() {
+  return (this.currentVarScope().flags & SCOPE_ASYNC) > 0 && !this.currentVarScope().inClassFieldInit;
+};
+prototypeAccessors.canAwait.get = function() {
+  for (var i = this.scopeStack.length - 1; i >= 0; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.inClassFieldInit || scope.flags & SCOPE_CLASS_STATIC_BLOCK) {
+      return false;
+    }
+    if (scope.flags & SCOPE_FUNCTION) {
+      return (scope.flags & SCOPE_ASYNC) > 0;
+    }
+  }
+  return this.inModule && this.options.ecmaVersion >= 13 || this.options.allowAwaitOutsideFunction;
+};
+prototypeAccessors.allowSuper.get = function() {
+  var ref2 = this.currentThisScope();
+  var flags = ref2.flags;
+  var inClassFieldInit = ref2.inClassFieldInit;
+  return (flags & SCOPE_SUPER) > 0 || inClassFieldInit || this.options.allowSuperOutsideMethod;
+};
+prototypeAccessors.allowDirectSuper.get = function() {
+  return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER) > 0;
+};
+prototypeAccessors.treatFunctionsAsVar.get = function() {
+  return this.treatFunctionsAsVarInScope(this.currentScope());
+};
+prototypeAccessors.allowNewDotTarget.get = function() {
+  var ref2 = this.currentThisScope();
+  var flags = ref2.flags;
+  var inClassFieldInit = ref2.inClassFieldInit;
+  return (flags & (SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK)) > 0 || inClassFieldInit;
+};
+prototypeAccessors.inClassStaticBlock.get = function() {
+  return (this.currentVarScope().flags & SCOPE_CLASS_STATIC_BLOCK) > 0;
+};
+Parser.extend = function extend2() {
+  var plugins = [], len = arguments.length;
+  while (len--)
+    plugins[len] = arguments[len];
+  var cls = this;
+  for (var i = 0; i < plugins.length; i++) {
+    cls = plugins[i](cls);
+  }
+  return cls;
+};
+Parser.parse = function parse2(input, options) {
+  return new this(options, input).parse();
+};
+Parser.parseExpressionAt = function parseExpressionAt(input, pos, options) {
+  var parser = new this(options, input, pos);
+  parser.nextToken();
+  return parser.parseExpression();
+};
+Parser.tokenizer = function tokenizer(input, options) {
+  return new this(options, input);
+};
+Object.defineProperties(Parser.prototype, prototypeAccessors);
+var pp$9 = Parser.prototype;
+var literal = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/;
+pp$9.strictDirective = function(start3) {
+  if (this.options.ecmaVersion < 5) {
+    return false;
+  }
+  for (; ; ) {
+    skipWhiteSpace.lastIndex = start3;
+    start3 += skipWhiteSpace.exec(this.input)[0].length;
+    var match = literal.exec(this.input.slice(start3));
+    if (!match) {
+      return false;
+    }
+    if ((match[1] || match[2]) === "use strict") {
+      skipWhiteSpace.lastIndex = start3 + match[0].length;
+      var spaceAfter = skipWhiteSpace.exec(this.input), end = spaceAfter.index + spaceAfter[0].length;
+      var next = this.input.charAt(end);
+      return next === ";" || next === "}" || lineBreak.test(spaceAfter[0]) && !(/[(`.[+\-/*%<>=,?^&]/.test(next) || next === "!" && this.input.charAt(end + 1) === "=");
+    }
+    start3 += match[0].length;
+    skipWhiteSpace.lastIndex = start3;
+    start3 += skipWhiteSpace.exec(this.input)[0].length;
+    if (this.input[start3] === ";") {
+      start3++;
+    }
+  }
+};
+pp$9.eat = function(type) {
+  if (this.type === type) {
+    this.next();
+    return true;
+  } else {
+    return false;
+  }
+};
+pp$9.isContextual = function(name2) {
+  return this.type === types$1.name && this.value === name2 && !this.containsEsc;
+};
+pp$9.eatContextual = function(name2) {
+  if (!this.isContextual(name2)) {
+    return false;
+  }
+  this.next();
+  return true;
+};
+pp$9.expectContextual = function(name2) {
+  if (!this.eatContextual(name2)) {
+    this.unexpected();
+  }
+};
+pp$9.canInsertSemicolon = function() {
+  return this.type === types$1.eof || this.type === types$1.braceR || lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+};
+pp$9.insertSemicolon = function() {
+  if (this.canInsertSemicolon()) {
+    if (this.options.onInsertedSemicolon) {
+      this.options.onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+    }
+    return true;
+  }
+};
+pp$9.semicolon = function() {
+  if (!this.eat(types$1.semi) && !this.insertSemicolon()) {
+    this.unexpected();
+  }
+};
+pp$9.afterTrailingComma = function(tokType, notNext) {
+  if (this.type === tokType) {
+    if (this.options.onTrailingComma) {
+      this.options.onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+    }
+    if (!notNext) {
+      this.next();
+    }
+    return true;
+  }
+};
+pp$9.expect = function(type) {
+  this.eat(type) || this.unexpected();
+};
+pp$9.unexpected = function(pos) {
+  this.raise(pos != null ? pos : this.start, "Unexpected token");
+};
+var DestructuringErrors = function DestructuringErrors2() {
+  this.shorthandAssign = this.trailingComma = this.parenthesizedAssign = this.parenthesizedBind = this.doubleProto = -1;
+};
+pp$9.checkPatternErrors = function(refDestructuringErrors, isAssign) {
+  if (!refDestructuringErrors) {
+    return;
+  }
+  if (refDestructuringErrors.trailingComma > -1) {
+    this.raiseRecoverable(refDestructuringErrors.trailingComma, "Comma is not permitted after the rest element");
+  }
+  var parens = isAssign ? refDestructuringErrors.parenthesizedAssign : refDestructuringErrors.parenthesizedBind;
+  if (parens > -1) {
+    this.raiseRecoverable(parens, isAssign ? "Assigning to rvalue" : "Parenthesized pattern");
+  }
+};
+pp$9.checkExpressionErrors = function(refDestructuringErrors, andThrow) {
+  if (!refDestructuringErrors) {
+    return false;
+  }
+  var shorthandAssign = refDestructuringErrors.shorthandAssign;
+  var doubleProto = refDestructuringErrors.doubleProto;
+  if (!andThrow) {
+    return shorthandAssign >= 0 || doubleProto >= 0;
+  }
+  if (shorthandAssign >= 0) {
+    this.raise(shorthandAssign, "Shorthand property assignments are valid only in destructuring patterns");
+  }
+  if (doubleProto >= 0) {
+    this.raiseRecoverable(doubleProto, "Redefinition of __proto__ property");
+  }
+};
+pp$9.checkYieldAwaitInDefaultParams = function() {
+  if (this.yieldPos && (!this.awaitPos || this.yieldPos < this.awaitPos)) {
+    this.raise(this.yieldPos, "Yield expression cannot be a default value");
+  }
+  if (this.awaitPos) {
+    this.raise(this.awaitPos, "Await expression cannot be a default value");
+  }
+};
+pp$9.isSimpleAssignTarget = function(expr) {
+  if (expr.type === "ParenthesizedExpression") {
+    return this.isSimpleAssignTarget(expr.expression);
+  }
+  return expr.type === "Identifier" || expr.type === "MemberExpression";
+};
+var pp$8 = Parser.prototype;
+pp$8.parseTopLevel = function(node) {
+  var exports = /* @__PURE__ */ Object.create(null);
+  if (!node.body) {
+    node.body = [];
+  }
+  while (this.type !== types$1.eof) {
+    var stmt = this.parseStatement(null, true, exports);
+    node.body.push(stmt);
+  }
+  if (this.inModule) {
+    for (var i = 0, list3 = Object.keys(this.undefinedExports); i < list3.length; i += 1) {
+      var name2 = list3[i];
+      this.raiseRecoverable(this.undefinedExports[name2].start, "Export '" + name2 + "' is not defined");
+    }
+  }
+  this.adaptDirectivePrologue(node.body);
+  this.next();
+  node.sourceType = this.options.sourceType;
+  return this.finishNode(node, "Program");
+};
+var loopLabel = { kind: "loop" };
+var switchLabel = { kind: "switch" };
+pp$8.isLet = function(context) {
+  if (this.options.ecmaVersion < 6 || !this.isContextual("let")) {
+    return false;
+  }
+  skipWhiteSpace.lastIndex = this.pos;
+  var skip = skipWhiteSpace.exec(this.input);
+  var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+  if (nextCh === 91 || nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+    return true;
+  }
+  if (context) {
+    return false;
+  }
+  if (nextCh === 123) {
+    return true;
+  }
+  if (isIdentifierStart(nextCh, true)) {
+    var pos = next + 1;
+    while (isIdentifierChar(nextCh = this.input.charCodeAt(pos), true)) {
+      ++pos;
+    }
+    if (nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+      return true;
+    }
+    var ident = this.input.slice(next, pos);
+    if (!keywordRelationalOperator.test(ident)) {
+      return true;
+    }
+  }
+  return false;
+};
+pp$8.isAsyncFunction = function() {
+  if (this.options.ecmaVersion < 8 || !this.isContextual("async")) {
+    return false;
+  }
+  skipWhiteSpace.lastIndex = this.pos;
+  var skip = skipWhiteSpace.exec(this.input);
+  var next = this.pos + skip[0].length, after;
+  return !lineBreak.test(this.input.slice(this.pos, next)) && this.input.slice(next, next + 8) === "function" && (next + 8 === this.input.length || !(isIdentifierChar(after = this.input.charCodeAt(next + 8)) || after > 55295 && after < 56320));
+};
+pp$8.parseStatement = function(context, topLevel, exports) {
+  var starttype = this.type, node = this.startNode(), kind;
+  if (this.isLet(context)) {
+    starttype = types$1._var;
+    kind = "let";
+  }
+  switch (starttype) {
+    case types$1._break:
+    case types$1._continue:
+      return this.parseBreakContinueStatement(node, starttype.keyword);
+    case types$1._debugger:
+      return this.parseDebuggerStatement(node);
+    case types$1._do:
+      return this.parseDoStatement(node);
+    case types$1._for:
+      return this.parseForStatement(node);
+    case types$1._function:
+      if (context && (this.strict || context !== "if" && context !== "label") && this.options.ecmaVersion >= 6) {
+        this.unexpected();
+      }
+      return this.parseFunctionStatement(node, false, !context);
+    case types$1._class:
+      if (context) {
+        this.unexpected();
+      }
+      return this.parseClass(node, true);
+    case types$1._if:
+      return this.parseIfStatement(node);
+    case types$1._return:
+      return this.parseReturnStatement(node);
+    case types$1._switch:
+      return this.parseSwitchStatement(node);
+    case types$1._throw:
+      return this.parseThrowStatement(node);
+    case types$1._try:
+      return this.parseTryStatement(node);
+    case types$1._const:
+    case types$1._var:
+      kind = kind || this.value;
+      if (context && kind !== "var") {
+        this.unexpected();
+      }
+      return this.parseVarStatement(node, kind);
+    case types$1._while:
+      return this.parseWhileStatement(node);
+    case types$1._with:
+      return this.parseWithStatement(node);
+    case types$1.braceL:
+      return this.parseBlock(true, node);
+    case types$1.semi:
+      return this.parseEmptyStatement(node);
+    case types$1._export:
+    case types$1._import:
+      if (this.options.ecmaVersion > 10 && starttype === types$1._import) {
+        skipWhiteSpace.lastIndex = this.pos;
+        var skip = skipWhiteSpace.exec(this.input);
+        var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+        if (nextCh === 40 || nextCh === 46) {
+          return this.parseExpressionStatement(node, this.parseExpression());
+        }
+      }
+      if (!this.options.allowImportExportEverywhere) {
+        if (!topLevel) {
+          this.raise(this.start, "'import' and 'export' may only appear at the top level");
+        }
+        if (!this.inModule) {
+          this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'");
+        }
+      }
+      return starttype === types$1._import ? this.parseImport(node) : this.parseExport(node, exports);
+    default:
+      if (this.isAsyncFunction()) {
+        if (context) {
+          this.unexpected();
+        }
+        this.next();
+        return this.parseFunctionStatement(node, true, !context);
+      }
+      var maybeName = this.value, expr = this.parseExpression();
+      if (starttype === types$1.name && expr.type === "Identifier" && this.eat(types$1.colon)) {
+        return this.parseLabeledStatement(node, maybeName, expr, context);
+      } else {
+        return this.parseExpressionStatement(node, expr);
+      }
+  }
+};
+pp$8.parseBreakContinueStatement = function(node, keyword) {
+  var isBreak = keyword === "break";
+  this.next();
+  if (this.eat(types$1.semi) || this.insertSemicolon()) {
+    node.label = null;
+  } else if (this.type !== types$1.name) {
+    this.unexpected();
+  } else {
+    node.label = this.parseIdent();
+    this.semicolon();
+  }
+  var i = 0;
+  for (; i < this.labels.length; ++i) {
+    var lab = this.labels[i];
+    if (node.label == null || lab.name === node.label.name) {
+      if (lab.kind != null && (isBreak || lab.kind === "loop")) {
+        break;
+      }
+      if (node.label && isBreak) {
+        break;
+      }
+    }
+  }
+  if (i === this.labels.length) {
+    this.raise(node.start, "Unsyntactic " + keyword);
+  }
+  return this.finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+};
+pp$8.parseDebuggerStatement = function(node) {
+  this.next();
+  this.semicolon();
+  return this.finishNode(node, "DebuggerStatement");
+};
+pp$8.parseDoStatement = function(node) {
+  this.next();
+  this.labels.push(loopLabel);
+  node.body = this.parseStatement("do");
+  this.labels.pop();
+  this.expect(types$1._while);
+  node.test = this.parseParenExpression();
+  if (this.options.ecmaVersion >= 6) {
+    this.eat(types$1.semi);
+  } else {
+    this.semicolon();
+  }
+  return this.finishNode(node, "DoWhileStatement");
+};
+pp$8.parseForStatement = function(node) {
+  this.next();
+  var awaitAt = this.options.ecmaVersion >= 9 && this.canAwait && this.eatContextual("await") ? this.lastTokStart : -1;
+  this.labels.push(loopLabel);
+  this.enterScope(0);
+  this.expect(types$1.parenL);
+  if (this.type === types$1.semi) {
+    if (awaitAt > -1) {
+      this.unexpected(awaitAt);
+    }
+    return this.parseFor(node, null);
+  }
+  var isLet = this.isLet();
+  if (this.type === types$1._var || this.type === types$1._const || isLet) {
+    var init$1 = this.startNode(), kind = isLet ? "let" : this.value;
+    this.next();
+    this.parseVar(init$1, true, kind);
+    this.finishNode(init$1, "VariableDeclaration");
+    if ((this.type === types$1._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) && init$1.declarations.length === 1) {
+      if (this.options.ecmaVersion >= 9) {
+        if (this.type === types$1._in) {
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+        } else {
+          node.await = awaitAt > -1;
+        }
+      }
+      return this.parseForIn(node, init$1);
+    }
+    if (awaitAt > -1) {
+      this.unexpected(awaitAt);
+    }
+    return this.parseFor(node, init$1);
+  }
+  var startsWithLet = this.isContextual("let"), isForOf = false;
+  var refDestructuringErrors = new DestructuringErrors();
+  var init = this.parseExpression(awaitAt > -1 ? "await" : true, refDestructuringErrors);
+  if (this.type === types$1._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+    if (this.options.ecmaVersion >= 9) {
+      if (this.type === types$1._in) {
+        if (awaitAt > -1) {
+          this.unexpected(awaitAt);
+        }
+      } else {
+        node.await = awaitAt > -1;
+      }
+    }
+    if (startsWithLet && isForOf) {
+      this.raise(init.start, "The left-hand side of a for-of loop may not start with 'let'.");
+    }
+    this.toAssignable(init, false, refDestructuringErrors);
+    this.checkLValPattern(init);
+    return this.parseForIn(node, init);
+  } else {
+    this.checkExpressionErrors(refDestructuringErrors, true);
+  }
+  if (awaitAt > -1) {
+    this.unexpected(awaitAt);
+  }
+  return this.parseFor(node, init);
+};
+pp$8.parseFunctionStatement = function(node, isAsync, declarationPosition) {
+  this.next();
+  return this.parseFunction(node, FUNC_STATEMENT | (declarationPosition ? 0 : FUNC_HANGING_STATEMENT), false, isAsync);
+};
+pp$8.parseIfStatement = function(node) {
+  this.next();
+  node.test = this.parseParenExpression();
+  node.consequent = this.parseStatement("if");
+  node.alternate = this.eat(types$1._else) ? this.parseStatement("if") : null;
+  return this.finishNode(node, "IfStatement");
+};
+pp$8.parseReturnStatement = function(node) {
+  if (!this.inFunction && !this.options.allowReturnOutsideFunction) {
+    this.raise(this.start, "'return' outside of function");
+  }
+  this.next();
+  if (this.eat(types$1.semi) || this.insertSemicolon()) {
+    node.argument = null;
+  } else {
+    node.argument = this.parseExpression();
+    this.semicolon();
+  }
+  return this.finishNode(node, "ReturnStatement");
+};
+pp$8.parseSwitchStatement = function(node) {
+  this.next();
+  node.discriminant = this.parseParenExpression();
+  node.cases = [];
+  this.expect(types$1.braceL);
+  this.labels.push(switchLabel);
+  this.enterScope(0);
+  var cur;
+  for (var sawDefault = false; this.type !== types$1.braceR; ) {
+    if (this.type === types$1._case || this.type === types$1._default) {
+      var isCase = this.type === types$1._case;
+      if (cur) {
+        this.finishNode(cur, "SwitchCase");
+      }
+      node.cases.push(cur = this.startNode());
+      cur.consequent = [];
+      this.next();
+      if (isCase) {
+        cur.test = this.parseExpression();
+      } else {
+        if (sawDefault) {
+          this.raiseRecoverable(this.lastTokStart, "Multiple default clauses");
+        }
+        sawDefault = true;
+        cur.test = null;
+      }
+      this.expect(types$1.colon);
+    } else {
+      if (!cur) {
+        this.unexpected();
+      }
+      cur.consequent.push(this.parseStatement(null));
+    }
+  }
+  this.exitScope();
+  if (cur) {
+    this.finishNode(cur, "SwitchCase");
+  }
+  this.next();
+  this.labels.pop();
+  return this.finishNode(node, "SwitchStatement");
+};
+pp$8.parseThrowStatement = function(node) {
+  this.next();
+  if (lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) {
+    this.raise(this.lastTokEnd, "Illegal newline after throw");
+  }
+  node.argument = this.parseExpression();
+  this.semicolon();
+  return this.finishNode(node, "ThrowStatement");
+};
+var empty$1 = [];
+pp$8.parseTryStatement = function(node) {
+  this.next();
+  node.block = this.parseBlock();
+  node.handler = null;
+  if (this.type === types$1._catch) {
+    var clause = this.startNode();
+    this.next();
+    if (this.eat(types$1.parenL)) {
+      clause.param = this.parseBindingAtom();
+      var simple = clause.param.type === "Identifier";
+      this.enterScope(simple ? SCOPE_SIMPLE_CATCH : 0);
+      this.checkLValPattern(clause.param, simple ? BIND_SIMPLE_CATCH : BIND_LEXICAL);
+      this.expect(types$1.parenR);
+    } else {
+      if (this.options.ecmaVersion < 10) {
+        this.unexpected();
+      }
+      clause.param = null;
+      this.enterScope(0);
+    }
+    clause.body = this.parseBlock(false);
+    this.exitScope();
+    node.handler = this.finishNode(clause, "CatchClause");
+  }
+  node.finalizer = this.eat(types$1._finally) ? this.parseBlock() : null;
+  if (!node.handler && !node.finalizer) {
+    this.raise(node.start, "Missing catch or finally clause");
+  }
+  return this.finishNode(node, "TryStatement");
+};
+pp$8.parseVarStatement = function(node, kind) {
+  this.next();
+  this.parseVar(node, false, kind);
+  this.semicolon();
+  return this.finishNode(node, "VariableDeclaration");
+};
+pp$8.parseWhileStatement = function(node) {
+  this.next();
+  node.test = this.parseParenExpression();
+  this.labels.push(loopLabel);
+  node.body = this.parseStatement("while");
+  this.labels.pop();
+  return this.finishNode(node, "WhileStatement");
+};
+pp$8.parseWithStatement = function(node) {
+  if (this.strict) {
+    this.raise(this.start, "'with' in strict mode");
+  }
+  this.next();
+  node.object = this.parseParenExpression();
+  node.body = this.parseStatement("with");
+  return this.finishNode(node, "WithStatement");
+};
+pp$8.parseEmptyStatement = function(node) {
+  this.next();
+  return this.finishNode(node, "EmptyStatement");
+};
+pp$8.parseLabeledStatement = function(node, maybeName, expr, context) {
+  for (var i$1 = 0, list3 = this.labels; i$1 < list3.length; i$1 += 1) {
+    var label = list3[i$1];
+    if (label.name === maybeName) {
+      this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+    }
+  }
+  var kind = this.type.isLoop ? "loop" : this.type === types$1._switch ? "switch" : null;
+  for (var i = this.labels.length - 1; i >= 0; i--) {
+    var label$1 = this.labels[i];
+    if (label$1.statementStart === node.start) {
+      label$1.statementStart = this.start;
+      label$1.kind = kind;
+    } else {
+      break;
+    }
+  }
+  this.labels.push({ name: maybeName, kind, statementStart: this.start });
+  node.body = this.parseStatement(context ? context.indexOf("label") === -1 ? context + "label" : context : "label");
+  this.labels.pop();
+  node.label = expr;
+  return this.finishNode(node, "LabeledStatement");
+};
+pp$8.parseExpressionStatement = function(node, expr) {
+  node.expression = expr;
+  this.semicolon();
+  return this.finishNode(node, "ExpressionStatement");
+};
+pp$8.parseBlock = function(createNewLexicalScope, node, exitStrict) {
+  if (createNewLexicalScope === void 0)
+    createNewLexicalScope = true;
+  if (node === void 0)
+    node = this.startNode();
+  node.body = [];
+  this.expect(types$1.braceL);
+  if (createNewLexicalScope) {
+    this.enterScope(0);
+  }
+  while (this.type !== types$1.braceR) {
+    var stmt = this.parseStatement(null);
+    node.body.push(stmt);
+  }
+  if (exitStrict) {
+    this.strict = false;
+  }
+  this.next();
+  if (createNewLexicalScope) {
+    this.exitScope();
+  }
+  return this.finishNode(node, "BlockStatement");
+};
+pp$8.parseFor = function(node, init) {
+  node.init = init;
+  this.expect(types$1.semi);
+  node.test = this.type === types$1.semi ? null : this.parseExpression();
+  this.expect(types$1.semi);
+  node.update = this.type === types$1.parenR ? null : this.parseExpression();
+  this.expect(types$1.parenR);
+  node.body = this.parseStatement("for");
+  this.exitScope();
+  this.labels.pop();
+  return this.finishNode(node, "ForStatement");
+};
+pp$8.parseForIn = function(node, init) {
+  var isForIn = this.type === types$1._in;
+  this.next();
+  if (init.type === "VariableDeclaration" && init.declarations[0].init != null && (!isForIn || this.options.ecmaVersion < 8 || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")) {
+    this.raise(
+      init.start,
+      (isForIn ? "for-in" : "for-of") + " loop variable declaration may not have an initializer"
+    );
+  }
+  node.left = init;
+  node.right = isForIn ? this.parseExpression() : this.parseMaybeAssign();
+  this.expect(types$1.parenR);
+  node.body = this.parseStatement("for");
+  this.exitScope();
+  this.labels.pop();
+  return this.finishNode(node, isForIn ? "ForInStatement" : "ForOfStatement");
+};
+pp$8.parseVar = function(node, isFor, kind) {
+  node.declarations = [];
+  node.kind = kind;
+  for (; ; ) {
+    var decl = this.startNode();
+    this.parseVarId(decl, kind);
+    if (this.eat(types$1.eq)) {
+      decl.init = this.parseMaybeAssign(isFor);
+    } else if (kind === "const" && !(this.type === types$1._in || this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+      this.unexpected();
+    } else if (decl.id.type !== "Identifier" && !(isFor && (this.type === types$1._in || this.isContextual("of")))) {
+      this.raise(this.lastTokEnd, "Complex binding patterns require an initialization value");
+    } else {
+      decl.init = null;
+    }
+    node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+    if (!this.eat(types$1.comma)) {
+      break;
+    }
+  }
+  return node;
+};
+pp$8.parseVarId = function(decl, kind) {
+  decl.id = this.parseBindingAtom();
+  this.checkLValPattern(decl.id, kind === "var" ? BIND_VAR : BIND_LEXICAL, false);
+};
+var FUNC_STATEMENT = 1;
+var FUNC_HANGING_STATEMENT = 2;
+var FUNC_NULLABLE_ID = 4;
+pp$8.parseFunction = function(node, statement, allowExpressionBody, isAsync, forInit) {
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 9 || this.options.ecmaVersion >= 6 && !isAsync) {
+    if (this.type === types$1.star && statement & FUNC_HANGING_STATEMENT) {
+      this.unexpected();
+    }
+    node.generator = this.eat(types$1.star);
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node.async = !!isAsync;
+  }
+  if (statement & FUNC_STATEMENT) {
+    node.id = statement & FUNC_NULLABLE_ID && this.type !== types$1.name ? null : this.parseIdent();
+    if (node.id && !(statement & FUNC_HANGING_STATEMENT)) {
+      this.checkLValSimple(node.id, this.strict || node.generator || node.async ? this.treatFunctionsAsVar ? BIND_VAR : BIND_LEXICAL : BIND_FUNCTION);
+    }
+  }
+  var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  this.enterScope(functionFlags(node.async, node.generator));
+  if (!(statement & FUNC_STATEMENT)) {
+    node.id = this.type === types$1.name ? this.parseIdent() : null;
+  }
+  this.parseFunctionParams(node);
+  this.parseFunctionBody(node, allowExpressionBody, false, forInit);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node, statement & FUNC_STATEMENT ? "FunctionDeclaration" : "FunctionExpression");
+};
+pp$8.parseFunctionParams = function(node) {
+  this.expect(types$1.parenL);
+  node.params = this.parseBindingList(types$1.parenR, false, this.options.ecmaVersion >= 8);
+  this.checkYieldAwaitInDefaultParams();
+};
+pp$8.parseClass = function(node, isStatement) {
+  this.next();
+  var oldStrict = this.strict;
+  this.strict = true;
+  this.parseClassId(node, isStatement);
+  this.parseClassSuper(node);
+  var privateNameMap = this.enterClassBody();
+  var classBody = this.startNode();
+  var hadConstructor = false;
+  classBody.body = [];
+  this.expect(types$1.braceL);
+  while (this.type !== types$1.braceR) {
+    var element2 = this.parseClassElement(node.superClass !== null);
+    if (element2) {
+      classBody.body.push(element2);
+      if (element2.type === "MethodDefinition" && element2.kind === "constructor") {
+        if (hadConstructor) {
+          this.raise(element2.start, "Duplicate constructor in the same class");
+        }
+        hadConstructor = true;
+      } else if (element2.key && element2.key.type === "PrivateIdentifier" && isPrivateNameConflicted(privateNameMap, element2)) {
+        this.raiseRecoverable(element2.key.start, "Identifier '#" + element2.key.name + "' has already been declared");
+      }
+    }
+  }
+  this.strict = oldStrict;
+  this.next();
+  node.body = this.finishNode(classBody, "ClassBody");
+  this.exitClassBody();
+  return this.finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
+};
+pp$8.parseClassElement = function(constructorAllowsSuper) {
+  if (this.eat(types$1.semi)) {
+    return null;
+  }
+  var ecmaVersion = this.options.ecmaVersion;
+  var node = this.startNode();
+  var keyName = "";
+  var isGenerator = false;
+  var isAsync = false;
+  var kind = "method";
+  var isStatic = false;
+  if (this.eatContextual("static")) {
+    if (ecmaVersion >= 13 && this.eat(types$1.braceL)) {
+      this.parseClassStaticBlock(node);
+      return node;
+    }
+    if (this.isClassElementNameStart() || this.type === types$1.star) {
+      isStatic = true;
+    } else {
+      keyName = "static";
+    }
+  }
+  node.static = isStatic;
+  if (!keyName && ecmaVersion >= 8 && this.eatContextual("async")) {
+    if ((this.isClassElementNameStart() || this.type === types$1.star) && !this.canInsertSemicolon()) {
+      isAsync = true;
+    } else {
+      keyName = "async";
+    }
+  }
+  if (!keyName && (ecmaVersion >= 9 || !isAsync) && this.eat(types$1.star)) {
+    isGenerator = true;
+  }
+  if (!keyName && !isAsync && !isGenerator) {
+    var lastValue = this.value;
+    if (this.eatContextual("get") || this.eatContextual("set")) {
+      if (this.isClassElementNameStart()) {
+        kind = lastValue;
+      } else {
+        keyName = lastValue;
+      }
+    }
+  }
+  if (keyName) {
+    node.computed = false;
+    node.key = this.startNodeAt(this.lastTokStart, this.lastTokStartLoc);
+    node.key.name = keyName;
+    this.finishNode(node.key, "Identifier");
+  } else {
+    this.parseClassElementName(node);
+  }
+  if (ecmaVersion < 13 || this.type === types$1.parenL || kind !== "method" || isGenerator || isAsync) {
+    var isConstructor = !node.static && checkKeyName(node, "constructor");
+    var allowsDirectSuper = isConstructor && constructorAllowsSuper;
+    if (isConstructor && kind !== "method") {
+      this.raise(node.key.start, "Constructor can't have get/set modifier");
+    }
+    node.kind = isConstructor ? "constructor" : kind;
+    this.parseClassMethod(node, isGenerator, isAsync, allowsDirectSuper);
+  } else {
+    this.parseClassField(node);
+  }
+  return node;
+};
+pp$8.isClassElementNameStart = function() {
+  return this.type === types$1.name || this.type === types$1.privateId || this.type === types$1.num || this.type === types$1.string || this.type === types$1.bracketL || this.type.keyword;
+};
+pp$8.parseClassElementName = function(element2) {
+  if (this.type === types$1.privateId) {
+    if (this.value === "constructor") {
+      this.raise(this.start, "Classes can't have an element named '#constructor'");
+    }
+    element2.computed = false;
+    element2.key = this.parsePrivateIdent();
+  } else {
+    this.parsePropertyName(element2);
+  }
+};
+pp$8.parseClassMethod = function(method, isGenerator, isAsync, allowsDirectSuper) {
+  var key = method.key;
+  if (method.kind === "constructor") {
+    if (isGenerator) {
+      this.raise(key.start, "Constructor can't be a generator");
+    }
+    if (isAsync) {
+      this.raise(key.start, "Constructor can't be an async method");
+    }
+  } else if (method.static && checkKeyName(method, "prototype")) {
+    this.raise(key.start, "Classes may not have a static property named prototype");
+  }
+  var value = method.value = this.parseMethod(isGenerator, isAsync, allowsDirectSuper);
+  if (method.kind === "get" && value.params.length !== 0) {
+    this.raiseRecoverable(value.start, "getter should have no params");
+  }
+  if (method.kind === "set" && value.params.length !== 1) {
+    this.raiseRecoverable(value.start, "setter should have exactly one param");
+  }
+  if (method.kind === "set" && value.params[0].type === "RestElement") {
+    this.raiseRecoverable(value.params[0].start, "Setter cannot use rest params");
+  }
+  return this.finishNode(method, "MethodDefinition");
+};
+pp$8.parseClassField = function(field) {
+  if (checkKeyName(field, "constructor")) {
+    this.raise(field.key.start, "Classes can't have a field named 'constructor'");
+  } else if (field.static && checkKeyName(field, "prototype")) {
+    this.raise(field.key.start, "Classes can't have a static field named 'prototype'");
+  }
+  if (this.eat(types$1.eq)) {
+    var scope = this.currentThisScope();
+    var inClassFieldInit = scope.inClassFieldInit;
+    scope.inClassFieldInit = true;
+    field.value = this.parseMaybeAssign();
+    scope.inClassFieldInit = inClassFieldInit;
+  } else {
+    field.value = null;
+  }
+  this.semicolon();
+  return this.finishNode(field, "PropertyDefinition");
+};
+pp$8.parseClassStaticBlock = function(node) {
+  node.body = [];
+  var oldLabels = this.labels;
+  this.labels = [];
+  this.enterScope(SCOPE_CLASS_STATIC_BLOCK | SCOPE_SUPER);
+  while (this.type !== types$1.braceR) {
+    var stmt = this.parseStatement(null);
+    node.body.push(stmt);
+  }
+  this.next();
+  this.exitScope();
+  this.labels = oldLabels;
+  return this.finishNode(node, "StaticBlock");
+};
+pp$8.parseClassId = function(node, isStatement) {
+  if (this.type === types$1.name) {
+    node.id = this.parseIdent();
+    if (isStatement) {
+      this.checkLValSimple(node.id, BIND_LEXICAL, false);
+    }
+  } else {
+    if (isStatement === true) {
+      this.unexpected();
+    }
+    node.id = null;
+  }
+};
+pp$8.parseClassSuper = function(node) {
+  node.superClass = this.eat(types$1._extends) ? this.parseExprSubscripts(false) : null;
+};
+pp$8.enterClassBody = function() {
+  var element2 = { declared: /* @__PURE__ */ Object.create(null), used: [] };
+  this.privateNameStack.push(element2);
+  return element2.declared;
+};
+pp$8.exitClassBody = function() {
+  var ref2 = this.privateNameStack.pop();
+  var declared = ref2.declared;
+  var used = ref2.used;
+  var len = this.privateNameStack.length;
+  var parent = len === 0 ? null : this.privateNameStack[len - 1];
+  for (var i = 0; i < used.length; ++i) {
+    var id = used[i];
+    if (!hasOwn(declared, id.name)) {
+      if (parent) {
+        parent.used.push(id);
+      } else {
+        this.raiseRecoverable(id.start, "Private field '#" + id.name + "' must be declared in an enclosing class");
+      }
+    }
+  }
+};
+function isPrivateNameConflicted(privateNameMap, element2) {
+  var name2 = element2.key.name;
+  var curr = privateNameMap[name2];
+  var next = "true";
+  if (element2.type === "MethodDefinition" && (element2.kind === "get" || element2.kind === "set")) {
+    next = (element2.static ? "s" : "i") + element2.kind;
+  }
+  if (curr === "iget" && next === "iset" || curr === "iset" && next === "iget" || curr === "sget" && next === "sset" || curr === "sset" && next === "sget") {
+    privateNameMap[name2] = "true";
+    return false;
+  } else if (!curr) {
+    privateNameMap[name2] = next;
+    return false;
+  } else {
+    return true;
+  }
+}
+function checkKeyName(node, name2) {
+  var computed = node.computed;
+  var key = node.key;
+  return !computed && (key.type === "Identifier" && key.name === name2 || key.type === "Literal" && key.value === name2);
+}
+pp$8.parseExport = function(node, exports) {
+  this.next();
+  if (this.eat(types$1.star)) {
+    if (this.options.ecmaVersion >= 11) {
+      if (this.eatContextual("as")) {
+        node.exported = this.parseModuleExportName();
+        this.checkExport(exports, node.exported, this.lastTokStart);
+      } else {
+        node.exported = null;
+      }
+    }
+    this.expectContextual("from");
+    if (this.type !== types$1.string) {
+      this.unexpected();
+    }
+    node.source = this.parseExprAtom();
+    this.semicolon();
+    return this.finishNode(node, "ExportAllDeclaration");
+  }
+  if (this.eat(types$1._default)) {
+    this.checkExport(exports, "default", this.lastTokStart);
+    var isAsync;
+    if (this.type === types$1._function || (isAsync = this.isAsyncFunction())) {
+      var fNode = this.startNode();
+      this.next();
+      if (isAsync) {
+        this.next();
+      }
+      node.declaration = this.parseFunction(fNode, FUNC_STATEMENT | FUNC_NULLABLE_ID, false, isAsync);
+    } else if (this.type === types$1._class) {
+      var cNode = this.startNode();
+      node.declaration = this.parseClass(cNode, "nullableID");
+    } else {
+      node.declaration = this.parseMaybeAssign();
+      this.semicolon();
+    }
+    return this.finishNode(node, "ExportDefaultDeclaration");
+  }
+  if (this.shouldParseExportStatement()) {
+    node.declaration = this.parseStatement(null);
+    if (node.declaration.type === "VariableDeclaration") {
+      this.checkVariableExport(exports, node.declaration.declarations);
+    } else {
+      this.checkExport(exports, node.declaration.id, node.declaration.id.start);
+    }
+    node.specifiers = [];
+    node.source = null;
+  } else {
+    node.declaration = null;
+    node.specifiers = this.parseExportSpecifiers(exports);
+    if (this.eatContextual("from")) {
+      if (this.type !== types$1.string) {
+        this.unexpected();
+      }
+      node.source = this.parseExprAtom();
+    } else {
+      for (var i = 0, list3 = node.specifiers; i < list3.length; i += 1) {
+        var spec = list3[i];
+        this.checkUnreserved(spec.local);
+        this.checkLocalExport(spec.local);
+        if (spec.local.type === "Literal") {
+          this.raise(spec.local.start, "A string literal cannot be used as an exported binding without `from`.");
+        }
+      }
+      node.source = null;
+    }
+    this.semicolon();
+  }
+  return this.finishNode(node, "ExportNamedDeclaration");
+};
+pp$8.checkExport = function(exports, name2, pos) {
+  if (!exports) {
+    return;
+  }
+  if (typeof name2 !== "string") {
+    name2 = name2.type === "Identifier" ? name2.name : name2.value;
+  }
+  if (hasOwn(exports, name2)) {
+    this.raiseRecoverable(pos, "Duplicate export '" + name2 + "'");
+  }
+  exports[name2] = true;
+};
+pp$8.checkPatternExport = function(exports, pat) {
+  var type = pat.type;
+  if (type === "Identifier") {
+    this.checkExport(exports, pat, pat.start);
+  } else if (type === "ObjectPattern") {
+    for (var i = 0, list3 = pat.properties; i < list3.length; i += 1) {
+      var prop = list3[i];
+      this.checkPatternExport(exports, prop);
+    }
+  } else if (type === "ArrayPattern") {
+    for (var i$1 = 0, list$1 = pat.elements; i$1 < list$1.length; i$1 += 1) {
+      var elt = list$1[i$1];
+      if (elt) {
+        this.checkPatternExport(exports, elt);
+      }
+    }
+  } else if (type === "Property") {
+    this.checkPatternExport(exports, pat.value);
+  } else if (type === "AssignmentPattern") {
+    this.checkPatternExport(exports, pat.left);
+  } else if (type === "RestElement") {
+    this.checkPatternExport(exports, pat.argument);
+  } else if (type === "ParenthesizedExpression") {
+    this.checkPatternExport(exports, pat.expression);
+  }
+};
+pp$8.checkVariableExport = function(exports, decls) {
+  if (!exports) {
+    return;
+  }
+  for (var i = 0, list3 = decls; i < list3.length; i += 1) {
+    var decl = list3[i];
+    this.checkPatternExport(exports, decl.id);
+  }
+};
+pp$8.shouldParseExportStatement = function() {
+  return this.type.keyword === "var" || this.type.keyword === "const" || this.type.keyword === "class" || this.type.keyword === "function" || this.isLet() || this.isAsyncFunction();
+};
+pp$8.parseExportSpecifiers = function(exports) {
+  var nodes = [], first = true;
+  this.expect(types$1.braceL);
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var node = this.startNode();
+    node.local = this.parseModuleExportName();
+    node.exported = this.eatContextual("as") ? this.parseModuleExportName() : node.local;
+    this.checkExport(
+      exports,
+      node.exported,
+      node.exported.start
+    );
+    nodes.push(this.finishNode(node, "ExportSpecifier"));
+  }
+  return nodes;
+};
+pp$8.parseImport = function(node) {
+  this.next();
+  if (this.type === types$1.string) {
+    node.specifiers = empty$1;
+    node.source = this.parseExprAtom();
+  } else {
+    node.specifiers = this.parseImportSpecifiers();
+    this.expectContextual("from");
+    node.source = this.type === types$1.string ? this.parseExprAtom() : this.unexpected();
+  }
+  this.semicolon();
+  return this.finishNode(node, "ImportDeclaration");
+};
+pp$8.parseImportSpecifiers = function() {
+  var nodes = [], first = true;
+  if (this.type === types$1.name) {
+    var node = this.startNode();
+    node.local = this.parseIdent();
+    this.checkLValSimple(node.local, BIND_LEXICAL);
+    nodes.push(this.finishNode(node, "ImportDefaultSpecifier"));
+    if (!this.eat(types$1.comma)) {
+      return nodes;
+    }
+  }
+  if (this.type === types$1.star) {
+    var node$1 = this.startNode();
+    this.next();
+    this.expectContextual("as");
+    node$1.local = this.parseIdent();
+    this.checkLValSimple(node$1.local, BIND_LEXICAL);
+    nodes.push(this.finishNode(node$1, "ImportNamespaceSpecifier"));
+    return nodes;
+  }
+  this.expect(types$1.braceL);
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var node$2 = this.startNode();
+    node$2.imported = this.parseModuleExportName();
+    if (this.eatContextual("as")) {
+      node$2.local = this.parseIdent();
+    } else {
+      this.checkUnreserved(node$2.imported);
+      node$2.local = node$2.imported;
+    }
+    this.checkLValSimple(node$2.local, BIND_LEXICAL);
+    nodes.push(this.finishNode(node$2, "ImportSpecifier"));
+  }
+  return nodes;
+};
+pp$8.parseModuleExportName = function() {
+  if (this.options.ecmaVersion >= 13 && this.type === types$1.string) {
+    var stringLiteral = this.parseLiteral(this.value);
+    if (loneSurrogate.test(stringLiteral.value)) {
+      this.raise(stringLiteral.start, "An export name cannot include a lone surrogate.");
+    }
+    return stringLiteral;
+  }
+  return this.parseIdent(true);
+};
+pp$8.adaptDirectivePrologue = function(statements) {
+  for (var i = 0; i < statements.length && this.isDirectiveCandidate(statements[i]); ++i) {
+    statements[i].directive = statements[i].expression.raw.slice(1, -1);
+  }
+};
+pp$8.isDirectiveCandidate = function(statement) {
+  return this.options.ecmaVersion >= 5 && statement.type === "ExpressionStatement" && statement.expression.type === "Literal" && typeof statement.expression.value === "string" && (this.input[statement.start] === '"' || this.input[statement.start] === "'");
+};
+var pp$7 = Parser.prototype;
+pp$7.toAssignable = function(node, isBinding, refDestructuringErrors) {
+  if (this.options.ecmaVersion >= 6 && node) {
+    switch (node.type) {
+      case "Identifier":
+        if (this.inAsync && node.name === "await") {
+          this.raise(node.start, "Cannot use 'await' as identifier inside an async function");
+        }
+        break;
+      case "ObjectPattern":
+      case "ArrayPattern":
+      case "AssignmentPattern":
+      case "RestElement":
+        break;
+      case "ObjectExpression":
+        node.type = "ObjectPattern";
+        if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        for (var i = 0, list3 = node.properties; i < list3.length; i += 1) {
+          var prop = list3[i];
+          this.toAssignable(prop, isBinding);
+          if (prop.type === "RestElement" && (prop.argument.type === "ArrayPattern" || prop.argument.type === "ObjectPattern")) {
+            this.raise(prop.argument.start, "Unexpected token");
+          }
+        }
+        break;
+      case "Property":
+        if (node.kind !== "init") {
+          this.raise(node.key.start, "Object pattern can't contain getter or setter");
+        }
+        this.toAssignable(node.value, isBinding);
+        break;
+      case "ArrayExpression":
+        node.type = "ArrayPattern";
+        if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        this.toAssignableList(node.elements, isBinding);
+        break;
+      case "SpreadElement":
+        node.type = "RestElement";
+        this.toAssignable(node.argument, isBinding);
+        if (node.argument.type === "AssignmentPattern") {
+          this.raise(node.argument.start, "Rest elements cannot have a default value");
+        }
+        break;
+      case "AssignmentExpression":
+        if (node.operator !== "=") {
+          this.raise(node.left.end, "Only '=' operator can be used for specifying default value.");
+        }
+        node.type = "AssignmentPattern";
+        delete node.operator;
+        this.toAssignable(node.left, isBinding);
+        break;
+      case "ParenthesizedExpression":
+        this.toAssignable(node.expression, isBinding, refDestructuringErrors);
+        break;
+      case "ChainExpression":
+        this.raiseRecoverable(node.start, "Optional chaining cannot appear in left-hand side");
+        break;
+      case "MemberExpression":
+        if (!isBinding) {
+          break;
+        }
+      default:
+        this.raise(node.start, "Assigning to rvalue");
+    }
+  } else if (refDestructuringErrors) {
+    this.checkPatternErrors(refDestructuringErrors, true);
+  }
+  return node;
+};
+pp$7.toAssignableList = function(exprList, isBinding) {
+  var end = exprList.length;
+  for (var i = 0; i < end; i++) {
+    var elt = exprList[i];
+    if (elt) {
+      this.toAssignable(elt, isBinding);
+    }
+  }
+  if (end) {
+    var last = exprList[end - 1];
+    if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier") {
+      this.unexpected(last.argument.start);
+    }
+  }
+  return exprList;
+};
+pp$7.parseSpread = function(refDestructuringErrors) {
+  var node = this.startNode();
+  this.next();
+  node.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+  return this.finishNode(node, "SpreadElement");
+};
+pp$7.parseRestBinding = function() {
+  var node = this.startNode();
+  this.next();
+  if (this.options.ecmaVersion === 6 && this.type !== types$1.name) {
+    this.unexpected();
+  }
+  node.argument = this.parseBindingAtom();
+  return this.finishNode(node, "RestElement");
+};
+pp$7.parseBindingAtom = function() {
+  if (this.options.ecmaVersion >= 6) {
+    switch (this.type) {
+      case types$1.bracketL:
+        var node = this.startNode();
+        this.next();
+        node.elements = this.parseBindingList(types$1.bracketR, true, true);
+        return this.finishNode(node, "ArrayPattern");
+      case types$1.braceL:
+        return this.parseObj(true);
+    }
+  }
+  return this.parseIdent();
+};
+pp$7.parseBindingList = function(close, allowEmpty, allowTrailingComma) {
+  var elts = [], first = true;
+  while (!this.eat(close)) {
+    if (first) {
+      first = false;
+    } else {
+      this.expect(types$1.comma);
+    }
+    if (allowEmpty && this.type === types$1.comma) {
+      elts.push(null);
+    } else if (allowTrailingComma && this.afterTrailingComma(close)) {
+      break;
+    } else if (this.type === types$1.ellipsis) {
+      var rest = this.parseRestBinding();
+      this.parseBindingListItem(rest);
+      elts.push(rest);
+      if (this.type === types$1.comma) {
+        this.raise(this.start, "Comma is not permitted after the rest element");
+      }
+      this.expect(close);
+      break;
+    } else {
+      var elem = this.parseMaybeDefault(this.start, this.startLoc);
+      this.parseBindingListItem(elem);
+      elts.push(elem);
+    }
+  }
+  return elts;
+};
+pp$7.parseBindingListItem = function(param) {
+  return param;
+};
+pp$7.parseMaybeDefault = function(startPos, startLoc, left) {
+  left = left || this.parseBindingAtom();
+  if (this.options.ecmaVersion < 6 || !this.eat(types$1.eq)) {
+    return left;
+  }
+  var node = this.startNodeAt(startPos, startLoc);
+  node.left = left;
+  node.right = this.parseMaybeAssign();
+  return this.finishNode(node, "AssignmentPattern");
+};
+pp$7.checkLValSimple = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0)
+    bindingType = BIND_NONE;
+  var isBind = bindingType !== BIND_NONE;
+  switch (expr.type) {
+    case "Identifier":
+      if (this.strict && this.reservedWordsStrictBind.test(expr.name)) {
+        this.raiseRecoverable(expr.start, (isBind ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+      }
+      if (isBind) {
+        if (bindingType === BIND_LEXICAL && expr.name === "let") {
+          this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name");
+        }
+        if (checkClashes) {
+          if (hasOwn(checkClashes, expr.name)) {
+            this.raiseRecoverable(expr.start, "Argument name clash");
+          }
+          checkClashes[expr.name] = true;
+        }
+        if (bindingType !== BIND_OUTSIDE) {
+          this.declareName(expr.name, bindingType, expr.start);
+        }
+      }
+      break;
+    case "ChainExpression":
+      this.raiseRecoverable(expr.start, "Optional chaining cannot appear in left-hand side");
+      break;
+    case "MemberExpression":
+      if (isBind) {
+        this.raiseRecoverable(expr.start, "Binding member expression");
+      }
+      break;
+    case "ParenthesizedExpression":
+      if (isBind) {
+        this.raiseRecoverable(expr.start, "Binding parenthesized expression");
+      }
+      return this.checkLValSimple(expr.expression, bindingType, checkClashes);
+    default:
+      this.raise(expr.start, (isBind ? "Binding" : "Assigning to") + " rvalue");
+  }
+};
+pp$7.checkLValPattern = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0)
+    bindingType = BIND_NONE;
+  switch (expr.type) {
+    case "ObjectPattern":
+      for (var i = 0, list3 = expr.properties; i < list3.length; i += 1) {
+        var prop = list3[i];
+        this.checkLValInnerPattern(prop, bindingType, checkClashes);
+      }
+      break;
+    case "ArrayPattern":
+      for (var i$1 = 0, list$1 = expr.elements; i$1 < list$1.length; i$1 += 1) {
+        var elem = list$1[i$1];
+        if (elem) {
+          this.checkLValInnerPattern(elem, bindingType, checkClashes);
+        }
+      }
+      break;
+    default:
+      this.checkLValSimple(expr, bindingType, checkClashes);
+  }
+};
+pp$7.checkLValInnerPattern = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0)
+    bindingType = BIND_NONE;
+  switch (expr.type) {
+    case "Property":
+      this.checkLValInnerPattern(expr.value, bindingType, checkClashes);
+      break;
+    case "AssignmentPattern":
+      this.checkLValPattern(expr.left, bindingType, checkClashes);
+      break;
+    case "RestElement":
+      this.checkLValPattern(expr.argument, bindingType, checkClashes);
+      break;
+    default:
+      this.checkLValPattern(expr, bindingType, checkClashes);
+  }
+};
+var TokContext = function TokContext2(token, isExpr, preserveSpace, override, generator) {
+  this.token = token;
+  this.isExpr = !!isExpr;
+  this.preserveSpace = !!preserveSpace;
+  this.override = override;
+  this.generator = !!generator;
+};
+var types = {
+  b_stat: new TokContext("{", false),
+  b_expr: new TokContext("{", true),
+  b_tmpl: new TokContext("${", false),
+  p_stat: new TokContext("(", false),
+  p_expr: new TokContext("(", true),
+  q_tmpl: new TokContext("`", true, true, function(p) {
+    return p.tryReadTemplateToken();
+  }),
+  f_stat: new TokContext("function", false),
+  f_expr: new TokContext("function", true),
+  f_expr_gen: new TokContext("function", true, false, null, true),
+  f_gen: new TokContext("function", false, false, null, true)
+};
+var pp$6 = Parser.prototype;
+pp$6.initialContext = function() {
+  return [types.b_stat];
+};
+pp$6.curContext = function() {
+  return this.context[this.context.length - 1];
+};
+pp$6.braceIsBlock = function(prevType) {
+  var parent = this.curContext();
+  if (parent === types.f_expr || parent === types.f_stat) {
+    return true;
+  }
+  if (prevType === types$1.colon && (parent === types.b_stat || parent === types.b_expr)) {
+    return !parent.isExpr;
+  }
+  if (prevType === types$1._return || prevType === types$1.name && this.exprAllowed) {
+    return lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+  }
+  if (prevType === types$1._else || prevType === types$1.semi || prevType === types$1.eof || prevType === types$1.parenR || prevType === types$1.arrow) {
+    return true;
+  }
+  if (prevType === types$1.braceL) {
+    return parent === types.b_stat;
+  }
+  if (prevType === types$1._var || prevType === types$1._const || prevType === types$1.name) {
+    return false;
+  }
+  return !this.exprAllowed;
+};
+pp$6.inGeneratorContext = function() {
+  for (var i = this.context.length - 1; i >= 1; i--) {
+    var context = this.context[i];
+    if (context.token === "function") {
+      return context.generator;
+    }
+  }
+  return false;
+};
+pp$6.updateContext = function(prevType) {
+  var update, type = this.type;
+  if (type.keyword && prevType === types$1.dot) {
+    this.exprAllowed = false;
+  } else if (update = type.updateContext) {
+    update.call(this, prevType);
+  } else {
+    this.exprAllowed = type.beforeExpr;
+  }
+};
+pp$6.overrideContext = function(tokenCtx) {
+  if (this.curContext() !== tokenCtx) {
+    this.context[this.context.length - 1] = tokenCtx;
+  }
+};
+types$1.parenR.updateContext = types$1.braceR.updateContext = function() {
+  if (this.context.length === 1) {
+    this.exprAllowed = true;
+    return;
+  }
+  var out = this.context.pop();
+  if (out === types.b_stat && this.curContext().token === "function") {
+    out = this.context.pop();
+  }
+  this.exprAllowed = !out.isExpr;
+};
+types$1.braceL.updateContext = function(prevType) {
+  this.context.push(this.braceIsBlock(prevType) ? types.b_stat : types.b_expr);
+  this.exprAllowed = true;
+};
+types$1.dollarBraceL.updateContext = function() {
+  this.context.push(types.b_tmpl);
+  this.exprAllowed = true;
+};
+types$1.parenL.updateContext = function(prevType) {
+  var statementParens = prevType === types$1._if || prevType === types$1._for || prevType === types$1._with || prevType === types$1._while;
+  this.context.push(statementParens ? types.p_stat : types.p_expr);
+  this.exprAllowed = true;
+};
+types$1.incDec.updateContext = function() {
+};
+types$1._function.updateContext = types$1._class.updateContext = function(prevType) {
+  if (prevType.beforeExpr && prevType !== types$1._else && !(prevType === types$1.semi && this.curContext() !== types.p_stat) && !(prevType === types$1._return && lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) && !((prevType === types$1.colon || prevType === types$1.braceL) && this.curContext() === types.b_stat)) {
+    this.context.push(types.f_expr);
+  } else {
+    this.context.push(types.f_stat);
+  }
+  this.exprAllowed = false;
+};
+types$1.backQuote.updateContext = function() {
+  if (this.curContext() === types.q_tmpl) {
+    this.context.pop();
+  } else {
+    this.context.push(types.q_tmpl);
+  }
+  this.exprAllowed = false;
+};
+types$1.star.updateContext = function(prevType) {
+  if (prevType === types$1._function) {
+    var index2 = this.context.length - 1;
+    if (this.context[index2] === types.f_expr) {
+      this.context[index2] = types.f_expr_gen;
+    } else {
+      this.context[index2] = types.f_gen;
+    }
+  }
+  this.exprAllowed = true;
+};
+types$1.name.updateContext = function(prevType) {
+  var allowed = false;
+  if (this.options.ecmaVersion >= 6 && prevType !== types$1.dot) {
+    if (this.value === "of" && !this.exprAllowed || this.value === "yield" && this.inGeneratorContext()) {
+      allowed = true;
+    }
+  }
+  this.exprAllowed = allowed;
+};
+var pp$5 = Parser.prototype;
+pp$5.checkPropClash = function(prop, propHash, refDestructuringErrors) {
+  if (this.options.ecmaVersion >= 9 && prop.type === "SpreadElement") {
+    return;
+  }
+  if (this.options.ecmaVersion >= 6 && (prop.computed || prop.method || prop.shorthand)) {
+    return;
+  }
+  var key = prop.key;
+  var name2;
+  switch (key.type) {
+    case "Identifier":
+      name2 = key.name;
+      break;
+    case "Literal":
+      name2 = String(key.value);
+      break;
+    default:
+      return;
+  }
+  var kind = prop.kind;
+  if (this.options.ecmaVersion >= 6) {
+    if (name2 === "__proto__" && kind === "init") {
+      if (propHash.proto) {
+        if (refDestructuringErrors) {
+          if (refDestructuringErrors.doubleProto < 0) {
+            refDestructuringErrors.doubleProto = key.start;
+          }
+        } else {
+          this.raiseRecoverable(key.start, "Redefinition of __proto__ property");
+        }
+      }
+      propHash.proto = true;
+    }
+    return;
+  }
+  name2 = "$" + name2;
+  var other = propHash[name2];
+  if (other) {
+    var redefinition;
+    if (kind === "init") {
+      redefinition = this.strict && other.init || other.get || other.set;
+    } else {
+      redefinition = other.init || other[kind];
+    }
+    if (redefinition) {
+      this.raiseRecoverable(key.start, "Redefinition of property");
+    }
+  } else {
+    other = propHash[name2] = {
+      init: false,
+      get: false,
+      set: false
+    };
+  }
+  other[kind] = true;
+};
+pp$5.parseExpression = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseMaybeAssign(forInit, refDestructuringErrors);
+  if (this.type === types$1.comma) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.expressions = [expr];
+    while (this.eat(types$1.comma)) {
+      node.expressions.push(this.parseMaybeAssign(forInit, refDestructuringErrors));
+    }
+    return this.finishNode(node, "SequenceExpression");
+  }
+  return expr;
+};
+pp$5.parseMaybeAssign = function(forInit, refDestructuringErrors, afterLeftParse) {
+  if (this.isContextual("yield")) {
+    if (this.inGenerator) {
+      return this.parseYield(forInit);
+    } else {
+      this.exprAllowed = false;
+    }
+  }
+  var ownDestructuringErrors = false, oldParenAssign = -1, oldTrailingComma = -1, oldDoubleProto = -1;
+  if (refDestructuringErrors) {
+    oldParenAssign = refDestructuringErrors.parenthesizedAssign;
+    oldTrailingComma = refDestructuringErrors.trailingComma;
+    oldDoubleProto = refDestructuringErrors.doubleProto;
+    refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = -1;
+  } else {
+    refDestructuringErrors = new DestructuringErrors();
+    ownDestructuringErrors = true;
+  }
+  var startPos = this.start, startLoc = this.startLoc;
+  if (this.type === types$1.parenL || this.type === types$1.name) {
+    this.potentialArrowAt = this.start;
+    this.potentialArrowInForAwait = forInit === "await";
+  }
+  var left = this.parseMaybeConditional(forInit, refDestructuringErrors);
+  if (afterLeftParse) {
+    left = afterLeftParse.call(this, left, startPos, startLoc);
+  }
+  if (this.type.isAssign) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.operator = this.value;
+    if (this.type === types$1.eq) {
+      left = this.toAssignable(left, false, refDestructuringErrors);
+    }
+    if (!ownDestructuringErrors) {
+      refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = refDestructuringErrors.doubleProto = -1;
+    }
+    if (refDestructuringErrors.shorthandAssign >= left.start) {
+      refDestructuringErrors.shorthandAssign = -1;
+    }
+    if (this.type === types$1.eq) {
+      this.checkLValPattern(left);
+    } else {
+      this.checkLValSimple(left);
+    }
+    node.left = left;
+    this.next();
+    node.right = this.parseMaybeAssign(forInit);
+    if (oldDoubleProto > -1) {
+      refDestructuringErrors.doubleProto = oldDoubleProto;
+    }
+    return this.finishNode(node, "AssignmentExpression");
+  } else {
+    if (ownDestructuringErrors) {
+      this.checkExpressionErrors(refDestructuringErrors, true);
+    }
+  }
+  if (oldParenAssign > -1) {
+    refDestructuringErrors.parenthesizedAssign = oldParenAssign;
+  }
+  if (oldTrailingComma > -1) {
+    refDestructuringErrors.trailingComma = oldTrailingComma;
+  }
+  return left;
+};
+pp$5.parseMaybeConditional = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseExprOps(forInit, refDestructuringErrors);
+  if (this.checkExpressionErrors(refDestructuringErrors)) {
+    return expr;
+  }
+  if (this.eat(types$1.question)) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.test = expr;
+    node.consequent = this.parseMaybeAssign();
+    this.expect(types$1.colon);
+    node.alternate = this.parseMaybeAssign(forInit);
+    return this.finishNode(node, "ConditionalExpression");
+  }
+  return expr;
+};
+pp$5.parseExprOps = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseMaybeUnary(refDestructuringErrors, false, false, forInit);
+  if (this.checkExpressionErrors(refDestructuringErrors)) {
+    return expr;
+  }
+  return expr.start === startPos && expr.type === "ArrowFunctionExpression" ? expr : this.parseExprOp(expr, startPos, startLoc, -1, forInit);
+};
+pp$5.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, forInit) {
+  var prec = this.type.binop;
+  if (prec != null && (!forInit || this.type !== types$1._in)) {
+    if (prec > minPrec) {
+      var logical = this.type === types$1.logicalOR || this.type === types$1.logicalAND;
+      var coalesce = this.type === types$1.coalesce;
+      if (coalesce) {
+        prec = types$1.logicalAND.binop;
+      }
+      var op = this.value;
+      this.next();
+      var startPos = this.start, startLoc = this.startLoc;
+      var right = this.parseExprOp(this.parseMaybeUnary(null, false, false, forInit), startPos, startLoc, prec, forInit);
+      var node = this.buildBinary(leftStartPos, leftStartLoc, left, right, op, logical || coalesce);
+      if (logical && this.type === types$1.coalesce || coalesce && (this.type === types$1.logicalOR || this.type === types$1.logicalAND)) {
+        this.raiseRecoverable(this.start, "Logical expressions and coalesce expressions cannot be mixed. Wrap either by parentheses");
+      }
+      return this.parseExprOp(node, leftStartPos, leftStartLoc, minPrec, forInit);
+    }
+  }
+  return left;
+};
+pp$5.buildBinary = function(startPos, startLoc, left, right, op, logical) {
+  if (right.type === "PrivateIdentifier") {
+    this.raise(right.start, "Private identifier can only be left side of binary expression");
+  }
+  var node = this.startNodeAt(startPos, startLoc);
+  node.left = left;
+  node.operator = op;
+  node.right = right;
+  return this.finishNode(node, logical ? "LogicalExpression" : "BinaryExpression");
+};
+pp$5.parseMaybeUnary = function(refDestructuringErrors, sawUnary, incDec, forInit) {
+  var startPos = this.start, startLoc = this.startLoc, expr;
+  if (this.isContextual("await") && this.canAwait) {
+    expr = this.parseAwait(forInit);
+    sawUnary = true;
+  } else if (this.type.prefix) {
+    var node = this.startNode(), update = this.type === types$1.incDec;
+    node.operator = this.value;
+    node.prefix = true;
+    this.next();
+    node.argument = this.parseMaybeUnary(null, true, update, forInit);
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    if (update) {
+      this.checkLValSimple(node.argument);
+    } else if (this.strict && node.operator === "delete" && node.argument.type === "Identifier") {
+      this.raiseRecoverable(node.start, "Deleting local variable in strict mode");
+    } else if (node.operator === "delete" && isPrivateFieldAccess(node.argument)) {
+      this.raiseRecoverable(node.start, "Private fields can not be deleted");
+    } else {
+      sawUnary = true;
+    }
+    expr = this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
+  } else if (!sawUnary && this.type === types$1.privateId) {
+    if (forInit || this.privateNameStack.length === 0) {
+      this.unexpected();
+    }
+    expr = this.parsePrivateIdent();
+    if (this.type !== types$1._in) {
+      this.unexpected();
+    }
+  } else {
+    expr = this.parseExprSubscripts(refDestructuringErrors, forInit);
+    if (this.checkExpressionErrors(refDestructuringErrors)) {
+      return expr;
+    }
+    while (this.type.postfix && !this.canInsertSemicolon()) {
+      var node$1 = this.startNodeAt(startPos, startLoc);
+      node$1.operator = this.value;
+      node$1.prefix = false;
+      node$1.argument = expr;
+      this.checkLValSimple(expr);
+      this.next();
+      expr = this.finishNode(node$1, "UpdateExpression");
+    }
+  }
+  if (!incDec && this.eat(types$1.starstar)) {
+    if (sawUnary) {
+      this.unexpected(this.lastTokStart);
+    } else {
+      return this.buildBinary(startPos, startLoc, expr, this.parseMaybeUnary(null, false, false, forInit), "**", false);
+    }
+  } else {
+    return expr;
+  }
+};
+function isPrivateFieldAccess(node) {
+  return node.type === "MemberExpression" && node.property.type === "PrivateIdentifier" || node.type === "ChainExpression" && isPrivateFieldAccess(node.expression);
+}
+pp$5.parseExprSubscripts = function(refDestructuringErrors, forInit) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseExprAtom(refDestructuringErrors, forInit);
+  if (expr.type === "ArrowFunctionExpression" && this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")") {
+    return expr;
+  }
+  var result = this.parseSubscripts(expr, startPos, startLoc, false, forInit);
+  if (refDestructuringErrors && result.type === "MemberExpression") {
+    if (refDestructuringErrors.parenthesizedAssign >= result.start) {
+      refDestructuringErrors.parenthesizedAssign = -1;
+    }
+    if (refDestructuringErrors.parenthesizedBind >= result.start) {
+      refDestructuringErrors.parenthesizedBind = -1;
+    }
+    if (refDestructuringErrors.trailingComma >= result.start) {
+      refDestructuringErrors.trailingComma = -1;
+    }
+  }
+  return result;
+};
+pp$5.parseSubscripts = function(base2, startPos, startLoc, noCalls, forInit) {
+  var maybeAsyncArrow = this.options.ecmaVersion >= 8 && base2.type === "Identifier" && base2.name === "async" && this.lastTokEnd === base2.end && !this.canInsertSemicolon() && base2.end - base2.start === 5 && this.potentialArrowAt === base2.start;
+  var optionalChained = false;
+  while (true) {
+    var element2 = this.parseSubscript(base2, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit);
+    if (element2.optional) {
+      optionalChained = true;
+    }
+    if (element2 === base2 || element2.type === "ArrowFunctionExpression") {
+      if (optionalChained) {
+        var chainNode = this.startNodeAt(startPos, startLoc);
+        chainNode.expression = element2;
+        element2 = this.finishNode(chainNode, "ChainExpression");
+      }
+      return element2;
+    }
+    base2 = element2;
+  }
+};
+pp$5.parseSubscript = function(base2, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
+  var optionalSupported = this.options.ecmaVersion >= 11;
+  var optional = optionalSupported && this.eat(types$1.questionDot);
+  if (noCalls && optional) {
+    this.raise(this.lastTokStart, "Optional chaining cannot appear in the callee of new expressions");
+  }
+  var computed = this.eat(types$1.bracketL);
+  if (computed || optional && this.type !== types$1.parenL && this.type !== types$1.backQuote || this.eat(types$1.dot)) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.object = base2;
+    if (computed) {
+      node.property = this.parseExpression();
+      this.expect(types$1.bracketR);
+    } else if (this.type === types$1.privateId && base2.type !== "Super") {
+      node.property = this.parsePrivateIdent();
+    } else {
+      node.property = this.parseIdent(this.options.allowReserved !== "never");
+    }
+    node.computed = !!computed;
+    if (optionalSupported) {
+      node.optional = optional;
+    }
+    base2 = this.finishNode(node, "MemberExpression");
+  } else if (!noCalls && this.eat(types$1.parenL)) {
+    var refDestructuringErrors = new DestructuringErrors(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+    this.yieldPos = 0;
+    this.awaitPos = 0;
+    this.awaitIdentPos = 0;
+    var exprList = this.parseExprList(types$1.parenR, this.options.ecmaVersion >= 8, false, refDestructuringErrors);
+    if (maybeAsyncArrow && !optional && !this.canInsertSemicolon() && this.eat(types$1.arrow)) {
+      this.checkPatternErrors(refDestructuringErrors, false);
+      this.checkYieldAwaitInDefaultParams();
+      if (this.awaitIdentPos > 0) {
+        this.raise(this.awaitIdentPos, "Cannot use 'await' as identifier inside an async function");
+      }
+      this.yieldPos = oldYieldPos;
+      this.awaitPos = oldAwaitPos;
+      this.awaitIdentPos = oldAwaitIdentPos;
+      return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, true, forInit);
+    }
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    this.yieldPos = oldYieldPos || this.yieldPos;
+    this.awaitPos = oldAwaitPos || this.awaitPos;
+    this.awaitIdentPos = oldAwaitIdentPos || this.awaitIdentPos;
+    var node$1 = this.startNodeAt(startPos, startLoc);
+    node$1.callee = base2;
+    node$1.arguments = exprList;
+    if (optionalSupported) {
+      node$1.optional = optional;
+    }
+    base2 = this.finishNode(node$1, "CallExpression");
+  } else if (this.type === types$1.backQuote) {
+    if (optional || optionalChained) {
+      this.raise(this.start, "Optional chaining cannot appear in the tag of tagged template expressions");
+    }
+    var node$2 = this.startNodeAt(startPos, startLoc);
+    node$2.tag = base2;
+    node$2.quasi = this.parseTemplate({ isTagged: true });
+    base2 = this.finishNode(node$2, "TaggedTemplateExpression");
+  }
+  return base2;
+};
+pp$5.parseExprAtom = function(refDestructuringErrors, forInit) {
+  if (this.type === types$1.slash) {
+    this.readRegexp();
+  }
+  var node, canBeArrow = this.potentialArrowAt === this.start;
+  switch (this.type) {
+    case types$1._super:
+      if (!this.allowSuper) {
+        this.raise(this.start, "'super' keyword outside a method");
+      }
+      node = this.startNode();
+      this.next();
+      if (this.type === types$1.parenL && !this.allowDirectSuper) {
+        this.raise(node.start, "super() call outside constructor of a subclass");
+      }
+      if (this.type !== types$1.dot && this.type !== types$1.bracketL && this.type !== types$1.parenL) {
+        this.unexpected();
+      }
+      return this.finishNode(node, "Super");
+    case types$1._this:
+      node = this.startNode();
+      this.next();
+      return this.finishNode(node, "ThisExpression");
+    case types$1.name:
+      var startPos = this.start, startLoc = this.startLoc, containsEsc = this.containsEsc;
+      var id = this.parseIdent(false);
+      if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === "async" && !this.canInsertSemicolon() && this.eat(types$1._function)) {
+        this.overrideContext(types.f_expr);
+        return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true, forInit);
+      }
+      if (canBeArrow && !this.canInsertSemicolon()) {
+        if (this.eat(types$1.arrow)) {
+          return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false, forInit);
+        }
+        if (this.options.ecmaVersion >= 8 && id.name === "async" && this.type === types$1.name && !containsEsc && (!this.potentialArrowInForAwait || this.value !== "of" || this.containsEsc)) {
+          id = this.parseIdent(false);
+          if (this.canInsertSemicolon() || !this.eat(types$1.arrow)) {
+            this.unexpected();
+          }
+          return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true, forInit);
+        }
+      }
+      return id;
+    case types$1.regexp:
+      var value = this.value;
+      node = this.parseLiteral(value.value);
+      node.regex = { pattern: value.pattern, flags: value.flags };
+      return node;
+    case types$1.num:
+    case types$1.string:
+      return this.parseLiteral(this.value);
+    case types$1._null:
+    case types$1._true:
+    case types$1._false:
+      node = this.startNode();
+      node.value = this.type === types$1._null ? null : this.type === types$1._true;
+      node.raw = this.type.keyword;
+      this.next();
+      return this.finishNode(node, "Literal");
+    case types$1.parenL:
+      var start3 = this.start, expr = this.parseParenAndDistinguishExpression(canBeArrow, forInit);
+      if (refDestructuringErrors) {
+        if (refDestructuringErrors.parenthesizedAssign < 0 && !this.isSimpleAssignTarget(expr)) {
+          refDestructuringErrors.parenthesizedAssign = start3;
+        }
+        if (refDestructuringErrors.parenthesizedBind < 0) {
+          refDestructuringErrors.parenthesizedBind = start3;
+        }
+      }
+      return expr;
+    case types$1.bracketL:
+      node = this.startNode();
+      this.next();
+      node.elements = this.parseExprList(types$1.bracketR, true, true, refDestructuringErrors);
+      return this.finishNode(node, "ArrayExpression");
+    case types$1.braceL:
+      this.overrideContext(types.b_expr);
+      return this.parseObj(false, refDestructuringErrors);
+    case types$1._function:
+      node = this.startNode();
+      this.next();
+      return this.parseFunction(node, 0);
+    case types$1._class:
+      return this.parseClass(this.startNode(), false);
+    case types$1._new:
+      return this.parseNew();
+    case types$1.backQuote:
+      return this.parseTemplate();
+    case types$1._import:
+      if (this.options.ecmaVersion >= 11) {
+        return this.parseExprImport();
+      } else {
+        return this.unexpected();
+      }
+    default:
+      this.unexpected();
+  }
+};
+pp$5.parseExprImport = function() {
+  var node = this.startNode();
+  if (this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword import");
+  }
+  var meta = this.parseIdent(true);
+  switch (this.type) {
+    case types$1.parenL:
+      return this.parseDynamicImport(node);
+    case types$1.dot:
+      node.meta = meta;
+      return this.parseImportMeta(node);
+    default:
+      this.unexpected();
+  }
+};
+pp$5.parseDynamicImport = function(node) {
+  this.next();
+  node.source = this.parseMaybeAssign();
+  if (!this.eat(types$1.parenR)) {
+    var errorPos = this.start;
+    if (this.eat(types$1.comma) && this.eat(types$1.parenR)) {
+      this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+    } else {
+      this.unexpected(errorPos);
+    }
+  }
+  return this.finishNode(node, "ImportExpression");
+};
+pp$5.parseImportMeta = function(node) {
+  this.next();
+  var containsEsc = this.containsEsc;
+  node.property = this.parseIdent(true);
+  if (node.property.name !== "meta") {
+    this.raiseRecoverable(node.property.start, "The only valid meta property for import is 'import.meta'");
+  }
+  if (containsEsc) {
+    this.raiseRecoverable(node.start, "'import.meta' must not contain escaped characters");
+  }
+  if (this.options.sourceType !== "module" && !this.options.allowImportExportEverywhere) {
+    this.raiseRecoverable(node.start, "Cannot use 'import.meta' outside a module");
+  }
+  return this.finishNode(node, "MetaProperty");
+};
+pp$5.parseLiteral = function(value) {
+  var node = this.startNode();
+  node.value = value;
+  node.raw = this.input.slice(this.start, this.end);
+  if (node.raw.charCodeAt(node.raw.length - 1) === 110) {
+    node.bigint = node.raw.slice(0, -1).replace(/_/g, "");
+  }
+  this.next();
+  return this.finishNode(node, "Literal");
+};
+pp$5.parseParenExpression = function() {
+  this.expect(types$1.parenL);
+  var val = this.parseExpression();
+  this.expect(types$1.parenR);
+  return val;
+};
+pp$5.parseParenAndDistinguishExpression = function(canBeArrow, forInit) {
+  var startPos = this.start, startLoc = this.startLoc, val, allowTrailingComma = this.options.ecmaVersion >= 8;
+  if (this.options.ecmaVersion >= 6) {
+    this.next();
+    var innerStartPos = this.start, innerStartLoc = this.startLoc;
+    var exprList = [], first = true, lastIsComma = false;
+    var refDestructuringErrors = new DestructuringErrors(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, spreadStart;
+    this.yieldPos = 0;
+    this.awaitPos = 0;
+    while (this.type !== types$1.parenR) {
+      first ? first = false : this.expect(types$1.comma);
+      if (allowTrailingComma && this.afterTrailingComma(types$1.parenR, true)) {
+        lastIsComma = true;
+        break;
+      } else if (this.type === types$1.ellipsis) {
+        spreadStart = this.start;
+        exprList.push(this.parseParenItem(this.parseRestBinding()));
+        if (this.type === types$1.comma) {
+          this.raise(this.start, "Comma is not permitted after the rest element");
+        }
+        break;
+      } else {
+        exprList.push(this.parseMaybeAssign(false, refDestructuringErrors, this.parseParenItem));
+      }
+    }
+    var innerEndPos = this.lastTokEnd, innerEndLoc = this.lastTokEndLoc;
+    this.expect(types$1.parenR);
+    if (canBeArrow && !this.canInsertSemicolon() && this.eat(types$1.arrow)) {
+      this.checkPatternErrors(refDestructuringErrors, false);
+      this.checkYieldAwaitInDefaultParams();
+      this.yieldPos = oldYieldPos;
+      this.awaitPos = oldAwaitPos;
+      return this.parseParenArrowList(startPos, startLoc, exprList, forInit);
+    }
+    if (!exprList.length || lastIsComma) {
+      this.unexpected(this.lastTokStart);
+    }
+    if (spreadStart) {
+      this.unexpected(spreadStart);
+    }
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    this.yieldPos = oldYieldPos || this.yieldPos;
+    this.awaitPos = oldAwaitPos || this.awaitPos;
+    if (exprList.length > 1) {
+      val = this.startNodeAt(innerStartPos, innerStartLoc);
+      val.expressions = exprList;
+      this.finishNodeAt(val, "SequenceExpression", innerEndPos, innerEndLoc);
+    } else {
+      val = exprList[0];
+    }
+  } else {
+    val = this.parseParenExpression();
+  }
+  if (this.options.preserveParens) {
+    var par = this.startNodeAt(startPos, startLoc);
+    par.expression = val;
+    return this.finishNode(par, "ParenthesizedExpression");
+  } else {
+    return val;
+  }
+};
+pp$5.parseParenItem = function(item) {
+  return item;
+};
+pp$5.parseParenArrowList = function(startPos, startLoc, exprList, forInit) {
+  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, false, forInit);
+};
+var empty = [];
+pp$5.parseNew = function() {
+  if (this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword new");
+  }
+  var node = this.startNode();
+  var meta = this.parseIdent(true);
+  if (this.options.ecmaVersion >= 6 && this.eat(types$1.dot)) {
+    node.meta = meta;
+    var containsEsc = this.containsEsc;
+    node.property = this.parseIdent(true);
+    if (node.property.name !== "target") {
+      this.raiseRecoverable(node.property.start, "The only valid meta property for new is 'new.target'");
+    }
+    if (containsEsc) {
+      this.raiseRecoverable(node.start, "'new.target' must not contain escaped characters");
+    }
+    if (!this.allowNewDotTarget) {
+      this.raiseRecoverable(node.start, "'new.target' can only be used in functions and class static block");
+    }
+    return this.finishNode(node, "MetaProperty");
+  }
+  var startPos = this.start, startLoc = this.startLoc, isImport = this.type === types$1._import;
+  node.callee = this.parseSubscripts(this.parseExprAtom(), startPos, startLoc, true, false);
+  if (isImport && node.callee.type === "ImportExpression") {
+    this.raise(startPos, "Cannot use new with import()");
+  }
+  if (this.eat(types$1.parenL)) {
+    node.arguments = this.parseExprList(types$1.parenR, this.options.ecmaVersion >= 8, false);
+  } else {
+    node.arguments = empty;
+  }
+  return this.finishNode(node, "NewExpression");
+};
+pp$5.parseTemplateElement = function(ref2) {
+  var isTagged = ref2.isTagged;
+  var elem = this.startNode();
+  if (this.type === types$1.invalidTemplate) {
+    if (!isTagged) {
+      this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal");
+    }
+    elem.value = {
+      raw: this.value,
+      cooked: null
+    };
+  } else {
+    elem.value = {
+      raw: this.input.slice(this.start, this.end).replace(/\r\n?/g, "\n"),
+      cooked: this.value
+    };
+  }
+  this.next();
+  elem.tail = this.type === types$1.backQuote;
+  return this.finishNode(elem, "TemplateElement");
+};
+pp$5.parseTemplate = function(ref2) {
+  if (ref2 === void 0)
+    ref2 = {};
+  var isTagged = ref2.isTagged;
+  if (isTagged === void 0)
+    isTagged = false;
+  var node = this.startNode();
+  this.next();
+  node.expressions = [];
+  var curElt = this.parseTemplateElement({ isTagged });
+  node.quasis = [curElt];
+  while (!curElt.tail) {
+    if (this.type === types$1.eof) {
+      this.raise(this.pos, "Unterminated template literal");
+    }
+    this.expect(types$1.dollarBraceL);
+    node.expressions.push(this.parseExpression());
+    this.expect(types$1.braceR);
+    node.quasis.push(curElt = this.parseTemplateElement({ isTagged }));
+  }
+  this.next();
+  return this.finishNode(node, "TemplateLiteral");
+};
+pp$5.isAsyncProp = function(prop) {
+  return !prop.computed && prop.key.type === "Identifier" && prop.key.name === "async" && (this.type === types$1.name || this.type === types$1.num || this.type === types$1.string || this.type === types$1.bracketL || this.type.keyword || this.options.ecmaVersion >= 9 && this.type === types$1.star) && !lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+};
+pp$5.parseObj = function(isPattern, refDestructuringErrors) {
+  var node = this.startNode(), first = true, propHash = {};
+  node.properties = [];
+  this.next();
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.options.ecmaVersion >= 5 && this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var prop = this.parseProperty(isPattern, refDestructuringErrors);
+    if (!isPattern) {
+      this.checkPropClash(prop, propHash, refDestructuringErrors);
+    }
+    node.properties.push(prop);
+  }
+  return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
+};
+pp$5.parseProperty = function(isPattern, refDestructuringErrors) {
+  var prop = this.startNode(), isGenerator, isAsync, startPos, startLoc;
+  if (this.options.ecmaVersion >= 9 && this.eat(types$1.ellipsis)) {
+    if (isPattern) {
+      prop.argument = this.parseIdent(false);
+      if (this.type === types$1.comma) {
+        this.raise(this.start, "Comma is not permitted after the rest element");
+      }
+      return this.finishNode(prop, "RestElement");
+    }
+    prop.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+    if (this.type === types$1.comma && refDestructuringErrors && refDestructuringErrors.trailingComma < 0) {
+      refDestructuringErrors.trailingComma = this.start;
+    }
+    return this.finishNode(prop, "SpreadElement");
+  }
+  if (this.options.ecmaVersion >= 6) {
+    prop.method = false;
+    prop.shorthand = false;
+    if (isPattern || refDestructuringErrors) {
+      startPos = this.start;
+      startLoc = this.startLoc;
+    }
+    if (!isPattern) {
+      isGenerator = this.eat(types$1.star);
+    }
+  }
+  var containsEsc = this.containsEsc;
+  this.parsePropertyName(prop);
+  if (!isPattern && !containsEsc && this.options.ecmaVersion >= 8 && !isGenerator && this.isAsyncProp(prop)) {
+    isAsync = true;
+    isGenerator = this.options.ecmaVersion >= 9 && this.eat(types$1.star);
+    this.parsePropertyName(prop, refDestructuringErrors);
+  } else {
+    isAsync = false;
+  }
+  this.parsePropertyValue(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc);
+  return this.finishNode(prop, "Property");
+};
+pp$5.parsePropertyValue = function(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc) {
+  if ((isGenerator || isAsync) && this.type === types$1.colon) {
+    this.unexpected();
+  }
+  if (this.eat(types$1.colon)) {
+    prop.value = isPattern ? this.parseMaybeDefault(this.start, this.startLoc) : this.parseMaybeAssign(false, refDestructuringErrors);
+    prop.kind = "init";
+  } else if (this.options.ecmaVersion >= 6 && this.type === types$1.parenL) {
+    if (isPattern) {
+      this.unexpected();
+    }
+    prop.kind = "init";
+    prop.method = true;
+    prop.value = this.parseMethod(isGenerator, isAsync);
+  } else if (!isPattern && !containsEsc && this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type !== types$1.comma && this.type !== types$1.braceR && this.type !== types$1.eq)) {
+    if (isGenerator || isAsync) {
+      this.unexpected();
+    }
+    prop.kind = prop.key.name;
+    this.parsePropertyName(prop);
+    prop.value = this.parseMethod(false);
+    var paramCount = prop.kind === "get" ? 0 : 1;
+    if (prop.value.params.length !== paramCount) {
+      var start3 = prop.value.start;
+      if (prop.kind === "get") {
+        this.raiseRecoverable(start3, "getter should have no params");
+      } else {
+        this.raiseRecoverable(start3, "setter should have exactly one param");
+      }
+    } else {
+      if (prop.kind === "set" && prop.value.params[0].type === "RestElement") {
+        this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params");
+      }
+    }
+  } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+    if (isGenerator || isAsync) {
+      this.unexpected();
+    }
+    this.checkUnreserved(prop.key);
+    if (prop.key.name === "await" && !this.awaitIdentPos) {
+      this.awaitIdentPos = startPos;
+    }
+    prop.kind = "init";
+    if (isPattern) {
+      prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+    } else if (this.type === types$1.eq && refDestructuringErrors) {
+      if (refDestructuringErrors.shorthandAssign < 0) {
+        refDestructuringErrors.shorthandAssign = this.start;
+      }
+      prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+    } else {
+      prop.value = this.copyNode(prop.key);
+    }
+    prop.shorthand = true;
+  } else {
+    this.unexpected();
+  }
+};
+pp$5.parsePropertyName = function(prop) {
+  if (this.options.ecmaVersion >= 6) {
+    if (this.eat(types$1.bracketL)) {
+      prop.computed = true;
+      prop.key = this.parseMaybeAssign();
+      this.expect(types$1.bracketR);
+      return prop.key;
+    } else {
+      prop.computed = false;
+    }
+  }
+  return prop.key = this.type === types$1.num || this.type === types$1.string ? this.parseExprAtom() : this.parseIdent(this.options.allowReserved !== "never");
+};
+pp$5.initFunction = function(node) {
+  node.id = null;
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = node.expression = false;
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node.async = false;
+  }
+};
+pp$5.parseMethod = function(isGenerator, isAsync, allowDirectSuper) {
+  var node = this.startNode(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = isGenerator;
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node.async = !!isAsync;
+  }
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  this.enterScope(functionFlags(isAsync, node.generator) | SCOPE_SUPER | (allowDirectSuper ? SCOPE_DIRECT_SUPER : 0));
+  this.expect(types$1.parenL);
+  node.params = this.parseBindingList(types$1.parenR, false, this.options.ecmaVersion >= 8);
+  this.checkYieldAwaitInDefaultParams();
+  this.parseFunctionBody(node, false, true, false);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node, "FunctionExpression");
+};
+pp$5.parseArrowExpression = function(node, params, isAsync, forInit) {
+  var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.enterScope(functionFlags(isAsync, false) | SCOPE_ARROW);
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 8) {
+    node.async = !!isAsync;
+  }
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  node.params = this.toAssignableList(params, true);
+  this.parseFunctionBody(node, true, false, forInit);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node, "ArrowFunctionExpression");
+};
+pp$5.parseFunctionBody = function(node, isArrowFunction, isMethod, forInit) {
+  var isExpression = isArrowFunction && this.type !== types$1.braceL;
+  var oldStrict = this.strict, useStrict = false;
+  if (isExpression) {
+    node.body = this.parseMaybeAssign(forInit);
+    node.expression = true;
+    this.checkParams(node, false);
+  } else {
+    var nonSimple = this.options.ecmaVersion >= 7 && !this.isSimpleParamList(node.params);
+    if (!oldStrict || nonSimple) {
+      useStrict = this.strictDirective(this.end);
+      if (useStrict && nonSimple) {
+        this.raiseRecoverable(node.start, "Illegal 'use strict' directive in function with non-simple parameter list");
+      }
+    }
+    var oldLabels = this.labels;
+    this.labels = [];
+    if (useStrict) {
+      this.strict = true;
+    }
+    this.checkParams(node, !oldStrict && !useStrict && !isArrowFunction && !isMethod && this.isSimpleParamList(node.params));
+    if (this.strict && node.id) {
+      this.checkLValSimple(node.id, BIND_OUTSIDE);
+    }
+    node.body = this.parseBlock(false, void 0, useStrict && !oldStrict);
+    node.expression = false;
+    this.adaptDirectivePrologue(node.body.body);
+    this.labels = oldLabels;
+  }
+  this.exitScope();
+};
+pp$5.isSimpleParamList = function(params) {
+  for (var i = 0, list3 = params; i < list3.length; i += 1) {
+    var param = list3[i];
+    if (param.type !== "Identifier") {
+      return false;
+    }
+  }
+  return true;
+};
+pp$5.checkParams = function(node, allowDuplicates) {
+  var nameHash = /* @__PURE__ */ Object.create(null);
+  for (var i = 0, list3 = node.params; i < list3.length; i += 1) {
+    var param = list3[i];
+    this.checkLValInnerPattern(param, BIND_VAR, allowDuplicates ? null : nameHash);
+  }
+};
+pp$5.parseExprList = function(close, allowTrailingComma, allowEmpty, refDestructuringErrors) {
+  var elts = [], first = true;
+  while (!this.eat(close)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (allowTrailingComma && this.afterTrailingComma(close)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var elt = void 0;
+    if (allowEmpty && this.type === types$1.comma) {
+      elt = null;
+    } else if (this.type === types$1.ellipsis) {
+      elt = this.parseSpread(refDestructuringErrors);
+      if (refDestructuringErrors && this.type === types$1.comma && refDestructuringErrors.trailingComma < 0) {
+        refDestructuringErrors.trailingComma = this.start;
+      }
+    } else {
+      elt = this.parseMaybeAssign(false, refDestructuringErrors);
+    }
+    elts.push(elt);
+  }
+  return elts;
+};
+pp$5.checkUnreserved = function(ref2) {
+  var start3 = ref2.start;
+  var end = ref2.end;
+  var name2 = ref2.name;
+  if (this.inGenerator && name2 === "yield") {
+    this.raiseRecoverable(start3, "Cannot use 'yield' as identifier inside a generator");
+  }
+  if (this.inAsync && name2 === "await") {
+    this.raiseRecoverable(start3, "Cannot use 'await' as identifier inside an async function");
+  }
+  if (this.currentThisScope().inClassFieldInit && name2 === "arguments") {
+    this.raiseRecoverable(start3, "Cannot use 'arguments' in class field initializer");
+  }
+  if (this.inClassStaticBlock && (name2 === "arguments" || name2 === "await")) {
+    this.raise(start3, "Cannot use " + name2 + " in class static initialization block");
+  }
+  if (this.keywords.test(name2)) {
+    this.raise(start3, "Unexpected keyword '" + name2 + "'");
+  }
+  if (this.options.ecmaVersion < 6 && this.input.slice(start3, end).indexOf("\\") !== -1) {
+    return;
+  }
+  var re = this.strict ? this.reservedWordsStrict : this.reservedWords;
+  if (re.test(name2)) {
+    if (!this.inAsync && name2 === "await") {
+      this.raiseRecoverable(start3, "Cannot use keyword 'await' outside an async function");
+    }
+    this.raiseRecoverable(start3, "The keyword '" + name2 + "' is reserved");
+  }
+};
+pp$5.parseIdent = function(liberal, isBinding) {
+  var node = this.startNode();
+  if (this.type === types$1.name) {
+    node.name = this.value;
+  } else if (this.type.keyword) {
+    node.name = this.type.keyword;
+    if ((node.name === "class" || node.name === "function") && (this.lastTokEnd !== this.lastTokStart + 1 || this.input.charCodeAt(this.lastTokStart) !== 46)) {
+      this.context.pop();
+    }
+  } else {
+    this.unexpected();
+  }
+  this.next(!!liberal);
+  this.finishNode(node, "Identifier");
+  if (!liberal) {
+    this.checkUnreserved(node);
+    if (node.name === "await" && !this.awaitIdentPos) {
+      this.awaitIdentPos = node.start;
+    }
+  }
+  return node;
+};
+pp$5.parsePrivateIdent = function() {
+  var node = this.startNode();
+  if (this.type === types$1.privateId) {
+    node.name = this.value;
+  } else {
+    this.unexpected();
+  }
+  this.next();
+  this.finishNode(node, "PrivateIdentifier");
+  if (this.privateNameStack.length === 0) {
+    this.raise(node.start, "Private field '#" + node.name + "' must be declared in an enclosing class");
+  } else {
+    this.privateNameStack[this.privateNameStack.length - 1].used.push(node);
+  }
+  return node;
+};
+pp$5.parseYield = function(forInit) {
+  if (!this.yieldPos) {
+    this.yieldPos = this.start;
+  }
+  var node = this.startNode();
+  this.next();
+  if (this.type === types$1.semi || this.canInsertSemicolon() || this.type !== types$1.star && !this.type.startsExpr) {
+    node.delegate = false;
+    node.argument = null;
+  } else {
+    node.delegate = this.eat(types$1.star);
+    node.argument = this.parseMaybeAssign(forInit);
+  }
+  return this.finishNode(node, "YieldExpression");
+};
+pp$5.parseAwait = function(forInit) {
+  if (!this.awaitPos) {
+    this.awaitPos = this.start;
+  }
+  var node = this.startNode();
+  this.next();
+  node.argument = this.parseMaybeUnary(null, true, false, forInit);
+  return this.finishNode(node, "AwaitExpression");
+};
+var pp$4 = Parser.prototype;
+pp$4.raise = function(pos, message) {
+  var loc = getLineInfo(this.input, pos);
+  message += " (" + loc.line + ":" + loc.column + ")";
+  var err = new SyntaxError(message);
+  err.pos = pos;
+  err.loc = loc;
+  err.raisedAt = this.pos;
+  throw err;
+};
+pp$4.raiseRecoverable = pp$4.raise;
+pp$4.curPosition = function() {
+  if (this.options.locations) {
+    return new Position(this.curLine, this.pos - this.lineStart);
+  }
+};
+var pp$3 = Parser.prototype;
+var Scope = function Scope2(flags) {
+  this.flags = flags;
+  this.var = [];
+  this.lexical = [];
+  this.functions = [];
+  this.inClassFieldInit = false;
+};
+pp$3.enterScope = function(flags) {
+  this.scopeStack.push(new Scope(flags));
+};
+pp$3.exitScope = function() {
+  this.scopeStack.pop();
+};
+pp$3.treatFunctionsAsVarInScope = function(scope) {
+  return scope.flags & SCOPE_FUNCTION || !this.inModule && scope.flags & SCOPE_TOP;
+};
+pp$3.declareName = function(name2, bindingType, pos) {
+  var redeclared = false;
+  if (bindingType === BIND_LEXICAL) {
+    var scope = this.currentScope();
+    redeclared = scope.lexical.indexOf(name2) > -1 || scope.functions.indexOf(name2) > -1 || scope.var.indexOf(name2) > -1;
+    scope.lexical.push(name2);
+    if (this.inModule && scope.flags & SCOPE_TOP) {
+      delete this.undefinedExports[name2];
+    }
+  } else if (bindingType === BIND_SIMPLE_CATCH) {
+    var scope$1 = this.currentScope();
+    scope$1.lexical.push(name2);
+  } else if (bindingType === BIND_FUNCTION) {
+    var scope$2 = this.currentScope();
+    if (this.treatFunctionsAsVar) {
+      redeclared = scope$2.lexical.indexOf(name2) > -1;
+    } else {
+      redeclared = scope$2.lexical.indexOf(name2) > -1 || scope$2.var.indexOf(name2) > -1;
+    }
+    scope$2.functions.push(name2);
+  } else {
+    for (var i = this.scopeStack.length - 1; i >= 0; --i) {
+      var scope$3 = this.scopeStack[i];
+      if (scope$3.lexical.indexOf(name2) > -1 && !(scope$3.flags & SCOPE_SIMPLE_CATCH && scope$3.lexical[0] === name2) || !this.treatFunctionsAsVarInScope(scope$3) && scope$3.functions.indexOf(name2) > -1) {
+        redeclared = true;
+        break;
+      }
+      scope$3.var.push(name2);
+      if (this.inModule && scope$3.flags & SCOPE_TOP) {
+        delete this.undefinedExports[name2];
+      }
+      if (scope$3.flags & SCOPE_VAR) {
+        break;
+      }
+    }
+  }
+  if (redeclared) {
+    this.raiseRecoverable(pos, "Identifier '" + name2 + "' has already been declared");
+  }
+};
+pp$3.checkLocalExport = function(id) {
+  if (this.scopeStack[0].lexical.indexOf(id.name) === -1 && this.scopeStack[0].var.indexOf(id.name) === -1) {
+    this.undefinedExports[id.name] = id;
+  }
+};
+pp$3.currentScope = function() {
+  return this.scopeStack[this.scopeStack.length - 1];
+};
+pp$3.currentVarScope = function() {
+  for (var i = this.scopeStack.length - 1; ; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.flags & SCOPE_VAR) {
+      return scope;
+    }
+  }
+};
+pp$3.currentThisScope = function() {
+  for (var i = this.scopeStack.length - 1; ; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.flags & SCOPE_VAR && !(scope.flags & SCOPE_ARROW)) {
+      return scope;
+    }
+  }
+};
+var Node = function Node2(parser, pos, loc) {
+  this.type = "";
+  this.start = pos;
+  this.end = 0;
+  if (parser.options.locations) {
+    this.loc = new SourceLocation(parser, loc);
+  }
+  if (parser.options.directSourceFile) {
+    this.sourceFile = parser.options.directSourceFile;
+  }
+  if (parser.options.ranges) {
+    this.range = [pos, 0];
+  }
+};
+var pp$2 = Parser.prototype;
+pp$2.startNode = function() {
+  return new Node(this, this.start, this.startLoc);
+};
+pp$2.startNodeAt = function(pos, loc) {
+  return new Node(this, pos, loc);
+};
+function finishNodeAt(node, type, pos, loc) {
+  node.type = type;
+  node.end = pos;
+  if (this.options.locations) {
+    node.loc.end = loc;
+  }
+  if (this.options.ranges) {
+    node.range[1] = pos;
+  }
+  return node;
+}
+pp$2.finishNode = function(node, type) {
+  return finishNodeAt.call(this, node, type, this.lastTokEnd, this.lastTokEndLoc);
+};
+pp$2.finishNodeAt = function(node, type, pos, loc) {
+  return finishNodeAt.call(this, node, type, pos, loc);
+};
+pp$2.copyNode = function(node) {
+  var newNode = new Node(this, node.start, this.startLoc);
+  for (var prop in node) {
+    newNode[prop] = node[prop];
+  }
+  return newNode;
+};
+var ecma9BinaryProperties = "ASCII ASCII_Hex_Digit AHex Alphabetic Alpha Any Assigned Bidi_Control Bidi_C Bidi_Mirrored Bidi_M Case_Ignorable CI Cased Changes_When_Casefolded CWCF Changes_When_Casemapped CWCM Changes_When_Lowercased CWL Changes_When_NFKC_Casefolded CWKCF Changes_When_Titlecased CWT Changes_When_Uppercased CWU Dash Default_Ignorable_Code_Point DI Deprecated Dep Diacritic Dia Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Extender Ext Grapheme_Base Gr_Base Grapheme_Extend Gr_Ext Hex_Digit Hex IDS_Binary_Operator IDSB IDS_Trinary_Operator IDST ID_Continue IDC ID_Start IDS Ideographic Ideo Join_Control Join_C Logical_Order_Exception LOE Lowercase Lower Math Noncharacter_Code_Point NChar Pattern_Syntax Pat_Syn Pattern_White_Space Pat_WS Quotation_Mark QMark Radical Regional_Indicator RI Sentence_Terminal STerm Soft_Dotted SD Terminal_Punctuation Term Unified_Ideograph UIdeo Uppercase Upper Variation_Selector VS White_Space space XID_Continue XIDC XID_Start XIDS";
+var ecma10BinaryProperties = ecma9BinaryProperties + " Extended_Pictographic";
+var ecma11BinaryProperties = ecma10BinaryProperties;
+var ecma12BinaryProperties = ecma11BinaryProperties + " EBase EComp EMod EPres ExtPict";
+var ecma13BinaryProperties = ecma12BinaryProperties;
+var unicodeBinaryProperties = {
+  9: ecma9BinaryProperties,
+  10: ecma10BinaryProperties,
+  11: ecma11BinaryProperties,
+  12: ecma12BinaryProperties,
+  13: ecma13BinaryProperties
+};
+var unicodeGeneralCategoryValues = "Cased_Letter LC Close_Punctuation Pe Connector_Punctuation Pc Control Cc cntrl Currency_Symbol Sc Dash_Punctuation Pd Decimal_Number Nd digit Enclosing_Mark Me Final_Punctuation Pf Format Cf Initial_Punctuation Pi Letter L Letter_Number Nl Line_Separator Zl Lowercase_Letter Ll Mark M Combining_Mark Math_Symbol Sm Modifier_Letter Lm Modifier_Symbol Sk Nonspacing_Mark Mn Number N Open_Punctuation Ps Other C Other_Letter Lo Other_Number No Other_Punctuation Po Other_Symbol So Paragraph_Separator Zp Private_Use Co Punctuation P punct Separator Z Space_Separator Zs Spacing_Mark Mc Surrogate Cs Symbol S Titlecase_Letter Lt Unassigned Cn Uppercase_Letter Lu";
+var ecma9ScriptValues = "Adlam Adlm Ahom Anatolian_Hieroglyphs Hluw Arabic Arab Armenian Armn Avestan Avst Balinese Bali Bamum Bamu Bassa_Vah Bass Batak Batk Bengali Beng Bhaiksuki Bhks Bopomofo Bopo Brahmi Brah Braille Brai Buginese Bugi Buhid Buhd Canadian_Aboriginal Cans Carian Cari Caucasian_Albanian Aghb Chakma Cakm Cham Cham Cherokee Cher Common Zyyy Coptic Copt Qaac Cuneiform Xsux Cypriot Cprt Cyrillic Cyrl Deseret Dsrt Devanagari Deva Duployan Dupl Egyptian_Hieroglyphs Egyp Elbasan Elba Ethiopic Ethi Georgian Geor Glagolitic Glag Gothic Goth Grantha Gran Greek Grek Gujarati Gujr Gurmukhi Guru Han Hani Hangul Hang Hanunoo Hano Hatran Hatr Hebrew Hebr Hiragana Hira Imperial_Aramaic Armi Inherited Zinh Qaai Inscriptional_Pahlavi Phli Inscriptional_Parthian Prti Javanese Java Kaithi Kthi Kannada Knda Katakana Kana Kayah_Li Kali Kharoshthi Khar Khmer Khmr Khojki Khoj Khudawadi Sind Lao Laoo Latin Latn Lepcha Lepc Limbu Limb Linear_A Lina Linear_B Linb Lisu Lisu Lycian Lyci Lydian Lydi Mahajani Mahj Malayalam Mlym Mandaic Mand Manichaean Mani Marchen Marc Masaram_Gondi Gonm Meetei_Mayek Mtei Mende_Kikakui Mend Meroitic_Cursive Merc Meroitic_Hieroglyphs Mero Miao Plrd Modi Mongolian Mong Mro Mroo Multani Mult Myanmar Mymr Nabataean Nbat New_Tai_Lue Talu Newa Newa Nko Nkoo Nushu Nshu Ogham Ogam Ol_Chiki Olck Old_Hungarian Hung Old_Italic Ital Old_North_Arabian Narb Old_Permic Perm Old_Persian Xpeo Old_South_Arabian Sarb Old_Turkic Orkh Oriya Orya Osage Osge Osmanya Osma Pahawh_Hmong Hmng Palmyrene Palm Pau_Cin_Hau Pauc Phags_Pa Phag Phoenician Phnx Psalter_Pahlavi Phlp Rejang Rjng Runic Runr Samaritan Samr Saurashtra Saur Sharada Shrd Shavian Shaw Siddham Sidd SignWriting Sgnw Sinhala Sinh Sora_Sompeng Sora Soyombo Soyo Sundanese Sund Syloti_Nagri Sylo Syriac Syrc Tagalog Tglg Tagbanwa Tagb Tai_Le Tale Tai_Tham Lana Tai_Viet Tavt Takri Takr Tamil Taml Tangut Tang Telugu Telu Thaana Thaa Thai Thai Tibetan Tibt Tifinagh Tfng Tirhuta Tirh Ugaritic Ugar Vai Vaii Warang_Citi Wara Yi Yiii Zanabazar_Square Zanb";
+var ecma10ScriptValues = ecma9ScriptValues + " Dogra Dogr Gunjala_Gondi Gong Hanifi_Rohingya Rohg Makasar Maka Medefaidrin Medf Old_Sogdian Sogo Sogdian Sogd";
+var ecma11ScriptValues = ecma10ScriptValues + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho";
+var ecma12ScriptValues = ecma11ScriptValues + " Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi";
+var ecma13ScriptValues = ecma12ScriptValues + " Cypro_Minoan Cpmn Old_Uyghur Ougr Tangsa Tnsa Toto Vithkuqi Vith";
+var unicodeScriptValues = {
+  9: ecma9ScriptValues,
+  10: ecma10ScriptValues,
+  11: ecma11ScriptValues,
+  12: ecma12ScriptValues,
+  13: ecma13ScriptValues
+};
+var data = {};
+function buildUnicodeData(ecmaVersion) {
+  var d = data[ecmaVersion] = {
+    binary: wordsRegexp(unicodeBinaryProperties[ecmaVersion] + " " + unicodeGeneralCategoryValues),
+    nonBinary: {
+      General_Category: wordsRegexp(unicodeGeneralCategoryValues),
+      Script: wordsRegexp(unicodeScriptValues[ecmaVersion])
+    }
+  };
+  d.nonBinary.Script_Extensions = d.nonBinary.Script;
+  d.nonBinary.gc = d.nonBinary.General_Category;
+  d.nonBinary.sc = d.nonBinary.Script;
+  d.nonBinary.scx = d.nonBinary.Script_Extensions;
+}
+for (i = 0, list3 = [9, 10, 11, 12, 13]; i < list3.length; i += 1) {
+  ecmaVersion = list3[i];
+  buildUnicodeData(ecmaVersion);
+}
+var ecmaVersion;
+var i;
+var list3;
+var pp$1 = Parser.prototype;
+var RegExpValidationState = function RegExpValidationState2(parser) {
+  this.parser = parser;
+  this.validFlags = "gim" + (parser.options.ecmaVersion >= 6 ? "uy" : "") + (parser.options.ecmaVersion >= 9 ? "s" : "") + (parser.options.ecmaVersion >= 13 ? "d" : "");
+  this.unicodeProperties = data[parser.options.ecmaVersion >= 13 ? 13 : parser.options.ecmaVersion];
+  this.source = "";
+  this.flags = "";
+  this.start = 0;
+  this.switchU = false;
+  this.switchN = false;
+  this.pos = 0;
+  this.lastIntValue = 0;
+  this.lastStringValue = "";
+  this.lastAssertionIsQuantifiable = false;
+  this.numCapturingParens = 0;
+  this.maxBackReference = 0;
+  this.groupNames = [];
+  this.backReferenceNames = [];
+};
+RegExpValidationState.prototype.reset = function reset(start3, pattern, flags) {
+  var unicode = flags.indexOf("u") !== -1;
+  this.start = start3 | 0;
+  this.source = pattern + "";
+  this.flags = flags;
+  this.switchU = unicode && this.parser.options.ecmaVersion >= 6;
+  this.switchN = unicode && this.parser.options.ecmaVersion >= 9;
+};
+RegExpValidationState.prototype.raise = function raise(message) {
+  this.parser.raiseRecoverable(this.start, "Invalid regular expression: /" + this.source + "/: " + message);
+};
+RegExpValidationState.prototype.at = function at(i, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  var s = this.source;
+  var l = s.length;
+  if (i >= l) {
+    return -1;
+  }
+  var c = s.charCodeAt(i);
+  if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l) {
+    return c;
+  }
+  var next = s.charCodeAt(i + 1);
+  return next >= 56320 && next <= 57343 ? (c << 10) + next - 56613888 : c;
+};
+RegExpValidationState.prototype.nextIndex = function nextIndex(i, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  var s = this.source;
+  var l = s.length;
+  if (i >= l) {
+    return l;
+  }
+  var c = s.charCodeAt(i), next;
+  if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l || (next = s.charCodeAt(i + 1)) < 56320 || next > 57343) {
+    return i + 1;
+  }
+  return i + 2;
+};
+RegExpValidationState.prototype.current = function current(forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  return this.at(this.pos, forceU);
+};
+RegExpValidationState.prototype.lookahead = function lookahead(forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  return this.at(this.nextIndex(this.pos, forceU), forceU);
+};
+RegExpValidationState.prototype.advance = function advance(forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  this.pos = this.nextIndex(this.pos, forceU);
+};
+RegExpValidationState.prototype.eat = function eat(ch, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  if (this.current(forceU) === ch) {
+    this.advance(forceU);
+    return true;
+  }
+  return false;
+};
+pp$1.validateRegExpFlags = function(state) {
+  var validFlags = state.validFlags;
+  var flags = state.flags;
+  for (var i = 0; i < flags.length; i++) {
+    var flag = flags.charAt(i);
+    if (validFlags.indexOf(flag) === -1) {
+      this.raise(state.start, "Invalid regular expression flag");
+    }
+    if (flags.indexOf(flag, i + 1) > -1) {
+      this.raise(state.start, "Duplicate regular expression flag");
+    }
+  }
+};
+pp$1.validateRegExpPattern = function(state) {
+  this.regexp_pattern(state);
+  if (!state.switchN && this.options.ecmaVersion >= 9 && state.groupNames.length > 0) {
+    state.switchN = true;
+    this.regexp_pattern(state);
+  }
+};
+pp$1.regexp_pattern = function(state) {
+  state.pos = 0;
+  state.lastIntValue = 0;
+  state.lastStringValue = "";
+  state.lastAssertionIsQuantifiable = false;
+  state.numCapturingParens = 0;
+  state.maxBackReference = 0;
+  state.groupNames.length = 0;
+  state.backReferenceNames.length = 0;
+  this.regexp_disjunction(state);
+  if (state.pos !== state.source.length) {
+    if (state.eat(41)) {
+      state.raise("Unmatched ')'");
+    }
+    if (state.eat(93) || state.eat(125)) {
+      state.raise("Lone quantifier brackets");
+    }
+  }
+  if (state.maxBackReference > state.numCapturingParens) {
+    state.raise("Invalid escape");
+  }
+  for (var i = 0, list3 = state.backReferenceNames; i < list3.length; i += 1) {
+    var name2 = list3[i];
+    if (state.groupNames.indexOf(name2) === -1) {
+      state.raise("Invalid named capture referenced");
+    }
+  }
+};
+pp$1.regexp_disjunction = function(state) {
+  this.regexp_alternative(state);
+  while (state.eat(124)) {
+    this.regexp_alternative(state);
+  }
+  if (this.regexp_eatQuantifier(state, true)) {
+    state.raise("Nothing to repeat");
+  }
+  if (state.eat(123)) {
+    state.raise("Lone quantifier brackets");
+  }
+};
+pp$1.regexp_alternative = function(state) {
+  while (state.pos < state.source.length && this.regexp_eatTerm(state)) {
+  }
+};
+pp$1.regexp_eatTerm = function(state) {
+  if (this.regexp_eatAssertion(state)) {
+    if (state.lastAssertionIsQuantifiable && this.regexp_eatQuantifier(state)) {
+      if (state.switchU) {
+        state.raise("Invalid quantifier");
+      }
+    }
+    return true;
+  }
+  if (state.switchU ? this.regexp_eatAtom(state) : this.regexp_eatExtendedAtom(state)) {
+    this.regexp_eatQuantifier(state);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatAssertion = function(state) {
+  var start3 = state.pos;
+  state.lastAssertionIsQuantifiable = false;
+  if (state.eat(94) || state.eat(36)) {
+    return true;
+  }
+  if (state.eat(92)) {
+    if (state.eat(66) || state.eat(98)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  if (state.eat(40) && state.eat(63)) {
+    var lookbehind = false;
+    if (this.options.ecmaVersion >= 9) {
+      lookbehind = state.eat(60);
+    }
+    if (state.eat(61) || state.eat(33)) {
+      this.regexp_disjunction(state);
+      if (!state.eat(41)) {
+        state.raise("Unterminated group");
+      }
+      state.lastAssertionIsQuantifiable = !lookbehind;
+      return true;
+    }
+  }
+  state.pos = start3;
+  return false;
+};
+pp$1.regexp_eatQuantifier = function(state, noError) {
+  if (noError === void 0)
+    noError = false;
+  if (this.regexp_eatQuantifierPrefix(state, noError)) {
+    state.eat(63);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatQuantifierPrefix = function(state, noError) {
+  return state.eat(42) || state.eat(43) || state.eat(63) || this.regexp_eatBracedQuantifier(state, noError);
+};
+pp$1.regexp_eatBracedQuantifier = function(state, noError) {
+  var start3 = state.pos;
+  if (state.eat(123)) {
+    var min = 0, max = -1;
+    if (this.regexp_eatDecimalDigits(state)) {
+      min = state.lastIntValue;
+      if (state.eat(44) && this.regexp_eatDecimalDigits(state)) {
+        max = state.lastIntValue;
+      }
+      if (state.eat(125)) {
+        if (max !== -1 && max < min && !noError) {
+          state.raise("numbers out of order in {} quantifier");
+        }
+        return true;
+      }
+    }
+    if (state.switchU && !noError) {
+      state.raise("Incomplete quantifier");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatAtom = function(state) {
+  return this.regexp_eatPatternCharacters(state) || state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state);
+};
+pp$1.regexp_eatReverseSolidusAtomEscape = function(state) {
+  var start3 = state.pos;
+  if (state.eat(92)) {
+    if (this.regexp_eatAtomEscape(state)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatUncapturingGroup = function(state) {
+  var start3 = state.pos;
+  if (state.eat(40)) {
+    if (state.eat(63) && state.eat(58)) {
+      this.regexp_disjunction(state);
+      if (state.eat(41)) {
+        return true;
+      }
+      state.raise("Unterminated group");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatCapturingGroup = function(state) {
+  if (state.eat(40)) {
+    if (this.options.ecmaVersion >= 9) {
+      this.regexp_groupSpecifier(state);
+    } else if (state.current() === 63) {
+      state.raise("Invalid group");
+    }
+    this.regexp_disjunction(state);
+    if (state.eat(41)) {
+      state.numCapturingParens += 1;
+      return true;
+    }
+    state.raise("Unterminated group");
+  }
+  return false;
+};
+pp$1.regexp_eatExtendedAtom = function(state) {
+  return state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state) || this.regexp_eatInvalidBracedQuantifier(state) || this.regexp_eatExtendedPatternCharacter(state);
+};
+pp$1.regexp_eatInvalidBracedQuantifier = function(state) {
+  if (this.regexp_eatBracedQuantifier(state, true)) {
+    state.raise("Nothing to repeat");
+  }
+  return false;
+};
+pp$1.regexp_eatSyntaxCharacter = function(state) {
+  var ch = state.current();
+  if (isSyntaxCharacter(ch)) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+function isSyntaxCharacter(ch) {
+  return ch === 36 || ch >= 40 && ch <= 43 || ch === 46 || ch === 63 || ch >= 91 && ch <= 94 || ch >= 123 && ch <= 125;
+}
+pp$1.regexp_eatPatternCharacters = function(state) {
+  var start3 = state.pos;
+  var ch = 0;
+  while ((ch = state.current()) !== -1 && !isSyntaxCharacter(ch)) {
+    state.advance();
+  }
+  return state.pos !== start3;
+};
+pp$1.regexp_eatExtendedPatternCharacter = function(state) {
+  var ch = state.current();
+  if (ch !== -1 && ch !== 36 && !(ch >= 40 && ch <= 43) && ch !== 46 && ch !== 63 && ch !== 91 && ch !== 94 && ch !== 124) {
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_groupSpecifier = function(state) {
+  if (state.eat(63)) {
+    if (this.regexp_eatGroupName(state)) {
+      if (state.groupNames.indexOf(state.lastStringValue) !== -1) {
+        state.raise("Duplicate capture group name");
+      }
+      state.groupNames.push(state.lastStringValue);
+      return;
+    }
+    state.raise("Invalid group");
+  }
+};
+pp$1.regexp_eatGroupName = function(state) {
+  state.lastStringValue = "";
+  if (state.eat(60)) {
+    if (this.regexp_eatRegExpIdentifierName(state) && state.eat(62)) {
+      return true;
+    }
+    state.raise("Invalid capture group name");
+  }
+  return false;
+};
+pp$1.regexp_eatRegExpIdentifierName = function(state) {
+  state.lastStringValue = "";
+  if (this.regexp_eatRegExpIdentifierStart(state)) {
+    state.lastStringValue += codePointToString(state.lastIntValue);
+    while (this.regexp_eatRegExpIdentifierPart(state)) {
+      state.lastStringValue += codePointToString(state.lastIntValue);
+    }
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatRegExpIdentifierStart = function(state) {
+  var start3 = state.pos;
+  var forceU = this.options.ecmaVersion >= 11;
+  var ch = state.current(forceU);
+  state.advance(forceU);
+  if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+    ch = state.lastIntValue;
+  }
+  if (isRegExpIdentifierStart(ch)) {
+    state.lastIntValue = ch;
+    return true;
+  }
+  state.pos = start3;
+  return false;
+};
+function isRegExpIdentifierStart(ch) {
+  return isIdentifierStart(ch, true) || ch === 36 || ch === 95;
+}
+pp$1.regexp_eatRegExpIdentifierPart = function(state) {
+  var start3 = state.pos;
+  var forceU = this.options.ecmaVersion >= 11;
+  var ch = state.current(forceU);
+  state.advance(forceU);
+  if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+    ch = state.lastIntValue;
+  }
+  if (isRegExpIdentifierPart(ch)) {
+    state.lastIntValue = ch;
+    return true;
+  }
+  state.pos = start3;
+  return false;
+};
+function isRegExpIdentifierPart(ch) {
+  return isIdentifierChar(ch, true) || ch === 36 || ch === 95 || ch === 8204 || ch === 8205;
+}
+pp$1.regexp_eatAtomEscape = function(state) {
+  if (this.regexp_eatBackReference(state) || this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state) || state.switchN && this.regexp_eatKGroupName(state)) {
+    return true;
+  }
+  if (state.switchU) {
+    if (state.current() === 99) {
+      state.raise("Invalid unicode escape");
+    }
+    state.raise("Invalid escape");
+  }
+  return false;
+};
+pp$1.regexp_eatBackReference = function(state) {
+  var start3 = state.pos;
+  if (this.regexp_eatDecimalEscape(state)) {
+    var n = state.lastIntValue;
+    if (state.switchU) {
+      if (n > state.maxBackReference) {
+        state.maxBackReference = n;
+      }
+      return true;
+    }
+    if (n <= state.numCapturingParens) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatKGroupName = function(state) {
+  if (state.eat(107)) {
+    if (this.regexp_eatGroupName(state)) {
+      state.backReferenceNames.push(state.lastStringValue);
+      return true;
+    }
+    state.raise("Invalid named reference");
+  }
+  return false;
+};
+pp$1.regexp_eatCharacterEscape = function(state) {
+  return this.regexp_eatControlEscape(state) || this.regexp_eatCControlLetter(state) || this.regexp_eatZero(state) || this.regexp_eatHexEscapeSequence(state) || this.regexp_eatRegExpUnicodeEscapeSequence(state, false) || !state.switchU && this.regexp_eatLegacyOctalEscapeSequence(state) || this.regexp_eatIdentityEscape(state);
+};
+pp$1.regexp_eatCControlLetter = function(state) {
+  var start3 = state.pos;
+  if (state.eat(99)) {
+    if (this.regexp_eatControlLetter(state)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatZero = function(state) {
+  if (state.current() === 48 && !isDecimalDigit(state.lookahead())) {
+    state.lastIntValue = 0;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatControlEscape = function(state) {
+  var ch = state.current();
+  if (ch === 116) {
+    state.lastIntValue = 9;
+    state.advance();
+    return true;
+  }
+  if (ch === 110) {
+    state.lastIntValue = 10;
+    state.advance();
+    return true;
+  }
+  if (ch === 118) {
+    state.lastIntValue = 11;
+    state.advance();
+    return true;
+  }
+  if (ch === 102) {
+    state.lastIntValue = 12;
+    state.advance();
+    return true;
+  }
+  if (ch === 114) {
+    state.lastIntValue = 13;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatControlLetter = function(state) {
+  var ch = state.current();
+  if (isControlLetter(ch)) {
+    state.lastIntValue = ch % 32;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+function isControlLetter(ch) {
+  return ch >= 65 && ch <= 90 || ch >= 97 && ch <= 122;
+}
+pp$1.regexp_eatRegExpUnicodeEscapeSequence = function(state, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  var start3 = state.pos;
+  var switchU = forceU || state.switchU;
+  if (state.eat(117)) {
+    if (this.regexp_eatFixedHexDigits(state, 4)) {
+      var lead = state.lastIntValue;
+      if (switchU && lead >= 55296 && lead <= 56319) {
+        var leadSurrogateEnd = state.pos;
+        if (state.eat(92) && state.eat(117) && this.regexp_eatFixedHexDigits(state, 4)) {
+          var trail = state.lastIntValue;
+          if (trail >= 56320 && trail <= 57343) {
+            state.lastIntValue = (lead - 55296) * 1024 + (trail - 56320) + 65536;
+            return true;
+          }
+        }
+        state.pos = leadSurrogateEnd;
+        state.lastIntValue = lead;
+      }
+      return true;
+    }
+    if (switchU && state.eat(123) && this.regexp_eatHexDigits(state) && state.eat(125) && isValidUnicode(state.lastIntValue)) {
+      return true;
+    }
+    if (switchU) {
+      state.raise("Invalid unicode escape");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+function isValidUnicode(ch) {
+  return ch >= 0 && ch <= 1114111;
+}
+pp$1.regexp_eatIdentityEscape = function(state) {
+  if (state.switchU) {
+    if (this.regexp_eatSyntaxCharacter(state)) {
+      return true;
+    }
+    if (state.eat(47)) {
+      state.lastIntValue = 47;
+      return true;
+    }
+    return false;
+  }
+  var ch = state.current();
+  if (ch !== 99 && (!state.switchN || ch !== 107)) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatDecimalEscape = function(state) {
+  state.lastIntValue = 0;
+  var ch = state.current();
+  if (ch >= 49 && ch <= 57) {
+    do {
+      state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+      state.advance();
+    } while ((ch = state.current()) >= 48 && ch <= 57);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatCharacterClassEscape = function(state) {
+  var ch = state.current();
+  if (isCharacterClassEscape(ch)) {
+    state.lastIntValue = -1;
+    state.advance();
+    return true;
+  }
+  if (state.switchU && this.options.ecmaVersion >= 9 && (ch === 80 || ch === 112)) {
+    state.lastIntValue = -1;
+    state.advance();
+    if (state.eat(123) && this.regexp_eatUnicodePropertyValueExpression(state) && state.eat(125)) {
+      return true;
+    }
+    state.raise("Invalid property name");
+  }
+  return false;
+};
+function isCharacterClassEscape(ch) {
+  return ch === 100 || ch === 68 || ch === 115 || ch === 83 || ch === 119 || ch === 87;
+}
+pp$1.regexp_eatUnicodePropertyValueExpression = function(state) {
+  var start3 = state.pos;
+  if (this.regexp_eatUnicodePropertyName(state) && state.eat(61)) {
+    var name2 = state.lastStringValue;
+    if (this.regexp_eatUnicodePropertyValue(state)) {
+      var value = state.lastStringValue;
+      this.regexp_validateUnicodePropertyNameAndValue(state, name2, value);
+      return true;
+    }
+  }
+  state.pos = start3;
+  if (this.regexp_eatLoneUnicodePropertyNameOrValue(state)) {
+    var nameOrValue = state.lastStringValue;
+    this.regexp_validateUnicodePropertyNameOrValue(state, nameOrValue);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_validateUnicodePropertyNameAndValue = function(state, name2, value) {
+  if (!hasOwn(state.unicodeProperties.nonBinary, name2)) {
+    state.raise("Invalid property name");
+  }
+  if (!state.unicodeProperties.nonBinary[name2].test(value)) {
+    state.raise("Invalid property value");
+  }
+};
+pp$1.regexp_validateUnicodePropertyNameOrValue = function(state, nameOrValue) {
+  if (!state.unicodeProperties.binary.test(nameOrValue)) {
+    state.raise("Invalid property name");
+  }
+};
+pp$1.regexp_eatUnicodePropertyName = function(state) {
+  var ch = 0;
+  state.lastStringValue = "";
+  while (isUnicodePropertyNameCharacter(ch = state.current())) {
+    state.lastStringValue += codePointToString(ch);
+    state.advance();
+  }
+  return state.lastStringValue !== "";
+};
+function isUnicodePropertyNameCharacter(ch) {
+  return isControlLetter(ch) || ch === 95;
+}
+pp$1.regexp_eatUnicodePropertyValue = function(state) {
+  var ch = 0;
+  state.lastStringValue = "";
+  while (isUnicodePropertyValueCharacter(ch = state.current())) {
+    state.lastStringValue += codePointToString(ch);
+    state.advance();
+  }
+  return state.lastStringValue !== "";
+};
+function isUnicodePropertyValueCharacter(ch) {
+  return isUnicodePropertyNameCharacter(ch) || isDecimalDigit(ch);
+}
+pp$1.regexp_eatLoneUnicodePropertyNameOrValue = function(state) {
+  return this.regexp_eatUnicodePropertyValue(state);
+};
+pp$1.regexp_eatCharacterClass = function(state) {
+  if (state.eat(91)) {
+    state.eat(94);
+    this.regexp_classRanges(state);
+    if (state.eat(93)) {
+      return true;
+    }
+    state.raise("Unterminated character class");
+  }
+  return false;
+};
+pp$1.regexp_classRanges = function(state) {
+  while (this.regexp_eatClassAtom(state)) {
+    var left = state.lastIntValue;
+    if (state.eat(45) && this.regexp_eatClassAtom(state)) {
+      var right = state.lastIntValue;
+      if (state.switchU && (left === -1 || right === -1)) {
+        state.raise("Invalid character class");
+      }
+      if (left !== -1 && right !== -1 && left > right) {
+        state.raise("Range out of order in character class");
+      }
+    }
+  }
+};
+pp$1.regexp_eatClassAtom = function(state) {
+  var start3 = state.pos;
+  if (state.eat(92)) {
+    if (this.regexp_eatClassEscape(state)) {
+      return true;
+    }
+    if (state.switchU) {
+      var ch$1 = state.current();
+      if (ch$1 === 99 || isOctalDigit(ch$1)) {
+        state.raise("Invalid class escape");
+      }
+      state.raise("Invalid escape");
+    }
+    state.pos = start3;
+  }
+  var ch = state.current();
+  if (ch !== 93) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatClassEscape = function(state) {
+  var start3 = state.pos;
+  if (state.eat(98)) {
+    state.lastIntValue = 8;
+    return true;
+  }
+  if (state.switchU && state.eat(45)) {
+    state.lastIntValue = 45;
+    return true;
+  }
+  if (!state.switchU && state.eat(99)) {
+    if (this.regexp_eatClassControlLetter(state)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state);
+};
+pp$1.regexp_eatClassControlLetter = function(state) {
+  var ch = state.current();
+  if (isDecimalDigit(ch) || ch === 95) {
+    state.lastIntValue = ch % 32;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatHexEscapeSequence = function(state) {
+  var start3 = state.pos;
+  if (state.eat(120)) {
+    if (this.regexp_eatFixedHexDigits(state, 2)) {
+      return true;
+    }
+    if (state.switchU) {
+      state.raise("Invalid escape");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatDecimalDigits = function(state) {
+  var start3 = state.pos;
+  var ch = 0;
+  state.lastIntValue = 0;
+  while (isDecimalDigit(ch = state.current())) {
+    state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+    state.advance();
+  }
+  return state.pos !== start3;
+};
+function isDecimalDigit(ch) {
+  return ch >= 48 && ch <= 57;
+}
+pp$1.regexp_eatHexDigits = function(state) {
+  var start3 = state.pos;
+  var ch = 0;
+  state.lastIntValue = 0;
+  while (isHexDigit(ch = state.current())) {
+    state.lastIntValue = 16 * state.lastIntValue + hexToInt(ch);
+    state.advance();
+  }
+  return state.pos !== start3;
+};
+function isHexDigit(ch) {
+  return ch >= 48 && ch <= 57 || ch >= 65 && ch <= 70 || ch >= 97 && ch <= 102;
+}
+function hexToInt(ch) {
+  if (ch >= 65 && ch <= 70) {
+    return 10 + (ch - 65);
+  }
+  if (ch >= 97 && ch <= 102) {
+    return 10 + (ch - 97);
+  }
+  return ch - 48;
+}
+pp$1.regexp_eatLegacyOctalEscapeSequence = function(state) {
+  if (this.regexp_eatOctalDigit(state)) {
+    var n1 = state.lastIntValue;
+    if (this.regexp_eatOctalDigit(state)) {
+      var n2 = state.lastIntValue;
+      if (n1 <= 3 && this.regexp_eatOctalDigit(state)) {
+        state.lastIntValue = n1 * 64 + n2 * 8 + state.lastIntValue;
+      } else {
+        state.lastIntValue = n1 * 8 + n2;
+      }
+    } else {
+      state.lastIntValue = n1;
+    }
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatOctalDigit = function(state) {
+  var ch = state.current();
+  if (isOctalDigit(ch)) {
+    state.lastIntValue = ch - 48;
+    state.advance();
+    return true;
+  }
+  state.lastIntValue = 0;
+  return false;
+};
+function isOctalDigit(ch) {
+  return ch >= 48 && ch <= 55;
+}
+pp$1.regexp_eatFixedHexDigits = function(state, length) {
+  var start3 = state.pos;
+  state.lastIntValue = 0;
+  for (var i = 0; i < length; ++i) {
+    var ch = state.current();
+    if (!isHexDigit(ch)) {
+      state.pos = start3;
+      return false;
+    }
+    state.lastIntValue = 16 * state.lastIntValue + hexToInt(ch);
+    state.advance();
+  }
+  return true;
+};
+var Token = function Token2(p) {
+  this.type = p.type;
+  this.value = p.value;
+  this.start = p.start;
+  this.end = p.end;
+  if (p.options.locations) {
+    this.loc = new SourceLocation(p, p.startLoc, p.endLoc);
+  }
+  if (p.options.ranges) {
+    this.range = [p.start, p.end];
+  }
+};
+var pp = Parser.prototype;
+pp.next = function(ignoreEscapeSequenceInKeyword) {
+  if (!ignoreEscapeSequenceInKeyword && this.type.keyword && this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword " + this.type.keyword);
+  }
+  if (this.options.onToken) {
+    this.options.onToken(new Token(this));
+  }
+  this.lastTokEnd = this.end;
+  this.lastTokStart = this.start;
+  this.lastTokEndLoc = this.endLoc;
+  this.lastTokStartLoc = this.startLoc;
+  this.nextToken();
+};
+pp.getToken = function() {
+  this.next();
+  return new Token(this);
+};
+if (typeof Symbol !== "undefined") {
+  pp[Symbol.iterator] = function() {
+    var this$1$1 = this;
+    return {
+      next: function() {
+        var token = this$1$1.getToken();
+        return {
+          done: token.type === types$1.eof,
+          value: token
+        };
+      }
+    };
+  };
+}
+pp.nextToken = function() {
+  var curContext = this.curContext();
+  if (!curContext || !curContext.preserveSpace) {
+    this.skipSpace();
+  }
+  this.start = this.pos;
+  if (this.options.locations) {
+    this.startLoc = this.curPosition();
+  }
+  if (this.pos >= this.input.length) {
+    return this.finishToken(types$1.eof);
+  }
+  if (curContext.override) {
+    return curContext.override(this);
+  } else {
+    this.readToken(this.fullCharCodeAtPos());
+  }
+};
+pp.readToken = function(code2) {
+  if (isIdentifierStart(code2, this.options.ecmaVersion >= 6) || code2 === 92) {
+    return this.readWord();
+  }
+  return this.getTokenFromCode(code2);
+};
+pp.fullCharCodeAtPos = function() {
+  var code2 = this.input.charCodeAt(this.pos);
+  if (code2 <= 55295 || code2 >= 56320) {
+    return code2;
+  }
+  var next = this.input.charCodeAt(this.pos + 1);
+  return next <= 56319 || next >= 57344 ? code2 : (code2 << 10) + next - 56613888;
+};
+pp.skipBlockComment = function() {
+  var startLoc = this.options.onComment && this.curPosition();
+  var start3 = this.pos, end = this.input.indexOf("*/", this.pos += 2);
+  if (end === -1) {
+    this.raise(this.pos - 2, "Unterminated comment");
+  }
+  this.pos = end + 2;
+  if (this.options.locations) {
+    for (var nextBreak = void 0, pos = start3; (nextBreak = nextLineBreak(this.input, pos, this.pos)) > -1; ) {
+      ++this.curLine;
+      pos = this.lineStart = nextBreak;
+    }
+  }
+  if (this.options.onComment) {
+    this.options.onComment(
+      true,
+      this.input.slice(start3 + 2, end),
+      start3,
+      this.pos,
+      startLoc,
+      this.curPosition()
+    );
+  }
+};
+pp.skipLineComment = function(startSkip) {
+  var start3 = this.pos;
+  var startLoc = this.options.onComment && this.curPosition();
+  var ch = this.input.charCodeAt(this.pos += startSkip);
+  while (this.pos < this.input.length && !isNewLine(ch)) {
+    ch = this.input.charCodeAt(++this.pos);
+  }
+  if (this.options.onComment) {
+    this.options.onComment(
+      false,
+      this.input.slice(start3 + startSkip, this.pos),
+      start3,
+      this.pos,
+      startLoc,
+      this.curPosition()
+    );
+  }
+};
+pp.skipSpace = function() {
+  loop:
+    while (this.pos < this.input.length) {
+      var ch = this.input.charCodeAt(this.pos);
+      switch (ch) {
+        case 32:
+        case 160:
+          ++this.pos;
+          break;
+        case 13:
+          if (this.input.charCodeAt(this.pos + 1) === 10) {
+            ++this.pos;
+          }
+        case 10:
+        case 8232:
+        case 8233:
+          ++this.pos;
+          if (this.options.locations) {
+            ++this.curLine;
+            this.lineStart = this.pos;
+          }
+          break;
+        case 47:
+          switch (this.input.charCodeAt(this.pos + 1)) {
+            case 42:
+              this.skipBlockComment();
+              break;
+            case 47:
+              this.skipLineComment(2);
+              break;
+            default:
+              break loop;
+          }
+          break;
+        default:
+          if (ch > 8 && ch < 14 || ch >= 5760 && nonASCIIwhitespace.test(String.fromCharCode(ch))) {
+            ++this.pos;
+          } else {
+            break loop;
+          }
+      }
+    }
+};
+pp.finishToken = function(type, val) {
+  this.end = this.pos;
+  if (this.options.locations) {
+    this.endLoc = this.curPosition();
+  }
+  var prevType = this.type;
+  this.type = type;
+  this.value = val;
+  this.updateContext(prevType);
+};
+pp.readToken_dot = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next >= 48 && next <= 57) {
+    return this.readNumber(true);
+  }
+  var next2 = this.input.charCodeAt(this.pos + 2);
+  if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) {
+    this.pos += 3;
+    return this.finishToken(types$1.ellipsis);
+  } else {
+    ++this.pos;
+    return this.finishToken(types$1.dot);
+  }
+};
+pp.readToken_slash = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (this.exprAllowed) {
+    ++this.pos;
+    return this.readRegexp();
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.slash, 1);
+};
+pp.readToken_mult_modulo_exp = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  var size = 1;
+  var tokentype = code2 === 42 ? types$1.star : types$1.modulo;
+  if (this.options.ecmaVersion >= 7 && code2 === 42 && next === 42) {
+    ++size;
+    tokentype = types$1.starstar;
+    next = this.input.charCodeAt(this.pos + 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, size + 1);
+  }
+  return this.finishOp(tokentype, size);
+};
+pp.readToken_pipe_amp = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code2) {
+    if (this.options.ecmaVersion >= 12) {
+      var next2 = this.input.charCodeAt(this.pos + 2);
+      if (next2 === 61) {
+        return this.finishOp(types$1.assign, 3);
+      }
+    }
+    return this.finishOp(code2 === 124 ? types$1.logicalOR : types$1.logicalAND, 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(code2 === 124 ? types$1.bitwiseOR : types$1.bitwiseAND, 1);
+};
+pp.readToken_caret = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.bitwiseXOR, 1);
+};
+pp.readToken_plus_min = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code2) {
+    if (next === 45 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 62 && (this.lastTokEnd === 0 || lineBreak.test(this.input.slice(this.lastTokEnd, this.pos)))) {
+      this.skipLineComment(3);
+      this.skipSpace();
+      return this.nextToken();
+    }
+    return this.finishOp(types$1.incDec, 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.plusMin, 1);
+};
+pp.readToken_lt_gt = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  var size = 1;
+  if (next === code2) {
+    size = code2 === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+    if (this.input.charCodeAt(this.pos + size) === 61) {
+      return this.finishOp(types$1.assign, size + 1);
+    }
+    return this.finishOp(types$1.bitShift, size);
+  }
+  if (next === 33 && code2 === 60 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 45 && this.input.charCodeAt(this.pos + 3) === 45) {
+    this.skipLineComment(4);
+    this.skipSpace();
+    return this.nextToken();
+  }
+  if (next === 61) {
+    size = 2;
+  }
+  return this.finishOp(types$1.relational, size);
+};
+pp.readToken_eq_excl = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) {
+    return this.finishOp(types$1.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+  }
+  if (code2 === 61 && next === 62 && this.options.ecmaVersion >= 6) {
+    this.pos += 2;
+    return this.finishToken(types$1.arrow);
+  }
+  return this.finishOp(code2 === 61 ? types$1.eq : types$1.prefix, 1);
+};
+pp.readToken_question = function() {
+  var ecmaVersion = this.options.ecmaVersion;
+  if (ecmaVersion >= 11) {
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === 46) {
+      var next2 = this.input.charCodeAt(this.pos + 2);
+      if (next2 < 48 || next2 > 57) {
+        return this.finishOp(types$1.questionDot, 2);
+      }
+    }
+    if (next === 63) {
+      if (ecmaVersion >= 12) {
+        var next2$1 = this.input.charCodeAt(this.pos + 2);
+        if (next2$1 === 61) {
+          return this.finishOp(types$1.assign, 3);
+        }
+      }
+      return this.finishOp(types$1.coalesce, 2);
+    }
+  }
+  return this.finishOp(types$1.question, 1);
+};
+pp.readToken_numberSign = function() {
+  var ecmaVersion = this.options.ecmaVersion;
+  var code2 = 35;
+  if (ecmaVersion >= 13) {
+    ++this.pos;
+    code2 = this.fullCharCodeAtPos();
+    if (isIdentifierStart(code2, true) || code2 === 92) {
+      return this.finishToken(types$1.privateId, this.readWord1());
+    }
+  }
+  this.raise(this.pos, "Unexpected character '" + codePointToString(code2) + "'");
+};
+pp.getTokenFromCode = function(code2) {
+  switch (code2) {
+    case 46:
+      return this.readToken_dot();
+    case 40:
+      ++this.pos;
+      return this.finishToken(types$1.parenL);
+    case 41:
+      ++this.pos;
+      return this.finishToken(types$1.parenR);
+    case 59:
+      ++this.pos;
+      return this.finishToken(types$1.semi);
+    case 44:
+      ++this.pos;
+      return this.finishToken(types$1.comma);
+    case 91:
+      ++this.pos;
+      return this.finishToken(types$1.bracketL);
+    case 93:
+      ++this.pos;
+      return this.finishToken(types$1.bracketR);
+    case 123:
+      ++this.pos;
+      return this.finishToken(types$1.braceL);
+    case 125:
+      ++this.pos;
+      return this.finishToken(types$1.braceR);
+    case 58:
+      ++this.pos;
+      return this.finishToken(types$1.colon);
+    case 96:
+      if (this.options.ecmaVersion < 6) {
+        break;
+      }
+      ++this.pos;
+      return this.finishToken(types$1.backQuote);
+    case 48:
+      var next = this.input.charCodeAt(this.pos + 1);
+      if (next === 120 || next === 88) {
+        return this.readRadixNumber(16);
+      }
+      if (this.options.ecmaVersion >= 6) {
+        if (next === 111 || next === 79) {
+          return this.readRadixNumber(8);
+        }
+        if (next === 98 || next === 66) {
+          return this.readRadixNumber(2);
+        }
+      }
+    case 49:
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 55:
+    case 56:
+    case 57:
+      return this.readNumber(false);
+    case 34:
+    case 39:
+      return this.readString(code2);
+    case 47:
+      return this.readToken_slash();
+    case 37:
+    case 42:
+      return this.readToken_mult_modulo_exp(code2);
+    case 124:
+    case 38:
+      return this.readToken_pipe_amp(code2);
+    case 94:
+      return this.readToken_caret();
+    case 43:
+    case 45:
+      return this.readToken_plus_min(code2);
+    case 60:
+    case 62:
+      return this.readToken_lt_gt(code2);
+    case 61:
+    case 33:
+      return this.readToken_eq_excl(code2);
+    case 63:
+      return this.readToken_question();
+    case 126:
+      return this.finishOp(types$1.prefix, 1);
+    case 35:
+      return this.readToken_numberSign();
+  }
+  this.raise(this.pos, "Unexpected character '" + codePointToString(code2) + "'");
+};
+pp.finishOp = function(type, size) {
+  var str = this.input.slice(this.pos, this.pos + size);
+  this.pos += size;
+  return this.finishToken(type, str);
+};
+pp.readRegexp = function() {
+  var escaped, inClass, start3 = this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(start3, "Unterminated regular expression");
+    }
+    var ch = this.input.charAt(this.pos);
+    if (lineBreak.test(ch)) {
+      this.raise(start3, "Unterminated regular expression");
+    }
+    if (!escaped) {
+      if (ch === "[") {
+        inClass = true;
+      } else if (ch === "]" && inClass) {
+        inClass = false;
+      } else if (ch === "/" && !inClass) {
+        break;
+      }
+      escaped = ch === "\\";
+    } else {
+      escaped = false;
+    }
+    ++this.pos;
+  }
+  var pattern = this.input.slice(start3, this.pos);
+  ++this.pos;
+  var flagsStart = this.pos;
+  var flags = this.readWord1();
+  if (this.containsEsc) {
+    this.unexpected(flagsStart);
+  }
+  var state = this.regexpState || (this.regexpState = new RegExpValidationState(this));
+  state.reset(start3, pattern, flags);
+  this.validateRegExpFlags(state);
+  this.validateRegExpPattern(state);
+  var value = null;
+  try {
+    value = new RegExp(pattern, flags);
+  } catch (e) {
+  }
+  return this.finishToken(types$1.regexp, { pattern, flags, value });
+};
+pp.readInt = function(radix, len, maybeLegacyOctalNumericLiteral) {
+  var allowSeparators = this.options.ecmaVersion >= 12 && len === void 0;
+  var isLegacyOctalNumericLiteral = maybeLegacyOctalNumericLiteral && this.input.charCodeAt(this.pos) === 48;
+  var start3 = this.pos, total = 0, lastCode = 0;
+  for (var i = 0, e = len == null ? Infinity : len; i < e; ++i, ++this.pos) {
+    var code2 = this.input.charCodeAt(this.pos), val = void 0;
+    if (allowSeparators && code2 === 95) {
+      if (isLegacyOctalNumericLiteral) {
+        this.raiseRecoverable(this.pos, "Numeric separator is not allowed in legacy octal numeric literals");
+      }
+      if (lastCode === 95) {
+        this.raiseRecoverable(this.pos, "Numeric separator must be exactly one underscore");
+      }
+      if (i === 0) {
+        this.raiseRecoverable(this.pos, "Numeric separator is not allowed at the first of digits");
+      }
+      lastCode = code2;
+      continue;
+    }
+    if (code2 >= 97) {
+      val = code2 - 97 + 10;
+    } else if (code2 >= 65) {
+      val = code2 - 65 + 10;
+    } else if (code2 >= 48 && code2 <= 57) {
+      val = code2 - 48;
+    } else {
+      val = Infinity;
+    }
+    if (val >= radix) {
+      break;
+    }
+    lastCode = code2;
+    total = total * radix + val;
+  }
+  if (allowSeparators && lastCode === 95) {
+    this.raiseRecoverable(this.pos - 1, "Numeric separator is not allowed at the last of digits");
+  }
+  if (this.pos === start3 || len != null && this.pos - start3 !== len) {
+    return null;
+  }
+  return total;
+};
+function stringToNumber(str, isLegacyOctalNumericLiteral) {
+  if (isLegacyOctalNumericLiteral) {
+    return parseInt(str, 8);
+  }
+  return parseFloat(str.replace(/_/g, ""));
+}
+function stringToBigInt(str) {
+  if (typeof BigInt !== "function") {
+    return null;
+  }
+  return BigInt(str.replace(/_/g, ""));
+}
+pp.readRadixNumber = function(radix) {
+  var start3 = this.pos;
+  this.pos += 2;
+  var val = this.readInt(radix);
+  if (val == null) {
+    this.raise(this.start + 2, "Expected number in radix " + radix);
+  }
+  if (this.options.ecmaVersion >= 11 && this.input.charCodeAt(this.pos) === 110) {
+    val = stringToBigInt(this.input.slice(start3, this.pos));
+    ++this.pos;
+  } else if (isIdentifierStart(this.fullCharCodeAtPos())) {
+    this.raise(this.pos, "Identifier directly after number");
+  }
+  return this.finishToken(types$1.num, val);
+};
+pp.readNumber = function(startsWithDot) {
+  var start3 = this.pos;
+  if (!startsWithDot && this.readInt(10, void 0, true) === null) {
+    this.raise(start3, "Invalid number");
+  }
+  var octal = this.pos - start3 >= 2 && this.input.charCodeAt(start3) === 48;
+  if (octal && this.strict) {
+    this.raise(start3, "Invalid number");
+  }
+  var next = this.input.charCodeAt(this.pos);
+  if (!octal && !startsWithDot && this.options.ecmaVersion >= 11 && next === 110) {
+    var val$1 = stringToBigInt(this.input.slice(start3, this.pos));
+    ++this.pos;
+    if (isIdentifierStart(this.fullCharCodeAtPos())) {
+      this.raise(this.pos, "Identifier directly after number");
+    }
+    return this.finishToken(types$1.num, val$1);
+  }
+  if (octal && /[89]/.test(this.input.slice(start3, this.pos))) {
+    octal = false;
+  }
+  if (next === 46 && !octal) {
+    ++this.pos;
+    this.readInt(10);
+    next = this.input.charCodeAt(this.pos);
+  }
+  if ((next === 69 || next === 101) && !octal) {
+    next = this.input.charCodeAt(++this.pos);
+    if (next === 43 || next === 45) {
+      ++this.pos;
+    }
+    if (this.readInt(10) === null) {
+      this.raise(start3, "Invalid number");
+    }
+  }
+  if (isIdentifierStart(this.fullCharCodeAtPos())) {
+    this.raise(this.pos, "Identifier directly after number");
+  }
+  var val = stringToNumber(this.input.slice(start3, this.pos), octal);
+  return this.finishToken(types$1.num, val);
+};
+pp.readCodePoint = function() {
+  var ch = this.input.charCodeAt(this.pos), code2;
+  if (ch === 123) {
+    if (this.options.ecmaVersion < 6) {
+      this.unexpected();
+    }
+    var codePos = ++this.pos;
+    code2 = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos);
+    ++this.pos;
+    if (code2 > 1114111) {
+      this.invalidStringToken(codePos, "Code point out of bounds");
+    }
+  } else {
+    code2 = this.readHexChar(4);
+  }
+  return code2;
+};
+pp.readString = function(quote) {
+  var out = "", chunkStart = ++this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(this.start, "Unterminated string constant");
+    }
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === quote) {
+      break;
+    }
+    if (ch === 92) {
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar(false);
+      chunkStart = this.pos;
+    } else if (ch === 8232 || ch === 8233) {
+      if (this.options.ecmaVersion < 10) {
+        this.raise(this.start, "Unterminated string constant");
+      }
+      ++this.pos;
+      if (this.options.locations) {
+        this.curLine++;
+        this.lineStart = this.pos;
+      }
+    } else {
+      if (isNewLine(ch)) {
+        this.raise(this.start, "Unterminated string constant");
+      }
+      ++this.pos;
+    }
+  }
+  out += this.input.slice(chunkStart, this.pos++);
+  return this.finishToken(types$1.string, out);
+};
+var INVALID_TEMPLATE_ESCAPE_ERROR = {};
+pp.tryReadTemplateToken = function() {
+  this.inTemplateElement = true;
+  try {
+    this.readTmplToken();
+  } catch (err) {
+    if (err === INVALID_TEMPLATE_ESCAPE_ERROR) {
+      this.readInvalidTemplateToken();
+    } else {
+      throw err;
+    }
+  }
+  this.inTemplateElement = false;
+};
+pp.invalidStringToken = function(position3, message) {
+  if (this.inTemplateElement && this.options.ecmaVersion >= 9) {
+    throw INVALID_TEMPLATE_ESCAPE_ERROR;
+  } else {
+    this.raise(position3, message);
+  }
+};
+pp.readTmplToken = function() {
+  var out = "", chunkStart = this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(this.start, "Unterminated template");
+    }
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) {
+      if (this.pos === this.start && (this.type === types$1.template || this.type === types$1.invalidTemplate)) {
+        if (ch === 36) {
+          this.pos += 2;
+          return this.finishToken(types$1.dollarBraceL);
+        } else {
+          ++this.pos;
+          return this.finishToken(types$1.backQuote);
+        }
+      }
+      out += this.input.slice(chunkStart, this.pos);
+      return this.finishToken(types$1.template, out);
+    }
+    if (ch === 92) {
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar(true);
+      chunkStart = this.pos;
+    } else if (isNewLine(ch)) {
+      out += this.input.slice(chunkStart, this.pos);
+      ++this.pos;
+      switch (ch) {
+        case 13:
+          if (this.input.charCodeAt(this.pos) === 10) {
+            ++this.pos;
+          }
+        case 10:
+          out += "\n";
+          break;
+        default:
+          out += String.fromCharCode(ch);
+          break;
+      }
+      if (this.options.locations) {
+        ++this.curLine;
+        this.lineStart = this.pos;
+      }
+      chunkStart = this.pos;
+    } else {
+      ++this.pos;
+    }
+  }
+};
+pp.readInvalidTemplateToken = function() {
+  for (; this.pos < this.input.length; this.pos++) {
+    switch (this.input[this.pos]) {
+      case "\\":
+        ++this.pos;
+        break;
+      case "$":
+        if (this.input[this.pos + 1] !== "{") {
+          break;
+        }
+      case "`":
+        return this.finishToken(types$1.invalidTemplate, this.input.slice(this.start, this.pos));
+    }
+  }
+  this.raise(this.start, "Unterminated template");
+};
+pp.readEscapedChar = function(inTemplate) {
+  var ch = this.input.charCodeAt(++this.pos);
+  ++this.pos;
+  switch (ch) {
+    case 110:
+      return "\n";
+    case 114:
+      return "\r";
+    case 120:
+      return String.fromCharCode(this.readHexChar(2));
+    case 117:
+      return codePointToString(this.readCodePoint());
+    case 116:
+      return "	";
+    case 98:
+      return "\b";
+    case 118:
+      return "\v";
+    case 102:
+      return "\f";
+    case 13:
+      if (this.input.charCodeAt(this.pos) === 10) {
+        ++this.pos;
+      }
+    case 10:
+      if (this.options.locations) {
+        this.lineStart = this.pos;
+        ++this.curLine;
+      }
+      return "";
+    case 56:
+    case 57:
+      if (this.strict) {
+        this.invalidStringToken(
+          this.pos - 1,
+          "Invalid escape sequence"
+        );
+      }
+      if (inTemplate) {
+        var codePos = this.pos - 1;
+        this.invalidStringToken(
+          codePos,
+          "Invalid escape sequence in template string"
+        );
+        return null;
+      }
+    default:
+      if (ch >= 48 && ch <= 55) {
+        var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+        var octal = parseInt(octalStr, 8);
+        if (octal > 255) {
+          octalStr = octalStr.slice(0, -1);
+          octal = parseInt(octalStr, 8);
+        }
+        this.pos += octalStr.length - 1;
+        ch = this.input.charCodeAt(this.pos);
+        if ((octalStr !== "0" || ch === 56 || ch === 57) && (this.strict || inTemplate)) {
+          this.invalidStringToken(
+            this.pos - 1 - octalStr.length,
+            inTemplate ? "Octal literal in template string" : "Octal literal in strict mode"
+          );
+        }
+        return String.fromCharCode(octal);
+      }
+      if (isNewLine(ch)) {
+        return "";
+      }
+      return String.fromCharCode(ch);
+  }
+};
+pp.readHexChar = function(len) {
+  var codePos = this.pos;
+  var n = this.readInt(16, len);
+  if (n === null) {
+    this.invalidStringToken(codePos, "Bad character escape sequence");
+  }
+  return n;
+};
+pp.readWord1 = function() {
+  this.containsEsc = false;
+  var word = "", first = true, chunkStart = this.pos;
+  var astral = this.options.ecmaVersion >= 6;
+  while (this.pos < this.input.length) {
+    var ch = this.fullCharCodeAtPos();
+    if (isIdentifierChar(ch, astral)) {
+      this.pos += ch <= 65535 ? 1 : 2;
+    } else if (ch === 92) {
+      this.containsEsc = true;
+      word += this.input.slice(chunkStart, this.pos);
+      var escStart = this.pos;
+      if (this.input.charCodeAt(++this.pos) !== 117) {
+        this.invalidStringToken(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+      }
+      ++this.pos;
+      var esc = this.readCodePoint();
+      if (!(first ? isIdentifierStart : isIdentifierChar)(esc, astral)) {
+        this.invalidStringToken(escStart, "Invalid Unicode escape");
+      }
+      word += codePointToString(esc);
+      chunkStart = this.pos;
+    } else {
+      break;
+    }
+    first = false;
+  }
+  return word + this.input.slice(chunkStart, this.pos);
+};
+pp.readWord = function() {
+  var word = this.readWord1();
+  var type = types$1.name;
+  if (this.keywords.test(word)) {
+    type = keywords[word];
+  }
+  return this.finishToken(type, word);
+};
+var version = "8.8.1";
+Parser.acorn = {
+  Parser,
+  version,
+  defaultOptions,
+  Position,
+  SourceLocation,
+  getLineInfo,
+  Node,
+  TokenType,
+  tokTypes: types$1,
+  keywordTypes: keywords,
+  TokContext,
+  tokContexts: types,
+  isIdentifierChar,
+  isIdentifierStart,
+  Token,
+  isNewLine,
+  lineBreak,
+  lineBreakG,
+  nonASCIIwhitespace
+};
+
+// node_modules/micromark-extension-mdxjs/index.js
+var import_acorn_jsx = __toESM(require_acorn_jsx(), 1);
+
+// node_modules/micromark-util-chunked/index.js
+function splice(list3, start3, remove, items) {
+  const end = list3.length;
+  let chunkStart = 0;
+  let parameters;
+  if (start3 < 0) {
+    start3 = -start3 > end ? 0 : end + start3;
+  } else {
+    start3 = start3 > end ? end : start3;
+  }
+  remove = remove > 0 ? remove : 0;
+  if (items.length < 1e4) {
+    parameters = Array.from(items);
+    parameters.unshift(start3, remove);
+    [].splice.apply(list3, parameters);
+  } else {
+    if (remove)
+      [].splice.apply(list3, [start3, remove]);
+    while (chunkStart < items.length) {
+      parameters = items.slice(chunkStart, chunkStart + 1e4);
+      parameters.unshift(start3, 0);
+      [].splice.apply(list3, parameters);
+      chunkStart += 1e4;
+      start3 += 1e4;
+    }
+  }
+}
+function push(list3, items) {
+  if (list3.length > 0) {
+    splice(list3, list3.length, 0, items);
+    return list3;
+  }
+  return items;
+}
+
+// node_modules/micromark-util-combine-extensions/index.js
+var hasOwnProperty2 = {}.hasOwnProperty;
+function combineExtensions(extensions) {
+  const all4 = {};
+  let index2 = -1;
+  while (++index2 < extensions.length) {
+    syntaxExtension(all4, extensions[index2]);
+  }
+  return all4;
+}
+function syntaxExtension(all4, extension2) {
+  let hook;
+  for (hook in extension2) {
+    const maybe = hasOwnProperty2.call(all4, hook) ? all4[hook] : void 0;
+    const left = maybe || (all4[hook] = {});
+    const right = extension2[hook];
+    let code2;
+    for (code2 in right) {
+      if (!hasOwnProperty2.call(left, code2))
+        left[code2] = [];
+      const value = right[code2];
+      constructs(
+        left[code2],
+        Array.isArray(value) ? value : value ? [value] : []
+      );
+    }
+  }
+}
+function constructs(existing, list3) {
+  let index2 = -1;
+  const before = [];
+  while (++index2 < list3.length) {
+    ;
+    (list3[index2].add === "after" ? existing : before).push(list3[index2]);
+  }
+  splice(existing, 0, 0, before);
+}
+
+// node_modules/micromark-util-character/lib/unicode-punctuation-regex.js
+var unicodePunctuationRegex = /[!-/:-@[-`{-~\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0A76\u0AF0\u0C77\u0C84\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E4F\u2E52\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]/;
+
+// node_modules/micromark-util-character/index.js
+var asciiAlpha = regexCheck(/[A-Za-z]/);
+var asciiDigit = regexCheck(/\d/);
+var asciiHexDigit = regexCheck(/[\dA-Fa-f]/);
+var asciiAlphanumeric = regexCheck(/[\dA-Za-z]/);
+var asciiPunctuation = regexCheck(/[!-/:-@[-`{-~]/);
+var asciiAtext = regexCheck(/[#-'*+\--9=?A-Z^-~]/);
+function asciiControl(code2) {
+  return code2 !== null && (code2 < 32 || code2 === 127);
+}
+function markdownLineEndingOrSpace(code2) {
+  return code2 !== null && (code2 < 0 || code2 === 32);
+}
+function markdownLineEnding(code2) {
+  return code2 !== null && code2 < -2;
+}
+function markdownSpace(code2) {
+  return code2 === -2 || code2 === -1 || code2 === 32;
+}
+var unicodeWhitespace = regexCheck(/\s/);
+var unicodePunctuation = regexCheck(unicodePunctuationRegex);
+function regexCheck(regex2) {
+  return check;
+  function check(code2) {
+    return code2 !== null && regex2.test(String.fromCharCode(code2));
+  }
+}
+
+// node_modules/micromark-factory-space/index.js
+function factorySpace(effects, ok2, type, max) {
+  const limit = max ? max - 1 : Number.POSITIVE_INFINITY;
+  let size = 0;
+  return start3;
+  function start3(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter(type);
+      return prefix(code2);
+    }
+    return ok2(code2);
+  }
+  function prefix(code2) {
+    if (markdownSpace(code2) && size++ < limit) {
+      effects.consume(code2);
+      return prefix;
+    }
+    effects.exit(type);
+    return ok2(code2);
+  }
+}
+
+// node_modules/unist-util-position-from-estree/index.js
+function positionFromEstree(value) {
+  const node = value || {};
+  const loc = node.loc || {};
+  const range = node.range || [0, 0];
+  const startOffset = range[0] || node.start;
+  const endOffset = range[1] || node.end;
+  return {
+    start: {
+      line: loc.start && typeof loc.start.line === "number" && loc.start.line > -1 ? loc.start.line : void 0,
+      column: loc.start && typeof loc.start.column === "number" && loc.start.column > -1 ? loc.start.column + 1 : void 0,
+      offset: typeof startOffset === "number" && startOffset > -1 ? startOffset : void 0
+    },
+    end: {
+      line: loc.end && typeof loc.end.line === "number" && loc.end.line > -1 ? loc.end.line : void 0,
+      column: loc.end && typeof loc.end.column === "number" && loc.end.column > -1 ? loc.end.column + 1 : void 0,
+      offset: typeof endOffset === "number" && endOffset > -1 ? endOffset : void 0
+    }
+  };
+}
+
+// node_modules/estree-util-visit/color.js
+function color(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/estree-util-visit/index.js
+var own2 = {}.hasOwnProperty;
+var CONTINUE = Symbol("continue");
+var SKIP = Symbol("skip");
+var EXIT = Symbol("exit");
+function visit(tree, visitor) {
+  let enter;
+  let leave;
+  if (typeof visitor === "function") {
+    enter = visitor;
+  } else if (visitor && typeof visitor === "object") {
+    enter = visitor.enter;
+    leave = visitor.leave;
+  }
+  build(tree, null, null, [])();
+  function build(node, key, index2, parents) {
+    if (nodelike(node)) {
+      visit3.displayName = "node (" + color(node.type) + ")";
+    }
+    return visit3;
+    function visit3() {
+      const result = enter ? toResult(enter(node, key, index2, parents)) : [];
+      if (result[0] === EXIT) {
+        return result;
+      }
+      if (result[0] !== SKIP) {
+        let cKey;
+        for (cKey in node) {
+          if (own2.call(node, cKey) && node[cKey] && typeof node[cKey] === "object" && cKey !== "data" && cKey !== "position") {
+            const value = node[cKey];
+            const grandparents = parents.concat(node);
+            if (Array.isArray(value)) {
+              let cIndex = 0;
+              while (cIndex > -1 && cIndex < value.length) {
+                const subvalue = value[cIndex];
+                if (nodelike(subvalue)) {
+                  const subresult = build(
+                    subvalue,
+                    cKey,
+                    cIndex,
+                    grandparents
+                  )();
+                  if (subresult[0] === EXIT)
+                    return subresult;
+                  cIndex = typeof subresult[1] === "number" ? subresult[1] : cIndex + 1;
+                } else {
+                  cIndex++;
+                }
+              }
+            } else if (nodelike(value)) {
+              const subresult = build(value, cKey, null, grandparents)();
+              if (subresult[0] === EXIT)
+                return subresult;
+            }
+          }
+        }
+      }
+      return leave ? toResult(leave(node, key, index2, parents)) : result;
+    }
+  }
+}
+function toResult(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE, value];
+  }
+  return [value];
+}
+function nodelike(value) {
+  return Boolean(
+    value && typeof value === "object" && typeof value.type === "string" && value.type.length > 0
+  );
+}
+
+// node_modules/micromark-util-events-to-acorn/node_modules/vfile-location/index.js
+function location(file) {
+  var value = String(file);
+  var indices = [];
+  var search2 = /\r?\n|\r/g;
+  while (search2.test(value)) {
+    indices.push(search2.lastIndex);
+  }
+  indices.push(value.length + 1);
+  return { toPoint, toOffset };
+  function toPoint(offset2) {
+    var index2 = -1;
+    if (offset2 > -1 && offset2 < indices[indices.length - 1]) {
+      while (++index2 < indices.length) {
+        if (indices[index2] > offset2) {
+          return {
+            line: index2 + 1,
+            column: offset2 - (indices[index2 - 1] || 0) + 1,
+            offset: offset2
+          };
+        }
+      }
+    }
+    return { line: void 0, column: void 0, offset: void 0 };
+  }
+  function toOffset(point3) {
+    var line = point3 && point3.line;
+    var column = point3 && point3.column;
+    var offset2;
+    if (typeof line === "number" && typeof column === "number" && !Number.isNaN(line) && !Number.isNaN(column) && line - 1 in indices) {
+      offset2 = (indices[line - 2] || 0) + column - 1 || 0;
+    }
+    return offset2 > -1 && offset2 < indices[indices.length - 1] ? offset2 : -1;
+  }
+}
+
+// node_modules/micromark-util-events-to-acorn/index.js
+function eventsToAcorn(events, options) {
+  const { prefix = "", suffix = "" } = options;
+  const acornOptions = Object.assign({}, options.acornOptions);
+  const comments = [];
+  const tokens = [];
+  const onComment = acornOptions.onComment;
+  const onToken = acornOptions.onToken;
+  const acornConfig = Object.assign({}, acornOptions, {
+    onComment: comments,
+    onToken: onToken ? tokens : void 0,
+    preserveParens: true
+  });
+  const chunks = [];
+  const lines = {};
+  let index2 = -1;
+  let swallow = false;
+  let estree;
+  let exception;
+  let startLine;
+  if (options.start) {
+    startLine = options.start.line;
+    lines[startLine] = options.start;
+  }
+  while (++index2 < events.length) {
+    const [kind, token, context] = events[index2];
+    if (kind === "exit") {
+      chunks.push(context.sliceSerialize(token));
+      setPoint(token.start);
+      setPoint(token.end);
+    }
+  }
+  const source = chunks.join("");
+  const value = prefix + source + suffix;
+  const isEmptyExpression = options.expression && empty2(source);
+  const place = location(source);
+  if (isEmptyExpression && !options.allowEmpty) {
+    throw new VFileMessage(
+      "Unexpected empty expression",
+      parseOffsetToUnistPoint(0),
+      "micromark-extension-mdx-expression:unexpected-empty-expression"
+    );
+  }
+  try {
+    estree = options.expression && !isEmptyExpression ? options.acorn.parseExpressionAt(value, 0, acornConfig) : options.acorn.parse(value, acornConfig);
+  } catch (error_) {
+    const error = error_;
+    const point3 = parseOffsetToUnistPoint(error.pos);
+    error.message = String(error.message).replace(/ \(\d+:\d+\)$/, "");
+    error.pos = point3.offset;
+    error.loc = {
+      line: point3.line,
+      column: point3.column - 1
+    };
+    exception = error;
+    swallow = error.raisedAt >= prefix.length + source.length || error.message === "Unterminated comment";
+  }
+  if (estree && options.expression && !isEmptyExpression) {
+    if (empty2(value.slice(estree.end, value.length - suffix.length))) {
+      estree = {
+        type: "Program",
+        start: 0,
+        end: prefix.length + source.length,
+        body: [
+          {
+            type: "ExpressionStatement",
+            expression: estree,
+            start: 0,
+            end: prefix.length + source.length
+          }
+        ],
+        sourceType: "module",
+        comments: []
+      };
+    } else {
+      const point3 = parseOffsetToUnistPoint(estree.end);
+      exception = new Error("Unexpected content after expression");
+      exception.pos = point3.offset;
+      exception.loc = {
+        line: point3.line,
+        column: point3.column - 1
+      };
+      estree = void 0;
+    }
+  }
+  if (estree) {
+    estree.comments = comments;
+    visit(estree, (esnode, field, index3, parents) => {
+      let context = parents[parents.length - 1];
+      let prop = field;
+      if (esnode.type === "ParenthesizedExpression" && context && prop) {
+        if (typeof index3 === "number") {
+          context = context[prop];
+          prop = index3;
+        }
+        context[prop] = esnode.expression;
+      }
+      fixPosition(esnode);
+    });
+    if (Array.isArray(onComment)) {
+      onComment.push(...comments);
+    } else if (typeof onComment === "function") {
+      for (const comment2 of comments) {
+        onComment(
+          comment2.type === "Block",
+          comment2.value,
+          comment2.start,
+          comment2.end,
+          comment2.loc.start,
+          comment2.loc.end
+        );
+      }
+    }
+    for (const token of tokens) {
+      fixPosition(token);
+      if (Array.isArray(onToken)) {
+        onToken.push(token);
+      } else {
+        onToken(token);
+      }
+    }
+  }
+  return {
+    estree,
+    error: exception,
+    swallow
+  };
+  function fixPosition(nodeOrToken) {
+    const pointStart2 = parseOffsetToUnistPoint(nodeOrToken.start);
+    const pointEnd2 = parseOffsetToUnistPoint(nodeOrToken.end);
+    nodeOrToken.start = pointStart2.offset;
+    nodeOrToken.end = pointEnd2.offset;
+    nodeOrToken.loc = {
+      start: {
+        line: pointStart2.line,
+        column: pointStart2.column - 1,
+        offset: pointStart2.offset
+      },
+      end: {
+        line: pointEnd2.line,
+        column: pointEnd2.column - 1,
+        offset: pointEnd2.offset
+      }
+    };
+    nodeOrToken.range = [nodeOrToken.start, nodeOrToken.end];
+  }
+  function parseOffsetToUnistPoint(acornOffset) {
+    let sourceOffset = acornOffset - prefix.length;
+    if (sourceOffset < 0) {
+      sourceOffset = 0;
+    } else if (sourceOffset > source.length) {
+      sourceOffset = source.length;
+    }
+    const pointInSource = place.toPoint(sourceOffset);
+    const line = startLine + (pointInSource.line - 1);
+    const column = lines[line].column + (pointInSource.column - 1);
+    const offset2 = lines[line].offset + (pointInSource.column - 1);
+    return {
+      line,
+      column,
+      offset: offset2
+    };
+  }
+  function setPoint(point3) {
+    if (!startLine || point3.line < startLine) {
+      startLine = point3.line;
+    }
+    if (!(point3.line in lines) || lines[point3.line].offset > point3.offset) {
+      lines[point3.line] = point3;
+    }
+  }
+}
+function empty2(value) {
+  return /^\s*$/.test(
+    value.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\r\n]*(\r\n|\n|\r)/g, "")
+  );
+}
+
+// node_modules/micromark-factory-mdx-expression/index.js
+function factoryMdxExpression(effects, ok2, type, markerType, chunkType, acorn, acornOptions, addResult, spread, allowEmpty, allowLazy, startColumn) {
+  const self2 = this;
+  const eventStart = this.events.length + 3;
+  const tail = this.events[this.events.length - 1];
+  const initialPrefix = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  const prefixExpressionIndent = initialPrefix ? initialPrefix + 1 : 0;
+  let balance = 1;
+  let startPosition;
+  let lastCrash;
+  return start3;
+  function start3(code2) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    startPosition = self2.now();
+    return atBreak;
+  }
+  function atBreak(code2) {
+    if (code2 === null) {
+      throw lastCrash || new VFileMessage(
+        "Unexpected end of file in expression, expected a corresponding closing brace for `{`",
+        self2.now(),
+        "micromark-extension-mdx-expression:unexpected-eof"
+      );
+    }
+    if (code2 === 125) {
+      return atClosingBrace(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      const prefixTagIndent = startColumn ? startColumn + 4 - self2.now().column : 0;
+      const indent = Math.max(prefixExpressionIndent, prefixTagIndent);
+      return indent ? factorySpace(effects, atBreak, "linePrefix", indent) : atBreak;
+    }
+    const now = self2.now();
+    if (now.line !== startPosition.line && !allowLazy && self2.parser.lazy[now.line]) {
+      throw new VFileMessage(
+        "Unexpected end of file in expression, expected a corresponding closing brace for `{`",
+        self2.now(),
+        "micromark-extension-mdx-expression:unexpected-eof"
+      );
+    }
+    effects.enter(chunkType);
+    return inside(code2);
+  }
+  function inside(code2) {
+    if (code2 === null || code2 === 125 || markdownLineEnding(code2)) {
+      effects.exit(chunkType);
+      return atBreak(code2);
+    }
+    if (code2 === 123 && !acorn) {
+      effects.consume(code2);
+      balance++;
+      return inside;
+    }
+    effects.consume(code2);
+    return inside;
+  }
+  function atClosingBrace(code2) {
+    balance--;
+    if (!acorn) {
+      if (balance) {
+        effects.enter(chunkType);
+        effects.consume(code2);
+        return inside;
+      }
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok2;
+    }
+    const result = eventsToAcorn(self2.events.slice(eventStart), {
+      acorn,
+      acornOptions,
+      start: startPosition,
+      expression: true,
+      allowEmpty,
+      prefix: spread ? "({" : "",
+      suffix: spread ? "})" : ""
+    });
+    const estree = result.estree;
+    if (spread && estree) {
+      const head = estree.body[0];
+      if (head.type !== "ExpressionStatement" || head.expression.type !== "ObjectExpression") {
+        throw new VFileMessage(
+          "Unexpected `" + head.type + "` in code: expected an object spread (`{...spread}`)",
+          positionFromEstree(head).start,
+          "micromark-extension-mdx-expression:non-spread"
+        );
+      } else if (head.expression.properties[1]) {
+        throw new VFileMessage(
+          "Unexpected extra content in spread: only a single spread is supported",
+          positionFromEstree(head.expression.properties[1]).start,
+          "micromark-extension-mdx-expression:spread-extra"
+        );
+      } else if (head.expression.properties[0] && head.expression.properties[0].type !== "SpreadElement") {
+        throw new VFileMessage(
+          "Unexpected `" + head.expression.properties[0].type + "` in code: only spread elements are supported",
+          positionFromEstree(head.expression.properties[0]).start,
+          "micromark-extension-mdx-expression:non-spread"
+        );
+      }
+    }
+    if (result.error) {
+      lastCrash = new VFileMessage(
+        "Could not parse expression with acorn: " + result.error.message,
+        {
+          line: result.error.loc.line,
+          column: result.error.loc.column + 1,
+          offset: result.error.pos
+        },
+        "micromark-extension-mdx-expression:acorn"
+      );
+      if (code2 !== null && result.swallow) {
+        effects.enter(chunkType);
+        effects.consume(code2);
+        return inside;
+      }
+      throw lastCrash;
+    }
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    Object.assign(
+      effects.exit(type),
+      addResult ? {
+        estree
+      } : void 0
+    );
+    return ok2;
+  }
+}
+
+// node_modules/micromark-extension-mdx-expression/lib/syntax.js
+function mdxExpression(options = {}) {
+  const addResult = options.addResult;
+  const acorn = options.acorn;
+  const spread = options.spread;
+  let allowEmpty = options.allowEmpty;
+  let acornOptions;
+  if (allowEmpty === null || allowEmpty === void 0) {
+    allowEmpty = true;
+  }
+  if (acorn) {
+    if (!acorn.parseExpressionAt) {
+      throw new Error(
+        "Expected a proper `acorn` instance passed in as `options.acorn`"
+      );
+    }
+    acornOptions = Object.assign(
+      {
+        ecmaVersion: 2020,
+        sourceType: "module"
+      },
+      options.acornOptions
+    );
+  } else if (options.acornOptions || options.addResult) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  return {
+    flow: {
+      [123]: {
+        tokenize: tokenizeFlowExpression,
+        concrete: true
+      }
+    },
+    text: {
+      [123]: {
+        tokenize: tokenizeTextExpression
+      }
+    }
+  };
+  function tokenizeFlowExpression(effects, ok2, nok) {
+    const self2 = this;
+    return start3;
+    function start3(code2) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        factorySpace(effects, after, "whitespace"),
+        "mdxFlowExpression",
+        "mdxFlowExpressionMarker",
+        "mdxFlowExpressionChunk",
+        acorn,
+        acornOptions,
+        addResult,
+        spread,
+        allowEmpty
+      )(code2);
+    }
+    function after(code2) {
+      return code2 === null || markdownLineEnding(code2) ? ok2(code2) : nok(code2);
+    }
+  }
+  function tokenizeTextExpression(effects, ok2) {
+    const self2 = this;
+    return start3;
+    function start3(code2) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        ok2,
+        "mdxTextExpression",
+        "mdxTextExpressionMarker",
+        "mdxTextExpressionChunk",
+        acorn,
+        acornOptions,
+        addResult,
+        spread,
+        allowEmpty,
+        true
+      )(code2);
+    }
+  }
+}
+
+// node_modules/estree-util-is-identifier-name/regex.js
+var start = /[$A-Z_a-z\u00AA\u00B5\u00BA\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u08A0-\u08B4\u08B6-\u08C7\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2C2E\u2C30-\u2C5E\u2C60-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFC\uA000-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7BF\uA7C2-\uA7CA\uA7F5-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/;
+var cont = /[\d\u00B7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1714\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u1810-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF\u1AC0\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u200C\u200D\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F]/;
+
+// node_modules/estree-util-is-identifier-name/index.js
+function start2(code2) {
+  return start.test(String.fromCharCode(code2));
+}
+function cont2(code2) {
+  const character = String.fromCharCode(code2);
+  return start.test(character) || cont.test(character);
+}
+function name(name2) {
+  let index2 = -1;
+  while (++index2 < name2.length) {
+    if (!(index2 ? cont2 : start2)(name2.charCodeAt(index2)))
+      return false;
+  }
+  return index2 > 0;
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/factory-tag.js
+var lazyLineEnd = {
+  tokenize: tokenizeLazyLineEnd,
+  partial: true
+};
+function factoryTag(effects, ok2, nok, acorn, acornOptions, addResult, allowLazy, tagType, tagMarkerType, tagClosingMarkerType, tagSelfClosingMarker, tagNameType, tagNamePrimaryType, tagNameMemberMarkerType, tagNameMemberType, tagNamePrefixMarkerType, tagNameLocalType, tagExpressionAttributeType, tagExpressionAttributeMarkerType, tagExpressionAttributeValueType, tagAttributeType, tagAttributeNameType, tagAttributeNamePrimaryType, tagAttributeNamePrefixMarkerType, tagAttributeNameLocalType, tagAttributeInitializerMarkerType, tagAttributeValueLiteralType, tagAttributeValueLiteralMarkerType, tagAttributeValueLiteralValueType, tagAttributeValueExpressionType, tagAttributeValueExpressionMarkerType, tagAttributeValueExpressionValueType) {
+  const self2 = this;
+  let returnState;
+  let marker;
+  let startPoint;
+  return start3;
+  function start3(code2) {
+    startPoint = self2.now();
+    effects.enter(tagType);
+    effects.enter(tagMarkerType);
+    effects.consume(code2);
+    effects.exit(tagMarkerType);
+    return afterStart;
+  }
+  function afterStart(code2) {
+    if (markdownLineEnding(code2) || markdownSpace(code2)) {
+      return nok(code2);
+    }
+    returnState = beforeName;
+    return optionalEsWhitespace(code2);
+  }
+  function beforeName(code2) {
+    if (code2 === 47) {
+      effects.enter(tagClosingMarkerType);
+      effects.consume(code2);
+      effects.exit(tagClosingMarkerType);
+      returnState = beforeClosingTagName;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    if (code2 !== null && start2(code2)) {
+      effects.enter(tagNameType);
+      effects.enter(tagNamePrimaryType);
+      effects.consume(code2);
+      return primaryName;
+    }
+    crash(
+      code2,
+      "before name",
+      "a character that can start a name, such as a letter, `$`, or `_`" + (code2 === 33 ? " (note: to create a comment in MDX, use `{/* text */}`)" : "")
+    );
+  }
+  function beforeClosingTagName(code2) {
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    if (code2 !== null && start2(code2)) {
+      effects.enter(tagNameType);
+      effects.enter(tagNamePrimaryType);
+      effects.consume(code2);
+      return primaryName;
+    }
+    crash(
+      code2,
+      "before name",
+      "a character that can start a name, such as a letter, `$`, or `_`" + (code2 === 42 || code2 === 47 ? " (note: JS comments in JSX tags are not supported in MDX)" : "")
+    );
+  }
+  function primaryName(code2) {
+    if (code2 === 45 || code2 !== null && cont2(code2)) {
+      effects.consume(code2);
+      return primaryName;
+    }
+    if (code2 === 46 || code2 === 47 || code2 === 58 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagNamePrimaryType);
+      returnState = afterPrimaryName;
+      return optionalEsWhitespace(code2);
+    }
+    crash(
+      code2,
+      "in name",
+      "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag" + (code2 === 64 ? " (note: to create a link in MDX, use `[text](url)`)" : "")
+    );
+  }
+  function afterPrimaryName(code2) {
+    if (code2 === 46) {
+      effects.enter(tagNameMemberMarkerType);
+      effects.consume(code2);
+      effects.exit(tagNameMemberMarkerType);
+      returnState = beforeMemberName;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 58) {
+      effects.enter(tagNamePrefixMarkerType);
+      effects.consume(code2);
+      effects.exit(tagNamePrefixMarkerType);
+      returnState = beforeLocalName;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && start2(code2)) {
+      effects.exit(tagNameType);
+      return beforeAttribute(code2);
+    }
+    crash(
+      code2,
+      "after name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function beforeMemberName(code2) {
+    if (code2 !== null && start2(code2)) {
+      effects.enter(tagNameMemberType);
+      effects.consume(code2);
+      return memberName;
+    }
+    crash(
+      code2,
+      "before member name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function memberName(code2) {
+    if (code2 === 45 || code2 !== null && cont2(code2)) {
+      effects.consume(code2);
+      return memberName;
+    }
+    if (code2 === 46 || code2 === 47 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagNameMemberType);
+      returnState = afterMemberName;
+      return optionalEsWhitespace(code2);
+    }
+    crash(
+      code2,
+      "in member name",
+      "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag" + (code2 === 64 ? " (note: to create a link in MDX, use `[text](url)`)" : "")
+    );
+  }
+  function afterMemberName(code2) {
+    if (code2 === 46) {
+      effects.enter(tagNameMemberMarkerType);
+      effects.consume(code2);
+      effects.exit(tagNameMemberMarkerType);
+      returnState = beforeMemberName;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && start2(code2)) {
+      effects.exit(tagNameType);
+      return beforeAttribute(code2);
+    }
+    crash(
+      code2,
+      "after member name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function beforeLocalName(code2) {
+    if (code2 !== null && start2(code2)) {
+      effects.enter(tagNameLocalType);
+      effects.consume(code2);
+      return localName;
+    }
+    crash(
+      code2,
+      "before local name",
+      "a character that can start a name, such as a letter, `$`, or `_`" + (code2 === 43 || code2 !== null && code2 > 46 && code2 < 58 ? " (note: to create a link in MDX, use `[text](url)`)" : "")
+    );
+  }
+  function localName(code2) {
+    if (code2 === 45 || code2 !== null && cont2(code2)) {
+      effects.consume(code2);
+      return localName;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagNameLocalType);
+      returnState = afterLocalName;
+      return optionalEsWhitespace(code2);
+    }
+    crash(
+      code2,
+      "in local name",
+      "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterLocalName(code2) {
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && start2(code2)) {
+      effects.exit(tagNameType);
+      return beforeAttribute(code2);
+    }
+    crash(
+      code2,
+      "after local name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function beforeAttribute(code2) {
+    if (code2 === 47) {
+      effects.enter(tagSelfClosingMarker);
+      effects.consume(code2);
+      effects.exit(tagSelfClosingMarker);
+      returnState = selfClosing;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    if (code2 === 123) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        afterAttributeExpression,
+        tagExpressionAttributeType,
+        tagExpressionAttributeMarkerType,
+        tagExpressionAttributeValueType,
+        acorn,
+        acornOptions,
+        addResult,
+        true,
+        false,
+        allowLazy,
+        startPoint.column
+      )(code2);
+    }
+    if (code2 !== null && start2(code2)) {
+      effects.enter(tagAttributeType);
+      effects.enter(tagAttributeNameType);
+      effects.enter(tagAttributeNamePrimaryType);
+      effects.consume(code2);
+      return attributePrimaryName;
+    }
+    crash(
+      code2,
+      "before attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterAttributeExpression(code2) {
+    returnState = beforeAttribute;
+    return optionalEsWhitespace(code2);
+  }
+  function attributePrimaryName(code2) {
+    if (code2 === 45 || code2 !== null && cont2(code2)) {
+      effects.consume(code2);
+      return attributePrimaryName;
+    }
+    if (code2 === 47 || code2 === 58 || code2 === 61 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagAttributeNamePrimaryType);
+      returnState = afterAttributePrimaryName;
+      return optionalEsWhitespace(code2);
+    }
+    crash(
+      code2,
+      "in attribute name",
+      "an attribute name character such as letters, digits, `$`, or `_`; `=` to initialize a value; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterAttributePrimaryName(code2) {
+    if (code2 === 58) {
+      effects.enter(tagAttributeNamePrefixMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeNamePrefixMarkerType);
+      returnState = beforeAttributeLocalName;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 61) {
+      effects.exit(tagAttributeNameType);
+      effects.enter(tagAttributeInitializerMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeInitializerMarkerType);
+      returnState = beforeAttributeValue;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2) || code2 !== null && start2(code2)) {
+      effects.exit(tagAttributeNameType);
+      effects.exit(tagAttributeType);
+      returnState = beforeAttribute;
+      return optionalEsWhitespace(code2);
+    }
+    crash(
+      code2,
+      "after attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag"
+    );
+  }
+  function beforeAttributeLocalName(code2) {
+    if (code2 !== null && start2(code2)) {
+      effects.enter(tagAttributeNameLocalType);
+      effects.consume(code2);
+      return attributeLocalName;
+    }
+    crash(
+      code2,
+      "before local attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag"
+    );
+  }
+  function attributeLocalName(code2) {
+    if (code2 === 45 || code2 !== null && cont2(code2)) {
+      effects.consume(code2);
+      return attributeLocalName;
+    }
+    if (code2 === 47 || code2 === 61 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagAttributeNameLocalType);
+      effects.exit(tagAttributeNameType);
+      returnState = afterAttributeLocalName;
+      return optionalEsWhitespace(code2);
+    }
+    crash(
+      code2,
+      "in local attribute name",
+      "an attribute name character such as letters, digits, `$`, or `_`; `=` to initialize a value; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterAttributeLocalName(code2) {
+    if (code2 === 61) {
+      effects.enter(tagAttributeInitializerMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeInitializerMarkerType);
+      returnState = beforeAttributeValue;
+      return optionalEsWhitespace;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && start2(code2)) {
+      effects.exit(tagAttributeType);
+      return beforeAttribute(code2);
+    }
+    crash(
+      code2,
+      "after local attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag"
+    );
+  }
+  function beforeAttributeValue(code2) {
+    if (code2 === 34 || code2 === 39) {
+      effects.enter(tagAttributeValueLiteralType);
+      effects.enter(tagAttributeValueLiteralMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeValueLiteralMarkerType);
+      marker = code2;
+      return attributeValueQuotedStart;
+    }
+    if (code2 === 123) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        afterAttributeValueExpression,
+        tagAttributeValueExpressionType,
+        tagAttributeValueExpressionMarkerType,
+        tagAttributeValueExpressionValueType,
+        acorn,
+        acornOptions,
+        addResult,
+        false,
+        false,
+        allowLazy,
+        startPoint.column
+      )(code2);
+    }
+    crash(
+      code2,
+      "before attribute value",
+      "a character that can start an attribute value, such as `\"`, `'`, or `{`" + (code2 === 60 ? " (note: to use an element or fragment as a prop value in MDX, use `{<element />}`)" : "")
+    );
+  }
+  function afterAttributeValueExpression(code2) {
+    effects.exit(tagAttributeType);
+    returnState = beforeAttribute;
+    return optionalEsWhitespace(code2);
+  }
+  function attributeValueQuotedStart(code2) {
+    if (code2 === null) {
+      crash(
+        code2,
+        "in attribute value",
+        "a corresponding closing quote `" + String.fromCharCode(marker) + "`"
+      );
+    }
+    if (code2 === marker) {
+      effects.enter(tagAttributeValueLiteralMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeValueLiteralMarkerType);
+      effects.exit(tagAttributeValueLiteralType);
+      effects.exit(tagAttributeType);
+      marker = void 0;
+      returnState = beforeAttribute;
+      return optionalEsWhitespace;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = attributeValueQuotedStart;
+      return optionalEsWhitespace(code2);
+    }
+    effects.enter(tagAttributeValueLiteralValueType);
+    return attributeValueQuoted(code2);
+  }
+  function attributeValueQuoted(code2) {
+    if (code2 === null || code2 === marker || markdownLineEnding(code2)) {
+      effects.exit(tagAttributeValueLiteralValueType);
+      return attributeValueQuotedStart(code2);
+    }
+    effects.consume(code2);
+    return attributeValueQuoted;
+  }
+  function selfClosing(code2) {
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    crash(
+      code2,
+      "after self-closing slash",
+      "`>` to end the tag" + (code2 === 42 || code2 === 47 ? " (note: JS comments in JSX tags are not supported in MDX)" : "")
+    );
+  }
+  function tagEnd(code2) {
+    effects.enter(tagMarkerType);
+    effects.consume(code2);
+    effects.exit(tagMarkerType);
+    effects.exit(tagType);
+    return ok2;
+  }
+  function optionalEsWhitespace(code2) {
+    if (markdownLineEnding(code2)) {
+      if (allowLazy) {
+        effects.enter("lineEnding");
+        effects.consume(code2);
+        effects.exit("lineEnding");
+        return factorySpace(effects, optionalEsWhitespace, "linePrefix", 4);
+      }
+      return effects.attempt(
+        lazyLineEnd,
+        factorySpace(effects, optionalEsWhitespace, "linePrefix", 4),
+        crashEol
+      )(code2);
+    }
+    if (markdownSpace(code2) || unicodeWhitespace(code2)) {
+      effects.enter("esWhitespace");
+      return optionalEsWhitespaceContinue(code2);
+    }
+    return returnState(code2);
+  }
+  function optionalEsWhitespaceContinue(code2) {
+    if (markdownLineEnding(code2) || !(markdownSpace(code2) || unicodeWhitespace(code2))) {
+      effects.exit("esWhitespace");
+      return optionalEsWhitespace(code2);
+    }
+    effects.consume(code2);
+    return optionalEsWhitespaceContinue;
+  }
+  function crashEol() {
+    throw new VFileMessage(
+      "Unexpected lazy line in container, expected line to be prefixed with `>` when in a block quote, whitespace when in a list, etc",
+      self2.now(),
+      "micromark-extension-mdx-jsx:unexpected-eof"
+    );
+  }
+  function crash(code2, at2, expect) {
+    throw new VFileMessage(
+      "Unexpected " + (code2 === null ? "end of file" : "character `" + (code2 === 96 ? "` ` `" : String.fromCharCode(code2)) + "` (" + serializeCharCode(code2) + ")") + " " + at2 + ", expected " + expect,
+      self2.now(),
+      "micromark-extension-mdx-jsx:unexpected-" + (code2 === null ? "eof" : "character")
+    );
+  }
+}
+function tokenizeLazyLineEnd(effects, ok2, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code2) {
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return lineStart;
+  }
+  function lineStart(code2) {
+    return self2.parser.lazy[self2.now().line] ? nok(code2) : ok2(code2);
+  }
+}
+function serializeCharCode(code2) {
+  return "U+" + code2.toString(16).toUpperCase().padStart(4, "0");
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/jsx-text.js
+function jsxText(acorn, acornOptions, addResult) {
+  return {
+    tokenize: tokenizeJsxText
+  };
+  function tokenizeJsxText(effects, ok2, nok) {
+    return factoryTag.call(
+      this,
+      effects,
+      ok2,
+      nok,
+      acorn,
+      acornOptions,
+      addResult,
+      true,
+      "mdxJsxTextTag",
+      "mdxJsxTextTagMarker",
+      "mdxJsxTextTagClosingMarker",
+      "mdxJsxTextTagSelfClosingMarker",
+      "mdxJsxTextTagName",
+      "mdxJsxTextTagNamePrimary",
+      "mdxJsxTextTagNameMemberMarker",
+      "mdxJsxTextTagNameMember",
+      "mdxJsxTextTagNamePrefixMarker",
+      "mdxJsxTextTagNameLocal",
+      "mdxJsxTextTagExpressionAttribute",
+      "mdxJsxTextTagExpressionAttributeMarker",
+      "mdxJsxTextTagExpressionAttributeValue",
+      "mdxJsxTextTagAttribute",
+      "mdxJsxTextTagAttributeName",
+      "mdxJsxTextTagAttributeNamePrimary",
+      "mdxJsxTextTagAttributeNamePrefixMarker",
+      "mdxJsxTextTagAttributeNameLocal",
+      "mdxJsxTextTagAttributeInitializerMarker",
+      "mdxJsxTextTagAttributeValueLiteral",
+      "mdxJsxTextTagAttributeValueLiteralMarker",
+      "mdxJsxTextTagAttributeValueLiteralValue",
+      "mdxJsxTextTagAttributeValueExpression",
+      "mdxJsxTextTagAttributeValueExpressionMarker",
+      "mdxJsxTextTagAttributeValueExpressionValue"
+    );
+  }
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/jsx-flow.js
+function jsxFlow(acorn, acornOptions, addResult) {
+  return {
+    tokenize: tokenizeJsxFlow,
+    concrete: true
+  };
+  function tokenizeJsxFlow(effects, ok2, nok) {
+    const self2 = this;
+    return start3;
+    function start3(code2) {
+      return factoryTag.call(
+        self2,
+        effects,
+        factorySpace(effects, after, "whitespace"),
+        nok,
+        acorn,
+        acornOptions,
+        addResult,
+        false,
+        "mdxJsxFlowTag",
+        "mdxJsxFlowTagMarker",
+        "mdxJsxFlowTagClosingMarker",
+        "mdxJsxFlowTagSelfClosingMarker",
+        "mdxJsxFlowTagName",
+        "mdxJsxFlowTagNamePrimary",
+        "mdxJsxFlowTagNameMemberMarker",
+        "mdxJsxFlowTagNameMember",
+        "mdxJsxFlowTagNamePrefixMarker",
+        "mdxJsxFlowTagNameLocal",
+        "mdxJsxFlowTagExpressionAttribute",
+        "mdxJsxFlowTagExpressionAttributeMarker",
+        "mdxJsxFlowTagExpressionAttributeValue",
+        "mdxJsxFlowTagAttribute",
+        "mdxJsxFlowTagAttributeName",
+        "mdxJsxFlowTagAttributeNamePrimary",
+        "mdxJsxFlowTagAttributeNamePrefixMarker",
+        "mdxJsxFlowTagAttributeNameLocal",
+        "mdxJsxFlowTagAttributeInitializerMarker",
+        "mdxJsxFlowTagAttributeValueLiteral",
+        "mdxJsxFlowTagAttributeValueLiteralMarker",
+        "mdxJsxFlowTagAttributeValueLiteralValue",
+        "mdxJsxFlowTagAttributeValueExpression",
+        "mdxJsxFlowTagAttributeValueExpressionMarker",
+        "mdxJsxFlowTagAttributeValueExpressionValue"
+      )(code2);
+    }
+    function after(code2) {
+      return code2 === 60 ? start3(code2) : code2 === null || markdownLineEnding(code2) ? ok2(code2) : nok(code2);
+    }
+  }
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/syntax.js
+function mdxJsx(options = {}) {
+  const acorn = options.acorn;
+  let acornOptions;
+  if (acorn) {
+    if (!acorn.parse || !acorn.parseExpressionAt) {
+      throw new Error(
+        "Expected a proper `acorn` instance passed in as `options.acorn`"
+      );
+    }
+    acornOptions = Object.assign(
+      {
+        ecmaVersion: 2020,
+        sourceType: "module"
+      },
+      options.acornOptions,
+      {
+        locations: true
+      }
+    );
+  } else if (options.acornOptions || options.addResult) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  return {
+    flow: {
+      [60]: jsxFlow(acorn, acornOptions, options.addResult)
+    },
+    text: {
+      [60]: jsxText(acorn, acornOptions, options.addResult)
+    }
+  };
+}
+
+// node_modules/micromark-extension-mdx-md/index.js
+var mdxMd = {
+  disable: { null: ["autolink", "codeIndented", "htmlFlow", "htmlText"] }
+};
+
+// node_modules/micromark-util-classify-character/index.js
+function classifyCharacter(code2) {
+  if (code2 === null || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+    return 1;
+  }
+  if (unicodePunctuation(code2)) {
+    return 2;
+  }
+}
+
+// node_modules/micromark-util-resolve-all/index.js
+function resolveAll(constructs2, events, context) {
+  const called = [];
+  let index2 = -1;
+  while (++index2 < constructs2.length) {
+    const resolve = constructs2[index2].resolveAll;
+    if (resolve && !called.includes(resolve)) {
+      events = resolve(events, context);
+      called.push(resolve);
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark-core-commonmark/lib/attention.js
+var attention = {
+  name: "attention",
+  tokenize: tokenizeAttention,
+  resolveAll: resolveAllAttention
+};
+function resolveAllAttention(events, context) {
+  let index2 = -1;
+  let open;
+  let group;
+  let text5;
+  let openingSequence;
+  let closingSequence;
+  let use;
+  let nextEvents;
+  let offset2;
+  while (++index2 < events.length) {
+    if (events[index2][0] === "enter" && events[index2][1].type === "attentionSequence" && events[index2][1]._close) {
+      open = index2;
+      while (open--) {
+        if (events[open][0] === "exit" && events[open][1].type === "attentionSequence" && events[open][1]._open && context.sliceSerialize(events[open][1]).charCodeAt(0) === context.sliceSerialize(events[index2][1]).charCodeAt(0)) {
+          if ((events[open][1]._close || events[index2][1]._open) && (events[index2][1].end.offset - events[index2][1].start.offset) % 3 && !((events[open][1].end.offset - events[open][1].start.offset + events[index2][1].end.offset - events[index2][1].start.offset) % 3)) {
+            continue;
+          }
+          use = events[open][1].end.offset - events[open][1].start.offset > 1 && events[index2][1].end.offset - events[index2][1].start.offset > 1 ? 2 : 1;
+          const start3 = Object.assign({}, events[open][1].end);
+          const end = Object.assign({}, events[index2][1].start);
+          movePoint(start3, -use);
+          movePoint(end, use);
+          openingSequence = {
+            type: use > 1 ? "strongSequence" : "emphasisSequence",
+            start: start3,
+            end: Object.assign({}, events[open][1].end)
+          };
+          closingSequence = {
+            type: use > 1 ? "strongSequence" : "emphasisSequence",
+            start: Object.assign({}, events[index2][1].start),
+            end
+          };
+          text5 = {
+            type: use > 1 ? "strongText" : "emphasisText",
+            start: Object.assign({}, events[open][1].end),
+            end: Object.assign({}, events[index2][1].start)
+          };
+          group = {
+            type: use > 1 ? "strong" : "emphasis",
+            start: Object.assign({}, openingSequence.start),
+            end: Object.assign({}, closingSequence.end)
+          };
+          events[open][1].end = Object.assign({}, openingSequence.start);
+          events[index2][1].start = Object.assign({}, closingSequence.end);
+          nextEvents = [];
+          if (events[open][1].end.offset - events[open][1].start.offset) {
+            nextEvents = push(nextEvents, [
+              ["enter", events[open][1], context],
+              ["exit", events[open][1], context]
+            ]);
+          }
+          nextEvents = push(nextEvents, [
+            ["enter", group, context],
+            ["enter", openingSequence, context],
+            ["exit", openingSequence, context],
+            ["enter", text5, context]
+          ]);
+          nextEvents = push(
+            nextEvents,
+            resolveAll(
+              context.parser.constructs.insideSpan.null,
+              events.slice(open + 1, index2),
+              context
+            )
+          );
+          nextEvents = push(nextEvents, [
+            ["exit", text5, context],
+            ["enter", closingSequence, context],
+            ["exit", closingSequence, context],
+            ["exit", group, context]
+          ]);
+          if (events[index2][1].end.offset - events[index2][1].start.offset) {
+            offset2 = 2;
+            nextEvents = push(nextEvents, [
+              ["enter", events[index2][1], context],
+              ["exit", events[index2][1], context]
+            ]);
+          } else {
+            offset2 = 0;
+          }
+          splice(events, open - 1, index2 - open + 3, nextEvents);
+          index2 = open + nextEvents.length - offset2 - 2;
+          break;
+        }
+      }
+    }
+  }
+  index2 = -1;
+  while (++index2 < events.length) {
+    if (events[index2][1].type === "attentionSequence") {
+      events[index2][1].type = "data";
+    }
+  }
+  return events;
+}
+function tokenizeAttention(effects, ok2) {
+  const attentionMarkers2 = this.parser.constructs.attentionMarkers.null;
+  const previous2 = this.previous;
+  const before = classifyCharacter(previous2);
+  let marker;
+  return start3;
+  function start3(code2) {
+    effects.enter("attentionSequence");
+    marker = code2;
+    return sequence(code2);
+  }
+  function sequence(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return sequence;
+    }
+    const token = effects.exit("attentionSequence");
+    const after = classifyCharacter(code2);
+    const open = !after || after === 2 && before || attentionMarkers2.includes(code2);
+    const close = !before || before === 2 && after || attentionMarkers2.includes(previous2);
+    token._open = Boolean(marker === 42 ? open : open && (before || !close));
+    token._close = Boolean(marker === 42 ? close : close && (after || !open));
+    return ok2(code2);
+  }
+}
+function movePoint(point3, offset2) {
+  point3.column += offset2;
+  point3.offset += offset2;
+  point3._bufferIndex += offset2;
+}
+
+// node_modules/micromark-core-commonmark/lib/autolink.js
+var autolink = {
+  name: "autolink",
+  tokenize: tokenizeAutolink
+};
+function tokenizeAutolink(effects, ok2, nok) {
+  let size = 1;
+  return start3;
+  function start3(code2) {
+    effects.enter("autolink");
+    effects.enter("autolinkMarker");
+    effects.consume(code2);
+    effects.exit("autolinkMarker");
+    effects.enter("autolinkProtocol");
+    return open;
+  }
+  function open(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return schemeOrEmailAtext;
+    }
+    return asciiAtext(code2) ? emailAtext(code2) : nok(code2);
+  }
+  function schemeOrEmailAtext(code2) {
+    return code2 === 43 || code2 === 45 || code2 === 46 || asciiAlphanumeric(code2) ? schemeInsideOrEmailAtext(code2) : emailAtext(code2);
+  }
+  function schemeInsideOrEmailAtext(code2) {
+    if (code2 === 58) {
+      effects.consume(code2);
+      return urlInside;
+    }
+    if ((code2 === 43 || code2 === 45 || code2 === 46 || asciiAlphanumeric(code2)) && size++ < 32) {
+      effects.consume(code2);
+      return schemeInsideOrEmailAtext;
+    }
+    return emailAtext(code2);
+  }
+  function urlInside(code2) {
+    if (code2 === 62) {
+      effects.exit("autolinkProtocol");
+      return end(code2);
+    }
+    if (code2 === null || code2 === 32 || code2 === 60 || asciiControl(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return urlInside;
+  }
+  function emailAtext(code2) {
+    if (code2 === 64) {
+      effects.consume(code2);
+      size = 0;
+      return emailAtSignOrDot;
+    }
+    if (asciiAtext(code2)) {
+      effects.consume(code2);
+      return emailAtext;
+    }
+    return nok(code2);
+  }
+  function emailAtSignOrDot(code2) {
+    return asciiAlphanumeric(code2) ? emailLabel(code2) : nok(code2);
+  }
+  function emailLabel(code2) {
+    if (code2 === 46) {
+      effects.consume(code2);
+      size = 0;
+      return emailAtSignOrDot;
+    }
+    if (code2 === 62) {
+      effects.exit("autolinkProtocol").type = "autolinkEmail";
+      return end(code2);
+    }
+    return emailValue(code2);
+  }
+  function emailValue(code2) {
+    if ((code2 === 45 || asciiAlphanumeric(code2)) && size++ < 63) {
+      effects.consume(code2);
+      return code2 === 45 ? emailValue : emailLabel;
+    }
+    return nok(code2);
+  }
+  function end(code2) {
+    effects.enter("autolinkMarker");
+    effects.consume(code2);
+    effects.exit("autolinkMarker");
+    effects.exit("autolink");
+    return ok2;
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/blank-line.js
+var blankLine = {
+  tokenize: tokenizeBlankLine,
+  partial: true
+};
+function tokenizeBlankLine(effects, ok2, nok) {
+  return factorySpace(effects, afterWhitespace, "linePrefix");
+  function afterWhitespace(code2) {
+    return code2 === null || markdownLineEnding(code2) ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/block-quote.js
+var blockQuote = {
+  name: "blockQuote",
+  tokenize: tokenizeBlockQuoteStart,
+  continuation: {
+    tokenize: tokenizeBlockQuoteContinuation
+  },
+  exit
+};
+function tokenizeBlockQuoteStart(effects, ok2, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code2) {
+    if (code2 === 62) {
+      const state = self2.containerState;
+      if (!state.open) {
+        effects.enter("blockQuote", {
+          _container: true
+        });
+        state.open = true;
+      }
+      effects.enter("blockQuotePrefix");
+      effects.enter("blockQuoteMarker");
+      effects.consume(code2);
+      effects.exit("blockQuoteMarker");
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter("blockQuotePrefixWhitespace");
+      effects.consume(code2);
+      effects.exit("blockQuotePrefixWhitespace");
+      effects.exit("blockQuotePrefix");
+      return ok2;
+    }
+    effects.exit("blockQuotePrefix");
+    return ok2(code2);
+  }
+}
+function tokenizeBlockQuoteContinuation(effects, ok2, nok) {
+  return factorySpace(
+    effects,
+    effects.attempt(blockQuote, ok2, nok),
+    "linePrefix",
+    this.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+  );
+}
+function exit(effects) {
+  effects.exit("blockQuote");
+}
+
+// node_modules/micromark-core-commonmark/lib/character-escape.js
+var characterEscape = {
+  name: "characterEscape",
+  tokenize: tokenizeCharacterEscape
+};
+function tokenizeCharacterEscape(effects, ok2, nok) {
+  return start3;
+  function start3(code2) {
+    effects.enter("characterEscape");
+    effects.enter("escapeMarker");
+    effects.consume(code2);
+    effects.exit("escapeMarker");
+    return open;
+  }
+  function open(code2) {
+    if (asciiPunctuation(code2)) {
+      effects.enter("characterEscapeValue");
+      effects.consume(code2);
+      effects.exit("characterEscapeValue");
+      effects.exit("characterEscape");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/character-entities/index.js
+var characterEntities = {
+  AElig: "\xC6",
+  AMP: "&",
+  Aacute: "\xC1",
+  Abreve: "\u0102",
+  Acirc: "\xC2",
+  Acy: "\u0410",
+  Afr: "\u{1D504}",
+  Agrave: "\xC0",
+  Alpha: "\u0391",
+  Amacr: "\u0100",
+  And: "\u2A53",
+  Aogon: "\u0104",
+  Aopf: "\u{1D538}",
+  ApplyFunction: "\u2061",
+  Aring: "\xC5",
+  Ascr: "\u{1D49C}",
+  Assign: "\u2254",
+  Atilde: "\xC3",
+  Auml: "\xC4",
+  Backslash: "\u2216",
+  Barv: "\u2AE7",
+  Barwed: "\u2306",
+  Bcy: "\u0411",
+  Because: "\u2235",
+  Bernoullis: "\u212C",
+  Beta: "\u0392",
+  Bfr: "\u{1D505}",
+  Bopf: "\u{1D539}",
+  Breve: "\u02D8",
+  Bscr: "\u212C",
+  Bumpeq: "\u224E",
+  CHcy: "\u0427",
+  COPY: "\xA9",
+  Cacute: "\u0106",
+  Cap: "\u22D2",
+  CapitalDifferentialD: "\u2145",
+  Cayleys: "\u212D",
+  Ccaron: "\u010C",
+  Ccedil: "\xC7",
+  Ccirc: "\u0108",
+  Cconint: "\u2230",
+  Cdot: "\u010A",
+  Cedilla: "\xB8",
+  CenterDot: "\xB7",
+  Cfr: "\u212D",
+  Chi: "\u03A7",
+  CircleDot: "\u2299",
+  CircleMinus: "\u2296",
+  CirclePlus: "\u2295",
+  CircleTimes: "\u2297",
+  ClockwiseContourIntegral: "\u2232",
+  CloseCurlyDoubleQuote: "\u201D",
+  CloseCurlyQuote: "\u2019",
+  Colon: "\u2237",
+  Colone: "\u2A74",
+  Congruent: "\u2261",
+  Conint: "\u222F",
+  ContourIntegral: "\u222E",
+  Copf: "\u2102",
+  Coproduct: "\u2210",
+  CounterClockwiseContourIntegral: "\u2233",
+  Cross: "\u2A2F",
+  Cscr: "\u{1D49E}",
+  Cup: "\u22D3",
+  CupCap: "\u224D",
+  DD: "\u2145",
+  DDotrahd: "\u2911",
+  DJcy: "\u0402",
+  DScy: "\u0405",
+  DZcy: "\u040F",
+  Dagger: "\u2021",
+  Darr: "\u21A1",
+  Dashv: "\u2AE4",
+  Dcaron: "\u010E",
+  Dcy: "\u0414",
+  Del: "\u2207",
+  Delta: "\u0394",
+  Dfr: "\u{1D507}",
+  DiacriticalAcute: "\xB4",
+  DiacriticalDot: "\u02D9",
+  DiacriticalDoubleAcute: "\u02DD",
+  DiacriticalGrave: "`",
+  DiacriticalTilde: "\u02DC",
+  Diamond: "\u22C4",
+  DifferentialD: "\u2146",
+  Dopf: "\u{1D53B}",
+  Dot: "\xA8",
+  DotDot: "\u20DC",
+  DotEqual: "\u2250",
+  DoubleContourIntegral: "\u222F",
+  DoubleDot: "\xA8",
+  DoubleDownArrow: "\u21D3",
+  DoubleLeftArrow: "\u21D0",
+  DoubleLeftRightArrow: "\u21D4",
+  DoubleLeftTee: "\u2AE4",
+  DoubleLongLeftArrow: "\u27F8",
+  DoubleLongLeftRightArrow: "\u27FA",
+  DoubleLongRightArrow: "\u27F9",
+  DoubleRightArrow: "\u21D2",
+  DoubleRightTee: "\u22A8",
+  DoubleUpArrow: "\u21D1",
+  DoubleUpDownArrow: "\u21D5",
+  DoubleVerticalBar: "\u2225",
+  DownArrow: "\u2193",
+  DownArrowBar: "\u2913",
+  DownArrowUpArrow: "\u21F5",
+  DownBreve: "\u0311",
+  DownLeftRightVector: "\u2950",
+  DownLeftTeeVector: "\u295E",
+  DownLeftVector: "\u21BD",
+  DownLeftVectorBar: "\u2956",
+  DownRightTeeVector: "\u295F",
+  DownRightVector: "\u21C1",
+  DownRightVectorBar: "\u2957",
+  DownTee: "\u22A4",
+  DownTeeArrow: "\u21A7",
+  Downarrow: "\u21D3",
+  Dscr: "\u{1D49F}",
+  Dstrok: "\u0110",
+  ENG: "\u014A",
+  ETH: "\xD0",
+  Eacute: "\xC9",
+  Ecaron: "\u011A",
+  Ecirc: "\xCA",
+  Ecy: "\u042D",
+  Edot: "\u0116",
+  Efr: "\u{1D508}",
+  Egrave: "\xC8",
+  Element: "\u2208",
+  Emacr: "\u0112",
+  EmptySmallSquare: "\u25FB",
+  EmptyVerySmallSquare: "\u25AB",
+  Eogon: "\u0118",
+  Eopf: "\u{1D53C}",
+  Epsilon: "\u0395",
+  Equal: "\u2A75",
+  EqualTilde: "\u2242",
+  Equilibrium: "\u21CC",
+  Escr: "\u2130",
+  Esim: "\u2A73",
+  Eta: "\u0397",
+  Euml: "\xCB",
+  Exists: "\u2203",
+  ExponentialE: "\u2147",
+  Fcy: "\u0424",
+  Ffr: "\u{1D509}",
+  FilledSmallSquare: "\u25FC",
+  FilledVerySmallSquare: "\u25AA",
+  Fopf: "\u{1D53D}",
+  ForAll: "\u2200",
+  Fouriertrf: "\u2131",
+  Fscr: "\u2131",
+  GJcy: "\u0403",
+  GT: ">",
+  Gamma: "\u0393",
+  Gammad: "\u03DC",
+  Gbreve: "\u011E",
+  Gcedil: "\u0122",
+  Gcirc: "\u011C",
+  Gcy: "\u0413",
+  Gdot: "\u0120",
+  Gfr: "\u{1D50A}",
+  Gg: "\u22D9",
+  Gopf: "\u{1D53E}",
+  GreaterEqual: "\u2265",
+  GreaterEqualLess: "\u22DB",
+  GreaterFullEqual: "\u2267",
+  GreaterGreater: "\u2AA2",
+  GreaterLess: "\u2277",
+  GreaterSlantEqual: "\u2A7E",
+  GreaterTilde: "\u2273",
+  Gscr: "\u{1D4A2}",
+  Gt: "\u226B",
+  HARDcy: "\u042A",
+  Hacek: "\u02C7",
+  Hat: "^",
+  Hcirc: "\u0124",
+  Hfr: "\u210C",
+  HilbertSpace: "\u210B",
+  Hopf: "\u210D",
+  HorizontalLine: "\u2500",
+  Hscr: "\u210B",
+  Hstrok: "\u0126",
+  HumpDownHump: "\u224E",
+  HumpEqual: "\u224F",
+  IEcy: "\u0415",
+  IJlig: "\u0132",
+  IOcy: "\u0401",
+  Iacute: "\xCD",
+  Icirc: "\xCE",
+  Icy: "\u0418",
+  Idot: "\u0130",
+  Ifr: "\u2111",
+  Igrave: "\xCC",
+  Im: "\u2111",
+  Imacr: "\u012A",
+  ImaginaryI: "\u2148",
+  Implies: "\u21D2",
+  Int: "\u222C",
+  Integral: "\u222B",
+  Intersection: "\u22C2",
+  InvisibleComma: "\u2063",
+  InvisibleTimes: "\u2062",
+  Iogon: "\u012E",
+  Iopf: "\u{1D540}",
+  Iota: "\u0399",
+  Iscr: "\u2110",
+  Itilde: "\u0128",
+  Iukcy: "\u0406",
+  Iuml: "\xCF",
+  Jcirc: "\u0134",
+  Jcy: "\u0419",
+  Jfr: "\u{1D50D}",
+  Jopf: "\u{1D541}",
+  Jscr: "\u{1D4A5}",
+  Jsercy: "\u0408",
+  Jukcy: "\u0404",
+  KHcy: "\u0425",
+  KJcy: "\u040C",
+  Kappa: "\u039A",
+  Kcedil: "\u0136",
+  Kcy: "\u041A",
+  Kfr: "\u{1D50E}",
+  Kopf: "\u{1D542}",
+  Kscr: "\u{1D4A6}",
+  LJcy: "\u0409",
+  LT: "<",
+  Lacute: "\u0139",
+  Lambda: "\u039B",
+  Lang: "\u27EA",
+  Laplacetrf: "\u2112",
+  Larr: "\u219E",
+  Lcaron: "\u013D",
+  Lcedil: "\u013B",
+  Lcy: "\u041B",
+  LeftAngleBracket: "\u27E8",
+  LeftArrow: "\u2190",
+  LeftArrowBar: "\u21E4",
+  LeftArrowRightArrow: "\u21C6",
+  LeftCeiling: "\u2308",
+  LeftDoubleBracket: "\u27E6",
+  LeftDownTeeVector: "\u2961",
+  LeftDownVector: "\u21C3",
+  LeftDownVectorBar: "\u2959",
+  LeftFloor: "\u230A",
+  LeftRightArrow: "\u2194",
+  LeftRightVector: "\u294E",
+  LeftTee: "\u22A3",
+  LeftTeeArrow: "\u21A4",
+  LeftTeeVector: "\u295A",
+  LeftTriangle: "\u22B2",
+  LeftTriangleBar: "\u29CF",
+  LeftTriangleEqual: "\u22B4",
+  LeftUpDownVector: "\u2951",
+  LeftUpTeeVector: "\u2960",
+  LeftUpVector: "\u21BF",
+  LeftUpVectorBar: "\u2958",
+  LeftVector: "\u21BC",
+  LeftVectorBar: "\u2952",
+  Leftarrow: "\u21D0",
+  Leftrightarrow: "\u21D4",
+  LessEqualGreater: "\u22DA",
+  LessFullEqual: "\u2266",
+  LessGreater: "\u2276",
+  LessLess: "\u2AA1",
+  LessSlantEqual: "\u2A7D",
+  LessTilde: "\u2272",
+  Lfr: "\u{1D50F}",
+  Ll: "\u22D8",
+  Lleftarrow: "\u21DA",
+  Lmidot: "\u013F",
+  LongLeftArrow: "\u27F5",
+  LongLeftRightArrow: "\u27F7",
+  LongRightArrow: "\u27F6",
+  Longleftarrow: "\u27F8",
+  Longleftrightarrow: "\u27FA",
+  Longrightarrow: "\u27F9",
+  Lopf: "\u{1D543}",
+  LowerLeftArrow: "\u2199",
+  LowerRightArrow: "\u2198",
+  Lscr: "\u2112",
+  Lsh: "\u21B0",
+  Lstrok: "\u0141",
+  Lt: "\u226A",
+  Map: "\u2905",
+  Mcy: "\u041C",
+  MediumSpace: "\u205F",
+  Mellintrf: "\u2133",
+  Mfr: "\u{1D510}",
+  MinusPlus: "\u2213",
+  Mopf: "\u{1D544}",
+  Mscr: "\u2133",
+  Mu: "\u039C",
+  NJcy: "\u040A",
+  Nacute: "\u0143",
+  Ncaron: "\u0147",
+  Ncedil: "\u0145",
+  Ncy: "\u041D",
+  NegativeMediumSpace: "\u200B",
+  NegativeThickSpace: "\u200B",
+  NegativeThinSpace: "\u200B",
+  NegativeVeryThinSpace: "\u200B",
+  NestedGreaterGreater: "\u226B",
+  NestedLessLess: "\u226A",
+  NewLine: "\n",
+  Nfr: "\u{1D511}",
+  NoBreak: "\u2060",
+  NonBreakingSpace: "\xA0",
+  Nopf: "\u2115",
+  Not: "\u2AEC",
+  NotCongruent: "\u2262",
+  NotCupCap: "\u226D",
+  NotDoubleVerticalBar: "\u2226",
+  NotElement: "\u2209",
+  NotEqual: "\u2260",
+  NotEqualTilde: "\u2242\u0338",
+  NotExists: "\u2204",
+  NotGreater: "\u226F",
+  NotGreaterEqual: "\u2271",
+  NotGreaterFullEqual: "\u2267\u0338",
+  NotGreaterGreater: "\u226B\u0338",
+  NotGreaterLess: "\u2279",
+  NotGreaterSlantEqual: "\u2A7E\u0338",
+  NotGreaterTilde: "\u2275",
+  NotHumpDownHump: "\u224E\u0338",
+  NotHumpEqual: "\u224F\u0338",
+  NotLeftTriangle: "\u22EA",
+  NotLeftTriangleBar: "\u29CF\u0338",
+  NotLeftTriangleEqual: "\u22EC",
+  NotLess: "\u226E",
+  NotLessEqual: "\u2270",
+  NotLessGreater: "\u2278",
+  NotLessLess: "\u226A\u0338",
+  NotLessSlantEqual: "\u2A7D\u0338",
+  NotLessTilde: "\u2274",
+  NotNestedGreaterGreater: "\u2AA2\u0338",
+  NotNestedLessLess: "\u2AA1\u0338",
+  NotPrecedes: "\u2280",
+  NotPrecedesEqual: "\u2AAF\u0338",
+  NotPrecedesSlantEqual: "\u22E0",
+  NotReverseElement: "\u220C",
+  NotRightTriangle: "\u22EB",
+  NotRightTriangleBar: "\u29D0\u0338",
+  NotRightTriangleEqual: "\u22ED",
+  NotSquareSubset: "\u228F\u0338",
+  NotSquareSubsetEqual: "\u22E2",
+  NotSquareSuperset: "\u2290\u0338",
+  NotSquareSupersetEqual: "\u22E3",
+  NotSubset: "\u2282\u20D2",
+  NotSubsetEqual: "\u2288",
+  NotSucceeds: "\u2281",
+  NotSucceedsEqual: "\u2AB0\u0338",
+  NotSucceedsSlantEqual: "\u22E1",
+  NotSucceedsTilde: "\u227F\u0338",
+  NotSuperset: "\u2283\u20D2",
+  NotSupersetEqual: "\u2289",
+  NotTilde: "\u2241",
+  NotTildeEqual: "\u2244",
+  NotTildeFullEqual: "\u2247",
+  NotTildeTilde: "\u2249",
+  NotVerticalBar: "\u2224",
+  Nscr: "\u{1D4A9}",
+  Ntilde: "\xD1",
+  Nu: "\u039D",
+  OElig: "\u0152",
+  Oacute: "\xD3",
+  Ocirc: "\xD4",
+  Ocy: "\u041E",
+  Odblac: "\u0150",
+  Ofr: "\u{1D512}",
+  Ograve: "\xD2",
+  Omacr: "\u014C",
+  Omega: "\u03A9",
+  Omicron: "\u039F",
+  Oopf: "\u{1D546}",
+  OpenCurlyDoubleQuote: "\u201C",
+  OpenCurlyQuote: "\u2018",
+  Or: "\u2A54",
+  Oscr: "\u{1D4AA}",
+  Oslash: "\xD8",
+  Otilde: "\xD5",
+  Otimes: "\u2A37",
+  Ouml: "\xD6",
+  OverBar: "\u203E",
+  OverBrace: "\u23DE",
+  OverBracket: "\u23B4",
+  OverParenthesis: "\u23DC",
+  PartialD: "\u2202",
+  Pcy: "\u041F",
+  Pfr: "\u{1D513}",
+  Phi: "\u03A6",
+  Pi: "\u03A0",
+  PlusMinus: "\xB1",
+  Poincareplane: "\u210C",
+  Popf: "\u2119",
+  Pr: "\u2ABB",
+  Precedes: "\u227A",
+  PrecedesEqual: "\u2AAF",
+  PrecedesSlantEqual: "\u227C",
+  PrecedesTilde: "\u227E",
+  Prime: "\u2033",
+  Product: "\u220F",
+  Proportion: "\u2237",
+  Proportional: "\u221D",
+  Pscr: "\u{1D4AB}",
+  Psi: "\u03A8",
+  QUOT: '"',
+  Qfr: "\u{1D514}",
+  Qopf: "\u211A",
+  Qscr: "\u{1D4AC}",
+  RBarr: "\u2910",
+  REG: "\xAE",
+  Racute: "\u0154",
+  Rang: "\u27EB",
+  Rarr: "\u21A0",
+  Rarrtl: "\u2916",
+  Rcaron: "\u0158",
+  Rcedil: "\u0156",
+  Rcy: "\u0420",
+  Re: "\u211C",
+  ReverseElement: "\u220B",
+  ReverseEquilibrium: "\u21CB",
+  ReverseUpEquilibrium: "\u296F",
+  Rfr: "\u211C",
+  Rho: "\u03A1",
+  RightAngleBracket: "\u27E9",
+  RightArrow: "\u2192",
+  RightArrowBar: "\u21E5",
+  RightArrowLeftArrow: "\u21C4",
+  RightCeiling: "\u2309",
+  RightDoubleBracket: "\u27E7",
+  RightDownTeeVector: "\u295D",
+  RightDownVector: "\u21C2",
+  RightDownVectorBar: "\u2955",
+  RightFloor: "\u230B",
+  RightTee: "\u22A2",
+  RightTeeArrow: "\u21A6",
+  RightTeeVector: "\u295B",
+  RightTriangle: "\u22B3",
+  RightTriangleBar: "\u29D0",
+  RightTriangleEqual: "\u22B5",
+  RightUpDownVector: "\u294F",
+  RightUpTeeVector: "\u295C",
+  RightUpVector: "\u21BE",
+  RightUpVectorBar: "\u2954",
+  RightVector: "\u21C0",
+  RightVectorBar: "\u2953",
+  Rightarrow: "\u21D2",
+  Ropf: "\u211D",
+  RoundImplies: "\u2970",
+  Rrightarrow: "\u21DB",
+  Rscr: "\u211B",
+  Rsh: "\u21B1",
+  RuleDelayed: "\u29F4",
+  SHCHcy: "\u0429",
+  SHcy: "\u0428",
+  SOFTcy: "\u042C",
+  Sacute: "\u015A",
+  Sc: "\u2ABC",
+  Scaron: "\u0160",
+  Scedil: "\u015E",
+  Scirc: "\u015C",
+  Scy: "\u0421",
+  Sfr: "\u{1D516}",
+  ShortDownArrow: "\u2193",
+  ShortLeftArrow: "\u2190",
+  ShortRightArrow: "\u2192",
+  ShortUpArrow: "\u2191",
+  Sigma: "\u03A3",
+  SmallCircle: "\u2218",
+  Sopf: "\u{1D54A}",
+  Sqrt: "\u221A",
+  Square: "\u25A1",
+  SquareIntersection: "\u2293",
+  SquareSubset: "\u228F",
+  SquareSubsetEqual: "\u2291",
+  SquareSuperset: "\u2290",
+  SquareSupersetEqual: "\u2292",
+  SquareUnion: "\u2294",
+  Sscr: "\u{1D4AE}",
+  Star: "\u22C6",
+  Sub: "\u22D0",
+  Subset: "\u22D0",
+  SubsetEqual: "\u2286",
+  Succeeds: "\u227B",
+  SucceedsEqual: "\u2AB0",
+  SucceedsSlantEqual: "\u227D",
+  SucceedsTilde: "\u227F",
+  SuchThat: "\u220B",
+  Sum: "\u2211",
+  Sup: "\u22D1",
+  Superset: "\u2283",
+  SupersetEqual: "\u2287",
+  Supset: "\u22D1",
+  THORN: "\xDE",
+  TRADE: "\u2122",
+  TSHcy: "\u040B",
+  TScy: "\u0426",
+  Tab: "	",
+  Tau: "\u03A4",
+  Tcaron: "\u0164",
+  Tcedil: "\u0162",
+  Tcy: "\u0422",
+  Tfr: "\u{1D517}",
+  Therefore: "\u2234",
+  Theta: "\u0398",
+  ThickSpace: "\u205F\u200A",
+  ThinSpace: "\u2009",
+  Tilde: "\u223C",
+  TildeEqual: "\u2243",
+  TildeFullEqual: "\u2245",
+  TildeTilde: "\u2248",
+  Topf: "\u{1D54B}",
+  TripleDot: "\u20DB",
+  Tscr: "\u{1D4AF}",
+  Tstrok: "\u0166",
+  Uacute: "\xDA",
+  Uarr: "\u219F",
+  Uarrocir: "\u2949",
+  Ubrcy: "\u040E",
+  Ubreve: "\u016C",
+  Ucirc: "\xDB",
+  Ucy: "\u0423",
+  Udblac: "\u0170",
+  Ufr: "\u{1D518}",
+  Ugrave: "\xD9",
+  Umacr: "\u016A",
+  UnderBar: "_",
+  UnderBrace: "\u23DF",
+  UnderBracket: "\u23B5",
+  UnderParenthesis: "\u23DD",
+  Union: "\u22C3",
+  UnionPlus: "\u228E",
+  Uogon: "\u0172",
+  Uopf: "\u{1D54C}",
+  UpArrow: "\u2191",
+  UpArrowBar: "\u2912",
+  UpArrowDownArrow: "\u21C5",
+  UpDownArrow: "\u2195",
+  UpEquilibrium: "\u296E",
+  UpTee: "\u22A5",
+  UpTeeArrow: "\u21A5",
+  Uparrow: "\u21D1",
+  Updownarrow: "\u21D5",
+  UpperLeftArrow: "\u2196",
+  UpperRightArrow: "\u2197",
+  Upsi: "\u03D2",
+  Upsilon: "\u03A5",
+  Uring: "\u016E",
+  Uscr: "\u{1D4B0}",
+  Utilde: "\u0168",
+  Uuml: "\xDC",
+  VDash: "\u22AB",
+  Vbar: "\u2AEB",
+  Vcy: "\u0412",
+  Vdash: "\u22A9",
+  Vdashl: "\u2AE6",
+  Vee: "\u22C1",
+  Verbar: "\u2016",
+  Vert: "\u2016",
+  VerticalBar: "\u2223",
+  VerticalLine: "|",
+  VerticalSeparator: "\u2758",
+  VerticalTilde: "\u2240",
+  VeryThinSpace: "\u200A",
+  Vfr: "\u{1D519}",
+  Vopf: "\u{1D54D}",
+  Vscr: "\u{1D4B1}",
+  Vvdash: "\u22AA",
+  Wcirc: "\u0174",
+  Wedge: "\u22C0",
+  Wfr: "\u{1D51A}",
+  Wopf: "\u{1D54E}",
+  Wscr: "\u{1D4B2}",
+  Xfr: "\u{1D51B}",
+  Xi: "\u039E",
+  Xopf: "\u{1D54F}",
+  Xscr: "\u{1D4B3}",
+  YAcy: "\u042F",
+  YIcy: "\u0407",
+  YUcy: "\u042E",
+  Yacute: "\xDD",
+  Ycirc: "\u0176",
+  Ycy: "\u042B",
+  Yfr: "\u{1D51C}",
+  Yopf: "\u{1D550}",
+  Yscr: "\u{1D4B4}",
+  Yuml: "\u0178",
+  ZHcy: "\u0416",
+  Zacute: "\u0179",
+  Zcaron: "\u017D",
+  Zcy: "\u0417",
+  Zdot: "\u017B",
+  ZeroWidthSpace: "\u200B",
+  Zeta: "\u0396",
+  Zfr: "\u2128",
+  Zopf: "\u2124",
+  Zscr: "\u{1D4B5}",
+  aacute: "\xE1",
+  abreve: "\u0103",
+  ac: "\u223E",
+  acE: "\u223E\u0333",
+  acd: "\u223F",
+  acirc: "\xE2",
+  acute: "\xB4",
+  acy: "\u0430",
+  aelig: "\xE6",
+  af: "\u2061",
+  afr: "\u{1D51E}",
+  agrave: "\xE0",
+  alefsym: "\u2135",
+  aleph: "\u2135",
+  alpha: "\u03B1",
+  amacr: "\u0101",
+  amalg: "\u2A3F",
+  amp: "&",
+  and: "\u2227",
+  andand: "\u2A55",
+  andd: "\u2A5C",
+  andslope: "\u2A58",
+  andv: "\u2A5A",
+  ang: "\u2220",
+  ange: "\u29A4",
+  angle: "\u2220",
+  angmsd: "\u2221",
+  angmsdaa: "\u29A8",
+  angmsdab: "\u29A9",
+  angmsdac: "\u29AA",
+  angmsdad: "\u29AB",
+  angmsdae: "\u29AC",
+  angmsdaf: "\u29AD",
+  angmsdag: "\u29AE",
+  angmsdah: "\u29AF",
+  angrt: "\u221F",
+  angrtvb: "\u22BE",
+  angrtvbd: "\u299D",
+  angsph: "\u2222",
+  angst: "\xC5",
+  angzarr: "\u237C",
+  aogon: "\u0105",
+  aopf: "\u{1D552}",
+  ap: "\u2248",
+  apE: "\u2A70",
+  apacir: "\u2A6F",
+  ape: "\u224A",
+  apid: "\u224B",
+  apos: "'",
+  approx: "\u2248",
+  approxeq: "\u224A",
+  aring: "\xE5",
+  ascr: "\u{1D4B6}",
+  ast: "*",
+  asymp: "\u2248",
+  asympeq: "\u224D",
+  atilde: "\xE3",
+  auml: "\xE4",
+  awconint: "\u2233",
+  awint: "\u2A11",
+  bNot: "\u2AED",
+  backcong: "\u224C",
+  backepsilon: "\u03F6",
+  backprime: "\u2035",
+  backsim: "\u223D",
+  backsimeq: "\u22CD",
+  barvee: "\u22BD",
+  barwed: "\u2305",
+  barwedge: "\u2305",
+  bbrk: "\u23B5",
+  bbrktbrk: "\u23B6",
+  bcong: "\u224C",
+  bcy: "\u0431",
+  bdquo: "\u201E",
+  becaus: "\u2235",
+  because: "\u2235",
+  bemptyv: "\u29B0",
+  bepsi: "\u03F6",
+  bernou: "\u212C",
+  beta: "\u03B2",
+  beth: "\u2136",
+  between: "\u226C",
+  bfr: "\u{1D51F}",
+  bigcap: "\u22C2",
+  bigcirc: "\u25EF",
+  bigcup: "\u22C3",
+  bigodot: "\u2A00",
+  bigoplus: "\u2A01",
+  bigotimes: "\u2A02",
+  bigsqcup: "\u2A06",
+  bigstar: "\u2605",
+  bigtriangledown: "\u25BD",
+  bigtriangleup: "\u25B3",
+  biguplus: "\u2A04",
+  bigvee: "\u22C1",
+  bigwedge: "\u22C0",
+  bkarow: "\u290D",
+  blacklozenge: "\u29EB",
+  blacksquare: "\u25AA",
+  blacktriangle: "\u25B4",
+  blacktriangledown: "\u25BE",
+  blacktriangleleft: "\u25C2",
+  blacktriangleright: "\u25B8",
+  blank: "\u2423",
+  blk12: "\u2592",
+  blk14: "\u2591",
+  blk34: "\u2593",
+  block: "\u2588",
+  bne: "=\u20E5",
+  bnequiv: "\u2261\u20E5",
+  bnot: "\u2310",
+  bopf: "\u{1D553}",
+  bot: "\u22A5",
+  bottom: "\u22A5",
+  bowtie: "\u22C8",
+  boxDL: "\u2557",
+  boxDR: "\u2554",
+  boxDl: "\u2556",
+  boxDr: "\u2553",
+  boxH: "\u2550",
+  boxHD: "\u2566",
+  boxHU: "\u2569",
+  boxHd: "\u2564",
+  boxHu: "\u2567",
+  boxUL: "\u255D",
+  boxUR: "\u255A",
+  boxUl: "\u255C",
+  boxUr: "\u2559",
+  boxV: "\u2551",
+  boxVH: "\u256C",
+  boxVL: "\u2563",
+  boxVR: "\u2560",
+  boxVh: "\u256B",
+  boxVl: "\u2562",
+  boxVr: "\u255F",
+  boxbox: "\u29C9",
+  boxdL: "\u2555",
+  boxdR: "\u2552",
+  boxdl: "\u2510",
+  boxdr: "\u250C",
+  boxh: "\u2500",
+  boxhD: "\u2565",
+  boxhU: "\u2568",
+  boxhd: "\u252C",
+  boxhu: "\u2534",
+  boxminus: "\u229F",
+  boxplus: "\u229E",
+  boxtimes: "\u22A0",
+  boxuL: "\u255B",
+  boxuR: "\u2558",
+  boxul: "\u2518",
+  boxur: "\u2514",
+  boxv: "\u2502",
+  boxvH: "\u256A",
+  boxvL: "\u2561",
+  boxvR: "\u255E",
+  boxvh: "\u253C",
+  boxvl: "\u2524",
+  boxvr: "\u251C",
+  bprime: "\u2035",
+  breve: "\u02D8",
+  brvbar: "\xA6",
+  bscr: "\u{1D4B7}",
+  bsemi: "\u204F",
+  bsim: "\u223D",
+  bsime: "\u22CD",
+  bsol: "\\",
+  bsolb: "\u29C5",
+  bsolhsub: "\u27C8",
+  bull: "\u2022",
+  bullet: "\u2022",
+  bump: "\u224E",
+  bumpE: "\u2AAE",
+  bumpe: "\u224F",
+  bumpeq: "\u224F",
+  cacute: "\u0107",
+  cap: "\u2229",
+  capand: "\u2A44",
+  capbrcup: "\u2A49",
+  capcap: "\u2A4B",
+  capcup: "\u2A47",
+  capdot: "\u2A40",
+  caps: "\u2229\uFE00",
+  caret: "\u2041",
+  caron: "\u02C7",
+  ccaps: "\u2A4D",
+  ccaron: "\u010D",
+  ccedil: "\xE7",
+  ccirc: "\u0109",
+  ccups: "\u2A4C",
+  ccupssm: "\u2A50",
+  cdot: "\u010B",
+  cedil: "\xB8",
+  cemptyv: "\u29B2",
+  cent: "\xA2",
+  centerdot: "\xB7",
+  cfr: "\u{1D520}",
+  chcy: "\u0447",
+  check: "\u2713",
+  checkmark: "\u2713",
+  chi: "\u03C7",
+  cir: "\u25CB",
+  cirE: "\u29C3",
+  circ: "\u02C6",
+  circeq: "\u2257",
+  circlearrowleft: "\u21BA",
+  circlearrowright: "\u21BB",
+  circledR: "\xAE",
+  circledS: "\u24C8",
+  circledast: "\u229B",
+  circledcirc: "\u229A",
+  circleddash: "\u229D",
+  cire: "\u2257",
+  cirfnint: "\u2A10",
+  cirmid: "\u2AEF",
+  cirscir: "\u29C2",
+  clubs: "\u2663",
+  clubsuit: "\u2663",
+  colon: ":",
+  colone: "\u2254",
+  coloneq: "\u2254",
+  comma: ",",
+  commat: "@",
+  comp: "\u2201",
+  compfn: "\u2218",
+  complement: "\u2201",
+  complexes: "\u2102",
+  cong: "\u2245",
+  congdot: "\u2A6D",
+  conint: "\u222E",
+  copf: "\u{1D554}",
+  coprod: "\u2210",
+  copy: "\xA9",
+  copysr: "\u2117",
+  crarr: "\u21B5",
+  cross: "\u2717",
+  cscr: "\u{1D4B8}",
+  csub: "\u2ACF",
+  csube: "\u2AD1",
+  csup: "\u2AD0",
+  csupe: "\u2AD2",
+  ctdot: "\u22EF",
+  cudarrl: "\u2938",
+  cudarrr: "\u2935",
+  cuepr: "\u22DE",
+  cuesc: "\u22DF",
+  cularr: "\u21B6",
+  cularrp: "\u293D",
+  cup: "\u222A",
+  cupbrcap: "\u2A48",
+  cupcap: "\u2A46",
+  cupcup: "\u2A4A",
+  cupdot: "\u228D",
+  cupor: "\u2A45",
+  cups: "\u222A\uFE00",
+  curarr: "\u21B7",
+  curarrm: "\u293C",
+  curlyeqprec: "\u22DE",
+  curlyeqsucc: "\u22DF",
+  curlyvee: "\u22CE",
+  curlywedge: "\u22CF",
+  curren: "\xA4",
+  curvearrowleft: "\u21B6",
+  curvearrowright: "\u21B7",
+  cuvee: "\u22CE",
+  cuwed: "\u22CF",
+  cwconint: "\u2232",
+  cwint: "\u2231",
+  cylcty: "\u232D",
+  dArr: "\u21D3",
+  dHar: "\u2965",
+  dagger: "\u2020",
+  daleth: "\u2138",
+  darr: "\u2193",
+  dash: "\u2010",
+  dashv: "\u22A3",
+  dbkarow: "\u290F",
+  dblac: "\u02DD",
+  dcaron: "\u010F",
+  dcy: "\u0434",
+  dd: "\u2146",
+  ddagger: "\u2021",
+  ddarr: "\u21CA",
+  ddotseq: "\u2A77",
+  deg: "\xB0",
+  delta: "\u03B4",
+  demptyv: "\u29B1",
+  dfisht: "\u297F",
+  dfr: "\u{1D521}",
+  dharl: "\u21C3",
+  dharr: "\u21C2",
+  diam: "\u22C4",
+  diamond: "\u22C4",
+  diamondsuit: "\u2666",
+  diams: "\u2666",
+  die: "\xA8",
+  digamma: "\u03DD",
+  disin: "\u22F2",
+  div: "\xF7",
+  divide: "\xF7",
+  divideontimes: "\u22C7",
+  divonx: "\u22C7",
+  djcy: "\u0452",
+  dlcorn: "\u231E",
+  dlcrop: "\u230D",
+  dollar: "$",
+  dopf: "\u{1D555}",
+  dot: "\u02D9",
+  doteq: "\u2250",
+  doteqdot: "\u2251",
+  dotminus: "\u2238",
+  dotplus: "\u2214",
+  dotsquare: "\u22A1",
+  doublebarwedge: "\u2306",
+  downarrow: "\u2193",
+  downdownarrows: "\u21CA",
+  downharpoonleft: "\u21C3",
+  downharpoonright: "\u21C2",
+  drbkarow: "\u2910",
+  drcorn: "\u231F",
+  drcrop: "\u230C",
+  dscr: "\u{1D4B9}",
+  dscy: "\u0455",
+  dsol: "\u29F6",
+  dstrok: "\u0111",
+  dtdot: "\u22F1",
+  dtri: "\u25BF",
+  dtrif: "\u25BE",
+  duarr: "\u21F5",
+  duhar: "\u296F",
+  dwangle: "\u29A6",
+  dzcy: "\u045F",
+  dzigrarr: "\u27FF",
+  eDDot: "\u2A77",
+  eDot: "\u2251",
+  eacute: "\xE9",
+  easter: "\u2A6E",
+  ecaron: "\u011B",
+  ecir: "\u2256",
+  ecirc: "\xEA",
+  ecolon: "\u2255",
+  ecy: "\u044D",
+  edot: "\u0117",
+  ee: "\u2147",
+  efDot: "\u2252",
+  efr: "\u{1D522}",
+  eg: "\u2A9A",
+  egrave: "\xE8",
+  egs: "\u2A96",
+  egsdot: "\u2A98",
+  el: "\u2A99",
+  elinters: "\u23E7",
+  ell: "\u2113",
+  els: "\u2A95",
+  elsdot: "\u2A97",
+  emacr: "\u0113",
+  empty: "\u2205",
+  emptyset: "\u2205",
+  emptyv: "\u2205",
+  emsp13: "\u2004",
+  emsp14: "\u2005",
+  emsp: "\u2003",
+  eng: "\u014B",
+  ensp: "\u2002",
+  eogon: "\u0119",
+  eopf: "\u{1D556}",
+  epar: "\u22D5",
+  eparsl: "\u29E3",
+  eplus: "\u2A71",
+  epsi: "\u03B5",
+  epsilon: "\u03B5",
+  epsiv: "\u03F5",
+  eqcirc: "\u2256",
+  eqcolon: "\u2255",
+  eqsim: "\u2242",
+  eqslantgtr: "\u2A96",
+  eqslantless: "\u2A95",
+  equals: "=",
+  equest: "\u225F",
+  equiv: "\u2261",
+  equivDD: "\u2A78",
+  eqvparsl: "\u29E5",
+  erDot: "\u2253",
+  erarr: "\u2971",
+  escr: "\u212F",
+  esdot: "\u2250",
+  esim: "\u2242",
+  eta: "\u03B7",
+  eth: "\xF0",
+  euml: "\xEB",
+  euro: "\u20AC",
+  excl: "!",
+  exist: "\u2203",
+  expectation: "\u2130",
+  exponentiale: "\u2147",
+  fallingdotseq: "\u2252",
+  fcy: "\u0444",
+  female: "\u2640",
+  ffilig: "\uFB03",
+  fflig: "\uFB00",
+  ffllig: "\uFB04",
+  ffr: "\u{1D523}",
+  filig: "\uFB01",
+  fjlig: "fj",
+  flat: "\u266D",
+  fllig: "\uFB02",
+  fltns: "\u25B1",
+  fnof: "\u0192",
+  fopf: "\u{1D557}",
+  forall: "\u2200",
+  fork: "\u22D4",
+  forkv: "\u2AD9",
+  fpartint: "\u2A0D",
+  frac12: "\xBD",
+  frac13: "\u2153",
+  frac14: "\xBC",
+  frac15: "\u2155",
+  frac16: "\u2159",
+  frac18: "\u215B",
+  frac23: "\u2154",
+  frac25: "\u2156",
+  frac34: "\xBE",
+  frac35: "\u2157",
+  frac38: "\u215C",
+  frac45: "\u2158",
+  frac56: "\u215A",
+  frac58: "\u215D",
+  frac78: "\u215E",
+  frasl: "\u2044",
+  frown: "\u2322",
+  fscr: "\u{1D4BB}",
+  gE: "\u2267",
+  gEl: "\u2A8C",
+  gacute: "\u01F5",
+  gamma: "\u03B3",
+  gammad: "\u03DD",
+  gap: "\u2A86",
+  gbreve: "\u011F",
+  gcirc: "\u011D",
+  gcy: "\u0433",
+  gdot: "\u0121",
+  ge: "\u2265",
+  gel: "\u22DB",
+  geq: "\u2265",
+  geqq: "\u2267",
+  geqslant: "\u2A7E",
+  ges: "\u2A7E",
+  gescc: "\u2AA9",
+  gesdot: "\u2A80",
+  gesdoto: "\u2A82",
+  gesdotol: "\u2A84",
+  gesl: "\u22DB\uFE00",
+  gesles: "\u2A94",
+  gfr: "\u{1D524}",
+  gg: "\u226B",
+  ggg: "\u22D9",
+  gimel: "\u2137",
+  gjcy: "\u0453",
+  gl: "\u2277",
+  glE: "\u2A92",
+  gla: "\u2AA5",
+  glj: "\u2AA4",
+  gnE: "\u2269",
+  gnap: "\u2A8A",
+  gnapprox: "\u2A8A",
+  gne: "\u2A88",
+  gneq: "\u2A88",
+  gneqq: "\u2269",
+  gnsim: "\u22E7",
+  gopf: "\u{1D558}",
+  grave: "`",
+  gscr: "\u210A",
+  gsim: "\u2273",
+  gsime: "\u2A8E",
+  gsiml: "\u2A90",
+  gt: ">",
+  gtcc: "\u2AA7",
+  gtcir: "\u2A7A",
+  gtdot: "\u22D7",
+  gtlPar: "\u2995",
+  gtquest: "\u2A7C",
+  gtrapprox: "\u2A86",
+  gtrarr: "\u2978",
+  gtrdot: "\u22D7",
+  gtreqless: "\u22DB",
+  gtreqqless: "\u2A8C",
+  gtrless: "\u2277",
+  gtrsim: "\u2273",
+  gvertneqq: "\u2269\uFE00",
+  gvnE: "\u2269\uFE00",
+  hArr: "\u21D4",
+  hairsp: "\u200A",
+  half: "\xBD",
+  hamilt: "\u210B",
+  hardcy: "\u044A",
+  harr: "\u2194",
+  harrcir: "\u2948",
+  harrw: "\u21AD",
+  hbar: "\u210F",
+  hcirc: "\u0125",
+  hearts: "\u2665",
+  heartsuit: "\u2665",
+  hellip: "\u2026",
+  hercon: "\u22B9",
+  hfr: "\u{1D525}",
+  hksearow: "\u2925",
+  hkswarow: "\u2926",
+  hoarr: "\u21FF",
+  homtht: "\u223B",
+  hookleftarrow: "\u21A9",
+  hookrightarrow: "\u21AA",
+  hopf: "\u{1D559}",
+  horbar: "\u2015",
+  hscr: "\u{1D4BD}",
+  hslash: "\u210F",
+  hstrok: "\u0127",
+  hybull: "\u2043",
+  hyphen: "\u2010",
+  iacute: "\xED",
+  ic: "\u2063",
+  icirc: "\xEE",
+  icy: "\u0438",
+  iecy: "\u0435",
+  iexcl: "\xA1",
+  iff: "\u21D4",
+  ifr: "\u{1D526}",
+  igrave: "\xEC",
+  ii: "\u2148",
+  iiiint: "\u2A0C",
+  iiint: "\u222D",
+  iinfin: "\u29DC",
+  iiota: "\u2129",
+  ijlig: "\u0133",
+  imacr: "\u012B",
+  image: "\u2111",
+  imagline: "\u2110",
+  imagpart: "\u2111",
+  imath: "\u0131",
+  imof: "\u22B7",
+  imped: "\u01B5",
+  in: "\u2208",
+  incare: "\u2105",
+  infin: "\u221E",
+  infintie: "\u29DD",
+  inodot: "\u0131",
+  int: "\u222B",
+  intcal: "\u22BA",
+  integers: "\u2124",
+  intercal: "\u22BA",
+  intlarhk: "\u2A17",
+  intprod: "\u2A3C",
+  iocy: "\u0451",
+  iogon: "\u012F",
+  iopf: "\u{1D55A}",
+  iota: "\u03B9",
+  iprod: "\u2A3C",
+  iquest: "\xBF",
+  iscr: "\u{1D4BE}",
+  isin: "\u2208",
+  isinE: "\u22F9",
+  isindot: "\u22F5",
+  isins: "\u22F4",
+  isinsv: "\u22F3",
+  isinv: "\u2208",
+  it: "\u2062",
+  itilde: "\u0129",
+  iukcy: "\u0456",
+  iuml: "\xEF",
+  jcirc: "\u0135",
+  jcy: "\u0439",
+  jfr: "\u{1D527}",
+  jmath: "\u0237",
+  jopf: "\u{1D55B}",
+  jscr: "\u{1D4BF}",
+  jsercy: "\u0458",
+  jukcy: "\u0454",
+  kappa: "\u03BA",
+  kappav: "\u03F0",
+  kcedil: "\u0137",
+  kcy: "\u043A",
+  kfr: "\u{1D528}",
+  kgreen: "\u0138",
+  khcy: "\u0445",
+  kjcy: "\u045C",
+  kopf: "\u{1D55C}",
+  kscr: "\u{1D4C0}",
+  lAarr: "\u21DA",
+  lArr: "\u21D0",
+  lAtail: "\u291B",
+  lBarr: "\u290E",
+  lE: "\u2266",
+  lEg: "\u2A8B",
+  lHar: "\u2962",
+  lacute: "\u013A",
+  laemptyv: "\u29B4",
+  lagran: "\u2112",
+  lambda: "\u03BB",
+  lang: "\u27E8",
+  langd: "\u2991",
+  langle: "\u27E8",
+  lap: "\u2A85",
+  laquo: "\xAB",
+  larr: "\u2190",
+  larrb: "\u21E4",
+  larrbfs: "\u291F",
+  larrfs: "\u291D",
+  larrhk: "\u21A9",
+  larrlp: "\u21AB",
+  larrpl: "\u2939",
+  larrsim: "\u2973",
+  larrtl: "\u21A2",
+  lat: "\u2AAB",
+  latail: "\u2919",
+  late: "\u2AAD",
+  lates: "\u2AAD\uFE00",
+  lbarr: "\u290C",
+  lbbrk: "\u2772",
+  lbrace: "{",
+  lbrack: "[",
+  lbrke: "\u298B",
+  lbrksld: "\u298F",
+  lbrkslu: "\u298D",
+  lcaron: "\u013E",
+  lcedil: "\u013C",
+  lceil: "\u2308",
+  lcub: "{",
+  lcy: "\u043B",
+  ldca: "\u2936",
+  ldquo: "\u201C",
+  ldquor: "\u201E",
+  ldrdhar: "\u2967",
+  ldrushar: "\u294B",
+  ldsh: "\u21B2",
+  le: "\u2264",
+  leftarrow: "\u2190",
+  leftarrowtail: "\u21A2",
+  leftharpoondown: "\u21BD",
+  leftharpoonup: "\u21BC",
+  leftleftarrows: "\u21C7",
+  leftrightarrow: "\u2194",
+  leftrightarrows: "\u21C6",
+  leftrightharpoons: "\u21CB",
+  leftrightsquigarrow: "\u21AD",
+  leftthreetimes: "\u22CB",
+  leg: "\u22DA",
+  leq: "\u2264",
+  leqq: "\u2266",
+  leqslant: "\u2A7D",
+  les: "\u2A7D",
+  lescc: "\u2AA8",
+  lesdot: "\u2A7F",
+  lesdoto: "\u2A81",
+  lesdotor: "\u2A83",
+  lesg: "\u22DA\uFE00",
+  lesges: "\u2A93",
+  lessapprox: "\u2A85",
+  lessdot: "\u22D6",
+  lesseqgtr: "\u22DA",
+  lesseqqgtr: "\u2A8B",
+  lessgtr: "\u2276",
+  lesssim: "\u2272",
+  lfisht: "\u297C",
+  lfloor: "\u230A",
+  lfr: "\u{1D529}",
+  lg: "\u2276",
+  lgE: "\u2A91",
+  lhard: "\u21BD",
+  lharu: "\u21BC",
+  lharul: "\u296A",
+  lhblk: "\u2584",
+  ljcy: "\u0459",
+  ll: "\u226A",
+  llarr: "\u21C7",
+  llcorner: "\u231E",
+  llhard: "\u296B",
+  lltri: "\u25FA",
+  lmidot: "\u0140",
+  lmoust: "\u23B0",
+  lmoustache: "\u23B0",
+  lnE: "\u2268",
+  lnap: "\u2A89",
+  lnapprox: "\u2A89",
+  lne: "\u2A87",
+  lneq: "\u2A87",
+  lneqq: "\u2268",
+  lnsim: "\u22E6",
+  loang: "\u27EC",
+  loarr: "\u21FD",
+  lobrk: "\u27E6",
+  longleftarrow: "\u27F5",
+  longleftrightarrow: "\u27F7",
+  longmapsto: "\u27FC",
+  longrightarrow: "\u27F6",
+  looparrowleft: "\u21AB",
+  looparrowright: "\u21AC",
+  lopar: "\u2985",
+  lopf: "\u{1D55D}",
+  loplus: "\u2A2D",
+  lotimes: "\u2A34",
+  lowast: "\u2217",
+  lowbar: "_",
+  loz: "\u25CA",
+  lozenge: "\u25CA",
+  lozf: "\u29EB",
+  lpar: "(",
+  lparlt: "\u2993",
+  lrarr: "\u21C6",
+  lrcorner: "\u231F",
+  lrhar: "\u21CB",
+  lrhard: "\u296D",
+  lrm: "\u200E",
+  lrtri: "\u22BF",
+  lsaquo: "\u2039",
+  lscr: "\u{1D4C1}",
+  lsh: "\u21B0",
+  lsim: "\u2272",
+  lsime: "\u2A8D",
+  lsimg: "\u2A8F",
+  lsqb: "[",
+  lsquo: "\u2018",
+  lsquor: "\u201A",
+  lstrok: "\u0142",
+  lt: "<",
+  ltcc: "\u2AA6",
+  ltcir: "\u2A79",
+  ltdot: "\u22D6",
+  lthree: "\u22CB",
+  ltimes: "\u22C9",
+  ltlarr: "\u2976",
+  ltquest: "\u2A7B",
+  ltrPar: "\u2996",
+  ltri: "\u25C3",
+  ltrie: "\u22B4",
+  ltrif: "\u25C2",
+  lurdshar: "\u294A",
+  luruhar: "\u2966",
+  lvertneqq: "\u2268\uFE00",
+  lvnE: "\u2268\uFE00",
+  mDDot: "\u223A",
+  macr: "\xAF",
+  male: "\u2642",
+  malt: "\u2720",
+  maltese: "\u2720",
+  map: "\u21A6",
+  mapsto: "\u21A6",
+  mapstodown: "\u21A7",
+  mapstoleft: "\u21A4",
+  mapstoup: "\u21A5",
+  marker: "\u25AE",
+  mcomma: "\u2A29",
+  mcy: "\u043C",
+  mdash: "\u2014",
+  measuredangle: "\u2221",
+  mfr: "\u{1D52A}",
+  mho: "\u2127",
+  micro: "\xB5",
+  mid: "\u2223",
+  midast: "*",
+  midcir: "\u2AF0",
+  middot: "\xB7",
+  minus: "\u2212",
+  minusb: "\u229F",
+  minusd: "\u2238",
+  minusdu: "\u2A2A",
+  mlcp: "\u2ADB",
+  mldr: "\u2026",
+  mnplus: "\u2213",
+  models: "\u22A7",
+  mopf: "\u{1D55E}",
+  mp: "\u2213",
+  mscr: "\u{1D4C2}",
+  mstpos: "\u223E",
+  mu: "\u03BC",
+  multimap: "\u22B8",
+  mumap: "\u22B8",
+  nGg: "\u22D9\u0338",
+  nGt: "\u226B\u20D2",
+  nGtv: "\u226B\u0338",
+  nLeftarrow: "\u21CD",
+  nLeftrightarrow: "\u21CE",
+  nLl: "\u22D8\u0338",
+  nLt: "\u226A\u20D2",
+  nLtv: "\u226A\u0338",
+  nRightarrow: "\u21CF",
+  nVDash: "\u22AF",
+  nVdash: "\u22AE",
+  nabla: "\u2207",
+  nacute: "\u0144",
+  nang: "\u2220\u20D2",
+  nap: "\u2249",
+  napE: "\u2A70\u0338",
+  napid: "\u224B\u0338",
+  napos: "\u0149",
+  napprox: "\u2249",
+  natur: "\u266E",
+  natural: "\u266E",
+  naturals: "\u2115",
+  nbsp: "\xA0",
+  nbump: "\u224E\u0338",
+  nbumpe: "\u224F\u0338",
+  ncap: "\u2A43",
+  ncaron: "\u0148",
+  ncedil: "\u0146",
+  ncong: "\u2247",
+  ncongdot: "\u2A6D\u0338",
+  ncup: "\u2A42",
+  ncy: "\u043D",
+  ndash: "\u2013",
+  ne: "\u2260",
+  neArr: "\u21D7",
+  nearhk: "\u2924",
+  nearr: "\u2197",
+  nearrow: "\u2197",
+  nedot: "\u2250\u0338",
+  nequiv: "\u2262",
+  nesear: "\u2928",
+  nesim: "\u2242\u0338",
+  nexist: "\u2204",
+  nexists: "\u2204",
+  nfr: "\u{1D52B}",
+  ngE: "\u2267\u0338",
+  nge: "\u2271",
+  ngeq: "\u2271",
+  ngeqq: "\u2267\u0338",
+  ngeqslant: "\u2A7E\u0338",
+  nges: "\u2A7E\u0338",
+  ngsim: "\u2275",
+  ngt: "\u226F",
+  ngtr: "\u226F",
+  nhArr: "\u21CE",
+  nharr: "\u21AE",
+  nhpar: "\u2AF2",
+  ni: "\u220B",
+  nis: "\u22FC",
+  nisd: "\u22FA",
+  niv: "\u220B",
+  njcy: "\u045A",
+  nlArr: "\u21CD",
+  nlE: "\u2266\u0338",
+  nlarr: "\u219A",
+  nldr: "\u2025",
+  nle: "\u2270",
+  nleftarrow: "\u219A",
+  nleftrightarrow: "\u21AE",
+  nleq: "\u2270",
+  nleqq: "\u2266\u0338",
+  nleqslant: "\u2A7D\u0338",
+  nles: "\u2A7D\u0338",
+  nless: "\u226E",
+  nlsim: "\u2274",
+  nlt: "\u226E",
+  nltri: "\u22EA",
+  nltrie: "\u22EC",
+  nmid: "\u2224",
+  nopf: "\u{1D55F}",
+  not: "\xAC",
+  notin: "\u2209",
+  notinE: "\u22F9\u0338",
+  notindot: "\u22F5\u0338",
+  notinva: "\u2209",
+  notinvb: "\u22F7",
+  notinvc: "\u22F6",
+  notni: "\u220C",
+  notniva: "\u220C",
+  notnivb: "\u22FE",
+  notnivc: "\u22FD",
+  npar: "\u2226",
+  nparallel: "\u2226",
+  nparsl: "\u2AFD\u20E5",
+  npart: "\u2202\u0338",
+  npolint: "\u2A14",
+  npr: "\u2280",
+  nprcue: "\u22E0",
+  npre: "\u2AAF\u0338",
+  nprec: "\u2280",
+  npreceq: "\u2AAF\u0338",
+  nrArr: "\u21CF",
+  nrarr: "\u219B",
+  nrarrc: "\u2933\u0338",
+  nrarrw: "\u219D\u0338",
+  nrightarrow: "\u219B",
+  nrtri: "\u22EB",
+  nrtrie: "\u22ED",
+  nsc: "\u2281",
+  nsccue: "\u22E1",
+  nsce: "\u2AB0\u0338",
+  nscr: "\u{1D4C3}",
+  nshortmid: "\u2224",
+  nshortparallel: "\u2226",
+  nsim: "\u2241",
+  nsime: "\u2244",
+  nsimeq: "\u2244",
+  nsmid: "\u2224",
+  nspar: "\u2226",
+  nsqsube: "\u22E2",
+  nsqsupe: "\u22E3",
+  nsub: "\u2284",
+  nsubE: "\u2AC5\u0338",
+  nsube: "\u2288",
+  nsubset: "\u2282\u20D2",
+  nsubseteq: "\u2288",
+  nsubseteqq: "\u2AC5\u0338",
+  nsucc: "\u2281",
+  nsucceq: "\u2AB0\u0338",
+  nsup: "\u2285",
+  nsupE: "\u2AC6\u0338",
+  nsupe: "\u2289",
+  nsupset: "\u2283\u20D2",
+  nsupseteq: "\u2289",
+  nsupseteqq: "\u2AC6\u0338",
+  ntgl: "\u2279",
+  ntilde: "\xF1",
+  ntlg: "\u2278",
+  ntriangleleft: "\u22EA",
+  ntrianglelefteq: "\u22EC",
+  ntriangleright: "\u22EB",
+  ntrianglerighteq: "\u22ED",
+  nu: "\u03BD",
+  num: "#",
+  numero: "\u2116",
+  numsp: "\u2007",
+  nvDash: "\u22AD",
+  nvHarr: "\u2904",
+  nvap: "\u224D\u20D2",
+  nvdash: "\u22AC",
+  nvge: "\u2265\u20D2",
+  nvgt: ">\u20D2",
+  nvinfin: "\u29DE",
+  nvlArr: "\u2902",
+  nvle: "\u2264\u20D2",
+  nvlt: "<\u20D2",
+  nvltrie: "\u22B4\u20D2",
+  nvrArr: "\u2903",
+  nvrtrie: "\u22B5\u20D2",
+  nvsim: "\u223C\u20D2",
+  nwArr: "\u21D6",
+  nwarhk: "\u2923",
+  nwarr: "\u2196",
+  nwarrow: "\u2196",
+  nwnear: "\u2927",
+  oS: "\u24C8",
+  oacute: "\xF3",
+  oast: "\u229B",
+  ocir: "\u229A",
+  ocirc: "\xF4",
+  ocy: "\u043E",
+  odash: "\u229D",
+  odblac: "\u0151",
+  odiv: "\u2A38",
+  odot: "\u2299",
+  odsold: "\u29BC",
+  oelig: "\u0153",
+  ofcir: "\u29BF",
+  ofr: "\u{1D52C}",
+  ogon: "\u02DB",
+  ograve: "\xF2",
+  ogt: "\u29C1",
+  ohbar: "\u29B5",
+  ohm: "\u03A9",
+  oint: "\u222E",
+  olarr: "\u21BA",
+  olcir: "\u29BE",
+  olcross: "\u29BB",
+  oline: "\u203E",
+  olt: "\u29C0",
+  omacr: "\u014D",
+  omega: "\u03C9",
+  omicron: "\u03BF",
+  omid: "\u29B6",
+  ominus: "\u2296",
+  oopf: "\u{1D560}",
+  opar: "\u29B7",
+  operp: "\u29B9",
+  oplus: "\u2295",
+  or: "\u2228",
+  orarr: "\u21BB",
+  ord: "\u2A5D",
+  order: "\u2134",
+  orderof: "\u2134",
+  ordf: "\xAA",
+  ordm: "\xBA",
+  origof: "\u22B6",
+  oror: "\u2A56",
+  orslope: "\u2A57",
+  orv: "\u2A5B",
+  oscr: "\u2134",
+  oslash: "\xF8",
+  osol: "\u2298",
+  otilde: "\xF5",
+  otimes: "\u2297",
+  otimesas: "\u2A36",
+  ouml: "\xF6",
+  ovbar: "\u233D",
+  par: "\u2225",
+  para: "\xB6",
+  parallel: "\u2225",
+  parsim: "\u2AF3",
+  parsl: "\u2AFD",
+  part: "\u2202",
+  pcy: "\u043F",
+  percnt: "%",
+  period: ".",
+  permil: "\u2030",
+  perp: "\u22A5",
+  pertenk: "\u2031",
+  pfr: "\u{1D52D}",
+  phi: "\u03C6",
+  phiv: "\u03D5",
+  phmmat: "\u2133",
+  phone: "\u260E",
+  pi: "\u03C0",
+  pitchfork: "\u22D4",
+  piv: "\u03D6",
+  planck: "\u210F",
+  planckh: "\u210E",
+  plankv: "\u210F",
+  plus: "+",
+  plusacir: "\u2A23",
+  plusb: "\u229E",
+  pluscir: "\u2A22",
+  plusdo: "\u2214",
+  plusdu: "\u2A25",
+  pluse: "\u2A72",
+  plusmn: "\xB1",
+  plussim: "\u2A26",
+  plustwo: "\u2A27",
+  pm: "\xB1",
+  pointint: "\u2A15",
+  popf: "\u{1D561}",
+  pound: "\xA3",
+  pr: "\u227A",
+  prE: "\u2AB3",
+  prap: "\u2AB7",
+  prcue: "\u227C",
+  pre: "\u2AAF",
+  prec: "\u227A",
+  precapprox: "\u2AB7",
+  preccurlyeq: "\u227C",
+  preceq: "\u2AAF",
+  precnapprox: "\u2AB9",
+  precneqq: "\u2AB5",
+  precnsim: "\u22E8",
+  precsim: "\u227E",
+  prime: "\u2032",
+  primes: "\u2119",
+  prnE: "\u2AB5",
+  prnap: "\u2AB9",
+  prnsim: "\u22E8",
+  prod: "\u220F",
+  profalar: "\u232E",
+  profline: "\u2312",
+  profsurf: "\u2313",
+  prop: "\u221D",
+  propto: "\u221D",
+  prsim: "\u227E",
+  prurel: "\u22B0",
+  pscr: "\u{1D4C5}",
+  psi: "\u03C8",
+  puncsp: "\u2008",
+  qfr: "\u{1D52E}",
+  qint: "\u2A0C",
+  qopf: "\u{1D562}",
+  qprime: "\u2057",
+  qscr: "\u{1D4C6}",
+  quaternions: "\u210D",
+  quatint: "\u2A16",
+  quest: "?",
+  questeq: "\u225F",
+  quot: '"',
+  rAarr: "\u21DB",
+  rArr: "\u21D2",
+  rAtail: "\u291C",
+  rBarr: "\u290F",
+  rHar: "\u2964",
+  race: "\u223D\u0331",
+  racute: "\u0155",
+  radic: "\u221A",
+  raemptyv: "\u29B3",
+  rang: "\u27E9",
+  rangd: "\u2992",
+  range: "\u29A5",
+  rangle: "\u27E9",
+  raquo: "\xBB",
+  rarr: "\u2192",
+  rarrap: "\u2975",
+  rarrb: "\u21E5",
+  rarrbfs: "\u2920",
+  rarrc: "\u2933",
+  rarrfs: "\u291E",
+  rarrhk: "\u21AA",
+  rarrlp: "\u21AC",
+  rarrpl: "\u2945",
+  rarrsim: "\u2974",
+  rarrtl: "\u21A3",
+  rarrw: "\u219D",
+  ratail: "\u291A",
+  ratio: "\u2236",
+  rationals: "\u211A",
+  rbarr: "\u290D",
+  rbbrk: "\u2773",
+  rbrace: "}",
+  rbrack: "]",
+  rbrke: "\u298C",
+  rbrksld: "\u298E",
+  rbrkslu: "\u2990",
+  rcaron: "\u0159",
+  rcedil: "\u0157",
+  rceil: "\u2309",
+  rcub: "}",
+  rcy: "\u0440",
+  rdca: "\u2937",
+  rdldhar: "\u2969",
+  rdquo: "\u201D",
+  rdquor: "\u201D",
+  rdsh: "\u21B3",
+  real: "\u211C",
+  realine: "\u211B",
+  realpart: "\u211C",
+  reals: "\u211D",
+  rect: "\u25AD",
+  reg: "\xAE",
+  rfisht: "\u297D",
+  rfloor: "\u230B",
+  rfr: "\u{1D52F}",
+  rhard: "\u21C1",
+  rharu: "\u21C0",
+  rharul: "\u296C",
+  rho: "\u03C1",
+  rhov: "\u03F1",
+  rightarrow: "\u2192",
+  rightarrowtail: "\u21A3",
+  rightharpoondown: "\u21C1",
+  rightharpoonup: "\u21C0",
+  rightleftarrows: "\u21C4",
+  rightleftharpoons: "\u21CC",
+  rightrightarrows: "\u21C9",
+  rightsquigarrow: "\u219D",
+  rightthreetimes: "\u22CC",
+  ring: "\u02DA",
+  risingdotseq: "\u2253",
+  rlarr: "\u21C4",
+  rlhar: "\u21CC",
+  rlm: "\u200F",
+  rmoust: "\u23B1",
+  rmoustache: "\u23B1",
+  rnmid: "\u2AEE",
+  roang: "\u27ED",
+  roarr: "\u21FE",
+  robrk: "\u27E7",
+  ropar: "\u2986",
+  ropf: "\u{1D563}",
+  roplus: "\u2A2E",
+  rotimes: "\u2A35",
+  rpar: ")",
+  rpargt: "\u2994",
+  rppolint: "\u2A12",
+  rrarr: "\u21C9",
+  rsaquo: "\u203A",
+  rscr: "\u{1D4C7}",
+  rsh: "\u21B1",
+  rsqb: "]",
+  rsquo: "\u2019",
+  rsquor: "\u2019",
+  rthree: "\u22CC",
+  rtimes: "\u22CA",
+  rtri: "\u25B9",
+  rtrie: "\u22B5",
+  rtrif: "\u25B8",
+  rtriltri: "\u29CE",
+  ruluhar: "\u2968",
+  rx: "\u211E",
+  sacute: "\u015B",
+  sbquo: "\u201A",
+  sc: "\u227B",
+  scE: "\u2AB4",
+  scap: "\u2AB8",
+  scaron: "\u0161",
+  sccue: "\u227D",
+  sce: "\u2AB0",
+  scedil: "\u015F",
+  scirc: "\u015D",
+  scnE: "\u2AB6",
+  scnap: "\u2ABA",
+  scnsim: "\u22E9",
+  scpolint: "\u2A13",
+  scsim: "\u227F",
+  scy: "\u0441",
+  sdot: "\u22C5",
+  sdotb: "\u22A1",
+  sdote: "\u2A66",
+  seArr: "\u21D8",
+  searhk: "\u2925",
+  searr: "\u2198",
+  searrow: "\u2198",
+  sect: "\xA7",
+  semi: ";",
+  seswar: "\u2929",
+  setminus: "\u2216",
+  setmn: "\u2216",
+  sext: "\u2736",
+  sfr: "\u{1D530}",
+  sfrown: "\u2322",
+  sharp: "\u266F",
+  shchcy: "\u0449",
+  shcy: "\u0448",
+  shortmid: "\u2223",
+  shortparallel: "\u2225",
+  shy: "\xAD",
+  sigma: "\u03C3",
+  sigmaf: "\u03C2",
+  sigmav: "\u03C2",
+  sim: "\u223C",
+  simdot: "\u2A6A",
+  sime: "\u2243",
+  simeq: "\u2243",
+  simg: "\u2A9E",
+  simgE: "\u2AA0",
+  siml: "\u2A9D",
+  simlE: "\u2A9F",
+  simne: "\u2246",
+  simplus: "\u2A24",
+  simrarr: "\u2972",
+  slarr: "\u2190",
+  smallsetminus: "\u2216",
+  smashp: "\u2A33",
+  smeparsl: "\u29E4",
+  smid: "\u2223",
+  smile: "\u2323",
+  smt: "\u2AAA",
+  smte: "\u2AAC",
+  smtes: "\u2AAC\uFE00",
+  softcy: "\u044C",
+  sol: "/",
+  solb: "\u29C4",
+  solbar: "\u233F",
+  sopf: "\u{1D564}",
+  spades: "\u2660",
+  spadesuit: "\u2660",
+  spar: "\u2225",
+  sqcap: "\u2293",
+  sqcaps: "\u2293\uFE00",
+  sqcup: "\u2294",
+  sqcups: "\u2294\uFE00",
+  sqsub: "\u228F",
+  sqsube: "\u2291",
+  sqsubset: "\u228F",
+  sqsubseteq: "\u2291",
+  sqsup: "\u2290",
+  sqsupe: "\u2292",
+  sqsupset: "\u2290",
+  sqsupseteq: "\u2292",
+  squ: "\u25A1",
+  square: "\u25A1",
+  squarf: "\u25AA",
+  squf: "\u25AA",
+  srarr: "\u2192",
+  sscr: "\u{1D4C8}",
+  ssetmn: "\u2216",
+  ssmile: "\u2323",
+  sstarf: "\u22C6",
+  star: "\u2606",
+  starf: "\u2605",
+  straightepsilon: "\u03F5",
+  straightphi: "\u03D5",
+  strns: "\xAF",
+  sub: "\u2282",
+  subE: "\u2AC5",
+  subdot: "\u2ABD",
+  sube: "\u2286",
+  subedot: "\u2AC3",
+  submult: "\u2AC1",
+  subnE: "\u2ACB",
+  subne: "\u228A",
+  subplus: "\u2ABF",
+  subrarr: "\u2979",
+  subset: "\u2282",
+  subseteq: "\u2286",
+  subseteqq: "\u2AC5",
+  subsetneq: "\u228A",
+  subsetneqq: "\u2ACB",
+  subsim: "\u2AC7",
+  subsub: "\u2AD5",
+  subsup: "\u2AD3",
+  succ: "\u227B",
+  succapprox: "\u2AB8",
+  succcurlyeq: "\u227D",
+  succeq: "\u2AB0",
+  succnapprox: "\u2ABA",
+  succneqq: "\u2AB6",
+  succnsim: "\u22E9",
+  succsim: "\u227F",
+  sum: "\u2211",
+  sung: "\u266A",
+  sup1: "\xB9",
+  sup2: "\xB2",
+  sup3: "\xB3",
+  sup: "\u2283",
+  supE: "\u2AC6",
+  supdot: "\u2ABE",
+  supdsub: "\u2AD8",
+  supe: "\u2287",
+  supedot: "\u2AC4",
+  suphsol: "\u27C9",
+  suphsub: "\u2AD7",
+  suplarr: "\u297B",
+  supmult: "\u2AC2",
+  supnE: "\u2ACC",
+  supne: "\u228B",
+  supplus: "\u2AC0",
+  supset: "\u2283",
+  supseteq: "\u2287",
+  supseteqq: "\u2AC6",
+  supsetneq: "\u228B",
+  supsetneqq: "\u2ACC",
+  supsim: "\u2AC8",
+  supsub: "\u2AD4",
+  supsup: "\u2AD6",
+  swArr: "\u21D9",
+  swarhk: "\u2926",
+  swarr: "\u2199",
+  swarrow: "\u2199",
+  swnwar: "\u292A",
+  szlig: "\xDF",
+  target: "\u2316",
+  tau: "\u03C4",
+  tbrk: "\u23B4",
+  tcaron: "\u0165",
+  tcedil: "\u0163",
+  tcy: "\u0442",
+  tdot: "\u20DB",
+  telrec: "\u2315",
+  tfr: "\u{1D531}",
+  there4: "\u2234",
+  therefore: "\u2234",
+  theta: "\u03B8",
+  thetasym: "\u03D1",
+  thetav: "\u03D1",
+  thickapprox: "\u2248",
+  thicksim: "\u223C",
+  thinsp: "\u2009",
+  thkap: "\u2248",
+  thksim: "\u223C",
+  thorn: "\xFE",
+  tilde: "\u02DC",
+  times: "\xD7",
+  timesb: "\u22A0",
+  timesbar: "\u2A31",
+  timesd: "\u2A30",
+  tint: "\u222D",
+  toea: "\u2928",
+  top: "\u22A4",
+  topbot: "\u2336",
+  topcir: "\u2AF1",
+  topf: "\u{1D565}",
+  topfork: "\u2ADA",
+  tosa: "\u2929",
+  tprime: "\u2034",
+  trade: "\u2122",
+  triangle: "\u25B5",
+  triangledown: "\u25BF",
+  triangleleft: "\u25C3",
+  trianglelefteq: "\u22B4",
+  triangleq: "\u225C",
+  triangleright: "\u25B9",
+  trianglerighteq: "\u22B5",
+  tridot: "\u25EC",
+  trie: "\u225C",
+  triminus: "\u2A3A",
+  triplus: "\u2A39",
+  trisb: "\u29CD",
+  tritime: "\u2A3B",
+  trpezium: "\u23E2",
+  tscr: "\u{1D4C9}",
+  tscy: "\u0446",
+  tshcy: "\u045B",
+  tstrok: "\u0167",
+  twixt: "\u226C",
+  twoheadleftarrow: "\u219E",
+  twoheadrightarrow: "\u21A0",
+  uArr: "\u21D1",
+  uHar: "\u2963",
+  uacute: "\xFA",
+  uarr: "\u2191",
+  ubrcy: "\u045E",
+  ubreve: "\u016D",
+  ucirc: "\xFB",
+  ucy: "\u0443",
+  udarr: "\u21C5",
+  udblac: "\u0171",
+  udhar: "\u296E",
+  ufisht: "\u297E",
+  ufr: "\u{1D532}",
+  ugrave: "\xF9",
+  uharl: "\u21BF",
+  uharr: "\u21BE",
+  uhblk: "\u2580",
+  ulcorn: "\u231C",
+  ulcorner: "\u231C",
+  ulcrop: "\u230F",
+  ultri: "\u25F8",
+  umacr: "\u016B",
+  uml: "\xA8",
+  uogon: "\u0173",
+  uopf: "\u{1D566}",
+  uparrow: "\u2191",
+  updownarrow: "\u2195",
+  upharpoonleft: "\u21BF",
+  upharpoonright: "\u21BE",
+  uplus: "\u228E",
+  upsi: "\u03C5",
+  upsih: "\u03D2",
+  upsilon: "\u03C5",
+  upuparrows: "\u21C8",
+  urcorn: "\u231D",
+  urcorner: "\u231D",
+  urcrop: "\u230E",
+  uring: "\u016F",
+  urtri: "\u25F9",
+  uscr: "\u{1D4CA}",
+  utdot: "\u22F0",
+  utilde: "\u0169",
+  utri: "\u25B5",
+  utrif: "\u25B4",
+  uuarr: "\u21C8",
+  uuml: "\xFC",
+  uwangle: "\u29A7",
+  vArr: "\u21D5",
+  vBar: "\u2AE8",
+  vBarv: "\u2AE9",
+  vDash: "\u22A8",
+  vangrt: "\u299C",
+  varepsilon: "\u03F5",
+  varkappa: "\u03F0",
+  varnothing: "\u2205",
+  varphi: "\u03D5",
+  varpi: "\u03D6",
+  varpropto: "\u221D",
+  varr: "\u2195",
+  varrho: "\u03F1",
+  varsigma: "\u03C2",
+  varsubsetneq: "\u228A\uFE00",
+  varsubsetneqq: "\u2ACB\uFE00",
+  varsupsetneq: "\u228B\uFE00",
+  varsupsetneqq: "\u2ACC\uFE00",
+  vartheta: "\u03D1",
+  vartriangleleft: "\u22B2",
+  vartriangleright: "\u22B3",
+  vcy: "\u0432",
+  vdash: "\u22A2",
+  vee: "\u2228",
+  veebar: "\u22BB",
+  veeeq: "\u225A",
+  vellip: "\u22EE",
+  verbar: "|",
+  vert: "|",
+  vfr: "\u{1D533}",
+  vltri: "\u22B2",
+  vnsub: "\u2282\u20D2",
+  vnsup: "\u2283\u20D2",
+  vopf: "\u{1D567}",
+  vprop: "\u221D",
+  vrtri: "\u22B3",
+  vscr: "\u{1D4CB}",
+  vsubnE: "\u2ACB\uFE00",
+  vsubne: "\u228A\uFE00",
+  vsupnE: "\u2ACC\uFE00",
+  vsupne: "\u228B\uFE00",
+  vzigzag: "\u299A",
+  wcirc: "\u0175",
+  wedbar: "\u2A5F",
+  wedge: "\u2227",
+  wedgeq: "\u2259",
+  weierp: "\u2118",
+  wfr: "\u{1D534}",
+  wopf: "\u{1D568}",
+  wp: "\u2118",
+  wr: "\u2240",
+  wreath: "\u2240",
+  wscr: "\u{1D4CC}",
+  xcap: "\u22C2",
+  xcirc: "\u25EF",
+  xcup: "\u22C3",
+  xdtri: "\u25BD",
+  xfr: "\u{1D535}",
+  xhArr: "\u27FA",
+  xharr: "\u27F7",
+  xi: "\u03BE",
+  xlArr: "\u27F8",
+  xlarr: "\u27F5",
+  xmap: "\u27FC",
+  xnis: "\u22FB",
+  xodot: "\u2A00",
+  xopf: "\u{1D569}",
+  xoplus: "\u2A01",
+  xotime: "\u2A02",
+  xrArr: "\u27F9",
+  xrarr: "\u27F6",
+  xscr: "\u{1D4CD}",
+  xsqcup: "\u2A06",
+  xuplus: "\u2A04",
+  xutri: "\u25B3",
+  xvee: "\u22C1",
+  xwedge: "\u22C0",
+  yacute: "\xFD",
+  yacy: "\u044F",
+  ycirc: "\u0177",
+  ycy: "\u044B",
+  yen: "\xA5",
+  yfr: "\u{1D536}",
+  yicy: "\u0457",
+  yopf: "\u{1D56A}",
+  yscr: "\u{1D4CE}",
+  yucy: "\u044E",
+  yuml: "\xFF",
+  zacute: "\u017A",
+  zcaron: "\u017E",
+  zcy: "\u0437",
+  zdot: "\u017C",
+  zeetrf: "\u2128",
+  zeta: "\u03B6",
+  zfr: "\u{1D537}",
+  zhcy: "\u0436",
+  zigrarr: "\u21DD",
+  zopf: "\u{1D56B}",
+  zscr: "\u{1D4CF}",
+  zwj: "\u200D",
+  zwnj: "\u200C"
+};
+
+// node_modules/decode-named-character-reference/index.js
+var own3 = {}.hasOwnProperty;
+function decodeNamedCharacterReference(value) {
+  return own3.call(characterEntities, value) ? characterEntities[value] : false;
+}
+
+// node_modules/micromark-core-commonmark/lib/character-reference.js
+var characterReference = {
+  name: "characterReference",
+  tokenize: tokenizeCharacterReference
+};
+function tokenizeCharacterReference(effects, ok2, nok) {
+  const self2 = this;
+  let size = 0;
+  let max;
+  let test;
+  return start3;
+  function start3(code2) {
+    effects.enter("characterReference");
+    effects.enter("characterReferenceMarker");
+    effects.consume(code2);
+    effects.exit("characterReferenceMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 35) {
+      effects.enter("characterReferenceMarkerNumeric");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarkerNumeric");
+      return numeric;
+    }
+    effects.enter("characterReferenceValue");
+    max = 31;
+    test = asciiAlphanumeric;
+    return value(code2);
+  }
+  function numeric(code2) {
+    if (code2 === 88 || code2 === 120) {
+      effects.enter("characterReferenceMarkerHexadecimal");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarkerHexadecimal");
+      effects.enter("characterReferenceValue");
+      max = 6;
+      test = asciiHexDigit;
+      return value;
+    }
+    effects.enter("characterReferenceValue");
+    max = 7;
+    test = asciiDigit;
+    return value(code2);
+  }
+  function value(code2) {
+    let token;
+    if (code2 === 59 && size) {
+      token = effects.exit("characterReferenceValue");
+      if (test === asciiAlphanumeric && !decodeNamedCharacterReference(self2.sliceSerialize(token))) {
+        return nok(code2);
+      }
+      effects.enter("characterReferenceMarker");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarker");
+      effects.exit("characterReference");
+      return ok2;
+    }
+    if (test(code2) && size++ < max) {
+      effects.consume(code2);
+      return value;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-fenced.js
+var codeFenced = {
+  name: "codeFenced",
+  tokenize: tokenizeCodeFenced,
+  concrete: true
+};
+function tokenizeCodeFenced(effects, ok2, nok) {
+  const self2 = this;
+  const closingFenceConstruct = {
+    tokenize: tokenizeClosingFence,
+    partial: true
+  };
+  const nonLazyLine = {
+    tokenize: tokenizeNonLazyLine,
+    partial: true
+  };
+  const tail = this.events[this.events.length - 1];
+  const initialPrefix = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  let sizeOpen = 0;
+  let marker;
+  return start3;
+  function start3(code2) {
+    effects.enter("codeFenced");
+    effects.enter("codeFencedFence");
+    effects.enter("codeFencedFenceSequence");
+    marker = code2;
+    return sequenceOpen(code2);
+  }
+  function sequenceOpen(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      sizeOpen++;
+      return sequenceOpen;
+    }
+    effects.exit("codeFencedFenceSequence");
+    return sizeOpen < 3 ? nok(code2) : factorySpace(effects, infoOpen, "whitespace")(code2);
+  }
+  function infoOpen(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return openAfter(code2);
+    }
+    effects.enter("codeFencedFenceInfo");
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return info(code2);
+  }
+  function info(code2) {
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      effects.exit("chunkString");
+      effects.exit("codeFencedFenceInfo");
+      return factorySpace(effects, infoAfter, "whitespace")(code2);
+    }
+    if (code2 === 96 && code2 === marker)
+      return nok(code2);
+    effects.consume(code2);
+    return info;
+  }
+  function infoAfter(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return openAfter(code2);
+    }
+    effects.enter("codeFencedFenceMeta");
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return meta(code2);
+  }
+  function meta(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("chunkString");
+      effects.exit("codeFencedFenceMeta");
+      return openAfter(code2);
+    }
+    if (code2 === 96 && code2 === marker)
+      return nok(code2);
+    effects.consume(code2);
+    return meta;
+  }
+  function openAfter(code2) {
+    effects.exit("codeFencedFence");
+    return self2.interrupt ? ok2(code2) : contentStart(code2);
+  }
+  function contentStart(code2) {
+    if (code2 === null) {
+      return after(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.attempt(
+        nonLazyLine,
+        effects.attempt(
+          closingFenceConstruct,
+          after,
+          initialPrefix ? factorySpace(
+            effects,
+            contentStart,
+            "linePrefix",
+            initialPrefix + 1
+          ) : contentStart
+        ),
+        after
+      )(code2);
+    }
+    effects.enter("codeFlowValue");
+    return contentContinue(code2);
+  }
+  function contentContinue(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("codeFlowValue");
+      return contentStart(code2);
+    }
+    effects.consume(code2);
+    return contentContinue;
+  }
+  function after(code2) {
+    effects.exit("codeFenced");
+    return ok2(code2);
+  }
+  function tokenizeNonLazyLine(effects2, ok3, nok2) {
+    const self3 = this;
+    return start4;
+    function start4(code2) {
+      effects2.enter("lineEnding");
+      effects2.consume(code2);
+      effects2.exit("lineEnding");
+      return lineStart;
+    }
+    function lineStart(code2) {
+      return self3.parser.lazy[self3.now().line] ? nok2(code2) : ok3(code2);
+    }
+  }
+  function tokenizeClosingFence(effects2, ok3, nok2) {
+    let size = 0;
+    return factorySpace(
+      effects2,
+      closingSequenceStart,
+      "linePrefix",
+      this.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+    );
+    function closingSequenceStart(code2) {
+      effects2.enter("codeFencedFence");
+      effects2.enter("codeFencedFenceSequence");
+      return closingSequence(code2);
+    }
+    function closingSequence(code2) {
+      if (code2 === marker) {
+        effects2.consume(code2);
+        size++;
+        return closingSequence;
+      }
+      if (size < sizeOpen)
+        return nok2(code2);
+      effects2.exit("codeFencedFenceSequence");
+      return factorySpace(effects2, closingSequenceEnd, "whitespace")(code2);
+    }
+    function closingSequenceEnd(code2) {
+      if (code2 === null || markdownLineEnding(code2)) {
+        effects2.exit("codeFencedFence");
+        return ok3(code2);
+      }
+      return nok2(code2);
+    }
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-indented.js
+var codeIndented = {
+  name: "codeIndented",
+  tokenize: tokenizeCodeIndented
+};
+var indentedContent = {
+  tokenize: tokenizeIndentedContent,
+  partial: true
+};
+function tokenizeCodeIndented(effects, ok2, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code2) {
+    effects.enter("codeIndented");
+    return factorySpace(effects, afterStartPrefix, "linePrefix", 4 + 1)(code2);
+  }
+  function afterStartPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4 ? afterPrefix(code2) : nok(code2);
+  }
+  function afterPrefix(code2) {
+    if (code2 === null) {
+      return after(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.attempt(indentedContent, afterPrefix, after)(code2);
+    }
+    effects.enter("codeFlowValue");
+    return content3(code2);
+  }
+  function content3(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("codeFlowValue");
+      return afterPrefix(code2);
+    }
+    effects.consume(code2);
+    return content3;
+  }
+  function after(code2) {
+    effects.exit("codeIndented");
+    return ok2(code2);
+  }
+}
+function tokenizeIndentedContent(effects, ok2, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code2) {
+    if (self2.parser.lazy[self2.now().line]) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return start3;
+    }
+    return factorySpace(effects, afterPrefix, "linePrefix", 4 + 1)(code2);
+  }
+  function afterPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4 ? ok2(code2) : markdownLineEnding(code2) ? start3(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-text.js
+var codeText = {
+  name: "codeText",
+  tokenize: tokenizeCodeText,
+  resolve: resolveCodeText,
+  previous
+};
+function resolveCodeText(events) {
+  let tailExitIndex = events.length - 4;
+  let headEnterIndex = 3;
+  let index2;
+  let enter;
+  if ((events[headEnterIndex][1].type === "lineEnding" || events[headEnterIndex][1].type === "space") && (events[tailExitIndex][1].type === "lineEnding" || events[tailExitIndex][1].type === "space")) {
+    index2 = headEnterIndex;
+    while (++index2 < tailExitIndex) {
+      if (events[index2][1].type === "codeTextData") {
+        events[headEnterIndex][1].type = "codeTextPadding";
+        events[tailExitIndex][1].type = "codeTextPadding";
+        headEnterIndex += 2;
+        tailExitIndex -= 2;
+        break;
+      }
+    }
+  }
+  index2 = headEnterIndex - 1;
+  tailExitIndex++;
+  while (++index2 <= tailExitIndex) {
+    if (enter === void 0) {
+      if (index2 !== tailExitIndex && events[index2][1].type !== "lineEnding") {
+        enter = index2;
+      }
+    } else if (index2 === tailExitIndex || events[index2][1].type === "lineEnding") {
+      events[enter][1].type = "codeTextData";
+      if (index2 !== enter + 2) {
+        events[enter][1].end = events[index2 - 1][1].end;
+        events.splice(enter + 2, index2 - enter - 2);
+        tailExitIndex -= index2 - enter - 2;
+        index2 = enter + 2;
+      }
+      enter = void 0;
+    }
+  }
+  return events;
+}
+function previous(code2) {
+  return code2 !== 96 || this.events[this.events.length - 1][1].type === "characterEscape";
+}
+function tokenizeCodeText(effects, ok2, nok) {
+  const self2 = this;
+  let sizeOpen = 0;
+  let size;
+  let token;
+  return start3;
+  function start3(code2) {
+    effects.enter("codeText");
+    effects.enter("codeTextSequence");
+    return openingSequence(code2);
+  }
+  function openingSequence(code2) {
+    if (code2 === 96) {
+      effects.consume(code2);
+      sizeOpen++;
+      return openingSequence;
+    }
+    effects.exit("codeTextSequence");
+    return gap(code2);
+  }
+  function gap(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 96) {
+      token = effects.enter("codeTextSequence");
+      size = 0;
+      return closingSequence(code2);
+    }
+    if (code2 === 32) {
+      effects.enter("space");
+      effects.consume(code2);
+      effects.exit("space");
+      return gap;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return gap;
+    }
+    effects.enter("codeTextData");
+    return data2(code2);
+  }
+  function data2(code2) {
+    if (code2 === null || code2 === 32 || code2 === 96 || markdownLineEnding(code2)) {
+      effects.exit("codeTextData");
+      return gap(code2);
+    }
+    effects.consume(code2);
+    return data2;
+  }
+  function closingSequence(code2) {
+    if (code2 === 96) {
+      effects.consume(code2);
+      size++;
+      return closingSequence;
+    }
+    if (size === sizeOpen) {
+      effects.exit("codeTextSequence");
+      effects.exit("codeText");
+      return ok2(code2);
+    }
+    token.type = "codeTextData";
+    return data2(code2);
+  }
+}
+
+// node_modules/micromark-util-subtokenize/index.js
+function subtokenize(events) {
+  const jumps = {};
+  let index2 = -1;
+  let event;
+  let lineIndex;
+  let otherIndex;
+  let otherEvent;
+  let parameters;
+  let subevents;
+  let more;
+  while (++index2 < events.length) {
+    while (index2 in jumps) {
+      index2 = jumps[index2];
+    }
+    event = events[index2];
+    if (index2 && event[1].type === "chunkFlow" && events[index2 - 1][1].type === "listItemPrefix") {
+      subevents = event[1]._tokenizer.events;
+      otherIndex = 0;
+      if (otherIndex < subevents.length && subevents[otherIndex][1].type === "lineEndingBlank") {
+        otherIndex += 2;
+      }
+      if (otherIndex < subevents.length && subevents[otherIndex][1].type === "content") {
+        while (++otherIndex < subevents.length) {
+          if (subevents[otherIndex][1].type === "content") {
+            break;
+          }
+          if (subevents[otherIndex][1].type === "chunkText") {
+            subevents[otherIndex][1]._isInFirstContentOfListItem = true;
+            otherIndex++;
+          }
+        }
+      }
+    }
+    if (event[0] === "enter") {
+      if (event[1].contentType) {
+        Object.assign(jumps, subcontent(events, index2));
+        index2 = jumps[index2];
+        more = true;
+      }
+    } else if (event[1]._container) {
+      otherIndex = index2;
+      lineIndex = void 0;
+      while (otherIndex--) {
+        otherEvent = events[otherIndex];
+        if (otherEvent[1].type === "lineEnding" || otherEvent[1].type === "lineEndingBlank") {
+          if (otherEvent[0] === "enter") {
+            if (lineIndex) {
+              events[lineIndex][1].type = "lineEndingBlank";
+            }
+            otherEvent[1].type = "lineEnding";
+            lineIndex = otherIndex;
+          }
+        } else {
+          break;
+        }
+      }
+      if (lineIndex) {
+        event[1].end = Object.assign({}, events[lineIndex][1].start);
+        parameters = events.slice(lineIndex, index2);
+        parameters.unshift(event);
+        splice(events, lineIndex, index2 - lineIndex + 1, parameters);
+      }
+    }
+  }
+  return !more;
+}
+function subcontent(events, eventIndex) {
+  const token = events[eventIndex][1];
+  const context = events[eventIndex][2];
+  let startPosition = eventIndex - 1;
+  const startPositions = [];
+  const tokenizer2 = token._tokenizer || context.parser[token.contentType](token.start);
+  const childEvents = tokenizer2.events;
+  const jumps = [];
+  const gaps = {};
+  let stream;
+  let previous2;
+  let index2 = -1;
+  let current2 = token;
+  let adjust = 0;
+  let start3 = 0;
+  const breaks = [start3];
+  while (current2) {
+    while (events[++startPosition][1] !== current2) {
+    }
+    startPositions.push(startPosition);
+    if (!current2._tokenizer) {
+      stream = context.sliceStream(current2);
+      if (!current2.next) {
+        stream.push(null);
+      }
+      if (previous2) {
+        tokenizer2.defineSkip(current2.start);
+      }
+      if (current2._isInFirstContentOfListItem) {
+        tokenizer2._gfmTasklistFirstContentOfListItem = true;
+      }
+      tokenizer2.write(stream);
+      if (current2._isInFirstContentOfListItem) {
+        tokenizer2._gfmTasklistFirstContentOfListItem = void 0;
+      }
+    }
+    previous2 = current2;
+    current2 = current2.next;
+  }
+  current2 = token;
+  while (++index2 < childEvents.length) {
+    if (childEvents[index2][0] === "exit" && childEvents[index2 - 1][0] === "enter" && childEvents[index2][1].type === childEvents[index2 - 1][1].type && childEvents[index2][1].start.line !== childEvents[index2][1].end.line) {
+      start3 = index2 + 1;
+      breaks.push(start3);
+      current2._tokenizer = void 0;
+      current2.previous = void 0;
+      current2 = current2.next;
+    }
+  }
+  tokenizer2.events = [];
+  if (current2) {
+    current2._tokenizer = void 0;
+    current2.previous = void 0;
+  } else {
+    breaks.pop();
+  }
+  index2 = breaks.length;
+  while (index2--) {
+    const slice2 = childEvents.slice(breaks[index2], breaks[index2 + 1]);
+    const start4 = startPositions.pop();
+    jumps.unshift([start4, start4 + slice2.length - 1]);
+    splice(events, start4, 2, slice2);
+  }
+  index2 = -1;
+  while (++index2 < jumps.length) {
+    gaps[adjust + jumps[index2][0]] = adjust + jumps[index2][1];
+    adjust += jumps[index2][1] - jumps[index2][0] - 1;
+  }
+  return gaps;
+}
+
+// node_modules/micromark-core-commonmark/lib/content.js
+var content = {
+  tokenize: tokenizeContent,
+  resolve: resolveContent
+};
+var continuationConstruct = {
+  tokenize: tokenizeContinuation,
+  partial: true
+};
+function resolveContent(events) {
+  subtokenize(events);
+  return events;
+}
+function tokenizeContent(effects, ok2) {
+  let previous2;
+  return start3;
+  function start3(code2) {
+    effects.enter("content");
+    previous2 = effects.enter("chunkContent", {
+      contentType: "content"
+    });
+    return data2(code2);
+  }
+  function data2(code2) {
+    if (code2 === null) {
+      return contentEnd(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.check(
+        continuationConstruct,
+        contentContinue,
+        contentEnd
+      )(code2);
+    }
+    effects.consume(code2);
+    return data2;
+  }
+  function contentEnd(code2) {
+    effects.exit("chunkContent");
+    effects.exit("content");
+    return ok2(code2);
+  }
+  function contentContinue(code2) {
+    effects.consume(code2);
+    effects.exit("chunkContent");
+    previous2.next = effects.enter("chunkContent", {
+      contentType: "content",
+      previous: previous2
+    });
+    previous2 = previous2.next;
+    return data2;
+  }
+}
+function tokenizeContinuation(effects, ok2, nok) {
+  const self2 = this;
+  return startLookahead;
+  function startLookahead(code2) {
+    effects.exit("chunkContent");
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, prefixed, "linePrefix");
+  }
+  function prefixed(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    const tail = self2.events[self2.events.length - 1];
+    if (!self2.parser.constructs.disable.null.includes("codeIndented") && tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4) {
+      return ok2(code2);
+    }
+    return effects.interrupt(self2.parser.constructs.flow, nok, ok2)(code2);
+  }
+}
+
+// node_modules/micromark-factory-destination/index.js
+function factoryDestination(effects, ok2, nok, type, literalType, literalMarkerType, rawType, stringType, max) {
+  const limit = max || Number.POSITIVE_INFINITY;
+  let balance = 0;
+  return start3;
+  function start3(code2) {
+    if (code2 === 60) {
+      effects.enter(type);
+      effects.enter(literalType);
+      effects.enter(literalMarkerType);
+      effects.consume(code2);
+      effects.exit(literalMarkerType);
+      return destinationEnclosedBefore;
+    }
+    if (code2 === null || code2 === 41 || asciiControl(code2)) {
+      return nok(code2);
+    }
+    effects.enter(type);
+    effects.enter(rawType);
+    effects.enter(stringType);
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return destinationRaw(code2);
+  }
+  function destinationEnclosedBefore(code2) {
+    if (code2 === 62) {
+      effects.enter(literalMarkerType);
+      effects.consume(code2);
+      effects.exit(literalMarkerType);
+      effects.exit(literalType);
+      effects.exit(type);
+      return ok2;
+    }
+    effects.enter(stringType);
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return destinationEnclosed(code2);
+  }
+  function destinationEnclosed(code2) {
+    if (code2 === 62) {
+      effects.exit("chunkString");
+      effects.exit(stringType);
+      return destinationEnclosedBefore(code2);
+    }
+    if (code2 === null || code2 === 60 || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? destinationEnclosedEscape : destinationEnclosed;
+  }
+  function destinationEnclosedEscape(code2) {
+    if (code2 === 60 || code2 === 62 || code2 === 92) {
+      effects.consume(code2);
+      return destinationEnclosed;
+    }
+    return destinationEnclosed(code2);
+  }
+  function destinationRaw(code2) {
+    if (code2 === 40) {
+      if (++balance > limit)
+        return nok(code2);
+      effects.consume(code2);
+      return destinationRaw;
+    }
+    if (code2 === 41) {
+      if (!balance--) {
+        effects.exit("chunkString");
+        effects.exit(stringType);
+        effects.exit(rawType);
+        effects.exit(type);
+        return ok2(code2);
+      }
+      effects.consume(code2);
+      return destinationRaw;
+    }
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      if (balance)
+        return nok(code2);
+      effects.exit("chunkString");
+      effects.exit(stringType);
+      effects.exit(rawType);
+      effects.exit(type);
+      return ok2(code2);
+    }
+    if (asciiControl(code2))
+      return nok(code2);
+    effects.consume(code2);
+    return code2 === 92 ? destinationRawEscape : destinationRaw;
+  }
+  function destinationRawEscape(code2) {
+    if (code2 === 40 || code2 === 41 || code2 === 92) {
+      effects.consume(code2);
+      return destinationRaw;
+    }
+    return destinationRaw(code2);
+  }
+}
+
+// node_modules/micromark-factory-label/index.js
+function factoryLabel(effects, ok2, nok, type, markerType, stringType) {
+  const self2 = this;
+  let size = 0;
+  let data2;
+  return start3;
+  function start3(code2) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    effects.enter(stringType);
+    return atBreak;
+  }
+  function atBreak(code2) {
+    if (code2 === null || code2 === 91 || code2 === 93 && !data2 || code2 === 94 && !size && "_hiddenFootnoteSupport" in self2.parser.constructs || size > 999) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      effects.exit(stringType);
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok2;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return atBreak;
+    }
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return label(code2);
+  }
+  function label(code2) {
+    if (code2 === null || code2 === 91 || code2 === 93 || markdownLineEnding(code2) || size++ > 999) {
+      effects.exit("chunkString");
+      return atBreak(code2);
+    }
+    effects.consume(code2);
+    data2 = data2 || !markdownSpace(code2);
+    return code2 === 92 ? labelEscape : label;
+  }
+  function labelEscape(code2) {
+    if (code2 === 91 || code2 === 92 || code2 === 93) {
+      effects.consume(code2);
+      size++;
+      return label;
+    }
+    return label(code2);
+  }
+}
+
+// node_modules/micromark-factory-title/index.js
+function factoryTitle(effects, ok2, nok, type, markerType, stringType) {
+  let marker;
+  return start3;
+  function start3(code2) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    marker = code2 === 40 ? 41 : code2;
+    return atFirstTitleBreak;
+  }
+  function atFirstTitleBreak(code2) {
+    if (code2 === marker) {
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok2;
+    }
+    effects.enter(stringType);
+    return atTitleBreak(code2);
+  }
+  function atTitleBreak(code2) {
+    if (code2 === marker) {
+      effects.exit(stringType);
+      return atFirstTitleBreak(marker);
+    }
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return factorySpace(effects, atTitleBreak, "linePrefix");
+    }
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return title(code2);
+  }
+  function title(code2) {
+    if (code2 === marker || code2 === null || markdownLineEnding(code2)) {
+      effects.exit("chunkString");
+      return atTitleBreak(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? titleEscape : title;
+  }
+  function titleEscape(code2) {
+    if (code2 === marker || code2 === 92) {
+      effects.consume(code2);
+      return title;
+    }
+    return title(code2);
+  }
+}
+
+// node_modules/micromark-factory-whitespace/index.js
+function factoryWhitespace(effects, ok2) {
+  let seen;
+  return start3;
+  function start3(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      seen = true;
+      return start3;
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(
+        effects,
+        start3,
+        seen ? "linePrefix" : "lineSuffix"
+      )(code2);
+    }
+    return ok2(code2);
+  }
+}
+
+// node_modules/micromark-util-normalize-identifier/index.js
+function normalizeIdentifier(value) {
+  return value.replace(/[\t\n\r ]+/g, " ").replace(/^ | $/g, "").toLowerCase().toUpperCase();
+}
+
+// node_modules/micromark-core-commonmark/lib/definition.js
+var definition = {
+  name: "definition",
+  tokenize: tokenizeDefinition
+};
+var titleConstruct = {
+  tokenize: tokenizeTitle,
+  partial: true
+};
+function tokenizeDefinition(effects, ok2, nok) {
+  const self2 = this;
+  let identifier;
+  return start3;
+  function start3(code2) {
+    effects.enter("definition");
+    return factoryLabel.call(
+      self2,
+      effects,
+      labelAfter,
+      nok,
+      "definitionLabel",
+      "definitionLabelMarker",
+      "definitionLabelString"
+    )(code2);
+  }
+  function labelAfter(code2) {
+    identifier = normalizeIdentifier(
+      self2.sliceSerialize(self2.events[self2.events.length - 1][1]).slice(1, -1)
+    );
+    if (code2 === 58) {
+      effects.enter("definitionMarker");
+      effects.consume(code2);
+      effects.exit("definitionMarker");
+      return factoryWhitespace(
+        effects,
+        factoryDestination(
+          effects,
+          effects.attempt(
+            titleConstruct,
+            factorySpace(effects, after, "whitespace"),
+            factorySpace(effects, after, "whitespace")
+          ),
+          nok,
+          "definitionDestination",
+          "definitionDestinationLiteral",
+          "definitionDestinationLiteralMarker",
+          "definitionDestinationRaw",
+          "definitionDestinationString"
+        )
+      );
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("definition");
+      if (!self2.parser.defined.includes(identifier)) {
+        self2.parser.defined.push(identifier);
+      }
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+function tokenizeTitle(effects, ok2, nok) {
+  return start3;
+  function start3(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, before)(code2) : nok(code2);
+  }
+  function before(code2) {
+    if (code2 === 34 || code2 === 39 || code2 === 40) {
+      return factoryTitle(
+        effects,
+        factorySpace(effects, after, "whitespace"),
+        nok,
+        "definitionTitle",
+        "definitionTitleMarker",
+        "definitionTitleString"
+      )(code2);
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return code2 === null || markdownLineEnding(code2) ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/hard-break-escape.js
+var hardBreakEscape = {
+  name: "hardBreakEscape",
+  tokenize: tokenizeHardBreakEscape
+};
+function tokenizeHardBreakEscape(effects, ok2, nok) {
+  return start3;
+  function start3(code2) {
+    effects.enter("hardBreakEscape");
+    effects.enter("escapeMarker");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.exit("escapeMarker");
+      effects.exit("hardBreakEscape");
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/heading-atx.js
+var headingAtx = {
+  name: "headingAtx",
+  tokenize: tokenizeHeadingAtx,
+  resolve: resolveHeadingAtx
+};
+function resolveHeadingAtx(events, context) {
+  let contentEnd = events.length - 2;
+  let contentStart = 3;
+  let content3;
+  let text5;
+  if (events[contentStart][1].type === "whitespace") {
+    contentStart += 2;
+  }
+  if (contentEnd - 2 > contentStart && events[contentEnd][1].type === "whitespace") {
+    contentEnd -= 2;
+  }
+  if (events[contentEnd][1].type === "atxHeadingSequence" && (contentStart === contentEnd - 1 || contentEnd - 4 > contentStart && events[contentEnd - 2][1].type === "whitespace")) {
+    contentEnd -= contentStart + 1 === contentEnd ? 2 : 4;
+  }
+  if (contentEnd > contentStart) {
+    content3 = {
+      type: "atxHeadingText",
+      start: events[contentStart][1].start,
+      end: events[contentEnd][1].end
+    };
+    text5 = {
+      type: "chunkText",
+      start: events[contentStart][1].start,
+      end: events[contentEnd][1].end,
+      contentType: "text"
+    };
+    splice(events, contentStart, contentEnd - contentStart + 1, [
+      ["enter", content3, context],
+      ["enter", text5, context],
+      ["exit", text5, context],
+      ["exit", content3, context]
+    ]);
+  }
+  return events;
+}
+function tokenizeHeadingAtx(effects, ok2, nok) {
+  const self2 = this;
+  let size = 0;
+  return start3;
+  function start3(code2) {
+    effects.enter("atxHeading");
+    effects.enter("atxHeadingSequence");
+    return fenceOpenInside(code2);
+  }
+  function fenceOpenInside(code2) {
+    if (code2 === 35 && size++ < 6) {
+      effects.consume(code2);
+      return fenceOpenInside;
+    }
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      effects.exit("atxHeadingSequence");
+      return self2.interrupt ? ok2(code2) : headingBreak(code2);
+    }
+    return nok(code2);
+  }
+  function headingBreak(code2) {
+    if (code2 === 35) {
+      effects.enter("atxHeadingSequence");
+      return sequence(code2);
+    }
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("atxHeading");
+      return ok2(code2);
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(effects, headingBreak, "whitespace")(code2);
+    }
+    effects.enter("atxHeadingText");
+    return data2(code2);
+  }
+  function sequence(code2) {
+    if (code2 === 35) {
+      effects.consume(code2);
+      return sequence;
+    }
+    effects.exit("atxHeadingSequence");
+    return headingBreak(code2);
+  }
+  function data2(code2) {
+    if (code2 === null || code2 === 35 || markdownLineEndingOrSpace(code2)) {
+      effects.exit("atxHeadingText");
+      return headingBreak(code2);
+    }
+    effects.consume(code2);
+    return data2;
+  }
+}
+
+// node_modules/micromark-util-html-tag-name/index.js
+var htmlBlockNames = [
+  "address",
+  "article",
+  "aside",
+  "base",
+  "basefont",
+  "blockquote",
+  "body",
+  "caption",
+  "center",
+  "col",
+  "colgroup",
+  "dd",
+  "details",
+  "dialog",
+  "dir",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hr",
+  "html",
+  "iframe",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "menu",
+  "menuitem",
+  "nav",
+  "noframes",
+  "ol",
+  "optgroup",
+  "option",
+  "p",
+  "param",
+  "section",
+  "summary",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "title",
+  "tr",
+  "track",
+  "ul"
+];
+var htmlRawNames = ["pre", "script", "style", "textarea"];
+
+// node_modules/micromark-core-commonmark/lib/html-flow.js
+var htmlFlow = {
+  name: "htmlFlow",
+  tokenize: tokenizeHtmlFlow,
+  resolveTo: resolveToHtmlFlow,
+  concrete: true
+};
+var nextBlankConstruct = {
+  tokenize: tokenizeNextBlank,
+  partial: true
+};
+function resolveToHtmlFlow(events) {
+  let index2 = events.length;
+  while (index2--) {
+    if (events[index2][0] === "enter" && events[index2][1].type === "htmlFlow") {
+      break;
+    }
+  }
+  if (index2 > 1 && events[index2 - 2][1].type === "linePrefix") {
+    events[index2][1].start = events[index2 - 2][1].start;
+    events[index2 + 1][1].start = events[index2 - 2][1].start;
+    events.splice(index2 - 2, 2);
+  }
+  return events;
+}
+function tokenizeHtmlFlow(effects, ok2, nok) {
+  const self2 = this;
+  let kind;
+  let startTag;
+  let buffer2;
+  let index2;
+  let marker;
+  return start3;
+  function start3(code2) {
+    effects.enter("htmlFlow");
+    effects.enter("htmlFlowData");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 33) {
+      effects.consume(code2);
+      return declarationStart;
+    }
+    if (code2 === 47) {
+      effects.consume(code2);
+      return tagCloseStart;
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      kind = 3;
+      return self2.interrupt ? ok2 : continuationDeclarationInside;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      buffer2 = String.fromCharCode(code2);
+      startTag = true;
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function declarationStart(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      kind = 2;
+      return commentOpenInside;
+    }
+    if (code2 === 91) {
+      effects.consume(code2);
+      kind = 5;
+      buffer2 = "CDATA[";
+      index2 = 0;
+      return cdataOpenInside;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      kind = 4;
+      return self2.interrupt ? ok2 : continuationDeclarationInside;
+    }
+    return nok(code2);
+  }
+  function commentOpenInside(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return self2.interrupt ? ok2 : continuationDeclarationInside;
+    }
+    return nok(code2);
+  }
+  function cdataOpenInside(code2) {
+    if (code2 === buffer2.charCodeAt(index2++)) {
+      effects.consume(code2);
+      return index2 === buffer2.length ? self2.interrupt ? ok2 : continuation : cdataOpenInside;
+    }
+    return nok(code2);
+  }
+  function tagCloseStart(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      buffer2 = String.fromCharCode(code2);
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function tagName(code2) {
+    if (code2 === null || code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      if (code2 !== 47 && startTag && htmlRawNames.includes(buffer2.toLowerCase())) {
+        kind = 1;
+        return self2.interrupt ? ok2(code2) : continuation(code2);
+      }
+      if (htmlBlockNames.includes(buffer2.toLowerCase())) {
+        kind = 6;
+        if (code2 === 47) {
+          effects.consume(code2);
+          return basicSelfClosing;
+        }
+        return self2.interrupt ? ok2(code2) : continuation(code2);
+      }
+      kind = 7;
+      return self2.interrupt && !self2.parser.lazy[self2.now().line] ? nok(code2) : startTag ? completeAttributeNameBefore(code2) : completeClosingTagAfter(code2);
+    }
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      buffer2 += String.fromCharCode(code2);
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function basicSelfClosing(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return self2.interrupt ? ok2 : continuation;
+    }
+    return nok(code2);
+  }
+  function completeClosingTagAfter(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeClosingTagAfter;
+    }
+    return completeEnd(code2);
+  }
+  function completeAttributeNameBefore(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return completeEnd;
+    }
+    if (code2 === 58 || code2 === 95 || asciiAlpha(code2)) {
+      effects.consume(code2);
+      return completeAttributeName;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeNameBefore;
+    }
+    return completeEnd(code2);
+  }
+  function completeAttributeName(code2) {
+    if (code2 === 45 || code2 === 46 || code2 === 58 || code2 === 95 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return completeAttributeName;
+    }
+    return completeAttributeNameAfter(code2);
+  }
+  function completeAttributeNameAfter(code2) {
+    if (code2 === 61) {
+      effects.consume(code2);
+      return completeAttributeValueBefore;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeNameAfter;
+    }
+    return completeAttributeNameBefore(code2);
+  }
+  function completeAttributeValueBefore(code2) {
+    if (code2 === null || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 34 || code2 === 39) {
+      effects.consume(code2);
+      marker = code2;
+      return completeAttributeValueQuoted;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeValueBefore;
+    }
+    marker = null;
+    return completeAttributeValueUnquoted(code2);
+  }
+  function completeAttributeValueQuoted(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    if (code2 === marker) {
+      effects.consume(code2);
+      return completeAttributeValueQuotedAfter;
+    }
+    effects.consume(code2);
+    return completeAttributeValueQuoted;
+  }
+  function completeAttributeValueUnquoted(code2) {
+    if (code2 === null || code2 === 34 || code2 === 39 || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96 || markdownLineEndingOrSpace(code2)) {
+      return completeAttributeNameAfter(code2);
+    }
+    effects.consume(code2);
+    return completeAttributeValueUnquoted;
+  }
+  function completeAttributeValueQuotedAfter(code2) {
+    if (code2 === 47 || code2 === 62 || markdownSpace(code2)) {
+      return completeAttributeNameBefore(code2);
+    }
+    return nok(code2);
+  }
+  function completeEnd(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return completeAfter;
+    }
+    return nok(code2);
+  }
+  function completeAfter(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAfter;
+    }
+    return code2 === null || markdownLineEnding(code2) ? continuation(code2) : nok(code2);
+  }
+  function continuation(code2) {
+    if (code2 === 45 && kind === 2) {
+      effects.consume(code2);
+      return continuationCommentInside;
+    }
+    if (code2 === 60 && kind === 1) {
+      effects.consume(code2);
+      return continuationRawTagOpen;
+    }
+    if (code2 === 62 && kind === 4) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (code2 === 63 && kind === 3) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    if (code2 === 93 && kind === 5) {
+      effects.consume(code2);
+      return continuationCharacterDataInside;
+    }
+    if (markdownLineEnding(code2) && (kind === 6 || kind === 7)) {
+      return effects.check(
+        nextBlankConstruct,
+        continuationClose,
+        continuationAtLineEnding
+      )(code2);
+    }
+    if (code2 === null || markdownLineEnding(code2)) {
+      return continuationAtLineEnding(code2);
+    }
+    effects.consume(code2);
+    return continuation;
+  }
+  function continuationAtLineEnding(code2) {
+    effects.exit("htmlFlowData");
+    return htmlContinueStart(code2);
+  }
+  function htmlContinueStart(code2) {
+    if (code2 === null) {
+      return done(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.attempt(
+        {
+          tokenize: htmlLineEnd,
+          partial: true
+        },
+        htmlContinueStart,
+        done
+      )(code2);
+    }
+    effects.enter("htmlFlowData");
+    return continuation(code2);
+  }
+  function htmlLineEnd(effects2, ok3, nok2) {
+    return start4;
+    function start4(code2) {
+      effects2.enter("lineEnding");
+      effects2.consume(code2);
+      effects2.exit("lineEnding");
+      return lineStart;
+    }
+    function lineStart(code2) {
+      return self2.parser.lazy[self2.now().line] ? nok2(code2) : ok3(code2);
+    }
+  }
+  function continuationCommentInside(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationRawTagOpen(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      buffer2 = "";
+      return continuationRawEndTag;
+    }
+    return continuation(code2);
+  }
+  function continuationRawEndTag(code2) {
+    if (code2 === 62 && htmlRawNames.includes(buffer2.toLowerCase())) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (asciiAlpha(code2) && buffer2.length < 8) {
+      effects.consume(code2);
+      buffer2 += String.fromCharCode(code2);
+      return continuationRawEndTag;
+    }
+    return continuation(code2);
+  }
+  function continuationCharacterDataInside(code2) {
+    if (code2 === 93) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationDeclarationInside(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (code2 === 45 && kind === 2) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationClose(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("htmlFlowData");
+      return done(code2);
+    }
+    effects.consume(code2);
+    return continuationClose;
+  }
+  function done(code2) {
+    effects.exit("htmlFlow");
+    return ok2(code2);
+  }
+}
+function tokenizeNextBlank(effects, ok2, nok) {
+  return start3;
+  function start3(code2) {
+    effects.exit("htmlFlowData");
+    effects.enter("lineEndingBlank");
+    effects.consume(code2);
+    effects.exit("lineEndingBlank");
+    return effects.attempt(blankLine, ok2, nok);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/html-text.js
+var htmlText = {
+  name: "htmlText",
+  tokenize: tokenizeHtmlText
+};
+function tokenizeHtmlText(effects, ok2, nok) {
+  const self2 = this;
+  let marker;
+  let buffer2;
+  let index2;
+  let returnState;
+  return start3;
+  function start3(code2) {
+    effects.enter("htmlText");
+    effects.enter("htmlTextData");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 33) {
+      effects.consume(code2);
+      return declarationOpen;
+    }
+    if (code2 === 47) {
+      effects.consume(code2);
+      return tagCloseStart;
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      return instruction;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagOpen;
+    }
+    return nok(code2);
+  }
+  function declarationOpen(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentOpen;
+    }
+    if (code2 === 91) {
+      effects.consume(code2);
+      buffer2 = "CDATA[";
+      index2 = 0;
+      return cdataOpen;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return declaration;
+    }
+    return nok(code2);
+  }
+  function commentOpen(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentStart;
+    }
+    return nok(code2);
+  }
+  function commentStart(code2) {
+    if (code2 === null || code2 === 62) {
+      return nok(code2);
+    }
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentStartDash;
+    }
+    return comment2(code2);
+  }
+  function commentStartDash(code2) {
+    if (code2 === null || code2 === 62) {
+      return nok(code2);
+    }
+    return comment2(code2);
+  }
+  function comment2(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = comment2;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return comment2;
+  }
+  function commentClose(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return end;
+    }
+    return comment2(code2);
+  }
+  function cdataOpen(code2) {
+    if (code2 === buffer2.charCodeAt(index2++)) {
+      effects.consume(code2);
+      return index2 === buffer2.length ? cdata : cdataOpen;
+    }
+    return nok(code2);
+  }
+  function cdata(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = cdata;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return cdata;
+  }
+  function cdataClose(code2) {
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataEnd;
+    }
+    return cdata(code2);
+  }
+  function cdataEnd(code2) {
+    if (code2 === 62) {
+      return end(code2);
+    }
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataEnd;
+    }
+    return cdata(code2);
+  }
+  function declaration(code2) {
+    if (code2 === null || code2 === 62) {
+      return end(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = declaration;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return declaration;
+  }
+  function instruction(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      return instructionClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = instruction;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return instruction;
+  }
+  function instructionClose(code2) {
+    return code2 === 62 ? end(code2) : instruction(code2);
+  }
+  function tagCloseStart(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagClose;
+    }
+    return nok(code2);
+  }
+  function tagClose(code2) {
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagClose;
+    }
+    return tagCloseBetween(code2);
+  }
+  function tagCloseBetween(code2) {
+    if (markdownLineEnding(code2)) {
+      returnState = tagCloseBetween;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagCloseBetween;
+    }
+    return end(code2);
+  }
+  function tagOpen(code2) {
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagOpen;
+    }
+    if (code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    return nok(code2);
+  }
+  function tagOpenBetween(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return end;
+    }
+    if (code2 === 58 || code2 === 95 || asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeName;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenBetween;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenBetween;
+    }
+    return end(code2);
+  }
+  function tagOpenAttributeName(code2) {
+    if (code2 === 45 || code2 === 46 || code2 === 58 || code2 === 95 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeName;
+    }
+    return tagOpenAttributeNameAfter(code2);
+  }
+  function tagOpenAttributeNameAfter(code2) {
+    if (code2 === 61) {
+      effects.consume(code2);
+      return tagOpenAttributeValueBefore;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeNameAfter;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeNameAfter;
+    }
+    return tagOpenBetween(code2);
+  }
+  function tagOpenAttributeValueBefore(code2) {
+    if (code2 === null || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 34 || code2 === 39) {
+      effects.consume(code2);
+      marker = code2;
+      return tagOpenAttributeValueQuoted;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeValueBefore;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeValueBefore;
+    }
+    effects.consume(code2);
+    marker = void 0;
+    return tagOpenAttributeValueUnquoted;
+  }
+  function tagOpenAttributeValueQuoted(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return tagOpenAttributeValueQuotedAfter;
+    }
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeValueQuoted;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return tagOpenAttributeValueQuoted;
+  }
+  function tagOpenAttributeValueQuotedAfter(code2) {
+    if (code2 === 62 || code2 === 47 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    return nok(code2);
+  }
+  function tagOpenAttributeValueUnquoted(code2) {
+    if (code2 === null || code2 === 34 || code2 === 39 || code2 === 60 || code2 === 61 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    effects.consume(code2);
+    return tagOpenAttributeValueUnquoted;
+  }
+  function atLineEnding(code2) {
+    effects.exit("htmlTextData");
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(
+      effects,
+      afterPrefix,
+      "linePrefix",
+      self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+    );
+  }
+  function afterPrefix(code2) {
+    effects.enter("htmlTextData");
+    return returnState(code2);
+  }
+  function end(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      effects.exit("htmlTextData");
+      effects.exit("htmlText");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-end.js
+var labelEnd = {
+  name: "labelEnd",
+  tokenize: tokenizeLabelEnd,
+  resolveTo: resolveToLabelEnd,
+  resolveAll: resolveAllLabelEnd
+};
+var resourceConstruct = {
+  tokenize: tokenizeResource
+};
+var fullReferenceConstruct = {
+  tokenize: tokenizeFullReference
+};
+var collapsedReferenceConstruct = {
+  tokenize: tokenizeCollapsedReference
+};
+function resolveAllLabelEnd(events) {
+  let index2 = -1;
+  let token;
+  while (++index2 < events.length) {
+    token = events[index2][1];
+    if (token.type === "labelImage" || token.type === "labelLink" || token.type === "labelEnd") {
+      events.splice(index2 + 1, token.type === "labelImage" ? 4 : 2);
+      token.type = "data";
+      index2++;
+    }
+  }
+  return events;
+}
+function resolveToLabelEnd(events, context) {
+  let index2 = events.length;
+  let offset2 = 0;
+  let token;
+  let open;
+  let close;
+  let media;
+  while (index2--) {
+    token = events[index2][1];
+    if (open) {
+      if (token.type === "link" || token.type === "labelLink" && token._inactive) {
+        break;
+      }
+      if (events[index2][0] === "enter" && token.type === "labelLink") {
+        token._inactive = true;
+      }
+    } else if (close) {
+      if (events[index2][0] === "enter" && (token.type === "labelImage" || token.type === "labelLink") && !token._balanced) {
+        open = index2;
+        if (token.type !== "labelLink") {
+          offset2 = 2;
+          break;
+        }
+      }
+    } else if (token.type === "labelEnd") {
+      close = index2;
+    }
+  }
+  const group = {
+    type: events[open][1].type === "labelLink" ? "link" : "image",
+    start: Object.assign({}, events[open][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  const label = {
+    type: "label",
+    start: Object.assign({}, events[open][1].start),
+    end: Object.assign({}, events[close][1].end)
+  };
+  const text5 = {
+    type: "labelText",
+    start: Object.assign({}, events[open + offset2 + 2][1].end),
+    end: Object.assign({}, events[close - 2][1].start)
+  };
+  media = [
+    ["enter", group, context],
+    ["enter", label, context]
+  ];
+  media = push(media, events.slice(open + 1, open + offset2 + 3));
+  media = push(media, [["enter", text5, context]]);
+  media = push(
+    media,
+    resolveAll(
+      context.parser.constructs.insideSpan.null,
+      events.slice(open + offset2 + 4, close - 3),
+      context
+    )
+  );
+  media = push(media, [
+    ["exit", text5, context],
+    events[close - 2],
+    events[close - 1],
+    ["exit", label, context]
+  ]);
+  media = push(media, events.slice(close + 1));
+  media = push(media, [["exit", group, context]]);
+  splice(events, open, events.length, media);
+  return events;
+}
+function tokenizeLabelEnd(effects, ok2, nok) {
+  const self2 = this;
+  let index2 = self2.events.length;
+  let labelStart;
+  let defined;
+  while (index2--) {
+    if ((self2.events[index2][1].type === "labelImage" || self2.events[index2][1].type === "labelLink") && !self2.events[index2][1]._balanced) {
+      labelStart = self2.events[index2][1];
+      break;
+    }
+  }
+  return start3;
+  function start3(code2) {
+    if (!labelStart) {
+      return nok(code2);
+    }
+    if (labelStart._inactive)
+      return balanced(code2);
+    defined = self2.parser.defined.includes(
+      normalizeIdentifier(
+        self2.sliceSerialize({
+          start: labelStart.end,
+          end: self2.now()
+        })
+      )
+    );
+    effects.enter("labelEnd");
+    effects.enter("labelMarker");
+    effects.consume(code2);
+    effects.exit("labelMarker");
+    effects.exit("labelEnd");
+    return afterLabelEnd;
+  }
+  function afterLabelEnd(code2) {
+    if (code2 === 40) {
+      return effects.attempt(
+        resourceConstruct,
+        ok2,
+        defined ? ok2 : balanced
+      )(code2);
+    }
+    if (code2 === 91) {
+      return effects.attempt(
+        fullReferenceConstruct,
+        ok2,
+        defined ? effects.attempt(collapsedReferenceConstruct, ok2, balanced) : balanced
+      )(code2);
+    }
+    return defined ? ok2(code2) : balanced(code2);
+  }
+  function balanced(code2) {
+    labelStart._balanced = true;
+    return nok(code2);
+  }
+}
+function tokenizeResource(effects, ok2, nok) {
+  return start3;
+  function start3(code2) {
+    effects.enter("resource");
+    effects.enter("resourceMarker");
+    effects.consume(code2);
+    effects.exit("resourceMarker");
+    return factoryWhitespace(effects, open);
+  }
+  function open(code2) {
+    if (code2 === 41) {
+      return end(code2);
+    }
+    return factoryDestination(
+      effects,
+      destinationAfter,
+      nok,
+      "resourceDestination",
+      "resourceDestinationLiteral",
+      "resourceDestinationLiteralMarker",
+      "resourceDestinationRaw",
+      "resourceDestinationString",
+      32
+    )(code2);
+  }
+  function destinationAfter(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, between)(code2) : end(code2);
+  }
+  function between(code2) {
+    if (code2 === 34 || code2 === 39 || code2 === 40) {
+      return factoryTitle(
+        effects,
+        factoryWhitespace(effects, end),
+        nok,
+        "resourceTitle",
+        "resourceTitleMarker",
+        "resourceTitleString"
+      )(code2);
+    }
+    return end(code2);
+  }
+  function end(code2) {
+    if (code2 === 41) {
+      effects.enter("resourceMarker");
+      effects.consume(code2);
+      effects.exit("resourceMarker");
+      effects.exit("resource");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+function tokenizeFullReference(effects, ok2, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code2) {
+    return factoryLabel.call(
+      self2,
+      effects,
+      afterLabel,
+      nok,
+      "reference",
+      "referenceMarker",
+      "referenceString"
+    )(code2);
+  }
+  function afterLabel(code2) {
+    return self2.parser.defined.includes(
+      normalizeIdentifier(
+        self2.sliceSerialize(self2.events[self2.events.length - 1][1]).slice(1, -1)
+      )
+    ) ? ok2(code2) : nok(code2);
+  }
+}
+function tokenizeCollapsedReference(effects, ok2, nok) {
+  return start3;
+  function start3(code2) {
+    effects.enter("reference");
+    effects.enter("referenceMarker");
+    effects.consume(code2);
+    effects.exit("referenceMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 93) {
+      effects.enter("referenceMarker");
+      effects.consume(code2);
+      effects.exit("referenceMarker");
+      effects.exit("reference");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-start-image.js
+var labelStartImage = {
+  name: "labelStartImage",
+  tokenize: tokenizeLabelStartImage,
+  resolveAll: labelEnd.resolveAll
+};
+function tokenizeLabelStartImage(effects, ok2, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code2) {
+    effects.enter("labelImage");
+    effects.enter("labelImageMarker");
+    effects.consume(code2);
+    effects.exit("labelImageMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 91) {
+      effects.enter("labelMarker");
+      effects.consume(code2);
+      effects.exit("labelMarker");
+      effects.exit("labelImage");
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return code2 === 94 && "_hiddenFootnoteSupport" in self2.parser.constructs ? nok(code2) : ok2(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-start-link.js
+var labelStartLink = {
+  name: "labelStartLink",
+  tokenize: tokenizeLabelStartLink,
+  resolveAll: labelEnd.resolveAll
+};
+function tokenizeLabelStartLink(effects, ok2, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code2) {
+    effects.enter("labelLink");
+    effects.enter("labelMarker");
+    effects.consume(code2);
+    effects.exit("labelMarker");
+    effects.exit("labelLink");
+    return after;
+  }
+  function after(code2) {
+    return code2 === 94 && "_hiddenFootnoteSupport" in self2.parser.constructs ? nok(code2) : ok2(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/line-ending.js
+var lineEnding = {
+  name: "lineEnding",
+  tokenize: tokenizeLineEnding
+};
+function tokenizeLineEnding(effects, ok2) {
+  return start3;
+  function start3(code2) {
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, ok2, "linePrefix");
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/thematic-break.js
+var thematicBreak = {
+  name: "thematicBreak",
+  tokenize: tokenizeThematicBreak
+};
+function tokenizeThematicBreak(effects, ok2, nok) {
+  let size = 0;
+  let marker;
+  return start3;
+  function start3(code2) {
+    effects.enter("thematicBreak");
+    marker = code2;
+    return atBreak(code2);
+  }
+  function atBreak(code2) {
+    if (code2 === marker) {
+      effects.enter("thematicBreakSequence");
+      return sequence(code2);
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(effects, atBreak, "whitespace")(code2);
+    }
+    if (size < 3 || code2 !== null && !markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    effects.exit("thematicBreak");
+    return ok2(code2);
+  }
+  function sequence(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      size++;
+      return sequence;
+    }
+    effects.exit("thematicBreakSequence");
+    return atBreak(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/list.js
+var list = {
+  name: "list",
+  tokenize: tokenizeListStart,
+  continuation: {
+    tokenize: tokenizeListContinuation
+  },
+  exit: tokenizeListEnd
+};
+var listItemPrefixWhitespaceConstruct = {
+  tokenize: tokenizeListItemPrefixWhitespace,
+  partial: true
+};
+var indentConstruct = {
+  tokenize: tokenizeIndent,
+  partial: true
+};
+function tokenizeListStart(effects, ok2, nok) {
+  const self2 = this;
+  const tail = self2.events[self2.events.length - 1];
+  let initialSize = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  let size = 0;
+  return start3;
+  function start3(code2) {
+    const kind = self2.containerState.type || (code2 === 42 || code2 === 43 || code2 === 45 ? "listUnordered" : "listOrdered");
+    if (kind === "listUnordered" ? !self2.containerState.marker || code2 === self2.containerState.marker : asciiDigit(code2)) {
+      if (!self2.containerState.type) {
+        self2.containerState.type = kind;
+        effects.enter(kind, {
+          _container: true
+        });
+      }
+      if (kind === "listUnordered") {
+        effects.enter("listItemPrefix");
+        return code2 === 42 || code2 === 45 ? effects.check(thematicBreak, nok, atMarker)(code2) : atMarker(code2);
+      }
+      if (!self2.interrupt || code2 === 49) {
+        effects.enter("listItemPrefix");
+        effects.enter("listItemValue");
+        return inside(code2);
+      }
+    }
+    return nok(code2);
+  }
+  function inside(code2) {
+    if (asciiDigit(code2) && ++size < 10) {
+      effects.consume(code2);
+      return inside;
+    }
+    if ((!self2.interrupt || size < 2) && (self2.containerState.marker ? code2 === self2.containerState.marker : code2 === 41 || code2 === 46)) {
+      effects.exit("listItemValue");
+      return atMarker(code2);
+    }
+    return nok(code2);
+  }
+  function atMarker(code2) {
+    effects.enter("listItemMarker");
+    effects.consume(code2);
+    effects.exit("listItemMarker");
+    self2.containerState.marker = self2.containerState.marker || code2;
+    return effects.check(
+      blankLine,
+      self2.interrupt ? nok : onBlank,
+      effects.attempt(
+        listItemPrefixWhitespaceConstruct,
+        endOfPrefix,
+        otherPrefix
+      )
+    );
+  }
+  function onBlank(code2) {
+    self2.containerState.initialBlankLine = true;
+    initialSize++;
+    return endOfPrefix(code2);
+  }
+  function otherPrefix(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter("listItemPrefixWhitespace");
+      effects.consume(code2);
+      effects.exit("listItemPrefixWhitespace");
+      return endOfPrefix;
+    }
+    return nok(code2);
+  }
+  function endOfPrefix(code2) {
+    self2.containerState.size = initialSize + self2.sliceSerialize(effects.exit("listItemPrefix"), true).length;
+    return ok2(code2);
+  }
+}
+function tokenizeListContinuation(effects, ok2, nok) {
+  const self2 = this;
+  self2.containerState._closeFlow = void 0;
+  return effects.check(blankLine, onBlank, notBlank);
+  function onBlank(code2) {
+    self2.containerState.furtherBlankLines = self2.containerState.furtherBlankLines || self2.containerState.initialBlankLine;
+    return factorySpace(
+      effects,
+      ok2,
+      "listItemIndent",
+      self2.containerState.size + 1
+    )(code2);
+  }
+  function notBlank(code2) {
+    if (self2.containerState.furtherBlankLines || !markdownSpace(code2)) {
+      self2.containerState.furtherBlankLines = void 0;
+      self2.containerState.initialBlankLine = void 0;
+      return notInCurrentItem(code2);
+    }
+    self2.containerState.furtherBlankLines = void 0;
+    self2.containerState.initialBlankLine = void 0;
+    return effects.attempt(indentConstruct, ok2, notInCurrentItem)(code2);
+  }
+  function notInCurrentItem(code2) {
+    self2.containerState._closeFlow = true;
+    self2.interrupt = void 0;
+    return factorySpace(
+      effects,
+      effects.attempt(list, ok2, nok),
+      "linePrefix",
+      self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+    )(code2);
+  }
+}
+function tokenizeIndent(effects, ok2, nok) {
+  const self2 = this;
+  return factorySpace(
+    effects,
+    afterPrefix,
+    "listItemIndent",
+    self2.containerState.size + 1
+  );
+  function afterPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return tail && tail[1].type === "listItemIndent" && tail[2].sliceSerialize(tail[1], true).length === self2.containerState.size ? ok2(code2) : nok(code2);
+  }
+}
+function tokenizeListEnd(effects) {
+  effects.exit(this.containerState.type);
+}
+function tokenizeListItemPrefixWhitespace(effects, ok2, nok) {
+  const self2 = this;
+  return factorySpace(
+    effects,
+    afterPrefix,
+    "listItemPrefixWhitespace",
+    self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4 + 1
+  );
+  function afterPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return !markdownSpace(code2) && tail && tail[1].type === "listItemPrefixWhitespace" ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/setext-underline.js
+var setextUnderline = {
+  name: "setextUnderline",
+  tokenize: tokenizeSetextUnderline,
+  resolveTo: resolveToSetextUnderline
+};
+function resolveToSetextUnderline(events, context) {
+  let index2 = events.length;
+  let content3;
+  let text5;
+  let definition2;
+  while (index2--) {
+    if (events[index2][0] === "enter") {
+      if (events[index2][1].type === "content") {
+        content3 = index2;
+        break;
+      }
+      if (events[index2][1].type === "paragraph") {
+        text5 = index2;
+      }
+    } else {
+      if (events[index2][1].type === "content") {
+        events.splice(index2, 1);
+      }
+      if (!definition2 && events[index2][1].type === "definition") {
+        definition2 = index2;
+      }
+    }
+  }
+  const heading2 = {
+    type: "setextHeading",
+    start: Object.assign({}, events[text5][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  events[text5][1].type = "setextHeadingText";
+  if (definition2) {
+    events.splice(text5, 0, ["enter", heading2, context]);
+    events.splice(definition2 + 1, 0, ["exit", events[content3][1], context]);
+    events[content3][1].end = Object.assign({}, events[definition2][1].end);
+  } else {
+    events[content3][1] = heading2;
+  }
+  events.push(["exit", heading2, context]);
+  return events;
+}
+function tokenizeSetextUnderline(effects, ok2, nok) {
+  const self2 = this;
+  let index2 = self2.events.length;
+  let marker;
+  let paragraph2;
+  while (index2--) {
+    if (self2.events[index2][1].type !== "lineEnding" && self2.events[index2][1].type !== "linePrefix" && self2.events[index2][1].type !== "content") {
+      paragraph2 = self2.events[index2][1].type === "paragraph";
+      break;
+    }
+  }
+  return start3;
+  function start3(code2) {
+    if (!self2.parser.lazy[self2.now().line] && (self2.interrupt || paragraph2)) {
+      effects.enter("setextHeadingLine");
+      effects.enter("setextHeadingLineSequence");
+      marker = code2;
+      return closingSequence(code2);
+    }
+    return nok(code2);
+  }
+  function closingSequence(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return closingSequence;
+    }
+    effects.exit("setextHeadingLineSequence");
+    return factorySpace(effects, closingSequenceEnd, "lineSuffix")(code2);
+  }
+  function closingSequenceEnd(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("setextHeadingLine");
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-extension-mdxjs-esm/lib/syntax.js
+var nextBlankConstruct2 = {
+  tokenize: tokenizeNextBlank2,
+  partial: true
+};
+var allowedAcornTypes = /* @__PURE__ */ new Set([
+  "ExportAllDeclaration",
+  "ExportDefaultDeclaration",
+  "ExportNamedDeclaration",
+  "ImportDeclaration"
+]);
+function mdxjsEsm(options) {
+  const exportImportConstruct = {
+    tokenize: tokenizeExportImport,
+    concrete: true
+  };
+  if (!options || !options.acorn || !options.acorn.parse) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  const acorn = options.acorn;
+  const acornOptions = Object.assign(
+    {
+      ecmaVersion: 2020,
+      sourceType: "module"
+    },
+    options.acornOptions
+  );
+  return {
+    flow: {
+      [101]: exportImportConstruct,
+      [105]: exportImportConstruct
+    }
+  };
+  function tokenizeExportImport(effects, ok2, nok) {
+    const self2 = this;
+    const definedModuleSpecifiers = self2.parser.definedModuleSpecifiers || (self2.parser.definedModuleSpecifiers = []);
+    const eventStart = this.events.length + 1;
+    let index2 = 0;
+    let buffer2;
+    return self2.interrupt ? nok : start3;
+    function start3(code2) {
+      if (self2.now().column > 1)
+        return nok(code2);
+      buffer2 = code2 === 101 ? "export" : "import";
+      effects.enter("mdxjsEsm");
+      effects.enter("mdxjsEsmData");
+      return keyword(code2);
+    }
+    function keyword(code2) {
+      if (code2 === buffer2.charCodeAt(index2++)) {
+        effects.consume(code2);
+        return index2 === buffer2.length ? after : keyword;
+      }
+      return nok(code2);
+    }
+    function after(code2) {
+      if (unicodeWhitespace(code2)) {
+        effects.consume(code2);
+        return rest;
+      }
+      return nok(code2);
+    }
+    function rest(code2) {
+      if (code2 === null) {
+        return atEndOfData(code2);
+      }
+      if (markdownLineEnding(code2)) {
+        return effects.check(nextBlankConstruct2, atEndOfData, atEol)(code2);
+      }
+      effects.consume(code2);
+      return rest;
+    }
+    function atEol(code2) {
+      effects.exit("mdxjsEsmData");
+      return lineStart(code2);
+    }
+    function lineStart(code2) {
+      if (markdownLineEnding(code2)) {
+        effects.enter("lineEnding");
+        effects.consume(code2);
+        effects.exit("lineEnding");
+        return lineStart;
+      }
+      if (code2 === null) {
+        return atEnd(code2);
+      }
+      effects.enter("mdxjsEsmData");
+      return rest(code2);
+    }
+    function atEndOfData(code2) {
+      effects.exit("mdxjsEsmData");
+      return atEnd(code2);
+    }
+    function atEnd(code2) {
+      let index3 = -1;
+      const result = eventsToAcorn(self2.events.slice(eventStart), {
+        acorn,
+        acornOptions,
+        prefix: definedModuleSpecifiers.length > 0 ? "var " + definedModuleSpecifiers.join(",") + "\n" : ""
+      });
+      if (code2 !== null && result.swallow) {
+        return lineStart(code2);
+      }
+      if (result.error) {
+        throw new VFileMessage(
+          "Could not parse import/exports with acorn: " + String(result.error),
+          {
+            line: result.error.loc.line,
+            column: result.error.loc.column + 1,
+            offset: result.error.pos
+          },
+          "micromark-extension-mdxjs-esm:acorn"
+        );
+      }
+      if (definedModuleSpecifiers.length > 0) {
+        result.estree.body.shift();
+      }
+      while (++index3 < result.estree.body.length) {
+        const node = result.estree.body[index3];
+        if (!allowedAcornTypes.has(node.type)) {
+          throw new VFileMessage(
+            "Unexpected `" + node.type + "` in code: only import/exports are supported",
+            positionFromEstree(node),
+            "micromark-extension-mdxjs-esm:non-esm"
+          );
+        }
+        if (node.type === "ImportDeclaration" && !self2.interrupt) {
+          let index4 = -1;
+          while (++index4 < node.specifiers.length) {
+            definedModuleSpecifiers.push(node.specifiers[index4].local.name);
+          }
+        }
+      }
+      Object.assign(
+        effects.exit("mdxjsEsm"),
+        options.addResult ? {
+          estree: result.estree
+        } : void 0
+      );
+      return ok2(code2);
+    }
+  }
+}
+function tokenizeNextBlank2(effects, ok2, nok) {
+  return start3;
+  function start3(code2) {
+    effects.exit("mdxjsEsmData");
+    effects.enter("lineEndingBlank");
+    effects.consume(code2);
+    effects.exit("lineEndingBlank");
+    return effects.attempt(blankLine, ok2, nok);
+  }
+}
+
+// node_modules/micromark-extension-mdxjs/index.js
+function mdxjs(options) {
+  const settings = Object.assign(
+    {
+      acorn: Parser.extend((0, import_acorn_jsx.default)()),
+      acornOptions: { ecmaVersion: 2020, sourceType: "module" },
+      addResult: true
+    },
+    options
+  );
+  return combineExtensions([
+    mdxjsEsm(settings),
+    mdxExpression(settings),
+    mdxJsx(settings),
+    mdxMd
+  ]);
+}
+
+// node_modules/mdast-util-mdx-expression/index.js
+var mdxExpressionFromMarkdown = {
+  enter: {
+    mdxFlowExpression: enterMdxFlowExpression,
+    mdxTextExpression: enterMdxTextExpression
+  },
+  exit: {
+    mdxFlowExpression: exitMdxExpression,
+    mdxFlowExpressionChunk: exitMdxExpressionData,
+    mdxTextExpression: exitMdxExpression,
+    mdxTextExpressionChunk: exitMdxExpressionData
+  }
+};
+var mdxExpressionToMarkdown = {
+  handlers: {
+    mdxFlowExpression: handleMdxExpression,
+    mdxTextExpression: handleMdxExpression
+  },
+  unsafe: [
+    { character: "{", inConstruct: ["phrasing"] },
+    { atBreak: true, character: "{" }
+  ]
+};
+function enterMdxFlowExpression(token) {
+  this.enter({ type: "mdxFlowExpression", value: "" }, token);
+  this.buffer();
+}
+function enterMdxTextExpression(token) {
+  this.enter({ type: "mdxTextExpression", value: "" }, token);
+  this.buffer();
+}
+function exitMdxExpression(token) {
+  const value = this.resume();
+  const estree = token.estree;
+  const node = this.exit(token);
+  node.value = value;
+  if (estree) {
+    node.data = { estree };
+  }
+}
+function exitMdxExpressionData(token) {
+  this.config.enter.data.call(this, token);
+  this.config.exit.data.call(this, token);
+}
+function handleMdxExpression(node) {
+  const value = node.value || "";
+  return "{" + value + "}";
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/ccount/index.js
+function ccount(value, character) {
+  const source = String(value);
+  if (typeof character !== "string") {
+    throw new TypeError("Expected character");
+  }
+  let count = 0;
+  let index2 = source.indexOf(character);
+  while (index2 !== -1) {
+    count++;
+    index2 = source.indexOf(character, index2 + character.length);
+  }
+  return count;
+}
+
+// node_modules/parse-entities/node_modules/character-entities-legacy/index.js
+var characterEntitiesLegacy = [
+  "AElig",
+  "AMP",
+  "Aacute",
+  "Acirc",
+  "Agrave",
+  "Aring",
+  "Atilde",
+  "Auml",
+  "COPY",
+  "Ccedil",
+  "ETH",
+  "Eacute",
+  "Ecirc",
+  "Egrave",
+  "Euml",
+  "GT",
+  "Iacute",
+  "Icirc",
+  "Igrave",
+  "Iuml",
+  "LT",
+  "Ntilde",
+  "Oacute",
+  "Ocirc",
+  "Ograve",
+  "Oslash",
+  "Otilde",
+  "Ouml",
+  "QUOT",
+  "REG",
+  "THORN",
+  "Uacute",
+  "Ucirc",
+  "Ugrave",
+  "Uuml",
+  "Yacute",
+  "aacute",
+  "acirc",
+  "acute",
+  "aelig",
+  "agrave",
+  "amp",
+  "aring",
+  "atilde",
+  "auml",
+  "brvbar",
+  "ccedil",
+  "cedil",
+  "cent",
+  "copy",
+  "curren",
+  "deg",
+  "divide",
+  "eacute",
+  "ecirc",
+  "egrave",
+  "eth",
+  "euml",
+  "frac12",
+  "frac14",
+  "frac34",
+  "gt",
+  "iacute",
+  "icirc",
+  "iexcl",
+  "igrave",
+  "iquest",
+  "iuml",
+  "laquo",
+  "lt",
+  "macr",
+  "micro",
+  "middot",
+  "nbsp",
+  "not",
+  "ntilde",
+  "oacute",
+  "ocirc",
+  "ograve",
+  "ordf",
+  "ordm",
+  "oslash",
+  "otilde",
+  "ouml",
+  "para",
+  "plusmn",
+  "pound",
+  "quot",
+  "raquo",
+  "reg",
+  "sect",
+  "shy",
+  "sup1",
+  "sup2",
+  "sup3",
+  "szlig",
+  "thorn",
+  "times",
+  "uacute",
+  "ucirc",
+  "ugrave",
+  "uml",
+  "uuml",
+  "yacute",
+  "yen",
+  "yuml"
+];
+
+// node_modules/character-reference-invalid/index.js
+var characterReferenceInvalid = {
+  0: "\uFFFD",
+  128: "\u20AC",
+  130: "\u201A",
+  131: "\u0192",
+  132: "\u201E",
+  133: "\u2026",
+  134: "\u2020",
+  135: "\u2021",
+  136: "\u02C6",
+  137: "\u2030",
+  138: "\u0160",
+  139: "\u2039",
+  140: "\u0152",
+  142: "\u017D",
+  145: "\u2018",
+  146: "\u2019",
+  147: "\u201C",
+  148: "\u201D",
+  149: "\u2022",
+  150: "\u2013",
+  151: "\u2014",
+  152: "\u02DC",
+  153: "\u2122",
+  154: "\u0161",
+  155: "\u203A",
+  156: "\u0153",
+  158: "\u017E",
+  159: "\u0178"
+};
+
+// node_modules/parse-entities/node_modules/is-decimal/index.js
+function isDecimal(character) {
+  const code2 = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code2 >= 48 && code2 <= 57;
+}
+
+// node_modules/is-hexadecimal/index.js
+function isHexadecimal(character) {
+  const code2 = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code2 >= 97 && code2 <= 102 || code2 >= 65 && code2 <= 70 || code2 >= 48 && code2 <= 57;
+}
+
+// node_modules/is-alphanumerical/node_modules/is-alphabetical/index.js
+function isAlphabetical(character) {
+  const code2 = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code2 >= 97 && code2 <= 122 || code2 >= 65 && code2 <= 90;
+}
+
+// node_modules/is-alphanumerical/node_modules/is-decimal/index.js
+function isDecimal2(character) {
+  const code2 = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code2 >= 48 && code2 <= 57;
+}
+
+// node_modules/is-alphanumerical/index.js
+function isAlphanumerical(character) {
+  return isAlphabetical(character) || isDecimal2(character);
+}
+
+// node_modules/parse-entities/lib/index.js
+var fromCharCode = String.fromCharCode;
+var messages = [
+  "",
+  "Named character references must be terminated by a semicolon",
+  "Numeric character references must be terminated by a semicolon",
+  "Named character references cannot be empty",
+  "Numeric character references cannot be empty",
+  "Named character references must be known",
+  "Numeric character references cannot be disallowed",
+  "Numeric character references cannot be outside the permissible Unicode range"
+];
+function parseEntities(value, options = {}) {
+  const additional = typeof options.additional === "string" ? options.additional.charCodeAt(0) : options.additional;
+  const result = [];
+  let index2 = 0;
+  let lines = -1;
+  let queue = "";
+  let point3;
+  let indent;
+  if (options.position) {
+    if ("start" in options.position || "indent" in options.position) {
+      indent = options.position.indent;
+      point3 = options.position.start;
+    } else {
+      point3 = options.position;
+    }
+  }
+  let line = (point3 ? point3.line : 0) || 1;
+  let column = (point3 ? point3.column : 0) || 1;
+  let previous2 = now();
+  let character;
+  index2--;
+  while (++index2 <= value.length) {
+    if (character === 10) {
+      column = (indent ? indent[lines] : 0) || 1;
+    }
+    character = value.charCodeAt(index2);
+    if (character === 38) {
+      const following = value.charCodeAt(index2 + 1);
+      if (following === 9 || following === 10 || following === 12 || following === 32 || following === 38 || following === 60 || Number.isNaN(following) || additional && following === additional) {
+        queue += fromCharCode(character);
+        column++;
+        continue;
+      }
+      const start3 = index2 + 1;
+      let begin = start3;
+      let end = start3;
+      let type;
+      if (following === 35) {
+        end = ++begin;
+        const following2 = value.charCodeAt(end);
+        if (following2 === 88 || following2 === 120) {
+          type = "hexadecimal";
+          end = ++begin;
+        } else {
+          type = "decimal";
+        }
+      } else {
+        type = "named";
+      }
+      let characterReferenceCharacters = "";
+      let characterReference2 = "";
+      let characters = "";
+      const test = type === "named" ? isAlphanumerical : type === "decimal" ? isDecimal : isHexadecimal;
+      end--;
+      while (++end <= value.length) {
+        const following2 = value.charCodeAt(end);
+        if (!test(following2)) {
+          break;
+        }
+        characters += fromCharCode(following2);
+        if (type === "named" && characterEntitiesLegacy.includes(characters)) {
+          characterReferenceCharacters = characters;
+          characterReference2 = decodeNamedCharacterReference(characters);
+        }
+      }
+      let terminated = value.charCodeAt(end) === 59;
+      if (terminated) {
+        end++;
+        const namedReference = type === "named" ? decodeNamedCharacterReference(characters) : false;
+        if (namedReference) {
+          characterReferenceCharacters = characters;
+          characterReference2 = namedReference;
+        }
+      }
+      let diff = 1 + end - start3;
+      let reference = "";
+      if (!terminated && options.nonTerminated === false) {
+      } else if (!characters) {
+        if (type !== "named") {
+          warning(4, diff);
+        }
+      } else if (type === "named") {
+        if (terminated && !characterReference2) {
+          warning(5, 1);
+        } else {
+          if (characterReferenceCharacters !== characters) {
+            end = begin + characterReferenceCharacters.length;
+            diff = 1 + end - begin;
+            terminated = false;
+          }
+          if (!terminated) {
+            const reason = characterReferenceCharacters ? 1 : 3;
+            if (options.attribute) {
+              const following2 = value.charCodeAt(end);
+              if (following2 === 61) {
+                warning(reason, diff);
+                characterReference2 = "";
+              } else if (isAlphanumerical(following2)) {
+                characterReference2 = "";
+              } else {
+                warning(reason, diff);
+              }
+            } else {
+              warning(reason, diff);
+            }
+          }
+        }
+        reference = characterReference2;
+      } else {
+        if (!terminated) {
+          warning(2, diff);
+        }
+        let referenceCode = Number.parseInt(
+          characters,
+          type === "hexadecimal" ? 16 : 10
+        );
+        if (prohibited(referenceCode)) {
+          warning(7, diff);
+          reference = fromCharCode(65533);
+        } else if (referenceCode in characterReferenceInvalid) {
+          warning(6, diff);
+          reference = characterReferenceInvalid[referenceCode];
+        } else {
+          let output = "";
+          if (disallowed(referenceCode)) {
+            warning(6, diff);
+          }
+          if (referenceCode > 65535) {
+            referenceCode -= 65536;
+            output += fromCharCode(referenceCode >>> (10 & 1023) | 55296);
+            referenceCode = 56320 | referenceCode & 1023;
+          }
+          reference = output + fromCharCode(referenceCode);
+        }
+      }
+      if (reference) {
+        flush();
+        previous2 = now();
+        index2 = end - 1;
+        column += end - start3 + 1;
+        result.push(reference);
+        const next = now();
+        next.offset++;
+        if (options.reference) {
+          options.reference.call(
+            options.referenceContext,
+            reference,
+            { start: previous2, end: next },
+            value.slice(start3 - 1, end)
+          );
+        }
+        previous2 = next;
+      } else {
+        characters = value.slice(start3 - 1, end);
+        queue += characters;
+        column += characters.length;
+        index2 = end - 1;
+      }
+    } else {
+      if (character === 10) {
+        line++;
+        lines++;
+        column = 0;
+      }
+      if (Number.isNaN(character)) {
+        flush();
+      } else {
+        queue += fromCharCode(character);
+        column++;
+      }
+    }
+  }
+  return result.join("");
+  function now() {
+    return {
+      line,
+      column,
+      offset: index2 + ((point3 ? point3.offset : 0) || 0)
+    };
+  }
+  function warning(code2, offset2) {
+    let position3;
+    if (options.warning) {
+      position3 = now();
+      position3.column += offset2;
+      position3.offset += offset2;
+      options.warning.call(
+        options.warningContext,
+        messages[code2],
+        position3,
+        code2
+      );
+    }
+  }
+  function flush() {
+    if (queue) {
+      result.push(queue);
+      if (options.text) {
+        options.text.call(options.textContext, queue, {
+          start: previous2,
+          end: now()
+        });
+      }
+      queue = "";
+    }
+  }
+}
+function prohibited(code2) {
+  return code2 >= 55296 && code2 <= 57343 || code2 > 1114111;
+}
+function disallowed(code2) {
+  return code2 >= 1 && code2 <= 8 || code2 === 11 || code2 >= 13 && code2 <= 31 || code2 >= 127 && code2 <= 159 || code2 >= 64976 && code2 <= 65007 || (code2 & 65535) === 65535 || (code2 & 65535) === 65534;
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/stringify-entities/lib/core.js
+function core(value, options) {
+  value = value.replace(
+    options.subset ? charactersToExpression(options.subset) : /["&'<>`]/g,
+    basic
+  );
+  if (options.subset || options.escapeOnly) {
+    return value;
+  }
+  return value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, surrogate).replace(
+    /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g,
+    basic
+  );
+  function surrogate(pair, index2, all4) {
+    return options.format(
+      (pair.charCodeAt(0) - 55296) * 1024 + pair.charCodeAt(1) - 56320 + 65536,
+      all4.charCodeAt(index2 + 2),
+      options
+    );
+  }
+  function basic(character, index2, all4) {
+    return options.format(
+      character.charCodeAt(0),
+      all4.charCodeAt(index2 + 1),
+      options
+    );
+  }
+}
+function charactersToExpression(subset) {
+  const groups = [];
+  let index2 = -1;
+  while (++index2 < subset.length) {
+    groups.push(subset[index2].replace(/[|\\{}()[\]^$+*?.]/g, "\\$&"));
+  }
+  return new RegExp("(?:" + groups.join("|") + ")", "g");
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/stringify-entities/lib/util/format-basic.js
+function formatBasic(code2) {
+  return "&#x" + code2.toString(16).toUpperCase() + ";";
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/stringify-entities/lib/index.js
+function stringifyEntitiesLight(value, options) {
+  return core(value, Object.assign({ format: formatBasic }, options));
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/track.js
+function track(options_) {
+  const options = options_ || {};
+  const now = options.now || {};
+  let lineShift = options.lineShift || 0;
+  let line = now.line || 1;
+  let column = now.column || 1;
+  return { move, current: current2, shift };
+  function current2() {
+    return { now: { line, column }, lineShift };
+  }
+  function shift(value) {
+    lineShift += value;
+  }
+  function move(value = "") {
+    const chunks = value.split(/\r?\n|\r/g);
+    const tail = chunks[chunks.length - 1];
+    line += chunks.length - 1;
+    column = chunks.length === 1 ? column + tail.length : 1 + tail.length + lineShift;
+    return value;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-flow.js
+function containerFlow(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const tracker = track(safeOptions);
+  const results = [];
+  let index2 = -1;
+  indexStack.push(-1);
+  while (++index2 < children.length) {
+    const child = children[index2];
+    indexStack[indexStack.length - 1] = index2;
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          before: "\n",
+          after: "\n",
+          ...tracker.current()
+        })
+      )
+    );
+    if (child.type !== "list") {
+      context.bulletLastUsed = void 0;
+    }
+    if (index2 < children.length - 1) {
+      results.push(tracker.move(between(child, children[index2 + 1])));
+    }
+  }
+  indexStack.pop();
+  return results.join("");
+  function between(left, right) {
+    let index3 = context.join.length;
+    while (index3--) {
+      const result = context.join[index3](left, right, parent, context);
+      if (result === true || result === 1) {
+        break;
+      }
+      if (typeof result === "number") {
+        return "\n".repeat(1 + result);
+      }
+      if (result === false) {
+        return "\n\n<!---->\n\n";
+      }
+    }
+    return "\n\n";
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-phrasing.js
+function containerPhrasing(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const results = [];
+  let index2 = -1;
+  let before = safeOptions.before;
+  indexStack.push(-1);
+  let tracker = track(safeOptions);
+  while (++index2 < children.length) {
+    const child = children[index2];
+    let after;
+    indexStack[indexStack.length - 1] = index2;
+    if (index2 + 1 < children.length) {
+      let handle = context.handle.handlers[children[index2 + 1].type];
+      if (handle && handle.peek)
+        handle = handle.peek;
+      after = handle ? handle(children[index2 + 1], parent, context, {
+        before: "",
+        after: "",
+        ...tracker.current()
+      }).charAt(0) : "";
+    } else {
+      after = safeOptions.after;
+    }
+    if (results.length > 0 && (before === "\r" || before === "\n") && child.type === "html") {
+      results[results.length - 1] = results[results.length - 1].replace(
+        /(\r?\n|\r)$/,
+        " "
+      );
+      before = " ";
+      tracker = track(safeOptions);
+      tracker.move(results.join(""));
+    }
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          ...tracker.current(),
+          before,
+          after
+        })
+      )
+    );
+    before = results[results.length - 1].slice(-1);
+  }
+  indexStack.pop();
+  return results.join("");
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/indent-lines.js
+var eol = /\r?\n|\r/g;
+function indentLines(value, map) {
+  const result = [];
+  let start3 = 0;
+  let line = 0;
+  let match;
+  while (match = eol.exec(value)) {
+    one3(value.slice(start3, match.index));
+    result.push(match[0]);
+    start3 = match.index + match[0].length;
+    line++;
+  }
+  one3(value.slice(start3));
+  return result.join("");
+  function one3(value2) {
+    result.push(map(value2, line, !value2));
+  }
+}
+
+// node_modules/mdast-util-mdx-jsx/lib/index.js
+function mdxJsxFromMarkdown() {
+  return {
+    canContainEols: ["mdxJsxTextElement"],
+    enter: {
+      mdxJsxFlowTag: enterMdxJsxTag,
+      mdxJsxFlowTagClosingMarker: enterMdxJsxTagClosingMarker,
+      mdxJsxFlowTagAttribute: enterMdxJsxTagAttribute,
+      mdxJsxFlowTagExpressionAttribute: enterMdxJsxTagExpressionAttribute,
+      mdxJsxFlowTagAttributeValueLiteral: buffer2,
+      mdxJsxFlowTagAttributeValueExpression: buffer2,
+      mdxJsxFlowTagSelfClosingMarker: enterMdxJsxTagSelfClosingMarker,
+      mdxJsxTextTag: enterMdxJsxTag,
+      mdxJsxTextTagClosingMarker: enterMdxJsxTagClosingMarker,
+      mdxJsxTextTagAttribute: enterMdxJsxTagAttribute,
+      mdxJsxTextTagExpressionAttribute: enterMdxJsxTagExpressionAttribute,
+      mdxJsxTextTagAttributeValueLiteral: buffer2,
+      mdxJsxTextTagAttributeValueExpression: buffer2,
+      mdxJsxTextTagSelfClosingMarker: enterMdxJsxTagSelfClosingMarker
+    },
+    exit: {
+      mdxJsxFlowTagClosingMarker: exitMdxJsxTagClosingMarker,
+      mdxJsxFlowTagNamePrimary: exitMdxJsxTagNamePrimary,
+      mdxJsxFlowTagNameMember: exitMdxJsxTagNameMember,
+      mdxJsxFlowTagNameLocal: exitMdxJsxTagNameLocal,
+      mdxJsxFlowTagExpressionAttribute: exitMdxJsxTagExpressionAttribute,
+      mdxJsxFlowTagExpressionAttributeValue: data2,
+      mdxJsxFlowTagAttributeNamePrimary: exitMdxJsxTagAttributeNamePrimary,
+      mdxJsxFlowTagAttributeNameLocal: exitMdxJsxTagAttributeNameLocal,
+      mdxJsxFlowTagAttributeValueLiteral: exitMdxJsxTagAttributeValueLiteral,
+      mdxJsxFlowTagAttributeValueLiteralValue: data2,
+      mdxJsxFlowTagAttributeValueExpression: exitMdxJsxTagAttributeValueExpression,
+      mdxJsxFlowTagAttributeValueExpressionValue: data2,
+      mdxJsxFlowTagSelfClosingMarker: exitMdxJsxTagSelfClosingMarker,
+      mdxJsxFlowTag: exitMdxJsxTag,
+      mdxJsxTextTagClosingMarker: exitMdxJsxTagClosingMarker,
+      mdxJsxTextTagNamePrimary: exitMdxJsxTagNamePrimary,
+      mdxJsxTextTagNameMember: exitMdxJsxTagNameMember,
+      mdxJsxTextTagNameLocal: exitMdxJsxTagNameLocal,
+      mdxJsxTextTagExpressionAttribute: exitMdxJsxTagExpressionAttribute,
+      mdxJsxTextTagExpressionAttributeValue: data2,
+      mdxJsxTextTagAttributeNamePrimary: exitMdxJsxTagAttributeNamePrimary,
+      mdxJsxTextTagAttributeNameLocal: exitMdxJsxTagAttributeNameLocal,
+      mdxJsxTextTagAttributeValueLiteral: exitMdxJsxTagAttributeValueLiteral,
+      mdxJsxTextTagAttributeValueLiteralValue: data2,
+      mdxJsxTextTagAttributeValueExpression: exitMdxJsxTagAttributeValueExpression,
+      mdxJsxTextTagAttributeValueExpressionValue: data2,
+      mdxJsxTextTagSelfClosingMarker: exitMdxJsxTagSelfClosingMarker,
+      mdxJsxTextTag: exitMdxJsxTag
+    }
+  };
+  function buffer2() {
+    this.buffer();
+  }
+  function data2(token) {
+    this.config.enter.data.call(this, token);
+    this.config.exit.data.call(this, token);
+  }
+  function enterMdxJsxTag(token) {
+    const tag = { name: null, attributes: [], start: token.start, end: token.end };
+    if (!this.getData("mdxJsxTagStack"))
+      this.setData("mdxJsxTagStack", []);
+    this.setData("mdxJsxTag", tag);
+    this.buffer();
+  }
+  function enterMdxJsxTagClosingMarker(token) {
+    const stack = this.getData("mdxJsxTagStack");
+    if (stack.length === 0) {
+      throw new VFileMessage(
+        "Unexpected closing slash `/` in tag, expected an open tag first",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-closing-slash"
+      );
+    }
+  }
+  function enterMdxJsxTagAnyAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    if (tag.close) {
+      throw new VFileMessage(
+        "Unexpected attribute in closing tag, expected the end of the tag",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-attribute"
+      );
+    }
+  }
+  function enterMdxJsxTagSelfClosingMarker(token) {
+    const tag = this.getData("mdxJsxTag");
+    if (tag.close) {
+      throw new VFileMessage(
+        "Unexpected self-closing slash `/` in closing tag, expected the end of the tag",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-self-closing-slash"
+      );
+    }
+  }
+  function exitMdxJsxTagClosingMarker() {
+    const tag = this.getData("mdxJsxTag");
+    tag.close = true;
+  }
+  function exitMdxJsxTagNamePrimary(token) {
+    const tag = this.getData("mdxJsxTag");
+    tag.name = this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagNameMember(token) {
+    const tag = this.getData("mdxJsxTag");
+    tag.name += "." + this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagNameLocal(token) {
+    const tag = this.getData("mdxJsxTag");
+    tag.name += ":" + this.sliceSerialize(token);
+  }
+  function enterMdxJsxTagAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    enterMdxJsxTagAnyAttribute.call(this, token);
+    tag.attributes.push({ type: "mdxJsxAttribute", name: "", value: null });
+  }
+  function enterMdxJsxTagExpressionAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    enterMdxJsxTagAnyAttribute.call(this, token);
+    tag.attributes.push({ type: "mdxJsxExpressionAttribute", value: "" });
+    this.buffer();
+  }
+  function exitMdxJsxTagExpressionAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    const tail = tag.attributes[tag.attributes.length - 1];
+    const estree = token.estree;
+    tail.value = this.resume();
+    if (estree) {
+      tail.data = { estree };
+    }
+  }
+  function exitMdxJsxTagAttributeNamePrimary(token) {
+    const tag = this.getData("mdxJsxTag");
+    const node = tag.attributes[tag.attributes.length - 1];
+    node.name = this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagAttributeNameLocal(token) {
+    const tag = this.getData("mdxJsxTag");
+    const node = tag.attributes[tag.attributes.length - 1];
+    node.name += ":" + this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagAttributeValueLiteral() {
+    const tag = this.getData("mdxJsxTag");
+    tag.attributes[tag.attributes.length - 1].value = parseEntities(
+      this.resume(),
+      { nonTerminated: false }
+    );
+  }
+  function exitMdxJsxTagAttributeValueExpression(token) {
+    const tag = this.getData("mdxJsxTag");
+    const tail = tag.attributes[tag.attributes.length - 1];
+    const node = { type: "mdxJsxAttributeValueExpression", value: this.resume() };
+    const estree = token.estree;
+    if (estree) {
+      node.data = { estree };
+    }
+    tail.value = node;
+  }
+  function exitMdxJsxTagSelfClosingMarker() {
+    const tag = this.getData("mdxJsxTag");
+    tag.selfClosing = true;
+  }
+  function exitMdxJsxTag(token) {
+    const tag = this.getData("mdxJsxTag");
+    const stack = this.getData("mdxJsxTagStack");
+    const tail = stack[stack.length - 1];
+    if (tag.close && tail.name !== tag.name) {
+      throw new VFileMessage(
+        "Unexpected closing tag `" + serializeAbbreviatedTag(tag) + "`, expected corresponding closing tag for `" + serializeAbbreviatedTag(tail) + "` (" + stringifyPosition(tail) + ")",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:end-tag-mismatch"
+      );
+    }
+    this.resume();
+    if (tag.close) {
+      stack.pop();
+    } else {
+      this.enter(
+        {
+          type: token.type === "mdxJsxTextTag" ? "mdxJsxTextElement" : "mdxJsxFlowElement",
+          name: tag.name,
+          attributes: tag.attributes,
+          children: []
+        },
+        token,
+        onErrorRightIsTag
+      );
+    }
+    if (tag.selfClosing || tag.close) {
+      this.exit(token, onErrorLeftIsTag);
+    } else {
+      stack.push(tag);
+    }
+  }
+  function onErrorRightIsTag(closing, open) {
+    const tag = this.getData("mdxJsxTag");
+    const place = closing ? " before the end of `" + closing.type + "`" : "";
+    const position3 = closing ? { start: closing.start, end: closing.end } : void 0;
+    throw new VFileMessage(
+      "Expected a closing tag for `" + serializeAbbreviatedTag(tag) + "` (" + stringifyPosition({ start: open.start, end: open.end }) + ")" + place,
+      position3,
+      "mdast-util-mdx-jsx:end-tag-mismatch"
+    );
+  }
+  function onErrorLeftIsTag(a, b) {
+    const tag = this.getData("mdxJsxTag");
+    throw new VFileMessage(
+      "Expected the closing tag `" + serializeAbbreviatedTag(tag) + "` either after the end of `" + b.type + "` (" + stringifyPosition(b.end) + ") or another opening tag after the start of `" + b.type + "` (" + stringifyPosition(b.start) + ")",
+      { start: a.start, end: a.end },
+      "mdast-util-mdx-jsx:end-tag-mismatch"
+    );
+  }
+  function serializeAbbreviatedTag(tag) {
+    return "<" + (tag.close ? "/" : "") + (tag.name || "") + ">";
+  }
+}
+function mdxJsxToMarkdown(options = {}) {
+  const {
+    quote = '"',
+    quoteSmart,
+    tightSelfClosing,
+    printWidth = Number.POSITIVE_INFINITY
+  } = options;
+  const alternative = quote === '"' ? "'" : '"';
+  if (quote !== '"' && quote !== "'") {
+    throw new Error(
+      "Cannot serialize attribute values with `" + quote + "` for `options.quote`, expected `\"`, or `'`"
+    );
+  }
+  mdxElement.peek = peekElement;
+  return {
+    handlers: {
+      mdxJsxFlowElement: mdxElement,
+      mdxJsxTextElement: mdxElement
+    },
+    unsafe: [
+      { character: "<", inConstruct: ["phrasing"] },
+      { atBreak: true, character: "<" }
+    ],
+    fences: true,
+    resourceLink: true
+  };
+  function mdxElement(node, _, context, safeOptions) {
+    const tracker = track(safeOptions);
+    const selfClosing = node.name && (!node.children || node.children.length === 0);
+    const exit2 = context.enter(node.type);
+    let index2 = -1;
+    const serializedAttributes = [];
+    let value = tracker.move("<" + (node.name || ""));
+    if (node.attributes && node.attributes.length > 0) {
+      if (!node.name) {
+        throw new Error("Cannot serialize fragment w/ attributes");
+      }
+      while (++index2 < node.attributes.length) {
+        const attribute = node.attributes[index2];
+        let result;
+        if (attribute.type === "mdxJsxExpressionAttribute") {
+          result = "{" + (attribute.value || "") + "}";
+        } else {
+          if (!attribute.name) {
+            throw new Error("Cannot serialize attribute w/o name");
+          }
+          const value2 = attribute.value;
+          const left = attribute.name;
+          let right = "";
+          if (value2 === void 0 || value2 === null) {
+          } else if (typeof value2 === "object") {
+            right = "{" + (value2.value || "") + "}";
+          } else {
+            const appliedQuote = quoteSmart && ccount(value2, quote) > ccount(value2, alternative) ? alternative : quote;
+            right = appliedQuote + stringifyEntitiesLight(value2, { subset: [appliedQuote] }) + appliedQuote;
+          }
+          result = left + (right ? "=" : "") + right;
+        }
+        serializedAttributes.push(result);
+      }
+    }
+    let attributesOnTheirOwnLine = false;
+    const attributesOnOneLine = serializedAttributes.join(" ");
+    if (node.type === "mdxJsxFlowElement" && (/\r?\n|\r/.test(attributesOnOneLine) || tracker.current().now.column + attributesOnOneLine.length + (selfClosing ? tightSelfClosing ? 2 : 3 : 1) > printWidth)) {
+      attributesOnTheirOwnLine = true;
+    }
+    if (attributesOnTheirOwnLine) {
+      value += tracker.move(
+        "\n" + indentLines(serializedAttributes.join("\n"), map)
+      );
+    } else if (attributesOnOneLine) {
+      value += tracker.move(" " + attributesOnOneLine);
+    }
+    if (attributesOnTheirOwnLine) {
+      value += tracker.move("\n");
+    }
+    if (selfClosing) {
+      value += tracker.move(
+        (tightSelfClosing || attributesOnTheirOwnLine ? "" : " ") + "/"
+      );
+    }
+    value += tracker.move(">");
+    if (node.children && node.children.length > 0) {
+      if (node.type === "mdxJsxFlowElement") {
+        tracker.shift(2);
+        value += tracker.move("\n");
+        value += tracker.move(
+          indentLines(containerFlow(node, context, tracker.current()), map)
+        );
+        value += tracker.move("\n");
+      } else {
+        value += tracker.move(
+          containerPhrasing(node, context, {
+            ...tracker.current(),
+            before: "<",
+            after: ">"
+          })
+        );
+      }
+    }
+    if (!selfClosing) {
+      value += tracker.move("</" + (node.name || "") + ">");
+    }
+    exit2();
+    return value;
+  }
+  function map(line, _, blank) {
+    return (blank ? "" : "  ") + line;
+  }
+  function peekElement() {
+    return "<";
+  }
+}
+
+// node_modules/mdast-util-mdxjs-esm/index.js
+var mdxjsEsmFromMarkdown = {
+  enter: { mdxjsEsm: enterMdxjsEsm },
+  exit: { mdxjsEsm: exitMdxjsEsm, mdxjsEsmData: exitMdxjsEsmData }
+};
+var mdxjsEsmToMarkdown = { handlers: { mdxjsEsm: handleMdxjsEsm } };
+function enterMdxjsEsm(token) {
+  this.enter({ type: "mdxjsEsm", value: "" }, token);
+  this.buffer();
+}
+function exitMdxjsEsm(token) {
+  const value = this.resume();
+  const node = this.exit(token);
+  const estree = token.estree;
+  node.value = value;
+  if (estree) {
+    node.data = { estree };
+  }
+}
+function exitMdxjsEsmData(token) {
+  this.config.enter.data.call(this, token);
+  this.config.exit.data.call(this, token);
+}
+function handleMdxjsEsm(node) {
+  return node.value || "";
+}
+
+// node_modules/mdast-util-mdx/index.js
+function mdxFromMarkdown() {
+  return [mdxExpressionFromMarkdown, mdxJsxFromMarkdown(), mdxjsEsmFromMarkdown];
+}
+function mdxToMarkdown(options) {
+  return {
+    extensions: [
+      mdxExpressionToMarkdown,
+      mdxJsxToMarkdown(options),
+      mdxjsEsmToMarkdown
+    ]
+  };
+}
+
+// node_modules/remark-mdx/index.js
+function remarkMdx(options = {}) {
+  const data2 = this.data();
+  add("micromarkExtensions", mdxjs(options));
+  add("fromMarkdownExtensions", mdxFromMarkdown());
+  add("toMarkdownExtensions", mdxToMarkdown(options));
+  function add(field, value) {
+    const list3 = data2[field] ? data2[field] : data2[field] = [];
+    list3.push(value);
+  }
+}
+
+// node_modules/mdast-util-to-string/index.js
+function toString2(node, options) {
+  var { includeImageAlt = true } = options || {};
+  return one(node, includeImageAlt);
+}
+function one(node, includeImageAlt) {
+  return node && typeof node === "object" && (node.value || (includeImageAlt ? node.alt : "") || "children" in node && all(node.children, includeImageAlt) || Array.isArray(node) && all(node, includeImageAlt)) || "";
+}
+function all(values, includeImageAlt) {
+  var result = [];
+  var index2 = -1;
+  while (++index2 < values.length) {
+    result[index2] = one(values[index2], includeImageAlt);
+  }
+  return result.join("");
+}
+
+// node_modules/micromark/lib/initialize/content.js
+var content2 = {
+  tokenize: initializeContent
+};
+function initializeContent(effects) {
+  const contentStart = effects.attempt(
+    this.parser.constructs.contentInitial,
+    afterContentStartConstruct,
+    paragraphInitial
+  );
+  let previous2;
+  return contentStart;
+  function afterContentStartConstruct(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, contentStart, "linePrefix");
+  }
+  function paragraphInitial(code2) {
+    effects.enter("paragraph");
+    return lineStart(code2);
+  }
+  function lineStart(code2) {
+    const token = effects.enter("chunkText", {
+      contentType: "text",
+      previous: previous2
+    });
+    if (previous2) {
+      previous2.next = token;
+    }
+    previous2 = token;
+    return data2(code2);
+  }
+  function data2(code2) {
+    if (code2 === null) {
+      effects.exit("chunkText");
+      effects.exit("paragraph");
+      effects.consume(code2);
+      return;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.consume(code2);
+      effects.exit("chunkText");
+      return lineStart;
+    }
+    effects.consume(code2);
+    return data2;
+  }
+}
+
+// node_modules/micromark/lib/initialize/document.js
+var document = {
+  tokenize: initializeDocument
+};
+var containerConstruct = {
+  tokenize: tokenizeContainer
+};
+function initializeDocument(effects) {
+  const self2 = this;
+  const stack = [];
+  let continued = 0;
+  let childFlow;
+  let childToken;
+  let lineStartOffset;
+  return start3;
+  function start3(code2) {
+    if (continued < stack.length) {
+      const item = stack[continued];
+      self2.containerState = item[1];
+      return effects.attempt(
+        item[0].continuation,
+        documentContinue,
+        checkNewContainers
+      )(code2);
+    }
+    return checkNewContainers(code2);
+  }
+  function documentContinue(code2) {
+    continued++;
+    if (self2.containerState._closeFlow) {
+      self2.containerState._closeFlow = void 0;
+      if (childFlow) {
+        closeFlow();
+      }
+      const indexBeforeExits = self2.events.length;
+      let indexBeforeFlow = indexBeforeExits;
+      let point3;
+      while (indexBeforeFlow--) {
+        if (self2.events[indexBeforeFlow][0] === "exit" && self2.events[indexBeforeFlow][1].type === "chunkFlow") {
+          point3 = self2.events[indexBeforeFlow][1].end;
+          break;
+        }
+      }
+      exitContainers(continued);
+      let index2 = indexBeforeExits;
+      while (index2 < self2.events.length) {
+        self2.events[index2][1].end = Object.assign({}, point3);
+        index2++;
+      }
+      splice(
+        self2.events,
+        indexBeforeFlow + 1,
+        0,
+        self2.events.slice(indexBeforeExits)
+      );
+      self2.events.length = index2;
+      return checkNewContainers(code2);
+    }
+    return start3(code2);
+  }
+  function checkNewContainers(code2) {
+    if (continued === stack.length) {
+      if (!childFlow) {
+        return documentContinued(code2);
+      }
+      if (childFlow.currentConstruct && childFlow.currentConstruct.concrete) {
+        return flowStart(code2);
+      }
+      self2.interrupt = Boolean(
+        childFlow.currentConstruct && !childFlow._gfmTableDynamicInterruptHack
+      );
+    }
+    self2.containerState = {};
+    return effects.check(
+      containerConstruct,
+      thereIsANewContainer,
+      thereIsNoNewContainer
+    )(code2);
+  }
+  function thereIsANewContainer(code2) {
+    if (childFlow)
+      closeFlow();
+    exitContainers(continued);
+    return documentContinued(code2);
+  }
+  function thereIsNoNewContainer(code2) {
+    self2.parser.lazy[self2.now().line] = continued !== stack.length;
+    lineStartOffset = self2.now().offset;
+    return flowStart(code2);
+  }
+  function documentContinued(code2) {
+    self2.containerState = {};
+    return effects.attempt(
+      containerConstruct,
+      containerContinue,
+      flowStart
+    )(code2);
+  }
+  function containerContinue(code2) {
+    continued++;
+    stack.push([self2.currentConstruct, self2.containerState]);
+    return documentContinued(code2);
+  }
+  function flowStart(code2) {
+    if (code2 === null) {
+      if (childFlow)
+        closeFlow();
+      exitContainers(0);
+      effects.consume(code2);
+      return;
+    }
+    childFlow = childFlow || self2.parser.flow(self2.now());
+    effects.enter("chunkFlow", {
+      contentType: "flow",
+      previous: childToken,
+      _tokenizer: childFlow
+    });
+    return flowContinue(code2);
+  }
+  function flowContinue(code2) {
+    if (code2 === null) {
+      writeToChild(effects.exit("chunkFlow"), true);
+      exitContainers(0);
+      effects.consume(code2);
+      return;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.consume(code2);
+      writeToChild(effects.exit("chunkFlow"));
+      continued = 0;
+      self2.interrupt = void 0;
+      return start3;
+    }
+    effects.consume(code2);
+    return flowContinue;
+  }
+  function writeToChild(token, eof) {
+    const stream = self2.sliceStream(token);
+    if (eof)
+      stream.push(null);
+    token.previous = childToken;
+    if (childToken)
+      childToken.next = token;
+    childToken = token;
+    childFlow.defineSkip(token.start);
+    childFlow.write(stream);
+    if (self2.parser.lazy[token.start.line]) {
+      let index2 = childFlow.events.length;
+      while (index2--) {
+        if (childFlow.events[index2][1].start.offset < lineStartOffset && (!childFlow.events[index2][1].end || childFlow.events[index2][1].end.offset > lineStartOffset)) {
+          return;
+        }
+      }
+      const indexBeforeExits = self2.events.length;
+      let indexBeforeFlow = indexBeforeExits;
+      let seen;
+      let point3;
+      while (indexBeforeFlow--) {
+        if (self2.events[indexBeforeFlow][0] === "exit" && self2.events[indexBeforeFlow][1].type === "chunkFlow") {
+          if (seen) {
+            point3 = self2.events[indexBeforeFlow][1].end;
+            break;
+          }
+          seen = true;
+        }
+      }
+      exitContainers(continued);
+      index2 = indexBeforeExits;
+      while (index2 < self2.events.length) {
+        self2.events[index2][1].end = Object.assign({}, point3);
+        index2++;
+      }
+      splice(
+        self2.events,
+        indexBeforeFlow + 1,
+        0,
+        self2.events.slice(indexBeforeExits)
+      );
+      self2.events.length = index2;
+    }
+  }
+  function exitContainers(size) {
+    let index2 = stack.length;
+    while (index2-- > size) {
+      const entry = stack[index2];
+      self2.containerState = entry[1];
+      entry[0].exit.call(self2, effects);
+    }
+    stack.length = size;
+  }
+  function closeFlow() {
+    childFlow.write([null]);
+    childToken = void 0;
+    childFlow = void 0;
+    self2.containerState._closeFlow = void 0;
+  }
+}
+function tokenizeContainer(effects, ok2, nok) {
+  return factorySpace(
+    effects,
+    effects.attempt(this.parser.constructs.document, ok2, nok),
+    "linePrefix",
+    this.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+  );
+}
+
+// node_modules/micromark/lib/initialize/flow.js
+var flow = {
+  tokenize: initializeFlow
+};
+function initializeFlow(effects) {
+  const self2 = this;
+  const initial = effects.attempt(
+    blankLine,
+    atBlankEnding,
+    effects.attempt(
+      this.parser.constructs.flowInitial,
+      afterConstruct,
+      factorySpace(
+        effects,
+        effects.attempt(
+          this.parser.constructs.flow,
+          afterConstruct,
+          effects.attempt(content, afterConstruct)
+        ),
+        "linePrefix"
+      )
+    )
+  );
+  return initial;
+  function atBlankEnding(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEndingBlank");
+    effects.consume(code2);
+    effects.exit("lineEndingBlank");
+    self2.currentConstruct = void 0;
+    return initial;
+  }
+  function afterConstruct(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    self2.currentConstruct = void 0;
+    return initial;
+  }
+}
+
+// node_modules/micromark/lib/initialize/text.js
+var resolver = {
+  resolveAll: createResolver()
+};
+var string = initializeFactory("string");
+var text = initializeFactory("text");
+function initializeFactory(field) {
+  return {
+    tokenize: initializeText,
+    resolveAll: createResolver(
+      field === "text" ? resolveAllLineSuffixes : void 0
+    )
+  };
+  function initializeText(effects) {
+    const self2 = this;
+    const constructs2 = this.parser.constructs[field];
+    const text5 = effects.attempt(constructs2, start3, notText);
+    return start3;
+    function start3(code2) {
+      return atBreak(code2) ? text5(code2) : notText(code2);
+    }
+    function notText(code2) {
+      if (code2 === null) {
+        effects.consume(code2);
+        return;
+      }
+      effects.enter("data");
+      effects.consume(code2);
+      return data2;
+    }
+    function data2(code2) {
+      if (atBreak(code2)) {
+        effects.exit("data");
+        return text5(code2);
+      }
+      effects.consume(code2);
+      return data2;
+    }
+    function atBreak(code2) {
+      if (code2 === null) {
+        return true;
+      }
+      const list3 = constructs2[code2];
+      let index2 = -1;
+      if (list3) {
+        while (++index2 < list3.length) {
+          const item = list3[index2];
+          if (!item.previous || item.previous.call(self2, self2.previous)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+  }
+}
+function createResolver(extraResolver) {
+  return resolveAllText;
+  function resolveAllText(events, context) {
+    let index2 = -1;
+    let enter;
+    while (++index2 <= events.length) {
+      if (enter === void 0) {
+        if (events[index2] && events[index2][1].type === "data") {
+          enter = index2;
+          index2++;
+        }
+      } else if (!events[index2] || events[index2][1].type !== "data") {
+        if (index2 !== enter + 2) {
+          events[enter][1].end = events[index2 - 1][1].end;
+          events.splice(enter + 2, index2 - enter - 2);
+          index2 = enter + 2;
+        }
+        enter = void 0;
+      }
+    }
+    return extraResolver ? extraResolver(events, context) : events;
+  }
+}
+function resolveAllLineSuffixes(events, context) {
+  let eventIndex = 0;
+  while (++eventIndex <= events.length) {
+    if ((eventIndex === events.length || events[eventIndex][1].type === "lineEnding") && events[eventIndex - 1][1].type === "data") {
+      const data2 = events[eventIndex - 1][1];
+      const chunks = context.sliceStream(data2);
+      let index2 = chunks.length;
+      let bufferIndex = -1;
+      let size = 0;
+      let tabs;
+      while (index2--) {
+        const chunk = chunks[index2];
+        if (typeof chunk === "string") {
+          bufferIndex = chunk.length;
+          while (chunk.charCodeAt(bufferIndex - 1) === 32) {
+            size++;
+            bufferIndex--;
+          }
+          if (bufferIndex)
+            break;
+          bufferIndex = -1;
+        } else if (chunk === -2) {
+          tabs = true;
+          size++;
+        } else if (chunk === -1) {
+        } else {
+          index2++;
+          break;
+        }
+      }
+      if (size) {
+        const token = {
+          type: eventIndex === events.length || tabs || size < 2 ? "lineSuffix" : "hardBreakTrailing",
+          start: {
+            line: data2.end.line,
+            column: data2.end.column - size,
+            offset: data2.end.offset - size,
+            _index: data2.start._index + index2,
+            _bufferIndex: index2 ? bufferIndex : data2.start._bufferIndex + bufferIndex
+          },
+          end: Object.assign({}, data2.end)
+        };
+        data2.end = Object.assign({}, token.start);
+        if (data2.start.offset === data2.end.offset) {
+          Object.assign(data2, token);
+        } else {
+          events.splice(
+            eventIndex,
+            0,
+            ["enter", token, context],
+            ["exit", token, context]
+          );
+          eventIndex += 2;
+        }
+      }
+      eventIndex++;
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark/lib/create-tokenizer.js
+function createTokenizer(parser, initialize, from) {
+  let point3 = Object.assign(
+    from ? Object.assign({}, from) : {
+      line: 1,
+      column: 1,
+      offset: 0
+    },
+    {
+      _index: 0,
+      _bufferIndex: -1
+    }
+  );
+  const columnStart = {};
+  const resolveAllConstructs = [];
+  let chunks = [];
+  let stack = [];
+  let consumed = true;
+  const effects = {
+    consume,
+    enter,
+    exit: exit2,
+    attempt: constructFactory(onsuccessfulconstruct),
+    check: constructFactory(onsuccessfulcheck),
+    interrupt: constructFactory(onsuccessfulcheck, {
+      interrupt: true
+    })
+  };
+  const context = {
+    previous: null,
+    code: null,
+    containerState: {},
+    events: [],
+    parser,
+    sliceStream,
+    sliceSerialize,
+    now,
+    defineSkip,
+    write
+  };
+  let state = initialize.tokenize.call(context, effects);
+  let expectedCode;
+  if (initialize.resolveAll) {
+    resolveAllConstructs.push(initialize);
+  }
+  return context;
+  function write(slice2) {
+    chunks = push(chunks, slice2);
+    main();
+    if (chunks[chunks.length - 1] !== null) {
+      return [];
+    }
+    addResult(initialize, 0);
+    context.events = resolveAll(resolveAllConstructs, context.events, context);
+    return context.events;
+  }
+  function sliceSerialize(token, expandTabs) {
+    return serializeChunks(sliceStream(token), expandTabs);
+  }
+  function sliceStream(token) {
+    return sliceChunks(chunks, token);
+  }
+  function now() {
+    return Object.assign({}, point3);
+  }
+  function defineSkip(value) {
+    columnStart[value.line] = value.column;
+    accountForPotentialSkip();
+  }
+  function main() {
+    let chunkIndex;
+    while (point3._index < chunks.length) {
+      const chunk = chunks[point3._index];
+      if (typeof chunk === "string") {
+        chunkIndex = point3._index;
+        if (point3._bufferIndex < 0) {
+          point3._bufferIndex = 0;
+        }
+        while (point3._index === chunkIndex && point3._bufferIndex < chunk.length) {
+          go(chunk.charCodeAt(point3._bufferIndex));
+        }
+      } else {
+        go(chunk);
+      }
+    }
+  }
+  function go(code2) {
+    consumed = void 0;
+    expectedCode = code2;
+    state = state(code2);
+  }
+  function consume(code2) {
+    if (markdownLineEnding(code2)) {
+      point3.line++;
+      point3.column = 1;
+      point3.offset += code2 === -3 ? 2 : 1;
+      accountForPotentialSkip();
+    } else if (code2 !== -1) {
+      point3.column++;
+      point3.offset++;
+    }
+    if (point3._bufferIndex < 0) {
+      point3._index++;
+    } else {
+      point3._bufferIndex++;
+      if (point3._bufferIndex === chunks[point3._index].length) {
+        point3._bufferIndex = -1;
+        point3._index++;
+      }
+    }
+    context.previous = code2;
+    consumed = true;
+  }
+  function enter(type, fields) {
+    const token = fields || {};
+    token.type = type;
+    token.start = now();
+    context.events.push(["enter", token, context]);
+    stack.push(token);
+    return token;
+  }
+  function exit2(type) {
+    const token = stack.pop();
+    token.end = now();
+    context.events.push(["exit", token, context]);
+    return token;
+  }
+  function onsuccessfulconstruct(construct, info) {
+    addResult(construct, info.from);
+  }
+  function onsuccessfulcheck(_, info) {
+    info.restore();
+  }
+  function constructFactory(onreturn, fields) {
+    return hook;
+    function hook(constructs2, returnState, bogusState) {
+      let listOfConstructs;
+      let constructIndex;
+      let currentConstruct;
+      let info;
+      return Array.isArray(constructs2) ? handleListOfConstructs(constructs2) : "tokenize" in constructs2 ? handleListOfConstructs([constructs2]) : handleMapOfConstructs(constructs2);
+      function handleMapOfConstructs(map) {
+        return start3;
+        function start3(code2) {
+          const def = code2 !== null && map[code2];
+          const all4 = code2 !== null && map.null;
+          const list3 = [
+            ...Array.isArray(def) ? def : def ? [def] : [],
+            ...Array.isArray(all4) ? all4 : all4 ? [all4] : []
+          ];
+          return handleListOfConstructs(list3)(code2);
+        }
+      }
+      function handleListOfConstructs(list3) {
+        listOfConstructs = list3;
+        constructIndex = 0;
+        if (list3.length === 0) {
+          return bogusState;
+        }
+        return handleConstruct(list3[constructIndex]);
+      }
+      function handleConstruct(construct) {
+        return start3;
+        function start3(code2) {
+          info = store();
+          currentConstruct = construct;
+          if (!construct.partial) {
+            context.currentConstruct = construct;
+          }
+          if (construct.name && context.parser.constructs.disable.null.includes(construct.name)) {
+            return nok(code2);
+          }
+          return construct.tokenize.call(
+            fields ? Object.assign(Object.create(context), fields) : context,
+            effects,
+            ok2,
+            nok
+          )(code2);
+        }
+      }
+      function ok2(code2) {
+        consumed = true;
+        onreturn(currentConstruct, info);
+        return returnState;
+      }
+      function nok(code2) {
+        consumed = true;
+        info.restore();
+        if (++constructIndex < listOfConstructs.length) {
+          return handleConstruct(listOfConstructs[constructIndex]);
+        }
+        return bogusState;
+      }
+    }
+  }
+  function addResult(construct, from2) {
+    if (construct.resolveAll && !resolveAllConstructs.includes(construct)) {
+      resolveAllConstructs.push(construct);
+    }
+    if (construct.resolve) {
+      splice(
+        context.events,
+        from2,
+        context.events.length - from2,
+        construct.resolve(context.events.slice(from2), context)
+      );
+    }
+    if (construct.resolveTo) {
+      context.events = construct.resolveTo(context.events, context);
+    }
+  }
+  function store() {
+    const startPoint = now();
+    const startPrevious = context.previous;
+    const startCurrentConstruct = context.currentConstruct;
+    const startEventsIndex = context.events.length;
+    const startStack = Array.from(stack);
+    return {
+      restore,
+      from: startEventsIndex
+    };
+    function restore() {
+      point3 = startPoint;
+      context.previous = startPrevious;
+      context.currentConstruct = startCurrentConstruct;
+      context.events.length = startEventsIndex;
+      stack = startStack;
+      accountForPotentialSkip();
+    }
+  }
+  function accountForPotentialSkip() {
+    if (point3.line in columnStart && point3.column < 2) {
+      point3.column = columnStart[point3.line];
+      point3.offset += columnStart[point3.line] - 1;
+    }
+  }
+}
+function sliceChunks(chunks, token) {
+  const startIndex = token.start._index;
+  const startBufferIndex = token.start._bufferIndex;
+  const endIndex = token.end._index;
+  const endBufferIndex = token.end._bufferIndex;
+  let view;
+  if (startIndex === endIndex) {
+    view = [chunks[startIndex].slice(startBufferIndex, endBufferIndex)];
+  } else {
+    view = chunks.slice(startIndex, endIndex);
+    if (startBufferIndex > -1) {
+      view[0] = view[0].slice(startBufferIndex);
+    }
+    if (endBufferIndex > 0) {
+      view.push(chunks[endIndex].slice(0, endBufferIndex));
+    }
+  }
+  return view;
+}
+function serializeChunks(chunks, expandTabs) {
+  let index2 = -1;
+  const result = [];
+  let atTab;
+  while (++index2 < chunks.length) {
+    const chunk = chunks[index2];
+    let value;
+    if (typeof chunk === "string") {
+      value = chunk;
+    } else
+      switch (chunk) {
+        case -5: {
+          value = "\r";
+          break;
+        }
+        case -4: {
+          value = "\n";
+          break;
+        }
+        case -3: {
+          value = "\r\n";
+          break;
+        }
+        case -2: {
+          value = expandTabs ? " " : "	";
+          break;
+        }
+        case -1: {
+          if (!expandTabs && atTab)
+            continue;
+          value = " ";
+          break;
+        }
+        default: {
+          value = String.fromCharCode(chunk);
+        }
+      }
+    atTab = chunk === -2;
+    result.push(value);
+  }
+  return result.join("");
+}
+
+// node_modules/micromark/lib/constructs.js
+var constructs_exports = {};
+__export(constructs_exports, {
+  attentionMarkers: () => attentionMarkers,
+  contentInitial: () => contentInitial,
+  disable: () => disable,
+  document: () => document2,
+  flow: () => flow2,
+  flowInitial: () => flowInitial,
+  insideSpan: () => insideSpan,
+  string: () => string2,
+  text: () => text2
+});
+var document2 = {
+  [42]: list,
+  [43]: list,
+  [45]: list,
+  [48]: list,
+  [49]: list,
+  [50]: list,
+  [51]: list,
+  [52]: list,
+  [53]: list,
+  [54]: list,
+  [55]: list,
+  [56]: list,
+  [57]: list,
+  [62]: blockQuote
+};
+var contentInitial = {
+  [91]: definition
+};
+var flowInitial = {
+  [-2]: codeIndented,
+  [-1]: codeIndented,
+  [32]: codeIndented
+};
+var flow2 = {
+  [35]: headingAtx,
+  [42]: thematicBreak,
+  [45]: [setextUnderline, thematicBreak],
+  [60]: htmlFlow,
+  [61]: setextUnderline,
+  [95]: thematicBreak,
+  [96]: codeFenced,
+  [126]: codeFenced
+};
+var string2 = {
+  [38]: characterReference,
+  [92]: characterEscape
+};
+var text2 = {
+  [-5]: lineEnding,
+  [-4]: lineEnding,
+  [-3]: lineEnding,
+  [33]: labelStartImage,
+  [38]: characterReference,
+  [42]: attention,
+  [60]: [autolink, htmlText],
+  [91]: labelStartLink,
+  [92]: [hardBreakEscape, characterEscape],
+  [93]: labelEnd,
+  [95]: attention,
+  [96]: codeText
+};
+var insideSpan = {
+  null: [attention, resolver]
+};
+var attentionMarkers = {
+  null: [42, 95]
+};
+var disable = {
+  null: []
+};
+
+// node_modules/micromark/lib/parse.js
+function parse3(options = {}) {
+  const constructs2 = combineExtensions(
+    [constructs_exports].concat(options.extensions || [])
+  );
+  const parser = {
+    defined: [],
+    lazy: {},
+    constructs: constructs2,
+    content: create5(content2),
+    document: create5(document),
+    flow: create5(flow),
+    string: create5(string),
+    text: create5(text)
+  };
+  return parser;
+  function create5(initial) {
+    return creator;
+    function creator(from) {
+      return createTokenizer(parser, initial, from);
+    }
+  }
+}
+
+// node_modules/micromark/lib/preprocess.js
+var search = /[\0\t\n\r]/g;
+function preprocess() {
+  let column = 1;
+  let buffer2 = "";
+  let start3 = true;
+  let atCarriageReturn;
+  return preprocessor;
+  function preprocessor(value, encoding, end) {
+    const chunks = [];
+    let match;
+    let next;
+    let startPosition;
+    let endPosition;
+    let code2;
+    value = buffer2 + value.toString(encoding);
+    startPosition = 0;
+    buffer2 = "";
+    if (start3) {
+      if (value.charCodeAt(0) === 65279) {
+        startPosition++;
+      }
+      start3 = void 0;
+    }
+    while (startPosition < value.length) {
+      search.lastIndex = startPosition;
+      match = search.exec(value);
+      endPosition = match && match.index !== void 0 ? match.index : value.length;
+      code2 = value.charCodeAt(endPosition);
+      if (!match) {
+        buffer2 = value.slice(startPosition);
+        break;
+      }
+      if (code2 === 10 && startPosition === endPosition && atCarriageReturn) {
+        chunks.push(-3);
+        atCarriageReturn = void 0;
+      } else {
+        if (atCarriageReturn) {
+          chunks.push(-5);
+          atCarriageReturn = void 0;
+        }
+        if (startPosition < endPosition) {
+          chunks.push(value.slice(startPosition, endPosition));
+          column += endPosition - startPosition;
+        }
+        switch (code2) {
+          case 0: {
+            chunks.push(65533);
+            column++;
+            break;
+          }
+          case 9: {
+            next = Math.ceil(column / 4) * 4;
+            chunks.push(-2);
+            while (column++ < next)
+              chunks.push(-1);
+            break;
+          }
+          case 10: {
+            chunks.push(-4);
+            column = 1;
+            break;
+          }
+          default: {
+            atCarriageReturn = true;
+            column = 1;
+          }
+        }
+      }
+      startPosition = endPosition + 1;
+    }
+    if (end) {
+      if (atCarriageReturn)
+        chunks.push(-5);
+      if (buffer2)
+        chunks.push(buffer2);
+      chunks.push(null);
+    }
+    return chunks;
+  }
+}
+
+// node_modules/micromark/lib/postprocess.js
+function postprocess(events) {
+  while (!subtokenize(events)) {
+  }
+  return events;
+}
+
+// node_modules/micromark-util-decode-numeric-character-reference/index.js
+function decodeNumericCharacterReference(value, base2) {
+  const code2 = Number.parseInt(value, base2);
+  if (code2 < 9 || code2 === 11 || code2 > 13 && code2 < 32 || code2 > 126 && code2 < 160 || code2 > 55295 && code2 < 57344 || code2 > 64975 && code2 < 65008 || (code2 & 65535) === 65535 || (code2 & 65535) === 65534 || code2 > 1114111) {
+    return "\uFFFD";
+  }
+  return String.fromCharCode(code2);
+}
+
+// node_modules/micromark-util-decode-string/index.js
+var characterEscapeOrReference = /\\([!-/:-@[-`{-~])|&(#(?:\d{1,7}|x[\da-f]{1,6})|[\da-z]{1,31});/gi;
+function decodeString(value) {
+  return value.replace(characterEscapeOrReference, decode);
+}
+function decode($0, $1, $2) {
+  if ($1) {
+    return $1;
+  }
+  const head = $2.charCodeAt(0);
+  if (head === 35) {
+    const head2 = $2.charCodeAt(1);
+    const hex = head2 === 120 || head2 === 88;
+    return decodeNumericCharacterReference($2.slice(hex ? 2 : 1), hex ? 16 : 10);
+  }
+  return decodeNamedCharacterReference($2) || $0;
+}
+
+// node_modules/mdast-util-from-markdown/lib/index.js
+var own4 = {}.hasOwnProperty;
+var fromMarkdown = function(value, encoding, options) {
+  if (typeof encoding !== "string") {
+    options = encoding;
+    encoding = void 0;
+  }
+  return compiler(options)(
+    postprocess(
+      parse3(options).document().write(preprocess()(value, encoding, true))
+    )
+  );
+};
+function compiler(options = {}) {
+  const config = configure(
+    {
+      transforms: [],
+      canContainEols: [
+        "emphasis",
+        "fragment",
+        "heading",
+        "paragraph",
+        "strong"
+      ],
+      enter: {
+        autolink: opener(link2),
+        autolinkProtocol: onenterdata,
+        autolinkEmail: onenterdata,
+        atxHeading: opener(heading2),
+        blockQuote: opener(blockQuote2),
+        characterEscape: onenterdata,
+        characterReference: onenterdata,
+        codeFenced: opener(codeFlow),
+        codeFencedFenceInfo: buffer2,
+        codeFencedFenceMeta: buffer2,
+        codeIndented: opener(codeFlow, buffer2),
+        codeText: opener(codeText2, buffer2),
+        codeTextData: onenterdata,
+        data: onenterdata,
+        codeFlowValue: onenterdata,
+        definition: opener(definition2),
+        definitionDestinationString: buffer2,
+        definitionLabelString: buffer2,
+        definitionTitleString: buffer2,
+        emphasis: opener(emphasis2),
+        hardBreakEscape: opener(hardBreak2),
+        hardBreakTrailing: opener(hardBreak2),
+        htmlFlow: opener(html4, buffer2),
+        htmlFlowData: onenterdata,
+        htmlText: opener(html4, buffer2),
+        htmlTextData: onenterdata,
+        image: opener(image2),
+        label: buffer2,
+        link: opener(link2),
+        listItem: opener(listItem2),
+        listItemValue: onenterlistitemvalue,
+        listOrdered: opener(list3, onenterlistordered),
+        listUnordered: opener(list3),
+        paragraph: opener(paragraph2),
+        reference: onenterreference,
+        referenceString: buffer2,
+        resourceDestinationString: buffer2,
+        resourceTitleString: buffer2,
+        setextHeading: opener(heading2),
+        strong: opener(strong2),
+        thematicBreak: opener(thematicBreak3)
+      },
+      exit: {
+        atxHeading: closer(),
+        atxHeadingSequence: onexitatxheadingsequence,
+        autolink: closer(),
+        autolinkEmail: onexitautolinkemail,
+        autolinkProtocol: onexitautolinkprotocol,
+        blockQuote: closer(),
+        characterEscapeValue: onexitdata,
+        characterReferenceMarkerHexadecimal: onexitcharacterreferencemarker,
+        characterReferenceMarkerNumeric: onexitcharacterreferencemarker,
+        characterReferenceValue: onexitcharacterreferencevalue,
+        codeFenced: closer(onexitcodefenced),
+        codeFencedFence: onexitcodefencedfence,
+        codeFencedFenceInfo: onexitcodefencedfenceinfo,
+        codeFencedFenceMeta: onexitcodefencedfencemeta,
+        codeFlowValue: onexitdata,
+        codeIndented: closer(onexitcodeindented),
+        codeText: closer(onexitcodetext),
+        codeTextData: onexitdata,
+        data: onexitdata,
+        definition: closer(),
+        definitionDestinationString: onexitdefinitiondestinationstring,
+        definitionLabelString: onexitdefinitionlabelstring,
+        definitionTitleString: onexitdefinitiontitlestring,
+        emphasis: closer(),
+        hardBreakEscape: closer(onexithardbreak),
+        hardBreakTrailing: closer(onexithardbreak),
+        htmlFlow: closer(onexithtmlflow),
+        htmlFlowData: onexitdata,
+        htmlText: closer(onexithtmltext),
+        htmlTextData: onexitdata,
+        image: closer(onexitimage),
+        label: onexitlabel,
+        labelText: onexitlabeltext,
+        lineEnding: onexitlineending,
+        link: closer(onexitlink),
+        listItem: closer(),
+        listOrdered: closer(),
+        listUnordered: closer(),
+        paragraph: closer(),
+        referenceString: onexitreferencestring,
+        resourceDestinationString: onexitresourcedestinationstring,
+        resourceTitleString: onexitresourcetitlestring,
+        resource: onexitresource,
+        setextHeading: closer(onexitsetextheading),
+        setextHeadingLineSequence: onexitsetextheadinglinesequence,
+        setextHeadingText: onexitsetextheadingtext,
+        strong: closer(),
+        thematicBreak: closer()
+      }
+    },
+    options.mdastExtensions || []
+  );
+  const data2 = {};
+  return compile2;
+  function compile2(events) {
+    let tree = {
+      type: "root",
+      children: []
+    };
+    const stack = [tree];
+    const tokenStack = [];
+    const listStack = [];
+    const context = {
+      stack,
+      tokenStack,
+      config,
+      enter,
+      exit: exit2,
+      buffer: buffer2,
+      resume,
+      setData,
+      getData
+    };
+    let index2 = -1;
+    while (++index2 < events.length) {
+      if (events[index2][1].type === "listOrdered" || events[index2][1].type === "listUnordered") {
+        if (events[index2][0] === "enter") {
+          listStack.push(index2);
+        } else {
+          const tail = listStack.pop();
+          index2 = prepareList(events, tail, index2);
+        }
+      }
+    }
+    index2 = -1;
+    while (++index2 < events.length) {
+      const handler = config[events[index2][0]];
+      if (own4.call(handler, events[index2][1].type)) {
+        handler[events[index2][1].type].call(
+          Object.assign(
+            {
+              sliceSerialize: events[index2][2].sliceSerialize
+            },
+            context
+          ),
+          events[index2][1]
+        );
+      }
+    }
+    if (tokenStack.length > 0) {
+      const tail = tokenStack[tokenStack.length - 1];
+      const handler = tail[1] || defaultOnError;
+      handler.call(context, void 0, tail[0]);
+    }
+    tree.position = {
+      start: point3(
+        events.length > 0 ? events[0][1].start : {
+          line: 1,
+          column: 1,
+          offset: 0
+        }
+      ),
+      end: point3(
+        events.length > 0 ? events[events.length - 2][1].end : {
+          line: 1,
+          column: 1,
+          offset: 0
+        }
+      )
+    };
+    index2 = -1;
+    while (++index2 < config.transforms.length) {
+      tree = config.transforms[index2](tree) || tree;
+    }
+    return tree;
+  }
+  function prepareList(events, start3, length) {
+    let index2 = start3 - 1;
+    let containerBalance = -1;
+    let listSpread = false;
+    let listItem3;
+    let lineIndex;
+    let firstBlankLineIndex;
+    let atMarker;
+    while (++index2 <= length) {
+      const event = events[index2];
+      if (event[1].type === "listUnordered" || event[1].type === "listOrdered" || event[1].type === "blockQuote") {
+        if (event[0] === "enter") {
+          containerBalance++;
+        } else {
+          containerBalance--;
+        }
+        atMarker = void 0;
+      } else if (event[1].type === "lineEndingBlank") {
+        if (event[0] === "enter") {
+          if (listItem3 && !atMarker && !containerBalance && !firstBlankLineIndex) {
+            firstBlankLineIndex = index2;
+          }
+          atMarker = void 0;
+        }
+      } else if (event[1].type === "linePrefix" || event[1].type === "listItemValue" || event[1].type === "listItemMarker" || event[1].type === "listItemPrefix" || event[1].type === "listItemPrefixWhitespace") {
+      } else {
+        atMarker = void 0;
+      }
+      if (!containerBalance && event[0] === "enter" && event[1].type === "listItemPrefix" || containerBalance === -1 && event[0] === "exit" && (event[1].type === "listUnordered" || event[1].type === "listOrdered")) {
+        if (listItem3) {
+          let tailIndex = index2;
+          lineIndex = void 0;
+          while (tailIndex--) {
+            const tailEvent = events[tailIndex];
+            if (tailEvent[1].type === "lineEnding" || tailEvent[1].type === "lineEndingBlank") {
+              if (tailEvent[0] === "exit")
+                continue;
+              if (lineIndex) {
+                events[lineIndex][1].type = "lineEndingBlank";
+                listSpread = true;
+              }
+              tailEvent[1].type = "lineEnding";
+              lineIndex = tailIndex;
+            } else if (tailEvent[1].type === "linePrefix" || tailEvent[1].type === "blockQuotePrefix" || tailEvent[1].type === "blockQuotePrefixWhitespace" || tailEvent[1].type === "blockQuoteMarker" || tailEvent[1].type === "listItemIndent") {
+            } else {
+              break;
+            }
+          }
+          if (firstBlankLineIndex && (!lineIndex || firstBlankLineIndex < lineIndex)) {
+            listItem3._spread = true;
+          }
+          listItem3.end = Object.assign(
+            {},
+            lineIndex ? events[lineIndex][1].start : event[1].end
+          );
+          events.splice(lineIndex || index2, 0, ["exit", listItem3, event[2]]);
+          index2++;
+          length++;
+        }
+        if (event[1].type === "listItemPrefix") {
+          listItem3 = {
+            type: "listItem",
+            _spread: false,
+            start: Object.assign({}, event[1].start)
+          };
+          events.splice(index2, 0, ["enter", listItem3, event[2]]);
+          index2++;
+          length++;
+          firstBlankLineIndex = void 0;
+          atMarker = true;
+        }
+      }
+    }
+    events[start3][1]._spread = listSpread;
+    return length;
+  }
+  function setData(key, value) {
+    data2[key] = value;
+  }
+  function getData(key) {
+    return data2[key];
+  }
+  function point3(d) {
+    return {
+      line: d.line,
+      column: d.column,
+      offset: d.offset
+    };
+  }
+  function opener(create5, and) {
+    return open;
+    function open(token) {
+      enter.call(this, create5(token), token);
+      if (and)
+        and.call(this, token);
+    }
+  }
+  function buffer2() {
+    this.stack.push({
+      type: "fragment",
+      children: []
+    });
+  }
+  function enter(node, token, errorHandler) {
+    const parent = this.stack[this.stack.length - 1];
+    parent.children.push(node);
+    this.stack.push(node);
+    this.tokenStack.push([token, errorHandler]);
+    node.position = {
+      start: point3(token.start)
+    };
+    return node;
+  }
+  function closer(and) {
+    return close;
+    function close(token) {
+      if (and)
+        and.call(this, token);
+      exit2.call(this, token);
+    }
+  }
+  function exit2(token, onExitError) {
+    const node = this.stack.pop();
+    const open = this.tokenStack.pop();
+    if (!open) {
+      throw new Error(
+        "Cannot close `" + token.type + "` (" + stringifyPosition({
+          start: token.start,
+          end: token.end
+        }) + "): it\u2019s not open"
+      );
+    } else if (open[0].type !== token.type) {
+      if (onExitError) {
+        onExitError.call(this, token, open[0]);
+      } else {
+        const handler = open[1] || defaultOnError;
+        handler.call(this, token, open[0]);
+      }
+    }
+    node.position.end = point3(token.end);
+    return node;
+  }
+  function resume() {
+    return toString2(this.stack.pop());
+  }
+  function onenterlistordered() {
+    setData("expectingFirstListItemValue", true);
+  }
+  function onenterlistitemvalue(token) {
+    if (getData("expectingFirstListItemValue")) {
+      const ancestor = this.stack[this.stack.length - 2];
+      ancestor.start = Number.parseInt(this.sliceSerialize(token), 10);
+      setData("expectingFirstListItemValue");
+    }
+  }
+  function onexitcodefencedfenceinfo() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.lang = data3;
+  }
+  function onexitcodefencedfencemeta() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.meta = data3;
+  }
+  function onexitcodefencedfence() {
+    if (getData("flowCodeInside"))
+      return;
+    this.buffer();
+    setData("flowCodeInside", true);
+  }
+  function onexitcodefenced() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data3.replace(/^(\r?\n|\r)|(\r?\n|\r)$/g, "");
+    setData("flowCodeInside");
+  }
+  function onexitcodeindented() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data3.replace(/(\r?\n|\r)$/g, "");
+  }
+  function onexitdefinitionlabelstring(token) {
+    const label = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.label = label;
+    node.identifier = normalizeIdentifier(
+      this.sliceSerialize(token)
+    ).toLowerCase();
+  }
+  function onexitdefinitiontitlestring() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.title = data3;
+  }
+  function onexitdefinitiondestinationstring() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.url = data3;
+  }
+  function onexitatxheadingsequence(token) {
+    const node = this.stack[this.stack.length - 1];
+    if (!node.depth) {
+      const depth = this.sliceSerialize(token).length;
+      node.depth = depth;
+    }
+  }
+  function onexitsetextheadingtext() {
+    setData("setextHeadingSlurpLineEnding", true);
+  }
+  function onexitsetextheadinglinesequence(token) {
+    const node = this.stack[this.stack.length - 1];
+    node.depth = this.sliceSerialize(token).charCodeAt(0) === 61 ? 1 : 2;
+  }
+  function onexitsetextheading() {
+    setData("setextHeadingSlurpLineEnding");
+  }
+  function onenterdata(token) {
+    const parent = this.stack[this.stack.length - 1];
+    let tail = parent.children[parent.children.length - 1];
+    if (!tail || tail.type !== "text") {
+      tail = text5();
+      tail.position = {
+        start: point3(token.start)
+      };
+      parent.children.push(tail);
+    }
+    this.stack.push(tail);
+  }
+  function onexitdata(token) {
+    const tail = this.stack.pop();
+    tail.value += this.sliceSerialize(token);
+    tail.position.end = point3(token.end);
+  }
+  function onexitlineending(token) {
+    const context = this.stack[this.stack.length - 1];
+    if (getData("atHardBreak")) {
+      const tail = context.children[context.children.length - 1];
+      tail.position.end = point3(token.end);
+      setData("atHardBreak");
+      return;
+    }
+    if (!getData("setextHeadingSlurpLineEnding") && config.canContainEols.includes(context.type)) {
+      onenterdata.call(this, token);
+      onexitdata.call(this, token);
+    }
+  }
+  function onexithardbreak() {
+    setData("atHardBreak", true);
+  }
+  function onexithtmlflow() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data3;
+  }
+  function onexithtmltext() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data3;
+  }
+  function onexitcodetext() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data3;
+  }
+  function onexitlink() {
+    const context = this.stack[this.stack.length - 1];
+    if (getData("inReference")) {
+      context.type += "Reference";
+      context.referenceType = getData("referenceType") || "shortcut";
+      delete context.url;
+      delete context.title;
+    } else {
+      delete context.identifier;
+      delete context.label;
+    }
+    setData("referenceType");
+  }
+  function onexitimage() {
+    const context = this.stack[this.stack.length - 1];
+    if (getData("inReference")) {
+      context.type += "Reference";
+      context.referenceType = getData("referenceType") || "shortcut";
+      delete context.url;
+      delete context.title;
+    } else {
+      delete context.identifier;
+      delete context.label;
+    }
+    setData("referenceType");
+  }
+  function onexitlabeltext(token) {
+    const ancestor = this.stack[this.stack.length - 2];
+    const string3 = this.sliceSerialize(token);
+    ancestor.label = decodeString(string3);
+    ancestor.identifier = normalizeIdentifier(string3).toLowerCase();
+  }
+  function onexitlabel() {
+    const fragment = this.stack[this.stack.length - 1];
+    const value = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    setData("inReference", true);
+    if (node.type === "link") {
+      node.children = fragment.children;
+    } else {
+      node.alt = value;
+    }
+  }
+  function onexitresourcedestinationstring() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.url = data3;
+  }
+  function onexitresourcetitlestring() {
+    const data3 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.title = data3;
+  }
+  function onexitresource() {
+    setData("inReference");
+  }
+  function onenterreference() {
+    setData("referenceType", "collapsed");
+  }
+  function onexitreferencestring(token) {
+    const label = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.label = label;
+    node.identifier = normalizeIdentifier(
+      this.sliceSerialize(token)
+    ).toLowerCase();
+    setData("referenceType", "full");
+  }
+  function onexitcharacterreferencemarker(token) {
+    setData("characterReferenceType", token.type);
+  }
+  function onexitcharacterreferencevalue(token) {
+    const data3 = this.sliceSerialize(token);
+    const type = getData("characterReferenceType");
+    let value;
+    if (type) {
+      value = decodeNumericCharacterReference(
+        data3,
+        type === "characterReferenceMarkerNumeric" ? 10 : 16
+      );
+      setData("characterReferenceType");
+    } else {
+      value = decodeNamedCharacterReference(data3);
+    }
+    const tail = this.stack.pop();
+    tail.value += value;
+    tail.position.end = point3(token.end);
+  }
+  function onexitautolinkprotocol(token) {
+    onexitdata.call(this, token);
+    const node = this.stack[this.stack.length - 1];
+    node.url = this.sliceSerialize(token);
+  }
+  function onexitautolinkemail(token) {
+    onexitdata.call(this, token);
+    const node = this.stack[this.stack.length - 1];
+    node.url = "mailto:" + this.sliceSerialize(token);
+  }
+  function blockQuote2() {
+    return {
+      type: "blockquote",
+      children: []
+    };
+  }
+  function codeFlow() {
+    return {
+      type: "code",
+      lang: null,
+      meta: null,
+      value: ""
+    };
+  }
+  function codeText2() {
+    return {
+      type: "inlineCode",
+      value: ""
+    };
+  }
+  function definition2() {
+    return {
+      type: "definition",
+      identifier: "",
+      label: null,
+      title: null,
+      url: ""
+    };
+  }
+  function emphasis2() {
+    return {
+      type: "emphasis",
+      children: []
+    };
+  }
+  function heading2() {
+    return {
+      type: "heading",
+      depth: void 0,
+      children: []
+    };
+  }
+  function hardBreak2() {
+    return {
+      type: "break"
+    };
+  }
+  function html4() {
+    return {
+      type: "html",
+      value: ""
+    };
+  }
+  function image2() {
+    return {
+      type: "image",
+      title: null,
+      url: "",
+      alt: null
+    };
+  }
+  function link2() {
+    return {
+      type: "link",
+      title: null,
+      url: "",
+      children: []
+    };
+  }
+  function list3(token) {
+    return {
+      type: "list",
+      ordered: token.type === "listOrdered",
+      start: null,
+      spread: token._spread,
+      children: []
+    };
+  }
+  function listItem2(token) {
+    return {
+      type: "listItem",
+      spread: token._spread,
+      checked: null,
+      children: []
+    };
+  }
+  function paragraph2() {
+    return {
+      type: "paragraph",
+      children: []
+    };
+  }
+  function strong2() {
+    return {
+      type: "strong",
+      children: []
+    };
+  }
+  function text5() {
+    return {
+      type: "text",
+      value: ""
+    };
+  }
+  function thematicBreak3() {
+    return {
+      type: "thematicBreak"
+    };
+  }
+}
+function configure(combined, extensions) {
+  let index2 = -1;
+  while (++index2 < extensions.length) {
+    const value = extensions[index2];
+    if (Array.isArray(value)) {
+      configure(combined, value);
+    } else {
+      extension(combined, value);
+    }
+  }
+  return combined;
+}
+function extension(combined, extension2) {
+  let key;
+  for (key in extension2) {
+    if (own4.call(extension2, key)) {
+      const list3 = key === "canContainEols" || key === "transforms";
+      const maybe = own4.call(combined, key) ? combined[key] : void 0;
+      const left = maybe || (combined[key] = list3 ? [] : {});
+      const right = extension2[key];
+      if (right) {
+        if (list3) {
+          combined[key] = [...left, ...right];
+        } else {
+          Object.assign(left, right);
+        }
+      }
+    }
+  }
+}
+function defaultOnError(left, right) {
+  if (left) {
+    throw new Error(
+      "Cannot close `" + left.type + "` (" + stringifyPosition({
+        start: left.start,
+        end: left.end
+      }) + "): a different token (`" + right.type + "`, " + stringifyPosition({
+        start: right.start,
+        end: right.end
+      }) + ") is open"
+    );
+  } else {
+    throw new Error(
+      "Cannot close document, a token (`" + right.type + "`, " + stringifyPosition({
+        start: right.start,
+        end: right.end
+      }) + ") is still open"
+    );
+  }
+}
+
+// node_modules/@mdx-js/mdx/node_modules/remark-parse/lib/index.js
+function remarkParse(options) {
+  const parser = (doc) => {
+    const settings = this.data("settings");
+    return fromMarkdown(
+      doc,
+      Object.assign({}, settings, options, {
+        extensions: this.data("micromarkExtensions") || [],
+        mdastExtensions: this.data("fromMarkdownExtensions") || []
+      })
+    );
+  };
+  Object.assign(this, { Parser: parser });
+}
+
+// node_modules/@mdx-js/mdx/node_modules/remark-parse/index.js
+var remark_parse_default = remarkParse;
+
+// node_modules/@mdx-js/mdx/node_modules/unist-builder/index.js
+var u = function(type, props, value) {
+  var node = { type: String(type) };
+  if ((value === void 0 || value === null) && (typeof props === "string" || Array.isArray(props))) {
+    value = props;
+  } else {
+    Object.assign(node, props);
+  }
+  if (Array.isArray(value)) {
+    node.children = value;
+  } else if (value !== void 0 && value !== null) {
+    node.value = String(value);
+  }
+  return node;
+};
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/traverse.js
+var own5 = {}.hasOwnProperty;
+function unknown(h, node) {
+  const data2 = node.data || {};
+  if ("value" in node && !(own5.call(data2, "hName") || own5.call(data2, "hProperties") || own5.call(data2, "hChildren"))) {
+    return h.augment(node, u("text", node.value));
+  }
+  return h(node, "div", all2(h, node));
+}
+function one2(h, node, parent) {
+  const type = node && node.type;
+  let fn;
+  if (!type) {
+    throw new Error("Expected node, got `" + node + "`");
+  }
+  if (own5.call(h.handlers, type)) {
+    fn = h.handlers[type];
+  } else if (h.passThrough && h.passThrough.includes(type)) {
+    fn = returnNode;
+  } else {
+    fn = h.unknownHandler;
+  }
+  return (typeof fn === "function" ? fn : unknown)(h, node, parent);
+}
+function returnNode(h, node) {
+  return "children" in node ? { ...node, children: all2(h, node) } : node;
+}
+function all2(h, parent) {
+  const values = [];
+  if ("children" in parent) {
+    const nodes = parent.children;
+    let index2 = -1;
+    while (++index2 < nodes.length) {
+      const result = one2(h, nodes[index2], parent);
+      if (result) {
+        if (index2 && nodes[index2 - 1].type === "break") {
+          if (!Array.isArray(result) && result.type === "text") {
+            result.value = result.value.replace(/^\s+/, "");
+          }
+          if (!Array.isArray(result) && result.type === "element") {
+            const head = result.children[0];
+            if (head && head.type === "text") {
+              head.value = head.value.replace(/^\s+/, "");
+            }
+          }
+        }
+        if (Array.isArray(result)) {
+          values.push(...result);
+        } else {
+          values.push(result);
+        }
+      }
+    }
+  }
+  return values;
+}
+
+// node_modules/unist-util-is/index.js
+var convert = function(test) {
+  if (test === void 0 || test === null) {
+    return ok;
+  }
+  if (typeof test === "string") {
+    return typeFactory(test);
+  }
+  if (typeof test === "object") {
+    return Array.isArray(test) ? anyFactory(test) : propsFactory(test);
+  }
+  if (typeof test === "function") {
+    return castFactory(test);
+  }
+  throw new Error("Expected function, string, or object as test");
+};
+function anyFactory(tests) {
+  const checks2 = [];
+  let index2 = -1;
+  while (++index2 < tests.length) {
+    checks2[index2] = convert(tests[index2]);
+  }
+  return castFactory(any);
+  function any(...parameters) {
+    let index3 = -1;
+    while (++index3 < checks2.length) {
+      if (checks2[index3].call(this, ...parameters))
+        return true;
+    }
+    return false;
+  }
+}
+function propsFactory(check) {
+  return castFactory(all4);
+  function all4(node) {
+    let key;
+    for (key in check) {
+      if (node[key] !== check[key])
+        return false;
+    }
+    return true;
+  }
+}
+function typeFactory(check) {
+  return castFactory(type);
+  function type(node) {
+    return node && node.type === check;
+  }
+}
+function castFactory(check) {
+  return assertion;
+  function assertion(...parameters) {
+    return Boolean(check.call(this, ...parameters));
+  }
+}
+function ok() {
+  return true;
+}
+
+// node_modules/unist-util-visit-parents/color.js
+function color2(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/unist-util-visit-parents/index.js
+var CONTINUE2 = true;
+var SKIP2 = "skip";
+var EXIT2 = false;
+var visitParents = function(tree, test, visitor, reverse) {
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+    test = null;
+  }
+  const is = convert(test);
+  const step = reverse ? -1 : 1;
+  factory2(tree, null, [])();
+  function factory2(node, index2, parents) {
+    const value = typeof node === "object" && node !== null ? node : {};
+    let name2;
+    if (typeof value.type === "string") {
+      name2 = typeof value.tagName === "string" ? value.tagName : typeof value.name === "string" ? value.name : void 0;
+      Object.defineProperty(visit3, "name", {
+        value: "node (" + color2(value.type + (name2 ? "<" + name2 + ">" : "")) + ")"
+      });
+    }
+    return visit3;
+    function visit3() {
+      let result = [];
+      let subresult;
+      let offset2;
+      let grandparents;
+      if (!test || is(node, index2, parents[parents.length - 1] || null)) {
+        result = toResult2(visitor(node, parents));
+        if (result[0] === EXIT2) {
+          return result;
+        }
+      }
+      if (node.children && result[0] !== SKIP2) {
+        offset2 = (reverse ? node.children.length : -1) + step;
+        grandparents = parents.concat(node);
+        while (offset2 > -1 && offset2 < node.children.length) {
+          subresult = factory2(node.children[offset2], offset2, grandparents)();
+          if (subresult[0] === EXIT2) {
+            return subresult;
+          }
+          offset2 = typeof subresult[1] === "number" ? subresult[1] : offset2 + step;
+        }
+      }
+      return result;
+    }
+  }
+};
+function toResult2(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE2, value];
+  }
+  return [value];
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unist-util-visit/index.js
+var visit2 = function(tree, test, visitor, reverse) {
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+    test = null;
+  }
+  visitParents(tree, test, overload, reverse);
+  function overload(node, parents) {
+    const parent = parents[parents.length - 1];
+    return visitor(
+      node,
+      parent ? parent.children.indexOf(node) : null,
+      parent
+    );
+  }
+};
+
+// node_modules/unist-util-position/index.js
+var pointStart = point2("start");
+var pointEnd = point2("end");
+function position2(node) {
+  return { start: pointStart(node), end: pointEnd(node) };
+}
+function point2(type) {
+  return point3;
+  function point3(node) {
+    const point4 = node && node.position && node.position[type] || {};
+    return {
+      line: point4.line || null,
+      column: point4.column || null,
+      offset: point4.offset > -1 ? point4.offset : null
+    };
+  }
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unist-util-generated/index.js
+function generated(node) {
+  return !node || !node.position || !node.position.start || !node.position.start.line || !node.position.start.column || !node.position.end || !node.position.end.line || !node.position.end.column;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-definitions/index.js
+var own6 = {}.hasOwnProperty;
+function definitions(node) {
+  const cache = /* @__PURE__ */ Object.create(null);
+  if (!node || !node.type) {
+    throw new Error("mdast-util-definitions expected node");
+  }
+  visit2(node, "definition", (definition3) => {
+    const id = clean(definition3.identifier);
+    if (id && !own6.call(cache, id)) {
+      cache[id] = definition3;
+    }
+  });
+  return definition2;
+  function definition2(identifier) {
+    const id = clean(identifier);
+    return id && own6.call(cache, id) ? cache[id] : null;
+  }
+}
+function clean(value) {
+  return String(value || "").toUpperCase();
+}
+
+// node_modules/micromark-util-sanitize-uri/index.js
+function normalizeUri(value) {
+  const result = [];
+  let index2 = -1;
+  let start3 = 0;
+  let skip = 0;
+  while (++index2 < value.length) {
+    const code2 = value.charCodeAt(index2);
+    let replace = "";
+    if (code2 === 37 && asciiAlphanumeric(value.charCodeAt(index2 + 1)) && asciiAlphanumeric(value.charCodeAt(index2 + 2))) {
+      skip = 2;
+    } else if (code2 < 128) {
+      if (!/[!#$&-;=?-Z_a-z~]/.test(String.fromCharCode(code2))) {
+        replace = String.fromCharCode(code2);
+      }
+    } else if (code2 > 55295 && code2 < 57344) {
+      const next = value.charCodeAt(index2 + 1);
+      if (code2 < 56320 && next > 56319 && next < 57344) {
+        replace = String.fromCharCode(code2, next);
+        skip = 1;
+      } else {
+        replace = "\uFFFD";
+      }
+    } else {
+      replace = String.fromCharCode(code2);
+    }
+    if (replace) {
+      result.push(value.slice(start3, index2), encodeURIComponent(replace));
+      start3 = index2 + skip + 1;
+      replace = "";
+    }
+    if (skip) {
+      index2 += skip;
+      skip = 0;
+    }
+  }
+  return result.join("") + value.slice(start3);
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/wrap.js
+function wrap2(nodes, loose) {
+  const result = [];
+  let index2 = -1;
+  if (loose) {
+    result.push(u("text", "\n"));
+  }
+  while (++index2 < nodes.length) {
+    if (index2)
+      result.push(u("text", "\n"));
+    result.push(nodes[index2]);
+  }
+  if (loose && nodes.length > 0) {
+    result.push(u("text", "\n"));
+  }
+  return result;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/footer.js
+function footer(h) {
+  let index2 = -1;
+  const listItems = [];
+  while (++index2 < h.footnoteOrder.length) {
+    const def = h.footnoteById[h.footnoteOrder[index2].toUpperCase()];
+    if (!def) {
+      continue;
+    }
+    const content3 = all2(h, def);
+    const id = String(def.identifier);
+    const safeId = normalizeUri(id.toLowerCase());
+    let referenceIndex = 0;
+    const backReferences = [];
+    while (++referenceIndex <= h.footnoteCounts[id]) {
+      const backReference = {
+        type: "element",
+        tagName: "a",
+        properties: {
+          href: "#" + h.clobberPrefix + "fnref-" + safeId + (referenceIndex > 1 ? "-" + referenceIndex : ""),
+          dataFootnoteBackref: true,
+          className: ["data-footnote-backref"],
+          ariaLabel: h.footnoteBackLabel
+        },
+        children: [{ type: "text", value: "\u21A9" }]
+      };
+      if (referenceIndex > 1) {
+        backReference.children.push({
+          type: "element",
+          tagName: "sup",
+          children: [{ type: "text", value: String(referenceIndex) }]
+        });
+      }
+      if (backReferences.length > 0) {
+        backReferences.push({ type: "text", value: " " });
+      }
+      backReferences.push(backReference);
+    }
+    const tail = content3[content3.length - 1];
+    if (tail && tail.type === "element" && tail.tagName === "p") {
+      const tailTail = tail.children[tail.children.length - 1];
+      if (tailTail && tailTail.type === "text") {
+        tailTail.value += " ";
+      } else {
+        tail.children.push({ type: "text", value: " " });
+      }
+      tail.children.push(...backReferences);
+    } else {
+      content3.push(...backReferences);
+    }
+    const listItem2 = {
+      type: "element",
+      tagName: "li",
+      properties: { id: h.clobberPrefix + "fn-" + safeId },
+      children: wrap2(content3, true)
+    };
+    if (def.position) {
+      listItem2.position = def.position;
+    }
+    listItems.push(listItem2);
+  }
+  if (listItems.length === 0) {
+    return null;
+  }
+  return {
+    type: "element",
+    tagName: "section",
+    properties: { dataFootnotes: true, className: ["footnotes"] },
+    children: [
+      {
+        type: "element",
+        tagName: h.footnoteLabelTagName,
+        properties: {
+          ...JSON.parse(JSON.stringify(h.footnoteLabelProperties)),
+          id: "footnote-label"
+        },
+        children: [u("text", h.footnoteLabel)]
+      },
+      { type: "text", value: "\n" },
+      {
+        type: "element",
+        tagName: "ol",
+        properties: {},
+        children: wrap2(listItems, true)
+      },
+      { type: "text", value: "\n" }
+    ]
+  };
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/blockquote.js
+function blockquote(h, node) {
+  return h(node, "blockquote", wrap2(all2(h, node), true));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/break.js
+function hardBreak(h, node) {
+  return [h(node, "br"), u("text", "\n")];
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/code.js
+function code(h, node) {
+  const value = node.value ? node.value + "\n" : "";
+  const lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/);
+  const props = {};
+  if (lang) {
+    props.className = ["language-" + lang];
+  }
+  const code2 = h(node, "code", props, [u("text", value)]);
+  if (node.meta) {
+    code2.data = { meta: node.meta };
+  }
+  return h(node.position, "pre", [code2]);
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/delete.js
+function strikethrough(h, node) {
+  return h(node, "del", all2(h, node));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/emphasis.js
+function emphasis(h, node) {
+  return h(node, "em", all2(h, node));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/footnote-reference.js
+function footnoteReference(h, node) {
+  const id = String(node.identifier);
+  const safeId = normalizeUri(id.toLowerCase());
+  const index2 = h.footnoteOrder.indexOf(id);
+  let counter;
+  if (index2 === -1) {
+    h.footnoteOrder.push(id);
+    h.footnoteCounts[id] = 1;
+    counter = h.footnoteOrder.length;
+  } else {
+    h.footnoteCounts[id]++;
+    counter = index2 + 1;
+  }
+  const reuseCounter = h.footnoteCounts[id];
+  return h(node, "sup", [
+    h(
+      node.position,
+      "a",
+      {
+        href: "#" + h.clobberPrefix + "fn-" + safeId,
+        id: h.clobberPrefix + "fnref-" + safeId + (reuseCounter > 1 ? "-" + reuseCounter : ""),
+        dataFootnoteRef: true,
+        ariaDescribedBy: "footnote-label"
+      },
+      [u("text", String(counter))]
+    )
+  ]);
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/footnote.js
+function footnote(h, node) {
+  const footnoteById = h.footnoteById;
+  let no = 1;
+  while (no in footnoteById)
+    no++;
+  const identifier = String(no);
+  footnoteById[identifier] = {
+    type: "footnoteDefinition",
+    identifier,
+    children: [{ type: "paragraph", children: node.children }],
+    position: node.position
+  };
+  return footnoteReference(h, {
+    type: "footnoteReference",
+    identifier,
+    position: node.position
+  });
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/heading.js
+function heading(h, node) {
+  return h(node, "h" + node.depth, all2(h, node));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/html.js
+function html(h, node) {
+  return h.dangerous ? h.augment(node, u("raw", node.value)) : null;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/revert.js
+function revert(h, node) {
+  const subtype = node.referenceType;
+  let suffix = "]";
+  if (subtype === "collapsed") {
+    suffix += "[]";
+  } else if (subtype === "full") {
+    suffix += "[" + (node.label || node.identifier) + "]";
+  }
+  if (node.type === "imageReference") {
+    return u("text", "![" + node.alt + suffix);
+  }
+  const contents = all2(h, node);
+  const head = contents[0];
+  if (head && head.type === "text") {
+    head.value = "[" + head.value;
+  } else {
+    contents.unshift(u("text", "["));
+  }
+  const tail = contents[contents.length - 1];
+  if (tail && tail.type === "text") {
+    tail.value += suffix;
+  } else {
+    contents.push(u("text", suffix));
+  }
+  return contents;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/image-reference.js
+function imageReference(h, node) {
+  const def = h.definition(node.identifier);
+  if (!def) {
+    return revert(h, node);
+  }
+  const props = { src: normalizeUri(def.url || ""), alt: node.alt };
+  if (def.title !== null && def.title !== void 0) {
+    props.title = def.title;
+  }
+  return h(node, "img", props);
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/image.js
+function image(h, node) {
+  const props = { src: normalizeUri(node.url), alt: node.alt };
+  if (node.title !== null && node.title !== void 0) {
+    props.title = node.title;
+  }
+  return h(node, "img", props);
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/inline-code.js
+function inlineCode(h, node) {
+  return h(node, "code", [u("text", node.value.replace(/\r?\n|\r/g, " "))]);
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/link-reference.js
+function linkReference(h, node) {
+  const def = h.definition(node.identifier);
+  if (!def) {
+    return revert(h, node);
+  }
+  const props = { href: normalizeUri(def.url || "") };
+  if (def.title !== null && def.title !== void 0) {
+    props.title = def.title;
+  }
+  return h(node, "a", props, all2(h, node));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/link.js
+function link(h, node) {
+  const props = { href: normalizeUri(node.url) };
+  if (node.title !== null && node.title !== void 0) {
+    props.title = node.title;
+  }
+  return h(node, "a", props, all2(h, node));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/list-item.js
+function listItem(h, node, parent) {
+  const result = all2(h, node);
+  const loose = parent ? listLoose(parent) : listItemLoose(node);
+  const props = {};
+  const wrapped = [];
+  if (typeof node.checked === "boolean") {
+    let paragraph2;
+    if (result[0] && result[0].type === "element" && result[0].tagName === "p") {
+      paragraph2 = result[0];
+    } else {
+      paragraph2 = h(null, "p", []);
+      result.unshift(paragraph2);
+    }
+    if (paragraph2.children.length > 0) {
+      paragraph2.children.unshift(u("text", " "));
+    }
+    paragraph2.children.unshift(
+      h(null, "input", {
+        type: "checkbox",
+        checked: node.checked,
+        disabled: true
+      })
+    );
+    props.className = ["task-list-item"];
+  }
+  let index2 = -1;
+  while (++index2 < result.length) {
+    const child = result[index2];
+    if (loose || index2 !== 0 || child.type !== "element" || child.tagName !== "p") {
+      wrapped.push(u("text", "\n"));
+    }
+    if (child.type === "element" && child.tagName === "p" && !loose) {
+      wrapped.push(...child.children);
+    } else {
+      wrapped.push(child);
+    }
+  }
+  const tail = result[result.length - 1];
+  if (tail && (loose || !("tagName" in tail) || tail.tagName !== "p")) {
+    wrapped.push(u("text", "\n"));
+  }
+  return h(node, "li", props, wrapped);
+}
+function listLoose(node) {
+  let loose = node.spread;
+  const children = node.children;
+  let index2 = -1;
+  while (!loose && ++index2 < children.length) {
+    loose = listItemLoose(children[index2]);
+  }
+  return Boolean(loose);
+}
+function listItemLoose(node) {
+  const spread = node.spread;
+  return spread === void 0 || spread === null ? node.children.length > 1 : spread;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/list.js
+function list2(h, node) {
+  const props = {};
+  const name2 = node.ordered ? "ol" : "ul";
+  const items = all2(h, node);
+  let index2 = -1;
+  if (typeof node.start === "number" && node.start !== 1) {
+    props.start = node.start;
+  }
+  while (++index2 < items.length) {
+    const item = items[index2];
+    if (item.type === "element" && item.tagName === "li" && item.properties && Array.isArray(item.properties.className) && item.properties.className.includes("task-list-item")) {
+      props.className = ["contains-task-list"];
+      break;
+    }
+  }
+  return h(node, name2, props, wrap2(items, true));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/paragraph.js
+function paragraph(h, node) {
+  return h(node, "p", all2(h, node));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/root.js
+function root(h, node) {
+  return h.augment(node, u("root", wrap2(all2(h, node))));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/strong.js
+function strong(h, node) {
+  return h(node, "strong", all2(h, node));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/table.js
+function table(h, node) {
+  const rows = node.children;
+  let index2 = -1;
+  const align = node.align || [];
+  const result = [];
+  while (++index2 < rows.length) {
+    const row = rows[index2].children;
+    const name2 = index2 === 0 ? "th" : "td";
+    const out = [];
+    let cellIndex = -1;
+    const length = node.align ? align.length : row.length;
+    while (++cellIndex < length) {
+      const cell = row[cellIndex];
+      out.push(
+        h(cell, name2, { align: align[cellIndex] }, cell ? all2(h, cell) : [])
+      );
+    }
+    result[index2] = h(rows[index2], "tr", wrap2(out, true));
+  }
+  return h(
+    node,
+    "table",
+    wrap2(
+      [h(result[0].position, "thead", wrap2([result[0]], true))].concat(
+        result[1] ? h(
+          {
+            start: pointStart(result[1]),
+            end: pointEnd(result[result.length - 1])
+          },
+          "tbody",
+          wrap2(result.slice(1), true)
+        ) : []
+      ),
+      true
+    )
+  );
+}
+
+// node_modules/trim-lines/index.js
+var tab = 9;
+var space = 32;
+function trimLines(value) {
+  const source = String(value);
+  const search2 = /\r?\n|\r/g;
+  let match = search2.exec(source);
+  let last = 0;
+  const lines = [];
+  while (match) {
+    lines.push(
+      trimLine(source.slice(last, match.index), last > 0, true),
+      match[0]
+    );
+    last = match.index + match[0].length;
+    match = search2.exec(source);
+  }
+  lines.push(trimLine(source.slice(last), last > 0, false));
+  return lines.join("");
+}
+function trimLine(value, start3, end) {
+  let startIndex = 0;
+  let endIndex = value.length;
+  if (start3) {
+    let code2 = value.codePointAt(startIndex);
+    while (code2 === tab || code2 === space) {
+      startIndex++;
+      code2 = value.codePointAt(startIndex);
+    }
+  }
+  if (end) {
+    let code2 = value.codePointAt(endIndex - 1);
+    while (code2 === tab || code2 === space) {
+      endIndex--;
+      code2 = value.codePointAt(endIndex - 1);
+    }
+  }
+  return endIndex > startIndex ? value.slice(startIndex, endIndex) : "";
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/text.js
+function text3(h, node) {
+  return h.augment(node, u("text", trimLines(String(node.value))));
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/thematic-break.js
+function thematicBreak2(h, node) {
+  return h(node, "hr");
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/handlers/index.js
+var handlers = {
+  blockquote,
+  break: hardBreak,
+  code,
+  delete: strikethrough,
+  emphasis,
+  footnoteReference,
+  footnote,
+  heading,
+  html,
+  imageReference,
+  image,
+  inlineCode,
+  linkReference,
+  link,
+  listItem,
+  list: list2,
+  paragraph,
+  root,
+  strong,
+  table,
+  text: text3,
+  thematicBreak: thematicBreak2,
+  toml: ignore,
+  yaml: ignore,
+  definition: ignore,
+  footnoteDefinition: ignore
+};
+function ignore() {
+  return null;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/mdast-util-to-hast/lib/index.js
+var own7 = {}.hasOwnProperty;
+function factory(tree, options) {
+  const settings = options || {};
+  const dangerous = settings.allowDangerousHtml || false;
+  const footnoteById = {};
+  h.dangerous = dangerous;
+  h.clobberPrefix = settings.clobberPrefix === void 0 || settings.clobberPrefix === null ? "user-content-" : settings.clobberPrefix;
+  h.footnoteLabel = settings.footnoteLabel || "Footnotes";
+  h.footnoteLabelTagName = settings.footnoteLabelTagName || "h2";
+  h.footnoteLabelProperties = settings.footnoteLabelProperties || {
+    className: ["sr-only"]
+  };
+  h.footnoteBackLabel = settings.footnoteBackLabel || "Back to content";
+  h.definition = definitions(tree);
+  h.footnoteById = footnoteById;
+  h.footnoteOrder = [];
+  h.footnoteCounts = {};
+  h.augment = augment;
+  h.handlers = { ...handlers, ...settings.handlers };
+  h.unknownHandler = settings.unknownHandler;
+  h.passThrough = settings.passThrough;
+  visit2(tree, "footnoteDefinition", (definition2) => {
+    const id = String(definition2.identifier).toUpperCase();
+    if (!own7.call(footnoteById, id)) {
+      footnoteById[id] = definition2;
+    }
+  });
+  return h;
+  function augment(left, right) {
+    if (left && "data" in left && left.data) {
+      const data2 = left.data;
+      if (data2.hName) {
+        if (right.type !== "element") {
+          right = {
+            type: "element",
+            tagName: "",
+            properties: {},
+            children: []
+          };
+        }
+        right.tagName = data2.hName;
+      }
+      if (right.type === "element" && data2.hProperties) {
+        right.properties = { ...right.properties, ...data2.hProperties };
+      }
+      if ("children" in right && right.children && data2.hChildren) {
+        right.children = data2.hChildren;
+      }
+    }
+    if (left) {
+      const ctx = "type" in left ? left : { position: left };
+      if (!generated(ctx)) {
+        right.position = { start: pointStart(ctx), end: pointEnd(ctx) };
+      }
+    }
+    return right;
+  }
+  function h(node, tagName, props, children) {
+    if (Array.isArray(props)) {
+      children = props;
+      props = {};
+    }
+    return augment(node, {
+      type: "element",
+      tagName,
+      properties: props || {},
+      children: children || []
+    });
+  }
+}
+function toHast(tree, options) {
+  const h = factory(tree, options);
+  const node = one2(h, tree, null);
+  const foot = footer(h);
+  if (foot) {
+    node.children.push(u("text", "\n"), foot);
+  }
+  return Array.isArray(node) ? { type: "root", children: node } : node;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/remark-rehype/lib/index.js
+var remarkRehype = function(destination, options) {
+  return destination && "run" in destination ? bridge(destination, options) : mutate(destination || options);
+};
+var lib_default = remarkRehype;
+function bridge(destination, options) {
+  return (node, file, next) => {
+    destination.run(toHast(node, options), file, (error) => {
+      next(error);
+    });
+  };
+}
+function mutate(options) {
+  return (node) => toHast(node, options);
+}
+
+// node_modules/estree-walker/src/walker.js
+var WalkerBase = class {
+  constructor() {
+    this.should_skip = false;
+    this.should_remove = false;
+    this.replacement = null;
+    this.context = {
+      skip: () => this.should_skip = true,
+      remove: () => this.should_remove = true,
+      replace: (node) => this.replacement = node
+    };
+  }
+  replace(parent, prop, index2, node) {
+    if (parent) {
+      if (index2 !== null) {
+        parent[prop][index2] = node;
+      } else {
+        parent[prop] = node;
+      }
+    }
+  }
+  remove(parent, prop, index2) {
+    if (parent) {
+      if (index2 !== null) {
+        parent[prop].splice(index2, 1);
+      } else {
+        delete parent[prop];
+      }
+    }
+  }
+};
+
+// node_modules/estree-walker/src/sync.js
+var SyncWalker = class extends WalkerBase {
+  constructor(enter, leave) {
+    super();
+    this.enter = enter;
+    this.leave = leave;
+  }
+  visit(node, parent, prop, index2) {
+    if (node) {
+      if (this.enter) {
+        const _should_skip = this.should_skip;
+        const _should_remove = this.should_remove;
+        const _replacement = this.replacement;
+        this.should_skip = false;
+        this.should_remove = false;
+        this.replacement = null;
+        this.enter.call(this.context, node, parent, prop, index2);
+        if (this.replacement) {
+          node = this.replacement;
+          this.replace(parent, prop, index2, node);
+        }
+        if (this.should_remove) {
+          this.remove(parent, prop, index2);
+        }
+        const skipped = this.should_skip;
+        const removed = this.should_remove;
+        this.should_skip = _should_skip;
+        this.should_remove = _should_remove;
+        this.replacement = _replacement;
+        if (skipped)
+          return node;
+        if (removed)
+          return null;
+      }
+      for (const key in node) {
+        const value = node[key];
+        if (typeof value !== "object") {
+          continue;
+        } else if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i += 1) {
+            if (value[i] !== null && typeof value[i].type === "string") {
+              if (!this.visit(value[i], node, key, i)) {
+                i--;
+              }
+            }
+          }
+        } else if (value !== null && typeof value.type === "string") {
+          this.visit(value, node, key, null);
+        }
+      }
+      if (this.leave) {
+        const _replacement = this.replacement;
+        const _should_remove = this.should_remove;
+        this.replacement = null;
+        this.should_remove = false;
+        this.leave.call(this.context, node, parent, prop, index2);
+        if (this.replacement) {
+          node = this.replacement;
+          this.replace(parent, prop, index2, node);
+        }
+        if (this.should_remove) {
+          this.remove(parent, prop, index2);
+        }
+        const removed = this.should_remove;
+        this.replacement = _replacement;
+        this.should_remove = _should_remove;
+        if (removed)
+          return null;
+      }
+    }
+    return node;
+  }
+};
+
+// node_modules/estree-walker/src/index.js
+function walk(ast, { enter, leave }) {
+  const instance = new SyncWalker(enter, leave);
+  return instance.visit(ast, null);
+}
+
+// node_modules/estree-util-build-jsx/lib/index.js
+var regex = /@(jsx|jsxFrag|jsxImportSource|jsxRuntime)\s+(\S+)/g;
+function buildJsx(tree, options = {}) {
+  let automatic = options.runtime === "automatic";
+  const annotations = {};
+  const imports = {};
+  walk(tree, {
+    enter(node) {
+      if (node.type === "Program") {
+        const comments = node.comments || [];
+        let index2 = -1;
+        while (++index2 < comments.length) {
+          regex.lastIndex = 0;
+          let match = regex.exec(comments[index2].value);
+          while (match) {
+            annotations[match[1]] = match[2];
+            match = regex.exec(comments[index2].value);
+          }
+        }
+        if (annotations.jsxRuntime) {
+          if (annotations.jsxRuntime === "automatic") {
+            automatic = true;
+            if (annotations.jsx) {
+              throw new Error("Unexpected `@jsx` pragma w/ automatic runtime");
+            }
+            if (annotations.jsxFrag) {
+              throw new Error(
+                "Unexpected `@jsxFrag` pragma w/ automatic runtime"
+              );
+            }
+          } else if (annotations.jsxRuntime === "classic") {
+            automatic = false;
+            if (annotations.jsxImportSource) {
+              throw new Error(
+                "Unexpected `@jsxImportSource` w/ classic runtime"
+              );
+            }
+          } else {
+            throw new Error(
+              "Unexpected `jsxRuntime` `" + annotations.jsxRuntime + "`, expected `automatic` or `classic`"
+            );
+          }
+        }
+      }
+    },
+    leave(node) {
+      if (node.type === "Program") {
+        const specifiers = [];
+        if (imports.fragment) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "Fragment" },
+            local: { type: "Identifier", name: "_Fragment" }
+          });
+        }
+        if (imports.jsx) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "jsx" },
+            local: { type: "Identifier", name: "_jsx" }
+          });
+        }
+        if (imports.jsxs) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "jsxs" },
+            local: { type: "Identifier", name: "_jsxs" }
+          });
+        }
+        if (imports.jsxDEV) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "jsxDEV" },
+            local: { type: "Identifier", name: "_jsxDEV" }
+          });
+        }
+        if (specifiers.length > 0) {
+          node.body.unshift({
+            type: "ImportDeclaration",
+            specifiers,
+            source: {
+              type: "Literal",
+              value: (annotations.jsxImportSource || options.importSource || "react") + (options.development ? "/jsx-dev-runtime" : "/jsx-runtime")
+            }
+          });
+        }
+      }
+      if (node.type !== "JSXElement" && node.type !== "JSXFragment") {
+        return;
+      }
+      const children = [];
+      let index2 = -1;
+      while (++index2 < node.children.length) {
+        const child = node.children[index2];
+        if (child.type === "JSXExpressionContainer") {
+          if (child.expression.type !== "JSXEmptyExpression") {
+            children.push(child.expression);
+          }
+        } else if (child.type === "JSXText") {
+          const value = child.value.replace(/\t/g, " ").replace(/ *(\r?\n|\r) */g, "\n").replace(/\n+/g, "\n").replace(/\n+$/, "").replace(/\n/g, " ");
+          if (value) {
+            children.push(create(child, { type: "Literal", value }));
+          }
+        } else {
+          children.push(child);
+        }
+      }
+      let name2;
+      let fields = [];
+      const objects = [];
+      let parameters = [];
+      let key;
+      if (node.type === "JSXElement") {
+        name2 = toIdentifier(node.openingElement.name);
+        if (name2.type === "Identifier" && /^[a-z]/.test(name2.name)) {
+          name2 = create(name2, { type: "Literal", value: name2.name });
+        }
+        let spread;
+        const attributes = node.openingElement.attributes;
+        let index3 = -1;
+        while (++index3 < attributes.length) {
+          const attribute = attributes[index3];
+          if (attribute.type === "JSXSpreadAttribute") {
+            if (fields.length > 0) {
+              objects.push({ type: "ObjectExpression", properties: fields });
+              fields = [];
+            }
+            objects.push(attribute.argument);
+            spread = true;
+          } else {
+            const prop = toProperty(attribute);
+            if (automatic && prop.key.type === "Identifier" && prop.key.name === "key") {
+              if (spread) {
+                throw new Error(
+                  "Expected `key` to come before any spread expressions"
+                );
+              }
+              key = prop.value;
+            } else {
+              fields.push(prop);
+            }
+          }
+        }
+      } else if (automatic) {
+        imports.fragment = true;
+        name2 = { type: "Identifier", name: "_Fragment" };
+      } else {
+        name2 = toMemberExpression(
+          annotations.jsxFrag || options.pragmaFrag || "React.Fragment"
+        );
+      }
+      if (automatic) {
+        if (children.length > 0) {
+          fields.push({
+            type: "Property",
+            key: { type: "Identifier", name: "children" },
+            value: children.length > 1 ? { type: "ArrayExpression", elements: children } : children[0],
+            kind: "init",
+            method: false,
+            shorthand: false,
+            computed: false
+          });
+        }
+      } else {
+        parameters = children;
+      }
+      if (fields.length > 0) {
+        objects.push({ type: "ObjectExpression", properties: fields });
+      }
+      let props;
+      let callee;
+      if (objects.length > 1) {
+        if (objects[0].type !== "ObjectExpression") {
+          objects.unshift({ type: "ObjectExpression", properties: [] });
+        }
+        props = {
+          type: "CallExpression",
+          callee: toMemberExpression("Object.assign"),
+          arguments: objects,
+          optional: false
+        };
+      } else if (objects.length > 0) {
+        props = objects[0];
+      }
+      if (automatic) {
+        parameters.push(props || { type: "ObjectExpression", properties: [] });
+        if (key) {
+          parameters.push(key);
+        } else if (options.development) {
+          parameters.push({ type: "Identifier", name: "undefined" });
+        }
+        const isStaticChildren = children.length > 1;
+        if (options.development) {
+          imports.jsxDEV = true;
+          callee = {
+            type: "Identifier",
+            name: "_jsxDEV"
+          };
+          parameters.push({ type: "Literal", value: isStaticChildren });
+          const source = {
+            type: "ObjectExpression",
+            properties: [
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: "init",
+                key: { type: "Identifier", name: "fileName" },
+                value: {
+                  type: "Literal",
+                  value: options.filePath || "<source.js>"
+                }
+              }
+            ]
+          };
+          if (node.loc) {
+            source.properties.push(
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: "init",
+                key: { type: "Identifier", name: "lineNumber" },
+                value: { type: "Literal", value: node.loc.start.line }
+              },
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: "init",
+                key: { type: "Identifier", name: "columnNumber" },
+                value: { type: "Literal", value: node.loc.start.column + 1 }
+              }
+            );
+          }
+          parameters.push(source, { type: "ThisExpression" });
+        } else if (isStaticChildren) {
+          imports.jsxs = true;
+          callee = { type: "Identifier", name: "_jsxs" };
+        } else {
+          imports.jsx = true;
+          callee = { type: "Identifier", name: "_jsx" };
+        }
+      } else {
+        if (props || parameters.length > 0) {
+          parameters.unshift(props || { type: "Literal", value: null });
+        }
+        callee = toMemberExpression(
+          annotations.jsx || options.pragma || "React.createElement"
+        );
+      }
+      parameters.unshift(name2);
+      this.replace(
+        create(node, {
+          type: "CallExpression",
+          callee,
+          arguments: parameters,
+          optional: false
+        })
+      );
+    }
+  });
+  return tree;
+}
+function toProperty(node) {
+  let value;
+  if (node.value) {
+    if (node.value.type === "JSXExpressionContainer") {
+      value = node.value.expression;
+    } else {
+      value = node.value;
+      delete value.raw;
+    }
+  } else {
+    value = { type: "Literal", value: true };
+  }
+  return create(node, {
+    type: "Property",
+    key: toIdentifier(node.name),
+    value,
+    kind: "init",
+    method: false,
+    shorthand: false,
+    computed: false
+  });
+}
+function toIdentifier(node) {
+  let replace;
+  if (node.type === "JSXMemberExpression") {
+    const id = toIdentifier(node.property);
+    replace = {
+      type: "MemberExpression",
+      object: toIdentifier(node.object),
+      property: id,
+      computed: id.type === "Literal",
+      optional: false
+    };
+  } else if (node.type === "JSXNamespacedName") {
+    replace = {
+      type: "Literal",
+      value: node.namespace.name + ":" + node.name.name
+    };
+  } else {
+    replace = name(node.name) ? { type: "Identifier", name: node.name } : { type: "Literal", value: node.name };
+  }
+  return create(node, replace);
+}
+function toMemberExpression(id) {
+  const identifiers = id.split(".");
+  let index2 = -1;
+  let result;
+  while (++index2 < identifiers.length) {
+    const prop = name(identifiers[index2]) ? { type: "Identifier", name: identifiers[index2] } : { type: "Literal", value: identifiers[index2] };
+    result = result ? {
+      type: "MemberExpression",
+      object: result,
+      property: prop,
+      computed: Boolean(index2 && prop.type === "Literal"),
+      optional: false
+    } : prop;
+  }
+  return result;
+}
+function create(from, node) {
+  const fields = ["start", "end", "loc", "range", "comments"];
+  let index2 = -1;
+  while (++index2 < fields.length) {
+    const field = fields[index2];
+    if (field in from) {
+      node[field] = from[field];
+    }
+  }
+  return node;
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-create.js
+function create2(template, node) {
+  const fields = ["start", "end", "loc", "range", "comments"];
+  let index2 = -1;
+  while (++index2 < fields.length) {
+    const field = fields[index2];
+    if (field in template) {
+      node[field] = template[field];
+    }
+  }
+  return node;
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-specifiers-to-declarations.js
+function specifiersToDeclarations(specifiers, init) {
+  let index2 = -1;
+  const declarations = [];
+  const otherSpecifiers = [];
+  let importNamespaceSpecifier;
+  while (++index2 < specifiers.length) {
+    const specifier = specifiers[index2];
+    if (specifier.type === "ImportNamespaceSpecifier") {
+      importNamespaceSpecifier = specifier;
+    } else {
+      otherSpecifiers.push(specifier);
+    }
+  }
+  if (importNamespaceSpecifier) {
+    declarations.push(
+      create2(importNamespaceSpecifier, {
+        type: "VariableDeclarator",
+        id: importNamespaceSpecifier.local,
+        init
+      })
+    );
+  }
+  declarations.push({
+    type: "VariableDeclarator",
+    id: {
+      type: "ObjectPattern",
+      properties: otherSpecifiers.map((specifier) => {
+        let key = specifier.type === "ImportSpecifier" ? specifier.imported : specifier.type === "ExportSpecifier" ? specifier.exported : { type: "Identifier", name: "default" };
+        let value = specifier.local;
+        if (specifier.type === "ExportSpecifier") {
+          value = key;
+          key = specifier.local;
+        }
+        return create2(specifier, {
+          type: "Property",
+          kind: "init",
+          shorthand: key.name === value.name,
+          method: false,
+          computed: false,
+          key,
+          value
+        });
+      })
+    },
+    init: importNamespaceSpecifier ? { type: "Identifier", name: importNamespaceSpecifier.local.name } : init
+  });
+  return declarations;
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-to-id-or-member-expression.js
+var toIdOrMemberExpression = toIdOrMemberExpressionFactory(
+  "Identifier",
+  "MemberExpression",
+  name
+);
+var toJsxIdOrMemberExpression = toIdOrMemberExpressionFactory(
+  "JSXIdentifier",
+  "JSXMemberExpression",
+  isJsxIdentifierName
+);
+function toIdOrMemberExpressionFactory(idType, memberType, isIdentifier) {
+  return toIdOrMemberExpression2;
+  function toIdOrMemberExpression2(ids) {
+    let index2 = -1;
+    let object;
+    while (++index2 < ids.length) {
+      const name2 = ids[index2];
+      const valid2 = typeof name2 === "string" && isIdentifier(name2);
+      if (idType === "JSXIdentifier" && !valid2) {
+        throw new Error("Cannot turn `" + name2 + "` into a JSX identifier");
+      }
+      const id = valid2 ? { type: idType, name: name2 } : { type: "Literal", value: name2 };
+      object = object ? {
+        type: memberType,
+        object,
+        property: id,
+        computed: id.type === "Literal",
+        optional: false
+      } : id;
+    }
+    if (!object)
+      throw new Error("Expected non-empty `ids` to be passed");
+    if (object.type === "Literal")
+      throw new Error("Expected identifier as left-most value");
+    return object;
+  }
+}
+function isJsxIdentifierName(name2) {
+  let index2 = -1;
+  while (++index2 < name2.length) {
+    if (!(index2 ? jsxCont : start2)(name2.charCodeAt(index2)))
+      return false;
+  }
+  return index2 > 0;
+}
+function jsxCont(code2) {
+  return code2 === 45 || cont2(code2);
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-jsx-build.js
+function recmaJsxBuild(options = {}) {
+  const { outputFormat } = options;
+  return (tree) => {
+    buildJsx(tree);
+    if (outputFormat === "function-body" && tree.body[0] && tree.body[0].type === "ImportDeclaration" && typeof tree.body[0].source.value === "string" && /\/jsx-runtime$/.test(tree.body[0].source.value)) {
+      tree.body[0] = {
+        type: "VariableDeclaration",
+        kind: "const",
+        declarations: specifiersToDeclarations(
+          tree.body[0].specifiers,
+          toIdOrMemberExpression(["arguments", 0])
+        )
+      };
+    }
+  };
+}
+
+// node_modules/is-reference/src/index.js
+function is_reference(node, parent) {
+  if (node.type === "MemberExpression") {
+    return !node.computed && is_reference(node.object, node);
+  }
+  if (node.type === "Identifier") {
+    if (!parent)
+      return true;
+    switch (parent.type) {
+      case "MemberExpression":
+        return parent.computed || node === parent.object;
+      case "MethodDefinition":
+        return parent.computed;
+      case "PropertyDefinition":
+        return parent.computed || node === parent.value;
+      case "Property":
+        return parent.computed || node === parent.value;
+      case "ExportSpecifier":
+      case "ImportSpecifier":
+        return node === parent.local;
+      case "LabeledStatement":
+      case "BreakStatement":
+      case "ContinueStatement":
+        return false;
+      default:
+        return true;
+    }
+  }
+  return false;
+}
+
+// node_modules/periscopic/src/index.js
+function analyze(expression) {
+  const map = /* @__PURE__ */ new WeakMap();
+  const globals = /* @__PURE__ */ new Map();
+  const scope = new Scope3(null, false);
+  const references = [];
+  let current_scope = scope;
+  walk(expression, {
+    enter(node, parent) {
+      switch (node.type) {
+        case "Identifier":
+          if (is_reference(node, parent)) {
+            references.push([current_scope, node]);
+          }
+          break;
+        case "ImportDeclaration":
+          node.specifiers.forEach((specifier) => {
+            current_scope.declarations.set(specifier.local.name, specifier);
+          });
+          break;
+        case "FunctionExpression":
+        case "FunctionDeclaration":
+        case "ArrowFunctionExpression":
+          if (node.type === "FunctionDeclaration") {
+            if (node.id) {
+              current_scope.declarations.set(node.id.name, node);
+            }
+            map.set(node, current_scope = new Scope3(current_scope, false));
+          } else {
+            map.set(node, current_scope = new Scope3(current_scope, false));
+            if (node.type === "FunctionExpression" && node.id) {
+              current_scope.declarations.set(node.id.name, node);
+            }
+          }
+          node.params.forEach((param) => {
+            extract_names(param).forEach((name2) => {
+              current_scope.declarations.set(name2, node);
+            });
+          });
+          break;
+        case "ForStatement":
+        case "ForInStatement":
+        case "ForOfStatement":
+          map.set(node, current_scope = new Scope3(current_scope, true));
+          break;
+        case "BlockStatement":
+          map.set(node, current_scope = new Scope3(current_scope, true));
+          break;
+        case "ClassDeclaration":
+        case "VariableDeclaration":
+          current_scope.add_declaration(node);
+          break;
+        case "CatchClause":
+          map.set(node, current_scope = new Scope3(current_scope, true));
+          if (node.param) {
+            extract_names(node.param).forEach((name2) => {
+              current_scope.declarations.set(name2, node.param);
+            });
+          }
+          break;
+      }
+    },
+    leave(node) {
+      if (map.has(node)) {
+        current_scope = current_scope.parent;
+      }
+    }
+  });
+  for (let i = references.length - 1; i >= 0; --i) {
+    const [scope2, reference] = references[i];
+    if (!scope2.references.has(reference.name)) {
+      add_reference(scope2, reference.name);
+    }
+    if (!scope2.find_owner(reference.name)) {
+      globals.set(reference.name, reference);
+    }
+  }
+  return { map, scope, globals };
+}
+function add_reference(scope, name2) {
+  scope.references.add(name2);
+  if (scope.parent)
+    add_reference(scope.parent, name2);
+}
+var Scope3 = class {
+  constructor(parent, block) {
+    this.parent = parent;
+    this.block = block;
+    this.declarations = /* @__PURE__ */ new Map();
+    this.initialised_declarations = /* @__PURE__ */ new Set();
+    this.references = /* @__PURE__ */ new Set();
+  }
+  add_declaration(node) {
+    if (node.type === "VariableDeclaration") {
+      if (node.kind === "var" && this.block && this.parent) {
+        this.parent.add_declaration(node);
+      } else {
+        const handle_declarator = (declarator) => {
+          extract_names(declarator.id).forEach((name2) => {
+            this.declarations.set(name2, node);
+            if (declarator.init)
+              this.initialised_declarations.add(name2);
+          });
+          ;
+        };
+        node.declarations.forEach(handle_declarator);
+      }
+    } else if (node.id) {
+      this.declarations.set(node.id.name, node);
+    }
+  }
+  find_owner(name2) {
+    if (this.declarations.has(name2))
+      return this;
+    return this.parent && this.parent.find_owner(name2);
+  }
+  has(name2) {
+    return this.declarations.has(name2) || !!this.parent && this.parent.has(name2);
+  }
+};
+function extract_names(param) {
+  return extract_identifiers(param).map((node) => node.name);
+}
+function extract_identifiers(param, nodes = []) {
+  switch (param.type) {
+    case "Identifier":
+      nodes.push(param);
+      break;
+    case "MemberExpression":
+      let object = param;
+      while (object.type === "MemberExpression") {
+        object = object.object;
+      }
+      nodes.push(object);
+      break;
+    case "ObjectPattern":
+      const handle_prop = (prop) => {
+        if (prop.type === "RestElement") {
+          extract_identifiers(prop.argument, nodes);
+        } else {
+          extract_identifiers(prop.value, nodes);
+        }
+      };
+      param.properties.forEach(handle_prop);
+      break;
+    case "ArrayPattern":
+      const handle_element = (element2) => {
+        if (element2)
+          extract_identifiers(element2, nodes);
+      };
+      param.elements.forEach(handle_element);
+      break;
+    case "RestElement":
+      extract_identifiers(param.argument, nodes);
+      break;
+    case "AssignmentPattern":
+      extract_identifiers(param.left, nodes);
+      break;
+  }
+  return nodes;
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-declaration-to-expression.js
+function declarationToExpression(declaration) {
+  if (declaration.type === "FunctionDeclaration") {
+    return { ...declaration, type: "FunctionExpression" };
+  }
+  if (declaration.type === "ClassDeclaration") {
+    return { ...declaration, type: "ClassExpression" };
+  }
+  throw new Error("Cannot turn `" + declaration.type + "` into an expression");
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-is-declaration.js
+function isDeclaration(node) {
+  const type = node && typeof node === "object" && node.type;
+  return Boolean(
+    type === "FunctionDeclaration" || type === "ClassDeclaration" || type === "VariableDeclaration"
+  );
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-document.js
+function recmaDocument(options = {}) {
+  const {
+    baseUrl,
+    useDynamicImport,
+    outputFormat = "program",
+    pragma = "React.createElement",
+    pragmaFrag = "React.Fragment",
+    pragmaImportSource = "react",
+    jsxImportSource = "react",
+    jsxRuntime = "automatic"
+  } = options;
+  return (tree, file) => {
+    const exportedIdentifiers = [];
+    const replacement = [];
+    const pragmas = [];
+    let exportAllCount = 0;
+    let layout;
+    let content3;
+    let child;
+    if (!tree.comments)
+      tree.comments = [];
+    if (jsxRuntime) {
+      pragmas.push("@jsxRuntime " + jsxRuntime);
+    }
+    if (jsxRuntime === "automatic" && jsxImportSource) {
+      pragmas.push("@jsxImportSource " + jsxImportSource);
+    }
+    if (jsxRuntime === "classic" && pragma) {
+      pragmas.push("@jsx " + pragma);
+    }
+    if (jsxRuntime === "classic" && pragmaFrag) {
+      pragmas.push("@jsxFrag " + pragmaFrag);
+    }
+    if (pragmas.length > 0) {
+      tree.comments.unshift({ type: "Block", value: pragmas.join(" ") });
+    }
+    if (jsxRuntime === "classic" && pragmaImportSource) {
+      if (!pragma) {
+        throw new Error(
+          "Missing `pragma` in classic runtime with `pragmaImportSource`"
+        );
+      }
+      handleEsm({
+        type: "ImportDeclaration",
+        specifiers: [
+          {
+            type: "ImportDefaultSpecifier",
+            local: { type: "Identifier", name: pragma.split(".")[0] }
+          }
+        ],
+        source: { type: "Literal", value: pragmaImportSource }
+      });
+    }
+    for (child of tree.body) {
+      if (child.type === "ExportDefaultDeclaration") {
+        if (layout) {
+          file.fail(
+            "Cannot specify multiple layouts (previous: " + stringifyPosition(positionFromEstree(layout)) + ")",
+            positionFromEstree(child),
+            "recma-document:duplicate-layout"
+          );
+        }
+        layout = child;
+        replacement.push({
+          type: "VariableDeclaration",
+          kind: "const",
+          declarations: [
+            {
+              type: "VariableDeclarator",
+              id: { type: "Identifier", name: "MDXLayout" },
+              init: isDeclaration(child.declaration) ? declarationToExpression(child.declaration) : child.declaration
+            }
+          ]
+        });
+      } else if (child.type === "ExportNamedDeclaration" && child.source) {
+        const source = child.source;
+        child.specifiers = child.specifiers.filter((specifier) => {
+          if (specifier.exported.name === "default") {
+            if (layout) {
+              file.fail(
+                "Cannot specify multiple layouts (previous: " + stringifyPosition(positionFromEstree(layout)) + ")",
+                positionFromEstree(child),
+                "recma-document:duplicate-layout"
+              );
+            }
+            layout = specifier;
+            handleEsm(
+              create2(specifier, {
+                type: "ImportDeclaration",
+                specifiers: [
+                  specifier.local.name === "default" ? {
+                    type: "ImportDefaultSpecifier",
+                    local: { type: "Identifier", name: "MDXLayout" }
+                  } : create2(specifier.local, {
+                    type: "ImportSpecifier",
+                    imported: specifier.local,
+                    local: { type: "Identifier", name: "MDXLayout" }
+                  })
+                ],
+                source: create2(source, { type: "Literal", value: source.value })
+              })
+            );
+            return false;
+          }
+          return true;
+        });
+        if (child.specifiers.length > 0) {
+          handleExport(child);
+        }
+      } else if (child.type === "ExportNamedDeclaration" || child.type === "ExportAllDeclaration") {
+        handleExport(child);
+      } else if (child.type === "ImportDeclaration") {
+        handleEsm(child);
+      } else if (child.type === "ExpressionStatement" && (child.expression.type === "JSXFragment" || child.expression.type === "JSXElement")) {
+        content3 = true;
+        replacement.push(...createMdxContent(child.expression, Boolean(layout)));
+      } else {
+        replacement.push(child);
+      }
+    }
+    if (!content3) {
+      replacement.push(...createMdxContent(void 0, Boolean(layout)));
+    }
+    exportedIdentifiers.push(["MDXContent", "default"]);
+    if (outputFormat === "function-body") {
+      replacement.push({
+        type: "ReturnStatement",
+        argument: {
+          type: "ObjectExpression",
+          properties: [
+            ...Array.from({ length: exportAllCount }).map(
+              (_, index2) => ({
+                type: "SpreadElement",
+                argument: { type: "Identifier", name: "_exportAll" + (index2 + 1) }
+              })
+            ),
+            ...exportedIdentifiers.map((d) => {
+              const prop = {
+                type: "Property",
+                kind: "init",
+                method: false,
+                computed: false,
+                shorthand: typeof d === "string",
+                key: {
+                  type: "Identifier",
+                  name: typeof d === "string" ? d : d[1]
+                },
+                value: {
+                  type: "Identifier",
+                  name: typeof d === "string" ? d : d[0]
+                }
+              };
+              return prop;
+            })
+          ]
+        }
+      });
+    } else {
+      replacement.push({
+        type: "ExportDefaultDeclaration",
+        declaration: { type: "Identifier", name: "MDXContent" }
+      });
+    }
+    tree.body = replacement;
+    if (baseUrl) {
+      walk(tree, {
+        enter(_node) {
+          const node = _node;
+          if (node.type === "MemberExpression" && "object" in node && node.object.type === "MetaProperty" && node.property.type === "Identifier" && node.object.meta.name === "import" && node.object.property.name === "meta" && node.property.name === "url") {
+            const replacement2 = { type: "Literal", value: baseUrl };
+            this.replace(replacement2);
+          }
+        }
+      });
+    }
+    function handleExport(node) {
+      if (node.type === "ExportNamedDeclaration") {
+        if (node.declaration) {
+          exportedIdentifiers.push(
+            ...analyze(node.declaration).scope.declarations.keys()
+          );
+        }
+        for (child of node.specifiers) {
+          exportedIdentifiers.push(child.exported.name);
+        }
+      }
+      handleEsm(node);
+    }
+    function handleEsm(node) {
+      if (baseUrl && node.source) {
+        let value = String(node.source.value);
+        try {
+          value = String(new URL(value));
+        } catch {
+          if (/^\.{0,2}\//.test(value)) {
+            value = String(new URL(value, baseUrl));
+          }
+        }
+        node.source = create2(node.source, { type: "Literal", value });
+      }
+      let replace;
+      let init;
+      if (outputFormat === "function-body") {
+        if (node.type === "ImportDeclaration" || node.type === "ExportAllDeclaration" || node.type === "ExportNamedDeclaration" && node.source) {
+          if (!useDynamicImport) {
+            file.fail(
+              "Cannot use `import` or `export \u2026 from` in `evaluate` (outputting a function body) by default: please set `useDynamicImport: true` (and probably specify a `baseUrl`)",
+              positionFromEstree(node),
+              "recma-document:invalid-esm-statement"
+            );
+          }
+          if (!node.source) {
+            throw new Error("Expected `node.source` to be defined");
+          }
+          init = {
+            type: "AwaitExpression",
+            argument: create2(node, {
+              type: "ImportExpression",
+              source: node.source
+            })
+          };
+          if ((node.type === "ImportDeclaration" || node.type === "ExportNamedDeclaration") && node.specifiers.length === 0) {
+            replace = { type: "ExpressionStatement", expression: init };
+          } else {
+            replace = {
+              type: "VariableDeclaration",
+              kind: "const",
+              declarations: node.type === "ExportAllDeclaration" ? [
+                {
+                  type: "VariableDeclarator",
+                  id: {
+                    type: "Identifier",
+                    name: "_exportAll" + ++exportAllCount
+                  },
+                  init
+                }
+              ] : specifiersToDeclarations(node.specifiers, init)
+            };
+          }
+        } else if (node.declaration) {
+          replace = node.declaration;
+        } else {
+          const declarators = node.specifiers.filter(
+            (specifier) => specifier.local.name !== specifier.exported.name
+          ).map((specifier) => ({
+            type: "VariableDeclarator",
+            id: specifier.exported,
+            init: specifier.local
+          }));
+          if (declarators.length > 0) {
+            replace = {
+              type: "VariableDeclaration",
+              kind: "const",
+              declarations: declarators
+            };
+          }
+        }
+      } else {
+        replace = node;
+      }
+      if (replace) {
+        replacement.push(replace);
+      }
+    }
+  };
+  function createMdxContent(content3, hasInternalLayout) {
+    const element2 = {
+      type: "JSXElement",
+      openingElement: {
+        type: "JSXOpeningElement",
+        name: { type: "JSXIdentifier", name: "MDXLayout" },
+        attributes: [
+          {
+            type: "JSXSpreadAttribute",
+            argument: { type: "Identifier", name: "props" }
+          }
+        ],
+        selfClosing: false
+      },
+      closingElement: {
+        type: "JSXClosingElement",
+        name: { type: "JSXIdentifier", name: "MDXLayout" }
+      },
+      children: [
+        {
+          type: "JSXElement",
+          openingElement: {
+            type: "JSXOpeningElement",
+            name: { type: "JSXIdentifier", name: "_createMdxContent" },
+            attributes: [
+              {
+                type: "JSXSpreadAttribute",
+                argument: { type: "Identifier", name: "props" }
+              }
+            ],
+            selfClosing: true
+          },
+          closingElement: null,
+          children: []
+        }
+      ]
+    };
+    let result = element2;
+    if (!hasInternalLayout) {
+      result = {
+        type: "ConditionalExpression",
+        test: { type: "Identifier", name: "MDXLayout" },
+        consequent: result,
+        alternate: {
+          type: "CallExpression",
+          callee: { type: "Identifier", name: "_createMdxContent" },
+          arguments: [{ type: "Identifier", name: "props" }],
+          optional: false
+        }
+      };
+    }
+    let argument = content3 || { type: "Literal", value: null };
+    if (argument && argument.type === "JSXFragment" && argument.children.length === 1 && argument.children[0].type === "JSXElement") {
+      argument = argument.children[0];
+    }
+    return [
+      {
+        type: "FunctionDeclaration",
+        id: { type: "Identifier", name: "_createMdxContent" },
+        params: [{ type: "Identifier", name: "props" }],
+        body: {
+          type: "BlockStatement",
+          body: [{ type: "ReturnStatement", argument }]
+        }
+      },
+      {
+        type: "FunctionDeclaration",
+        id: { type: "Identifier", name: "MDXContent" },
+        params: [
+          {
+            type: "AssignmentPattern",
+            left: { type: "Identifier", name: "props" },
+            right: { type: "ObjectExpression", properties: [] }
+          }
+        ],
+        body: {
+          type: "BlockStatement",
+          body: [
+            {
+              type: "ReturnStatement",
+              argument: result
+            }
+          ]
+        }
+      }
+    ];
+  }
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-to-binary-addition.js
+function toBinaryAddition(expressions) {
+  let index2 = -1;
+  let left;
+  while (++index2 < expressions.length) {
+    const right = expressions[index2];
+    left = left ? { type: "BinaryExpression", left, operator: "+", right } : right;
+  }
+  if (!left)
+    throw new Error("Expected non-empty `expressions` to be passed");
+  return left;
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-jsx-rewrite.js
+var own8 = {}.hasOwnProperty;
+function recmaJsxRewrite(options = {}) {
+  const { development: development2, providerImportSource, outputFormat } = options;
+  return (tree, file) => {
+    const scopeInfo = analyze(tree);
+    const fnStack = [];
+    let importProvider;
+    let createErrorHelper;
+    let currentScope;
+    walk(tree, {
+      enter(_node) {
+        const node = _node;
+        const newScope = scopeInfo.map.get(node);
+        if (node.type === "FunctionDeclaration" || node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression") {
+          fnStack.push({
+            objects: [],
+            components: [],
+            tags: [],
+            references: {},
+            idToInvalidComponentName: /* @__PURE__ */ new Map(),
+            node
+          });
+          if (isNamedFunction(node, "MDXContent") && newScope && !inScope(newScope, "MDXLayout")) {
+            fnStack[0].components.push("MDXLayout");
+          }
+        }
+        const fnScope = fnStack[0];
+        if (!fnScope || !isNamedFunction(fnScope.node, "_createMdxContent") && !providerImportSource) {
+          return;
+        }
+        if (newScope) {
+          newScope.node = node;
+          currentScope = newScope;
+        }
+        if (currentScope && node.type === "JSXElement") {
+          let name2 = node.openingElement.name;
+          if (name2.type === "JSXMemberExpression") {
+            const ids = [];
+            while (name2.type === "JSXMemberExpression") {
+              ids.unshift(name2.property.name);
+              name2 = name2.object;
+            }
+            ids.unshift(name2.name);
+            const fullId = ids.join(".");
+            const id = name2.name;
+            const isInScope = inScope(currentScope, id);
+            if (!own8.call(fnScope.references, fullId)) {
+              const parentScope = currentScope.parent;
+              if (!isInScope || parentScope && parentScope.node.type === "FunctionDeclaration" && isNamedFunction(parentScope.node, "_createMdxContent")) {
+                fnScope.references[fullId] = { node, component: true };
+              }
+            }
+            if (!fnScope.objects.includes(id) && !isInScope) {
+              fnScope.objects.push(id);
+            }
+          } else if (name2.type === "JSXNamespacedName") {
+          } else if (name(name2.name) && !/^[a-z]/.test(name2.name)) {
+            const id = name2.name;
+            if (!inScope(currentScope, id)) {
+              if (id !== "MDXLayout" && !own8.call(fnScope.references, id)) {
+                fnScope.references[id] = { node, component: true };
+              }
+              if (!fnScope.components.includes(id)) {
+                fnScope.components.push(id);
+              }
+            }
+          } else if (node.data && node.data._mdxExplicitJsx) {
+          } else {
+            const id = name2.name;
+            if (!fnScope.tags.includes(id)) {
+              fnScope.tags.push(id);
+            }
+            let jsxIdExpression = ["_components", id];
+            if (name(id) === false) {
+              let invalidComponentName = fnScope.idToInvalidComponentName.get(id);
+              if (invalidComponentName === void 0) {
+                invalidComponentName = `_component${fnScope.idToInvalidComponentName.size}`;
+                fnScope.idToInvalidComponentName.set(id, invalidComponentName);
+              }
+              jsxIdExpression = [invalidComponentName];
+            }
+            node.openingElement.name = toJsxIdOrMemberExpression(jsxIdExpression);
+            if (node.closingElement) {
+              node.closingElement.name = toJsxIdOrMemberExpression(jsxIdExpression);
+            }
+          }
+        }
+      },
+      leave(node) {
+        const defaults = [];
+        const actual = [];
+        const parameters = [];
+        const declarations = [];
+        if (currentScope && currentScope.node === node) {
+          currentScope = currentScope.parent;
+        }
+        if (node.type === "FunctionDeclaration" || node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression") {
+          const fn = node;
+          const scope = fnStack[fnStack.length - 1];
+          let name2;
+          for (name2 of scope.tags) {
+            defaults.push({
+              type: "Property",
+              kind: "init",
+              key: name(name2) ? { type: "Identifier", name: name2 } : { type: "Literal", value: name2 },
+              value: { type: "Literal", value: name2 },
+              method: false,
+              shorthand: false,
+              computed: false
+            });
+          }
+          actual.push(...scope.components);
+          for (name2 of scope.objects) {
+            if (!actual.includes(name2)) {
+              actual.push(name2);
+            }
+          }
+          const statements = [];
+          if (defaults.length > 0 || actual.length > 0 || scope.idToInvalidComponentName.size > 0) {
+            if (providerImportSource) {
+              importProvider = true;
+              parameters.push({
+                type: "CallExpression",
+                callee: { type: "Identifier", name: "_provideComponents" },
+                arguments: [],
+                optional: false
+              });
+            }
+            if (isNamedFunction(scope.node, "MDXContent") || isNamedFunction(scope.node, "_createMdxContent")) {
+              parameters.push(toIdOrMemberExpression(["props", "components"]));
+            }
+            if (defaults.length > 0 || parameters.length > 1) {
+              parameters.unshift({
+                type: "ObjectExpression",
+                properties: defaults
+              });
+            }
+            let componentsInit = parameters.length > 1 ? {
+              type: "CallExpression",
+              callee: toIdOrMemberExpression(["Object", "assign"]),
+              arguments: parameters,
+              optional: false
+            } : parameters[0].type === "MemberExpression" ? {
+              type: "LogicalExpression",
+              operator: "||",
+              left: parameters[0],
+              right: { type: "ObjectExpression", properties: [] }
+            } : parameters[0];
+            let componentsPattern;
+            if (actual.length > 0) {
+              componentsPattern = {
+                type: "ObjectPattern",
+                properties: actual.map((name3) => ({
+                  type: "Property",
+                  kind: "init",
+                  key: {
+                    type: "Identifier",
+                    name: name3 === "MDXLayout" ? "wrapper" : name3
+                  },
+                  value: { type: "Identifier", name: name3 },
+                  method: false,
+                  shorthand: name3 !== "MDXLayout",
+                  computed: false
+                }))
+              };
+            }
+            if (scope.tags.length > 0) {
+              declarations.push({
+                type: "VariableDeclarator",
+                id: { type: "Identifier", name: "_components" },
+                init: componentsInit
+              });
+              componentsInit = { type: "Identifier", name: "_components" };
+            }
+            if (isNamedFunction(scope.node, "_createMdxContent")) {
+              for (const [
+                id,
+                componentName
+              ] of scope.idToInvalidComponentName) {
+                declarations.push({
+                  type: "VariableDeclarator",
+                  id: { type: "Identifier", name: componentName },
+                  init: {
+                    type: "MemberExpression",
+                    object: { type: "Identifier", name: "_components" },
+                    property: { type: "Literal", value: id },
+                    computed: true,
+                    optional: false
+                  }
+                });
+              }
+            }
+            if (componentsPattern) {
+              declarations.push({
+                type: "VariableDeclarator",
+                id: componentsPattern,
+                init: componentsInit
+              });
+            }
+            if (declarations.length > 0) {
+              statements.push({
+                type: "VariableDeclaration",
+                kind: "const",
+                declarations
+              });
+            }
+          }
+          let key;
+          for (key in scope.references) {
+            if (own8.call(scope.references, key)) {
+              const parts = key.split(".");
+              let index3 = 0;
+              while (++index3 < parts.length) {
+                const partial = parts.slice(0, index3).join(".");
+                if (!own8.call(scope.references, partial)) {
+                  scope.references[partial] = {
+                    node: scope.references[key].node,
+                    component: false
+                  };
+                }
+              }
+            }
+          }
+          const references = Object.keys(scope.references).sort();
+          let index2 = -1;
+          while (++index2 < references.length) {
+            const id = references[index2];
+            const info = scope.references[id];
+            const place = stringifyPosition(positionFromEstree(info.node));
+            const parameters2 = [
+              { type: "Literal", value: id },
+              { type: "Literal", value: info.component }
+            ];
+            createErrorHelper = true;
+            if (development2 && place !== "1:1-1:1") {
+              parameters2.push({ type: "Literal", value: place });
+            }
+            statements.push({
+              type: "IfStatement",
+              test: {
+                type: "UnaryExpression",
+                operator: "!",
+                prefix: true,
+                argument: toIdOrMemberExpression(id.split("."))
+              },
+              consequent: {
+                type: "ExpressionStatement",
+                expression: {
+                  type: "CallExpression",
+                  callee: { type: "Identifier", name: "_missingMdxReference" },
+                  arguments: parameters2,
+                  optional: false
+                }
+              },
+              alternate: null
+            });
+          }
+          if (statements.length > 0) {
+            if (fn.body.type !== "BlockStatement") {
+              fn.body = {
+                type: "BlockStatement",
+                body: [{ type: "ReturnStatement", argument: fn.body }]
+              };
+            }
+            fn.body.body.unshift(...statements);
+          }
+          fnStack.pop();
+        }
+      }
+    });
+    if (importProvider && providerImportSource) {
+      tree.body.unshift(
+        createImportProvider(providerImportSource, outputFormat)
+      );
+    }
+    if (createErrorHelper) {
+      const message = [
+        { type: "Literal", value: "Expected " },
+        {
+          type: "ConditionalExpression",
+          test: { type: "Identifier", name: "component" },
+          consequent: { type: "Literal", value: "component" },
+          alternate: { type: "Literal", value: "object" }
+        },
+        { type: "Literal", value: " `" },
+        { type: "Identifier", name: "id" },
+        {
+          type: "Literal",
+          value: "` to be defined: you likely forgot to import, pass, or provide it."
+        }
+      ];
+      const parameters = [
+        { type: "Identifier", name: "id" },
+        { type: "Identifier", name: "component" }
+      ];
+      if (development2) {
+        message.push({
+          type: "ConditionalExpression",
+          test: { type: "Identifier", name: "place" },
+          consequent: toBinaryAddition([
+            { type: "Literal", value: "\nIt\u2019s referenced in your code at `" },
+            { type: "Identifier", name: "place" },
+            {
+              type: "Literal",
+              value: (file.path ? "` in `" + file.path : "") + "`"
+            }
+          ]),
+          alternate: { type: "Literal", value: "" }
+        });
+        parameters.push({ type: "Identifier", name: "place" });
+      }
+      tree.body.push({
+        type: "FunctionDeclaration",
+        id: { type: "Identifier", name: "_missingMdxReference" },
+        generator: false,
+        async: false,
+        params: parameters,
+        body: {
+          type: "BlockStatement",
+          body: [
+            {
+              type: "ThrowStatement",
+              argument: {
+                type: "NewExpression",
+                callee: { type: "Identifier", name: "Error" },
+                arguments: [toBinaryAddition(message)]
+              }
+            }
+          ]
+        }
+      });
+    }
+  };
+}
+function createImportProvider(providerImportSource, outputFormat) {
+  const specifiers = [
+    {
+      type: "ImportSpecifier",
+      imported: { type: "Identifier", name: "useMDXComponents" },
+      local: { type: "Identifier", name: "_provideComponents" }
+    }
+  ];
+  return outputFormat === "function-body" ? {
+    type: "VariableDeclaration",
+    kind: "const",
+    declarations: specifiersToDeclarations(
+      specifiers,
+      toIdOrMemberExpression(["arguments", 0])
+    )
+  } : {
+    type: "ImportDeclaration",
+    specifiers,
+    source: { type: "Literal", value: providerImportSource }
+  };
+}
+function isNamedFunction(node, name2) {
+  return Boolean(node && "id" in node && node.id && node.id.name === name2);
+}
+function inScope(scope, id) {
+  let currentScope = scope;
+  while (currentScope) {
+    if (currentScope.declarations.has(id)) {
+      return true;
+    }
+    currentScope = currentScope.parent;
+  }
+  return false;
+}
+
+// node_modules/astring/dist/astring.mjs
+var { stringify } = JSON;
+if (!String.prototype.repeat) {
+  throw new Error(
+    "String.prototype.repeat is undefined, see https://github.com/davidbonnet/astring#installation"
+  );
+}
+if (!String.prototype.endsWith) {
+  throw new Error(
+    "String.prototype.endsWith is undefined, see https://github.com/davidbonnet/astring#installation"
+  );
+}
+var OPERATOR_PRECEDENCE = {
+  "||": 3,
+  "&&": 4,
+  "|": 5,
+  "??": 5,
+  "^": 6,
+  "&": 7,
+  "==": 8,
+  "!=": 8,
+  "===": 8,
+  "!==": 8,
+  "<": 9,
+  ">": 9,
+  "<=": 9,
+  ">=": 9,
+  in: 9,
+  instanceof: 9,
+  "<<": 10,
+  ">>": 10,
+  ">>>": 10,
+  "+": 11,
+  "-": 11,
+  "*": 12,
+  "%": 12,
+  "/": 12,
+  "**": 13
+};
+var NEEDS_PARENTHESES = 17;
+var EXPRESSIONS_PRECEDENCE = {
+  ArrayExpression: 20,
+  TaggedTemplateExpression: 20,
+  ThisExpression: 20,
+  Identifier: 20,
+  PrivateIdentifier: 20,
+  Literal: 18,
+  TemplateLiteral: 20,
+  Super: 20,
+  SequenceExpression: 20,
+  MemberExpression: 19,
+  ChainExpression: 19,
+  CallExpression: 19,
+  NewExpression: 19,
+  ArrowFunctionExpression: NEEDS_PARENTHESES,
+  ClassExpression: NEEDS_PARENTHESES,
+  FunctionExpression: NEEDS_PARENTHESES,
+  ObjectExpression: NEEDS_PARENTHESES,
+  UpdateExpression: 16,
+  UnaryExpression: 15,
+  AwaitExpression: 15,
+  BinaryExpression: 14,
+  LogicalExpression: 13,
+  ConditionalExpression: 4,
+  AssignmentExpression: 3,
+  YieldExpression: 2,
+  RestElement: 1
+};
+function formatSequence(state, nodes) {
+  const { generator } = state;
+  state.write("(");
+  if (nodes != null && nodes.length > 0) {
+    generator[nodes[0].type](nodes[0], state);
+    const { length } = nodes;
+    for (let i = 1; i < length; i++) {
+      const param = nodes[i];
+      state.write(", ");
+      generator[param.type](param, state);
+    }
+  }
+  state.write(")");
+}
+function expressionNeedsParenthesis(state, node, parentNode, isRightHand) {
+  const nodePrecedence = state.expressionsPrecedence[node.type];
+  if (nodePrecedence === NEEDS_PARENTHESES) {
+    return true;
+  }
+  const parentNodePrecedence = state.expressionsPrecedence[parentNode.type];
+  if (nodePrecedence !== parentNodePrecedence) {
+    return !isRightHand && nodePrecedence === 15 && parentNodePrecedence === 14 && parentNode.operator === "**" || nodePrecedence < parentNodePrecedence;
+  }
+  if (nodePrecedence !== 13 && nodePrecedence !== 14) {
+    return false;
+  }
+  if (node.operator === "**" && parentNode.operator === "**") {
+    return !isRightHand;
+  }
+  if (isRightHand) {
+    return OPERATOR_PRECEDENCE[node.operator] <= OPERATOR_PRECEDENCE[parentNode.operator];
+  }
+  return OPERATOR_PRECEDENCE[node.operator] < OPERATOR_PRECEDENCE[parentNode.operator];
+}
+function formatExpression(state, node, parentNode, isRightHand) {
+  const { generator } = state;
+  if (expressionNeedsParenthesis(state, node, parentNode, isRightHand)) {
+    state.write("(");
+    generator[node.type](node, state);
+    state.write(")");
+  } else {
+    generator[node.type](node, state);
+  }
+}
+function reindent(state, text5, indent, lineEnd) {
+  const lines = text5.split("\n");
+  const end = lines.length - 1;
+  state.write(lines[0].trim());
+  if (end > 0) {
+    state.write(lineEnd);
+    for (let i = 1; i < end; i++) {
+      state.write(indent + lines[i].trim() + lineEnd);
+    }
+    state.write(indent + lines[end].trim());
+  }
+}
+function formatComments(state, comments, indent, lineEnd) {
+  const { length } = comments;
+  for (let i = 0; i < length; i++) {
+    const comment2 = comments[i];
+    state.write(indent);
+    if (comment2.type[0] === "L") {
+      state.write("// " + comment2.value.trim() + "\n", comment2);
+    } else {
+      state.write("/*");
+      reindent(state, comment2.value, indent, lineEnd);
+      state.write("*/" + lineEnd);
+    }
+  }
+}
+function hasCallExpression(node) {
+  let currentNode = node;
+  while (currentNode != null) {
+    const { type } = currentNode;
+    if (type[0] === "C" && type[1] === "a") {
+      return true;
+    } else if (type[0] === "M" && type[1] === "e" && type[2] === "m") {
+      currentNode = currentNode.object;
+    } else {
+      return false;
+    }
+  }
+}
+function formatVariableDeclaration(state, node) {
+  const { generator } = state;
+  const { declarations } = node;
+  state.write(node.kind + " ");
+  const { length } = declarations;
+  if (length > 0) {
+    generator.VariableDeclarator(declarations[0], state);
+    for (let i = 1; i < length; i++) {
+      state.write(", ");
+      generator.VariableDeclarator(declarations[i], state);
+    }
+  }
+}
+var ForInStatement;
+var FunctionDeclaration;
+var RestElement;
+var BinaryExpression;
+var ArrayExpression;
+var BlockStatement;
+var GENERATOR = {
+  Program(node, state) {
+    const indent = state.indent.repeat(state.indentLevel);
+    const { lineEnd, writeComments } = state;
+    if (writeComments && node.comments != null) {
+      formatComments(state, node.comments, indent, lineEnd);
+    }
+    const statements = node.body;
+    const { length } = statements;
+    for (let i = 0; i < length; i++) {
+      const statement = statements[i];
+      if (writeComments && statement.comments != null) {
+        formatComments(state, statement.comments, indent, lineEnd);
+      }
+      state.write(indent);
+      this[statement.type](statement, state);
+      state.write(lineEnd);
+    }
+    if (writeComments && node.trailingComments != null) {
+      formatComments(state, node.trailingComments, indent, lineEnd);
+    }
+  },
+  BlockStatement: BlockStatement = function(node, state) {
+    const indent = state.indent.repeat(state.indentLevel++);
+    const { lineEnd, writeComments } = state;
+    const statementIndent = indent + state.indent;
+    state.write("{");
+    const statements = node.body;
+    if (statements != null && statements.length > 0) {
+      state.write(lineEnd);
+      if (writeComments && node.comments != null) {
+        formatComments(state, node.comments, statementIndent, lineEnd);
+      }
+      const { length } = statements;
+      for (let i = 0; i < length; i++) {
+        const statement = statements[i];
+        if (writeComments && statement.comments != null) {
+          formatComments(state, statement.comments, statementIndent, lineEnd);
+        }
+        state.write(statementIndent);
+        this[statement.type](statement, state);
+        state.write(lineEnd);
+      }
+      state.write(indent);
+    } else {
+      if (writeComments && node.comments != null) {
+        state.write(lineEnd);
+        formatComments(state, node.comments, statementIndent, lineEnd);
+        state.write(indent);
+      }
+    }
+    if (writeComments && node.trailingComments != null) {
+      formatComments(state, node.trailingComments, statementIndent, lineEnd);
+    }
+    state.write("}");
+    state.indentLevel--;
+  },
+  ClassBody: BlockStatement,
+  StaticBlock(node, state) {
+    state.write("static ");
+    this.BlockStatement(node, state);
+  },
+  EmptyStatement(node, state) {
+    state.write(";");
+  },
+  ExpressionStatement(node, state) {
+    const precedence = state.expressionsPrecedence[node.expression.type];
+    if (precedence === NEEDS_PARENTHESES || precedence === 3 && node.expression.left.type[0] === "O") {
+      state.write("(");
+      this[node.expression.type](node.expression, state);
+      state.write(")");
+    } else {
+      this[node.expression.type](node.expression, state);
+    }
+    state.write(";");
+  },
+  IfStatement(node, state) {
+    state.write("if (");
+    this[node.test.type](node.test, state);
+    state.write(") ");
+    this[node.consequent.type](node.consequent, state);
+    if (node.alternate != null) {
+      state.write(" else ");
+      this[node.alternate.type](node.alternate, state);
+    }
+  },
+  LabeledStatement(node, state) {
+    this[node.label.type](node.label, state);
+    state.write(": ");
+    this[node.body.type](node.body, state);
+  },
+  BreakStatement(node, state) {
+    state.write("break");
+    if (node.label != null) {
+      state.write(" ");
+      this[node.label.type](node.label, state);
+    }
+    state.write(";");
+  },
+  ContinueStatement(node, state) {
+    state.write("continue");
+    if (node.label != null) {
+      state.write(" ");
+      this[node.label.type](node.label, state);
+    }
+    state.write(";");
+  },
+  WithStatement(node, state) {
+    state.write("with (");
+    this[node.object.type](node.object, state);
+    state.write(") ");
+    this[node.body.type](node.body, state);
+  },
+  SwitchStatement(node, state) {
+    const indent = state.indent.repeat(state.indentLevel++);
+    const { lineEnd, writeComments } = state;
+    state.indentLevel++;
+    const caseIndent = indent + state.indent;
+    const statementIndent = caseIndent + state.indent;
+    state.write("switch (");
+    this[node.discriminant.type](node.discriminant, state);
+    state.write(") {" + lineEnd);
+    const { cases: occurences } = node;
+    const { length: occurencesCount } = occurences;
+    for (let i = 0; i < occurencesCount; i++) {
+      const occurence = occurences[i];
+      if (writeComments && occurence.comments != null) {
+        formatComments(state, occurence.comments, caseIndent, lineEnd);
+      }
+      if (occurence.test) {
+        state.write(caseIndent + "case ");
+        this[occurence.test.type](occurence.test, state);
+        state.write(":" + lineEnd);
+      } else {
+        state.write(caseIndent + "default:" + lineEnd);
+      }
+      const { consequent } = occurence;
+      const { length: consequentCount } = consequent;
+      for (let i2 = 0; i2 < consequentCount; i2++) {
+        const statement = consequent[i2];
+        if (writeComments && statement.comments != null) {
+          formatComments(state, statement.comments, statementIndent, lineEnd);
+        }
+        state.write(statementIndent);
+        this[statement.type](statement, state);
+        state.write(lineEnd);
+      }
+    }
+    state.indentLevel -= 2;
+    state.write(indent + "}");
+  },
+  ReturnStatement(node, state) {
+    state.write("return");
+    if (node.argument) {
+      state.write(" ");
+      this[node.argument.type](node.argument, state);
+    }
+    state.write(";");
+  },
+  ThrowStatement(node, state) {
+    state.write("throw ");
+    this[node.argument.type](node.argument, state);
+    state.write(";");
+  },
+  TryStatement(node, state) {
+    state.write("try ");
+    this[node.block.type](node.block, state);
+    if (node.handler) {
+      const { handler } = node;
+      if (handler.param == null) {
+        state.write(" catch ");
+      } else {
+        state.write(" catch (");
+        this[handler.param.type](handler.param, state);
+        state.write(") ");
+      }
+      this[handler.body.type](handler.body, state);
+    }
+    if (node.finalizer) {
+      state.write(" finally ");
+      this[node.finalizer.type](node.finalizer, state);
+    }
+  },
+  WhileStatement(node, state) {
+    state.write("while (");
+    this[node.test.type](node.test, state);
+    state.write(") ");
+    this[node.body.type](node.body, state);
+  },
+  DoWhileStatement(node, state) {
+    state.write("do ");
+    this[node.body.type](node.body, state);
+    state.write(" while (");
+    this[node.test.type](node.test, state);
+    state.write(");");
+  },
+  ForStatement(node, state) {
+    state.write("for (");
+    if (node.init != null) {
+      const { init } = node;
+      if (init.type[0] === "V") {
+        formatVariableDeclaration(state, init);
+      } else {
+        this[init.type](init, state);
+      }
+    }
+    state.write("; ");
+    if (node.test) {
+      this[node.test.type](node.test, state);
+    }
+    state.write("; ");
+    if (node.update) {
+      this[node.update.type](node.update, state);
+    }
+    state.write(") ");
+    this[node.body.type](node.body, state);
+  },
+  ForInStatement: ForInStatement = function(node, state) {
+    state.write(`for ${node.await ? "await " : ""}(`);
+    const { left } = node;
+    if (left.type[0] === "V") {
+      formatVariableDeclaration(state, left);
+    } else {
+      this[left.type](left, state);
+    }
+    state.write(node.type[3] === "I" ? " in " : " of ");
+    this[node.right.type](node.right, state);
+    state.write(") ");
+    this[node.body.type](node.body, state);
+  },
+  ForOfStatement: ForInStatement,
+  DebuggerStatement(node, state) {
+    state.write("debugger;", node);
+  },
+  FunctionDeclaration: FunctionDeclaration = function(node, state) {
+    state.write(
+      (node.async ? "async " : "") + (node.generator ? "function* " : "function ") + (node.id ? node.id.name : ""),
+      node
+    );
+    formatSequence(state, node.params);
+    state.write(" ");
+    this[node.body.type](node.body, state);
+  },
+  FunctionExpression: FunctionDeclaration,
+  VariableDeclaration(node, state) {
+    formatVariableDeclaration(state, node);
+    state.write(";");
+  },
+  VariableDeclarator(node, state) {
+    this[node.id.type](node.id, state);
+    if (node.init != null) {
+      state.write(" = ");
+      this[node.init.type](node.init, state);
+    }
+  },
+  ClassDeclaration(node, state) {
+    state.write("class " + (node.id ? `${node.id.name} ` : ""), node);
+    if (node.superClass) {
+      state.write("extends ");
+      const { superClass } = node;
+      const { type } = superClass;
+      const precedence = state.expressionsPrecedence[type];
+      if ((type[0] !== "C" || type[1] !== "l" || type[5] !== "E") && (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.ClassExpression)) {
+        state.write("(");
+        this[node.superClass.type](superClass, state);
+        state.write(")");
+      } else {
+        this[superClass.type](superClass, state);
+      }
+      state.write(" ");
+    }
+    this.ClassBody(node.body, state);
+  },
+  ImportDeclaration(node, state) {
+    state.write("import ");
+    const { specifiers } = node;
+    const { length } = specifiers;
+    let i = 0;
+    if (length > 0) {
+      for (; i < length; ) {
+        if (i > 0) {
+          state.write(", ");
+        }
+        const specifier = specifiers[i];
+        const type = specifier.type[6];
+        if (type === "D") {
+          state.write(specifier.local.name, specifier);
+          i++;
+        } else if (type === "N") {
+          state.write("* as " + specifier.local.name, specifier);
+          i++;
+        } else {
+          break;
+        }
+      }
+      if (i < length) {
+        state.write("{");
+        for (; ; ) {
+          const specifier = specifiers[i];
+          const { name: name2 } = specifier.imported;
+          state.write(name2, specifier);
+          if (name2 !== specifier.local.name) {
+            state.write(" as " + specifier.local.name);
+          }
+          if (++i < length) {
+            state.write(", ");
+          } else {
+            break;
+          }
+        }
+        state.write("}");
+      }
+      state.write(" from ");
+    }
+    this.Literal(node.source, state);
+    state.write(";");
+  },
+  ImportExpression(node, state) {
+    state.write("import(");
+    this[node.source.type](node.source, state);
+    state.write(")");
+  },
+  ExportDefaultDeclaration(node, state) {
+    state.write("export default ");
+    this[node.declaration.type](node.declaration, state);
+    if (state.expressionsPrecedence[node.declaration.type] != null && node.declaration.type[0] !== "F") {
+      state.write(";");
+    }
+  },
+  ExportNamedDeclaration(node, state) {
+    state.write("export ");
+    if (node.declaration) {
+      this[node.declaration.type](node.declaration, state);
+    } else {
+      state.write("{");
+      const { specifiers } = node, { length } = specifiers;
+      if (length > 0) {
+        for (let i = 0; ; ) {
+          const specifier = specifiers[i];
+          const { name: name2 } = specifier.local;
+          state.write(name2, specifier);
+          if (name2 !== specifier.exported.name) {
+            state.write(" as " + specifier.exported.name);
+          }
+          if (++i < length) {
+            state.write(", ");
+          } else {
+            break;
+          }
+        }
+      }
+      state.write("}");
+      if (node.source) {
+        state.write(" from ");
+        this.Literal(node.source, state);
+      }
+      state.write(";");
+    }
+  },
+  ExportAllDeclaration(node, state) {
+    if (node.exported != null) {
+      state.write("export * as " + node.exported.name + " from ");
+    } else {
+      state.write("export * from ");
+    }
+    this.Literal(node.source, state);
+    state.write(";");
+  },
+  MethodDefinition(node, state) {
+    if (node.static) {
+      state.write("static ");
+    }
+    const kind = node.kind[0];
+    if (kind === "g" || kind === "s") {
+      state.write(node.kind + " ");
+    }
+    if (node.value.async) {
+      state.write("async ");
+    }
+    if (node.value.generator) {
+      state.write("*");
+    }
+    if (node.computed) {
+      state.write("[");
+      this[node.key.type](node.key, state);
+      state.write("]");
+    } else {
+      this[node.key.type](node.key, state);
+    }
+    formatSequence(state, node.value.params);
+    state.write(" ");
+    this[node.value.body.type](node.value.body, state);
+  },
+  ClassExpression(node, state) {
+    this.ClassDeclaration(node, state);
+  },
+  ArrowFunctionExpression(node, state) {
+    state.write(node.async ? "async " : "", node);
+    const { params } = node;
+    if (params != null) {
+      if (params.length === 1 && params[0].type[0] === "I") {
+        state.write(params[0].name, params[0]);
+      } else {
+        formatSequence(state, node.params);
+      }
+    }
+    state.write(" => ");
+    if (node.body.type[0] === "O") {
+      state.write("(");
+      this.ObjectExpression(node.body, state);
+      state.write(")");
+    } else {
+      this[node.body.type](node.body, state);
+    }
+  },
+  ThisExpression(node, state) {
+    state.write("this", node);
+  },
+  Super(node, state) {
+    state.write("super", node);
+  },
+  RestElement: RestElement = function(node, state) {
+    state.write("...");
+    this[node.argument.type](node.argument, state);
+  },
+  SpreadElement: RestElement,
+  YieldExpression(node, state) {
+    state.write(node.delegate ? "yield*" : "yield");
+    if (node.argument) {
+      state.write(" ");
+      this[node.argument.type](node.argument, state);
+    }
+  },
+  AwaitExpression(node, state) {
+    state.write("await ", node);
+    formatExpression(state, node.argument, node);
+  },
+  TemplateLiteral(node, state) {
+    const { quasis, expressions } = node;
+    state.write("`");
+    const { length } = expressions;
+    for (let i = 0; i < length; i++) {
+      const expression = expressions[i];
+      const quasi2 = quasis[i];
+      state.write(quasi2.value.raw, quasi2);
+      state.write("${");
+      this[expression.type](expression, state);
+      state.write("}");
+    }
+    const quasi = quasis[quasis.length - 1];
+    state.write(quasi.value.raw, quasi);
+    state.write("`");
+  },
+  TemplateElement(node, state) {
+    state.write(node.value.raw, node);
+  },
+  TaggedTemplateExpression(node, state) {
+    formatExpression(state, node.tag, node);
+    this[node.quasi.type](node.quasi, state);
+  },
+  ArrayExpression: ArrayExpression = function(node, state) {
+    state.write("[");
+    if (node.elements.length > 0) {
+      const { elements } = node, { length } = elements;
+      for (let i = 0; ; ) {
+        const element2 = elements[i];
+        if (element2 != null) {
+          this[element2.type](element2, state);
+        }
+        if (++i < length) {
+          state.write(", ");
+        } else {
+          if (element2 == null) {
+            state.write(", ");
+          }
+          break;
+        }
+      }
+    }
+    state.write("]");
+  },
+  ArrayPattern: ArrayExpression,
+  ObjectExpression(node, state) {
+    const indent = state.indent.repeat(state.indentLevel++);
+    const { lineEnd, writeComments } = state;
+    const propertyIndent = indent + state.indent;
+    state.write("{");
+    if (node.properties.length > 0) {
+      state.write(lineEnd);
+      if (writeComments && node.comments != null) {
+        formatComments(state, node.comments, propertyIndent, lineEnd);
+      }
+      const comma = "," + lineEnd;
+      const { properties } = node, { length } = properties;
+      for (let i = 0; ; ) {
+        const property = properties[i];
+        if (writeComments && property.comments != null) {
+          formatComments(state, property.comments, propertyIndent, lineEnd);
+        }
+        state.write(propertyIndent);
+        this[property.type](property, state);
+        if (++i < length) {
+          state.write(comma);
+        } else {
+          break;
+        }
+      }
+      state.write(lineEnd);
+      if (writeComments && node.trailingComments != null) {
+        formatComments(state, node.trailingComments, propertyIndent, lineEnd);
+      }
+      state.write(indent + "}");
+    } else if (writeComments) {
+      if (node.comments != null) {
+        state.write(lineEnd);
+        formatComments(state, node.comments, propertyIndent, lineEnd);
+        if (node.trailingComments != null) {
+          formatComments(state, node.trailingComments, propertyIndent, lineEnd);
+        }
+        state.write(indent + "}");
+      } else if (node.trailingComments != null) {
+        state.write(lineEnd);
+        formatComments(state, node.trailingComments, propertyIndent, lineEnd);
+        state.write(indent + "}");
+      } else {
+        state.write("}");
+      }
+    } else {
+      state.write("}");
+    }
+    state.indentLevel--;
+  },
+  Property(node, state) {
+    if (node.method || node.kind[0] !== "i") {
+      this.MethodDefinition(node, state);
+    } else {
+      if (!node.shorthand) {
+        if (node.computed) {
+          state.write("[");
+          this[node.key.type](node.key, state);
+          state.write("]");
+        } else {
+          this[node.key.type](node.key, state);
+        }
+        state.write(": ");
+      }
+      this[node.value.type](node.value, state);
+    }
+  },
+  PropertyDefinition(node, state) {
+    if (node.static) {
+      state.write("static ");
+    }
+    this[node.key.type](node.key, state);
+    if (node.value == null) {
+      return;
+    }
+    state.write(" = ");
+    this[node.value.type](node.value, state);
+  },
+  ObjectPattern(node, state) {
+    state.write("{");
+    if (node.properties.length > 0) {
+      const { properties } = node, { length } = properties;
+      for (let i = 0; ; ) {
+        this[properties[i].type](properties[i], state);
+        if (++i < length) {
+          state.write(", ");
+        } else {
+          break;
+        }
+      }
+    }
+    state.write("}");
+  },
+  SequenceExpression(node, state) {
+    formatSequence(state, node.expressions);
+  },
+  UnaryExpression(node, state) {
+    if (node.prefix) {
+      const {
+        operator,
+        argument,
+        argument: { type }
+      } = node;
+      state.write(operator);
+      const needsParentheses = expressionNeedsParenthesis(state, argument, node);
+      if (!needsParentheses && (operator.length > 1 || type[0] === "U" && (type[1] === "n" || type[1] === "p") && argument.prefix && argument.operator[0] === operator && (operator === "+" || operator === "-"))) {
+        state.write(" ");
+      }
+      if (needsParentheses) {
+        state.write(operator.length > 1 ? " (" : "(");
+        this[type](argument, state);
+        state.write(")");
+      } else {
+        this[type](argument, state);
+      }
+    } else {
+      this[node.argument.type](node.argument, state);
+      state.write(node.operator);
+    }
+  },
+  UpdateExpression(node, state) {
+    if (node.prefix) {
+      state.write(node.operator);
+      this[node.argument.type](node.argument, state);
+    } else {
+      this[node.argument.type](node.argument, state);
+      state.write(node.operator);
+    }
+  },
+  AssignmentExpression(node, state) {
+    this[node.left.type](node.left, state);
+    state.write(" " + node.operator + " ");
+    this[node.right.type](node.right, state);
+  },
+  AssignmentPattern(node, state) {
+    this[node.left.type](node.left, state);
+    state.write(" = ");
+    this[node.right.type](node.right, state);
+  },
+  BinaryExpression: BinaryExpression = function(node, state) {
+    const isIn = node.operator === "in";
+    if (isIn) {
+      state.write("(");
+    }
+    formatExpression(state, node.left, node, false);
+    state.write(" " + node.operator + " ");
+    formatExpression(state, node.right, node, true);
+    if (isIn) {
+      state.write(")");
+    }
+  },
+  LogicalExpression: BinaryExpression,
+  ConditionalExpression(node, state) {
+    const { test } = node;
+    const precedence = state.expressionsPrecedence[test.type];
+    if (precedence === NEEDS_PARENTHESES || precedence <= state.expressionsPrecedence.ConditionalExpression) {
+      state.write("(");
+      this[test.type](test, state);
+      state.write(")");
+    } else {
+      this[test.type](test, state);
+    }
+    state.write(" ? ");
+    this[node.consequent.type](node.consequent, state);
+    state.write(" : ");
+    this[node.alternate.type](node.alternate, state);
+  },
+  NewExpression(node, state) {
+    state.write("new ");
+    const precedence = state.expressionsPrecedence[node.callee.type];
+    if (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.CallExpression || hasCallExpression(node.callee)) {
+      state.write("(");
+      this[node.callee.type](node.callee, state);
+      state.write(")");
+    } else {
+      this[node.callee.type](node.callee, state);
+    }
+    formatSequence(state, node["arguments"]);
+  },
+  CallExpression(node, state) {
+    const precedence = state.expressionsPrecedence[node.callee.type];
+    if (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.CallExpression) {
+      state.write("(");
+      this[node.callee.type](node.callee, state);
+      state.write(")");
+    } else {
+      this[node.callee.type](node.callee, state);
+    }
+    if (node.optional) {
+      state.write("?.");
+    }
+    formatSequence(state, node["arguments"]);
+  },
+  ChainExpression(node, state) {
+    this[node.expression.type](node.expression, state);
+  },
+  MemberExpression(node, state) {
+    const precedence = state.expressionsPrecedence[node.object.type];
+    if (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.MemberExpression) {
+      state.write("(");
+      this[node.object.type](node.object, state);
+      state.write(")");
+    } else {
+      this[node.object.type](node.object, state);
+    }
+    if (node.computed) {
+      if (node.optional) {
+        state.write("?.");
+      }
+      state.write("[");
+      this[node.property.type](node.property, state);
+      state.write("]");
+    } else {
+      if (node.optional) {
+        state.write("?.");
+      } else {
+        state.write(".");
+      }
+      this[node.property.type](node.property, state);
+    }
+  },
+  MetaProperty(node, state) {
+    state.write(node.meta.name + "." + node.property.name, node);
+  },
+  Identifier(node, state) {
+    state.write(node.name, node);
+  },
+  PrivateIdentifier(node, state) {
+    state.write(`#${node.name}`, node);
+  },
+  Literal(node, state) {
+    if (node.raw != null) {
+      state.write(node.raw, node);
+    } else if (node.regex != null) {
+      this.RegExpLiteral(node, state);
+    } else if (node.bigint != null) {
+      state.write(node.bigint + "n", node);
+    } else {
+      state.write(stringify(node.value), node);
+    }
+  },
+  RegExpLiteral(node, state) {
+    const { regex: regex2 } = node;
+    state.write(`/${regex2.pattern}/${regex2.flags}`, node);
+  }
+};
+var EMPTY_OBJECT = {};
+var State = class {
+  constructor(options) {
+    const setup = options == null ? EMPTY_OBJECT : options;
+    this.output = "";
+    if (setup.output != null) {
+      this.output = setup.output;
+      this.write = this.writeToStream;
+    } else {
+      this.output = "";
+    }
+    this.generator = setup.generator != null ? setup.generator : GENERATOR;
+    this.expressionsPrecedence = setup.expressionsPrecedence != null ? setup.expressionsPrecedence : EXPRESSIONS_PRECEDENCE;
+    this.indent = setup.indent != null ? setup.indent : "  ";
+    this.lineEnd = setup.lineEnd != null ? setup.lineEnd : "\n";
+    this.indentLevel = setup.startingIndentLevel != null ? setup.startingIndentLevel : 0;
+    this.writeComments = setup.comments ? setup.comments : false;
+    if (setup.sourceMap != null) {
+      this.write = setup.output == null ? this.writeAndMap : this.writeToStreamAndMap;
+      this.sourceMap = setup.sourceMap;
+      this.line = 1;
+      this.column = 0;
+      this.lineEndSize = this.lineEnd.split("\n").length - 1;
+      this.mapping = {
+        original: null,
+        generated: this,
+        name: void 0,
+        source: setup.sourceMap.file || setup.sourceMap._file
+      };
+    }
+  }
+  write(code2) {
+    this.output += code2;
+  }
+  writeToStream(code2) {
+    this.output.write(code2);
+  }
+  writeAndMap(code2, node) {
+    this.output += code2;
+    this.map(code2, node);
+  }
+  writeToStreamAndMap(code2, node) {
+    this.output.write(code2);
+    this.map(code2, node);
+  }
+  map(code2, node) {
+    if (node != null) {
+      const { type } = node;
+      if (type[0] === "L" && type[2] === "n") {
+        this.column = 0;
+        this.line++;
+        return;
+      }
+      if (node.loc != null) {
+        const { mapping } = this;
+        mapping.original = node.loc.start;
+        mapping.name = node.name;
+        this.sourceMap.addMapping(mapping);
+      }
+      if (type[0] === "T" && type[8] === "E" || type[0] === "L" && type[1] === "i" && typeof node.value === "string") {
+        const { length: length2 } = code2;
+        let { column, line } = this;
+        for (let i = 0; i < length2; i++) {
+          if (code2[i] === "\n") {
+            column = 0;
+            line++;
+          } else {
+            column++;
+          }
+        }
+        this.column = column;
+        this.line = line;
+        return;
+      }
+    }
+    const { length } = code2;
+    const { lineEnd } = this;
+    if (length > 0) {
+      if (this.lineEndSize > 0 && (lineEnd.length === 1 ? code2[length - 1] === lineEnd : code2.endsWith(lineEnd))) {
+        this.line += this.lineEndSize;
+        this.column = 0;
+      } else {
+        this.column += length;
+      }
+    }
+  }
+  toString() {
+    return this.output;
+  }
+};
+function generate(node, options) {
+  const state = new State(options);
+  state.generator[node.type](node, state);
+  return state.output;
+}
+
+// node_modules/estree-util-to-js/lib/index.js
+var toJs = function(tree, options = {}) {
+  const { SourceMapGenerator, filePath, handlers: handlers2 } = options;
+  const sourceMap = SourceMapGenerator ? new SourceMapGenerator({ file: filePath || "<unknown>.js" }) : void 0;
+  const value = generate(tree, {
+    comments: true,
+    generator: { ...GENERATOR, ...handlers2 },
+    sourceMap
+  });
+  const map = sourceMap ? sourceMap.toJSON() : void 0;
+  return { value, map };
+};
+
+// node_modules/estree-util-to-js/lib/jsx.js
+var jsx = {
+  JSXAttribute,
+  JSXClosingElement,
+  JSXClosingFragment,
+  JSXElement,
+  JSXEmptyExpression,
+  JSXExpressionContainer,
+  JSXFragment,
+  JSXIdentifier,
+  JSXMemberExpression,
+  JSXNamespacedName,
+  JSXOpeningElement,
+  JSXOpeningFragment,
+  JSXSpreadAttribute,
+  JSXText
+};
+function JSXAttribute(node, state) {
+  this[node.name.type](node.name, state);
+  if (node.value !== void 0 && node.value !== null) {
+    state.write("=");
+    if (node.value.type === "Literal") {
+      state.write(
+        '"' + encodeJsx(String(node.value.value)).replace(/"/g, "&quot;") + '"',
+        node
+      );
+    } else {
+      this[node.value.type](node.value, state);
+    }
+  }
+}
+function JSXClosingElement(node, state) {
+  state.write("</");
+  this[node.name.type](node.name, state);
+  state.write(">");
+}
+function JSXClosingFragment(node, state) {
+  state.write("</>", node);
+}
+function JSXElement(node, state) {
+  let index2 = -1;
+  this[node.openingElement.type](node.openingElement, state);
+  if (node.children) {
+    while (++index2 < node.children.length) {
+      const child = node.children[index2];
+      if (child.type === "JSXSpreadChild") {
+        throw new Error("JSX spread children are not supported");
+      }
+      this[child.type](child, state);
+    }
+  }
+  if (node.closingElement) {
+    this[node.closingElement.type](node.closingElement, state);
+  }
+}
+function JSXEmptyExpression() {
+}
+function JSXExpressionContainer(node, state) {
+  state.write("{");
+  this[node.expression.type](node.expression, state);
+  state.write("}");
+}
+function JSXFragment(node, state) {
+  let index2 = -1;
+  this[node.openingFragment.type](node.openingFragment, state);
+  if (node.children) {
+    while (++index2 < node.children.length) {
+      const child = node.children[index2];
+      if (child.type === "JSXSpreadChild") {
+        throw new Error("JSX spread children are not supported");
+      }
+      this[child.type](child, state);
+    }
+  }
+  this[node.closingFragment.type](node.closingFragment, state);
+}
+function JSXIdentifier(node, state) {
+  state.write(node.name, node);
+}
+function JSXMemberExpression(node, state) {
+  this[node.object.type](node.object, state);
+  state.write(".");
+  this[node.property.type](node.property, state);
+}
+function JSXNamespacedName(node, state) {
+  this[node.namespace.type](node.namespace, state);
+  state.write(":");
+  this[node.name.type](node.name, state);
+}
+function JSXOpeningElement(node, state) {
+  let index2 = -1;
+  state.write("<");
+  this[node.name.type](node.name, state);
+  if (node.attributes) {
+    while (++index2 < node.attributes.length) {
+      state.write(" ");
+      this[node.attributes[index2].type](node.attributes[index2], state);
+    }
+  }
+  state.write(node.selfClosing ? " />" : ">");
+}
+function JSXOpeningFragment(node, state) {
+  state.write("<>", node);
+}
+function JSXSpreadAttribute(node, state) {
+  state.write("{");
+  this.SpreadElement(node, state);
+  state.write("}");
+}
+function JSXText(node, state) {
+  state.write(
+    encodeJsx(node.value).replace(
+      /[<>{}]/g,
+      ($0) => $0 === "<" ? "&lt;" : $0 === ">" ? "&gt;" : $0 === "{" ? "&#123;" : "&#125;"
+    ),
+    node
+  );
+}
+function encodeJsx(value) {
+  return value.replace(/&(?=[#a-z])/gi, "&amp;");
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-stringify.js
+function recmaStringify(options = {}) {
+  const { SourceMapGenerator } = options;
+  Object.assign(this, { Compiler: compiler2 });
+  function compiler2(tree, file) {
+    const result = SourceMapGenerator ? toJs(tree, {
+      filePath: file.path || "unknown.mdx",
+      SourceMapGenerator,
+      handlers: jsx
+    }) : toJs(tree, { handlers: jsx });
+    file.map = result.map;
+    return result.value;
+  }
+}
+
+// node_modules/hast-util-to-estree/node_modules/comma-separated-tokens/index.js
+function stringify2(values, options) {
+  var settings = options || {};
+  if (values[values.length - 1] === "") {
+    values = values.concat("");
+  }
+  return values.join(
+    (settings.padRight ? " " : "") + "," + (settings.padLeft === false ? "" : " ")
+  ).trim();
+}
+
+// node_modules/estree-util-attach-comments/index.js
+var own9 = {}.hasOwnProperty;
+function attachComments(tree, comments) {
+  const list3 = (comments || []).concat().sort(compare);
+  if (list3.length > 0)
+    walk2(tree, { comments: list3, index: 0 });
+  return tree;
+}
+function walk2(node, state) {
+  if (state.index === state.comments.length) {
+    return;
+  }
+  const children = [];
+  const comments = [];
+  let key;
+  for (key in node) {
+    if (own9.call(node, key)) {
+      const value = node[key];
+      if (value && typeof value === "object" && key !== "comments") {
+        if (Array.isArray(value)) {
+          let index3 = -1;
+          while (++index3 < value.length) {
+            if (value[index3] && typeof value[index3].type === "string") {
+              children.push(value[index3]);
+            }
+          }
+        } else if (typeof value.type === "string") {
+          children.push(value);
+        }
+      }
+    }
+  }
+  children.sort(compare);
+  comments.push(...slice(state, node, false, { leading: true, trailing: false }));
+  let index2 = -1;
+  while (++index2 < children.length) {
+    walk2(children[index2], state);
+  }
+  comments.push(
+    ...slice(state, node, true, {
+      leading: false,
+      trailing: children.length > 0
+    })
+  );
+  if (comments.length > 0) {
+    node.comments = comments;
+  }
+}
+function slice(state, node, compareEnd, fields) {
+  const result = [];
+  while (state.comments[state.index] && compare(state.comments[state.index], node, compareEnd) < 1) {
+    result.push(Object.assign({}, state.comments[state.index++], fields));
+  }
+  return result;
+}
+function compare(left, right, compareEnd) {
+  const field = compareEnd ? "end" : "start";
+  if (left.range && right.range) {
+    return left.range[0] - right.range[compareEnd ? 1 : 0];
+  }
+  if (left.loc && left.loc.start && right.loc && right.loc[field]) {
+    return left.loc.start.line - right.loc[field].line || left.loc.start.column - right.loc[field].column;
+  }
+  if ("start" in left && field in right) {
+    return left.start - right[field];
+  }
+  return Number.NaN;
+}
+
+// node_modules/hast-util-to-estree/node_modules/hast-util-whitespace/index.js
+function whitespace(thing) {
+  var value = thing && typeof thing === "object" && thing.type === "text" ? thing.value || "" : thing;
+  return typeof value === "string" && value.replace(/[ \t\n\f\r]/g, "") === "";
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/schema.js
+var Schema = class {
+  constructor(property, normal, space2) {
+    this.property = property;
+    this.normal = normal;
+    if (space2) {
+      this.space = space2;
+    }
+  }
+};
+Schema.prototype.property = {};
+Schema.prototype.normal = {};
+Schema.prototype.space = null;
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/merge.js
+function merge(definitions2, space2) {
+  const property = {};
+  const normal = {};
+  let index2 = -1;
+  while (++index2 < definitions2.length) {
+    Object.assign(property, definitions2[index2].property);
+    Object.assign(normal, definitions2[index2].normal);
+  }
+  return new Schema(property, normal, space2);
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/normalize.js
+function normalize(value) {
+  return value.toLowerCase();
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/info.js
+var Info = class {
+  constructor(property, attribute) {
+    this.property = property;
+    this.attribute = attribute;
+  }
+};
+Info.prototype.space = null;
+Info.prototype.boolean = false;
+Info.prototype.booleanish = false;
+Info.prototype.overloadedBoolean = false;
+Info.prototype.number = false;
+Info.prototype.commaSeparated = false;
+Info.prototype.spaceSeparated = false;
+Info.prototype.commaOrSpaceSeparated = false;
+Info.prototype.mustUseProperty = false;
+Info.prototype.defined = false;
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/types.js
+var types_exports = {};
+__export(types_exports, {
+  boolean: () => boolean,
+  booleanish: () => booleanish,
+  commaOrSpaceSeparated: () => commaOrSpaceSeparated,
+  commaSeparated: () => commaSeparated,
+  number: () => number,
+  overloadedBoolean: () => overloadedBoolean,
+  spaceSeparated: () => spaceSeparated
+});
+var powers = 0;
+var boolean = increment();
+var booleanish = increment();
+var overloadedBoolean = increment();
+var number = increment();
+var spaceSeparated = increment();
+var commaSeparated = increment();
+var commaOrSpaceSeparated = increment();
+function increment() {
+  return 2 ** ++powers;
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/defined-info.js
+var checks = Object.keys(types_exports);
+var DefinedInfo = class extends Info {
+  constructor(property, attribute, mask, space2) {
+    let index2 = -1;
+    super(property, attribute);
+    mark(this, "space", space2);
+    if (typeof mask === "number") {
+      while (++index2 < checks.length) {
+        const check = checks[index2];
+        mark(this, checks[index2], (mask & types_exports[check]) === types_exports[check]);
+      }
+    }
+  }
+};
+DefinedInfo.prototype.defined = true;
+function mark(values, key, value) {
+  if (value) {
+    values[key] = value;
+  }
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/create.js
+var own10 = {}.hasOwnProperty;
+function create3(definition2) {
+  const property = {};
+  const normal = {};
+  let prop;
+  for (prop in definition2.properties) {
+    if (own10.call(definition2.properties, prop)) {
+      const value = definition2.properties[prop];
+      const info = new DefinedInfo(
+        prop,
+        definition2.transform(definition2.attributes || {}, prop),
+        value,
+        definition2.space
+      );
+      if (definition2.mustUseProperty && definition2.mustUseProperty.includes(prop)) {
+        info.mustUseProperty = true;
+      }
+      property[prop] = info;
+      normal[normalize(prop)] = prop;
+      normal[normalize(info.attribute)] = prop;
+    }
+  }
+  return new Schema(property, normal, definition2.space);
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/xlink.js
+var xlink = create3({
+  space: "xlink",
+  transform(_, prop) {
+    return "xlink:" + prop.slice(5).toLowerCase();
+  },
+  properties: {
+    xLinkActuate: null,
+    xLinkArcRole: null,
+    xLinkHref: null,
+    xLinkRole: null,
+    xLinkShow: null,
+    xLinkTitle: null,
+    xLinkType: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/xml.js
+var xml = create3({
+  space: "xml",
+  transform(_, prop) {
+    return "xml:" + prop.slice(3).toLowerCase();
+  },
+  properties: { xmlLang: null, xmlBase: null, xmlSpace: null }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/case-sensitive-transform.js
+function caseSensitiveTransform(attributes, attribute) {
+  return attribute in attributes ? attributes[attribute] : attribute;
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/case-insensitive-transform.js
+function caseInsensitiveTransform(attributes, property) {
+  return caseSensitiveTransform(attributes, property.toLowerCase());
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/xmlns.js
+var xmlns = create3({
+  space: "xmlns",
+  attributes: { xmlnsxlink: "xmlns:xlink" },
+  transform: caseInsensitiveTransform,
+  properties: { xmlns: null, xmlnsXLink: null }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/aria.js
+var aria = create3({
+  transform(_, prop) {
+    return prop === "role" ? prop : "aria-" + prop.slice(4).toLowerCase();
+  },
+  properties: {
+    ariaActiveDescendant: null,
+    ariaAtomic: booleanish,
+    ariaAutoComplete: null,
+    ariaBusy: booleanish,
+    ariaChecked: booleanish,
+    ariaColCount: number,
+    ariaColIndex: number,
+    ariaColSpan: number,
+    ariaControls: spaceSeparated,
+    ariaCurrent: null,
+    ariaDescribedBy: spaceSeparated,
+    ariaDetails: null,
+    ariaDisabled: booleanish,
+    ariaDropEffect: spaceSeparated,
+    ariaErrorMessage: null,
+    ariaExpanded: booleanish,
+    ariaFlowTo: spaceSeparated,
+    ariaGrabbed: booleanish,
+    ariaHasPopup: null,
+    ariaHidden: booleanish,
+    ariaInvalid: null,
+    ariaKeyShortcuts: null,
+    ariaLabel: null,
+    ariaLabelledBy: spaceSeparated,
+    ariaLevel: number,
+    ariaLive: null,
+    ariaModal: booleanish,
+    ariaMultiLine: booleanish,
+    ariaMultiSelectable: booleanish,
+    ariaOrientation: null,
+    ariaOwns: spaceSeparated,
+    ariaPlaceholder: null,
+    ariaPosInSet: number,
+    ariaPressed: booleanish,
+    ariaReadOnly: booleanish,
+    ariaRelevant: null,
+    ariaRequired: booleanish,
+    ariaRoleDescription: spaceSeparated,
+    ariaRowCount: number,
+    ariaRowIndex: number,
+    ariaRowSpan: number,
+    ariaSelected: booleanish,
+    ariaSetSize: number,
+    ariaSort: null,
+    ariaValueMax: number,
+    ariaValueMin: number,
+    ariaValueNow: number,
+    ariaValueText: null,
+    role: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/html.js
+var html2 = create3({
+  space: "html",
+  attributes: {
+    acceptcharset: "accept-charset",
+    classname: "class",
+    htmlfor: "for",
+    httpequiv: "http-equiv"
+  },
+  transform: caseInsensitiveTransform,
+  mustUseProperty: ["checked", "multiple", "muted", "selected"],
+  properties: {
+    abbr: null,
+    accept: commaSeparated,
+    acceptCharset: spaceSeparated,
+    accessKey: spaceSeparated,
+    action: null,
+    allow: null,
+    allowFullScreen: boolean,
+    allowPaymentRequest: boolean,
+    allowUserMedia: boolean,
+    alt: null,
+    as: null,
+    async: boolean,
+    autoCapitalize: null,
+    autoComplete: spaceSeparated,
+    autoFocus: boolean,
+    autoPlay: boolean,
+    capture: boolean,
+    charSet: null,
+    checked: boolean,
+    cite: null,
+    className: spaceSeparated,
+    cols: number,
+    colSpan: null,
+    content: null,
+    contentEditable: booleanish,
+    controls: boolean,
+    controlsList: spaceSeparated,
+    coords: number | commaSeparated,
+    crossOrigin: null,
+    data: null,
+    dateTime: null,
+    decoding: null,
+    default: boolean,
+    defer: boolean,
+    dir: null,
+    dirName: null,
+    disabled: boolean,
+    download: overloadedBoolean,
+    draggable: booleanish,
+    encType: null,
+    enterKeyHint: null,
+    form: null,
+    formAction: null,
+    formEncType: null,
+    formMethod: null,
+    formNoValidate: boolean,
+    formTarget: null,
+    headers: spaceSeparated,
+    height: number,
+    hidden: boolean,
+    high: number,
+    href: null,
+    hrefLang: null,
+    htmlFor: spaceSeparated,
+    httpEquiv: spaceSeparated,
+    id: null,
+    imageSizes: null,
+    imageSrcSet: null,
+    inputMode: null,
+    integrity: null,
+    is: null,
+    isMap: boolean,
+    itemId: null,
+    itemProp: spaceSeparated,
+    itemRef: spaceSeparated,
+    itemScope: boolean,
+    itemType: spaceSeparated,
+    kind: null,
+    label: null,
+    lang: null,
+    language: null,
+    list: null,
+    loading: null,
+    loop: boolean,
+    low: number,
+    manifest: null,
+    max: null,
+    maxLength: number,
+    media: null,
+    method: null,
+    min: null,
+    minLength: number,
+    multiple: boolean,
+    muted: boolean,
+    name: null,
+    nonce: null,
+    noModule: boolean,
+    noValidate: boolean,
+    onAbort: null,
+    onAfterPrint: null,
+    onAuxClick: null,
+    onBeforePrint: null,
+    onBeforeUnload: null,
+    onBlur: null,
+    onCancel: null,
+    onCanPlay: null,
+    onCanPlayThrough: null,
+    onChange: null,
+    onClick: null,
+    onClose: null,
+    onContextLost: null,
+    onContextMenu: null,
+    onContextRestored: null,
+    onCopy: null,
+    onCueChange: null,
+    onCut: null,
+    onDblClick: null,
+    onDrag: null,
+    onDragEnd: null,
+    onDragEnter: null,
+    onDragExit: null,
+    onDragLeave: null,
+    onDragOver: null,
+    onDragStart: null,
+    onDrop: null,
+    onDurationChange: null,
+    onEmptied: null,
+    onEnded: null,
+    onError: null,
+    onFocus: null,
+    onFormData: null,
+    onHashChange: null,
+    onInput: null,
+    onInvalid: null,
+    onKeyDown: null,
+    onKeyPress: null,
+    onKeyUp: null,
+    onLanguageChange: null,
+    onLoad: null,
+    onLoadedData: null,
+    onLoadedMetadata: null,
+    onLoadEnd: null,
+    onLoadStart: null,
+    onMessage: null,
+    onMessageError: null,
+    onMouseDown: null,
+    onMouseEnter: null,
+    onMouseLeave: null,
+    onMouseMove: null,
+    onMouseOut: null,
+    onMouseOver: null,
+    onMouseUp: null,
+    onOffline: null,
+    onOnline: null,
+    onPageHide: null,
+    onPageShow: null,
+    onPaste: null,
+    onPause: null,
+    onPlay: null,
+    onPlaying: null,
+    onPopState: null,
+    onProgress: null,
+    onRateChange: null,
+    onRejectionHandled: null,
+    onReset: null,
+    onResize: null,
+    onScroll: null,
+    onSecurityPolicyViolation: null,
+    onSeeked: null,
+    onSeeking: null,
+    onSelect: null,
+    onSlotChange: null,
+    onStalled: null,
+    onStorage: null,
+    onSubmit: null,
+    onSuspend: null,
+    onTimeUpdate: null,
+    onToggle: null,
+    onUnhandledRejection: null,
+    onUnload: null,
+    onVolumeChange: null,
+    onWaiting: null,
+    onWheel: null,
+    open: boolean,
+    optimum: number,
+    pattern: null,
+    ping: spaceSeparated,
+    placeholder: null,
+    playsInline: boolean,
+    poster: null,
+    preload: null,
+    readOnly: boolean,
+    referrerPolicy: null,
+    rel: spaceSeparated,
+    required: boolean,
+    reversed: boolean,
+    rows: number,
+    rowSpan: number,
+    sandbox: spaceSeparated,
+    scope: null,
+    scoped: boolean,
+    seamless: boolean,
+    selected: boolean,
+    shape: null,
+    size: number,
+    sizes: null,
+    slot: null,
+    span: number,
+    spellCheck: booleanish,
+    src: null,
+    srcDoc: null,
+    srcLang: null,
+    srcSet: null,
+    start: number,
+    step: null,
+    style: null,
+    tabIndex: number,
+    target: null,
+    title: null,
+    translate: null,
+    type: null,
+    typeMustMatch: boolean,
+    useMap: null,
+    value: booleanish,
+    width: number,
+    wrap: null,
+    align: null,
+    aLink: null,
+    archive: spaceSeparated,
+    axis: null,
+    background: null,
+    bgColor: null,
+    border: number,
+    borderColor: null,
+    bottomMargin: number,
+    cellPadding: null,
+    cellSpacing: null,
+    char: null,
+    charOff: null,
+    classId: null,
+    clear: null,
+    code: null,
+    codeBase: null,
+    codeType: null,
+    color: null,
+    compact: boolean,
+    declare: boolean,
+    event: null,
+    face: null,
+    frame: null,
+    frameBorder: null,
+    hSpace: number,
+    leftMargin: number,
+    link: null,
+    longDesc: null,
+    lowSrc: null,
+    marginHeight: number,
+    marginWidth: number,
+    noResize: boolean,
+    noHref: boolean,
+    noShade: boolean,
+    noWrap: boolean,
+    object: null,
+    profile: null,
+    prompt: null,
+    rev: null,
+    rightMargin: number,
+    rules: null,
+    scheme: null,
+    scrolling: booleanish,
+    standby: null,
+    summary: null,
+    text: null,
+    topMargin: number,
+    valueType: null,
+    version: null,
+    vAlign: null,
+    vLink: null,
+    vSpace: number,
+    allowTransparency: null,
+    autoCorrect: null,
+    autoSave: null,
+    disablePictureInPicture: boolean,
+    disableRemotePlayback: boolean,
+    prefix: null,
+    property: null,
+    results: number,
+    security: null,
+    unselectable: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/svg.js
+var svg = create3({
+  space: "svg",
+  attributes: {
+    accentHeight: "accent-height",
+    alignmentBaseline: "alignment-baseline",
+    arabicForm: "arabic-form",
+    baselineShift: "baseline-shift",
+    capHeight: "cap-height",
+    className: "class",
+    clipPath: "clip-path",
+    clipRule: "clip-rule",
+    colorInterpolation: "color-interpolation",
+    colorInterpolationFilters: "color-interpolation-filters",
+    colorProfile: "color-profile",
+    colorRendering: "color-rendering",
+    crossOrigin: "crossorigin",
+    dataType: "datatype",
+    dominantBaseline: "dominant-baseline",
+    enableBackground: "enable-background",
+    fillOpacity: "fill-opacity",
+    fillRule: "fill-rule",
+    floodColor: "flood-color",
+    floodOpacity: "flood-opacity",
+    fontFamily: "font-family",
+    fontSize: "font-size",
+    fontSizeAdjust: "font-size-adjust",
+    fontStretch: "font-stretch",
+    fontStyle: "font-style",
+    fontVariant: "font-variant",
+    fontWeight: "font-weight",
+    glyphName: "glyph-name",
+    glyphOrientationHorizontal: "glyph-orientation-horizontal",
+    glyphOrientationVertical: "glyph-orientation-vertical",
+    hrefLang: "hreflang",
+    horizAdvX: "horiz-adv-x",
+    horizOriginX: "horiz-origin-x",
+    horizOriginY: "horiz-origin-y",
+    imageRendering: "image-rendering",
+    letterSpacing: "letter-spacing",
+    lightingColor: "lighting-color",
+    markerEnd: "marker-end",
+    markerMid: "marker-mid",
+    markerStart: "marker-start",
+    navDown: "nav-down",
+    navDownLeft: "nav-down-left",
+    navDownRight: "nav-down-right",
+    navLeft: "nav-left",
+    navNext: "nav-next",
+    navPrev: "nav-prev",
+    navRight: "nav-right",
+    navUp: "nav-up",
+    navUpLeft: "nav-up-left",
+    navUpRight: "nav-up-right",
+    onAbort: "onabort",
+    onActivate: "onactivate",
+    onAfterPrint: "onafterprint",
+    onBeforePrint: "onbeforeprint",
+    onBegin: "onbegin",
+    onCancel: "oncancel",
+    onCanPlay: "oncanplay",
+    onCanPlayThrough: "oncanplaythrough",
+    onChange: "onchange",
+    onClick: "onclick",
+    onClose: "onclose",
+    onCopy: "oncopy",
+    onCueChange: "oncuechange",
+    onCut: "oncut",
+    onDblClick: "ondblclick",
+    onDrag: "ondrag",
+    onDragEnd: "ondragend",
+    onDragEnter: "ondragenter",
+    onDragExit: "ondragexit",
+    onDragLeave: "ondragleave",
+    onDragOver: "ondragover",
+    onDragStart: "ondragstart",
+    onDrop: "ondrop",
+    onDurationChange: "ondurationchange",
+    onEmptied: "onemptied",
+    onEnd: "onend",
+    onEnded: "onended",
+    onError: "onerror",
+    onFocus: "onfocus",
+    onFocusIn: "onfocusin",
+    onFocusOut: "onfocusout",
+    onHashChange: "onhashchange",
+    onInput: "oninput",
+    onInvalid: "oninvalid",
+    onKeyDown: "onkeydown",
+    onKeyPress: "onkeypress",
+    onKeyUp: "onkeyup",
+    onLoad: "onload",
+    onLoadedData: "onloadeddata",
+    onLoadedMetadata: "onloadedmetadata",
+    onLoadStart: "onloadstart",
+    onMessage: "onmessage",
+    onMouseDown: "onmousedown",
+    onMouseEnter: "onmouseenter",
+    onMouseLeave: "onmouseleave",
+    onMouseMove: "onmousemove",
+    onMouseOut: "onmouseout",
+    onMouseOver: "onmouseover",
+    onMouseUp: "onmouseup",
+    onMouseWheel: "onmousewheel",
+    onOffline: "onoffline",
+    onOnline: "ononline",
+    onPageHide: "onpagehide",
+    onPageShow: "onpageshow",
+    onPaste: "onpaste",
+    onPause: "onpause",
+    onPlay: "onplay",
+    onPlaying: "onplaying",
+    onPopState: "onpopstate",
+    onProgress: "onprogress",
+    onRateChange: "onratechange",
+    onRepeat: "onrepeat",
+    onReset: "onreset",
+    onResize: "onresize",
+    onScroll: "onscroll",
+    onSeeked: "onseeked",
+    onSeeking: "onseeking",
+    onSelect: "onselect",
+    onShow: "onshow",
+    onStalled: "onstalled",
+    onStorage: "onstorage",
+    onSubmit: "onsubmit",
+    onSuspend: "onsuspend",
+    onTimeUpdate: "ontimeupdate",
+    onToggle: "ontoggle",
+    onUnload: "onunload",
+    onVolumeChange: "onvolumechange",
+    onWaiting: "onwaiting",
+    onZoom: "onzoom",
+    overlinePosition: "overline-position",
+    overlineThickness: "overline-thickness",
+    paintOrder: "paint-order",
+    panose1: "panose-1",
+    pointerEvents: "pointer-events",
+    referrerPolicy: "referrerpolicy",
+    renderingIntent: "rendering-intent",
+    shapeRendering: "shape-rendering",
+    stopColor: "stop-color",
+    stopOpacity: "stop-opacity",
+    strikethroughPosition: "strikethrough-position",
+    strikethroughThickness: "strikethrough-thickness",
+    strokeDashArray: "stroke-dasharray",
+    strokeDashOffset: "stroke-dashoffset",
+    strokeLineCap: "stroke-linecap",
+    strokeLineJoin: "stroke-linejoin",
+    strokeMiterLimit: "stroke-miterlimit",
+    strokeOpacity: "stroke-opacity",
+    strokeWidth: "stroke-width",
+    tabIndex: "tabindex",
+    textAnchor: "text-anchor",
+    textDecoration: "text-decoration",
+    textRendering: "text-rendering",
+    typeOf: "typeof",
+    underlinePosition: "underline-position",
+    underlineThickness: "underline-thickness",
+    unicodeBidi: "unicode-bidi",
+    unicodeRange: "unicode-range",
+    unitsPerEm: "units-per-em",
+    vAlphabetic: "v-alphabetic",
+    vHanging: "v-hanging",
+    vIdeographic: "v-ideographic",
+    vMathematical: "v-mathematical",
+    vectorEffect: "vector-effect",
+    vertAdvY: "vert-adv-y",
+    vertOriginX: "vert-origin-x",
+    vertOriginY: "vert-origin-y",
+    wordSpacing: "word-spacing",
+    writingMode: "writing-mode",
+    xHeight: "x-height",
+    playbackOrder: "playbackorder",
+    timelineBegin: "timelinebegin"
+  },
+  transform: caseSensitiveTransform,
+  properties: {
+    about: commaOrSpaceSeparated,
+    accentHeight: number,
+    accumulate: null,
+    additive: null,
+    alignmentBaseline: null,
+    alphabetic: number,
+    amplitude: number,
+    arabicForm: null,
+    ascent: number,
+    attributeName: null,
+    attributeType: null,
+    azimuth: number,
+    bandwidth: null,
+    baselineShift: null,
+    baseFrequency: null,
+    baseProfile: null,
+    bbox: null,
+    begin: null,
+    bias: number,
+    by: null,
+    calcMode: null,
+    capHeight: number,
+    className: spaceSeparated,
+    clip: null,
+    clipPath: null,
+    clipPathUnits: null,
+    clipRule: null,
+    color: null,
+    colorInterpolation: null,
+    colorInterpolationFilters: null,
+    colorProfile: null,
+    colorRendering: null,
+    content: null,
+    contentScriptType: null,
+    contentStyleType: null,
+    crossOrigin: null,
+    cursor: null,
+    cx: null,
+    cy: null,
+    d: null,
+    dataType: null,
+    defaultAction: null,
+    descent: number,
+    diffuseConstant: number,
+    direction: null,
+    display: null,
+    dur: null,
+    divisor: number,
+    dominantBaseline: null,
+    download: boolean,
+    dx: null,
+    dy: null,
+    edgeMode: null,
+    editable: null,
+    elevation: number,
+    enableBackground: null,
+    end: null,
+    event: null,
+    exponent: number,
+    externalResourcesRequired: null,
+    fill: null,
+    fillOpacity: number,
+    fillRule: null,
+    filter: null,
+    filterRes: null,
+    filterUnits: null,
+    floodColor: null,
+    floodOpacity: null,
+    focusable: null,
+    focusHighlight: null,
+    fontFamily: null,
+    fontSize: null,
+    fontSizeAdjust: null,
+    fontStretch: null,
+    fontStyle: null,
+    fontVariant: null,
+    fontWeight: null,
+    format: null,
+    fr: null,
+    from: null,
+    fx: null,
+    fy: null,
+    g1: commaSeparated,
+    g2: commaSeparated,
+    glyphName: commaSeparated,
+    glyphOrientationHorizontal: null,
+    glyphOrientationVertical: null,
+    glyphRef: null,
+    gradientTransform: null,
+    gradientUnits: null,
+    handler: null,
+    hanging: number,
+    hatchContentUnits: null,
+    hatchUnits: null,
+    height: null,
+    href: null,
+    hrefLang: null,
+    horizAdvX: number,
+    horizOriginX: number,
+    horizOriginY: number,
+    id: null,
+    ideographic: number,
+    imageRendering: null,
+    initialVisibility: null,
+    in: null,
+    in2: null,
+    intercept: number,
+    k: number,
+    k1: number,
+    k2: number,
+    k3: number,
+    k4: number,
+    kernelMatrix: commaOrSpaceSeparated,
+    kernelUnitLength: null,
+    keyPoints: null,
+    keySplines: null,
+    keyTimes: null,
+    kerning: null,
+    lang: null,
+    lengthAdjust: null,
+    letterSpacing: null,
+    lightingColor: null,
+    limitingConeAngle: number,
+    local: null,
+    markerEnd: null,
+    markerMid: null,
+    markerStart: null,
+    markerHeight: null,
+    markerUnits: null,
+    markerWidth: null,
+    mask: null,
+    maskContentUnits: null,
+    maskUnits: null,
+    mathematical: null,
+    max: null,
+    media: null,
+    mediaCharacterEncoding: null,
+    mediaContentEncodings: null,
+    mediaSize: number,
+    mediaTime: null,
+    method: null,
+    min: null,
+    mode: null,
+    name: null,
+    navDown: null,
+    navDownLeft: null,
+    navDownRight: null,
+    navLeft: null,
+    navNext: null,
+    navPrev: null,
+    navRight: null,
+    navUp: null,
+    navUpLeft: null,
+    navUpRight: null,
+    numOctaves: null,
+    observer: null,
+    offset: null,
+    onAbort: null,
+    onActivate: null,
+    onAfterPrint: null,
+    onBeforePrint: null,
+    onBegin: null,
+    onCancel: null,
+    onCanPlay: null,
+    onCanPlayThrough: null,
+    onChange: null,
+    onClick: null,
+    onClose: null,
+    onCopy: null,
+    onCueChange: null,
+    onCut: null,
+    onDblClick: null,
+    onDrag: null,
+    onDragEnd: null,
+    onDragEnter: null,
+    onDragExit: null,
+    onDragLeave: null,
+    onDragOver: null,
+    onDragStart: null,
+    onDrop: null,
+    onDurationChange: null,
+    onEmptied: null,
+    onEnd: null,
+    onEnded: null,
+    onError: null,
+    onFocus: null,
+    onFocusIn: null,
+    onFocusOut: null,
+    onHashChange: null,
+    onInput: null,
+    onInvalid: null,
+    onKeyDown: null,
+    onKeyPress: null,
+    onKeyUp: null,
+    onLoad: null,
+    onLoadedData: null,
+    onLoadedMetadata: null,
+    onLoadStart: null,
+    onMessage: null,
+    onMouseDown: null,
+    onMouseEnter: null,
+    onMouseLeave: null,
+    onMouseMove: null,
+    onMouseOut: null,
+    onMouseOver: null,
+    onMouseUp: null,
+    onMouseWheel: null,
+    onOffline: null,
+    onOnline: null,
+    onPageHide: null,
+    onPageShow: null,
+    onPaste: null,
+    onPause: null,
+    onPlay: null,
+    onPlaying: null,
+    onPopState: null,
+    onProgress: null,
+    onRateChange: null,
+    onRepeat: null,
+    onReset: null,
+    onResize: null,
+    onScroll: null,
+    onSeeked: null,
+    onSeeking: null,
+    onSelect: null,
+    onShow: null,
+    onStalled: null,
+    onStorage: null,
+    onSubmit: null,
+    onSuspend: null,
+    onTimeUpdate: null,
+    onToggle: null,
+    onUnload: null,
+    onVolumeChange: null,
+    onWaiting: null,
+    onZoom: null,
+    opacity: null,
+    operator: null,
+    order: null,
+    orient: null,
+    orientation: null,
+    origin: null,
+    overflow: null,
+    overlay: null,
+    overlinePosition: number,
+    overlineThickness: number,
+    paintOrder: null,
+    panose1: null,
+    path: null,
+    pathLength: number,
+    patternContentUnits: null,
+    patternTransform: null,
+    patternUnits: null,
+    phase: null,
+    ping: spaceSeparated,
+    pitch: null,
+    playbackOrder: null,
+    pointerEvents: null,
+    points: null,
+    pointsAtX: number,
+    pointsAtY: number,
+    pointsAtZ: number,
+    preserveAlpha: null,
+    preserveAspectRatio: null,
+    primitiveUnits: null,
+    propagate: null,
+    property: commaOrSpaceSeparated,
+    r: null,
+    radius: null,
+    referrerPolicy: null,
+    refX: null,
+    refY: null,
+    rel: commaOrSpaceSeparated,
+    rev: commaOrSpaceSeparated,
+    renderingIntent: null,
+    repeatCount: null,
+    repeatDur: null,
+    requiredExtensions: commaOrSpaceSeparated,
+    requiredFeatures: commaOrSpaceSeparated,
+    requiredFonts: commaOrSpaceSeparated,
+    requiredFormats: commaOrSpaceSeparated,
+    resource: null,
+    restart: null,
+    result: null,
+    rotate: null,
+    rx: null,
+    ry: null,
+    scale: null,
+    seed: null,
+    shapeRendering: null,
+    side: null,
+    slope: null,
+    snapshotTime: null,
+    specularConstant: number,
+    specularExponent: number,
+    spreadMethod: null,
+    spacing: null,
+    startOffset: null,
+    stdDeviation: null,
+    stemh: null,
+    stemv: null,
+    stitchTiles: null,
+    stopColor: null,
+    stopOpacity: null,
+    strikethroughPosition: number,
+    strikethroughThickness: number,
+    string: null,
+    stroke: null,
+    strokeDashArray: commaOrSpaceSeparated,
+    strokeDashOffset: null,
+    strokeLineCap: null,
+    strokeLineJoin: null,
+    strokeMiterLimit: number,
+    strokeOpacity: number,
+    strokeWidth: null,
+    style: null,
+    surfaceScale: number,
+    syncBehavior: null,
+    syncBehaviorDefault: null,
+    syncMaster: null,
+    syncTolerance: null,
+    syncToleranceDefault: null,
+    systemLanguage: commaOrSpaceSeparated,
+    tabIndex: number,
+    tableValues: null,
+    target: null,
+    targetX: number,
+    targetY: number,
+    textAnchor: null,
+    textDecoration: null,
+    textRendering: null,
+    textLength: null,
+    timelineBegin: null,
+    title: null,
+    transformBehavior: null,
+    type: null,
+    typeOf: commaOrSpaceSeparated,
+    to: null,
+    transform: null,
+    u1: null,
+    u2: null,
+    underlinePosition: number,
+    underlineThickness: number,
+    unicode: null,
+    unicodeBidi: null,
+    unicodeRange: null,
+    unitsPerEm: number,
+    values: null,
+    vAlphabetic: number,
+    vMathematical: number,
+    vectorEffect: null,
+    vHanging: number,
+    vIdeographic: number,
+    version: null,
+    vertAdvY: number,
+    vertOriginX: number,
+    vertOriginY: number,
+    viewBox: null,
+    viewTarget: null,
+    visibility: null,
+    width: null,
+    widths: null,
+    wordSpacing: null,
+    writingMode: null,
+    x: null,
+    x1: null,
+    x2: null,
+    xChannelSelector: null,
+    xHeight: number,
+    y: null,
+    y1: null,
+    y2: null,
+    yChannelSelector: null,
+    z: null,
+    zoomAndPan: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/find.js
+var valid = /^data[-\w.:]+$/i;
+var dash = /-[a-z]/g;
+var cap = /[A-Z]/g;
+function find(schema, value) {
+  const normal = normalize(value);
+  let prop = value;
+  let Type = Info;
+  if (normal in schema.normal) {
+    return schema.property[schema.normal[normal]];
+  }
+  if (normal.length > 4 && normal.slice(0, 4) === "data" && valid.test(value)) {
+    if (value.charAt(4) === "-") {
+      const rest = value.slice(5).replace(dash, camelcase);
+      prop = "data" + rest.charAt(0).toUpperCase() + rest.slice(1);
+    } else {
+      const rest = value.slice(4);
+      if (!dash.test(rest)) {
+        let dashes = rest.replace(cap, kebab);
+        if (dashes.charAt(0) !== "-") {
+          dashes = "-" + dashes;
+        }
+        value = "data" + dashes;
+      }
+    }
+    Type = DefinedInfo;
+  }
+  return new Type(prop, value);
+}
+function kebab($0) {
+  return "-" + $0.toLowerCase();
+}
+function camelcase($0) {
+  return $0.charAt(1).toUpperCase();
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/hast-to-react.js
+var hastToReact = {
+  classId: "classID",
+  dataType: "datatype",
+  itemId: "itemID",
+  strokeDashArray: "strokeDasharray",
+  strokeDashOffset: "strokeDashoffset",
+  strokeLineCap: "strokeLinecap",
+  strokeLineJoin: "strokeLinejoin",
+  strokeMiterLimit: "strokeMiterlimit",
+  typeOf: "typeof",
+  xLinkActuate: "xlinkActuate",
+  xLinkArcRole: "xlinkArcrole",
+  xLinkHref: "xlinkHref",
+  xLinkRole: "xlinkRole",
+  xLinkShow: "xlinkShow",
+  xLinkTitle: "xlinkTitle",
+  xLinkType: "xlinkType",
+  xmlnsXLink: "xmlnsXlink"
+};
+
+// node_modules/hast-util-to-estree/node_modules/property-information/index.js
+var html3 = merge([xml, xlink, xmlns, aria, html2], "html");
+var svg2 = merge([xml, xlink, xmlns, aria, svg], "svg");
+
+// node_modules/hast-util-to-estree/node_modules/space-separated-tokens/index.js
+function stringify3(values) {
+  return values.join(" ").trim();
+}
+
+// node_modules/hast-util-to-estree/lib/index.js
+var import_style_to_object = __toESM(require_style_to_object(), 1);
+
+// node_modules/zwitch/index.js
+var own11 = {}.hasOwnProperty;
+function zwitch(key, options) {
+  var settings = options || {};
+  function one3(value) {
+    var fn = one3.invalid;
+    var handlers2 = one3.handlers;
+    if (value && own11.call(value, key)) {
+      fn = own11.call(handlers2, value[key]) ? handlers2[value[key]] : one3.unknown;
+    }
+    if (fn) {
+      return fn.apply(this, arguments);
+    }
+  }
+  one3.handlers = settings.handlers || {};
+  one3.invalid = settings.invalid;
+  one3.unknown = settings.unknown;
+  return one3;
+}
+
+// node_modules/hast-util-to-estree/lib/index.js
+var toReact = hastToReact;
+var own12 = {}.hasOwnProperty;
+var tableElements = /* @__PURE__ */ new Set([
+  "table",
+  "thead",
+  "tbody",
+  "tfoot",
+  "tr",
+  "th",
+  "td"
+]);
+function toEstree(tree, options = {}) {
+  const context = {
+    schema: options.space === "svg" ? svg2 : html3,
+    comments: [],
+    esm: [],
+    handle: zwitch("type", {
+      invalid,
+      unknown: unknown2,
+      handlers: Object.assign(
+        {},
+        {
+          comment,
+          doctype: ignore2,
+          element,
+          mdxjsEsm: mdxjsEsm2,
+          mdxFlowExpression: mdxExpression2,
+          mdxJsxFlowElement: mdxJsxElement,
+          mdxJsxTextElement: mdxJsxElement,
+          mdxTextExpression: mdxExpression2,
+          root: root2,
+          text: text4
+        },
+        options.handlers
+      )
+    })
+  };
+  let result = context.handle(tree, context);
+  const body = context.esm;
+  if (result) {
+    if (result.type !== "JSXFragment" && result.type !== "JSXElement") {
+      result = create4(tree, {
+        type: "JSXFragment",
+        openingFragment: { type: "JSXOpeningFragment" },
+        closingFragment: { type: "JSXClosingFragment" },
+        children: [result]
+      });
+    }
+    body.push(create4(tree, { type: "ExpressionStatement", expression: result }));
+  }
+  return create4(tree, {
+    type: "Program",
+    body,
+    sourceType: "module",
+    comments: context.comments
+  });
+}
+function invalid(value) {
+  throw new Error("Cannot handle value `" + value + "`, expected node");
+}
+function unknown2(node) {
+  throw new Error("Cannot handle unknown node `" + node.type + "`");
+}
+function ignore2() {
+}
+function comment(node, context) {
+  const esnode = inherit(node, { type: "Block", value: node.value });
+  context.comments.push(esnode);
+  return create4(node, {
+    type: "JSXExpressionContainer",
+    expression: create4(node, {
+      type: "JSXEmptyExpression",
+      comments: [Object.assign({}, esnode, { leading: false, trailing: true })]
+    })
+  });
+}
+function element(node, context) {
+  const parentSchema = context.schema;
+  let schema = parentSchema;
+  const props = node.properties || {};
+  if (parentSchema.space === "html" && node.tagName.toLowerCase() === "svg") {
+    schema = svg2;
+    context.schema = schema;
+  }
+  const children = all3(node, context);
+  const attributes = [];
+  let prop;
+  for (prop in props) {
+    if (own12.call(props, prop)) {
+      let value = props[prop];
+      const info = find(schema, prop);
+      let attributeValue;
+      if (value === void 0 || value === null || typeof value === "number" && Number.isNaN(value) || value === false || !value && info.boolean) {
+        continue;
+      }
+      prop = info.space ? toReact[info.property] || info.property : info.attribute;
+      if (Array.isArray(value)) {
+        value = info.commaSeparated ? stringify2(value) : stringify3(value);
+      }
+      if (prop === "style") {
+        const styleValue = typeof value === "string" ? parseStyle(value, node.tagName) : value;
+        const cssProperties = [];
+        let cssProp;
+        for (cssProp in styleValue) {
+          if (own12.call(styleValue, cssProp)) {
+            cssProperties.push({
+              type: "Property",
+              method: false,
+              shorthand: false,
+              computed: false,
+              key: { type: "Identifier", name: cssProp },
+              value: { type: "Literal", value: String(styleValue[cssProp]) },
+              kind: "init"
+            });
+          }
+        }
+        attributeValue = {
+          type: "JSXExpressionContainer",
+          expression: { type: "ObjectExpression", properties: cssProperties }
+        };
+      } else if (value === true) {
+        attributeValue = null;
+      } else {
+        attributeValue = { type: "Literal", value: String(value) };
+      }
+      if (jsxIdentifierName(prop)) {
+        attributes.push({
+          type: "JSXAttribute",
+          name: { type: "JSXIdentifier", name: prop },
+          value: attributeValue
+        });
+      } else {
+        attributes.push({
+          type: "JSXSpreadAttribute",
+          argument: {
+            type: "ObjectExpression",
+            properties: [
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                key: { type: "Literal", value: String(prop) },
+                value: attributeValue || { type: "Literal", value: true },
+                kind: "init"
+              }
+            ]
+          }
+        });
+      }
+    }
+  }
+  context.schema = parentSchema;
+  return inherit(node, {
+    type: "JSXElement",
+    openingElement: {
+      type: "JSXOpeningElement",
+      attributes,
+      name: createJsxName(node.tagName),
+      selfClosing: children.length === 0
+    },
+    closingElement: children.length > 0 ? { type: "JSXClosingElement", name: createJsxName(node.tagName) } : null,
+    children
+  });
+}
+function mdxjsEsm2(node, context) {
+  const estree = node.data && node.data.estree;
+  const comments = estree && estree.comments || [];
+  if (estree) {
+    context.comments.push(...comments);
+    attachComments(estree, comments);
+    context.esm.push(...estree.body);
+  }
+}
+function mdxExpression2(node, context) {
+  const estree = node.data && node.data.estree;
+  const comments = estree && estree.comments || [];
+  let expression;
+  if (estree) {
+    context.comments.push(...comments);
+    attachComments(estree, estree.comments);
+    expression = estree.body[0] && estree.body[0].type === "ExpressionStatement" && estree.body[0].expression || void 0;
+  }
+  return inherit(node, {
+    type: "JSXExpressionContainer",
+    expression: expression || create4(node, { type: "JSXEmptyExpression" })
+  });
+}
+function mdxJsxElement(node, context) {
+  const parentSchema = context.schema;
+  let schema = parentSchema;
+  const attrs = node.attributes || [];
+  let index2 = -1;
+  if (node.name && parentSchema.space === "html" && node.name.toLowerCase() === "svg") {
+    schema = svg2;
+    context.schema = schema;
+  }
+  const children = all3(node, context);
+  const attributes = [];
+  while (++index2 < attrs.length) {
+    const attr = attrs[index2];
+    const value = attr.value;
+    let attributeValue;
+    if (attr.type === "mdxJsxAttribute") {
+      if (value === void 0 || value === null) {
+        attributeValue = null;
+      } else if (typeof value === "object") {
+        const estree = value.data && value.data.estree;
+        const comments = estree && estree.comments || [];
+        let expression;
+        if (estree) {
+          context.comments.push(...comments);
+          attachComments(estree, estree.comments);
+          expression = estree.body[0] && estree.body[0].type === "ExpressionStatement" && estree.body[0].expression || void 0;
+        }
+        attributeValue = inherit(value, {
+          type: "JSXExpressionContainer",
+          expression: expression || { type: "JSXEmptyExpression" }
+        });
+      } else {
+        attributeValue = { type: "Literal", value: String(value) };
+      }
+      attributes.push(
+        inherit(attr, {
+          type: "JSXAttribute",
+          name: createJsxName(attr.name, true),
+          value: attributeValue
+        })
+      );
+    } else {
+      const estree = attr.data && attr.data.estree;
+      const comments = estree && estree.comments || [];
+      let argumentValue;
+      if (estree) {
+        context.comments.push(...comments);
+        attachComments(estree, estree.comments);
+        argumentValue = estree.body[0] && estree.body[0].type === "ExpressionStatement" && estree.body[0].expression && estree.body[0].expression.type === "ObjectExpression" && estree.body[0].expression.properties && estree.body[0].expression.properties[0] && estree.body[0].expression.properties[0].type === "SpreadElement" && estree.body[0].expression.properties[0].argument || void 0;
+      }
+      attributes.push(
+        inherit(attr, {
+          type: "JSXSpreadAttribute",
+          argument: argumentValue || { type: "ObjectExpression", properties: [] }
+        })
+      );
+    }
+  }
+  context.schema = parentSchema;
+  return inherit(
+    node,
+    node.name ? {
+      type: "JSXElement",
+      openingElement: {
+        type: "JSXOpeningElement",
+        attributes,
+        name: createJsxName(node.name),
+        selfClosing: children.length === 0
+      },
+      closingElement: children.length > 0 ? { type: "JSXClosingElement", name: createJsxName(node.name) } : null,
+      children
+    } : {
+      type: "JSXFragment",
+      openingFragment: { type: "JSXOpeningFragment" },
+      closingFragment: { type: "JSXClosingFragment" },
+      children
+    }
+  );
+}
+function root2(node, context) {
+  const children = all3(node, context);
+  const cleanChildren = [];
+  let index2 = -1;
+  let queue;
+  while (++index2 < children.length) {
+    const child = children[index2];
+    if (child.type === "JSXExpressionContainer" && child.expression.type === "Literal" && whitespace(child.expression.value)) {
+      if (queue)
+        queue.push(child);
+    } else {
+      if (queue)
+        cleanChildren.push(...queue);
+      cleanChildren.push(child);
+      queue = [];
+    }
+  }
+  return inherit(node, {
+    type: "JSXFragment",
+    openingFragment: { type: "JSXOpeningFragment" },
+    closingFragment: { type: "JSXClosingFragment" },
+    children: cleanChildren
+  });
+}
+function text4(node) {
+  const value = String(node.value || "");
+  if (!value)
+    return;
+  return create4(node, {
+    type: "JSXExpressionContainer",
+    expression: inherit(node, { type: "Literal", value })
+  });
+}
+function all3(parent, context) {
+  const children = parent.children || [];
+  let index2 = -1;
+  const results = [];
+  const ignoreLineBreak = context.schema.space === "html" && parent.type === "element" && tableElements.has(parent.tagName.toLowerCase());
+  while (++index2 < children.length) {
+    const child = children[index2];
+    if (ignoreLineBreak && child.type === "text" && child.value === "\n") {
+      continue;
+    }
+    const result = context.handle(child, context);
+    if (Array.isArray(result)) {
+      results.push(...result);
+    } else if (result) {
+      results.push(result);
+    }
+  }
+  return results;
+}
+function inherit(hast, esnode) {
+  const left = hast.data;
+  let right;
+  let key;
+  create4(hast, esnode);
+  if (left) {
+    for (key in left) {
+      if (own12.call(left, key) && key !== "estree") {
+        if (!right)
+          right = {};
+        right[key] = left[key];
+      }
+    }
+    if (right) {
+      esnode.data = right;
+    }
+  }
+  return esnode;
+}
+function create4(hast, esnode) {
+  const p = position2(hast);
+  if (p.start.line && p.start.offset !== void 0 && p.end.offset !== void 0) {
+    esnode.start = p.start.offset;
+    esnode.end = p.end.offset;
+    esnode.loc = {
+      start: { line: p.start.line, column: p.start.column - 1 },
+      end: { line: p.end.line, column: p.end.column - 1 }
+    };
+    esnode.range = [p.start.offset, p.end.offset];
+  }
+  return esnode;
+}
+var createJsxName = function(name2, attribute) {
+  if (!attribute && name2.includes(".")) {
+    const parts = name2.split(".");
+    let part = parts.shift();
+    let node = { type: "JSXIdentifier", name: part };
+    while (part = parts.shift()) {
+      node = {
+        type: "JSXMemberExpression",
+        object: node,
+        property: { type: "JSXIdentifier", name: part }
+      };
+    }
+    return node;
+  }
+  if (name2.includes(":")) {
+    const parts = name2.split(":");
+    return {
+      type: "JSXNamespacedName",
+      namespace: { type: "JSXIdentifier", name: parts[0] },
+      name: { type: "JSXIdentifier", name: parts[1] }
+    };
+  }
+  return { type: "JSXIdentifier", name: name2 };
+};
+function parseStyle(value, tagName) {
+  const result = {};
+  try {
+    (0, import_style_to_object.default)(value, iterator);
+  } catch (error) {
+    const exception = error;
+    exception.message = tagName + "[style]" + exception.message.slice("undefined".length);
+    throw error;
+  }
+  return result;
+  function iterator(name2, value2) {
+    if (name2.slice(0, 4) === "-ms-")
+      name2 = "ms-" + name2.slice(4);
+    result[name2.replace(/-([a-z])/g, styleReplacer)] = value2;
+  }
+}
+function styleReplacer(_, $1) {
+  return $1.toUpperCase();
+}
+function jsxIdentifierName(name2) {
+  let index2 = -1;
+  while (++index2 < name2.length) {
+    if (!(index2 ? cont3 : start2)(name2.charCodeAt(index2)))
+      return false;
+  }
+  return index2 > 0;
+  function cont3(code2) {
+    return cont2(code2) || code2 === 45;
+  }
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/rehype-recma.js
+function rehypeRecma() {
+  return (tree) => toEstree(tree);
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/rehype-remove-raw.js
+function rehypeRemoveRaw() {
+  return (tree) => {
+    visit2(tree, "raw", (_, index2, parent) => {
+      if (parent && typeof index2 === "number") {
+        parent.children.splice(index2, 1);
+        return index2;
+      }
+    });
+  };
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/remark-mark-and-unravel.js
+function remarkMarkAndUnravel() {
+  return (tree) => {
+    visit2(tree, (node, index2, parent_) => {
+      const parent = parent_;
+      let offset2 = -1;
+      let all4 = true;
+      let oneOrMore;
+      if (parent && typeof index2 === "number" && node.type === "paragraph") {
+        const children = node.children;
+        while (++offset2 < children.length) {
+          const child = children[offset2];
+          if (child.type === "mdxJsxTextElement" || child.type === "mdxTextExpression") {
+            oneOrMore = true;
+          } else if (child.type === "text" && /^[\t\r\n ]+$/.test(String(child.value))) {
+          } else {
+            all4 = false;
+            break;
+          }
+        }
+        if (all4 && oneOrMore) {
+          offset2 = -1;
+          while (++offset2 < children.length) {
+            const child = children[offset2];
+            if (child.type === "mdxJsxTextElement") {
+              child.type = "mdxJsxFlowElement";
+            }
+            if (child.type === "mdxTextExpression") {
+              child.type = "mdxFlowExpression";
+            }
+          }
+          parent.children.splice(index2, 1, ...children);
+          return index2;
+        }
+      }
+      if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+        const data2 = node.data || (node.data = {});
+        data2._mdxExplicitJsx = true;
+      }
+    });
+  };
+}
+
+// node_modules/@mdx-js/mdx/lib/node-types.js
+var nodeTypes = [
+  "mdxFlowExpression",
+  "mdxJsxFlowElement",
+  "mdxJsxTextElement",
+  "mdxTextExpression",
+  "mdxjsEsm"
+];
+
+// node_modules/@mdx-js/mdx/lib/condition.js
+var import_process2 = __toESM(require("process"), 1);
+var development = import_process2.default.env.NODE_ENV === "development";
+
+// node_modules/@mdx-js/mdx/lib/core.js
+var removedOptions = [
+  "filepath",
+  "compilers",
+  "hastPlugins",
+  "mdPlugins",
+  "skipExport",
+  "wrapExport"
+];
+function createProcessor(options = {}) {
+  const {
+    development: development2 = development,
+    jsx: jsx2,
+    format,
+    outputFormat,
+    providerImportSource,
+    recmaPlugins,
+    rehypePlugins,
+    remarkPlugins,
+    remarkRehypeOptions = {},
+    SourceMapGenerator,
+    ...rest
+  } = options;
+  let index2 = -1;
+  while (++index2 < removedOptions.length) {
+    const key = removedOptions[index2];
+    if (key in options) {
+      throw new Error(
+        "`options." + key + "` is no longer supported. Please see <https://mdxjs.com/migrating/v2/> for more information"
+      );
+    }
+  }
+  if (format === "detect") {
+    throw new Error(
+      "Incorrect `format: 'detect'`: `createProcessor` can support either `md` or `mdx`; it does not support detecting the format"
+    );
+  }
+  const pipeline = unified().use(remark_parse_default);
+  if (format !== "md") {
+    pipeline.use(remarkMdx);
+  }
+  pipeline.use(remarkMarkAndUnravel).use(remarkPlugins || []).use(lib_default, {
+    ...remarkRehypeOptions,
+    allowDangerousHtml: true,
+    passThrough: [...remarkRehypeOptions.passThrough || [], ...nodeTypes]
+  }).use(rehypePlugins || []);
+  if (format === "md") {
+    pipeline.use(rehypeRemoveRaw);
+  }
+  pipeline.use(rehypeRecma).use(recmaDocument, { ...rest, outputFormat }).use(recmaJsxRewrite, { development: development2, providerImportSource, outputFormat });
+  if (!jsx2) {
+    pipeline.use(recmaJsxBuild, { outputFormat });
+  }
+  pipeline.use(recmaStringify, { SourceMapGenerator }).use(recmaPlugins || []);
+  return pipeline;
+}
+
+// node_modules/@mdx-js/mdx/lib/util/extnames.js
+var import_markdown_extensions = __toESM(require_markdown_extensions2(), 1);
+var md = import_markdown_extensions.default.map((d) => "." + d);
+
+// node_modules/@mdx-js/mdx/lib/util/resolve-file-and-options.js
+function resolveFileAndOptions(vfileCompatible, options) {
+  const file = looksLikeAVFile2(vfileCompatible) ? vfileCompatible : new VFile(vfileCompatible);
+  const { format, ...rest } = options || {};
+  return {
+    file,
+    options: {
+      format: format === "md" || format === "mdx" ? format : file.extname && (rest.mdExtensions || md).includes(file.extname) ? "md" : "mdx",
+      ...rest
+    }
+  };
+}
+function looksLikeAVFile2(value) {
+  return Boolean(
+    value && typeof value === "object" && "message" in value && "messages" in value
+  );
+}
+
+// node_modules/@mdx-js/mdx/lib/compile.js
+function compile(vfileCompatible, compileOptions) {
+  const { file, options } = resolveFileAndOptions(vfileCompatible, compileOptions);
+  return createProcessor(options).process(file);
+}
+function compileSync(vfileCompatible, compileOptions) {
+  const { file, options } = resolveFileAndOptions(vfileCompatible, compileOptions);
+  return createProcessor(options).processSync(file);
+}
+
+// node_modules/@mdx-js/mdx/lib/run.js
+var AsyncFunction = Object.getPrototypeOf(run).constructor;
+async function run(file, options) {
+  return new AsyncFunction(String(file))(options);
+}
+function runSync(file, options) {
+  return new Function(String(file))(options);
+}
+
+// node_modules/@mdx-js/mdx/lib/util/resolve-evaluate-options.js
+function resolveEvaluateOptions(options) {
+  const { Fragment, jsx: jsx2, jsxs, useMDXComponents, ...rest } = options || {};
+  if (!Fragment)
+    throw new Error("Expected `Fragment` given to `evaluate`");
+  if (!jsx2)
+    throw new Error("Expected `jsx` given to `evaluate`");
+  if (!jsxs)
+    throw new Error("Expected `jsxs` given to `evaluate`");
+  return {
+    compiletime: {
+      ...rest,
+      outputFormat: "function-body",
+      providerImportSource: useMDXComponents ? "#" : void 0
+    },
+    runtime: { Fragment, jsx: jsx2, jsxs, useMDXComponents }
+  };
+}
+
+// node_modules/@mdx-js/mdx/lib/evaluate.js
+async function evaluate(vfileCompatible, evaluateOptions) {
+  const { compiletime, runtime } = resolveEvaluateOptions(evaluateOptions);
+  return run(await compile(vfileCompatible, compiletime), runtime);
+}
+function evaluateSync(vfileCompatible, evaluateOptions) {
+  const { compiletime, runtime } = resolveEvaluateOptions(evaluateOptions);
+  return runSync(compileSync(vfileCompatible, compiletime), runtime);
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  compile,
+  compileSync,
+  createProcessor,
+  evaluate,
+  evaluateSync,
+  nodeTypes,
+  run,
+  runSync
+});
+/*!
+ * Determine if an object is a Buffer
+ *
+ * @author   Feross Aboukhadijeh <https://feross.org>
+ * @license  MIT
+ */

--- a/jest/vendor/estree-util-value-to-estree@2.1.0.js
+++ b/jest/vendor/estree-util-value-to-estree@2.1.0.js
@@ -1,0 +1,151 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/estree-util-value-to-estree/index.js
+var estree_util_value_to_estree_exports = {};
+__export(estree_util_value_to_estree_exports, {
+  valueToEstree: () => valueToEstree
+});
+module.exports = __toCommonJS(estree_util_value_to_estree_exports);
+
+// node_modules/estree-util-value-to-estree/node_modules/is-plain-obj/index.js
+function isPlainObject(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in value) && !(Symbol.iterator in value);
+}
+
+// node_modules/estree-util-value-to-estree/index.js
+function valueToEstree(value, options = {}) {
+  if (value === void 0 || value === Number.POSITIVE_INFINITY || Number.isNaN(value)) {
+    return { type: "Identifier", name: String(value) };
+  }
+  if (value == null || typeof value === "string" || typeof value === "boolean") {
+    return { type: "Literal", value };
+  }
+  if (typeof value === "bigint") {
+    return value >= 0 ? { type: "Literal", value, bigint: String(value) } : {
+      type: "UnaryExpression",
+      operator: "-",
+      prefix: true,
+      argument: valueToEstree(-value, options)
+    };
+  }
+  if (typeof value === "number") {
+    return value >= 0 ? { type: "Literal", value } : {
+      type: "UnaryExpression",
+      operator: "-",
+      prefix: true,
+      argument: valueToEstree(-value, options)
+    };
+  }
+  if (typeof value === "symbol") {
+    if (value.description && value === Symbol.for(value.description)) {
+      return {
+        type: "CallExpression",
+        optional: false,
+        callee: {
+          type: "MemberExpression",
+          computed: false,
+          optional: false,
+          object: { type: "Identifier", name: "Symbol" },
+          property: { type: "Identifier", name: "for" }
+        },
+        arguments: [valueToEstree(value.description, options)]
+      };
+    }
+    throw new TypeError(`Only global symbols are supported, got: ${String(value)}`);
+  }
+  if (Array.isArray(value)) {
+    const elements = [];
+    for (let i = 0; i < value.length; i += 1) {
+      elements.push(i in value ? valueToEstree(value[i], options) : null);
+    }
+    return { type: "ArrayExpression", elements };
+  }
+  if (value instanceof Boolean || value instanceof Number || value instanceof String) {
+    return {
+      type: "NewExpression",
+      callee: { type: "Identifier", name: value.constructor.name },
+      arguments: [valueToEstree(value.valueOf())]
+    };
+  }
+  if (value instanceof RegExp) {
+    return {
+      type: "Literal",
+      value,
+      regex: { pattern: value.source, flags: value.flags }
+    };
+  }
+  if (value instanceof Date) {
+    return {
+      type: "NewExpression",
+      callee: { type: "Identifier", name: "Date" },
+      arguments: [valueToEstree(value.getTime(), options)]
+    };
+  }
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
+    return {
+      type: "CallExpression",
+      optional: false,
+      callee: {
+        type: "MemberExpression",
+        computed: false,
+        optional: false,
+        object: { type: "Identifier", name: "Buffer" },
+        property: { type: "Identifier", name: "from" }
+      },
+      arguments: [valueToEstree([...value])]
+    };
+  }
+  if (value instanceof BigInt64Array || value instanceof BigUint64Array || value instanceof Float32Array || value instanceof Float64Array || value instanceof Int8Array || value instanceof Int16Array || value instanceof Int32Array || value instanceof Map || value instanceof Set || value instanceof Uint8Array || value instanceof Uint8ClampedArray || value instanceof Uint16Array || value instanceof Uint32Array) {
+    return {
+      type: "NewExpression",
+      callee: { type: "Identifier", name: value.constructor.name },
+      arguments: [valueToEstree([...value], options)]
+    };
+  }
+  if (value instanceof URL || value instanceof URLSearchParams) {
+    return {
+      type: "NewExpression",
+      callee: { type: "Identifier", name: value.constructor.name },
+      arguments: [valueToEstree(String(value), options)]
+    };
+  }
+  if (options.instanceAsObject || isPlainObject(value)) {
+    return {
+      type: "ObjectExpression",
+      properties: Reflect.ownKeys(value).map((key) => ({
+        type: "Property",
+        method: false,
+        shorthand: false,
+        computed: typeof key !== "string",
+        kind: "init",
+        key: valueToEstree(key, options),
+        value: valueToEstree(value[key], options)
+      }))
+    };
+  }
+  throw new TypeError(`Unsupported value: ${String(value)}`);
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  valueToEstree
+});

--- a/jest/vendor/mdast-util-to-string@3.1.0.js
+++ b/jest/vendor/mdast-util-to-string@3.1.0.js
@@ -1,0 +1,43 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all2) => {
+  for (var name in all2)
+    __defProp(target, name, { get: all2[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/mdast-util-to-string/index.js
+var mdast_util_to_string_exports = {};
+__export(mdast_util_to_string_exports, {
+  toString: () => toString
+});
+module.exports = __toCommonJS(mdast_util_to_string_exports);
+function toString(node, options) {
+  var { includeImageAlt = true } = options || {};
+  return one(node, includeImageAlt);
+}
+function one(node, includeImageAlt) {
+  return node && typeof node === "object" && (node.value || (includeImageAlt ? node.alt : "") || "children" in node && all(node.children, includeImageAlt) || Array.isArray(node) && all(node, includeImageAlt)) || "";
+}
+function all(values, includeImageAlt) {
+  var result = [];
+  var index = -1;
+  while (++index < values.length) {
+    result[index] = one(values[index], includeImageAlt);
+  }
+  return result.join("");
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  toString
+});

--- a/jest/vendor/remark-directive@2.0.1.js
+++ b/jest/vendor/remark-directive@2.0.1.js
@@ -1,0 +1,3846 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/remark-directive/index.js
+var remark_directive_exports = {};
+__export(remark_directive_exports, {
+  default: () => remarkDirective201
+});
+module.exports = __toCommonJS(remark_directive_exports);
+
+// node_modules/micromark-util-character/lib/unicode-punctuation-regex.js
+var unicodePunctuationRegex = /[!-/:-@[-`{-~\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0A76\u0AF0\u0C77\u0C84\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E4F\u2E52\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]/;
+
+// node_modules/micromark-util-character/index.js
+var asciiAlpha = regexCheck(/[A-Za-z]/);
+var asciiDigit = regexCheck(/\d/);
+var asciiHexDigit = regexCheck(/[\dA-Fa-f]/);
+var asciiAlphanumeric = regexCheck(/[\dA-Za-z]/);
+var asciiPunctuation = regexCheck(/[!-/:-@[-`{-~]/);
+var asciiAtext = regexCheck(/[#-'*+\--9=?A-Z^-~]/);
+function markdownLineEndingOrSpace(code) {
+  return code !== null && (code < 0 || code === 32);
+}
+function markdownLineEnding(code) {
+  return code !== null && code < -2;
+}
+function markdownSpace(code) {
+  return code === -2 || code === -1 || code === 32;
+}
+var unicodeWhitespace = regexCheck(/\s/);
+var unicodePunctuation = regexCheck(unicodePunctuationRegex);
+function regexCheck(regex) {
+  return check;
+  function check(code) {
+    return code !== null && regex.test(String.fromCharCode(code));
+  }
+}
+
+// node_modules/micromark-factory-space/index.js
+function factorySpace(effects, ok2, type, max) {
+  const limit = max ? max - 1 : Number.POSITIVE_INFINITY;
+  let size = 0;
+  return start;
+  function start(code) {
+    if (markdownSpace(code)) {
+      effects.enter(type);
+      return prefix(code);
+    }
+    return ok2(code);
+  }
+  function prefix(code) {
+    if (markdownSpace(code) && size++ < limit) {
+      effects.consume(code);
+      return prefix;
+    }
+    effects.exit(type);
+    return ok2(code);
+  }
+}
+
+// node_modules/micromark-factory-whitespace/index.js
+function factoryWhitespace(effects, ok2) {
+  let seen;
+  return start;
+  function start(code) {
+    if (markdownLineEnding(code)) {
+      effects.enter("lineEnding");
+      effects.consume(code);
+      effects.exit("lineEnding");
+      seen = true;
+      return start;
+    }
+    if (markdownSpace(code)) {
+      return factorySpace(
+        effects,
+        start,
+        seen ? "linePrefix" : "lineSuffix"
+      )(code);
+    }
+    return ok2(code);
+  }
+}
+
+// node_modules/micromark-extension-directive/lib/factory-attributes.js
+function factoryAttributes(effects, ok2, nok, attributesType, attributesMarkerType, attributeType, attributeIdType, attributeClassType, attributeNameType, attributeInitializerType, attributeValueLiteralType, attributeValueType, attributeValueMarker, attributeValueData, disallowEol) {
+  let type;
+  let marker;
+  return start;
+  function start(code) {
+    effects.enter(attributesType);
+    effects.enter(attributesMarkerType);
+    effects.consume(code);
+    effects.exit(attributesMarkerType);
+    return between;
+  }
+  function between(code) {
+    if (code === 35) {
+      type = attributeIdType;
+      return shortcutStart(code);
+    }
+    if (code === 46) {
+      type = attributeClassType;
+      return shortcutStart(code);
+    }
+    if (code === 58 || code === 95 || asciiAlpha(code)) {
+      effects.enter(attributeType);
+      effects.enter(attributeNameType);
+      effects.consume(code);
+      return name;
+    }
+    if (disallowEol && markdownSpace(code)) {
+      return factorySpace(effects, between, "whitespace")(code);
+    }
+    if (!disallowEol && markdownLineEndingOrSpace(code)) {
+      return factoryWhitespace(effects, between)(code);
+    }
+    return end(code);
+  }
+  function shortcutStart(code) {
+    effects.enter(attributeType);
+    effects.enter(type);
+    effects.enter(type + "Marker");
+    effects.consume(code);
+    effects.exit(type + "Marker");
+    return shortcutStartAfter;
+  }
+  function shortcutStartAfter(code) {
+    if (code === null || code === 34 || code === 35 || code === 39 || code === 46 || code === 60 || code === 61 || code === 62 || code === 96 || code === 125 || markdownLineEndingOrSpace(code)) {
+      return nok(code);
+    }
+    effects.enter(type + "Value");
+    effects.consume(code);
+    return shortcut2;
+  }
+  function shortcut2(code) {
+    if (code === null || code === 34 || code === 39 || code === 60 || code === 61 || code === 62 || code === 96) {
+      return nok(code);
+    }
+    if (code === 35 || code === 46 || code === 125 || markdownLineEndingOrSpace(code)) {
+      effects.exit(type + "Value");
+      effects.exit(type);
+      effects.exit(attributeType);
+      return between(code);
+    }
+    effects.consume(code);
+    return shortcut2;
+  }
+  function name(code) {
+    if (code === 45 || code === 46 || code === 58 || code === 95 || asciiAlphanumeric(code)) {
+      effects.consume(code);
+      return name;
+    }
+    effects.exit(attributeNameType);
+    if (disallowEol && markdownSpace(code)) {
+      return factorySpace(effects, nameAfter, "whitespace")(code);
+    }
+    if (!disallowEol && markdownLineEndingOrSpace(code)) {
+      return factoryWhitespace(effects, nameAfter)(code);
+    }
+    return nameAfter(code);
+  }
+  function nameAfter(code) {
+    if (code === 61) {
+      effects.enter(attributeInitializerType);
+      effects.consume(code);
+      effects.exit(attributeInitializerType);
+      return valueBefore;
+    }
+    effects.exit(attributeType);
+    return between(code);
+  }
+  function valueBefore(code) {
+    if (code === null || code === 60 || code === 61 || code === 62 || code === 96 || code === 125 || disallowEol && markdownLineEnding(code)) {
+      return nok(code);
+    }
+    if (code === 34 || code === 39) {
+      effects.enter(attributeValueLiteralType);
+      effects.enter(attributeValueMarker);
+      effects.consume(code);
+      effects.exit(attributeValueMarker);
+      marker = code;
+      return valueQuotedStart;
+    }
+    if (disallowEol && markdownSpace(code)) {
+      return factorySpace(effects, valueBefore, "whitespace")(code);
+    }
+    if (!disallowEol && markdownLineEndingOrSpace(code)) {
+      return factoryWhitespace(effects, valueBefore)(code);
+    }
+    effects.enter(attributeValueType);
+    effects.enter(attributeValueData);
+    effects.consume(code);
+    marker = void 0;
+    return valueUnquoted;
+  }
+  function valueUnquoted(code) {
+    if (code === null || code === 34 || code === 39 || code === 60 || code === 61 || code === 62 || code === 96) {
+      return nok(code);
+    }
+    if (code === 125 || markdownLineEndingOrSpace(code)) {
+      effects.exit(attributeValueData);
+      effects.exit(attributeValueType);
+      effects.exit(attributeType);
+      return between(code);
+    }
+    effects.consume(code);
+    return valueUnquoted;
+  }
+  function valueQuotedStart(code) {
+    if (code === marker) {
+      effects.enter(attributeValueMarker);
+      effects.consume(code);
+      effects.exit(attributeValueMarker);
+      effects.exit(attributeValueLiteralType);
+      effects.exit(attributeType);
+      return valueQuotedAfter;
+    }
+    effects.enter(attributeValueType);
+    return valueQuotedBetween(code);
+  }
+  function valueQuotedBetween(code) {
+    if (code === marker) {
+      effects.exit(attributeValueType);
+      return valueQuotedStart(code);
+    }
+    if (code === null) {
+      return nok(code);
+    }
+    if (markdownLineEnding(code)) {
+      return disallowEol ? nok(code) : factoryWhitespace(effects, valueQuotedBetween)(code);
+    }
+    effects.enter(attributeValueData);
+    effects.consume(code);
+    return valueQuoted;
+  }
+  function valueQuoted(code) {
+    if (code === marker || code === null || markdownLineEnding(code)) {
+      effects.exit(attributeValueData);
+      return valueQuotedBetween(code);
+    }
+    effects.consume(code);
+    return valueQuoted;
+  }
+  function valueQuotedAfter(code) {
+    return code === 125 || markdownLineEndingOrSpace(code) ? between(code) : end(code);
+  }
+  function end(code) {
+    if (code === 125) {
+      effects.enter(attributesMarkerType);
+      effects.consume(code);
+      effects.exit(attributesMarkerType);
+      effects.exit(attributesType);
+      return ok2;
+    }
+    return nok(code);
+  }
+}
+
+// node_modules/micromark-extension-directive/lib/factory-label.js
+function factoryLabel(effects, ok2, nok, type, markerType, stringType, disallowEol) {
+  let size = 0;
+  let balance = 0;
+  let previous2;
+  return start;
+  function start(code) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code);
+    effects.exit(markerType);
+    return afterStart;
+  }
+  function afterStart(code) {
+    if (code === 93) {
+      effects.enter(markerType);
+      effects.consume(code);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok2;
+    }
+    effects.enter(stringType);
+    return lineStart(code);
+  }
+  function lineStart(code) {
+    if (code === 93 && !balance) {
+      return atClosingBrace(code);
+    }
+    const token = effects.enter("chunkText", {
+      contentType: "text",
+      previous: previous2
+    });
+    if (previous2)
+      previous2.next = token;
+    previous2 = token;
+    return data(code);
+  }
+  function data(code) {
+    if (code === null || size > 999) {
+      return nok(code);
+    }
+    if (code === 91 && ++balance > 32) {
+      return nok(code);
+    }
+    if (code === 93 && !balance--) {
+      effects.exit("chunkText");
+      return atClosingBrace(code);
+    }
+    if (markdownLineEnding(code)) {
+      if (disallowEol) {
+        return nok(code);
+      }
+      effects.consume(code);
+      effects.exit("chunkText");
+      return lineStart;
+    }
+    effects.consume(code);
+    return code === 92 ? dataEscape : data;
+  }
+  function dataEscape(code) {
+    if (code === 91 || code === 92 || code === 93) {
+      effects.consume(code);
+      size++;
+      return data;
+    }
+    return data(code);
+  }
+  function atClosingBrace(code) {
+    effects.exit(stringType);
+    effects.enter(markerType);
+    effects.consume(code);
+    effects.exit(markerType);
+    effects.exit(type);
+    return ok2;
+  }
+}
+
+// node_modules/micromark-extension-directive/lib/factory-name.js
+function factoryName(effects, ok2, nok, type) {
+  const self = this;
+  return start;
+  function start(code) {
+    if (asciiAlpha(code)) {
+      effects.enter(type);
+      effects.consume(code);
+      return name;
+    }
+    return nok(code);
+  }
+  function name(code) {
+    if (code === 45 || code === 95 || asciiAlphanumeric(code)) {
+      effects.consume(code);
+      return name;
+    }
+    effects.exit(type);
+    return self.previous === 45 || self.previous === 95 ? nok(code) : ok2(code);
+  }
+}
+
+// node_modules/micromark-extension-directive/lib/directive-container.js
+var directiveContainer = {
+  tokenize: tokenizeDirectiveContainer,
+  concrete: true
+};
+var label = {
+  tokenize: tokenizeLabel,
+  partial: true
+};
+var attributes = {
+  tokenize: tokenizeAttributes,
+  partial: true
+};
+var nonLazyLine = {
+  tokenize: tokenizeNonLazyLine,
+  partial: true
+};
+function tokenizeDirectiveContainer(effects, ok2, nok) {
+  const self = this;
+  const tail = self.events[self.events.length - 1];
+  const initialSize = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  let sizeOpen = 0;
+  let previous2;
+  return start;
+  function start(code) {
+    effects.enter("directiveContainer");
+    effects.enter("directiveContainerFence");
+    effects.enter("directiveContainerSequence");
+    return sequenceOpen(code);
+  }
+  function sequenceOpen(code) {
+    if (code === 58) {
+      effects.consume(code);
+      sizeOpen++;
+      return sequenceOpen;
+    }
+    if (sizeOpen < 3) {
+      return nok(code);
+    }
+    effects.exit("directiveContainerSequence");
+    return factoryName.call(
+      self,
+      effects,
+      afterName,
+      nok,
+      "directiveContainerName"
+    )(code);
+  }
+  function afterName(code) {
+    return code === 91 ? effects.attempt(label, afterLabel, afterLabel)(code) : afterLabel(code);
+  }
+  function afterLabel(code) {
+    return code === 123 ? effects.attempt(attributes, afterAttributes, afterAttributes)(code) : afterAttributes(code);
+  }
+  function afterAttributes(code) {
+    return factorySpace(effects, openAfter, "whitespace")(code);
+  }
+  function openAfter(code) {
+    effects.exit("directiveContainerFence");
+    if (code === null) {
+      return afterOpening(code);
+    }
+    if (markdownLineEnding(code)) {
+      if (self.interrupt) {
+        return ok2(code);
+      }
+      return effects.attempt(nonLazyLine, contentStart, afterOpening)(code);
+    }
+    return nok(code);
+  }
+  function afterOpening(code) {
+    effects.exit("directiveContainer");
+    return ok2(code);
+  }
+  function contentStart(code) {
+    if (code === null) {
+      effects.exit("directiveContainer");
+      return ok2(code);
+    }
+    effects.enter("directiveContainerContent");
+    return lineStart(code);
+  }
+  function lineStart(code) {
+    if (code === null) {
+      return after(code);
+    }
+    return effects.attempt(
+      {
+        tokenize: tokenizeClosingFence,
+        partial: true
+      },
+      after,
+      initialSize ? factorySpace(effects, chunkStart, "linePrefix", initialSize + 1) : chunkStart
+    )(code);
+  }
+  function chunkStart(code) {
+    if (code === null) {
+      return after(code);
+    }
+    const token = effects.enter("chunkDocument", {
+      contentType: "document",
+      previous: previous2
+    });
+    if (previous2)
+      previous2.next = token;
+    previous2 = token;
+    return contentContinue(code);
+  }
+  function contentContinue(code) {
+    if (code === null) {
+      const t = effects.exit("chunkDocument");
+      self.parser.lazy[t.start.line] = false;
+      return after(code);
+    }
+    if (markdownLineEnding(code)) {
+      return effects.check(nonLazyLine, nonLazyLineAfter, lineAfter)(code);
+    }
+    effects.consume(code);
+    return contentContinue;
+  }
+  function nonLazyLineAfter(code) {
+    effects.consume(code);
+    const t = effects.exit("chunkDocument");
+    self.parser.lazy[t.start.line] = false;
+    return lineStart;
+  }
+  function lineAfter(code) {
+    const t = effects.exit("chunkDocument");
+    self.parser.lazy[t.start.line] = false;
+    return after(code);
+  }
+  function after(code) {
+    effects.exit("directiveContainerContent");
+    effects.exit("directiveContainer");
+    return ok2(code);
+  }
+  function tokenizeClosingFence(effects2, ok3, nok2) {
+    let size = 0;
+    return factorySpace(effects2, closingPrefixAfter, "linePrefix", 4);
+    function closingPrefixAfter(code) {
+      effects2.enter("directiveContainerFence");
+      effects2.enter("directiveContainerSequence");
+      return closingSequence(code);
+    }
+    function closingSequence(code) {
+      if (code === 58) {
+        effects2.consume(code);
+        size++;
+        return closingSequence;
+      }
+      if (size < sizeOpen)
+        return nok2(code);
+      effects2.exit("directiveContainerSequence");
+      return factorySpace(effects2, closingSequenceEnd, "whitespace")(code);
+    }
+    function closingSequenceEnd(code) {
+      if (code === null || markdownLineEnding(code)) {
+        effects2.exit("directiveContainerFence");
+        return ok3(code);
+      }
+      return nok2(code);
+    }
+  }
+}
+function tokenizeLabel(effects, ok2, nok) {
+  return factoryLabel(
+    effects,
+    ok2,
+    nok,
+    "directiveContainerLabel",
+    "directiveContainerLabelMarker",
+    "directiveContainerLabelString",
+    true
+  );
+}
+function tokenizeAttributes(effects, ok2, nok) {
+  return factoryAttributes(
+    effects,
+    ok2,
+    nok,
+    "directiveContainerAttributes",
+    "directiveContainerAttributesMarker",
+    "directiveContainerAttribute",
+    "directiveContainerAttributeId",
+    "directiveContainerAttributeClass",
+    "directiveContainerAttributeName",
+    "directiveContainerAttributeInitializerMarker",
+    "directiveContainerAttributeValueLiteral",
+    "directiveContainerAttributeValue",
+    "directiveContainerAttributeValueMarker",
+    "directiveContainerAttributeValueData",
+    true
+  );
+}
+function tokenizeNonLazyLine(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code) {
+    effects.enter("lineEnding");
+    effects.consume(code);
+    effects.exit("lineEnding");
+    return lineStart;
+  }
+  function lineStart(code) {
+    return self.parser.lazy[self.now().line] ? nok(code) : ok2(code);
+  }
+}
+
+// node_modules/micromark-extension-directive/lib/directive-leaf.js
+var directiveLeaf = {
+  tokenize: tokenizeDirectiveLeaf
+};
+var label2 = {
+  tokenize: tokenizeLabel2,
+  partial: true
+};
+var attributes2 = {
+  tokenize: tokenizeAttributes2,
+  partial: true
+};
+function tokenizeDirectiveLeaf(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code) {
+    effects.enter("directiveLeaf");
+    effects.enter("directiveLeafSequence");
+    effects.consume(code);
+    return inStart;
+  }
+  function inStart(code) {
+    if (code === 58) {
+      effects.consume(code);
+      effects.exit("directiveLeafSequence");
+      return factoryName.call(
+        self,
+        effects,
+        afterName,
+        nok,
+        "directiveLeafName"
+      );
+    }
+    return nok(code);
+  }
+  function afterName(code) {
+    return code === 91 ? effects.attempt(label2, afterLabel, afterLabel)(code) : afterLabel(code);
+  }
+  function afterLabel(code) {
+    return code === 123 ? effects.attempt(attributes2, afterAttributes, afterAttributes)(code) : afterAttributes(code);
+  }
+  function afterAttributes(code) {
+    return factorySpace(effects, end, "whitespace")(code);
+  }
+  function end(code) {
+    if (code === null || markdownLineEnding(code)) {
+      effects.exit("directiveLeaf");
+      return ok2(code);
+    }
+    return nok(code);
+  }
+}
+function tokenizeLabel2(effects, ok2, nok) {
+  return factoryLabel(
+    effects,
+    ok2,
+    nok,
+    "directiveLeafLabel",
+    "directiveLeafLabelMarker",
+    "directiveLeafLabelString",
+    true
+  );
+}
+function tokenizeAttributes2(effects, ok2, nok) {
+  return factoryAttributes(
+    effects,
+    ok2,
+    nok,
+    "directiveLeafAttributes",
+    "directiveLeafAttributesMarker",
+    "directiveLeafAttribute",
+    "directiveLeafAttributeId",
+    "directiveLeafAttributeClass",
+    "directiveLeafAttributeName",
+    "directiveLeafAttributeInitializerMarker",
+    "directiveLeafAttributeValueLiteral",
+    "directiveLeafAttributeValue",
+    "directiveLeafAttributeValueMarker",
+    "directiveLeafAttributeValueData",
+    true
+  );
+}
+
+// node_modules/micromark-extension-directive/lib/directive-text.js
+var directiveText = {
+  tokenize: tokenizeDirectiveText,
+  previous
+};
+var label3 = {
+  tokenize: tokenizeLabel3,
+  partial: true
+};
+var attributes3 = {
+  tokenize: tokenizeAttributes3,
+  partial: true
+};
+function previous(code) {
+  return code !== 58 || this.events[this.events.length - 1][1].type === "characterEscape";
+}
+function tokenizeDirectiveText(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code) {
+    effects.enter("directiveText");
+    effects.enter("directiveTextMarker");
+    effects.consume(code);
+    effects.exit("directiveTextMarker");
+    return factoryName.call(self, effects, afterName, nok, "directiveTextName");
+  }
+  function afterName(code) {
+    return code === 58 ? nok(code) : code === 91 ? effects.attempt(label3, afterLabel, afterLabel)(code) : afterLabel(code);
+  }
+  function afterLabel(code) {
+    return code === 123 ? effects.attempt(attributes3, afterAttributes, afterAttributes)(code) : afterAttributes(code);
+  }
+  function afterAttributes(code) {
+    effects.exit("directiveText");
+    return ok2(code);
+  }
+}
+function tokenizeLabel3(effects, ok2, nok) {
+  return factoryLabel(
+    effects,
+    ok2,
+    nok,
+    "directiveTextLabel",
+    "directiveTextLabelMarker",
+    "directiveTextLabelString"
+  );
+}
+function tokenizeAttributes3(effects, ok2, nok) {
+  return factoryAttributes(
+    effects,
+    ok2,
+    nok,
+    "directiveTextAttributes",
+    "directiveTextAttributesMarker",
+    "directiveTextAttribute",
+    "directiveTextAttributeId",
+    "directiveTextAttributeClass",
+    "directiveTextAttributeName",
+    "directiveTextAttributeInitializerMarker",
+    "directiveTextAttributeValueLiteral",
+    "directiveTextAttributeValue",
+    "directiveTextAttributeValueMarker",
+    "directiveTextAttributeValueData"
+  );
+}
+
+// node_modules/micromark-extension-directive/lib/syntax.js
+function directive() {
+  return {
+    text: {
+      [58]: directiveText
+    },
+    flow: {
+      [58]: [directiveContainer, directiveLeaf]
+    }
+  };
+}
+
+// node_modules/parse-entities/node_modules/character-entities-legacy/index.js
+var characterEntitiesLegacy = [
+  "AElig",
+  "AMP",
+  "Aacute",
+  "Acirc",
+  "Agrave",
+  "Aring",
+  "Atilde",
+  "Auml",
+  "COPY",
+  "Ccedil",
+  "ETH",
+  "Eacute",
+  "Ecirc",
+  "Egrave",
+  "Euml",
+  "GT",
+  "Iacute",
+  "Icirc",
+  "Igrave",
+  "Iuml",
+  "LT",
+  "Ntilde",
+  "Oacute",
+  "Ocirc",
+  "Ograve",
+  "Oslash",
+  "Otilde",
+  "Ouml",
+  "QUOT",
+  "REG",
+  "THORN",
+  "Uacute",
+  "Ucirc",
+  "Ugrave",
+  "Uuml",
+  "Yacute",
+  "aacute",
+  "acirc",
+  "acute",
+  "aelig",
+  "agrave",
+  "amp",
+  "aring",
+  "atilde",
+  "auml",
+  "brvbar",
+  "ccedil",
+  "cedil",
+  "cent",
+  "copy",
+  "curren",
+  "deg",
+  "divide",
+  "eacute",
+  "ecirc",
+  "egrave",
+  "eth",
+  "euml",
+  "frac12",
+  "frac14",
+  "frac34",
+  "gt",
+  "iacute",
+  "icirc",
+  "iexcl",
+  "igrave",
+  "iquest",
+  "iuml",
+  "laquo",
+  "lt",
+  "macr",
+  "micro",
+  "middot",
+  "nbsp",
+  "not",
+  "ntilde",
+  "oacute",
+  "ocirc",
+  "ograve",
+  "ordf",
+  "ordm",
+  "oslash",
+  "otilde",
+  "ouml",
+  "para",
+  "plusmn",
+  "pound",
+  "quot",
+  "raquo",
+  "reg",
+  "sect",
+  "shy",
+  "sup1",
+  "sup2",
+  "sup3",
+  "szlig",
+  "thorn",
+  "times",
+  "uacute",
+  "ucirc",
+  "ugrave",
+  "uml",
+  "uuml",
+  "yacute",
+  "yen",
+  "yuml"
+];
+
+// node_modules/character-reference-invalid/index.js
+var characterReferenceInvalid = {
+  0: "\uFFFD",
+  128: "\u20AC",
+  130: "\u201A",
+  131: "\u0192",
+  132: "\u201E",
+  133: "\u2026",
+  134: "\u2020",
+  135: "\u2021",
+  136: "\u02C6",
+  137: "\u2030",
+  138: "\u0160",
+  139: "\u2039",
+  140: "\u0152",
+  142: "\u017D",
+  145: "\u2018",
+  146: "\u2019",
+  147: "\u201C",
+  148: "\u201D",
+  149: "\u2022",
+  150: "\u2013",
+  151: "\u2014",
+  152: "\u02DC",
+  153: "\u2122",
+  154: "\u0161",
+  155: "\u203A",
+  156: "\u0153",
+  158: "\u017E",
+  159: "\u0178"
+};
+
+// node_modules/parse-entities/node_modules/is-decimal/index.js
+function isDecimal(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 48 && code <= 57;
+}
+
+// node_modules/is-hexadecimal/index.js
+function isHexadecimal(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 97 && code <= 102 || code >= 65 && code <= 70 || code >= 48 && code <= 57;
+}
+
+// node_modules/is-alphanumerical/node_modules/is-alphabetical/index.js
+function isAlphabetical(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 97 && code <= 122 || code >= 65 && code <= 90;
+}
+
+// node_modules/is-alphanumerical/node_modules/is-decimal/index.js
+function isDecimal2(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 48 && code <= 57;
+}
+
+// node_modules/is-alphanumerical/index.js
+function isAlphanumerical(character) {
+  return isAlphabetical(character) || isDecimal2(character);
+}
+
+// node_modules/character-entities/index.js
+var characterEntities = {
+  AElig: "\xC6",
+  AMP: "&",
+  Aacute: "\xC1",
+  Abreve: "\u0102",
+  Acirc: "\xC2",
+  Acy: "\u0410",
+  Afr: "\u{1D504}",
+  Agrave: "\xC0",
+  Alpha: "\u0391",
+  Amacr: "\u0100",
+  And: "\u2A53",
+  Aogon: "\u0104",
+  Aopf: "\u{1D538}",
+  ApplyFunction: "\u2061",
+  Aring: "\xC5",
+  Ascr: "\u{1D49C}",
+  Assign: "\u2254",
+  Atilde: "\xC3",
+  Auml: "\xC4",
+  Backslash: "\u2216",
+  Barv: "\u2AE7",
+  Barwed: "\u2306",
+  Bcy: "\u0411",
+  Because: "\u2235",
+  Bernoullis: "\u212C",
+  Beta: "\u0392",
+  Bfr: "\u{1D505}",
+  Bopf: "\u{1D539}",
+  Breve: "\u02D8",
+  Bscr: "\u212C",
+  Bumpeq: "\u224E",
+  CHcy: "\u0427",
+  COPY: "\xA9",
+  Cacute: "\u0106",
+  Cap: "\u22D2",
+  CapitalDifferentialD: "\u2145",
+  Cayleys: "\u212D",
+  Ccaron: "\u010C",
+  Ccedil: "\xC7",
+  Ccirc: "\u0108",
+  Cconint: "\u2230",
+  Cdot: "\u010A",
+  Cedilla: "\xB8",
+  CenterDot: "\xB7",
+  Cfr: "\u212D",
+  Chi: "\u03A7",
+  CircleDot: "\u2299",
+  CircleMinus: "\u2296",
+  CirclePlus: "\u2295",
+  CircleTimes: "\u2297",
+  ClockwiseContourIntegral: "\u2232",
+  CloseCurlyDoubleQuote: "\u201D",
+  CloseCurlyQuote: "\u2019",
+  Colon: "\u2237",
+  Colone: "\u2A74",
+  Congruent: "\u2261",
+  Conint: "\u222F",
+  ContourIntegral: "\u222E",
+  Copf: "\u2102",
+  Coproduct: "\u2210",
+  CounterClockwiseContourIntegral: "\u2233",
+  Cross: "\u2A2F",
+  Cscr: "\u{1D49E}",
+  Cup: "\u22D3",
+  CupCap: "\u224D",
+  DD: "\u2145",
+  DDotrahd: "\u2911",
+  DJcy: "\u0402",
+  DScy: "\u0405",
+  DZcy: "\u040F",
+  Dagger: "\u2021",
+  Darr: "\u21A1",
+  Dashv: "\u2AE4",
+  Dcaron: "\u010E",
+  Dcy: "\u0414",
+  Del: "\u2207",
+  Delta: "\u0394",
+  Dfr: "\u{1D507}",
+  DiacriticalAcute: "\xB4",
+  DiacriticalDot: "\u02D9",
+  DiacriticalDoubleAcute: "\u02DD",
+  DiacriticalGrave: "`",
+  DiacriticalTilde: "\u02DC",
+  Diamond: "\u22C4",
+  DifferentialD: "\u2146",
+  Dopf: "\u{1D53B}",
+  Dot: "\xA8",
+  DotDot: "\u20DC",
+  DotEqual: "\u2250",
+  DoubleContourIntegral: "\u222F",
+  DoubleDot: "\xA8",
+  DoubleDownArrow: "\u21D3",
+  DoubleLeftArrow: "\u21D0",
+  DoubleLeftRightArrow: "\u21D4",
+  DoubleLeftTee: "\u2AE4",
+  DoubleLongLeftArrow: "\u27F8",
+  DoubleLongLeftRightArrow: "\u27FA",
+  DoubleLongRightArrow: "\u27F9",
+  DoubleRightArrow: "\u21D2",
+  DoubleRightTee: "\u22A8",
+  DoubleUpArrow: "\u21D1",
+  DoubleUpDownArrow: "\u21D5",
+  DoubleVerticalBar: "\u2225",
+  DownArrow: "\u2193",
+  DownArrowBar: "\u2913",
+  DownArrowUpArrow: "\u21F5",
+  DownBreve: "\u0311",
+  DownLeftRightVector: "\u2950",
+  DownLeftTeeVector: "\u295E",
+  DownLeftVector: "\u21BD",
+  DownLeftVectorBar: "\u2956",
+  DownRightTeeVector: "\u295F",
+  DownRightVector: "\u21C1",
+  DownRightVectorBar: "\u2957",
+  DownTee: "\u22A4",
+  DownTeeArrow: "\u21A7",
+  Downarrow: "\u21D3",
+  Dscr: "\u{1D49F}",
+  Dstrok: "\u0110",
+  ENG: "\u014A",
+  ETH: "\xD0",
+  Eacute: "\xC9",
+  Ecaron: "\u011A",
+  Ecirc: "\xCA",
+  Ecy: "\u042D",
+  Edot: "\u0116",
+  Efr: "\u{1D508}",
+  Egrave: "\xC8",
+  Element: "\u2208",
+  Emacr: "\u0112",
+  EmptySmallSquare: "\u25FB",
+  EmptyVerySmallSquare: "\u25AB",
+  Eogon: "\u0118",
+  Eopf: "\u{1D53C}",
+  Epsilon: "\u0395",
+  Equal: "\u2A75",
+  EqualTilde: "\u2242",
+  Equilibrium: "\u21CC",
+  Escr: "\u2130",
+  Esim: "\u2A73",
+  Eta: "\u0397",
+  Euml: "\xCB",
+  Exists: "\u2203",
+  ExponentialE: "\u2147",
+  Fcy: "\u0424",
+  Ffr: "\u{1D509}",
+  FilledSmallSquare: "\u25FC",
+  FilledVerySmallSquare: "\u25AA",
+  Fopf: "\u{1D53D}",
+  ForAll: "\u2200",
+  Fouriertrf: "\u2131",
+  Fscr: "\u2131",
+  GJcy: "\u0403",
+  GT: ">",
+  Gamma: "\u0393",
+  Gammad: "\u03DC",
+  Gbreve: "\u011E",
+  Gcedil: "\u0122",
+  Gcirc: "\u011C",
+  Gcy: "\u0413",
+  Gdot: "\u0120",
+  Gfr: "\u{1D50A}",
+  Gg: "\u22D9",
+  Gopf: "\u{1D53E}",
+  GreaterEqual: "\u2265",
+  GreaterEqualLess: "\u22DB",
+  GreaterFullEqual: "\u2267",
+  GreaterGreater: "\u2AA2",
+  GreaterLess: "\u2277",
+  GreaterSlantEqual: "\u2A7E",
+  GreaterTilde: "\u2273",
+  Gscr: "\u{1D4A2}",
+  Gt: "\u226B",
+  HARDcy: "\u042A",
+  Hacek: "\u02C7",
+  Hat: "^",
+  Hcirc: "\u0124",
+  Hfr: "\u210C",
+  HilbertSpace: "\u210B",
+  Hopf: "\u210D",
+  HorizontalLine: "\u2500",
+  Hscr: "\u210B",
+  Hstrok: "\u0126",
+  HumpDownHump: "\u224E",
+  HumpEqual: "\u224F",
+  IEcy: "\u0415",
+  IJlig: "\u0132",
+  IOcy: "\u0401",
+  Iacute: "\xCD",
+  Icirc: "\xCE",
+  Icy: "\u0418",
+  Idot: "\u0130",
+  Ifr: "\u2111",
+  Igrave: "\xCC",
+  Im: "\u2111",
+  Imacr: "\u012A",
+  ImaginaryI: "\u2148",
+  Implies: "\u21D2",
+  Int: "\u222C",
+  Integral: "\u222B",
+  Intersection: "\u22C2",
+  InvisibleComma: "\u2063",
+  InvisibleTimes: "\u2062",
+  Iogon: "\u012E",
+  Iopf: "\u{1D540}",
+  Iota: "\u0399",
+  Iscr: "\u2110",
+  Itilde: "\u0128",
+  Iukcy: "\u0406",
+  Iuml: "\xCF",
+  Jcirc: "\u0134",
+  Jcy: "\u0419",
+  Jfr: "\u{1D50D}",
+  Jopf: "\u{1D541}",
+  Jscr: "\u{1D4A5}",
+  Jsercy: "\u0408",
+  Jukcy: "\u0404",
+  KHcy: "\u0425",
+  KJcy: "\u040C",
+  Kappa: "\u039A",
+  Kcedil: "\u0136",
+  Kcy: "\u041A",
+  Kfr: "\u{1D50E}",
+  Kopf: "\u{1D542}",
+  Kscr: "\u{1D4A6}",
+  LJcy: "\u0409",
+  LT: "<",
+  Lacute: "\u0139",
+  Lambda: "\u039B",
+  Lang: "\u27EA",
+  Laplacetrf: "\u2112",
+  Larr: "\u219E",
+  Lcaron: "\u013D",
+  Lcedil: "\u013B",
+  Lcy: "\u041B",
+  LeftAngleBracket: "\u27E8",
+  LeftArrow: "\u2190",
+  LeftArrowBar: "\u21E4",
+  LeftArrowRightArrow: "\u21C6",
+  LeftCeiling: "\u2308",
+  LeftDoubleBracket: "\u27E6",
+  LeftDownTeeVector: "\u2961",
+  LeftDownVector: "\u21C3",
+  LeftDownVectorBar: "\u2959",
+  LeftFloor: "\u230A",
+  LeftRightArrow: "\u2194",
+  LeftRightVector: "\u294E",
+  LeftTee: "\u22A3",
+  LeftTeeArrow: "\u21A4",
+  LeftTeeVector: "\u295A",
+  LeftTriangle: "\u22B2",
+  LeftTriangleBar: "\u29CF",
+  LeftTriangleEqual: "\u22B4",
+  LeftUpDownVector: "\u2951",
+  LeftUpTeeVector: "\u2960",
+  LeftUpVector: "\u21BF",
+  LeftUpVectorBar: "\u2958",
+  LeftVector: "\u21BC",
+  LeftVectorBar: "\u2952",
+  Leftarrow: "\u21D0",
+  Leftrightarrow: "\u21D4",
+  LessEqualGreater: "\u22DA",
+  LessFullEqual: "\u2266",
+  LessGreater: "\u2276",
+  LessLess: "\u2AA1",
+  LessSlantEqual: "\u2A7D",
+  LessTilde: "\u2272",
+  Lfr: "\u{1D50F}",
+  Ll: "\u22D8",
+  Lleftarrow: "\u21DA",
+  Lmidot: "\u013F",
+  LongLeftArrow: "\u27F5",
+  LongLeftRightArrow: "\u27F7",
+  LongRightArrow: "\u27F6",
+  Longleftarrow: "\u27F8",
+  Longleftrightarrow: "\u27FA",
+  Longrightarrow: "\u27F9",
+  Lopf: "\u{1D543}",
+  LowerLeftArrow: "\u2199",
+  LowerRightArrow: "\u2198",
+  Lscr: "\u2112",
+  Lsh: "\u21B0",
+  Lstrok: "\u0141",
+  Lt: "\u226A",
+  Map: "\u2905",
+  Mcy: "\u041C",
+  MediumSpace: "\u205F",
+  Mellintrf: "\u2133",
+  Mfr: "\u{1D510}",
+  MinusPlus: "\u2213",
+  Mopf: "\u{1D544}",
+  Mscr: "\u2133",
+  Mu: "\u039C",
+  NJcy: "\u040A",
+  Nacute: "\u0143",
+  Ncaron: "\u0147",
+  Ncedil: "\u0145",
+  Ncy: "\u041D",
+  NegativeMediumSpace: "\u200B",
+  NegativeThickSpace: "\u200B",
+  NegativeThinSpace: "\u200B",
+  NegativeVeryThinSpace: "\u200B",
+  NestedGreaterGreater: "\u226B",
+  NestedLessLess: "\u226A",
+  NewLine: "\n",
+  Nfr: "\u{1D511}",
+  NoBreak: "\u2060",
+  NonBreakingSpace: "\xA0",
+  Nopf: "\u2115",
+  Not: "\u2AEC",
+  NotCongruent: "\u2262",
+  NotCupCap: "\u226D",
+  NotDoubleVerticalBar: "\u2226",
+  NotElement: "\u2209",
+  NotEqual: "\u2260",
+  NotEqualTilde: "\u2242\u0338",
+  NotExists: "\u2204",
+  NotGreater: "\u226F",
+  NotGreaterEqual: "\u2271",
+  NotGreaterFullEqual: "\u2267\u0338",
+  NotGreaterGreater: "\u226B\u0338",
+  NotGreaterLess: "\u2279",
+  NotGreaterSlantEqual: "\u2A7E\u0338",
+  NotGreaterTilde: "\u2275",
+  NotHumpDownHump: "\u224E\u0338",
+  NotHumpEqual: "\u224F\u0338",
+  NotLeftTriangle: "\u22EA",
+  NotLeftTriangleBar: "\u29CF\u0338",
+  NotLeftTriangleEqual: "\u22EC",
+  NotLess: "\u226E",
+  NotLessEqual: "\u2270",
+  NotLessGreater: "\u2278",
+  NotLessLess: "\u226A\u0338",
+  NotLessSlantEqual: "\u2A7D\u0338",
+  NotLessTilde: "\u2274",
+  NotNestedGreaterGreater: "\u2AA2\u0338",
+  NotNestedLessLess: "\u2AA1\u0338",
+  NotPrecedes: "\u2280",
+  NotPrecedesEqual: "\u2AAF\u0338",
+  NotPrecedesSlantEqual: "\u22E0",
+  NotReverseElement: "\u220C",
+  NotRightTriangle: "\u22EB",
+  NotRightTriangleBar: "\u29D0\u0338",
+  NotRightTriangleEqual: "\u22ED",
+  NotSquareSubset: "\u228F\u0338",
+  NotSquareSubsetEqual: "\u22E2",
+  NotSquareSuperset: "\u2290\u0338",
+  NotSquareSupersetEqual: "\u22E3",
+  NotSubset: "\u2282\u20D2",
+  NotSubsetEqual: "\u2288",
+  NotSucceeds: "\u2281",
+  NotSucceedsEqual: "\u2AB0\u0338",
+  NotSucceedsSlantEqual: "\u22E1",
+  NotSucceedsTilde: "\u227F\u0338",
+  NotSuperset: "\u2283\u20D2",
+  NotSupersetEqual: "\u2289",
+  NotTilde: "\u2241",
+  NotTildeEqual: "\u2244",
+  NotTildeFullEqual: "\u2247",
+  NotTildeTilde: "\u2249",
+  NotVerticalBar: "\u2224",
+  Nscr: "\u{1D4A9}",
+  Ntilde: "\xD1",
+  Nu: "\u039D",
+  OElig: "\u0152",
+  Oacute: "\xD3",
+  Ocirc: "\xD4",
+  Ocy: "\u041E",
+  Odblac: "\u0150",
+  Ofr: "\u{1D512}",
+  Ograve: "\xD2",
+  Omacr: "\u014C",
+  Omega: "\u03A9",
+  Omicron: "\u039F",
+  Oopf: "\u{1D546}",
+  OpenCurlyDoubleQuote: "\u201C",
+  OpenCurlyQuote: "\u2018",
+  Or: "\u2A54",
+  Oscr: "\u{1D4AA}",
+  Oslash: "\xD8",
+  Otilde: "\xD5",
+  Otimes: "\u2A37",
+  Ouml: "\xD6",
+  OverBar: "\u203E",
+  OverBrace: "\u23DE",
+  OverBracket: "\u23B4",
+  OverParenthesis: "\u23DC",
+  PartialD: "\u2202",
+  Pcy: "\u041F",
+  Pfr: "\u{1D513}",
+  Phi: "\u03A6",
+  Pi: "\u03A0",
+  PlusMinus: "\xB1",
+  Poincareplane: "\u210C",
+  Popf: "\u2119",
+  Pr: "\u2ABB",
+  Precedes: "\u227A",
+  PrecedesEqual: "\u2AAF",
+  PrecedesSlantEqual: "\u227C",
+  PrecedesTilde: "\u227E",
+  Prime: "\u2033",
+  Product: "\u220F",
+  Proportion: "\u2237",
+  Proportional: "\u221D",
+  Pscr: "\u{1D4AB}",
+  Psi: "\u03A8",
+  QUOT: '"',
+  Qfr: "\u{1D514}",
+  Qopf: "\u211A",
+  Qscr: "\u{1D4AC}",
+  RBarr: "\u2910",
+  REG: "\xAE",
+  Racute: "\u0154",
+  Rang: "\u27EB",
+  Rarr: "\u21A0",
+  Rarrtl: "\u2916",
+  Rcaron: "\u0158",
+  Rcedil: "\u0156",
+  Rcy: "\u0420",
+  Re: "\u211C",
+  ReverseElement: "\u220B",
+  ReverseEquilibrium: "\u21CB",
+  ReverseUpEquilibrium: "\u296F",
+  Rfr: "\u211C",
+  Rho: "\u03A1",
+  RightAngleBracket: "\u27E9",
+  RightArrow: "\u2192",
+  RightArrowBar: "\u21E5",
+  RightArrowLeftArrow: "\u21C4",
+  RightCeiling: "\u2309",
+  RightDoubleBracket: "\u27E7",
+  RightDownTeeVector: "\u295D",
+  RightDownVector: "\u21C2",
+  RightDownVectorBar: "\u2955",
+  RightFloor: "\u230B",
+  RightTee: "\u22A2",
+  RightTeeArrow: "\u21A6",
+  RightTeeVector: "\u295B",
+  RightTriangle: "\u22B3",
+  RightTriangleBar: "\u29D0",
+  RightTriangleEqual: "\u22B5",
+  RightUpDownVector: "\u294F",
+  RightUpTeeVector: "\u295C",
+  RightUpVector: "\u21BE",
+  RightUpVectorBar: "\u2954",
+  RightVector: "\u21C0",
+  RightVectorBar: "\u2953",
+  Rightarrow: "\u21D2",
+  Ropf: "\u211D",
+  RoundImplies: "\u2970",
+  Rrightarrow: "\u21DB",
+  Rscr: "\u211B",
+  Rsh: "\u21B1",
+  RuleDelayed: "\u29F4",
+  SHCHcy: "\u0429",
+  SHcy: "\u0428",
+  SOFTcy: "\u042C",
+  Sacute: "\u015A",
+  Sc: "\u2ABC",
+  Scaron: "\u0160",
+  Scedil: "\u015E",
+  Scirc: "\u015C",
+  Scy: "\u0421",
+  Sfr: "\u{1D516}",
+  ShortDownArrow: "\u2193",
+  ShortLeftArrow: "\u2190",
+  ShortRightArrow: "\u2192",
+  ShortUpArrow: "\u2191",
+  Sigma: "\u03A3",
+  SmallCircle: "\u2218",
+  Sopf: "\u{1D54A}",
+  Sqrt: "\u221A",
+  Square: "\u25A1",
+  SquareIntersection: "\u2293",
+  SquareSubset: "\u228F",
+  SquareSubsetEqual: "\u2291",
+  SquareSuperset: "\u2290",
+  SquareSupersetEqual: "\u2292",
+  SquareUnion: "\u2294",
+  Sscr: "\u{1D4AE}",
+  Star: "\u22C6",
+  Sub: "\u22D0",
+  Subset: "\u22D0",
+  SubsetEqual: "\u2286",
+  Succeeds: "\u227B",
+  SucceedsEqual: "\u2AB0",
+  SucceedsSlantEqual: "\u227D",
+  SucceedsTilde: "\u227F",
+  SuchThat: "\u220B",
+  Sum: "\u2211",
+  Sup: "\u22D1",
+  Superset: "\u2283",
+  SupersetEqual: "\u2287",
+  Supset: "\u22D1",
+  THORN: "\xDE",
+  TRADE: "\u2122",
+  TSHcy: "\u040B",
+  TScy: "\u0426",
+  Tab: "	",
+  Tau: "\u03A4",
+  Tcaron: "\u0164",
+  Tcedil: "\u0162",
+  Tcy: "\u0422",
+  Tfr: "\u{1D517}",
+  Therefore: "\u2234",
+  Theta: "\u0398",
+  ThickSpace: "\u205F\u200A",
+  ThinSpace: "\u2009",
+  Tilde: "\u223C",
+  TildeEqual: "\u2243",
+  TildeFullEqual: "\u2245",
+  TildeTilde: "\u2248",
+  Topf: "\u{1D54B}",
+  TripleDot: "\u20DB",
+  Tscr: "\u{1D4AF}",
+  Tstrok: "\u0166",
+  Uacute: "\xDA",
+  Uarr: "\u219F",
+  Uarrocir: "\u2949",
+  Ubrcy: "\u040E",
+  Ubreve: "\u016C",
+  Ucirc: "\xDB",
+  Ucy: "\u0423",
+  Udblac: "\u0170",
+  Ufr: "\u{1D518}",
+  Ugrave: "\xD9",
+  Umacr: "\u016A",
+  UnderBar: "_",
+  UnderBrace: "\u23DF",
+  UnderBracket: "\u23B5",
+  UnderParenthesis: "\u23DD",
+  Union: "\u22C3",
+  UnionPlus: "\u228E",
+  Uogon: "\u0172",
+  Uopf: "\u{1D54C}",
+  UpArrow: "\u2191",
+  UpArrowBar: "\u2912",
+  UpArrowDownArrow: "\u21C5",
+  UpDownArrow: "\u2195",
+  UpEquilibrium: "\u296E",
+  UpTee: "\u22A5",
+  UpTeeArrow: "\u21A5",
+  Uparrow: "\u21D1",
+  Updownarrow: "\u21D5",
+  UpperLeftArrow: "\u2196",
+  UpperRightArrow: "\u2197",
+  Upsi: "\u03D2",
+  Upsilon: "\u03A5",
+  Uring: "\u016E",
+  Uscr: "\u{1D4B0}",
+  Utilde: "\u0168",
+  Uuml: "\xDC",
+  VDash: "\u22AB",
+  Vbar: "\u2AEB",
+  Vcy: "\u0412",
+  Vdash: "\u22A9",
+  Vdashl: "\u2AE6",
+  Vee: "\u22C1",
+  Verbar: "\u2016",
+  Vert: "\u2016",
+  VerticalBar: "\u2223",
+  VerticalLine: "|",
+  VerticalSeparator: "\u2758",
+  VerticalTilde: "\u2240",
+  VeryThinSpace: "\u200A",
+  Vfr: "\u{1D519}",
+  Vopf: "\u{1D54D}",
+  Vscr: "\u{1D4B1}",
+  Vvdash: "\u22AA",
+  Wcirc: "\u0174",
+  Wedge: "\u22C0",
+  Wfr: "\u{1D51A}",
+  Wopf: "\u{1D54E}",
+  Wscr: "\u{1D4B2}",
+  Xfr: "\u{1D51B}",
+  Xi: "\u039E",
+  Xopf: "\u{1D54F}",
+  Xscr: "\u{1D4B3}",
+  YAcy: "\u042F",
+  YIcy: "\u0407",
+  YUcy: "\u042E",
+  Yacute: "\xDD",
+  Ycirc: "\u0176",
+  Ycy: "\u042B",
+  Yfr: "\u{1D51C}",
+  Yopf: "\u{1D550}",
+  Yscr: "\u{1D4B4}",
+  Yuml: "\u0178",
+  ZHcy: "\u0416",
+  Zacute: "\u0179",
+  Zcaron: "\u017D",
+  Zcy: "\u0417",
+  Zdot: "\u017B",
+  ZeroWidthSpace: "\u200B",
+  Zeta: "\u0396",
+  Zfr: "\u2128",
+  Zopf: "\u2124",
+  Zscr: "\u{1D4B5}",
+  aacute: "\xE1",
+  abreve: "\u0103",
+  ac: "\u223E",
+  acE: "\u223E\u0333",
+  acd: "\u223F",
+  acirc: "\xE2",
+  acute: "\xB4",
+  acy: "\u0430",
+  aelig: "\xE6",
+  af: "\u2061",
+  afr: "\u{1D51E}",
+  agrave: "\xE0",
+  alefsym: "\u2135",
+  aleph: "\u2135",
+  alpha: "\u03B1",
+  amacr: "\u0101",
+  amalg: "\u2A3F",
+  amp: "&",
+  and: "\u2227",
+  andand: "\u2A55",
+  andd: "\u2A5C",
+  andslope: "\u2A58",
+  andv: "\u2A5A",
+  ang: "\u2220",
+  ange: "\u29A4",
+  angle: "\u2220",
+  angmsd: "\u2221",
+  angmsdaa: "\u29A8",
+  angmsdab: "\u29A9",
+  angmsdac: "\u29AA",
+  angmsdad: "\u29AB",
+  angmsdae: "\u29AC",
+  angmsdaf: "\u29AD",
+  angmsdag: "\u29AE",
+  angmsdah: "\u29AF",
+  angrt: "\u221F",
+  angrtvb: "\u22BE",
+  angrtvbd: "\u299D",
+  angsph: "\u2222",
+  angst: "\xC5",
+  angzarr: "\u237C",
+  aogon: "\u0105",
+  aopf: "\u{1D552}",
+  ap: "\u2248",
+  apE: "\u2A70",
+  apacir: "\u2A6F",
+  ape: "\u224A",
+  apid: "\u224B",
+  apos: "'",
+  approx: "\u2248",
+  approxeq: "\u224A",
+  aring: "\xE5",
+  ascr: "\u{1D4B6}",
+  ast: "*",
+  asymp: "\u2248",
+  asympeq: "\u224D",
+  atilde: "\xE3",
+  auml: "\xE4",
+  awconint: "\u2233",
+  awint: "\u2A11",
+  bNot: "\u2AED",
+  backcong: "\u224C",
+  backepsilon: "\u03F6",
+  backprime: "\u2035",
+  backsim: "\u223D",
+  backsimeq: "\u22CD",
+  barvee: "\u22BD",
+  barwed: "\u2305",
+  barwedge: "\u2305",
+  bbrk: "\u23B5",
+  bbrktbrk: "\u23B6",
+  bcong: "\u224C",
+  bcy: "\u0431",
+  bdquo: "\u201E",
+  becaus: "\u2235",
+  because: "\u2235",
+  bemptyv: "\u29B0",
+  bepsi: "\u03F6",
+  bernou: "\u212C",
+  beta: "\u03B2",
+  beth: "\u2136",
+  between: "\u226C",
+  bfr: "\u{1D51F}",
+  bigcap: "\u22C2",
+  bigcirc: "\u25EF",
+  bigcup: "\u22C3",
+  bigodot: "\u2A00",
+  bigoplus: "\u2A01",
+  bigotimes: "\u2A02",
+  bigsqcup: "\u2A06",
+  bigstar: "\u2605",
+  bigtriangledown: "\u25BD",
+  bigtriangleup: "\u25B3",
+  biguplus: "\u2A04",
+  bigvee: "\u22C1",
+  bigwedge: "\u22C0",
+  bkarow: "\u290D",
+  blacklozenge: "\u29EB",
+  blacksquare: "\u25AA",
+  blacktriangle: "\u25B4",
+  blacktriangledown: "\u25BE",
+  blacktriangleleft: "\u25C2",
+  blacktriangleright: "\u25B8",
+  blank: "\u2423",
+  blk12: "\u2592",
+  blk14: "\u2591",
+  blk34: "\u2593",
+  block: "\u2588",
+  bne: "=\u20E5",
+  bnequiv: "\u2261\u20E5",
+  bnot: "\u2310",
+  bopf: "\u{1D553}",
+  bot: "\u22A5",
+  bottom: "\u22A5",
+  bowtie: "\u22C8",
+  boxDL: "\u2557",
+  boxDR: "\u2554",
+  boxDl: "\u2556",
+  boxDr: "\u2553",
+  boxH: "\u2550",
+  boxHD: "\u2566",
+  boxHU: "\u2569",
+  boxHd: "\u2564",
+  boxHu: "\u2567",
+  boxUL: "\u255D",
+  boxUR: "\u255A",
+  boxUl: "\u255C",
+  boxUr: "\u2559",
+  boxV: "\u2551",
+  boxVH: "\u256C",
+  boxVL: "\u2563",
+  boxVR: "\u2560",
+  boxVh: "\u256B",
+  boxVl: "\u2562",
+  boxVr: "\u255F",
+  boxbox: "\u29C9",
+  boxdL: "\u2555",
+  boxdR: "\u2552",
+  boxdl: "\u2510",
+  boxdr: "\u250C",
+  boxh: "\u2500",
+  boxhD: "\u2565",
+  boxhU: "\u2568",
+  boxhd: "\u252C",
+  boxhu: "\u2534",
+  boxminus: "\u229F",
+  boxplus: "\u229E",
+  boxtimes: "\u22A0",
+  boxuL: "\u255B",
+  boxuR: "\u2558",
+  boxul: "\u2518",
+  boxur: "\u2514",
+  boxv: "\u2502",
+  boxvH: "\u256A",
+  boxvL: "\u2561",
+  boxvR: "\u255E",
+  boxvh: "\u253C",
+  boxvl: "\u2524",
+  boxvr: "\u251C",
+  bprime: "\u2035",
+  breve: "\u02D8",
+  brvbar: "\xA6",
+  bscr: "\u{1D4B7}",
+  bsemi: "\u204F",
+  bsim: "\u223D",
+  bsime: "\u22CD",
+  bsol: "\\",
+  bsolb: "\u29C5",
+  bsolhsub: "\u27C8",
+  bull: "\u2022",
+  bullet: "\u2022",
+  bump: "\u224E",
+  bumpE: "\u2AAE",
+  bumpe: "\u224F",
+  bumpeq: "\u224F",
+  cacute: "\u0107",
+  cap: "\u2229",
+  capand: "\u2A44",
+  capbrcup: "\u2A49",
+  capcap: "\u2A4B",
+  capcup: "\u2A47",
+  capdot: "\u2A40",
+  caps: "\u2229\uFE00",
+  caret: "\u2041",
+  caron: "\u02C7",
+  ccaps: "\u2A4D",
+  ccaron: "\u010D",
+  ccedil: "\xE7",
+  ccirc: "\u0109",
+  ccups: "\u2A4C",
+  ccupssm: "\u2A50",
+  cdot: "\u010B",
+  cedil: "\xB8",
+  cemptyv: "\u29B2",
+  cent: "\xA2",
+  centerdot: "\xB7",
+  cfr: "\u{1D520}",
+  chcy: "\u0447",
+  check: "\u2713",
+  checkmark: "\u2713",
+  chi: "\u03C7",
+  cir: "\u25CB",
+  cirE: "\u29C3",
+  circ: "\u02C6",
+  circeq: "\u2257",
+  circlearrowleft: "\u21BA",
+  circlearrowright: "\u21BB",
+  circledR: "\xAE",
+  circledS: "\u24C8",
+  circledast: "\u229B",
+  circledcirc: "\u229A",
+  circleddash: "\u229D",
+  cire: "\u2257",
+  cirfnint: "\u2A10",
+  cirmid: "\u2AEF",
+  cirscir: "\u29C2",
+  clubs: "\u2663",
+  clubsuit: "\u2663",
+  colon: ":",
+  colone: "\u2254",
+  coloneq: "\u2254",
+  comma: ",",
+  commat: "@",
+  comp: "\u2201",
+  compfn: "\u2218",
+  complement: "\u2201",
+  complexes: "\u2102",
+  cong: "\u2245",
+  congdot: "\u2A6D",
+  conint: "\u222E",
+  copf: "\u{1D554}",
+  coprod: "\u2210",
+  copy: "\xA9",
+  copysr: "\u2117",
+  crarr: "\u21B5",
+  cross: "\u2717",
+  cscr: "\u{1D4B8}",
+  csub: "\u2ACF",
+  csube: "\u2AD1",
+  csup: "\u2AD0",
+  csupe: "\u2AD2",
+  ctdot: "\u22EF",
+  cudarrl: "\u2938",
+  cudarrr: "\u2935",
+  cuepr: "\u22DE",
+  cuesc: "\u22DF",
+  cularr: "\u21B6",
+  cularrp: "\u293D",
+  cup: "\u222A",
+  cupbrcap: "\u2A48",
+  cupcap: "\u2A46",
+  cupcup: "\u2A4A",
+  cupdot: "\u228D",
+  cupor: "\u2A45",
+  cups: "\u222A\uFE00",
+  curarr: "\u21B7",
+  curarrm: "\u293C",
+  curlyeqprec: "\u22DE",
+  curlyeqsucc: "\u22DF",
+  curlyvee: "\u22CE",
+  curlywedge: "\u22CF",
+  curren: "\xA4",
+  curvearrowleft: "\u21B6",
+  curvearrowright: "\u21B7",
+  cuvee: "\u22CE",
+  cuwed: "\u22CF",
+  cwconint: "\u2232",
+  cwint: "\u2231",
+  cylcty: "\u232D",
+  dArr: "\u21D3",
+  dHar: "\u2965",
+  dagger: "\u2020",
+  daleth: "\u2138",
+  darr: "\u2193",
+  dash: "\u2010",
+  dashv: "\u22A3",
+  dbkarow: "\u290F",
+  dblac: "\u02DD",
+  dcaron: "\u010F",
+  dcy: "\u0434",
+  dd: "\u2146",
+  ddagger: "\u2021",
+  ddarr: "\u21CA",
+  ddotseq: "\u2A77",
+  deg: "\xB0",
+  delta: "\u03B4",
+  demptyv: "\u29B1",
+  dfisht: "\u297F",
+  dfr: "\u{1D521}",
+  dharl: "\u21C3",
+  dharr: "\u21C2",
+  diam: "\u22C4",
+  diamond: "\u22C4",
+  diamondsuit: "\u2666",
+  diams: "\u2666",
+  die: "\xA8",
+  digamma: "\u03DD",
+  disin: "\u22F2",
+  div: "\xF7",
+  divide: "\xF7",
+  divideontimes: "\u22C7",
+  divonx: "\u22C7",
+  djcy: "\u0452",
+  dlcorn: "\u231E",
+  dlcrop: "\u230D",
+  dollar: "$",
+  dopf: "\u{1D555}",
+  dot: "\u02D9",
+  doteq: "\u2250",
+  doteqdot: "\u2251",
+  dotminus: "\u2238",
+  dotplus: "\u2214",
+  dotsquare: "\u22A1",
+  doublebarwedge: "\u2306",
+  downarrow: "\u2193",
+  downdownarrows: "\u21CA",
+  downharpoonleft: "\u21C3",
+  downharpoonright: "\u21C2",
+  drbkarow: "\u2910",
+  drcorn: "\u231F",
+  drcrop: "\u230C",
+  dscr: "\u{1D4B9}",
+  dscy: "\u0455",
+  dsol: "\u29F6",
+  dstrok: "\u0111",
+  dtdot: "\u22F1",
+  dtri: "\u25BF",
+  dtrif: "\u25BE",
+  duarr: "\u21F5",
+  duhar: "\u296F",
+  dwangle: "\u29A6",
+  dzcy: "\u045F",
+  dzigrarr: "\u27FF",
+  eDDot: "\u2A77",
+  eDot: "\u2251",
+  eacute: "\xE9",
+  easter: "\u2A6E",
+  ecaron: "\u011B",
+  ecir: "\u2256",
+  ecirc: "\xEA",
+  ecolon: "\u2255",
+  ecy: "\u044D",
+  edot: "\u0117",
+  ee: "\u2147",
+  efDot: "\u2252",
+  efr: "\u{1D522}",
+  eg: "\u2A9A",
+  egrave: "\xE8",
+  egs: "\u2A96",
+  egsdot: "\u2A98",
+  el: "\u2A99",
+  elinters: "\u23E7",
+  ell: "\u2113",
+  els: "\u2A95",
+  elsdot: "\u2A97",
+  emacr: "\u0113",
+  empty: "\u2205",
+  emptyset: "\u2205",
+  emptyv: "\u2205",
+  emsp13: "\u2004",
+  emsp14: "\u2005",
+  emsp: "\u2003",
+  eng: "\u014B",
+  ensp: "\u2002",
+  eogon: "\u0119",
+  eopf: "\u{1D556}",
+  epar: "\u22D5",
+  eparsl: "\u29E3",
+  eplus: "\u2A71",
+  epsi: "\u03B5",
+  epsilon: "\u03B5",
+  epsiv: "\u03F5",
+  eqcirc: "\u2256",
+  eqcolon: "\u2255",
+  eqsim: "\u2242",
+  eqslantgtr: "\u2A96",
+  eqslantless: "\u2A95",
+  equals: "=",
+  equest: "\u225F",
+  equiv: "\u2261",
+  equivDD: "\u2A78",
+  eqvparsl: "\u29E5",
+  erDot: "\u2253",
+  erarr: "\u2971",
+  escr: "\u212F",
+  esdot: "\u2250",
+  esim: "\u2242",
+  eta: "\u03B7",
+  eth: "\xF0",
+  euml: "\xEB",
+  euro: "\u20AC",
+  excl: "!",
+  exist: "\u2203",
+  expectation: "\u2130",
+  exponentiale: "\u2147",
+  fallingdotseq: "\u2252",
+  fcy: "\u0444",
+  female: "\u2640",
+  ffilig: "\uFB03",
+  fflig: "\uFB00",
+  ffllig: "\uFB04",
+  ffr: "\u{1D523}",
+  filig: "\uFB01",
+  fjlig: "fj",
+  flat: "\u266D",
+  fllig: "\uFB02",
+  fltns: "\u25B1",
+  fnof: "\u0192",
+  fopf: "\u{1D557}",
+  forall: "\u2200",
+  fork: "\u22D4",
+  forkv: "\u2AD9",
+  fpartint: "\u2A0D",
+  frac12: "\xBD",
+  frac13: "\u2153",
+  frac14: "\xBC",
+  frac15: "\u2155",
+  frac16: "\u2159",
+  frac18: "\u215B",
+  frac23: "\u2154",
+  frac25: "\u2156",
+  frac34: "\xBE",
+  frac35: "\u2157",
+  frac38: "\u215C",
+  frac45: "\u2158",
+  frac56: "\u215A",
+  frac58: "\u215D",
+  frac78: "\u215E",
+  frasl: "\u2044",
+  frown: "\u2322",
+  fscr: "\u{1D4BB}",
+  gE: "\u2267",
+  gEl: "\u2A8C",
+  gacute: "\u01F5",
+  gamma: "\u03B3",
+  gammad: "\u03DD",
+  gap: "\u2A86",
+  gbreve: "\u011F",
+  gcirc: "\u011D",
+  gcy: "\u0433",
+  gdot: "\u0121",
+  ge: "\u2265",
+  gel: "\u22DB",
+  geq: "\u2265",
+  geqq: "\u2267",
+  geqslant: "\u2A7E",
+  ges: "\u2A7E",
+  gescc: "\u2AA9",
+  gesdot: "\u2A80",
+  gesdoto: "\u2A82",
+  gesdotol: "\u2A84",
+  gesl: "\u22DB\uFE00",
+  gesles: "\u2A94",
+  gfr: "\u{1D524}",
+  gg: "\u226B",
+  ggg: "\u22D9",
+  gimel: "\u2137",
+  gjcy: "\u0453",
+  gl: "\u2277",
+  glE: "\u2A92",
+  gla: "\u2AA5",
+  glj: "\u2AA4",
+  gnE: "\u2269",
+  gnap: "\u2A8A",
+  gnapprox: "\u2A8A",
+  gne: "\u2A88",
+  gneq: "\u2A88",
+  gneqq: "\u2269",
+  gnsim: "\u22E7",
+  gopf: "\u{1D558}",
+  grave: "`",
+  gscr: "\u210A",
+  gsim: "\u2273",
+  gsime: "\u2A8E",
+  gsiml: "\u2A90",
+  gt: ">",
+  gtcc: "\u2AA7",
+  gtcir: "\u2A7A",
+  gtdot: "\u22D7",
+  gtlPar: "\u2995",
+  gtquest: "\u2A7C",
+  gtrapprox: "\u2A86",
+  gtrarr: "\u2978",
+  gtrdot: "\u22D7",
+  gtreqless: "\u22DB",
+  gtreqqless: "\u2A8C",
+  gtrless: "\u2277",
+  gtrsim: "\u2273",
+  gvertneqq: "\u2269\uFE00",
+  gvnE: "\u2269\uFE00",
+  hArr: "\u21D4",
+  hairsp: "\u200A",
+  half: "\xBD",
+  hamilt: "\u210B",
+  hardcy: "\u044A",
+  harr: "\u2194",
+  harrcir: "\u2948",
+  harrw: "\u21AD",
+  hbar: "\u210F",
+  hcirc: "\u0125",
+  hearts: "\u2665",
+  heartsuit: "\u2665",
+  hellip: "\u2026",
+  hercon: "\u22B9",
+  hfr: "\u{1D525}",
+  hksearow: "\u2925",
+  hkswarow: "\u2926",
+  hoarr: "\u21FF",
+  homtht: "\u223B",
+  hookleftarrow: "\u21A9",
+  hookrightarrow: "\u21AA",
+  hopf: "\u{1D559}",
+  horbar: "\u2015",
+  hscr: "\u{1D4BD}",
+  hslash: "\u210F",
+  hstrok: "\u0127",
+  hybull: "\u2043",
+  hyphen: "\u2010",
+  iacute: "\xED",
+  ic: "\u2063",
+  icirc: "\xEE",
+  icy: "\u0438",
+  iecy: "\u0435",
+  iexcl: "\xA1",
+  iff: "\u21D4",
+  ifr: "\u{1D526}",
+  igrave: "\xEC",
+  ii: "\u2148",
+  iiiint: "\u2A0C",
+  iiint: "\u222D",
+  iinfin: "\u29DC",
+  iiota: "\u2129",
+  ijlig: "\u0133",
+  imacr: "\u012B",
+  image: "\u2111",
+  imagline: "\u2110",
+  imagpart: "\u2111",
+  imath: "\u0131",
+  imof: "\u22B7",
+  imped: "\u01B5",
+  in: "\u2208",
+  incare: "\u2105",
+  infin: "\u221E",
+  infintie: "\u29DD",
+  inodot: "\u0131",
+  int: "\u222B",
+  intcal: "\u22BA",
+  integers: "\u2124",
+  intercal: "\u22BA",
+  intlarhk: "\u2A17",
+  intprod: "\u2A3C",
+  iocy: "\u0451",
+  iogon: "\u012F",
+  iopf: "\u{1D55A}",
+  iota: "\u03B9",
+  iprod: "\u2A3C",
+  iquest: "\xBF",
+  iscr: "\u{1D4BE}",
+  isin: "\u2208",
+  isinE: "\u22F9",
+  isindot: "\u22F5",
+  isins: "\u22F4",
+  isinsv: "\u22F3",
+  isinv: "\u2208",
+  it: "\u2062",
+  itilde: "\u0129",
+  iukcy: "\u0456",
+  iuml: "\xEF",
+  jcirc: "\u0135",
+  jcy: "\u0439",
+  jfr: "\u{1D527}",
+  jmath: "\u0237",
+  jopf: "\u{1D55B}",
+  jscr: "\u{1D4BF}",
+  jsercy: "\u0458",
+  jukcy: "\u0454",
+  kappa: "\u03BA",
+  kappav: "\u03F0",
+  kcedil: "\u0137",
+  kcy: "\u043A",
+  kfr: "\u{1D528}",
+  kgreen: "\u0138",
+  khcy: "\u0445",
+  kjcy: "\u045C",
+  kopf: "\u{1D55C}",
+  kscr: "\u{1D4C0}",
+  lAarr: "\u21DA",
+  lArr: "\u21D0",
+  lAtail: "\u291B",
+  lBarr: "\u290E",
+  lE: "\u2266",
+  lEg: "\u2A8B",
+  lHar: "\u2962",
+  lacute: "\u013A",
+  laemptyv: "\u29B4",
+  lagran: "\u2112",
+  lambda: "\u03BB",
+  lang: "\u27E8",
+  langd: "\u2991",
+  langle: "\u27E8",
+  lap: "\u2A85",
+  laquo: "\xAB",
+  larr: "\u2190",
+  larrb: "\u21E4",
+  larrbfs: "\u291F",
+  larrfs: "\u291D",
+  larrhk: "\u21A9",
+  larrlp: "\u21AB",
+  larrpl: "\u2939",
+  larrsim: "\u2973",
+  larrtl: "\u21A2",
+  lat: "\u2AAB",
+  latail: "\u2919",
+  late: "\u2AAD",
+  lates: "\u2AAD\uFE00",
+  lbarr: "\u290C",
+  lbbrk: "\u2772",
+  lbrace: "{",
+  lbrack: "[",
+  lbrke: "\u298B",
+  lbrksld: "\u298F",
+  lbrkslu: "\u298D",
+  lcaron: "\u013E",
+  lcedil: "\u013C",
+  lceil: "\u2308",
+  lcub: "{",
+  lcy: "\u043B",
+  ldca: "\u2936",
+  ldquo: "\u201C",
+  ldquor: "\u201E",
+  ldrdhar: "\u2967",
+  ldrushar: "\u294B",
+  ldsh: "\u21B2",
+  le: "\u2264",
+  leftarrow: "\u2190",
+  leftarrowtail: "\u21A2",
+  leftharpoondown: "\u21BD",
+  leftharpoonup: "\u21BC",
+  leftleftarrows: "\u21C7",
+  leftrightarrow: "\u2194",
+  leftrightarrows: "\u21C6",
+  leftrightharpoons: "\u21CB",
+  leftrightsquigarrow: "\u21AD",
+  leftthreetimes: "\u22CB",
+  leg: "\u22DA",
+  leq: "\u2264",
+  leqq: "\u2266",
+  leqslant: "\u2A7D",
+  les: "\u2A7D",
+  lescc: "\u2AA8",
+  lesdot: "\u2A7F",
+  lesdoto: "\u2A81",
+  lesdotor: "\u2A83",
+  lesg: "\u22DA\uFE00",
+  lesges: "\u2A93",
+  lessapprox: "\u2A85",
+  lessdot: "\u22D6",
+  lesseqgtr: "\u22DA",
+  lesseqqgtr: "\u2A8B",
+  lessgtr: "\u2276",
+  lesssim: "\u2272",
+  lfisht: "\u297C",
+  lfloor: "\u230A",
+  lfr: "\u{1D529}",
+  lg: "\u2276",
+  lgE: "\u2A91",
+  lhard: "\u21BD",
+  lharu: "\u21BC",
+  lharul: "\u296A",
+  lhblk: "\u2584",
+  ljcy: "\u0459",
+  ll: "\u226A",
+  llarr: "\u21C7",
+  llcorner: "\u231E",
+  llhard: "\u296B",
+  lltri: "\u25FA",
+  lmidot: "\u0140",
+  lmoust: "\u23B0",
+  lmoustache: "\u23B0",
+  lnE: "\u2268",
+  lnap: "\u2A89",
+  lnapprox: "\u2A89",
+  lne: "\u2A87",
+  lneq: "\u2A87",
+  lneqq: "\u2268",
+  lnsim: "\u22E6",
+  loang: "\u27EC",
+  loarr: "\u21FD",
+  lobrk: "\u27E6",
+  longleftarrow: "\u27F5",
+  longleftrightarrow: "\u27F7",
+  longmapsto: "\u27FC",
+  longrightarrow: "\u27F6",
+  looparrowleft: "\u21AB",
+  looparrowright: "\u21AC",
+  lopar: "\u2985",
+  lopf: "\u{1D55D}",
+  loplus: "\u2A2D",
+  lotimes: "\u2A34",
+  lowast: "\u2217",
+  lowbar: "_",
+  loz: "\u25CA",
+  lozenge: "\u25CA",
+  lozf: "\u29EB",
+  lpar: "(",
+  lparlt: "\u2993",
+  lrarr: "\u21C6",
+  lrcorner: "\u231F",
+  lrhar: "\u21CB",
+  lrhard: "\u296D",
+  lrm: "\u200E",
+  lrtri: "\u22BF",
+  lsaquo: "\u2039",
+  lscr: "\u{1D4C1}",
+  lsh: "\u21B0",
+  lsim: "\u2272",
+  lsime: "\u2A8D",
+  lsimg: "\u2A8F",
+  lsqb: "[",
+  lsquo: "\u2018",
+  lsquor: "\u201A",
+  lstrok: "\u0142",
+  lt: "<",
+  ltcc: "\u2AA6",
+  ltcir: "\u2A79",
+  ltdot: "\u22D6",
+  lthree: "\u22CB",
+  ltimes: "\u22C9",
+  ltlarr: "\u2976",
+  ltquest: "\u2A7B",
+  ltrPar: "\u2996",
+  ltri: "\u25C3",
+  ltrie: "\u22B4",
+  ltrif: "\u25C2",
+  lurdshar: "\u294A",
+  luruhar: "\u2966",
+  lvertneqq: "\u2268\uFE00",
+  lvnE: "\u2268\uFE00",
+  mDDot: "\u223A",
+  macr: "\xAF",
+  male: "\u2642",
+  malt: "\u2720",
+  maltese: "\u2720",
+  map: "\u21A6",
+  mapsto: "\u21A6",
+  mapstodown: "\u21A7",
+  mapstoleft: "\u21A4",
+  mapstoup: "\u21A5",
+  marker: "\u25AE",
+  mcomma: "\u2A29",
+  mcy: "\u043C",
+  mdash: "\u2014",
+  measuredangle: "\u2221",
+  mfr: "\u{1D52A}",
+  mho: "\u2127",
+  micro: "\xB5",
+  mid: "\u2223",
+  midast: "*",
+  midcir: "\u2AF0",
+  middot: "\xB7",
+  minus: "\u2212",
+  minusb: "\u229F",
+  minusd: "\u2238",
+  minusdu: "\u2A2A",
+  mlcp: "\u2ADB",
+  mldr: "\u2026",
+  mnplus: "\u2213",
+  models: "\u22A7",
+  mopf: "\u{1D55E}",
+  mp: "\u2213",
+  mscr: "\u{1D4C2}",
+  mstpos: "\u223E",
+  mu: "\u03BC",
+  multimap: "\u22B8",
+  mumap: "\u22B8",
+  nGg: "\u22D9\u0338",
+  nGt: "\u226B\u20D2",
+  nGtv: "\u226B\u0338",
+  nLeftarrow: "\u21CD",
+  nLeftrightarrow: "\u21CE",
+  nLl: "\u22D8\u0338",
+  nLt: "\u226A\u20D2",
+  nLtv: "\u226A\u0338",
+  nRightarrow: "\u21CF",
+  nVDash: "\u22AF",
+  nVdash: "\u22AE",
+  nabla: "\u2207",
+  nacute: "\u0144",
+  nang: "\u2220\u20D2",
+  nap: "\u2249",
+  napE: "\u2A70\u0338",
+  napid: "\u224B\u0338",
+  napos: "\u0149",
+  napprox: "\u2249",
+  natur: "\u266E",
+  natural: "\u266E",
+  naturals: "\u2115",
+  nbsp: "\xA0",
+  nbump: "\u224E\u0338",
+  nbumpe: "\u224F\u0338",
+  ncap: "\u2A43",
+  ncaron: "\u0148",
+  ncedil: "\u0146",
+  ncong: "\u2247",
+  ncongdot: "\u2A6D\u0338",
+  ncup: "\u2A42",
+  ncy: "\u043D",
+  ndash: "\u2013",
+  ne: "\u2260",
+  neArr: "\u21D7",
+  nearhk: "\u2924",
+  nearr: "\u2197",
+  nearrow: "\u2197",
+  nedot: "\u2250\u0338",
+  nequiv: "\u2262",
+  nesear: "\u2928",
+  nesim: "\u2242\u0338",
+  nexist: "\u2204",
+  nexists: "\u2204",
+  nfr: "\u{1D52B}",
+  ngE: "\u2267\u0338",
+  nge: "\u2271",
+  ngeq: "\u2271",
+  ngeqq: "\u2267\u0338",
+  ngeqslant: "\u2A7E\u0338",
+  nges: "\u2A7E\u0338",
+  ngsim: "\u2275",
+  ngt: "\u226F",
+  ngtr: "\u226F",
+  nhArr: "\u21CE",
+  nharr: "\u21AE",
+  nhpar: "\u2AF2",
+  ni: "\u220B",
+  nis: "\u22FC",
+  nisd: "\u22FA",
+  niv: "\u220B",
+  njcy: "\u045A",
+  nlArr: "\u21CD",
+  nlE: "\u2266\u0338",
+  nlarr: "\u219A",
+  nldr: "\u2025",
+  nle: "\u2270",
+  nleftarrow: "\u219A",
+  nleftrightarrow: "\u21AE",
+  nleq: "\u2270",
+  nleqq: "\u2266\u0338",
+  nleqslant: "\u2A7D\u0338",
+  nles: "\u2A7D\u0338",
+  nless: "\u226E",
+  nlsim: "\u2274",
+  nlt: "\u226E",
+  nltri: "\u22EA",
+  nltrie: "\u22EC",
+  nmid: "\u2224",
+  nopf: "\u{1D55F}",
+  not: "\xAC",
+  notin: "\u2209",
+  notinE: "\u22F9\u0338",
+  notindot: "\u22F5\u0338",
+  notinva: "\u2209",
+  notinvb: "\u22F7",
+  notinvc: "\u22F6",
+  notni: "\u220C",
+  notniva: "\u220C",
+  notnivb: "\u22FE",
+  notnivc: "\u22FD",
+  npar: "\u2226",
+  nparallel: "\u2226",
+  nparsl: "\u2AFD\u20E5",
+  npart: "\u2202\u0338",
+  npolint: "\u2A14",
+  npr: "\u2280",
+  nprcue: "\u22E0",
+  npre: "\u2AAF\u0338",
+  nprec: "\u2280",
+  npreceq: "\u2AAF\u0338",
+  nrArr: "\u21CF",
+  nrarr: "\u219B",
+  nrarrc: "\u2933\u0338",
+  nrarrw: "\u219D\u0338",
+  nrightarrow: "\u219B",
+  nrtri: "\u22EB",
+  nrtrie: "\u22ED",
+  nsc: "\u2281",
+  nsccue: "\u22E1",
+  nsce: "\u2AB0\u0338",
+  nscr: "\u{1D4C3}",
+  nshortmid: "\u2224",
+  nshortparallel: "\u2226",
+  nsim: "\u2241",
+  nsime: "\u2244",
+  nsimeq: "\u2244",
+  nsmid: "\u2224",
+  nspar: "\u2226",
+  nsqsube: "\u22E2",
+  nsqsupe: "\u22E3",
+  nsub: "\u2284",
+  nsubE: "\u2AC5\u0338",
+  nsube: "\u2288",
+  nsubset: "\u2282\u20D2",
+  nsubseteq: "\u2288",
+  nsubseteqq: "\u2AC5\u0338",
+  nsucc: "\u2281",
+  nsucceq: "\u2AB0\u0338",
+  nsup: "\u2285",
+  nsupE: "\u2AC6\u0338",
+  nsupe: "\u2289",
+  nsupset: "\u2283\u20D2",
+  nsupseteq: "\u2289",
+  nsupseteqq: "\u2AC6\u0338",
+  ntgl: "\u2279",
+  ntilde: "\xF1",
+  ntlg: "\u2278",
+  ntriangleleft: "\u22EA",
+  ntrianglelefteq: "\u22EC",
+  ntriangleright: "\u22EB",
+  ntrianglerighteq: "\u22ED",
+  nu: "\u03BD",
+  num: "#",
+  numero: "\u2116",
+  numsp: "\u2007",
+  nvDash: "\u22AD",
+  nvHarr: "\u2904",
+  nvap: "\u224D\u20D2",
+  nvdash: "\u22AC",
+  nvge: "\u2265\u20D2",
+  nvgt: ">\u20D2",
+  nvinfin: "\u29DE",
+  nvlArr: "\u2902",
+  nvle: "\u2264\u20D2",
+  nvlt: "<\u20D2",
+  nvltrie: "\u22B4\u20D2",
+  nvrArr: "\u2903",
+  nvrtrie: "\u22B5\u20D2",
+  nvsim: "\u223C\u20D2",
+  nwArr: "\u21D6",
+  nwarhk: "\u2923",
+  nwarr: "\u2196",
+  nwarrow: "\u2196",
+  nwnear: "\u2927",
+  oS: "\u24C8",
+  oacute: "\xF3",
+  oast: "\u229B",
+  ocir: "\u229A",
+  ocirc: "\xF4",
+  ocy: "\u043E",
+  odash: "\u229D",
+  odblac: "\u0151",
+  odiv: "\u2A38",
+  odot: "\u2299",
+  odsold: "\u29BC",
+  oelig: "\u0153",
+  ofcir: "\u29BF",
+  ofr: "\u{1D52C}",
+  ogon: "\u02DB",
+  ograve: "\xF2",
+  ogt: "\u29C1",
+  ohbar: "\u29B5",
+  ohm: "\u03A9",
+  oint: "\u222E",
+  olarr: "\u21BA",
+  olcir: "\u29BE",
+  olcross: "\u29BB",
+  oline: "\u203E",
+  olt: "\u29C0",
+  omacr: "\u014D",
+  omega: "\u03C9",
+  omicron: "\u03BF",
+  omid: "\u29B6",
+  ominus: "\u2296",
+  oopf: "\u{1D560}",
+  opar: "\u29B7",
+  operp: "\u29B9",
+  oplus: "\u2295",
+  or: "\u2228",
+  orarr: "\u21BB",
+  ord: "\u2A5D",
+  order: "\u2134",
+  orderof: "\u2134",
+  ordf: "\xAA",
+  ordm: "\xBA",
+  origof: "\u22B6",
+  oror: "\u2A56",
+  orslope: "\u2A57",
+  orv: "\u2A5B",
+  oscr: "\u2134",
+  oslash: "\xF8",
+  osol: "\u2298",
+  otilde: "\xF5",
+  otimes: "\u2297",
+  otimesas: "\u2A36",
+  ouml: "\xF6",
+  ovbar: "\u233D",
+  par: "\u2225",
+  para: "\xB6",
+  parallel: "\u2225",
+  parsim: "\u2AF3",
+  parsl: "\u2AFD",
+  part: "\u2202",
+  pcy: "\u043F",
+  percnt: "%",
+  period: ".",
+  permil: "\u2030",
+  perp: "\u22A5",
+  pertenk: "\u2031",
+  pfr: "\u{1D52D}",
+  phi: "\u03C6",
+  phiv: "\u03D5",
+  phmmat: "\u2133",
+  phone: "\u260E",
+  pi: "\u03C0",
+  pitchfork: "\u22D4",
+  piv: "\u03D6",
+  planck: "\u210F",
+  planckh: "\u210E",
+  plankv: "\u210F",
+  plus: "+",
+  plusacir: "\u2A23",
+  plusb: "\u229E",
+  pluscir: "\u2A22",
+  plusdo: "\u2214",
+  plusdu: "\u2A25",
+  pluse: "\u2A72",
+  plusmn: "\xB1",
+  plussim: "\u2A26",
+  plustwo: "\u2A27",
+  pm: "\xB1",
+  pointint: "\u2A15",
+  popf: "\u{1D561}",
+  pound: "\xA3",
+  pr: "\u227A",
+  prE: "\u2AB3",
+  prap: "\u2AB7",
+  prcue: "\u227C",
+  pre: "\u2AAF",
+  prec: "\u227A",
+  precapprox: "\u2AB7",
+  preccurlyeq: "\u227C",
+  preceq: "\u2AAF",
+  precnapprox: "\u2AB9",
+  precneqq: "\u2AB5",
+  precnsim: "\u22E8",
+  precsim: "\u227E",
+  prime: "\u2032",
+  primes: "\u2119",
+  prnE: "\u2AB5",
+  prnap: "\u2AB9",
+  prnsim: "\u22E8",
+  prod: "\u220F",
+  profalar: "\u232E",
+  profline: "\u2312",
+  profsurf: "\u2313",
+  prop: "\u221D",
+  propto: "\u221D",
+  prsim: "\u227E",
+  prurel: "\u22B0",
+  pscr: "\u{1D4C5}",
+  psi: "\u03C8",
+  puncsp: "\u2008",
+  qfr: "\u{1D52E}",
+  qint: "\u2A0C",
+  qopf: "\u{1D562}",
+  qprime: "\u2057",
+  qscr: "\u{1D4C6}",
+  quaternions: "\u210D",
+  quatint: "\u2A16",
+  quest: "?",
+  questeq: "\u225F",
+  quot: '"',
+  rAarr: "\u21DB",
+  rArr: "\u21D2",
+  rAtail: "\u291C",
+  rBarr: "\u290F",
+  rHar: "\u2964",
+  race: "\u223D\u0331",
+  racute: "\u0155",
+  radic: "\u221A",
+  raemptyv: "\u29B3",
+  rang: "\u27E9",
+  rangd: "\u2992",
+  range: "\u29A5",
+  rangle: "\u27E9",
+  raquo: "\xBB",
+  rarr: "\u2192",
+  rarrap: "\u2975",
+  rarrb: "\u21E5",
+  rarrbfs: "\u2920",
+  rarrc: "\u2933",
+  rarrfs: "\u291E",
+  rarrhk: "\u21AA",
+  rarrlp: "\u21AC",
+  rarrpl: "\u2945",
+  rarrsim: "\u2974",
+  rarrtl: "\u21A3",
+  rarrw: "\u219D",
+  ratail: "\u291A",
+  ratio: "\u2236",
+  rationals: "\u211A",
+  rbarr: "\u290D",
+  rbbrk: "\u2773",
+  rbrace: "}",
+  rbrack: "]",
+  rbrke: "\u298C",
+  rbrksld: "\u298E",
+  rbrkslu: "\u2990",
+  rcaron: "\u0159",
+  rcedil: "\u0157",
+  rceil: "\u2309",
+  rcub: "}",
+  rcy: "\u0440",
+  rdca: "\u2937",
+  rdldhar: "\u2969",
+  rdquo: "\u201D",
+  rdquor: "\u201D",
+  rdsh: "\u21B3",
+  real: "\u211C",
+  realine: "\u211B",
+  realpart: "\u211C",
+  reals: "\u211D",
+  rect: "\u25AD",
+  reg: "\xAE",
+  rfisht: "\u297D",
+  rfloor: "\u230B",
+  rfr: "\u{1D52F}",
+  rhard: "\u21C1",
+  rharu: "\u21C0",
+  rharul: "\u296C",
+  rho: "\u03C1",
+  rhov: "\u03F1",
+  rightarrow: "\u2192",
+  rightarrowtail: "\u21A3",
+  rightharpoondown: "\u21C1",
+  rightharpoonup: "\u21C0",
+  rightleftarrows: "\u21C4",
+  rightleftharpoons: "\u21CC",
+  rightrightarrows: "\u21C9",
+  rightsquigarrow: "\u219D",
+  rightthreetimes: "\u22CC",
+  ring: "\u02DA",
+  risingdotseq: "\u2253",
+  rlarr: "\u21C4",
+  rlhar: "\u21CC",
+  rlm: "\u200F",
+  rmoust: "\u23B1",
+  rmoustache: "\u23B1",
+  rnmid: "\u2AEE",
+  roang: "\u27ED",
+  roarr: "\u21FE",
+  robrk: "\u27E7",
+  ropar: "\u2986",
+  ropf: "\u{1D563}",
+  roplus: "\u2A2E",
+  rotimes: "\u2A35",
+  rpar: ")",
+  rpargt: "\u2994",
+  rppolint: "\u2A12",
+  rrarr: "\u21C9",
+  rsaquo: "\u203A",
+  rscr: "\u{1D4C7}",
+  rsh: "\u21B1",
+  rsqb: "]",
+  rsquo: "\u2019",
+  rsquor: "\u2019",
+  rthree: "\u22CC",
+  rtimes: "\u22CA",
+  rtri: "\u25B9",
+  rtrie: "\u22B5",
+  rtrif: "\u25B8",
+  rtriltri: "\u29CE",
+  ruluhar: "\u2968",
+  rx: "\u211E",
+  sacute: "\u015B",
+  sbquo: "\u201A",
+  sc: "\u227B",
+  scE: "\u2AB4",
+  scap: "\u2AB8",
+  scaron: "\u0161",
+  sccue: "\u227D",
+  sce: "\u2AB0",
+  scedil: "\u015F",
+  scirc: "\u015D",
+  scnE: "\u2AB6",
+  scnap: "\u2ABA",
+  scnsim: "\u22E9",
+  scpolint: "\u2A13",
+  scsim: "\u227F",
+  scy: "\u0441",
+  sdot: "\u22C5",
+  sdotb: "\u22A1",
+  sdote: "\u2A66",
+  seArr: "\u21D8",
+  searhk: "\u2925",
+  searr: "\u2198",
+  searrow: "\u2198",
+  sect: "\xA7",
+  semi: ";",
+  seswar: "\u2929",
+  setminus: "\u2216",
+  setmn: "\u2216",
+  sext: "\u2736",
+  sfr: "\u{1D530}",
+  sfrown: "\u2322",
+  sharp: "\u266F",
+  shchcy: "\u0449",
+  shcy: "\u0448",
+  shortmid: "\u2223",
+  shortparallel: "\u2225",
+  shy: "\xAD",
+  sigma: "\u03C3",
+  sigmaf: "\u03C2",
+  sigmav: "\u03C2",
+  sim: "\u223C",
+  simdot: "\u2A6A",
+  sime: "\u2243",
+  simeq: "\u2243",
+  simg: "\u2A9E",
+  simgE: "\u2AA0",
+  siml: "\u2A9D",
+  simlE: "\u2A9F",
+  simne: "\u2246",
+  simplus: "\u2A24",
+  simrarr: "\u2972",
+  slarr: "\u2190",
+  smallsetminus: "\u2216",
+  smashp: "\u2A33",
+  smeparsl: "\u29E4",
+  smid: "\u2223",
+  smile: "\u2323",
+  smt: "\u2AAA",
+  smte: "\u2AAC",
+  smtes: "\u2AAC\uFE00",
+  softcy: "\u044C",
+  sol: "/",
+  solb: "\u29C4",
+  solbar: "\u233F",
+  sopf: "\u{1D564}",
+  spades: "\u2660",
+  spadesuit: "\u2660",
+  spar: "\u2225",
+  sqcap: "\u2293",
+  sqcaps: "\u2293\uFE00",
+  sqcup: "\u2294",
+  sqcups: "\u2294\uFE00",
+  sqsub: "\u228F",
+  sqsube: "\u2291",
+  sqsubset: "\u228F",
+  sqsubseteq: "\u2291",
+  sqsup: "\u2290",
+  sqsupe: "\u2292",
+  sqsupset: "\u2290",
+  sqsupseteq: "\u2292",
+  squ: "\u25A1",
+  square: "\u25A1",
+  squarf: "\u25AA",
+  squf: "\u25AA",
+  srarr: "\u2192",
+  sscr: "\u{1D4C8}",
+  ssetmn: "\u2216",
+  ssmile: "\u2323",
+  sstarf: "\u22C6",
+  star: "\u2606",
+  starf: "\u2605",
+  straightepsilon: "\u03F5",
+  straightphi: "\u03D5",
+  strns: "\xAF",
+  sub: "\u2282",
+  subE: "\u2AC5",
+  subdot: "\u2ABD",
+  sube: "\u2286",
+  subedot: "\u2AC3",
+  submult: "\u2AC1",
+  subnE: "\u2ACB",
+  subne: "\u228A",
+  subplus: "\u2ABF",
+  subrarr: "\u2979",
+  subset: "\u2282",
+  subseteq: "\u2286",
+  subseteqq: "\u2AC5",
+  subsetneq: "\u228A",
+  subsetneqq: "\u2ACB",
+  subsim: "\u2AC7",
+  subsub: "\u2AD5",
+  subsup: "\u2AD3",
+  succ: "\u227B",
+  succapprox: "\u2AB8",
+  succcurlyeq: "\u227D",
+  succeq: "\u2AB0",
+  succnapprox: "\u2ABA",
+  succneqq: "\u2AB6",
+  succnsim: "\u22E9",
+  succsim: "\u227F",
+  sum: "\u2211",
+  sung: "\u266A",
+  sup1: "\xB9",
+  sup2: "\xB2",
+  sup3: "\xB3",
+  sup: "\u2283",
+  supE: "\u2AC6",
+  supdot: "\u2ABE",
+  supdsub: "\u2AD8",
+  supe: "\u2287",
+  supedot: "\u2AC4",
+  suphsol: "\u27C9",
+  suphsub: "\u2AD7",
+  suplarr: "\u297B",
+  supmult: "\u2AC2",
+  supnE: "\u2ACC",
+  supne: "\u228B",
+  supplus: "\u2AC0",
+  supset: "\u2283",
+  supseteq: "\u2287",
+  supseteqq: "\u2AC6",
+  supsetneq: "\u228B",
+  supsetneqq: "\u2ACC",
+  supsim: "\u2AC8",
+  supsub: "\u2AD4",
+  supsup: "\u2AD6",
+  swArr: "\u21D9",
+  swarhk: "\u2926",
+  swarr: "\u2199",
+  swarrow: "\u2199",
+  swnwar: "\u292A",
+  szlig: "\xDF",
+  target: "\u2316",
+  tau: "\u03C4",
+  tbrk: "\u23B4",
+  tcaron: "\u0165",
+  tcedil: "\u0163",
+  tcy: "\u0442",
+  tdot: "\u20DB",
+  telrec: "\u2315",
+  tfr: "\u{1D531}",
+  there4: "\u2234",
+  therefore: "\u2234",
+  theta: "\u03B8",
+  thetasym: "\u03D1",
+  thetav: "\u03D1",
+  thickapprox: "\u2248",
+  thicksim: "\u223C",
+  thinsp: "\u2009",
+  thkap: "\u2248",
+  thksim: "\u223C",
+  thorn: "\xFE",
+  tilde: "\u02DC",
+  times: "\xD7",
+  timesb: "\u22A0",
+  timesbar: "\u2A31",
+  timesd: "\u2A30",
+  tint: "\u222D",
+  toea: "\u2928",
+  top: "\u22A4",
+  topbot: "\u2336",
+  topcir: "\u2AF1",
+  topf: "\u{1D565}",
+  topfork: "\u2ADA",
+  tosa: "\u2929",
+  tprime: "\u2034",
+  trade: "\u2122",
+  triangle: "\u25B5",
+  triangledown: "\u25BF",
+  triangleleft: "\u25C3",
+  trianglelefteq: "\u22B4",
+  triangleq: "\u225C",
+  triangleright: "\u25B9",
+  trianglerighteq: "\u22B5",
+  tridot: "\u25EC",
+  trie: "\u225C",
+  triminus: "\u2A3A",
+  triplus: "\u2A39",
+  trisb: "\u29CD",
+  tritime: "\u2A3B",
+  trpezium: "\u23E2",
+  tscr: "\u{1D4C9}",
+  tscy: "\u0446",
+  tshcy: "\u045B",
+  tstrok: "\u0167",
+  twixt: "\u226C",
+  twoheadleftarrow: "\u219E",
+  twoheadrightarrow: "\u21A0",
+  uArr: "\u21D1",
+  uHar: "\u2963",
+  uacute: "\xFA",
+  uarr: "\u2191",
+  ubrcy: "\u045E",
+  ubreve: "\u016D",
+  ucirc: "\xFB",
+  ucy: "\u0443",
+  udarr: "\u21C5",
+  udblac: "\u0171",
+  udhar: "\u296E",
+  ufisht: "\u297E",
+  ufr: "\u{1D532}",
+  ugrave: "\xF9",
+  uharl: "\u21BF",
+  uharr: "\u21BE",
+  uhblk: "\u2580",
+  ulcorn: "\u231C",
+  ulcorner: "\u231C",
+  ulcrop: "\u230F",
+  ultri: "\u25F8",
+  umacr: "\u016B",
+  uml: "\xA8",
+  uogon: "\u0173",
+  uopf: "\u{1D566}",
+  uparrow: "\u2191",
+  updownarrow: "\u2195",
+  upharpoonleft: "\u21BF",
+  upharpoonright: "\u21BE",
+  uplus: "\u228E",
+  upsi: "\u03C5",
+  upsih: "\u03D2",
+  upsilon: "\u03C5",
+  upuparrows: "\u21C8",
+  urcorn: "\u231D",
+  urcorner: "\u231D",
+  urcrop: "\u230E",
+  uring: "\u016F",
+  urtri: "\u25F9",
+  uscr: "\u{1D4CA}",
+  utdot: "\u22F0",
+  utilde: "\u0169",
+  utri: "\u25B5",
+  utrif: "\u25B4",
+  uuarr: "\u21C8",
+  uuml: "\xFC",
+  uwangle: "\u29A7",
+  vArr: "\u21D5",
+  vBar: "\u2AE8",
+  vBarv: "\u2AE9",
+  vDash: "\u22A8",
+  vangrt: "\u299C",
+  varepsilon: "\u03F5",
+  varkappa: "\u03F0",
+  varnothing: "\u2205",
+  varphi: "\u03D5",
+  varpi: "\u03D6",
+  varpropto: "\u221D",
+  varr: "\u2195",
+  varrho: "\u03F1",
+  varsigma: "\u03C2",
+  varsubsetneq: "\u228A\uFE00",
+  varsubsetneqq: "\u2ACB\uFE00",
+  varsupsetneq: "\u228B\uFE00",
+  varsupsetneqq: "\u2ACC\uFE00",
+  vartheta: "\u03D1",
+  vartriangleleft: "\u22B2",
+  vartriangleright: "\u22B3",
+  vcy: "\u0432",
+  vdash: "\u22A2",
+  vee: "\u2228",
+  veebar: "\u22BB",
+  veeeq: "\u225A",
+  vellip: "\u22EE",
+  verbar: "|",
+  vert: "|",
+  vfr: "\u{1D533}",
+  vltri: "\u22B2",
+  vnsub: "\u2282\u20D2",
+  vnsup: "\u2283\u20D2",
+  vopf: "\u{1D567}",
+  vprop: "\u221D",
+  vrtri: "\u22B3",
+  vscr: "\u{1D4CB}",
+  vsubnE: "\u2ACB\uFE00",
+  vsubne: "\u228A\uFE00",
+  vsupnE: "\u2ACC\uFE00",
+  vsupne: "\u228B\uFE00",
+  vzigzag: "\u299A",
+  wcirc: "\u0175",
+  wedbar: "\u2A5F",
+  wedge: "\u2227",
+  wedgeq: "\u2259",
+  weierp: "\u2118",
+  wfr: "\u{1D534}",
+  wopf: "\u{1D568}",
+  wp: "\u2118",
+  wr: "\u2240",
+  wreath: "\u2240",
+  wscr: "\u{1D4CC}",
+  xcap: "\u22C2",
+  xcirc: "\u25EF",
+  xcup: "\u22C3",
+  xdtri: "\u25BD",
+  xfr: "\u{1D535}",
+  xhArr: "\u27FA",
+  xharr: "\u27F7",
+  xi: "\u03BE",
+  xlArr: "\u27F8",
+  xlarr: "\u27F5",
+  xmap: "\u27FC",
+  xnis: "\u22FB",
+  xodot: "\u2A00",
+  xopf: "\u{1D569}",
+  xoplus: "\u2A01",
+  xotime: "\u2A02",
+  xrArr: "\u27F9",
+  xrarr: "\u27F6",
+  xscr: "\u{1D4CD}",
+  xsqcup: "\u2A06",
+  xuplus: "\u2A04",
+  xutri: "\u25B3",
+  xvee: "\u22C1",
+  xwedge: "\u22C0",
+  yacute: "\xFD",
+  yacy: "\u044F",
+  ycirc: "\u0177",
+  ycy: "\u044B",
+  yen: "\xA5",
+  yfr: "\u{1D536}",
+  yicy: "\u0457",
+  yopf: "\u{1D56A}",
+  yscr: "\u{1D4CE}",
+  yucy: "\u044E",
+  yuml: "\xFF",
+  zacute: "\u017A",
+  zcaron: "\u017E",
+  zcy: "\u0437",
+  zdot: "\u017C",
+  zeetrf: "\u2128",
+  zeta: "\u03B6",
+  zfr: "\u{1D537}",
+  zhcy: "\u0436",
+  zigrarr: "\u21DD",
+  zopf: "\u{1D56B}",
+  zscr: "\u{1D4CF}",
+  zwj: "\u200D",
+  zwnj: "\u200C"
+};
+
+// node_modules/decode-named-character-reference/index.js
+var own = {}.hasOwnProperty;
+function decodeNamedCharacterReference(value) {
+  return own.call(characterEntities, value) ? characterEntities[value] : false;
+}
+
+// node_modules/parse-entities/lib/index.js
+var fromCharCode = String.fromCharCode;
+var messages = [
+  "",
+  "Named character references must be terminated by a semicolon",
+  "Numeric character references must be terminated by a semicolon",
+  "Named character references cannot be empty",
+  "Numeric character references cannot be empty",
+  "Named character references must be known",
+  "Numeric character references cannot be disallowed",
+  "Numeric character references cannot be outside the permissible Unicode range"
+];
+function parseEntities(value, options = {}) {
+  const additional = typeof options.additional === "string" ? options.additional.charCodeAt(0) : options.additional;
+  const result = [];
+  let index = 0;
+  let lines = -1;
+  let queue = "";
+  let point;
+  let indent;
+  if (options.position) {
+    if ("start" in options.position || "indent" in options.position) {
+      indent = options.position.indent;
+      point = options.position.start;
+    } else {
+      point = options.position;
+    }
+  }
+  let line = (point ? point.line : 0) || 1;
+  let column = (point ? point.column : 0) || 1;
+  let previous2 = now();
+  let character;
+  index--;
+  while (++index <= value.length) {
+    if (character === 10) {
+      column = (indent ? indent[lines] : 0) || 1;
+    }
+    character = value.charCodeAt(index);
+    if (character === 38) {
+      const following = value.charCodeAt(index + 1);
+      if (following === 9 || following === 10 || following === 12 || following === 32 || following === 38 || following === 60 || Number.isNaN(following) || additional && following === additional) {
+        queue += fromCharCode(character);
+        column++;
+        continue;
+      }
+      const start = index + 1;
+      let begin = start;
+      let end = start;
+      let type;
+      if (following === 35) {
+        end = ++begin;
+        const following2 = value.charCodeAt(end);
+        if (following2 === 88 || following2 === 120) {
+          type = "hexadecimal";
+          end = ++begin;
+        } else {
+          type = "decimal";
+        }
+      } else {
+        type = "named";
+      }
+      let characterReferenceCharacters = "";
+      let characterReference = "";
+      let characters = "";
+      const test = type === "named" ? isAlphanumerical : type === "decimal" ? isDecimal : isHexadecimal;
+      end--;
+      while (++end <= value.length) {
+        const following2 = value.charCodeAt(end);
+        if (!test(following2)) {
+          break;
+        }
+        characters += fromCharCode(following2);
+        if (type === "named" && characterEntitiesLegacy.includes(characters)) {
+          characterReferenceCharacters = characters;
+          characterReference = decodeNamedCharacterReference(characters);
+        }
+      }
+      let terminated = value.charCodeAt(end) === 59;
+      if (terminated) {
+        end++;
+        const namedReference = type === "named" ? decodeNamedCharacterReference(characters) : false;
+        if (namedReference) {
+          characterReferenceCharacters = characters;
+          characterReference = namedReference;
+        }
+      }
+      let diff = 1 + end - start;
+      let reference = "";
+      if (!terminated && options.nonTerminated === false) {
+      } else if (!characters) {
+        if (type !== "named") {
+          warning(4, diff);
+        }
+      } else if (type === "named") {
+        if (terminated && !characterReference) {
+          warning(5, 1);
+        } else {
+          if (characterReferenceCharacters !== characters) {
+            end = begin + characterReferenceCharacters.length;
+            diff = 1 + end - begin;
+            terminated = false;
+          }
+          if (!terminated) {
+            const reason = characterReferenceCharacters ? 1 : 3;
+            if (options.attribute) {
+              const following2 = value.charCodeAt(end);
+              if (following2 === 61) {
+                warning(reason, diff);
+                characterReference = "";
+              } else if (isAlphanumerical(following2)) {
+                characterReference = "";
+              } else {
+                warning(reason, diff);
+              }
+            } else {
+              warning(reason, diff);
+            }
+          }
+        }
+        reference = characterReference;
+      } else {
+        if (!terminated) {
+          warning(2, diff);
+        }
+        let referenceCode = Number.parseInt(
+          characters,
+          type === "hexadecimal" ? 16 : 10
+        );
+        if (prohibited(referenceCode)) {
+          warning(7, diff);
+          reference = fromCharCode(65533);
+        } else if (referenceCode in characterReferenceInvalid) {
+          warning(6, diff);
+          reference = characterReferenceInvalid[referenceCode];
+        } else {
+          let output = "";
+          if (disallowed(referenceCode)) {
+            warning(6, diff);
+          }
+          if (referenceCode > 65535) {
+            referenceCode -= 65536;
+            output += fromCharCode(referenceCode >>> (10 & 1023) | 55296);
+            referenceCode = 56320 | referenceCode & 1023;
+          }
+          reference = output + fromCharCode(referenceCode);
+        }
+      }
+      if (reference) {
+        flush();
+        previous2 = now();
+        index = end - 1;
+        column += end - start + 1;
+        result.push(reference);
+        const next = now();
+        next.offset++;
+        if (options.reference) {
+          options.reference.call(
+            options.referenceContext,
+            reference,
+            { start: previous2, end: next },
+            value.slice(start - 1, end)
+          );
+        }
+        previous2 = next;
+      } else {
+        characters = value.slice(start - 1, end);
+        queue += characters;
+        column += characters.length;
+        index = end - 1;
+      }
+    } else {
+      if (character === 10) {
+        line++;
+        lines++;
+        column = 0;
+      }
+      if (Number.isNaN(character)) {
+        flush();
+      } else {
+        queue += fromCharCode(character);
+        column++;
+      }
+    }
+  }
+  return result.join("");
+  function now() {
+    return {
+      line,
+      column,
+      offset: index + ((point ? point.offset : 0) || 0)
+    };
+  }
+  function warning(code, offset) {
+    let position;
+    if (options.warning) {
+      position = now();
+      position.column += offset;
+      position.offset += offset;
+      options.warning.call(
+        options.warningContext,
+        messages[code],
+        position,
+        code
+      );
+    }
+  }
+  function flush() {
+    if (queue) {
+      result.push(queue);
+      if (options.text) {
+        options.text.call(options.textContext, queue, {
+          start: previous2,
+          end: now()
+        });
+      }
+      queue = "";
+    }
+  }
+}
+function prohibited(code) {
+  return code >= 55296 && code <= 57343 || code > 1114111;
+}
+function disallowed(code) {
+  return code >= 1 && code <= 8 || code === 11 || code >= 13 && code <= 31 || code >= 127 && code <= 159 || code >= 64976 && code <= 65007 || (code & 65535) === 65535 || (code & 65535) === 65534;
+}
+
+// node_modules/mdast-util-directive/node_modules/stringify-entities/lib/core.js
+function core(value, options) {
+  value = value.replace(
+    options.subset ? charactersToExpression(options.subset) : /["&'<>`]/g,
+    basic
+  );
+  if (options.subset || options.escapeOnly) {
+    return value;
+  }
+  return value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, surrogate).replace(
+    /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g,
+    basic
+  );
+  function surrogate(pair, index, all) {
+    return options.format(
+      (pair.charCodeAt(0) - 55296) * 1024 + pair.charCodeAt(1) - 56320 + 65536,
+      all.charCodeAt(index + 2),
+      options
+    );
+  }
+  function basic(character, index, all) {
+    return options.format(
+      character.charCodeAt(0),
+      all.charCodeAt(index + 1),
+      options
+    );
+  }
+}
+function charactersToExpression(subset) {
+  const groups = [];
+  let index = -1;
+  while (++index < subset.length) {
+    groups.push(subset[index].replace(/[|\\{}()[\]^$+*?.]/g, "\\$&"));
+  }
+  return new RegExp("(?:" + groups.join("|") + ")", "g");
+}
+
+// node_modules/mdast-util-directive/node_modules/stringify-entities/lib/util/format-basic.js
+function formatBasic(code) {
+  return "&#x" + code.toString(16).toUpperCase() + ";";
+}
+
+// node_modules/mdast-util-directive/node_modules/stringify-entities/lib/index.js
+function stringifyEntitiesLight(value, options) {
+  return core(value, Object.assign({ format: formatBasic }, options));
+}
+
+// node_modules/unist-util-is/index.js
+var convert = function(test) {
+  if (test === void 0 || test === null) {
+    return ok;
+  }
+  if (typeof test === "string") {
+    return typeFactory(test);
+  }
+  if (typeof test === "object") {
+    return Array.isArray(test) ? anyFactory(test) : propsFactory(test);
+  }
+  if (typeof test === "function") {
+    return castFactory(test);
+  }
+  throw new Error("Expected function, string, or object as test");
+};
+function anyFactory(tests) {
+  const checks = [];
+  let index = -1;
+  while (++index < tests.length) {
+    checks[index] = convert(tests[index]);
+  }
+  return castFactory(any);
+  function any(...parameters) {
+    let index2 = -1;
+    while (++index2 < checks.length) {
+      if (checks[index2].call(this, ...parameters))
+        return true;
+    }
+    return false;
+  }
+}
+function propsFactory(check) {
+  return castFactory(all);
+  function all(node) {
+    let key;
+    for (key in check) {
+      if (node[key] !== check[key])
+        return false;
+    }
+    return true;
+  }
+}
+function typeFactory(check) {
+  return castFactory(type);
+  function type(node) {
+    return node && node.type === check;
+  }
+}
+function castFactory(check) {
+  return assertion;
+  function assertion(...parameters) {
+    return Boolean(check.call(this, ...parameters));
+  }
+}
+function ok() {
+  return true;
+}
+
+// node_modules/unist-util-visit-parents/color.js
+function color(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/unist-util-visit-parents/index.js
+var CONTINUE = true;
+var SKIP = "skip";
+var EXIT = false;
+var visitParents = function(tree, test, visitor, reverse) {
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+    test = null;
+  }
+  const is = convert(test);
+  const step = reverse ? -1 : 1;
+  factory(tree, null, [])();
+  function factory(node, index, parents) {
+    const value = typeof node === "object" && node !== null ? node : {};
+    let name;
+    if (typeof value.type === "string") {
+      name = typeof value.tagName === "string" ? value.tagName : typeof value.name === "string" ? value.name : void 0;
+      Object.defineProperty(visit, "name", {
+        value: "node (" + color(value.type + (name ? "<" + name + ">" : "")) + ")"
+      });
+    }
+    return visit;
+    function visit() {
+      let result = [];
+      let subresult;
+      let offset;
+      let grandparents;
+      if (!test || is(node, index, parents[parents.length - 1] || null)) {
+        result = toResult(visitor(node, parents));
+        if (result[0] === EXIT) {
+          return result;
+        }
+      }
+      if (node.children && result[0] !== SKIP) {
+        offset = (reverse ? node.children.length : -1) + step;
+        grandparents = parents.concat(node);
+        while (offset > -1 && offset < node.children.length) {
+          subresult = factory(node.children[offset], offset, grandparents)();
+          if (subresult[0] === EXIT) {
+            return subresult;
+          }
+          offset = typeof subresult[1] === "number" ? subresult[1] : offset + step;
+        }
+      }
+      return result;
+    }
+  }
+};
+function toResult(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE, value];
+  }
+  return [value];
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/track.js
+function track(options_) {
+  const options = options_ || {};
+  const now = options.now || {};
+  let lineShift = options.lineShift || 0;
+  let line = now.line || 1;
+  let column = now.column || 1;
+  return { move, current, shift };
+  function current() {
+    return { now: { line, column }, lineShift };
+  }
+  function shift(value) {
+    lineShift += value;
+  }
+  function move(value = "") {
+    const chunks = value.split(/\r?\n|\r/g);
+    const tail = chunks[chunks.length - 1];
+    line += chunks.length - 1;
+    column = chunks.length === 1 ? column + tail.length : 1 + tail.length + lineShift;
+    return value;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-flow.js
+function containerFlow(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const tracker = track(safeOptions);
+  const results = [];
+  let index = -1;
+  indexStack.push(-1);
+  while (++index < children.length) {
+    const child = children[index];
+    indexStack[indexStack.length - 1] = index;
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          before: "\n",
+          after: "\n",
+          ...tracker.current()
+        })
+      )
+    );
+    if (child.type !== "list") {
+      context.bulletLastUsed = void 0;
+    }
+    if (index < children.length - 1) {
+      results.push(tracker.move(between(child, children[index + 1])));
+    }
+  }
+  indexStack.pop();
+  return results.join("");
+  function between(left, right) {
+    let index2 = context.join.length;
+    while (index2--) {
+      const result = context.join[index2](left, right, parent, context);
+      if (result === true || result === 1) {
+        break;
+      }
+      if (typeof result === "number") {
+        return "\n".repeat(1 + result);
+      }
+      if (result === false) {
+        return "\n\n<!---->\n\n";
+      }
+    }
+    return "\n\n";
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-phrasing.js
+function containerPhrasing(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const results = [];
+  let index = -1;
+  let before = safeOptions.before;
+  indexStack.push(-1);
+  let tracker = track(safeOptions);
+  while (++index < children.length) {
+    const child = children[index];
+    let after;
+    indexStack[indexStack.length - 1] = index;
+    if (index + 1 < children.length) {
+      let handle = context.handle.handlers[children[index + 1].type];
+      if (handle && handle.peek)
+        handle = handle.peek;
+      after = handle ? handle(children[index + 1], parent, context, {
+        before: "",
+        after: "",
+        ...tracker.current()
+      }).charAt(0) : "";
+    } else {
+      after = safeOptions.after;
+    }
+    if (results.length > 0 && (before === "\r" || before === "\n") && child.type === "html") {
+      results[results.length - 1] = results[results.length - 1].replace(
+        /(\r?\n|\r)$/,
+        " "
+      );
+      before = " ";
+      tracker = track(safeOptions);
+      tracker.move(results.join(""));
+    }
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          ...tracker.current(),
+          before,
+          after
+        })
+      )
+    );
+    before = results[results.length - 1].slice(-1);
+  }
+  indexStack.pop();
+  return results.join("");
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-quote.js
+function checkQuote(context) {
+  const marker = context.options.quote || '"';
+  if (marker !== '"' && marker !== "'") {
+    throw new Error(
+      "Cannot serialize title with `" + marker + "` for `options.quote`, expected `\"`, or `'`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-directive/index.js
+var own2 = {}.hasOwnProperty;
+var shortcut = /^[^\t\n\r "#'.<=>`}]+$/;
+handleDirective.peek = peekDirective;
+var directiveFromMarkdown = {
+  canContainEols: ["textDirective"],
+  enter: {
+    directiveContainer: enterContainer,
+    directiveContainerAttributes: enterAttributes,
+    directiveContainerLabel: enterContainerLabel,
+    directiveLeaf: enterLeaf,
+    directiveLeafAttributes: enterAttributes,
+    directiveText: enterText,
+    directiveTextAttributes: enterAttributes
+  },
+  exit: {
+    directiveContainer: exit,
+    directiveContainerAttributeClassValue: exitAttributeClassValue,
+    directiveContainerAttributeIdValue: exitAttributeIdValue,
+    directiveContainerAttributeName: exitAttributeName,
+    directiveContainerAttributeValue: exitAttributeValue,
+    directiveContainerAttributes: exitAttributes,
+    directiveContainerLabel: exitContainerLabel,
+    directiveContainerName: exitName,
+    directiveLeaf: exit,
+    directiveLeafAttributeClassValue: exitAttributeClassValue,
+    directiveLeafAttributeIdValue: exitAttributeIdValue,
+    directiveLeafAttributeName: exitAttributeName,
+    directiveLeafAttributeValue: exitAttributeValue,
+    directiveLeafAttributes: exitAttributes,
+    directiveLeafName: exitName,
+    directiveText: exit,
+    directiveTextAttributeClassValue: exitAttributeClassValue,
+    directiveTextAttributeIdValue: exitAttributeIdValue,
+    directiveTextAttributeName: exitAttributeName,
+    directiveTextAttributeValue: exitAttributeValue,
+    directiveTextAttributes: exitAttributes,
+    directiveTextName: exitName
+  }
+};
+var directiveToMarkdown = {
+  unsafe: [
+    {
+      character: "\r",
+      inConstruct: ["leafDirectiveLabel", "containerDirectiveLabel"]
+    },
+    {
+      character: "\n",
+      inConstruct: ["leafDirectiveLabel", "containerDirectiveLabel"]
+    },
+    {
+      before: "[^:]",
+      character: ":",
+      after: "[A-Za-z]",
+      inConstruct: ["phrasing"]
+    },
+    { atBreak: true, character: ":", after: ":" }
+  ],
+  handlers: {
+    containerDirective: handleDirective,
+    leafDirective: handleDirective,
+    textDirective: handleDirective
+  }
+};
+function enterContainer(token) {
+  enter.call(this, "containerDirective", token);
+}
+function enterLeaf(token) {
+  enter.call(this, "leafDirective", token);
+}
+function enterText(token) {
+  enter.call(this, "textDirective", token);
+}
+function enter(type, token) {
+  this.enter({ type, name: "", attributes: {}, children: [] }, token);
+}
+function exitName(token) {
+  const node = this.stack[this.stack.length - 1];
+  node.name = this.sliceSerialize(token);
+}
+function enterContainerLabel(token) {
+  this.enter(
+    { type: "paragraph", data: { directiveLabel: true }, children: [] },
+    token
+  );
+}
+function exitContainerLabel(token) {
+  this.exit(token);
+}
+function enterAttributes() {
+  this.setData("directiveAttributes", []);
+  this.buffer();
+}
+function exitAttributeIdValue(token) {
+  const list = this.getData("directiveAttributes");
+  list.push([
+    "id",
+    parseEntities(this.sliceSerialize(token), {
+      attribute: true
+    })
+  ]);
+}
+function exitAttributeClassValue(token) {
+  const list = this.getData("directiveAttributes");
+  list.push([
+    "class",
+    parseEntities(this.sliceSerialize(token), {
+      attribute: true
+    })
+  ]);
+}
+function exitAttributeValue(token) {
+  const list = this.getData("directiveAttributes");
+  list[list.length - 1][1] = parseEntities(this.sliceSerialize(token), {
+    attribute: true
+  });
+}
+function exitAttributeName(token) {
+  const list = this.getData("directiveAttributes");
+  list.push([this.sliceSerialize(token), ""]);
+}
+function exitAttributes() {
+  const list = this.getData("directiveAttributes");
+  const cleaned = {};
+  let index = -1;
+  while (++index < list.length) {
+    const attribute = list[index];
+    if (attribute[0] === "class" && cleaned.class) {
+      cleaned.class += " " + attribute[1];
+    } else {
+      cleaned[attribute[0]] = attribute[1];
+    }
+  }
+  this.setData("directiveAttributes");
+  this.resume();
+  const node = this.stack[this.stack.length - 1];
+  node.attributes = cleaned;
+}
+function exit(token) {
+  this.exit(token);
+}
+function handleDirective(node, _, context, safeOptions) {
+  const tracker = track(safeOptions);
+  const sequence = fence(node);
+  const exit2 = context.enter(node.type);
+  let value = tracker.move(sequence + (node.name || ""));
+  let label4 = node;
+  if (node.type === "containerDirective") {
+    const head = (node.children || [])[0];
+    label4 = inlineDirectiveLabel(head) ? head : void 0;
+  }
+  if (label4 && label4.children && label4.children.length > 0) {
+    const exit3 = context.enter("label");
+    const subexit = context.enter(node.type + "Label");
+    value += tracker.move("[");
+    value += tracker.move(
+      containerPhrasing(label4, context, {
+        ...tracker.current(),
+        before: value,
+        after: "]"
+      })
+    );
+    value += tracker.move("]");
+    subexit();
+    exit3();
+  }
+  value += tracker.move(attributes4(node, context));
+  if (node.type === "containerDirective") {
+    const head = (node.children || [])[0];
+    let shallow = node;
+    if (inlineDirectiveLabel(head)) {
+      shallow = Object.assign({}, node, { children: node.children.slice(1) });
+    }
+    if (shallow && shallow.children && shallow.children.length > 0) {
+      value += tracker.move("\n");
+      value += tracker.move(containerFlow(shallow, context, tracker.current()));
+    }
+    value += tracker.move("\n" + sequence);
+  }
+  exit2();
+  return value;
+}
+function peekDirective() {
+  return ":";
+}
+function attributes4(node, context) {
+  const quote = checkQuote(context);
+  const subset = node.type === "textDirective" ? [quote] : [quote, "\n", "\r"];
+  const attrs = node.attributes || {};
+  const values = [];
+  let classesFull;
+  let classes;
+  let id;
+  let key;
+  for (key in attrs) {
+    if (own2.call(attrs, key) && attrs[key] !== void 0 && attrs[key] !== null) {
+      const value = String(attrs[key]);
+      if (key === "id") {
+        id = shortcut.test(value) ? "#" + value : quoted("id", value);
+      } else if (key === "class") {
+        const list = value.split(/[\t\n\r ]+/g);
+        const classesFullList = [];
+        const classesList = [];
+        let index = -1;
+        while (++index < list.length) {
+          ;
+          (shortcut.test(list[index]) ? classesList : classesFullList).push(
+            list[index]
+          );
+        }
+        classesFull = classesFullList.length > 0 ? quoted("class", classesFullList.join(" ")) : "";
+        classes = classesList.length > 0 ? "." + classesList.join(".") : "";
+      } else {
+        values.push(quoted(key, value));
+      }
+    }
+  }
+  if (classesFull) {
+    values.unshift(classesFull);
+  }
+  if (classes) {
+    values.unshift(classes);
+  }
+  if (id) {
+    values.unshift(id);
+  }
+  return values.length > 0 ? "{" + values.join(" ") + "}" : "";
+  function quoted(key2, value) {
+    return key2 + (value ? "=" + quote + stringifyEntitiesLight(value, { subset }) + quote : "");
+  }
+}
+function inlineDirectiveLabel(node) {
+  return Boolean(
+    node && node.type === "paragraph" && node.data && node.data.directiveLabel
+  );
+}
+function fence(node) {
+  let size = 0;
+  if (node.type === "containerDirective") {
+    visitParents(node, "containerDirective", onvisit);
+    size += 3;
+  } else if (node.type === "leafDirective") {
+    size = 2;
+  } else {
+    size = 1;
+  }
+  return ":".repeat(size);
+  function onvisit(_, parents) {
+    let index = parents.length;
+    let nesting = 0;
+    while (index--) {
+      if (parents[index].type === "containerDirective") {
+        nesting++;
+      }
+    }
+    if (nesting > size)
+      size = nesting;
+  }
+}
+
+// node_modules/remark-directive/index.js
+function remarkDirective201() {
+  const data = this.data();
+  add("micromarkExtensions", directive());
+  add("fromMarkdownExtensions", directiveFromMarkdown);
+  add("toMarkdownExtensions", directiveToMarkdown);
+  function add(field, value) {
+    const list = data[field] ? data[field] : data[field] = [];
+    list.push(value);
+  }
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {});

--- a/jest/vendor/remark-gfm@3.0.1.js
+++ b/jest/vendor/remark-gfm@3.0.1.js
@@ -1,0 +1,4907 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/remark-gfm/index.js
+var remark_gfm_exports = {};
+__export(remark_gfm_exports, {
+  default: () => remarkGfm
+});
+module.exports = __toCommonJS(remark_gfm_exports);
+
+// node_modules/micromark-util-chunked/index.js
+function splice(list, start, remove, items) {
+  const end = list.length;
+  let chunkStart = 0;
+  let parameters;
+  if (start < 0) {
+    start = -start > end ? 0 : end + start;
+  } else {
+    start = start > end ? end : start;
+  }
+  remove = remove > 0 ? remove : 0;
+  if (items.length < 1e4) {
+    parameters = Array.from(items);
+    parameters.unshift(start, remove);
+    [].splice.apply(list, parameters);
+  } else {
+    if (remove)
+      [].splice.apply(list, [start, remove]);
+    while (chunkStart < items.length) {
+      parameters = items.slice(chunkStart, chunkStart + 1e4);
+      parameters.unshift(start, 0);
+      [].splice.apply(list, parameters);
+      chunkStart += 1e4;
+      start += 1e4;
+    }
+  }
+}
+
+// node_modules/micromark-util-combine-extensions/index.js
+var hasOwnProperty = {}.hasOwnProperty;
+function combineExtensions(extensions) {
+  const all = {};
+  let index = -1;
+  while (++index < extensions.length) {
+    syntaxExtension(all, extensions[index]);
+  }
+  return all;
+}
+function syntaxExtension(all, extension) {
+  let hook;
+  for (hook in extension) {
+    const maybe = hasOwnProperty.call(all, hook) ? all[hook] : void 0;
+    const left = maybe || (all[hook] = {});
+    const right = extension[hook];
+    let code2;
+    for (code2 in right) {
+      if (!hasOwnProperty.call(left, code2))
+        left[code2] = [];
+      const value = right[code2];
+      constructs(
+        left[code2],
+        Array.isArray(value) ? value : value ? [value] : []
+      );
+    }
+  }
+}
+function constructs(existing, list) {
+  let index = -1;
+  const before = [];
+  while (++index < list.length) {
+    ;
+    (list[index].add === "after" ? existing : before).push(list[index]);
+  }
+  splice(existing, 0, 0, before);
+}
+
+// node_modules/micromark-util-character/lib/unicode-punctuation-regex.js
+var unicodePunctuationRegex = /[!-/:-@[-`{-~\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0A76\u0AF0\u0C77\u0C84\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E4F\u2E52\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]/;
+
+// node_modules/micromark-util-character/index.js
+var asciiAlpha = regexCheck(/[A-Za-z]/);
+var asciiDigit = regexCheck(/\d/);
+var asciiHexDigit = regexCheck(/[\dA-Fa-f]/);
+var asciiAlphanumeric = regexCheck(/[\dA-Za-z]/);
+var asciiPunctuation = regexCheck(/[!-/:-@[-`{-~]/);
+var asciiAtext = regexCheck(/[#-'*+\--9=?A-Z^-~]/);
+function asciiControl(code2) {
+  return code2 !== null && (code2 < 32 || code2 === 127);
+}
+function markdownLineEndingOrSpace(code2) {
+  return code2 !== null && (code2 < 0 || code2 === 32);
+}
+function markdownLineEnding(code2) {
+  return code2 !== null && code2 < -2;
+}
+function markdownSpace(code2) {
+  return code2 === -2 || code2 === -1 || code2 === 32;
+}
+var unicodeWhitespace = regexCheck(/\s/);
+var unicodePunctuation = regexCheck(unicodePunctuationRegex);
+function regexCheck(regex) {
+  return check;
+  function check(code2) {
+    return code2 !== null && regex.test(String.fromCharCode(code2));
+  }
+}
+
+// node_modules/micromark-extension-gfm-autolink-literal/lib/syntax.js
+var www = {
+  tokenize: tokenizeWww,
+  partial: true
+};
+var domain = {
+  tokenize: tokenizeDomain,
+  partial: true
+};
+var path = {
+  tokenize: tokenizePath,
+  partial: true
+};
+var punctuation = {
+  tokenize: tokenizePunctuation,
+  partial: true
+};
+var namedCharacterReference = {
+  tokenize: tokenizeNamedCharacterReference,
+  partial: true
+};
+var wwwAutolink = {
+  tokenize: tokenizeWwwAutolink,
+  previous: previousWww
+};
+var httpAutolink = {
+  tokenize: tokenizeHttpAutolink,
+  previous: previousHttp
+};
+var emailAutolink = {
+  tokenize: tokenizeEmailAutolink,
+  previous: previousEmail
+};
+var text = {};
+var gfmAutolinkLiteral = {
+  text
+};
+var code = 48;
+while (code < 123) {
+  text[code] = emailAutolink;
+  code++;
+  if (code === 58)
+    code = 65;
+  else if (code === 91)
+    code = 97;
+}
+text[43] = emailAutolink;
+text[45] = emailAutolink;
+text[46] = emailAutolink;
+text[95] = emailAutolink;
+text[72] = [emailAutolink, httpAutolink];
+text[104] = [emailAutolink, httpAutolink];
+text[87] = [emailAutolink, wwwAutolink];
+text[119] = [emailAutolink, wwwAutolink];
+function tokenizeEmailAutolink(effects, ok2, nok) {
+  const self = this;
+  let hasDot;
+  let hasDigitInLastSegment;
+  return start;
+  function start(code2) {
+    if (!gfmAtext(code2) || !previousEmail(self.previous) || previousUnbalanced(self.events)) {
+      return nok(code2);
+    }
+    effects.enter("literalAutolink");
+    effects.enter("literalAutolinkEmail");
+    return atext(code2);
+  }
+  function atext(code2) {
+    if (gfmAtext(code2)) {
+      effects.consume(code2);
+      return atext;
+    }
+    if (code2 === 64) {
+      effects.consume(code2);
+      return label;
+    }
+    return nok(code2);
+  }
+  function label(code2) {
+    if (code2 === 46) {
+      return effects.check(punctuation, done, dotContinuation)(code2);
+    }
+    if (code2 === 45 || code2 === 95) {
+      return effects.check(punctuation, nok, dashOrUnderscoreContinuation)(code2);
+    }
+    if (asciiAlphanumeric(code2)) {
+      if (!hasDigitInLastSegment && asciiDigit(code2)) {
+        hasDigitInLastSegment = true;
+      }
+      effects.consume(code2);
+      return label;
+    }
+    return done(code2);
+  }
+  function dotContinuation(code2) {
+    effects.consume(code2);
+    hasDot = true;
+    hasDigitInLastSegment = void 0;
+    return label;
+  }
+  function dashOrUnderscoreContinuation(code2) {
+    effects.consume(code2);
+    return afterDashOrUnderscore;
+  }
+  function afterDashOrUnderscore(code2) {
+    if (code2 === 46) {
+      return effects.check(punctuation, nok, dotContinuation)(code2);
+    }
+    return label(code2);
+  }
+  function done(code2) {
+    if (hasDot && !hasDigitInLastSegment) {
+      effects.exit("literalAutolinkEmail");
+      effects.exit("literalAutolink");
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+function tokenizeWwwAutolink(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    if (code2 !== 87 && code2 !== 119 || !previousWww(self.previous) || previousUnbalanced(self.events)) {
+      return nok(code2);
+    }
+    effects.enter("literalAutolink");
+    effects.enter("literalAutolinkWww");
+    return effects.check(
+      www,
+      effects.attempt(domain, effects.attempt(path, done), nok),
+      nok
+    )(code2);
+  }
+  function done(code2) {
+    effects.exit("literalAutolinkWww");
+    effects.exit("literalAutolink");
+    return ok2(code2);
+  }
+}
+function tokenizeHttpAutolink(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    if (code2 !== 72 && code2 !== 104 || !previousHttp(self.previous) || previousUnbalanced(self.events)) {
+      return nok(code2);
+    }
+    effects.enter("literalAutolink");
+    effects.enter("literalAutolinkHttp");
+    effects.consume(code2);
+    return t1;
+  }
+  function t1(code2) {
+    if (code2 === 84 || code2 === 116) {
+      effects.consume(code2);
+      return t2;
+    }
+    return nok(code2);
+  }
+  function t2(code2) {
+    if (code2 === 84 || code2 === 116) {
+      effects.consume(code2);
+      return p;
+    }
+    return nok(code2);
+  }
+  function p(code2) {
+    if (code2 === 80 || code2 === 112) {
+      effects.consume(code2);
+      return s;
+    }
+    return nok(code2);
+  }
+  function s(code2) {
+    if (code2 === 83 || code2 === 115) {
+      effects.consume(code2);
+      return colon;
+    }
+    return colon(code2);
+  }
+  function colon(code2) {
+    if (code2 === 58) {
+      effects.consume(code2);
+      return slash1;
+    }
+    return nok(code2);
+  }
+  function slash1(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return slash2;
+    }
+    return nok(code2);
+  }
+  function slash2(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return code2 === null || asciiControl(code2) || unicodeWhitespace(code2) || unicodePunctuation(code2) ? nok(code2) : effects.attempt(domain, effects.attempt(path, done), nok)(code2);
+  }
+  function done(code2) {
+    effects.exit("literalAutolinkHttp");
+    effects.exit("literalAutolink");
+    return ok2(code2);
+  }
+}
+function tokenizeWww(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.consume(code2);
+    return w2;
+  }
+  function w2(code2) {
+    if (code2 === 87 || code2 === 119) {
+      effects.consume(code2);
+      return w3;
+    }
+    return nok(code2);
+  }
+  function w3(code2) {
+    if (code2 === 87 || code2 === 119) {
+      effects.consume(code2);
+      return dot;
+    }
+    return nok(code2);
+  }
+  function dot(code2) {
+    if (code2 === 46) {
+      effects.consume(code2);
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return code2 === null || markdownLineEnding(code2) ? nok(code2) : ok2(code2);
+  }
+}
+function tokenizeDomain(effects, ok2, nok) {
+  let hasUnderscoreInLastSegment;
+  let hasUnderscoreInLastLastSegment;
+  return domain2;
+  function domain2(code2) {
+    if (code2 === 38) {
+      return effects.check(
+        namedCharacterReference,
+        done,
+        punctuationContinuation
+      )(code2);
+    }
+    if (code2 === 46 || code2 === 95) {
+      return effects.check(punctuation, done, punctuationContinuation)(code2);
+    }
+    if (code2 === null || asciiControl(code2) || unicodeWhitespace(code2) || code2 !== 45 && unicodePunctuation(code2)) {
+      return done(code2);
+    }
+    effects.consume(code2);
+    return domain2;
+  }
+  function punctuationContinuation(code2) {
+    if (code2 === 46) {
+      hasUnderscoreInLastLastSegment = hasUnderscoreInLastSegment;
+      hasUnderscoreInLastSegment = void 0;
+      effects.consume(code2);
+      return domain2;
+    }
+    if (code2 === 95)
+      hasUnderscoreInLastSegment = true;
+    effects.consume(code2);
+    return domain2;
+  }
+  function done(code2) {
+    if (!hasUnderscoreInLastLastSegment && !hasUnderscoreInLastSegment) {
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+function tokenizePath(effects, ok2) {
+  let balance = 0;
+  return inPath;
+  function inPath(code2) {
+    if (code2 === 38) {
+      return effects.check(
+        namedCharacterReference,
+        ok2,
+        continuedPunctuation
+      )(code2);
+    }
+    if (code2 === 40) {
+      balance++;
+    }
+    if (code2 === 41) {
+      return effects.check(
+        punctuation,
+        parenAtPathEnd,
+        continuedPunctuation
+      )(code2);
+    }
+    if (pathEnd(code2)) {
+      return ok2(code2);
+    }
+    if (trailingPunctuation(code2)) {
+      return effects.check(punctuation, ok2, continuedPunctuation)(code2);
+    }
+    effects.consume(code2);
+    return inPath;
+  }
+  function continuedPunctuation(code2) {
+    effects.consume(code2);
+    return inPath;
+  }
+  function parenAtPathEnd(code2) {
+    balance--;
+    return balance < 0 ? ok2(code2) : continuedPunctuation(code2);
+  }
+}
+function tokenizeNamedCharacterReference(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.consume(code2);
+    return inside;
+  }
+  function inside(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return inside;
+    }
+    if (code2 === 59) {
+      effects.consume(code2);
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return pathEnd(code2) ? ok2(code2) : nok(code2);
+  }
+}
+function tokenizePunctuation(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.consume(code2);
+    return after;
+  }
+  function after(code2) {
+    if (trailingPunctuation(code2)) {
+      effects.consume(code2);
+      return after;
+    }
+    return pathEnd(code2) ? ok2(code2) : nok(code2);
+  }
+}
+function trailingPunctuation(code2) {
+  return code2 === 33 || code2 === 34 || code2 === 39 || code2 === 41 || code2 === 42 || code2 === 44 || code2 === 46 || code2 === 58 || code2 === 59 || code2 === 60 || code2 === 63 || code2 === 95 || code2 === 126;
+}
+function pathEnd(code2) {
+  return code2 === null || code2 === 60 || markdownLineEndingOrSpace(code2);
+}
+function gfmAtext(code2) {
+  return code2 === 43 || code2 === 45 || code2 === 46 || code2 === 95 || asciiAlphanumeric(code2);
+}
+function previousWww(code2) {
+  return code2 === null || code2 === 40 || code2 === 42 || code2 === 95 || code2 === 126 || markdownLineEndingOrSpace(code2);
+}
+function previousHttp(code2) {
+  return code2 === null || !asciiAlpha(code2);
+}
+function previousEmail(code2) {
+  return code2 !== 47 && previousHttp(code2);
+}
+function previousUnbalanced(events) {
+  let index = events.length;
+  let result = false;
+  while (index--) {
+    const token = events[index][1];
+    if ((token.type === "labelLink" || token.type === "labelImage") && !token._balanced) {
+      result = true;
+      break;
+    }
+    if (token._gfmAutolinkLiteralWalkedInto) {
+      result = false;
+      break;
+    }
+  }
+  if (events.length > 0 && !result) {
+    events[events.length - 1][1]._gfmAutolinkLiteralWalkedInto = true;
+  }
+  return result;
+}
+
+// node_modules/micromark-util-classify-character/index.js
+function classifyCharacter(code2) {
+  if (code2 === null || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+    return 1;
+  }
+  if (unicodePunctuation(code2)) {
+    return 2;
+  }
+}
+
+// node_modules/micromark-util-resolve-all/index.js
+function resolveAll(constructs2, events, context) {
+  const called = [];
+  let index = -1;
+  while (++index < constructs2.length) {
+    const resolve = constructs2[index].resolveAll;
+    if (resolve && !called.includes(resolve)) {
+      events = resolve(events, context);
+      called.push(resolve);
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark-factory-space/index.js
+function factorySpace(effects, ok2, type, max) {
+  const limit = max ? max - 1 : Number.POSITIVE_INFINITY;
+  let size = 0;
+  return start;
+  function start(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter(type);
+      return prefix(code2);
+    }
+    return ok2(code2);
+  }
+  function prefix(code2) {
+    if (markdownSpace(code2) && size++ < limit) {
+      effects.consume(code2);
+      return prefix;
+    }
+    effects.exit(type);
+    return ok2(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/blank-line.js
+var blankLine = {
+  tokenize: tokenizeBlankLine,
+  partial: true
+};
+function tokenizeBlankLine(effects, ok2, nok) {
+  return factorySpace(effects, afterWhitespace, "linePrefix");
+  function afterWhitespace(code2) {
+    return code2 === null || markdownLineEnding(code2) ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/character-entities/index.js
+var characterEntities = {
+  AElig: "\xC6",
+  AMP: "&",
+  Aacute: "\xC1",
+  Abreve: "\u0102",
+  Acirc: "\xC2",
+  Acy: "\u0410",
+  Afr: "\u{1D504}",
+  Agrave: "\xC0",
+  Alpha: "\u0391",
+  Amacr: "\u0100",
+  And: "\u2A53",
+  Aogon: "\u0104",
+  Aopf: "\u{1D538}",
+  ApplyFunction: "\u2061",
+  Aring: "\xC5",
+  Ascr: "\u{1D49C}",
+  Assign: "\u2254",
+  Atilde: "\xC3",
+  Auml: "\xC4",
+  Backslash: "\u2216",
+  Barv: "\u2AE7",
+  Barwed: "\u2306",
+  Bcy: "\u0411",
+  Because: "\u2235",
+  Bernoullis: "\u212C",
+  Beta: "\u0392",
+  Bfr: "\u{1D505}",
+  Bopf: "\u{1D539}",
+  Breve: "\u02D8",
+  Bscr: "\u212C",
+  Bumpeq: "\u224E",
+  CHcy: "\u0427",
+  COPY: "\xA9",
+  Cacute: "\u0106",
+  Cap: "\u22D2",
+  CapitalDifferentialD: "\u2145",
+  Cayleys: "\u212D",
+  Ccaron: "\u010C",
+  Ccedil: "\xC7",
+  Ccirc: "\u0108",
+  Cconint: "\u2230",
+  Cdot: "\u010A",
+  Cedilla: "\xB8",
+  CenterDot: "\xB7",
+  Cfr: "\u212D",
+  Chi: "\u03A7",
+  CircleDot: "\u2299",
+  CircleMinus: "\u2296",
+  CirclePlus: "\u2295",
+  CircleTimes: "\u2297",
+  ClockwiseContourIntegral: "\u2232",
+  CloseCurlyDoubleQuote: "\u201D",
+  CloseCurlyQuote: "\u2019",
+  Colon: "\u2237",
+  Colone: "\u2A74",
+  Congruent: "\u2261",
+  Conint: "\u222F",
+  ContourIntegral: "\u222E",
+  Copf: "\u2102",
+  Coproduct: "\u2210",
+  CounterClockwiseContourIntegral: "\u2233",
+  Cross: "\u2A2F",
+  Cscr: "\u{1D49E}",
+  Cup: "\u22D3",
+  CupCap: "\u224D",
+  DD: "\u2145",
+  DDotrahd: "\u2911",
+  DJcy: "\u0402",
+  DScy: "\u0405",
+  DZcy: "\u040F",
+  Dagger: "\u2021",
+  Darr: "\u21A1",
+  Dashv: "\u2AE4",
+  Dcaron: "\u010E",
+  Dcy: "\u0414",
+  Del: "\u2207",
+  Delta: "\u0394",
+  Dfr: "\u{1D507}",
+  DiacriticalAcute: "\xB4",
+  DiacriticalDot: "\u02D9",
+  DiacriticalDoubleAcute: "\u02DD",
+  DiacriticalGrave: "`",
+  DiacriticalTilde: "\u02DC",
+  Diamond: "\u22C4",
+  DifferentialD: "\u2146",
+  Dopf: "\u{1D53B}",
+  Dot: "\xA8",
+  DotDot: "\u20DC",
+  DotEqual: "\u2250",
+  DoubleContourIntegral: "\u222F",
+  DoubleDot: "\xA8",
+  DoubleDownArrow: "\u21D3",
+  DoubleLeftArrow: "\u21D0",
+  DoubleLeftRightArrow: "\u21D4",
+  DoubleLeftTee: "\u2AE4",
+  DoubleLongLeftArrow: "\u27F8",
+  DoubleLongLeftRightArrow: "\u27FA",
+  DoubleLongRightArrow: "\u27F9",
+  DoubleRightArrow: "\u21D2",
+  DoubleRightTee: "\u22A8",
+  DoubleUpArrow: "\u21D1",
+  DoubleUpDownArrow: "\u21D5",
+  DoubleVerticalBar: "\u2225",
+  DownArrow: "\u2193",
+  DownArrowBar: "\u2913",
+  DownArrowUpArrow: "\u21F5",
+  DownBreve: "\u0311",
+  DownLeftRightVector: "\u2950",
+  DownLeftTeeVector: "\u295E",
+  DownLeftVector: "\u21BD",
+  DownLeftVectorBar: "\u2956",
+  DownRightTeeVector: "\u295F",
+  DownRightVector: "\u21C1",
+  DownRightVectorBar: "\u2957",
+  DownTee: "\u22A4",
+  DownTeeArrow: "\u21A7",
+  Downarrow: "\u21D3",
+  Dscr: "\u{1D49F}",
+  Dstrok: "\u0110",
+  ENG: "\u014A",
+  ETH: "\xD0",
+  Eacute: "\xC9",
+  Ecaron: "\u011A",
+  Ecirc: "\xCA",
+  Ecy: "\u042D",
+  Edot: "\u0116",
+  Efr: "\u{1D508}",
+  Egrave: "\xC8",
+  Element: "\u2208",
+  Emacr: "\u0112",
+  EmptySmallSquare: "\u25FB",
+  EmptyVerySmallSquare: "\u25AB",
+  Eogon: "\u0118",
+  Eopf: "\u{1D53C}",
+  Epsilon: "\u0395",
+  Equal: "\u2A75",
+  EqualTilde: "\u2242",
+  Equilibrium: "\u21CC",
+  Escr: "\u2130",
+  Esim: "\u2A73",
+  Eta: "\u0397",
+  Euml: "\xCB",
+  Exists: "\u2203",
+  ExponentialE: "\u2147",
+  Fcy: "\u0424",
+  Ffr: "\u{1D509}",
+  FilledSmallSquare: "\u25FC",
+  FilledVerySmallSquare: "\u25AA",
+  Fopf: "\u{1D53D}",
+  ForAll: "\u2200",
+  Fouriertrf: "\u2131",
+  Fscr: "\u2131",
+  GJcy: "\u0403",
+  GT: ">",
+  Gamma: "\u0393",
+  Gammad: "\u03DC",
+  Gbreve: "\u011E",
+  Gcedil: "\u0122",
+  Gcirc: "\u011C",
+  Gcy: "\u0413",
+  Gdot: "\u0120",
+  Gfr: "\u{1D50A}",
+  Gg: "\u22D9",
+  Gopf: "\u{1D53E}",
+  GreaterEqual: "\u2265",
+  GreaterEqualLess: "\u22DB",
+  GreaterFullEqual: "\u2267",
+  GreaterGreater: "\u2AA2",
+  GreaterLess: "\u2277",
+  GreaterSlantEqual: "\u2A7E",
+  GreaterTilde: "\u2273",
+  Gscr: "\u{1D4A2}",
+  Gt: "\u226B",
+  HARDcy: "\u042A",
+  Hacek: "\u02C7",
+  Hat: "^",
+  Hcirc: "\u0124",
+  Hfr: "\u210C",
+  HilbertSpace: "\u210B",
+  Hopf: "\u210D",
+  HorizontalLine: "\u2500",
+  Hscr: "\u210B",
+  Hstrok: "\u0126",
+  HumpDownHump: "\u224E",
+  HumpEqual: "\u224F",
+  IEcy: "\u0415",
+  IJlig: "\u0132",
+  IOcy: "\u0401",
+  Iacute: "\xCD",
+  Icirc: "\xCE",
+  Icy: "\u0418",
+  Idot: "\u0130",
+  Ifr: "\u2111",
+  Igrave: "\xCC",
+  Im: "\u2111",
+  Imacr: "\u012A",
+  ImaginaryI: "\u2148",
+  Implies: "\u21D2",
+  Int: "\u222C",
+  Integral: "\u222B",
+  Intersection: "\u22C2",
+  InvisibleComma: "\u2063",
+  InvisibleTimes: "\u2062",
+  Iogon: "\u012E",
+  Iopf: "\u{1D540}",
+  Iota: "\u0399",
+  Iscr: "\u2110",
+  Itilde: "\u0128",
+  Iukcy: "\u0406",
+  Iuml: "\xCF",
+  Jcirc: "\u0134",
+  Jcy: "\u0419",
+  Jfr: "\u{1D50D}",
+  Jopf: "\u{1D541}",
+  Jscr: "\u{1D4A5}",
+  Jsercy: "\u0408",
+  Jukcy: "\u0404",
+  KHcy: "\u0425",
+  KJcy: "\u040C",
+  Kappa: "\u039A",
+  Kcedil: "\u0136",
+  Kcy: "\u041A",
+  Kfr: "\u{1D50E}",
+  Kopf: "\u{1D542}",
+  Kscr: "\u{1D4A6}",
+  LJcy: "\u0409",
+  LT: "<",
+  Lacute: "\u0139",
+  Lambda: "\u039B",
+  Lang: "\u27EA",
+  Laplacetrf: "\u2112",
+  Larr: "\u219E",
+  Lcaron: "\u013D",
+  Lcedil: "\u013B",
+  Lcy: "\u041B",
+  LeftAngleBracket: "\u27E8",
+  LeftArrow: "\u2190",
+  LeftArrowBar: "\u21E4",
+  LeftArrowRightArrow: "\u21C6",
+  LeftCeiling: "\u2308",
+  LeftDoubleBracket: "\u27E6",
+  LeftDownTeeVector: "\u2961",
+  LeftDownVector: "\u21C3",
+  LeftDownVectorBar: "\u2959",
+  LeftFloor: "\u230A",
+  LeftRightArrow: "\u2194",
+  LeftRightVector: "\u294E",
+  LeftTee: "\u22A3",
+  LeftTeeArrow: "\u21A4",
+  LeftTeeVector: "\u295A",
+  LeftTriangle: "\u22B2",
+  LeftTriangleBar: "\u29CF",
+  LeftTriangleEqual: "\u22B4",
+  LeftUpDownVector: "\u2951",
+  LeftUpTeeVector: "\u2960",
+  LeftUpVector: "\u21BF",
+  LeftUpVectorBar: "\u2958",
+  LeftVector: "\u21BC",
+  LeftVectorBar: "\u2952",
+  Leftarrow: "\u21D0",
+  Leftrightarrow: "\u21D4",
+  LessEqualGreater: "\u22DA",
+  LessFullEqual: "\u2266",
+  LessGreater: "\u2276",
+  LessLess: "\u2AA1",
+  LessSlantEqual: "\u2A7D",
+  LessTilde: "\u2272",
+  Lfr: "\u{1D50F}",
+  Ll: "\u22D8",
+  Lleftarrow: "\u21DA",
+  Lmidot: "\u013F",
+  LongLeftArrow: "\u27F5",
+  LongLeftRightArrow: "\u27F7",
+  LongRightArrow: "\u27F6",
+  Longleftarrow: "\u27F8",
+  Longleftrightarrow: "\u27FA",
+  Longrightarrow: "\u27F9",
+  Lopf: "\u{1D543}",
+  LowerLeftArrow: "\u2199",
+  LowerRightArrow: "\u2198",
+  Lscr: "\u2112",
+  Lsh: "\u21B0",
+  Lstrok: "\u0141",
+  Lt: "\u226A",
+  Map: "\u2905",
+  Mcy: "\u041C",
+  MediumSpace: "\u205F",
+  Mellintrf: "\u2133",
+  Mfr: "\u{1D510}",
+  MinusPlus: "\u2213",
+  Mopf: "\u{1D544}",
+  Mscr: "\u2133",
+  Mu: "\u039C",
+  NJcy: "\u040A",
+  Nacute: "\u0143",
+  Ncaron: "\u0147",
+  Ncedil: "\u0145",
+  Ncy: "\u041D",
+  NegativeMediumSpace: "\u200B",
+  NegativeThickSpace: "\u200B",
+  NegativeThinSpace: "\u200B",
+  NegativeVeryThinSpace: "\u200B",
+  NestedGreaterGreater: "\u226B",
+  NestedLessLess: "\u226A",
+  NewLine: "\n",
+  Nfr: "\u{1D511}",
+  NoBreak: "\u2060",
+  NonBreakingSpace: "\xA0",
+  Nopf: "\u2115",
+  Not: "\u2AEC",
+  NotCongruent: "\u2262",
+  NotCupCap: "\u226D",
+  NotDoubleVerticalBar: "\u2226",
+  NotElement: "\u2209",
+  NotEqual: "\u2260",
+  NotEqualTilde: "\u2242\u0338",
+  NotExists: "\u2204",
+  NotGreater: "\u226F",
+  NotGreaterEqual: "\u2271",
+  NotGreaterFullEqual: "\u2267\u0338",
+  NotGreaterGreater: "\u226B\u0338",
+  NotGreaterLess: "\u2279",
+  NotGreaterSlantEqual: "\u2A7E\u0338",
+  NotGreaterTilde: "\u2275",
+  NotHumpDownHump: "\u224E\u0338",
+  NotHumpEqual: "\u224F\u0338",
+  NotLeftTriangle: "\u22EA",
+  NotLeftTriangleBar: "\u29CF\u0338",
+  NotLeftTriangleEqual: "\u22EC",
+  NotLess: "\u226E",
+  NotLessEqual: "\u2270",
+  NotLessGreater: "\u2278",
+  NotLessLess: "\u226A\u0338",
+  NotLessSlantEqual: "\u2A7D\u0338",
+  NotLessTilde: "\u2274",
+  NotNestedGreaterGreater: "\u2AA2\u0338",
+  NotNestedLessLess: "\u2AA1\u0338",
+  NotPrecedes: "\u2280",
+  NotPrecedesEqual: "\u2AAF\u0338",
+  NotPrecedesSlantEqual: "\u22E0",
+  NotReverseElement: "\u220C",
+  NotRightTriangle: "\u22EB",
+  NotRightTriangleBar: "\u29D0\u0338",
+  NotRightTriangleEqual: "\u22ED",
+  NotSquareSubset: "\u228F\u0338",
+  NotSquareSubsetEqual: "\u22E2",
+  NotSquareSuperset: "\u2290\u0338",
+  NotSquareSupersetEqual: "\u22E3",
+  NotSubset: "\u2282\u20D2",
+  NotSubsetEqual: "\u2288",
+  NotSucceeds: "\u2281",
+  NotSucceedsEqual: "\u2AB0\u0338",
+  NotSucceedsSlantEqual: "\u22E1",
+  NotSucceedsTilde: "\u227F\u0338",
+  NotSuperset: "\u2283\u20D2",
+  NotSupersetEqual: "\u2289",
+  NotTilde: "\u2241",
+  NotTildeEqual: "\u2244",
+  NotTildeFullEqual: "\u2247",
+  NotTildeTilde: "\u2249",
+  NotVerticalBar: "\u2224",
+  Nscr: "\u{1D4A9}",
+  Ntilde: "\xD1",
+  Nu: "\u039D",
+  OElig: "\u0152",
+  Oacute: "\xD3",
+  Ocirc: "\xD4",
+  Ocy: "\u041E",
+  Odblac: "\u0150",
+  Ofr: "\u{1D512}",
+  Ograve: "\xD2",
+  Omacr: "\u014C",
+  Omega: "\u03A9",
+  Omicron: "\u039F",
+  Oopf: "\u{1D546}",
+  OpenCurlyDoubleQuote: "\u201C",
+  OpenCurlyQuote: "\u2018",
+  Or: "\u2A54",
+  Oscr: "\u{1D4AA}",
+  Oslash: "\xD8",
+  Otilde: "\xD5",
+  Otimes: "\u2A37",
+  Ouml: "\xD6",
+  OverBar: "\u203E",
+  OverBrace: "\u23DE",
+  OverBracket: "\u23B4",
+  OverParenthesis: "\u23DC",
+  PartialD: "\u2202",
+  Pcy: "\u041F",
+  Pfr: "\u{1D513}",
+  Phi: "\u03A6",
+  Pi: "\u03A0",
+  PlusMinus: "\xB1",
+  Poincareplane: "\u210C",
+  Popf: "\u2119",
+  Pr: "\u2ABB",
+  Precedes: "\u227A",
+  PrecedesEqual: "\u2AAF",
+  PrecedesSlantEqual: "\u227C",
+  PrecedesTilde: "\u227E",
+  Prime: "\u2033",
+  Product: "\u220F",
+  Proportion: "\u2237",
+  Proportional: "\u221D",
+  Pscr: "\u{1D4AB}",
+  Psi: "\u03A8",
+  QUOT: '"',
+  Qfr: "\u{1D514}",
+  Qopf: "\u211A",
+  Qscr: "\u{1D4AC}",
+  RBarr: "\u2910",
+  REG: "\xAE",
+  Racute: "\u0154",
+  Rang: "\u27EB",
+  Rarr: "\u21A0",
+  Rarrtl: "\u2916",
+  Rcaron: "\u0158",
+  Rcedil: "\u0156",
+  Rcy: "\u0420",
+  Re: "\u211C",
+  ReverseElement: "\u220B",
+  ReverseEquilibrium: "\u21CB",
+  ReverseUpEquilibrium: "\u296F",
+  Rfr: "\u211C",
+  Rho: "\u03A1",
+  RightAngleBracket: "\u27E9",
+  RightArrow: "\u2192",
+  RightArrowBar: "\u21E5",
+  RightArrowLeftArrow: "\u21C4",
+  RightCeiling: "\u2309",
+  RightDoubleBracket: "\u27E7",
+  RightDownTeeVector: "\u295D",
+  RightDownVector: "\u21C2",
+  RightDownVectorBar: "\u2955",
+  RightFloor: "\u230B",
+  RightTee: "\u22A2",
+  RightTeeArrow: "\u21A6",
+  RightTeeVector: "\u295B",
+  RightTriangle: "\u22B3",
+  RightTriangleBar: "\u29D0",
+  RightTriangleEqual: "\u22B5",
+  RightUpDownVector: "\u294F",
+  RightUpTeeVector: "\u295C",
+  RightUpVector: "\u21BE",
+  RightUpVectorBar: "\u2954",
+  RightVector: "\u21C0",
+  RightVectorBar: "\u2953",
+  Rightarrow: "\u21D2",
+  Ropf: "\u211D",
+  RoundImplies: "\u2970",
+  Rrightarrow: "\u21DB",
+  Rscr: "\u211B",
+  Rsh: "\u21B1",
+  RuleDelayed: "\u29F4",
+  SHCHcy: "\u0429",
+  SHcy: "\u0428",
+  SOFTcy: "\u042C",
+  Sacute: "\u015A",
+  Sc: "\u2ABC",
+  Scaron: "\u0160",
+  Scedil: "\u015E",
+  Scirc: "\u015C",
+  Scy: "\u0421",
+  Sfr: "\u{1D516}",
+  ShortDownArrow: "\u2193",
+  ShortLeftArrow: "\u2190",
+  ShortRightArrow: "\u2192",
+  ShortUpArrow: "\u2191",
+  Sigma: "\u03A3",
+  SmallCircle: "\u2218",
+  Sopf: "\u{1D54A}",
+  Sqrt: "\u221A",
+  Square: "\u25A1",
+  SquareIntersection: "\u2293",
+  SquareSubset: "\u228F",
+  SquareSubsetEqual: "\u2291",
+  SquareSuperset: "\u2290",
+  SquareSupersetEqual: "\u2292",
+  SquareUnion: "\u2294",
+  Sscr: "\u{1D4AE}",
+  Star: "\u22C6",
+  Sub: "\u22D0",
+  Subset: "\u22D0",
+  SubsetEqual: "\u2286",
+  Succeeds: "\u227B",
+  SucceedsEqual: "\u2AB0",
+  SucceedsSlantEqual: "\u227D",
+  SucceedsTilde: "\u227F",
+  SuchThat: "\u220B",
+  Sum: "\u2211",
+  Sup: "\u22D1",
+  Superset: "\u2283",
+  SupersetEqual: "\u2287",
+  Supset: "\u22D1",
+  THORN: "\xDE",
+  TRADE: "\u2122",
+  TSHcy: "\u040B",
+  TScy: "\u0426",
+  Tab: "	",
+  Tau: "\u03A4",
+  Tcaron: "\u0164",
+  Tcedil: "\u0162",
+  Tcy: "\u0422",
+  Tfr: "\u{1D517}",
+  Therefore: "\u2234",
+  Theta: "\u0398",
+  ThickSpace: "\u205F\u200A",
+  ThinSpace: "\u2009",
+  Tilde: "\u223C",
+  TildeEqual: "\u2243",
+  TildeFullEqual: "\u2245",
+  TildeTilde: "\u2248",
+  Topf: "\u{1D54B}",
+  TripleDot: "\u20DB",
+  Tscr: "\u{1D4AF}",
+  Tstrok: "\u0166",
+  Uacute: "\xDA",
+  Uarr: "\u219F",
+  Uarrocir: "\u2949",
+  Ubrcy: "\u040E",
+  Ubreve: "\u016C",
+  Ucirc: "\xDB",
+  Ucy: "\u0423",
+  Udblac: "\u0170",
+  Ufr: "\u{1D518}",
+  Ugrave: "\xD9",
+  Umacr: "\u016A",
+  UnderBar: "_",
+  UnderBrace: "\u23DF",
+  UnderBracket: "\u23B5",
+  UnderParenthesis: "\u23DD",
+  Union: "\u22C3",
+  UnionPlus: "\u228E",
+  Uogon: "\u0172",
+  Uopf: "\u{1D54C}",
+  UpArrow: "\u2191",
+  UpArrowBar: "\u2912",
+  UpArrowDownArrow: "\u21C5",
+  UpDownArrow: "\u2195",
+  UpEquilibrium: "\u296E",
+  UpTee: "\u22A5",
+  UpTeeArrow: "\u21A5",
+  Uparrow: "\u21D1",
+  Updownarrow: "\u21D5",
+  UpperLeftArrow: "\u2196",
+  UpperRightArrow: "\u2197",
+  Upsi: "\u03D2",
+  Upsilon: "\u03A5",
+  Uring: "\u016E",
+  Uscr: "\u{1D4B0}",
+  Utilde: "\u0168",
+  Uuml: "\xDC",
+  VDash: "\u22AB",
+  Vbar: "\u2AEB",
+  Vcy: "\u0412",
+  Vdash: "\u22A9",
+  Vdashl: "\u2AE6",
+  Vee: "\u22C1",
+  Verbar: "\u2016",
+  Vert: "\u2016",
+  VerticalBar: "\u2223",
+  VerticalLine: "|",
+  VerticalSeparator: "\u2758",
+  VerticalTilde: "\u2240",
+  VeryThinSpace: "\u200A",
+  Vfr: "\u{1D519}",
+  Vopf: "\u{1D54D}",
+  Vscr: "\u{1D4B1}",
+  Vvdash: "\u22AA",
+  Wcirc: "\u0174",
+  Wedge: "\u22C0",
+  Wfr: "\u{1D51A}",
+  Wopf: "\u{1D54E}",
+  Wscr: "\u{1D4B2}",
+  Xfr: "\u{1D51B}",
+  Xi: "\u039E",
+  Xopf: "\u{1D54F}",
+  Xscr: "\u{1D4B3}",
+  YAcy: "\u042F",
+  YIcy: "\u0407",
+  YUcy: "\u042E",
+  Yacute: "\xDD",
+  Ycirc: "\u0176",
+  Ycy: "\u042B",
+  Yfr: "\u{1D51C}",
+  Yopf: "\u{1D550}",
+  Yscr: "\u{1D4B4}",
+  Yuml: "\u0178",
+  ZHcy: "\u0416",
+  Zacute: "\u0179",
+  Zcaron: "\u017D",
+  Zcy: "\u0417",
+  Zdot: "\u017B",
+  ZeroWidthSpace: "\u200B",
+  Zeta: "\u0396",
+  Zfr: "\u2128",
+  Zopf: "\u2124",
+  Zscr: "\u{1D4B5}",
+  aacute: "\xE1",
+  abreve: "\u0103",
+  ac: "\u223E",
+  acE: "\u223E\u0333",
+  acd: "\u223F",
+  acirc: "\xE2",
+  acute: "\xB4",
+  acy: "\u0430",
+  aelig: "\xE6",
+  af: "\u2061",
+  afr: "\u{1D51E}",
+  agrave: "\xE0",
+  alefsym: "\u2135",
+  aleph: "\u2135",
+  alpha: "\u03B1",
+  amacr: "\u0101",
+  amalg: "\u2A3F",
+  amp: "&",
+  and: "\u2227",
+  andand: "\u2A55",
+  andd: "\u2A5C",
+  andslope: "\u2A58",
+  andv: "\u2A5A",
+  ang: "\u2220",
+  ange: "\u29A4",
+  angle: "\u2220",
+  angmsd: "\u2221",
+  angmsdaa: "\u29A8",
+  angmsdab: "\u29A9",
+  angmsdac: "\u29AA",
+  angmsdad: "\u29AB",
+  angmsdae: "\u29AC",
+  angmsdaf: "\u29AD",
+  angmsdag: "\u29AE",
+  angmsdah: "\u29AF",
+  angrt: "\u221F",
+  angrtvb: "\u22BE",
+  angrtvbd: "\u299D",
+  angsph: "\u2222",
+  angst: "\xC5",
+  angzarr: "\u237C",
+  aogon: "\u0105",
+  aopf: "\u{1D552}",
+  ap: "\u2248",
+  apE: "\u2A70",
+  apacir: "\u2A6F",
+  ape: "\u224A",
+  apid: "\u224B",
+  apos: "'",
+  approx: "\u2248",
+  approxeq: "\u224A",
+  aring: "\xE5",
+  ascr: "\u{1D4B6}",
+  ast: "*",
+  asymp: "\u2248",
+  asympeq: "\u224D",
+  atilde: "\xE3",
+  auml: "\xE4",
+  awconint: "\u2233",
+  awint: "\u2A11",
+  bNot: "\u2AED",
+  backcong: "\u224C",
+  backepsilon: "\u03F6",
+  backprime: "\u2035",
+  backsim: "\u223D",
+  backsimeq: "\u22CD",
+  barvee: "\u22BD",
+  barwed: "\u2305",
+  barwedge: "\u2305",
+  bbrk: "\u23B5",
+  bbrktbrk: "\u23B6",
+  bcong: "\u224C",
+  bcy: "\u0431",
+  bdquo: "\u201E",
+  becaus: "\u2235",
+  because: "\u2235",
+  bemptyv: "\u29B0",
+  bepsi: "\u03F6",
+  bernou: "\u212C",
+  beta: "\u03B2",
+  beth: "\u2136",
+  between: "\u226C",
+  bfr: "\u{1D51F}",
+  bigcap: "\u22C2",
+  bigcirc: "\u25EF",
+  bigcup: "\u22C3",
+  bigodot: "\u2A00",
+  bigoplus: "\u2A01",
+  bigotimes: "\u2A02",
+  bigsqcup: "\u2A06",
+  bigstar: "\u2605",
+  bigtriangledown: "\u25BD",
+  bigtriangleup: "\u25B3",
+  biguplus: "\u2A04",
+  bigvee: "\u22C1",
+  bigwedge: "\u22C0",
+  bkarow: "\u290D",
+  blacklozenge: "\u29EB",
+  blacksquare: "\u25AA",
+  blacktriangle: "\u25B4",
+  blacktriangledown: "\u25BE",
+  blacktriangleleft: "\u25C2",
+  blacktriangleright: "\u25B8",
+  blank: "\u2423",
+  blk12: "\u2592",
+  blk14: "\u2591",
+  blk34: "\u2593",
+  block: "\u2588",
+  bne: "=\u20E5",
+  bnequiv: "\u2261\u20E5",
+  bnot: "\u2310",
+  bopf: "\u{1D553}",
+  bot: "\u22A5",
+  bottom: "\u22A5",
+  bowtie: "\u22C8",
+  boxDL: "\u2557",
+  boxDR: "\u2554",
+  boxDl: "\u2556",
+  boxDr: "\u2553",
+  boxH: "\u2550",
+  boxHD: "\u2566",
+  boxHU: "\u2569",
+  boxHd: "\u2564",
+  boxHu: "\u2567",
+  boxUL: "\u255D",
+  boxUR: "\u255A",
+  boxUl: "\u255C",
+  boxUr: "\u2559",
+  boxV: "\u2551",
+  boxVH: "\u256C",
+  boxVL: "\u2563",
+  boxVR: "\u2560",
+  boxVh: "\u256B",
+  boxVl: "\u2562",
+  boxVr: "\u255F",
+  boxbox: "\u29C9",
+  boxdL: "\u2555",
+  boxdR: "\u2552",
+  boxdl: "\u2510",
+  boxdr: "\u250C",
+  boxh: "\u2500",
+  boxhD: "\u2565",
+  boxhU: "\u2568",
+  boxhd: "\u252C",
+  boxhu: "\u2534",
+  boxminus: "\u229F",
+  boxplus: "\u229E",
+  boxtimes: "\u22A0",
+  boxuL: "\u255B",
+  boxuR: "\u2558",
+  boxul: "\u2518",
+  boxur: "\u2514",
+  boxv: "\u2502",
+  boxvH: "\u256A",
+  boxvL: "\u2561",
+  boxvR: "\u255E",
+  boxvh: "\u253C",
+  boxvl: "\u2524",
+  boxvr: "\u251C",
+  bprime: "\u2035",
+  breve: "\u02D8",
+  brvbar: "\xA6",
+  bscr: "\u{1D4B7}",
+  bsemi: "\u204F",
+  bsim: "\u223D",
+  bsime: "\u22CD",
+  bsol: "\\",
+  bsolb: "\u29C5",
+  bsolhsub: "\u27C8",
+  bull: "\u2022",
+  bullet: "\u2022",
+  bump: "\u224E",
+  bumpE: "\u2AAE",
+  bumpe: "\u224F",
+  bumpeq: "\u224F",
+  cacute: "\u0107",
+  cap: "\u2229",
+  capand: "\u2A44",
+  capbrcup: "\u2A49",
+  capcap: "\u2A4B",
+  capcup: "\u2A47",
+  capdot: "\u2A40",
+  caps: "\u2229\uFE00",
+  caret: "\u2041",
+  caron: "\u02C7",
+  ccaps: "\u2A4D",
+  ccaron: "\u010D",
+  ccedil: "\xE7",
+  ccirc: "\u0109",
+  ccups: "\u2A4C",
+  ccupssm: "\u2A50",
+  cdot: "\u010B",
+  cedil: "\xB8",
+  cemptyv: "\u29B2",
+  cent: "\xA2",
+  centerdot: "\xB7",
+  cfr: "\u{1D520}",
+  chcy: "\u0447",
+  check: "\u2713",
+  checkmark: "\u2713",
+  chi: "\u03C7",
+  cir: "\u25CB",
+  cirE: "\u29C3",
+  circ: "\u02C6",
+  circeq: "\u2257",
+  circlearrowleft: "\u21BA",
+  circlearrowright: "\u21BB",
+  circledR: "\xAE",
+  circledS: "\u24C8",
+  circledast: "\u229B",
+  circledcirc: "\u229A",
+  circleddash: "\u229D",
+  cire: "\u2257",
+  cirfnint: "\u2A10",
+  cirmid: "\u2AEF",
+  cirscir: "\u29C2",
+  clubs: "\u2663",
+  clubsuit: "\u2663",
+  colon: ":",
+  colone: "\u2254",
+  coloneq: "\u2254",
+  comma: ",",
+  commat: "@",
+  comp: "\u2201",
+  compfn: "\u2218",
+  complement: "\u2201",
+  complexes: "\u2102",
+  cong: "\u2245",
+  congdot: "\u2A6D",
+  conint: "\u222E",
+  copf: "\u{1D554}",
+  coprod: "\u2210",
+  copy: "\xA9",
+  copysr: "\u2117",
+  crarr: "\u21B5",
+  cross: "\u2717",
+  cscr: "\u{1D4B8}",
+  csub: "\u2ACF",
+  csube: "\u2AD1",
+  csup: "\u2AD0",
+  csupe: "\u2AD2",
+  ctdot: "\u22EF",
+  cudarrl: "\u2938",
+  cudarrr: "\u2935",
+  cuepr: "\u22DE",
+  cuesc: "\u22DF",
+  cularr: "\u21B6",
+  cularrp: "\u293D",
+  cup: "\u222A",
+  cupbrcap: "\u2A48",
+  cupcap: "\u2A46",
+  cupcup: "\u2A4A",
+  cupdot: "\u228D",
+  cupor: "\u2A45",
+  cups: "\u222A\uFE00",
+  curarr: "\u21B7",
+  curarrm: "\u293C",
+  curlyeqprec: "\u22DE",
+  curlyeqsucc: "\u22DF",
+  curlyvee: "\u22CE",
+  curlywedge: "\u22CF",
+  curren: "\xA4",
+  curvearrowleft: "\u21B6",
+  curvearrowright: "\u21B7",
+  cuvee: "\u22CE",
+  cuwed: "\u22CF",
+  cwconint: "\u2232",
+  cwint: "\u2231",
+  cylcty: "\u232D",
+  dArr: "\u21D3",
+  dHar: "\u2965",
+  dagger: "\u2020",
+  daleth: "\u2138",
+  darr: "\u2193",
+  dash: "\u2010",
+  dashv: "\u22A3",
+  dbkarow: "\u290F",
+  dblac: "\u02DD",
+  dcaron: "\u010F",
+  dcy: "\u0434",
+  dd: "\u2146",
+  ddagger: "\u2021",
+  ddarr: "\u21CA",
+  ddotseq: "\u2A77",
+  deg: "\xB0",
+  delta: "\u03B4",
+  demptyv: "\u29B1",
+  dfisht: "\u297F",
+  dfr: "\u{1D521}",
+  dharl: "\u21C3",
+  dharr: "\u21C2",
+  diam: "\u22C4",
+  diamond: "\u22C4",
+  diamondsuit: "\u2666",
+  diams: "\u2666",
+  die: "\xA8",
+  digamma: "\u03DD",
+  disin: "\u22F2",
+  div: "\xF7",
+  divide: "\xF7",
+  divideontimes: "\u22C7",
+  divonx: "\u22C7",
+  djcy: "\u0452",
+  dlcorn: "\u231E",
+  dlcrop: "\u230D",
+  dollar: "$",
+  dopf: "\u{1D555}",
+  dot: "\u02D9",
+  doteq: "\u2250",
+  doteqdot: "\u2251",
+  dotminus: "\u2238",
+  dotplus: "\u2214",
+  dotsquare: "\u22A1",
+  doublebarwedge: "\u2306",
+  downarrow: "\u2193",
+  downdownarrows: "\u21CA",
+  downharpoonleft: "\u21C3",
+  downharpoonright: "\u21C2",
+  drbkarow: "\u2910",
+  drcorn: "\u231F",
+  drcrop: "\u230C",
+  dscr: "\u{1D4B9}",
+  dscy: "\u0455",
+  dsol: "\u29F6",
+  dstrok: "\u0111",
+  dtdot: "\u22F1",
+  dtri: "\u25BF",
+  dtrif: "\u25BE",
+  duarr: "\u21F5",
+  duhar: "\u296F",
+  dwangle: "\u29A6",
+  dzcy: "\u045F",
+  dzigrarr: "\u27FF",
+  eDDot: "\u2A77",
+  eDot: "\u2251",
+  eacute: "\xE9",
+  easter: "\u2A6E",
+  ecaron: "\u011B",
+  ecir: "\u2256",
+  ecirc: "\xEA",
+  ecolon: "\u2255",
+  ecy: "\u044D",
+  edot: "\u0117",
+  ee: "\u2147",
+  efDot: "\u2252",
+  efr: "\u{1D522}",
+  eg: "\u2A9A",
+  egrave: "\xE8",
+  egs: "\u2A96",
+  egsdot: "\u2A98",
+  el: "\u2A99",
+  elinters: "\u23E7",
+  ell: "\u2113",
+  els: "\u2A95",
+  elsdot: "\u2A97",
+  emacr: "\u0113",
+  empty: "\u2205",
+  emptyset: "\u2205",
+  emptyv: "\u2205",
+  emsp13: "\u2004",
+  emsp14: "\u2005",
+  emsp: "\u2003",
+  eng: "\u014B",
+  ensp: "\u2002",
+  eogon: "\u0119",
+  eopf: "\u{1D556}",
+  epar: "\u22D5",
+  eparsl: "\u29E3",
+  eplus: "\u2A71",
+  epsi: "\u03B5",
+  epsilon: "\u03B5",
+  epsiv: "\u03F5",
+  eqcirc: "\u2256",
+  eqcolon: "\u2255",
+  eqsim: "\u2242",
+  eqslantgtr: "\u2A96",
+  eqslantless: "\u2A95",
+  equals: "=",
+  equest: "\u225F",
+  equiv: "\u2261",
+  equivDD: "\u2A78",
+  eqvparsl: "\u29E5",
+  erDot: "\u2253",
+  erarr: "\u2971",
+  escr: "\u212F",
+  esdot: "\u2250",
+  esim: "\u2242",
+  eta: "\u03B7",
+  eth: "\xF0",
+  euml: "\xEB",
+  euro: "\u20AC",
+  excl: "!",
+  exist: "\u2203",
+  expectation: "\u2130",
+  exponentiale: "\u2147",
+  fallingdotseq: "\u2252",
+  fcy: "\u0444",
+  female: "\u2640",
+  ffilig: "\uFB03",
+  fflig: "\uFB00",
+  ffllig: "\uFB04",
+  ffr: "\u{1D523}",
+  filig: "\uFB01",
+  fjlig: "fj",
+  flat: "\u266D",
+  fllig: "\uFB02",
+  fltns: "\u25B1",
+  fnof: "\u0192",
+  fopf: "\u{1D557}",
+  forall: "\u2200",
+  fork: "\u22D4",
+  forkv: "\u2AD9",
+  fpartint: "\u2A0D",
+  frac12: "\xBD",
+  frac13: "\u2153",
+  frac14: "\xBC",
+  frac15: "\u2155",
+  frac16: "\u2159",
+  frac18: "\u215B",
+  frac23: "\u2154",
+  frac25: "\u2156",
+  frac34: "\xBE",
+  frac35: "\u2157",
+  frac38: "\u215C",
+  frac45: "\u2158",
+  frac56: "\u215A",
+  frac58: "\u215D",
+  frac78: "\u215E",
+  frasl: "\u2044",
+  frown: "\u2322",
+  fscr: "\u{1D4BB}",
+  gE: "\u2267",
+  gEl: "\u2A8C",
+  gacute: "\u01F5",
+  gamma: "\u03B3",
+  gammad: "\u03DD",
+  gap: "\u2A86",
+  gbreve: "\u011F",
+  gcirc: "\u011D",
+  gcy: "\u0433",
+  gdot: "\u0121",
+  ge: "\u2265",
+  gel: "\u22DB",
+  geq: "\u2265",
+  geqq: "\u2267",
+  geqslant: "\u2A7E",
+  ges: "\u2A7E",
+  gescc: "\u2AA9",
+  gesdot: "\u2A80",
+  gesdoto: "\u2A82",
+  gesdotol: "\u2A84",
+  gesl: "\u22DB\uFE00",
+  gesles: "\u2A94",
+  gfr: "\u{1D524}",
+  gg: "\u226B",
+  ggg: "\u22D9",
+  gimel: "\u2137",
+  gjcy: "\u0453",
+  gl: "\u2277",
+  glE: "\u2A92",
+  gla: "\u2AA5",
+  glj: "\u2AA4",
+  gnE: "\u2269",
+  gnap: "\u2A8A",
+  gnapprox: "\u2A8A",
+  gne: "\u2A88",
+  gneq: "\u2A88",
+  gneqq: "\u2269",
+  gnsim: "\u22E7",
+  gopf: "\u{1D558}",
+  grave: "`",
+  gscr: "\u210A",
+  gsim: "\u2273",
+  gsime: "\u2A8E",
+  gsiml: "\u2A90",
+  gt: ">",
+  gtcc: "\u2AA7",
+  gtcir: "\u2A7A",
+  gtdot: "\u22D7",
+  gtlPar: "\u2995",
+  gtquest: "\u2A7C",
+  gtrapprox: "\u2A86",
+  gtrarr: "\u2978",
+  gtrdot: "\u22D7",
+  gtreqless: "\u22DB",
+  gtreqqless: "\u2A8C",
+  gtrless: "\u2277",
+  gtrsim: "\u2273",
+  gvertneqq: "\u2269\uFE00",
+  gvnE: "\u2269\uFE00",
+  hArr: "\u21D4",
+  hairsp: "\u200A",
+  half: "\xBD",
+  hamilt: "\u210B",
+  hardcy: "\u044A",
+  harr: "\u2194",
+  harrcir: "\u2948",
+  harrw: "\u21AD",
+  hbar: "\u210F",
+  hcirc: "\u0125",
+  hearts: "\u2665",
+  heartsuit: "\u2665",
+  hellip: "\u2026",
+  hercon: "\u22B9",
+  hfr: "\u{1D525}",
+  hksearow: "\u2925",
+  hkswarow: "\u2926",
+  hoarr: "\u21FF",
+  homtht: "\u223B",
+  hookleftarrow: "\u21A9",
+  hookrightarrow: "\u21AA",
+  hopf: "\u{1D559}",
+  horbar: "\u2015",
+  hscr: "\u{1D4BD}",
+  hslash: "\u210F",
+  hstrok: "\u0127",
+  hybull: "\u2043",
+  hyphen: "\u2010",
+  iacute: "\xED",
+  ic: "\u2063",
+  icirc: "\xEE",
+  icy: "\u0438",
+  iecy: "\u0435",
+  iexcl: "\xA1",
+  iff: "\u21D4",
+  ifr: "\u{1D526}",
+  igrave: "\xEC",
+  ii: "\u2148",
+  iiiint: "\u2A0C",
+  iiint: "\u222D",
+  iinfin: "\u29DC",
+  iiota: "\u2129",
+  ijlig: "\u0133",
+  imacr: "\u012B",
+  image: "\u2111",
+  imagline: "\u2110",
+  imagpart: "\u2111",
+  imath: "\u0131",
+  imof: "\u22B7",
+  imped: "\u01B5",
+  in: "\u2208",
+  incare: "\u2105",
+  infin: "\u221E",
+  infintie: "\u29DD",
+  inodot: "\u0131",
+  int: "\u222B",
+  intcal: "\u22BA",
+  integers: "\u2124",
+  intercal: "\u22BA",
+  intlarhk: "\u2A17",
+  intprod: "\u2A3C",
+  iocy: "\u0451",
+  iogon: "\u012F",
+  iopf: "\u{1D55A}",
+  iota: "\u03B9",
+  iprod: "\u2A3C",
+  iquest: "\xBF",
+  iscr: "\u{1D4BE}",
+  isin: "\u2208",
+  isinE: "\u22F9",
+  isindot: "\u22F5",
+  isins: "\u22F4",
+  isinsv: "\u22F3",
+  isinv: "\u2208",
+  it: "\u2062",
+  itilde: "\u0129",
+  iukcy: "\u0456",
+  iuml: "\xEF",
+  jcirc: "\u0135",
+  jcy: "\u0439",
+  jfr: "\u{1D527}",
+  jmath: "\u0237",
+  jopf: "\u{1D55B}",
+  jscr: "\u{1D4BF}",
+  jsercy: "\u0458",
+  jukcy: "\u0454",
+  kappa: "\u03BA",
+  kappav: "\u03F0",
+  kcedil: "\u0137",
+  kcy: "\u043A",
+  kfr: "\u{1D528}",
+  kgreen: "\u0138",
+  khcy: "\u0445",
+  kjcy: "\u045C",
+  kopf: "\u{1D55C}",
+  kscr: "\u{1D4C0}",
+  lAarr: "\u21DA",
+  lArr: "\u21D0",
+  lAtail: "\u291B",
+  lBarr: "\u290E",
+  lE: "\u2266",
+  lEg: "\u2A8B",
+  lHar: "\u2962",
+  lacute: "\u013A",
+  laemptyv: "\u29B4",
+  lagran: "\u2112",
+  lambda: "\u03BB",
+  lang: "\u27E8",
+  langd: "\u2991",
+  langle: "\u27E8",
+  lap: "\u2A85",
+  laquo: "\xAB",
+  larr: "\u2190",
+  larrb: "\u21E4",
+  larrbfs: "\u291F",
+  larrfs: "\u291D",
+  larrhk: "\u21A9",
+  larrlp: "\u21AB",
+  larrpl: "\u2939",
+  larrsim: "\u2973",
+  larrtl: "\u21A2",
+  lat: "\u2AAB",
+  latail: "\u2919",
+  late: "\u2AAD",
+  lates: "\u2AAD\uFE00",
+  lbarr: "\u290C",
+  lbbrk: "\u2772",
+  lbrace: "{",
+  lbrack: "[",
+  lbrke: "\u298B",
+  lbrksld: "\u298F",
+  lbrkslu: "\u298D",
+  lcaron: "\u013E",
+  lcedil: "\u013C",
+  lceil: "\u2308",
+  lcub: "{",
+  lcy: "\u043B",
+  ldca: "\u2936",
+  ldquo: "\u201C",
+  ldquor: "\u201E",
+  ldrdhar: "\u2967",
+  ldrushar: "\u294B",
+  ldsh: "\u21B2",
+  le: "\u2264",
+  leftarrow: "\u2190",
+  leftarrowtail: "\u21A2",
+  leftharpoondown: "\u21BD",
+  leftharpoonup: "\u21BC",
+  leftleftarrows: "\u21C7",
+  leftrightarrow: "\u2194",
+  leftrightarrows: "\u21C6",
+  leftrightharpoons: "\u21CB",
+  leftrightsquigarrow: "\u21AD",
+  leftthreetimes: "\u22CB",
+  leg: "\u22DA",
+  leq: "\u2264",
+  leqq: "\u2266",
+  leqslant: "\u2A7D",
+  les: "\u2A7D",
+  lescc: "\u2AA8",
+  lesdot: "\u2A7F",
+  lesdoto: "\u2A81",
+  lesdotor: "\u2A83",
+  lesg: "\u22DA\uFE00",
+  lesges: "\u2A93",
+  lessapprox: "\u2A85",
+  lessdot: "\u22D6",
+  lesseqgtr: "\u22DA",
+  lesseqqgtr: "\u2A8B",
+  lessgtr: "\u2276",
+  lesssim: "\u2272",
+  lfisht: "\u297C",
+  lfloor: "\u230A",
+  lfr: "\u{1D529}",
+  lg: "\u2276",
+  lgE: "\u2A91",
+  lhard: "\u21BD",
+  lharu: "\u21BC",
+  lharul: "\u296A",
+  lhblk: "\u2584",
+  ljcy: "\u0459",
+  ll: "\u226A",
+  llarr: "\u21C7",
+  llcorner: "\u231E",
+  llhard: "\u296B",
+  lltri: "\u25FA",
+  lmidot: "\u0140",
+  lmoust: "\u23B0",
+  lmoustache: "\u23B0",
+  lnE: "\u2268",
+  lnap: "\u2A89",
+  lnapprox: "\u2A89",
+  lne: "\u2A87",
+  lneq: "\u2A87",
+  lneqq: "\u2268",
+  lnsim: "\u22E6",
+  loang: "\u27EC",
+  loarr: "\u21FD",
+  lobrk: "\u27E6",
+  longleftarrow: "\u27F5",
+  longleftrightarrow: "\u27F7",
+  longmapsto: "\u27FC",
+  longrightarrow: "\u27F6",
+  looparrowleft: "\u21AB",
+  looparrowright: "\u21AC",
+  lopar: "\u2985",
+  lopf: "\u{1D55D}",
+  loplus: "\u2A2D",
+  lotimes: "\u2A34",
+  lowast: "\u2217",
+  lowbar: "_",
+  loz: "\u25CA",
+  lozenge: "\u25CA",
+  lozf: "\u29EB",
+  lpar: "(",
+  lparlt: "\u2993",
+  lrarr: "\u21C6",
+  lrcorner: "\u231F",
+  lrhar: "\u21CB",
+  lrhard: "\u296D",
+  lrm: "\u200E",
+  lrtri: "\u22BF",
+  lsaquo: "\u2039",
+  lscr: "\u{1D4C1}",
+  lsh: "\u21B0",
+  lsim: "\u2272",
+  lsime: "\u2A8D",
+  lsimg: "\u2A8F",
+  lsqb: "[",
+  lsquo: "\u2018",
+  lsquor: "\u201A",
+  lstrok: "\u0142",
+  lt: "<",
+  ltcc: "\u2AA6",
+  ltcir: "\u2A79",
+  ltdot: "\u22D6",
+  lthree: "\u22CB",
+  ltimes: "\u22C9",
+  ltlarr: "\u2976",
+  ltquest: "\u2A7B",
+  ltrPar: "\u2996",
+  ltri: "\u25C3",
+  ltrie: "\u22B4",
+  ltrif: "\u25C2",
+  lurdshar: "\u294A",
+  luruhar: "\u2966",
+  lvertneqq: "\u2268\uFE00",
+  lvnE: "\u2268\uFE00",
+  mDDot: "\u223A",
+  macr: "\xAF",
+  male: "\u2642",
+  malt: "\u2720",
+  maltese: "\u2720",
+  map: "\u21A6",
+  mapsto: "\u21A6",
+  mapstodown: "\u21A7",
+  mapstoleft: "\u21A4",
+  mapstoup: "\u21A5",
+  marker: "\u25AE",
+  mcomma: "\u2A29",
+  mcy: "\u043C",
+  mdash: "\u2014",
+  measuredangle: "\u2221",
+  mfr: "\u{1D52A}",
+  mho: "\u2127",
+  micro: "\xB5",
+  mid: "\u2223",
+  midast: "*",
+  midcir: "\u2AF0",
+  middot: "\xB7",
+  minus: "\u2212",
+  minusb: "\u229F",
+  minusd: "\u2238",
+  minusdu: "\u2A2A",
+  mlcp: "\u2ADB",
+  mldr: "\u2026",
+  mnplus: "\u2213",
+  models: "\u22A7",
+  mopf: "\u{1D55E}",
+  mp: "\u2213",
+  mscr: "\u{1D4C2}",
+  mstpos: "\u223E",
+  mu: "\u03BC",
+  multimap: "\u22B8",
+  mumap: "\u22B8",
+  nGg: "\u22D9\u0338",
+  nGt: "\u226B\u20D2",
+  nGtv: "\u226B\u0338",
+  nLeftarrow: "\u21CD",
+  nLeftrightarrow: "\u21CE",
+  nLl: "\u22D8\u0338",
+  nLt: "\u226A\u20D2",
+  nLtv: "\u226A\u0338",
+  nRightarrow: "\u21CF",
+  nVDash: "\u22AF",
+  nVdash: "\u22AE",
+  nabla: "\u2207",
+  nacute: "\u0144",
+  nang: "\u2220\u20D2",
+  nap: "\u2249",
+  napE: "\u2A70\u0338",
+  napid: "\u224B\u0338",
+  napos: "\u0149",
+  napprox: "\u2249",
+  natur: "\u266E",
+  natural: "\u266E",
+  naturals: "\u2115",
+  nbsp: "\xA0",
+  nbump: "\u224E\u0338",
+  nbumpe: "\u224F\u0338",
+  ncap: "\u2A43",
+  ncaron: "\u0148",
+  ncedil: "\u0146",
+  ncong: "\u2247",
+  ncongdot: "\u2A6D\u0338",
+  ncup: "\u2A42",
+  ncy: "\u043D",
+  ndash: "\u2013",
+  ne: "\u2260",
+  neArr: "\u21D7",
+  nearhk: "\u2924",
+  nearr: "\u2197",
+  nearrow: "\u2197",
+  nedot: "\u2250\u0338",
+  nequiv: "\u2262",
+  nesear: "\u2928",
+  nesim: "\u2242\u0338",
+  nexist: "\u2204",
+  nexists: "\u2204",
+  nfr: "\u{1D52B}",
+  ngE: "\u2267\u0338",
+  nge: "\u2271",
+  ngeq: "\u2271",
+  ngeqq: "\u2267\u0338",
+  ngeqslant: "\u2A7E\u0338",
+  nges: "\u2A7E\u0338",
+  ngsim: "\u2275",
+  ngt: "\u226F",
+  ngtr: "\u226F",
+  nhArr: "\u21CE",
+  nharr: "\u21AE",
+  nhpar: "\u2AF2",
+  ni: "\u220B",
+  nis: "\u22FC",
+  nisd: "\u22FA",
+  niv: "\u220B",
+  njcy: "\u045A",
+  nlArr: "\u21CD",
+  nlE: "\u2266\u0338",
+  nlarr: "\u219A",
+  nldr: "\u2025",
+  nle: "\u2270",
+  nleftarrow: "\u219A",
+  nleftrightarrow: "\u21AE",
+  nleq: "\u2270",
+  nleqq: "\u2266\u0338",
+  nleqslant: "\u2A7D\u0338",
+  nles: "\u2A7D\u0338",
+  nless: "\u226E",
+  nlsim: "\u2274",
+  nlt: "\u226E",
+  nltri: "\u22EA",
+  nltrie: "\u22EC",
+  nmid: "\u2224",
+  nopf: "\u{1D55F}",
+  not: "\xAC",
+  notin: "\u2209",
+  notinE: "\u22F9\u0338",
+  notindot: "\u22F5\u0338",
+  notinva: "\u2209",
+  notinvb: "\u22F7",
+  notinvc: "\u22F6",
+  notni: "\u220C",
+  notniva: "\u220C",
+  notnivb: "\u22FE",
+  notnivc: "\u22FD",
+  npar: "\u2226",
+  nparallel: "\u2226",
+  nparsl: "\u2AFD\u20E5",
+  npart: "\u2202\u0338",
+  npolint: "\u2A14",
+  npr: "\u2280",
+  nprcue: "\u22E0",
+  npre: "\u2AAF\u0338",
+  nprec: "\u2280",
+  npreceq: "\u2AAF\u0338",
+  nrArr: "\u21CF",
+  nrarr: "\u219B",
+  nrarrc: "\u2933\u0338",
+  nrarrw: "\u219D\u0338",
+  nrightarrow: "\u219B",
+  nrtri: "\u22EB",
+  nrtrie: "\u22ED",
+  nsc: "\u2281",
+  nsccue: "\u22E1",
+  nsce: "\u2AB0\u0338",
+  nscr: "\u{1D4C3}",
+  nshortmid: "\u2224",
+  nshortparallel: "\u2226",
+  nsim: "\u2241",
+  nsime: "\u2244",
+  nsimeq: "\u2244",
+  nsmid: "\u2224",
+  nspar: "\u2226",
+  nsqsube: "\u22E2",
+  nsqsupe: "\u22E3",
+  nsub: "\u2284",
+  nsubE: "\u2AC5\u0338",
+  nsube: "\u2288",
+  nsubset: "\u2282\u20D2",
+  nsubseteq: "\u2288",
+  nsubseteqq: "\u2AC5\u0338",
+  nsucc: "\u2281",
+  nsucceq: "\u2AB0\u0338",
+  nsup: "\u2285",
+  nsupE: "\u2AC6\u0338",
+  nsupe: "\u2289",
+  nsupset: "\u2283\u20D2",
+  nsupseteq: "\u2289",
+  nsupseteqq: "\u2AC6\u0338",
+  ntgl: "\u2279",
+  ntilde: "\xF1",
+  ntlg: "\u2278",
+  ntriangleleft: "\u22EA",
+  ntrianglelefteq: "\u22EC",
+  ntriangleright: "\u22EB",
+  ntrianglerighteq: "\u22ED",
+  nu: "\u03BD",
+  num: "#",
+  numero: "\u2116",
+  numsp: "\u2007",
+  nvDash: "\u22AD",
+  nvHarr: "\u2904",
+  nvap: "\u224D\u20D2",
+  nvdash: "\u22AC",
+  nvge: "\u2265\u20D2",
+  nvgt: ">\u20D2",
+  nvinfin: "\u29DE",
+  nvlArr: "\u2902",
+  nvle: "\u2264\u20D2",
+  nvlt: "<\u20D2",
+  nvltrie: "\u22B4\u20D2",
+  nvrArr: "\u2903",
+  nvrtrie: "\u22B5\u20D2",
+  nvsim: "\u223C\u20D2",
+  nwArr: "\u21D6",
+  nwarhk: "\u2923",
+  nwarr: "\u2196",
+  nwarrow: "\u2196",
+  nwnear: "\u2927",
+  oS: "\u24C8",
+  oacute: "\xF3",
+  oast: "\u229B",
+  ocir: "\u229A",
+  ocirc: "\xF4",
+  ocy: "\u043E",
+  odash: "\u229D",
+  odblac: "\u0151",
+  odiv: "\u2A38",
+  odot: "\u2299",
+  odsold: "\u29BC",
+  oelig: "\u0153",
+  ofcir: "\u29BF",
+  ofr: "\u{1D52C}",
+  ogon: "\u02DB",
+  ograve: "\xF2",
+  ogt: "\u29C1",
+  ohbar: "\u29B5",
+  ohm: "\u03A9",
+  oint: "\u222E",
+  olarr: "\u21BA",
+  olcir: "\u29BE",
+  olcross: "\u29BB",
+  oline: "\u203E",
+  olt: "\u29C0",
+  omacr: "\u014D",
+  omega: "\u03C9",
+  omicron: "\u03BF",
+  omid: "\u29B6",
+  ominus: "\u2296",
+  oopf: "\u{1D560}",
+  opar: "\u29B7",
+  operp: "\u29B9",
+  oplus: "\u2295",
+  or: "\u2228",
+  orarr: "\u21BB",
+  ord: "\u2A5D",
+  order: "\u2134",
+  orderof: "\u2134",
+  ordf: "\xAA",
+  ordm: "\xBA",
+  origof: "\u22B6",
+  oror: "\u2A56",
+  orslope: "\u2A57",
+  orv: "\u2A5B",
+  oscr: "\u2134",
+  oslash: "\xF8",
+  osol: "\u2298",
+  otilde: "\xF5",
+  otimes: "\u2297",
+  otimesas: "\u2A36",
+  ouml: "\xF6",
+  ovbar: "\u233D",
+  par: "\u2225",
+  para: "\xB6",
+  parallel: "\u2225",
+  parsim: "\u2AF3",
+  parsl: "\u2AFD",
+  part: "\u2202",
+  pcy: "\u043F",
+  percnt: "%",
+  period: ".",
+  permil: "\u2030",
+  perp: "\u22A5",
+  pertenk: "\u2031",
+  pfr: "\u{1D52D}",
+  phi: "\u03C6",
+  phiv: "\u03D5",
+  phmmat: "\u2133",
+  phone: "\u260E",
+  pi: "\u03C0",
+  pitchfork: "\u22D4",
+  piv: "\u03D6",
+  planck: "\u210F",
+  planckh: "\u210E",
+  plankv: "\u210F",
+  plus: "+",
+  plusacir: "\u2A23",
+  plusb: "\u229E",
+  pluscir: "\u2A22",
+  plusdo: "\u2214",
+  plusdu: "\u2A25",
+  pluse: "\u2A72",
+  plusmn: "\xB1",
+  plussim: "\u2A26",
+  plustwo: "\u2A27",
+  pm: "\xB1",
+  pointint: "\u2A15",
+  popf: "\u{1D561}",
+  pound: "\xA3",
+  pr: "\u227A",
+  prE: "\u2AB3",
+  prap: "\u2AB7",
+  prcue: "\u227C",
+  pre: "\u2AAF",
+  prec: "\u227A",
+  precapprox: "\u2AB7",
+  preccurlyeq: "\u227C",
+  preceq: "\u2AAF",
+  precnapprox: "\u2AB9",
+  precneqq: "\u2AB5",
+  precnsim: "\u22E8",
+  precsim: "\u227E",
+  prime: "\u2032",
+  primes: "\u2119",
+  prnE: "\u2AB5",
+  prnap: "\u2AB9",
+  prnsim: "\u22E8",
+  prod: "\u220F",
+  profalar: "\u232E",
+  profline: "\u2312",
+  profsurf: "\u2313",
+  prop: "\u221D",
+  propto: "\u221D",
+  prsim: "\u227E",
+  prurel: "\u22B0",
+  pscr: "\u{1D4C5}",
+  psi: "\u03C8",
+  puncsp: "\u2008",
+  qfr: "\u{1D52E}",
+  qint: "\u2A0C",
+  qopf: "\u{1D562}",
+  qprime: "\u2057",
+  qscr: "\u{1D4C6}",
+  quaternions: "\u210D",
+  quatint: "\u2A16",
+  quest: "?",
+  questeq: "\u225F",
+  quot: '"',
+  rAarr: "\u21DB",
+  rArr: "\u21D2",
+  rAtail: "\u291C",
+  rBarr: "\u290F",
+  rHar: "\u2964",
+  race: "\u223D\u0331",
+  racute: "\u0155",
+  radic: "\u221A",
+  raemptyv: "\u29B3",
+  rang: "\u27E9",
+  rangd: "\u2992",
+  range: "\u29A5",
+  rangle: "\u27E9",
+  raquo: "\xBB",
+  rarr: "\u2192",
+  rarrap: "\u2975",
+  rarrb: "\u21E5",
+  rarrbfs: "\u2920",
+  rarrc: "\u2933",
+  rarrfs: "\u291E",
+  rarrhk: "\u21AA",
+  rarrlp: "\u21AC",
+  rarrpl: "\u2945",
+  rarrsim: "\u2974",
+  rarrtl: "\u21A3",
+  rarrw: "\u219D",
+  ratail: "\u291A",
+  ratio: "\u2236",
+  rationals: "\u211A",
+  rbarr: "\u290D",
+  rbbrk: "\u2773",
+  rbrace: "}",
+  rbrack: "]",
+  rbrke: "\u298C",
+  rbrksld: "\u298E",
+  rbrkslu: "\u2990",
+  rcaron: "\u0159",
+  rcedil: "\u0157",
+  rceil: "\u2309",
+  rcub: "}",
+  rcy: "\u0440",
+  rdca: "\u2937",
+  rdldhar: "\u2969",
+  rdquo: "\u201D",
+  rdquor: "\u201D",
+  rdsh: "\u21B3",
+  real: "\u211C",
+  realine: "\u211B",
+  realpart: "\u211C",
+  reals: "\u211D",
+  rect: "\u25AD",
+  reg: "\xAE",
+  rfisht: "\u297D",
+  rfloor: "\u230B",
+  rfr: "\u{1D52F}",
+  rhard: "\u21C1",
+  rharu: "\u21C0",
+  rharul: "\u296C",
+  rho: "\u03C1",
+  rhov: "\u03F1",
+  rightarrow: "\u2192",
+  rightarrowtail: "\u21A3",
+  rightharpoondown: "\u21C1",
+  rightharpoonup: "\u21C0",
+  rightleftarrows: "\u21C4",
+  rightleftharpoons: "\u21CC",
+  rightrightarrows: "\u21C9",
+  rightsquigarrow: "\u219D",
+  rightthreetimes: "\u22CC",
+  ring: "\u02DA",
+  risingdotseq: "\u2253",
+  rlarr: "\u21C4",
+  rlhar: "\u21CC",
+  rlm: "\u200F",
+  rmoust: "\u23B1",
+  rmoustache: "\u23B1",
+  rnmid: "\u2AEE",
+  roang: "\u27ED",
+  roarr: "\u21FE",
+  robrk: "\u27E7",
+  ropar: "\u2986",
+  ropf: "\u{1D563}",
+  roplus: "\u2A2E",
+  rotimes: "\u2A35",
+  rpar: ")",
+  rpargt: "\u2994",
+  rppolint: "\u2A12",
+  rrarr: "\u21C9",
+  rsaquo: "\u203A",
+  rscr: "\u{1D4C7}",
+  rsh: "\u21B1",
+  rsqb: "]",
+  rsquo: "\u2019",
+  rsquor: "\u2019",
+  rthree: "\u22CC",
+  rtimes: "\u22CA",
+  rtri: "\u25B9",
+  rtrie: "\u22B5",
+  rtrif: "\u25B8",
+  rtriltri: "\u29CE",
+  ruluhar: "\u2968",
+  rx: "\u211E",
+  sacute: "\u015B",
+  sbquo: "\u201A",
+  sc: "\u227B",
+  scE: "\u2AB4",
+  scap: "\u2AB8",
+  scaron: "\u0161",
+  sccue: "\u227D",
+  sce: "\u2AB0",
+  scedil: "\u015F",
+  scirc: "\u015D",
+  scnE: "\u2AB6",
+  scnap: "\u2ABA",
+  scnsim: "\u22E9",
+  scpolint: "\u2A13",
+  scsim: "\u227F",
+  scy: "\u0441",
+  sdot: "\u22C5",
+  sdotb: "\u22A1",
+  sdote: "\u2A66",
+  seArr: "\u21D8",
+  searhk: "\u2925",
+  searr: "\u2198",
+  searrow: "\u2198",
+  sect: "\xA7",
+  semi: ";",
+  seswar: "\u2929",
+  setminus: "\u2216",
+  setmn: "\u2216",
+  sext: "\u2736",
+  sfr: "\u{1D530}",
+  sfrown: "\u2322",
+  sharp: "\u266F",
+  shchcy: "\u0449",
+  shcy: "\u0448",
+  shortmid: "\u2223",
+  shortparallel: "\u2225",
+  shy: "\xAD",
+  sigma: "\u03C3",
+  sigmaf: "\u03C2",
+  sigmav: "\u03C2",
+  sim: "\u223C",
+  simdot: "\u2A6A",
+  sime: "\u2243",
+  simeq: "\u2243",
+  simg: "\u2A9E",
+  simgE: "\u2AA0",
+  siml: "\u2A9D",
+  simlE: "\u2A9F",
+  simne: "\u2246",
+  simplus: "\u2A24",
+  simrarr: "\u2972",
+  slarr: "\u2190",
+  smallsetminus: "\u2216",
+  smashp: "\u2A33",
+  smeparsl: "\u29E4",
+  smid: "\u2223",
+  smile: "\u2323",
+  smt: "\u2AAA",
+  smte: "\u2AAC",
+  smtes: "\u2AAC\uFE00",
+  softcy: "\u044C",
+  sol: "/",
+  solb: "\u29C4",
+  solbar: "\u233F",
+  sopf: "\u{1D564}",
+  spades: "\u2660",
+  spadesuit: "\u2660",
+  spar: "\u2225",
+  sqcap: "\u2293",
+  sqcaps: "\u2293\uFE00",
+  sqcup: "\u2294",
+  sqcups: "\u2294\uFE00",
+  sqsub: "\u228F",
+  sqsube: "\u2291",
+  sqsubset: "\u228F",
+  sqsubseteq: "\u2291",
+  sqsup: "\u2290",
+  sqsupe: "\u2292",
+  sqsupset: "\u2290",
+  sqsupseteq: "\u2292",
+  squ: "\u25A1",
+  square: "\u25A1",
+  squarf: "\u25AA",
+  squf: "\u25AA",
+  srarr: "\u2192",
+  sscr: "\u{1D4C8}",
+  ssetmn: "\u2216",
+  ssmile: "\u2323",
+  sstarf: "\u22C6",
+  star: "\u2606",
+  starf: "\u2605",
+  straightepsilon: "\u03F5",
+  straightphi: "\u03D5",
+  strns: "\xAF",
+  sub: "\u2282",
+  subE: "\u2AC5",
+  subdot: "\u2ABD",
+  sube: "\u2286",
+  subedot: "\u2AC3",
+  submult: "\u2AC1",
+  subnE: "\u2ACB",
+  subne: "\u228A",
+  subplus: "\u2ABF",
+  subrarr: "\u2979",
+  subset: "\u2282",
+  subseteq: "\u2286",
+  subseteqq: "\u2AC5",
+  subsetneq: "\u228A",
+  subsetneqq: "\u2ACB",
+  subsim: "\u2AC7",
+  subsub: "\u2AD5",
+  subsup: "\u2AD3",
+  succ: "\u227B",
+  succapprox: "\u2AB8",
+  succcurlyeq: "\u227D",
+  succeq: "\u2AB0",
+  succnapprox: "\u2ABA",
+  succneqq: "\u2AB6",
+  succnsim: "\u22E9",
+  succsim: "\u227F",
+  sum: "\u2211",
+  sung: "\u266A",
+  sup1: "\xB9",
+  sup2: "\xB2",
+  sup3: "\xB3",
+  sup: "\u2283",
+  supE: "\u2AC6",
+  supdot: "\u2ABE",
+  supdsub: "\u2AD8",
+  supe: "\u2287",
+  supedot: "\u2AC4",
+  suphsol: "\u27C9",
+  suphsub: "\u2AD7",
+  suplarr: "\u297B",
+  supmult: "\u2AC2",
+  supnE: "\u2ACC",
+  supne: "\u228B",
+  supplus: "\u2AC0",
+  supset: "\u2283",
+  supseteq: "\u2287",
+  supseteqq: "\u2AC6",
+  supsetneq: "\u228B",
+  supsetneqq: "\u2ACC",
+  supsim: "\u2AC8",
+  supsub: "\u2AD4",
+  supsup: "\u2AD6",
+  swArr: "\u21D9",
+  swarhk: "\u2926",
+  swarr: "\u2199",
+  swarrow: "\u2199",
+  swnwar: "\u292A",
+  szlig: "\xDF",
+  target: "\u2316",
+  tau: "\u03C4",
+  tbrk: "\u23B4",
+  tcaron: "\u0165",
+  tcedil: "\u0163",
+  tcy: "\u0442",
+  tdot: "\u20DB",
+  telrec: "\u2315",
+  tfr: "\u{1D531}",
+  there4: "\u2234",
+  therefore: "\u2234",
+  theta: "\u03B8",
+  thetasym: "\u03D1",
+  thetav: "\u03D1",
+  thickapprox: "\u2248",
+  thicksim: "\u223C",
+  thinsp: "\u2009",
+  thkap: "\u2248",
+  thksim: "\u223C",
+  thorn: "\xFE",
+  tilde: "\u02DC",
+  times: "\xD7",
+  timesb: "\u22A0",
+  timesbar: "\u2A31",
+  timesd: "\u2A30",
+  tint: "\u222D",
+  toea: "\u2928",
+  top: "\u22A4",
+  topbot: "\u2336",
+  topcir: "\u2AF1",
+  topf: "\u{1D565}",
+  topfork: "\u2ADA",
+  tosa: "\u2929",
+  tprime: "\u2034",
+  trade: "\u2122",
+  triangle: "\u25B5",
+  triangledown: "\u25BF",
+  triangleleft: "\u25C3",
+  trianglelefteq: "\u22B4",
+  triangleq: "\u225C",
+  triangleright: "\u25B9",
+  trianglerighteq: "\u22B5",
+  tridot: "\u25EC",
+  trie: "\u225C",
+  triminus: "\u2A3A",
+  triplus: "\u2A39",
+  trisb: "\u29CD",
+  tritime: "\u2A3B",
+  trpezium: "\u23E2",
+  tscr: "\u{1D4C9}",
+  tscy: "\u0446",
+  tshcy: "\u045B",
+  tstrok: "\u0167",
+  twixt: "\u226C",
+  twoheadleftarrow: "\u219E",
+  twoheadrightarrow: "\u21A0",
+  uArr: "\u21D1",
+  uHar: "\u2963",
+  uacute: "\xFA",
+  uarr: "\u2191",
+  ubrcy: "\u045E",
+  ubreve: "\u016D",
+  ucirc: "\xFB",
+  ucy: "\u0443",
+  udarr: "\u21C5",
+  udblac: "\u0171",
+  udhar: "\u296E",
+  ufisht: "\u297E",
+  ufr: "\u{1D532}",
+  ugrave: "\xF9",
+  uharl: "\u21BF",
+  uharr: "\u21BE",
+  uhblk: "\u2580",
+  ulcorn: "\u231C",
+  ulcorner: "\u231C",
+  ulcrop: "\u230F",
+  ultri: "\u25F8",
+  umacr: "\u016B",
+  uml: "\xA8",
+  uogon: "\u0173",
+  uopf: "\u{1D566}",
+  uparrow: "\u2191",
+  updownarrow: "\u2195",
+  upharpoonleft: "\u21BF",
+  upharpoonright: "\u21BE",
+  uplus: "\u228E",
+  upsi: "\u03C5",
+  upsih: "\u03D2",
+  upsilon: "\u03C5",
+  upuparrows: "\u21C8",
+  urcorn: "\u231D",
+  urcorner: "\u231D",
+  urcrop: "\u230E",
+  uring: "\u016F",
+  urtri: "\u25F9",
+  uscr: "\u{1D4CA}",
+  utdot: "\u22F0",
+  utilde: "\u0169",
+  utri: "\u25B5",
+  utrif: "\u25B4",
+  uuarr: "\u21C8",
+  uuml: "\xFC",
+  uwangle: "\u29A7",
+  vArr: "\u21D5",
+  vBar: "\u2AE8",
+  vBarv: "\u2AE9",
+  vDash: "\u22A8",
+  vangrt: "\u299C",
+  varepsilon: "\u03F5",
+  varkappa: "\u03F0",
+  varnothing: "\u2205",
+  varphi: "\u03D5",
+  varpi: "\u03D6",
+  varpropto: "\u221D",
+  varr: "\u2195",
+  varrho: "\u03F1",
+  varsigma: "\u03C2",
+  varsubsetneq: "\u228A\uFE00",
+  varsubsetneqq: "\u2ACB\uFE00",
+  varsupsetneq: "\u228B\uFE00",
+  varsupsetneqq: "\u2ACC\uFE00",
+  vartheta: "\u03D1",
+  vartriangleleft: "\u22B2",
+  vartriangleright: "\u22B3",
+  vcy: "\u0432",
+  vdash: "\u22A2",
+  vee: "\u2228",
+  veebar: "\u22BB",
+  veeeq: "\u225A",
+  vellip: "\u22EE",
+  verbar: "|",
+  vert: "|",
+  vfr: "\u{1D533}",
+  vltri: "\u22B2",
+  vnsub: "\u2282\u20D2",
+  vnsup: "\u2283\u20D2",
+  vopf: "\u{1D567}",
+  vprop: "\u221D",
+  vrtri: "\u22B3",
+  vscr: "\u{1D4CB}",
+  vsubnE: "\u2ACB\uFE00",
+  vsubne: "\u228A\uFE00",
+  vsupnE: "\u2ACC\uFE00",
+  vsupne: "\u228B\uFE00",
+  vzigzag: "\u299A",
+  wcirc: "\u0175",
+  wedbar: "\u2A5F",
+  wedge: "\u2227",
+  wedgeq: "\u2259",
+  weierp: "\u2118",
+  wfr: "\u{1D534}",
+  wopf: "\u{1D568}",
+  wp: "\u2118",
+  wr: "\u2240",
+  wreath: "\u2240",
+  wscr: "\u{1D4CC}",
+  xcap: "\u22C2",
+  xcirc: "\u25EF",
+  xcup: "\u22C3",
+  xdtri: "\u25BD",
+  xfr: "\u{1D535}",
+  xhArr: "\u27FA",
+  xharr: "\u27F7",
+  xi: "\u03BE",
+  xlArr: "\u27F8",
+  xlarr: "\u27F5",
+  xmap: "\u27FC",
+  xnis: "\u22FB",
+  xodot: "\u2A00",
+  xopf: "\u{1D569}",
+  xoplus: "\u2A01",
+  xotime: "\u2A02",
+  xrArr: "\u27F9",
+  xrarr: "\u27F6",
+  xscr: "\u{1D4CD}",
+  xsqcup: "\u2A06",
+  xuplus: "\u2A04",
+  xutri: "\u25B3",
+  xvee: "\u22C1",
+  xwedge: "\u22C0",
+  yacute: "\xFD",
+  yacy: "\u044F",
+  ycirc: "\u0177",
+  ycy: "\u044B",
+  yen: "\xA5",
+  yfr: "\u{1D536}",
+  yicy: "\u0457",
+  yopf: "\u{1D56A}",
+  yscr: "\u{1D4CE}",
+  yucy: "\u044E",
+  yuml: "\xFF",
+  zacute: "\u017A",
+  zcaron: "\u017E",
+  zcy: "\u0437",
+  zdot: "\u017C",
+  zeetrf: "\u2128",
+  zeta: "\u03B6",
+  zfr: "\u{1D537}",
+  zhcy: "\u0436",
+  zigrarr: "\u21DD",
+  zopf: "\u{1D56B}",
+  zscr: "\u{1D4CF}",
+  zwj: "\u200D",
+  zwnj: "\u200C"
+};
+
+// node_modules/decode-named-character-reference/index.js
+var own = {}.hasOwnProperty;
+function decodeNamedCharacterReference(value) {
+  return own.call(characterEntities, value) ? characterEntities[value] : false;
+}
+
+// node_modules/micromark-util-normalize-identifier/index.js
+function normalizeIdentifier(value) {
+  return value.replace(/[\t\n\r ]+/g, " ").replace(/^ | $/g, "").toLowerCase().toUpperCase();
+}
+
+// node_modules/micromark-extension-gfm-footnote/lib/syntax.js
+var indent = {
+  tokenize: tokenizeIndent,
+  partial: true
+};
+function gfmFootnote() {
+  return {
+    document: {
+      [91]: {
+        tokenize: tokenizeDefinitionStart,
+        continuation: {
+          tokenize: tokenizeDefinitionContinuation
+        },
+        exit: gfmFootnoteDefinitionEnd
+      }
+    },
+    text: {
+      [91]: {
+        tokenize: tokenizeGfmFootnoteCall
+      },
+      [93]: {
+        add: "after",
+        tokenize: tokenizePotentialGfmFootnoteCall,
+        resolveTo: resolveToPotentialGfmFootnoteCall
+      }
+    }
+  };
+}
+function tokenizePotentialGfmFootnoteCall(effects, ok2, nok) {
+  const self = this;
+  let index = self.events.length;
+  const defined = self.parser.gfmFootnotes || (self.parser.gfmFootnotes = []);
+  let labelStart;
+  while (index--) {
+    const token = self.events[index][1];
+    if (token.type === "labelImage") {
+      labelStart = token;
+      break;
+    }
+    if (token.type === "gfmFootnoteCall" || token.type === "labelLink" || token.type === "label" || token.type === "image" || token.type === "link") {
+      break;
+    }
+  }
+  return start;
+  function start(code2) {
+    if (!labelStart || !labelStart._balanced) {
+      return nok(code2);
+    }
+    const id = normalizeIdentifier(
+      self.sliceSerialize({
+        start: labelStart.end,
+        end: self.now()
+      })
+    );
+    if (id.charCodeAt(0) !== 94 || !defined.includes(id.slice(1))) {
+      return nok(code2);
+    }
+    effects.enter("gfmFootnoteCallLabelMarker");
+    effects.consume(code2);
+    effects.exit("gfmFootnoteCallLabelMarker");
+    return ok2(code2);
+  }
+}
+function resolveToPotentialGfmFootnoteCall(events, context) {
+  let index = events.length;
+  let labelStart;
+  while (index--) {
+    if (events[index][1].type === "labelImage" && events[index][0] === "enter") {
+      labelStart = events[index][1];
+      break;
+    }
+  }
+  events[index + 1][1].type = "data";
+  events[index + 3][1].type = "gfmFootnoteCallLabelMarker";
+  const call = {
+    type: "gfmFootnoteCall",
+    start: Object.assign({}, events[index + 3][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  const marker = {
+    type: "gfmFootnoteCallMarker",
+    start: Object.assign({}, events[index + 3][1].end),
+    end: Object.assign({}, events[index + 3][1].end)
+  };
+  marker.end.column++;
+  marker.end.offset++;
+  marker.end._bufferIndex++;
+  const string = {
+    type: "gfmFootnoteCallString",
+    start: Object.assign({}, marker.end),
+    end: Object.assign({}, events[events.length - 1][1].start)
+  };
+  const chunk = {
+    type: "chunkString",
+    contentType: "string",
+    start: Object.assign({}, string.start),
+    end: Object.assign({}, string.end)
+  };
+  const replacement = [
+    events[index + 1],
+    events[index + 2],
+    ["enter", call, context],
+    events[index + 3],
+    events[index + 4],
+    ["enter", marker, context],
+    ["exit", marker, context],
+    ["enter", string, context],
+    ["enter", chunk, context],
+    ["exit", chunk, context],
+    ["exit", string, context],
+    events[events.length - 2],
+    events[events.length - 1],
+    ["exit", call, context]
+  ];
+  events.splice(index, events.length - index + 1, ...replacement);
+  return events;
+}
+function tokenizeGfmFootnoteCall(effects, ok2, nok) {
+  const self = this;
+  const defined = self.parser.gfmFootnotes || (self.parser.gfmFootnotes = []);
+  let size = 0;
+  let data;
+  return start;
+  function start(code2) {
+    effects.enter("gfmFootnoteCall");
+    effects.enter("gfmFootnoteCallLabelMarker");
+    effects.consume(code2);
+    effects.exit("gfmFootnoteCallLabelMarker");
+    return callStart;
+  }
+  function callStart(code2) {
+    if (code2 !== 94)
+      return nok(code2);
+    effects.enter("gfmFootnoteCallMarker");
+    effects.consume(code2);
+    effects.exit("gfmFootnoteCallMarker");
+    effects.enter("gfmFootnoteCallString");
+    effects.enter("chunkString").contentType = "string";
+    return callData;
+  }
+  function callData(code2) {
+    let token;
+    if (code2 === null || code2 === 91 || size++ > 999) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      if (!data) {
+        return nok(code2);
+      }
+      effects.exit("chunkString");
+      token = effects.exit("gfmFootnoteCallString");
+      return defined.includes(normalizeIdentifier(self.sliceSerialize(token))) ? end(code2) : nok(code2);
+    }
+    effects.consume(code2);
+    if (!markdownLineEndingOrSpace(code2)) {
+      data = true;
+    }
+    return code2 === 92 ? callEscape : callData;
+  }
+  function callEscape(code2) {
+    if (code2 === 91 || code2 === 92 || code2 === 93) {
+      effects.consume(code2);
+      size++;
+      return callData;
+    }
+    return callData(code2);
+  }
+  function end(code2) {
+    effects.enter("gfmFootnoteCallLabelMarker");
+    effects.consume(code2);
+    effects.exit("gfmFootnoteCallLabelMarker");
+    effects.exit("gfmFootnoteCall");
+    return ok2;
+  }
+}
+function tokenizeDefinitionStart(effects, ok2, nok) {
+  const self = this;
+  const defined = self.parser.gfmFootnotes || (self.parser.gfmFootnotes = []);
+  let identifier;
+  let size = 0;
+  let data;
+  return start;
+  function start(code2) {
+    effects.enter("gfmFootnoteDefinition")._container = true;
+    effects.enter("gfmFootnoteDefinitionLabel");
+    effects.enter("gfmFootnoteDefinitionLabelMarker");
+    effects.consume(code2);
+    effects.exit("gfmFootnoteDefinitionLabelMarker");
+    return labelStart;
+  }
+  function labelStart(code2) {
+    if (code2 === 94) {
+      effects.enter("gfmFootnoteDefinitionMarker");
+      effects.consume(code2);
+      effects.exit("gfmFootnoteDefinitionMarker");
+      effects.enter("gfmFootnoteDefinitionLabelString");
+      return atBreak;
+    }
+    return nok(code2);
+  }
+  function atBreak(code2) {
+    let token;
+    if (code2 === null || code2 === 91 || size > 999) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      if (!data) {
+        return nok(code2);
+      }
+      token = effects.exit("gfmFootnoteDefinitionLabelString");
+      identifier = normalizeIdentifier(self.sliceSerialize(token));
+      effects.enter("gfmFootnoteDefinitionLabelMarker");
+      effects.consume(code2);
+      effects.exit("gfmFootnoteDefinitionLabelMarker");
+      effects.exit("gfmFootnoteDefinitionLabel");
+      return labelAfter;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      size++;
+      return atBreak;
+    }
+    effects.enter("chunkString").contentType = "string";
+    return label(code2);
+  }
+  function label(code2) {
+    if (code2 === null || markdownLineEnding(code2) || code2 === 91 || code2 === 93 || size > 999) {
+      effects.exit("chunkString");
+      return atBreak(code2);
+    }
+    if (!markdownLineEndingOrSpace(code2)) {
+      data = true;
+    }
+    size++;
+    effects.consume(code2);
+    return code2 === 92 ? labelEscape : label;
+  }
+  function labelEscape(code2) {
+    if (code2 === 91 || code2 === 92 || code2 === 93) {
+      effects.consume(code2);
+      size++;
+      return label;
+    }
+    return label(code2);
+  }
+  function labelAfter(code2) {
+    if (code2 === 58) {
+      effects.enter("definitionMarker");
+      effects.consume(code2);
+      effects.exit("definitionMarker");
+      return factorySpace(effects, done, "gfmFootnoteDefinitionWhitespace");
+    }
+    return nok(code2);
+  }
+  function done(code2) {
+    if (!defined.includes(identifier)) {
+      defined.push(identifier);
+    }
+    return ok2(code2);
+  }
+}
+function tokenizeDefinitionContinuation(effects, ok2, nok) {
+  return effects.check(blankLine, ok2, effects.attempt(indent, ok2, nok));
+}
+function gfmFootnoteDefinitionEnd(effects) {
+  effects.exit("gfmFootnoteDefinition");
+}
+function tokenizeIndent(effects, ok2, nok) {
+  const self = this;
+  return factorySpace(
+    effects,
+    afterPrefix,
+    "gfmFootnoteDefinitionIndent",
+    4 + 1
+  );
+  function afterPrefix(code2) {
+    const tail = self.events[self.events.length - 1];
+    return tail && tail[1].type === "gfmFootnoteDefinitionIndent" && tail[2].sliceSerialize(tail[1], true).length === 4 ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-extension-gfm-strikethrough/lib/syntax.js
+function gfmStrikethrough(options = {}) {
+  let single = options.singleTilde;
+  const tokenizer = {
+    tokenize: tokenizeStrikethrough,
+    resolveAll: resolveAllStrikethrough
+  };
+  if (single === null || single === void 0) {
+    single = true;
+  }
+  return {
+    text: {
+      [126]: tokenizer
+    },
+    insideSpan: {
+      null: [tokenizer]
+    },
+    attentionMarkers: {
+      null: [126]
+    }
+  };
+  function resolveAllStrikethrough(events, context) {
+    let index = -1;
+    while (++index < events.length) {
+      if (events[index][0] === "enter" && events[index][1].type === "strikethroughSequenceTemporary" && events[index][1]._close) {
+        let open = index;
+        while (open--) {
+          if (events[open][0] === "exit" && events[open][1].type === "strikethroughSequenceTemporary" && events[open][1]._open && events[index][1].end.offset - events[index][1].start.offset === events[open][1].end.offset - events[open][1].start.offset) {
+            events[index][1].type = "strikethroughSequence";
+            events[open][1].type = "strikethroughSequence";
+            const strikethrough = {
+              type: "strikethrough",
+              start: Object.assign({}, events[open][1].start),
+              end: Object.assign({}, events[index][1].end)
+            };
+            const text2 = {
+              type: "strikethroughText",
+              start: Object.assign({}, events[open][1].end),
+              end: Object.assign({}, events[index][1].start)
+            };
+            const nextEvents = [
+              ["enter", strikethrough, context],
+              ["enter", events[open][1], context],
+              ["exit", events[open][1], context],
+              ["enter", text2, context]
+            ];
+            splice(
+              nextEvents,
+              nextEvents.length,
+              0,
+              resolveAll(
+                context.parser.constructs.insideSpan.null,
+                events.slice(open + 1, index),
+                context
+              )
+            );
+            splice(nextEvents, nextEvents.length, 0, [
+              ["exit", text2, context],
+              ["enter", events[index][1], context],
+              ["exit", events[index][1], context],
+              ["exit", strikethrough, context]
+            ]);
+            splice(events, open - 1, index - open + 3, nextEvents);
+            index = open + nextEvents.length - 2;
+            break;
+          }
+        }
+      }
+    }
+    index = -1;
+    while (++index < events.length) {
+      if (events[index][1].type === "strikethroughSequenceTemporary") {
+        events[index][1].type = "data";
+      }
+    }
+    return events;
+  }
+  function tokenizeStrikethrough(effects, ok2, nok) {
+    const previous2 = this.previous;
+    const events = this.events;
+    let size = 0;
+    return start;
+    function start(code2) {
+      if (previous2 === 126 && events[events.length - 1][1].type !== "characterEscape") {
+        return nok(code2);
+      }
+      effects.enter("strikethroughSequenceTemporary");
+      return more(code2);
+    }
+    function more(code2) {
+      const before = classifyCharacter(previous2);
+      if (code2 === 126) {
+        if (size > 1)
+          return nok(code2);
+        effects.consume(code2);
+        size++;
+        return more;
+      }
+      if (size < 2 && !single)
+        return nok(code2);
+      const token = effects.exit("strikethroughSequenceTemporary");
+      const after = classifyCharacter(code2);
+      token._open = !after || after === 2 && Boolean(before);
+      token._close = !before || before === 2 && Boolean(after);
+      return ok2(code2);
+    }
+  }
+}
+
+// node_modules/micromark-extension-gfm-table/lib/syntax.js
+var gfmTable = {
+  flow: {
+    null: {
+      tokenize: tokenizeTable,
+      resolve: resolveTable
+    }
+  }
+};
+var nextPrefixedOrBlank = {
+  tokenize: tokenizeNextPrefixedOrBlank,
+  partial: true
+};
+function resolveTable(events, context) {
+  let index = -1;
+  let inHead;
+  let inDelimiterRow;
+  let inRow;
+  let contentStart;
+  let contentEnd;
+  let cellStart;
+  let seenCellInRow;
+  while (++index < events.length) {
+    const token = events[index][1];
+    if (inRow) {
+      if (token.type === "temporaryTableCellContent") {
+        contentStart = contentStart || index;
+        contentEnd = index;
+      }
+      if ((token.type === "tableCellDivider" || token.type === "tableRow") && contentEnd) {
+        const content = {
+          type: "tableContent",
+          start: events[contentStart][1].start,
+          end: events[contentEnd][1].end
+        };
+        const text2 = {
+          type: "chunkText",
+          start: content.start,
+          end: content.end,
+          contentType: "text"
+        };
+        events.splice(
+          contentStart,
+          contentEnd - contentStart + 1,
+          ["enter", content, context],
+          ["enter", text2, context],
+          ["exit", text2, context],
+          ["exit", content, context]
+        );
+        index -= contentEnd - contentStart - 3;
+        contentStart = void 0;
+        contentEnd = void 0;
+      }
+    }
+    if (events[index][0] === "exit" && cellStart !== void 0 && cellStart + (seenCellInRow ? 0 : 1) < index && (token.type === "tableCellDivider" || token.type === "tableRow" && (cellStart + 3 < index || events[cellStart][1].type !== "whitespace"))) {
+      const cell = {
+        type: inDelimiterRow ? "tableDelimiter" : inHead ? "tableHeader" : "tableData",
+        start: events[cellStart][1].start,
+        end: events[index][1].end
+      };
+      events.splice(index + (token.type === "tableCellDivider" ? 1 : 0), 0, [
+        "exit",
+        cell,
+        context
+      ]);
+      events.splice(cellStart, 0, ["enter", cell, context]);
+      index += 2;
+      cellStart = index + 1;
+      seenCellInRow = true;
+    }
+    if (token.type === "tableRow") {
+      inRow = events[index][0] === "enter";
+      if (inRow) {
+        cellStart = index + 1;
+        seenCellInRow = false;
+      }
+    }
+    if (token.type === "tableDelimiterRow") {
+      inDelimiterRow = events[index][0] === "enter";
+      if (inDelimiterRow) {
+        cellStart = index + 1;
+        seenCellInRow = false;
+      }
+    }
+    if (token.type === "tableHead") {
+      inHead = events[index][0] === "enter";
+    }
+  }
+  return events;
+}
+function tokenizeTable(effects, ok2, nok) {
+  const self = this;
+  const align = [];
+  let tableHeaderCount = 0;
+  let seenDelimiter;
+  let hasDash;
+  return start;
+  function start(code2) {
+    effects.enter("table")._align = align;
+    effects.enter("tableHead");
+    effects.enter("tableRow");
+    if (code2 === 124) {
+      return cellDividerHead(code2);
+    }
+    tableHeaderCount++;
+    effects.enter("temporaryTableCellContent");
+    return inCellContentHead(code2);
+  }
+  function cellDividerHead(code2) {
+    effects.enter("tableCellDivider");
+    effects.consume(code2);
+    effects.exit("tableCellDivider");
+    seenDelimiter = true;
+    return cellBreakHead;
+  }
+  function cellBreakHead(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return atRowEndHead(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.enter("whitespace");
+      effects.consume(code2);
+      return inWhitespaceHead;
+    }
+    if (seenDelimiter) {
+      seenDelimiter = void 0;
+      tableHeaderCount++;
+    }
+    if (code2 === 124) {
+      return cellDividerHead(code2);
+    }
+    effects.enter("temporaryTableCellContent");
+    return inCellContentHead(code2);
+  }
+  function inWhitespaceHead(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return inWhitespaceHead;
+    }
+    effects.exit("whitespace");
+    return cellBreakHead(code2);
+  }
+  function inCellContentHead(code2) {
+    if (code2 === null || code2 === 124 || markdownLineEndingOrSpace(code2)) {
+      effects.exit("temporaryTableCellContent");
+      return cellBreakHead(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? inCellContentEscapeHead : inCellContentHead;
+  }
+  function inCellContentEscapeHead(code2) {
+    if (code2 === 92 || code2 === 124) {
+      effects.consume(code2);
+      return inCellContentHead;
+    }
+    return inCellContentHead(code2);
+  }
+  function atRowEndHead(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    effects.exit("tableRow");
+    effects.exit("tableHead");
+    const originalInterrupt = self.interrupt;
+    self.interrupt = true;
+    return effects.attempt(
+      {
+        tokenize: tokenizeRowEnd,
+        partial: true
+      },
+      function(code3) {
+        self.interrupt = originalInterrupt;
+        effects.enter("tableDelimiterRow");
+        return atDelimiterRowBreak(code3);
+      },
+      function(code3) {
+        self.interrupt = originalInterrupt;
+        return nok(code3);
+      }
+    )(code2);
+  }
+  function atDelimiterRowBreak(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return rowEndDelimiter(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.enter("whitespace");
+      effects.consume(code2);
+      return inWhitespaceDelimiter;
+    }
+    if (code2 === 45) {
+      effects.enter("tableDelimiterFiller");
+      effects.consume(code2);
+      hasDash = true;
+      align.push("none");
+      return inFillerDelimiter;
+    }
+    if (code2 === 58) {
+      effects.enter("tableDelimiterAlignment");
+      effects.consume(code2);
+      effects.exit("tableDelimiterAlignment");
+      align.push("left");
+      return afterLeftAlignment;
+    }
+    if (code2 === 124) {
+      effects.enter("tableCellDivider");
+      effects.consume(code2);
+      effects.exit("tableCellDivider");
+      return atDelimiterRowBreak;
+    }
+    return nok(code2);
+  }
+  function inWhitespaceDelimiter(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return inWhitespaceDelimiter;
+    }
+    effects.exit("whitespace");
+    return atDelimiterRowBreak(code2);
+  }
+  function inFillerDelimiter(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return inFillerDelimiter;
+    }
+    effects.exit("tableDelimiterFiller");
+    if (code2 === 58) {
+      effects.enter("tableDelimiterAlignment");
+      effects.consume(code2);
+      effects.exit("tableDelimiterAlignment");
+      align[align.length - 1] = align[align.length - 1] === "left" ? "center" : "right";
+      return afterRightAlignment;
+    }
+    return atDelimiterRowBreak(code2);
+  }
+  function afterLeftAlignment(code2) {
+    if (code2 === 45) {
+      effects.enter("tableDelimiterFiller");
+      effects.consume(code2);
+      hasDash = true;
+      return inFillerDelimiter;
+    }
+    return nok(code2);
+  }
+  function afterRightAlignment(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return rowEndDelimiter(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.enter("whitespace");
+      effects.consume(code2);
+      return inWhitespaceDelimiter;
+    }
+    if (code2 === 124) {
+      effects.enter("tableCellDivider");
+      effects.consume(code2);
+      effects.exit("tableCellDivider");
+      return atDelimiterRowBreak;
+    }
+    return nok(code2);
+  }
+  function rowEndDelimiter(code2) {
+    effects.exit("tableDelimiterRow");
+    if (!hasDash || tableHeaderCount !== align.length) {
+      return nok(code2);
+    }
+    if (code2 === null) {
+      return tableClose(code2);
+    }
+    return effects.check(
+      nextPrefixedOrBlank,
+      tableClose,
+      effects.attempt(
+        {
+          tokenize: tokenizeRowEnd,
+          partial: true
+        },
+        factorySpace(effects, bodyStart, "linePrefix", 4),
+        tableClose
+      )
+    )(code2);
+  }
+  function tableClose(code2) {
+    effects.exit("table");
+    return ok2(code2);
+  }
+  function bodyStart(code2) {
+    effects.enter("tableBody");
+    return rowStartBody(code2);
+  }
+  function rowStartBody(code2) {
+    effects.enter("tableRow");
+    if (code2 === 124) {
+      return cellDividerBody(code2);
+    }
+    effects.enter("temporaryTableCellContent");
+    return inCellContentBody(code2);
+  }
+  function cellDividerBody(code2) {
+    effects.enter("tableCellDivider");
+    effects.consume(code2);
+    effects.exit("tableCellDivider");
+    return cellBreakBody;
+  }
+  function cellBreakBody(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return atRowEndBody(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.enter("whitespace");
+      effects.consume(code2);
+      return inWhitespaceBody;
+    }
+    if (code2 === 124) {
+      return cellDividerBody(code2);
+    }
+    effects.enter("temporaryTableCellContent");
+    return inCellContentBody(code2);
+  }
+  function inWhitespaceBody(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return inWhitespaceBody;
+    }
+    effects.exit("whitespace");
+    return cellBreakBody(code2);
+  }
+  function inCellContentBody(code2) {
+    if (code2 === null || code2 === 124 || markdownLineEndingOrSpace(code2)) {
+      effects.exit("temporaryTableCellContent");
+      return cellBreakBody(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? inCellContentEscapeBody : inCellContentBody;
+  }
+  function inCellContentEscapeBody(code2) {
+    if (code2 === 92 || code2 === 124) {
+      effects.consume(code2);
+      return inCellContentBody;
+    }
+    return inCellContentBody(code2);
+  }
+  function atRowEndBody(code2) {
+    effects.exit("tableRow");
+    if (code2 === null) {
+      return tableBodyClose(code2);
+    }
+    return effects.check(
+      nextPrefixedOrBlank,
+      tableBodyClose,
+      effects.attempt(
+        {
+          tokenize: tokenizeRowEnd,
+          partial: true
+        },
+        factorySpace(effects, rowStartBody, "linePrefix", 4),
+        tableBodyClose
+      )
+    )(code2);
+  }
+  function tableBodyClose(code2) {
+    effects.exit("tableBody");
+    return tableClose(code2);
+  }
+  function tokenizeRowEnd(effects2, ok3, nok2) {
+    return start2;
+    function start2(code2) {
+      effects2.enter("lineEnding");
+      effects2.consume(code2);
+      effects2.exit("lineEnding");
+      return factorySpace(effects2, prefixed, "linePrefix");
+    }
+    function prefixed(code2) {
+      if (self.parser.lazy[self.now().line] || code2 === null || markdownLineEnding(code2)) {
+        return nok2(code2);
+      }
+      const tail = self.events[self.events.length - 1];
+      if (!self.parser.constructs.disable.null.includes("codeIndented") && tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4) {
+        return nok2(code2);
+      }
+      self._gfmTableDynamicInterruptHack = true;
+      return effects2.check(
+        self.parser.constructs.flow,
+        function(code3) {
+          self._gfmTableDynamicInterruptHack = false;
+          return nok2(code3);
+        },
+        function(code3) {
+          self._gfmTableDynamicInterruptHack = false;
+          return ok3(code3);
+        }
+      )(code2);
+    }
+  }
+}
+function tokenizeNextPrefixedOrBlank(effects, ok2, nok) {
+  let size = 0;
+  return start;
+  function start(code2) {
+    effects.enter("check");
+    effects.consume(code2);
+    return whitespace;
+  }
+  function whitespace(code2) {
+    if (code2 === -1 || code2 === 32) {
+      effects.consume(code2);
+      size++;
+      return size === 4 ? ok2 : whitespace;
+    }
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-extension-gfm-task-list-item/lib/syntax.js
+var tasklistCheck = {
+  tokenize: tokenizeTasklistCheck
+};
+var gfmTaskListItem = {
+  text: {
+    [91]: tasklistCheck
+  }
+};
+function tokenizeTasklistCheck(effects, ok2, nok) {
+  const self = this;
+  return open;
+  function open(code2) {
+    if (self.previous !== null || !self._gfmTasklistFirstContentOfListItem) {
+      return nok(code2);
+    }
+    effects.enter("taskListCheck");
+    effects.enter("taskListCheckMarker");
+    effects.consume(code2);
+    effects.exit("taskListCheckMarker");
+    return inside;
+  }
+  function inside(code2) {
+    if (markdownLineEndingOrSpace(code2)) {
+      effects.enter("taskListCheckValueUnchecked");
+      effects.consume(code2);
+      effects.exit("taskListCheckValueUnchecked");
+      return close;
+    }
+    if (code2 === 88 || code2 === 120) {
+      effects.enter("taskListCheckValueChecked");
+      effects.consume(code2);
+      effects.exit("taskListCheckValueChecked");
+      return close;
+    }
+    return nok(code2);
+  }
+  function close(code2) {
+    if (code2 === 93) {
+      effects.enter("taskListCheckMarker");
+      effects.consume(code2);
+      effects.exit("taskListCheckMarker");
+      effects.exit("taskListCheck");
+      return effects.check(
+        {
+          tokenize: spaceThenNonSpace
+        },
+        ok2,
+        nok
+      );
+    }
+    return nok(code2);
+  }
+}
+function spaceThenNonSpace(effects, ok2, nok) {
+  const self = this;
+  return factorySpace(effects, after, "whitespace");
+  function after(code2) {
+    const tail = self.events[self.events.length - 1];
+    return (tail && tail[1].type === "whitespace" || markdownLineEnding(code2)) && code2 !== null ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-extension-gfm/index.js
+function gfm(options) {
+  return combineExtensions([
+    gfmAutolinkLiteral,
+    gfmFootnote(),
+    gfmStrikethrough(options),
+    gfmTable,
+    gfmTaskListItem
+  ]);
+}
+
+// node_modules/mdast-util-gfm-autolink-literal/node_modules/ccount/index.js
+function ccount(value, character) {
+  const source = String(value);
+  if (typeof character !== "string") {
+    throw new TypeError("Expected character");
+  }
+  let count = 0;
+  let index = source.indexOf(character);
+  while (index !== -1) {
+    count++;
+    index = source.indexOf(character, index + character.length);
+  }
+  return count;
+}
+
+// node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp/index.js
+function escapeStringRegexp(string) {
+  if (typeof string !== "string") {
+    throw new TypeError("Expected a string");
+  }
+  return string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
+}
+
+// node_modules/unist-util-is/index.js
+var convert = function(test) {
+  if (test === void 0 || test === null) {
+    return ok;
+  }
+  if (typeof test === "string") {
+    return typeFactory(test);
+  }
+  if (typeof test === "object") {
+    return Array.isArray(test) ? anyFactory(test) : propsFactory(test);
+  }
+  if (typeof test === "function") {
+    return castFactory(test);
+  }
+  throw new Error("Expected function, string, or object as test");
+};
+function anyFactory(tests) {
+  const checks = [];
+  let index = -1;
+  while (++index < tests.length) {
+    checks[index] = convert(tests[index]);
+  }
+  return castFactory(any);
+  function any(...parameters) {
+    let index2 = -1;
+    while (++index2 < checks.length) {
+      if (checks[index2].call(this, ...parameters))
+        return true;
+    }
+    return false;
+  }
+}
+function propsFactory(check) {
+  return castFactory(all);
+  function all(node) {
+    let key;
+    for (key in check) {
+      if (node[key] !== check[key])
+        return false;
+    }
+    return true;
+  }
+}
+function typeFactory(check) {
+  return castFactory(type);
+  function type(node) {
+    return node && node.type === check;
+  }
+}
+function castFactory(check) {
+  return assertion;
+  function assertion(...parameters) {
+    return Boolean(check.call(this, ...parameters));
+  }
+}
+function ok() {
+  return true;
+}
+
+// node_modules/unist-util-visit-parents/color.js
+function color(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/unist-util-visit-parents/index.js
+var CONTINUE = true;
+var SKIP = "skip";
+var EXIT = false;
+var visitParents = function(tree, test, visitor, reverse) {
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+    test = null;
+  }
+  const is = convert(test);
+  const step = reverse ? -1 : 1;
+  factory(tree, null, [])();
+  function factory(node, index, parents) {
+    const value = typeof node === "object" && node !== null ? node : {};
+    let name;
+    if (typeof value.type === "string") {
+      name = typeof value.tagName === "string" ? value.tagName : typeof value.name === "string" ? value.name : void 0;
+      Object.defineProperty(visit, "name", {
+        value: "node (" + color(value.type + (name ? "<" + name + ">" : "")) + ")"
+      });
+    }
+    return visit;
+    function visit() {
+      let result = [];
+      let subresult;
+      let offset;
+      let grandparents;
+      if (!test || is(node, index, parents[parents.length - 1] || null)) {
+        result = toResult(visitor(node, parents));
+        if (result[0] === EXIT) {
+          return result;
+        }
+      }
+      if (node.children && result[0] !== SKIP) {
+        offset = (reverse ? node.children.length : -1) + step;
+        grandparents = parents.concat(node);
+        while (offset > -1 && offset < node.children.length) {
+          subresult = factory(node.children[offset], offset, grandparents)();
+          if (subresult[0] === EXIT) {
+            return subresult;
+          }
+          offset = typeof subresult[1] === "number" ? subresult[1] : offset + step;
+        }
+      }
+      return result;
+    }
+  }
+};
+function toResult(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE, value];
+  }
+  return [value];
+}
+
+// node_modules/mdast-util-find-and-replace/lib/index.js
+var own2 = {}.hasOwnProperty;
+var findAndReplace = function(tree, find, replace2, options) {
+  let settings;
+  let schema;
+  if (typeof find === "string" || find instanceof RegExp) {
+    schema = [[find, replace2]];
+    settings = options;
+  } else {
+    schema = find;
+    settings = replace2;
+  }
+  if (!settings) {
+    settings = {};
+  }
+  const ignored = convert(settings.ignore || []);
+  const pairs = toPairs(schema);
+  let pairIndex = -1;
+  while (++pairIndex < pairs.length) {
+    visitParents(tree, "text", visitor);
+  }
+  return tree;
+  function visitor(node, parents) {
+    let index = -1;
+    let grandparent;
+    while (++index < parents.length) {
+      const parent = parents[index];
+      if (ignored(
+        parent,
+        grandparent ? grandparent.children.indexOf(parent) : void 0,
+        grandparent
+      )) {
+        return;
+      }
+      grandparent = parent;
+    }
+    if (grandparent) {
+      return handler(node, parents);
+    }
+  }
+  function handler(node, parents) {
+    const parent = parents[parents.length - 1];
+    const find2 = pairs[pairIndex][0];
+    const replace3 = pairs[pairIndex][1];
+    let start = 0;
+    const index = parent.children.indexOf(node);
+    let change = false;
+    let nodes = [];
+    let position;
+    find2.lastIndex = 0;
+    let match = find2.exec(node.value);
+    while (match) {
+      position = match.index;
+      const matchObject = {
+        index: match.index,
+        input: match.input,
+        stack: [...parents, node]
+      };
+      let value = replace3(...match, matchObject);
+      if (typeof value === "string") {
+        value = value.length > 0 ? { type: "text", value } : void 0;
+      }
+      if (value !== false) {
+        if (start !== position) {
+          nodes.push({
+            type: "text",
+            value: node.value.slice(start, position)
+          });
+        }
+        if (Array.isArray(value)) {
+          nodes.push(...value);
+        } else if (value) {
+          nodes.push(value);
+        }
+        start = position + match[0].length;
+        change = true;
+      }
+      if (!find2.global) {
+        break;
+      }
+      match = find2.exec(node.value);
+    }
+    if (change) {
+      if (start < node.value.length) {
+        nodes.push({ type: "text", value: node.value.slice(start) });
+      }
+      parent.children.splice(index, 1, ...nodes);
+    } else {
+      nodes = [node];
+    }
+    return index + nodes.length;
+  }
+};
+function toPairs(schema) {
+  const result = [];
+  if (typeof schema !== "object") {
+    throw new TypeError("Expected array or object as schema");
+  }
+  if (Array.isArray(schema)) {
+    let index = -1;
+    while (++index < schema.length) {
+      result.push([
+        toExpression(schema[index][0]),
+        toFunction(schema[index][1])
+      ]);
+    }
+  } else {
+    let key;
+    for (key in schema) {
+      if (own2.call(schema, key)) {
+        result.push([toExpression(key), toFunction(schema[key])]);
+      }
+    }
+  }
+  return result;
+}
+function toExpression(find) {
+  return typeof find === "string" ? new RegExp(escapeStringRegexp(find), "g") : find;
+}
+function toFunction(replace2) {
+  return typeof replace2 === "function" ? replace2 : () => replace2;
+}
+
+// node_modules/mdast-util-gfm-autolink-literal/index.js
+var inConstruct = "phrasing";
+var notInConstruct = ["autolink", "link", "image", "label"];
+var gfmAutolinkLiteralFromMarkdown = {
+  transforms: [transformGfmAutolinkLiterals],
+  enter: {
+    literalAutolink: enterLiteralAutolink,
+    literalAutolinkEmail: enterLiteralAutolinkValue,
+    literalAutolinkHttp: enterLiteralAutolinkValue,
+    literalAutolinkWww: enterLiteralAutolinkValue
+  },
+  exit: {
+    literalAutolink: exitLiteralAutolink,
+    literalAutolinkEmail: exitLiteralAutolinkEmail,
+    literalAutolinkHttp: exitLiteralAutolinkHttp,
+    literalAutolinkWww: exitLiteralAutolinkWww
+  }
+};
+var gfmAutolinkLiteralToMarkdown = {
+  unsafe: [
+    {
+      character: "@",
+      before: "[+\\-.\\w]",
+      after: "[\\-.\\w]",
+      inConstruct,
+      notInConstruct
+    },
+    {
+      character: ".",
+      before: "[Ww]",
+      after: "[\\-.\\w]",
+      inConstruct,
+      notInConstruct
+    },
+    { character: ":", before: "[ps]", after: "\\/", inConstruct, notInConstruct }
+  ]
+};
+function enterLiteralAutolink(token) {
+  this.enter({ type: "link", title: null, url: "", children: [] }, token);
+}
+function enterLiteralAutolinkValue(token) {
+  this.config.enter.autolinkProtocol.call(this, token);
+}
+function exitLiteralAutolinkHttp(token) {
+  this.config.exit.autolinkProtocol.call(this, token);
+}
+function exitLiteralAutolinkWww(token) {
+  this.config.exit.data.call(this, token);
+  const node = this.stack[this.stack.length - 1];
+  node.url = "http://" + this.sliceSerialize(token);
+}
+function exitLiteralAutolinkEmail(token) {
+  this.config.exit.autolinkEmail.call(this, token);
+}
+function exitLiteralAutolink(token) {
+  this.exit(token);
+}
+function transformGfmAutolinkLiterals(tree) {
+  findAndReplace(
+    tree,
+    [
+      [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
+      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/g, findEmail]
+    ],
+    { ignore: ["link", "linkReference"] }
+  );
+}
+function findUrl(_, protocol, domain2, path2, match) {
+  let prefix = "";
+  if (!previous(match)) {
+    return false;
+  }
+  if (/^w/i.test(protocol)) {
+    domain2 = protocol + domain2;
+    protocol = "";
+    prefix = "http://";
+  }
+  if (!isCorrectDomain(domain2)) {
+    return false;
+  }
+  const parts = splitUrl(domain2 + path2);
+  if (!parts[0])
+    return false;
+  const result = {
+    type: "link",
+    title: null,
+    url: prefix + protocol + parts[0],
+    children: [{ type: "text", value: protocol + parts[0] }]
+  };
+  if (parts[1]) {
+    return [result, { type: "text", value: parts[1] }];
+  }
+  return result;
+}
+function findEmail(_, atext, label, match) {
+  if (!previous(match, true) || /[_-\d]$/.test(label)) {
+    return false;
+  }
+  return {
+    type: "link",
+    title: null,
+    url: "mailto:" + atext + "@" + label,
+    children: [{ type: "text", value: atext + "@" + label }]
+  };
+}
+function isCorrectDomain(domain2) {
+  const parts = domain2.split(".");
+  if (parts.length < 2 || parts[parts.length - 1] && (/_/.test(parts[parts.length - 1]) || !/[a-zA-Z\d]/.test(parts[parts.length - 1])) || parts[parts.length - 2] && (/_/.test(parts[parts.length - 2]) || !/[a-zA-Z\d]/.test(parts[parts.length - 2]))) {
+    return false;
+  }
+  return true;
+}
+function splitUrl(url) {
+  const trailExec = /[!"&'),.:;<>?\]}]+$/.exec(url);
+  let closingParenIndex;
+  let openingParens;
+  let closingParens;
+  let trail;
+  if (trailExec) {
+    url = url.slice(0, trailExec.index);
+    trail = trailExec[0];
+    closingParenIndex = trail.indexOf(")");
+    openingParens = ccount(url, "(");
+    closingParens = ccount(url, ")");
+    while (closingParenIndex !== -1 && openingParens > closingParens) {
+      url += trail.slice(0, closingParenIndex + 1);
+      trail = trail.slice(closingParenIndex + 1);
+      closingParenIndex = trail.indexOf(")");
+      closingParens++;
+    }
+  }
+  return [url, trail];
+}
+function previous(match, email) {
+  const code2 = match.input.charCodeAt(match.index - 1);
+  return (match.index === 0 || unicodeWhitespace(code2) || unicodePunctuation(code2)) && (!email || code2 !== 47);
+}
+
+// node_modules/micromark-util-decode-numeric-character-reference/index.js
+function decodeNumericCharacterReference(value, base) {
+  const code2 = Number.parseInt(value, base);
+  if (code2 < 9 || code2 === 11 || code2 > 13 && code2 < 32 || code2 > 126 && code2 < 160 || code2 > 55295 && code2 < 57344 || code2 > 64975 && code2 < 65008 || (code2 & 65535) === 65535 || (code2 & 65535) === 65534 || code2 > 1114111) {
+    return "\uFFFD";
+  }
+  return String.fromCharCode(code2);
+}
+
+// node_modules/micromark-util-decode-string/index.js
+var characterEscapeOrReference = /\\([!-/:-@[-`{-~])|&(#(?:\d{1,7}|x[\da-f]{1,6})|[\da-z]{1,31});/gi;
+function decodeString(value) {
+  return value.replace(characterEscapeOrReference, decode);
+}
+function decode($0, $1, $2) {
+  if ($1) {
+    return $1;
+  }
+  const head = $2.charCodeAt(0);
+  if (head === 35) {
+    const head2 = $2.charCodeAt(1);
+    const hex = head2 === 120 || head2 === 88;
+    return decodeNumericCharacterReference($2.slice(hex ? 2 : 1), hex ? 16 : 10);
+  }
+  return decodeNamedCharacterReference($2) || $0;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/association.js
+function association(node) {
+  if (node.label || !node.identifier) {
+    return node.label || "";
+  }
+  return decodeString(node.identifier);
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/track.js
+function track(options_) {
+  const options = options_ || {};
+  const now = options.now || {};
+  let lineShift = options.lineShift || 0;
+  let line = now.line || 1;
+  let column = now.column || 1;
+  return { move, current, shift };
+  function current() {
+    return { now: { line, column }, lineShift };
+  }
+  function shift(value) {
+    lineShift += value;
+  }
+  function move(value = "") {
+    const chunks = value.split(/\r?\n|\r/g);
+    const tail = chunks[chunks.length - 1];
+    line += chunks.length - 1;
+    column = chunks.length === 1 ? column + tail.length : 1 + tail.length + lineShift;
+    return value;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-flow.js
+function containerFlow(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const tracker = track(safeOptions);
+  const results = [];
+  let index = -1;
+  indexStack.push(-1);
+  while (++index < children.length) {
+    const child = children[index];
+    indexStack[indexStack.length - 1] = index;
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          before: "\n",
+          after: "\n",
+          ...tracker.current()
+        })
+      )
+    );
+    if (child.type !== "list") {
+      context.bulletLastUsed = void 0;
+    }
+    if (index < children.length - 1) {
+      results.push(tracker.move(between(child, children[index + 1])));
+    }
+  }
+  indexStack.pop();
+  return results.join("");
+  function between(left, right) {
+    let index2 = context.join.length;
+    while (index2--) {
+      const result = context.join[index2](left, right, parent, context);
+      if (result === true || result === 1) {
+        break;
+      }
+      if (typeof result === "number") {
+        return "\n".repeat(1 + result);
+      }
+      if (result === false) {
+        return "\n\n<!---->\n\n";
+      }
+    }
+    return "\n\n";
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/indent-lines.js
+var eol = /\r?\n|\r/g;
+function indentLines(value, map) {
+  const result = [];
+  let start = 0;
+  let line = 0;
+  let match;
+  while (match = eol.exec(value)) {
+    one(value.slice(start, match.index));
+    result.push(match[0]);
+    start = match.index + match[0].length;
+    line++;
+  }
+  one(value.slice(start));
+  return result.join("");
+  function one(value2) {
+    result.push(map(value2, line, !value2));
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/pattern-compile.js
+function patternCompile(pattern) {
+  if (!pattern._compiled) {
+    const before = (pattern.atBreak ? "[\\r\\n][\\t ]*" : "") + (pattern.before ? "(?:" + pattern.before + ")" : "");
+    pattern._compiled = new RegExp(
+      (before ? "(" + before + ")" : "") + (/[|\\{}()[\]^$+*?.-]/.test(pattern.character) ? "\\" : "") + pattern.character + (pattern.after ? "(?:" + pattern.after + ")" : ""),
+      "g"
+    );
+  }
+  return pattern._compiled;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/pattern-in-scope.js
+function patternInScope(stack, pattern) {
+  return listInScope(stack, pattern.inConstruct, true) && !listInScope(stack, pattern.notInConstruct, false);
+}
+function listInScope(stack, list, none) {
+  if (!list) {
+    return none;
+  }
+  if (typeof list === "string") {
+    list = [list];
+  }
+  let index = -1;
+  while (++index < list.length) {
+    if (stack.includes(list[index])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/safe.js
+function safe(context, input, config) {
+  const value = (config.before || "") + (input || "") + (config.after || "");
+  const positions = [];
+  const result = [];
+  const infos = {};
+  let index = -1;
+  while (++index < context.unsafe.length) {
+    const pattern = context.unsafe[index];
+    if (!patternInScope(context.stack, pattern)) {
+      continue;
+    }
+    const expression = patternCompile(pattern);
+    let match;
+    while (match = expression.exec(value)) {
+      const before = "before" in pattern || Boolean(pattern.atBreak);
+      const after = "after" in pattern;
+      const position = match.index + (before ? match[1].length : 0);
+      if (positions.includes(position)) {
+        if (infos[position].before && !before) {
+          infos[position].before = false;
+        }
+        if (infos[position].after && !after) {
+          infos[position].after = false;
+        }
+      } else {
+        positions.push(position);
+        infos[position] = { before, after };
+      }
+    }
+  }
+  positions.sort(numerical);
+  let start = config.before ? config.before.length : 0;
+  const end = value.length - (config.after ? config.after.length : 0);
+  index = -1;
+  while (++index < positions.length) {
+    const position = positions[index];
+    if (position < start || position >= end) {
+      continue;
+    }
+    if (position + 1 < end && positions[index + 1] === position + 1 && infos[position].after && !infos[position + 1].before && !infos[position + 1].after || positions[index - 1] === position - 1 && infos[position].before && !infos[position - 1].before && !infos[position - 1].after) {
+      continue;
+    }
+    if (start !== position) {
+      result.push(escapeBackslashes(value.slice(start, position), "\\"));
+    }
+    start = position;
+    if (/[!-/:-@[-`{-~]/.test(value.charAt(position)) && (!config.encode || !config.encode.includes(value.charAt(position)))) {
+      result.push("\\");
+    } else {
+      result.push(
+        "&#x" + value.charCodeAt(position).toString(16).toUpperCase() + ";"
+      );
+      start++;
+    }
+  }
+  result.push(escapeBackslashes(value.slice(start, end), config.after));
+  return result.join("");
+}
+function numerical(a, b) {
+  return a - b;
+}
+function escapeBackslashes(value, after) {
+  const expression = /\\(?=[!-/:-@[-`{-~])/g;
+  const positions = [];
+  const results = [];
+  const whole = value + after;
+  let index = -1;
+  let start = 0;
+  let match;
+  while (match = expression.exec(whole)) {
+    positions.push(match.index);
+  }
+  while (++index < positions.length) {
+    if (start !== positions[index]) {
+      results.push(value.slice(start, positions[index]));
+    }
+    results.push("\\");
+    start = positions[index];
+  }
+  results.push(value.slice(start));
+  return results.join("");
+}
+
+// node_modules/mdast-util-gfm-footnote/index.js
+function gfmFootnoteFromMarkdown() {
+  return {
+    enter: {
+      gfmFootnoteDefinition: enterFootnoteDefinition,
+      gfmFootnoteDefinitionLabelString: enterFootnoteDefinitionLabelString,
+      gfmFootnoteCall: enterFootnoteCall,
+      gfmFootnoteCallString: enterFootnoteCallString
+    },
+    exit: {
+      gfmFootnoteDefinition: exitFootnoteDefinition,
+      gfmFootnoteDefinitionLabelString: exitFootnoteDefinitionLabelString,
+      gfmFootnoteCall: exitFootnoteCall,
+      gfmFootnoteCallString: exitFootnoteCallString
+    }
+  };
+  function enterFootnoteDefinition(token) {
+    this.enter(
+      { type: "footnoteDefinition", identifier: "", label: "", children: [] },
+      token
+    );
+  }
+  function enterFootnoteDefinitionLabelString() {
+    this.buffer();
+  }
+  function exitFootnoteDefinitionLabelString(token) {
+    const label = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.label = label;
+    node.identifier = normalizeIdentifier(
+      this.sliceSerialize(token)
+    ).toLowerCase();
+  }
+  function exitFootnoteDefinition(token) {
+    this.exit(token);
+  }
+  function enterFootnoteCall(token) {
+    this.enter({ type: "footnoteReference", identifier: "", label: "" }, token);
+  }
+  function enterFootnoteCallString() {
+    this.buffer();
+  }
+  function exitFootnoteCallString(token) {
+    const label = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.label = label;
+    node.identifier = normalizeIdentifier(
+      this.sliceSerialize(token)
+    ).toLowerCase();
+  }
+  function exitFootnoteCall(token) {
+    this.exit(token);
+  }
+}
+function gfmFootnoteToMarkdown() {
+  footnoteReference.peek = footnoteReferencePeek;
+  return {
+    unsafe: [{ character: "[", inConstruct: ["phrasing", "label", "reference"] }],
+    handlers: { footnoteDefinition, footnoteReference }
+  };
+  function footnoteReference(node, _, context, safeOptions) {
+    const tracker = track(safeOptions);
+    let value = tracker.move("[^");
+    const exit2 = context.enter("footnoteReference");
+    const subexit = context.enter("reference");
+    value += tracker.move(
+      safe(context, association(node), {
+        ...tracker.current(),
+        before: value,
+        after: "]"
+      })
+    );
+    subexit();
+    exit2();
+    value += tracker.move("]");
+    return value;
+  }
+  function footnoteReferencePeek() {
+    return "[";
+  }
+  function footnoteDefinition(node, _, context, safeOptions) {
+    const tracker = track(safeOptions);
+    let value = tracker.move("[^");
+    const exit2 = context.enter("footnoteDefinition");
+    const subexit = context.enter("label");
+    value += tracker.move(
+      safe(context, association(node), {
+        ...tracker.current(),
+        before: value,
+        after: "]"
+      })
+    );
+    subexit();
+    value += tracker.move(
+      "]:" + (node.children && node.children.length > 0 ? " " : "")
+    );
+    tracker.shift(4);
+    value += tracker.move(
+      indentLines(containerFlow(node, context, tracker.current()), map)
+    );
+    exit2();
+    return value;
+    function map(line, index, blank) {
+      if (index) {
+        return (blank ? "" : "    ") + line;
+      }
+      return line;
+    }
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-phrasing.js
+function containerPhrasing(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const results = [];
+  let index = -1;
+  let before = safeOptions.before;
+  indexStack.push(-1);
+  let tracker = track(safeOptions);
+  while (++index < children.length) {
+    const child = children[index];
+    let after;
+    indexStack[indexStack.length - 1] = index;
+    if (index + 1 < children.length) {
+      let handle = context.handle.handlers[children[index + 1].type];
+      if (handle && handle.peek)
+        handle = handle.peek;
+      after = handle ? handle(children[index + 1], parent, context, {
+        before: "",
+        after: "",
+        ...tracker.current()
+      }).charAt(0) : "";
+    } else {
+      after = safeOptions.after;
+    }
+    if (results.length > 0 && (before === "\r" || before === "\n") && child.type === "html") {
+      results[results.length - 1] = results[results.length - 1].replace(
+        /(\r?\n|\r)$/,
+        " "
+      );
+      before = " ";
+      tracker = track(safeOptions);
+      tracker.move(results.join(""));
+    }
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          ...tracker.current(),
+          before,
+          after
+        })
+      )
+    );
+    before = results[results.length - 1].slice(-1);
+  }
+  indexStack.pop();
+  return results.join("");
+}
+
+// node_modules/mdast-util-gfm-strikethrough/index.js
+var gfmStrikethroughFromMarkdown = {
+  canContainEols: ["delete"],
+  enter: { strikethrough: enterStrikethrough },
+  exit: { strikethrough: exitStrikethrough }
+};
+var gfmStrikethroughToMarkdown = {
+  unsafe: [{ character: "~", inConstruct: "phrasing" }],
+  handlers: { delete: handleDelete }
+};
+handleDelete.peek = peekDelete;
+function enterStrikethrough(token) {
+  this.enter({ type: "delete", children: [] }, token);
+}
+function exitStrikethrough(token) {
+  this.exit(token);
+}
+function handleDelete(node, _, context, safeOptions) {
+  const tracker = track(safeOptions);
+  const exit2 = context.enter("emphasis");
+  let value = tracker.move("~~");
+  value += containerPhrasing(node, context, {
+    ...tracker.current(),
+    before: value,
+    after: "~"
+  });
+  value += tracker.move("~~");
+  exit2();
+  return value;
+}
+function peekDelete() {
+  return "~";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/inline-code.js
+inlineCode.peek = inlineCodePeek;
+function inlineCode(node, _, context) {
+  let value = node.value || "";
+  let sequence = "`";
+  let index = -1;
+  while (new RegExp("(^|[^`])" + sequence + "([^`]|$)").test(value)) {
+    sequence += "`";
+  }
+  if (/[^ \r\n]/.test(value) && (/^[ \r\n]/.test(value) && /[ \r\n]$/.test(value) || /^`|`$/.test(value))) {
+    value = " " + value + " ";
+  }
+  while (++index < context.unsafe.length) {
+    const pattern = context.unsafe[index];
+    const expression = patternCompile(pattern);
+    let match;
+    if (!pattern.atBreak)
+      continue;
+    while (match = expression.exec(value)) {
+      let position = match.index;
+      if (value.charCodeAt(position) === 10 && value.charCodeAt(position - 1) === 13) {
+        position--;
+      }
+      value = value.slice(0, position) + " " + value.slice(match.index + 1);
+    }
+  }
+  return sequence + value + sequence;
+}
+function inlineCodePeek() {
+  return "`";
+}
+
+// node_modules/mdast-util-gfm-table/node_modules/markdown-table/index.js
+function markdownTable(table, options = {}) {
+  const align = (options.align || []).concat();
+  const stringLength = options.stringLength || defaultStringLength;
+  const alignments = [];
+  const cellMatrix = [];
+  const sizeMatrix = [];
+  const longestCellByColumn = [];
+  let mostCellsPerRow = 0;
+  let rowIndex = -1;
+  while (++rowIndex < table.length) {
+    const row2 = [];
+    const sizes2 = [];
+    let columnIndex2 = -1;
+    if (table[rowIndex].length > mostCellsPerRow) {
+      mostCellsPerRow = table[rowIndex].length;
+    }
+    while (++columnIndex2 < table[rowIndex].length) {
+      const cell = serialize(table[rowIndex][columnIndex2]);
+      if (options.alignDelimiters !== false) {
+        const size = stringLength(cell);
+        sizes2[columnIndex2] = size;
+        if (longestCellByColumn[columnIndex2] === void 0 || size > longestCellByColumn[columnIndex2]) {
+          longestCellByColumn[columnIndex2] = size;
+        }
+      }
+      row2.push(cell);
+    }
+    cellMatrix[rowIndex] = row2;
+    sizeMatrix[rowIndex] = sizes2;
+  }
+  let columnIndex = -1;
+  if (typeof align === "object" && "length" in align) {
+    while (++columnIndex < mostCellsPerRow) {
+      alignments[columnIndex] = toAlignment(align[columnIndex]);
+    }
+  } else {
+    const code2 = toAlignment(align);
+    while (++columnIndex < mostCellsPerRow) {
+      alignments[columnIndex] = code2;
+    }
+  }
+  columnIndex = -1;
+  const row = [];
+  const sizes = [];
+  while (++columnIndex < mostCellsPerRow) {
+    const code2 = alignments[columnIndex];
+    let before = "";
+    let after = "";
+    if (code2 === 99) {
+      before = ":";
+      after = ":";
+    } else if (code2 === 108) {
+      before = ":";
+    } else if (code2 === 114) {
+      after = ":";
+    }
+    let size = options.alignDelimiters === false ? 1 : Math.max(
+      1,
+      longestCellByColumn[columnIndex] - before.length - after.length
+    );
+    const cell = before + "-".repeat(size) + after;
+    if (options.alignDelimiters !== false) {
+      size = before.length + size + after.length;
+      if (size > longestCellByColumn[columnIndex]) {
+        longestCellByColumn[columnIndex] = size;
+      }
+      sizes[columnIndex] = size;
+    }
+    row[columnIndex] = cell;
+  }
+  cellMatrix.splice(1, 0, row);
+  sizeMatrix.splice(1, 0, sizes);
+  rowIndex = -1;
+  const lines = [];
+  while (++rowIndex < cellMatrix.length) {
+    const row2 = cellMatrix[rowIndex];
+    const sizes2 = sizeMatrix[rowIndex];
+    columnIndex = -1;
+    const line = [];
+    while (++columnIndex < mostCellsPerRow) {
+      const cell = row2[columnIndex] || "";
+      let before = "";
+      let after = "";
+      if (options.alignDelimiters !== false) {
+        const size = longestCellByColumn[columnIndex] - (sizes2[columnIndex] || 0);
+        const code2 = alignments[columnIndex];
+        if (code2 === 114) {
+          before = " ".repeat(size);
+        } else if (code2 === 99) {
+          if (size % 2) {
+            before = " ".repeat(size / 2 + 0.5);
+            after = " ".repeat(size / 2 - 0.5);
+          } else {
+            before = " ".repeat(size / 2);
+            after = before;
+          }
+        } else {
+          after = " ".repeat(size);
+        }
+      }
+      if (options.delimiterStart !== false && !columnIndex) {
+        line.push("|");
+      }
+      if (options.padding !== false && !(options.alignDelimiters === false && cell === "") && (options.delimiterStart !== false || columnIndex)) {
+        line.push(" ");
+      }
+      if (options.alignDelimiters !== false) {
+        line.push(before);
+      }
+      line.push(cell);
+      if (options.alignDelimiters !== false) {
+        line.push(after);
+      }
+      if (options.padding !== false) {
+        line.push(" ");
+      }
+      if (options.delimiterEnd !== false || columnIndex !== mostCellsPerRow - 1) {
+        line.push("|");
+      }
+    }
+    lines.push(
+      options.delimiterEnd === false ? line.join("").replace(/ +$/, "") : line.join("")
+    );
+  }
+  return lines.join("\n");
+}
+function serialize(value) {
+  return value === null || value === void 0 ? "" : String(value);
+}
+function defaultStringLength(value) {
+  return value.length;
+}
+function toAlignment(value) {
+  const code2 = typeof value === "string" ? value.codePointAt(0) : 0;
+  return code2 === 67 || code2 === 99 ? 99 : code2 === 76 || code2 === 108 ? 108 : code2 === 82 || code2 === 114 ? 114 : 0;
+}
+
+// node_modules/mdast-util-gfm-table/lib/index.js
+var gfmTableFromMarkdown = {
+  enter: {
+    table: enterTable,
+    tableData: enterCell,
+    tableHeader: enterCell,
+    tableRow: enterRow
+  },
+  exit: {
+    codeText: exitCodeText,
+    table: exitTable,
+    tableData: exit,
+    tableHeader: exit,
+    tableRow: exit
+  }
+};
+function enterTable(token) {
+  const align = token._align;
+  this.enter(
+    {
+      type: "table",
+      align: align.map((d) => d === "none" ? null : d),
+      children: []
+    },
+    token
+  );
+  this.setData("inTable", true);
+}
+function exitTable(token) {
+  this.exit(token);
+  this.setData("inTable");
+}
+function enterRow(token) {
+  this.enter({ type: "tableRow", children: [] }, token);
+}
+function exit(token) {
+  this.exit(token);
+}
+function enterCell(token) {
+  this.enter({ type: "tableCell", children: [] }, token);
+}
+function exitCodeText(token) {
+  let value = this.resume();
+  if (this.getData("inTable")) {
+    value = value.replace(/\\([\\|])/g, replace);
+  }
+  const node = this.stack[this.stack.length - 1];
+  node.value = value;
+  this.exit(token);
+}
+function replace($0, $1) {
+  return $1 === "|" ? $1 : $0;
+}
+function gfmTableToMarkdown(options) {
+  const settings = options || {};
+  const padding = settings.tableCellPadding;
+  const alignDelimiters = settings.tablePipeAlign;
+  const stringLength = settings.stringLength;
+  const around = padding ? " " : "|";
+  return {
+    unsafe: [
+      { character: "\r", inConstruct: "tableCell" },
+      { character: "\n", inConstruct: "tableCell" },
+      { atBreak: true, character: "|", after: "[	 :-]" },
+      { character: "|", inConstruct: "tableCell" },
+      { atBreak: true, character: ":", after: "-" },
+      { atBreak: true, character: "-", after: "[:|-]" }
+    ],
+    handlers: {
+      table: handleTable,
+      tableRow: handleTableRow,
+      tableCell: handleTableCell,
+      inlineCode: inlineCodeWithTable
+    }
+  };
+  function handleTable(node, _, context, safeOptions) {
+    return serializeData(
+      handleTableAsData(node, context, safeOptions),
+      node.align
+    );
+  }
+  function handleTableRow(node, _, context, safeOptions) {
+    const row = handleTableRowAsData(node, context, safeOptions);
+    const value = serializeData([row]);
+    return value.slice(0, value.indexOf("\n"));
+  }
+  function handleTableCell(node, _, context, safeOptions) {
+    const exit2 = context.enter("tableCell");
+    const subexit = context.enter("phrasing");
+    const value = containerPhrasing(node, context, {
+      ...safeOptions,
+      before: around,
+      after: around
+    });
+    subexit();
+    exit2();
+    return value;
+  }
+  function serializeData(matrix, align) {
+    return markdownTable(matrix, {
+      align,
+      alignDelimiters,
+      padding,
+      stringLength
+    });
+  }
+  function handleTableAsData(node, context, safeOptions) {
+    const children = node.children;
+    let index = -1;
+    const result = [];
+    const subexit = context.enter("table");
+    while (++index < children.length) {
+      result[index] = handleTableRowAsData(
+        children[index],
+        context,
+        safeOptions
+      );
+    }
+    subexit();
+    return result;
+  }
+  function handleTableRowAsData(node, context, safeOptions) {
+    const children = node.children;
+    let index = -1;
+    const result = [];
+    const subexit = context.enter("tableRow");
+    while (++index < children.length) {
+      result[index] = handleTableCell(
+        children[index],
+        node,
+        context,
+        safeOptions
+      );
+    }
+    subexit();
+    return result;
+  }
+  function inlineCodeWithTable(node, parent, context) {
+    let value = inlineCode(node, parent, context);
+    if (context.stack.includes("tableCell")) {
+      value = value.replace(/\|/g, "\\$&");
+    }
+    return value;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet.js
+function checkBullet(context) {
+  const marker = context.options.bullet || "*";
+  if (marker !== "*" && marker !== "+" && marker !== "-") {
+    throw new Error(
+      "Cannot serialize items with `" + marker + "` for `options.bullet`, expected `*`, `+`, or `-`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-list-item-indent.js
+function checkListItemIndent(context) {
+  const style = context.options.listItemIndent || "tab";
+  if (style === 1 || style === "1") {
+    return "one";
+  }
+  if (style !== "tab" && style !== "one" && style !== "mixed") {
+    throw new Error(
+      "Cannot serialize items with `" + style + "` for `options.listItemIndent`, expected `tab`, `one`, or `mixed`"
+    );
+  }
+  return style;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/list-item.js
+function listItem(node, parent, context, safeOptions) {
+  const listItemIndent = checkListItemIndent(context);
+  let bullet = context.bulletCurrent || checkBullet(context);
+  if (parent && parent.type === "list" && parent.ordered) {
+    bullet = (typeof parent.start === "number" && parent.start > -1 ? parent.start : 1) + (context.options.incrementListMarker === false ? 0 : parent.children.indexOf(node)) + bullet;
+  }
+  let size = bullet.length + 1;
+  if (listItemIndent === "tab" || listItemIndent === "mixed" && (parent && parent.type === "list" && parent.spread || node.spread)) {
+    size = Math.ceil(size / 4) * 4;
+  }
+  const tracker = track(safeOptions);
+  tracker.move(bullet + " ".repeat(size - bullet.length));
+  tracker.shift(size);
+  const exit2 = context.enter("listItem");
+  const value = indentLines(
+    containerFlow(node, context, tracker.current()),
+    map
+  );
+  exit2();
+  return value;
+  function map(line, index, blank) {
+    if (index) {
+      return (blank ? "" : " ".repeat(size)) + line;
+    }
+    return (blank ? bullet : bullet + " ".repeat(size - bullet.length)) + line;
+  }
+}
+
+// node_modules/mdast-util-gfm-task-list-item/index.js
+var gfmTaskListItemFromMarkdown = {
+  exit: {
+    taskListCheckValueChecked: exitCheck,
+    taskListCheckValueUnchecked: exitCheck,
+    paragraph: exitParagraphWithTaskListItem
+  }
+};
+var gfmTaskListItemToMarkdown = {
+  unsafe: [{ atBreak: true, character: "-", after: "[:|-]" }],
+  handlers: { listItem: listItemWithTaskListItem }
+};
+function exitCheck(token) {
+  const node = this.stack[this.stack.length - 2];
+  node.checked = token.type === "taskListCheckValueChecked";
+}
+function exitParagraphWithTaskListItem(token) {
+  const parent = this.stack[this.stack.length - 2];
+  const node = this.stack[this.stack.length - 1];
+  const siblings = parent.children;
+  const head = node.children[0];
+  let index = -1;
+  let firstParaghraph;
+  if (parent && parent.type === "listItem" && typeof parent.checked === "boolean" && head && head.type === "text") {
+    while (++index < siblings.length) {
+      const sibling = siblings[index];
+      if (sibling.type === "paragraph") {
+        firstParaghraph = sibling;
+        break;
+      }
+    }
+    if (firstParaghraph === node) {
+      head.value = head.value.slice(1);
+      if (head.value.length === 0) {
+        node.children.shift();
+      } else if (node.position && head.position && typeof head.position.start.offset === "number") {
+        head.position.start.column++;
+        head.position.start.offset++;
+        node.position.start = Object.assign({}, head.position.start);
+      }
+    }
+  }
+  this.exit(token);
+}
+function listItemWithTaskListItem(node, parent, context, safeOptions) {
+  const head = node.children[0];
+  const checkable = typeof node.checked === "boolean" && head && head.type === "paragraph";
+  const checkbox = "[" + (node.checked ? "x" : " ") + "] ";
+  const tracker = track(safeOptions);
+  if (checkable) {
+    tracker.move(checkbox);
+  }
+  let value = listItem(node, parent, context, {
+    ...safeOptions,
+    ...tracker.current()
+  });
+  if (checkable) {
+    value = value.replace(/^(?:[*+-]|\d+\.)([\r\n]| {1,3})/, check);
+  }
+  return value;
+  function check($0) {
+    return $0 + checkbox;
+  }
+}
+
+// node_modules/mdast-util-gfm/lib/index.js
+function gfmFromMarkdown() {
+  return [
+    gfmAutolinkLiteralFromMarkdown,
+    gfmFootnoteFromMarkdown(),
+    gfmStrikethroughFromMarkdown,
+    gfmTableFromMarkdown,
+    gfmTaskListItemFromMarkdown
+  ];
+}
+function gfmToMarkdown(options) {
+  return {
+    extensions: [
+      gfmAutolinkLiteralToMarkdown,
+      gfmFootnoteToMarkdown(),
+      gfmStrikethroughToMarkdown,
+      gfmTableToMarkdown(options),
+      gfmTaskListItemToMarkdown
+    ]
+  };
+}
+
+// node_modules/remark-gfm/index.js
+function remarkGfm(options = {}) {
+  const data = this.data();
+  add("micromarkExtensions", gfm(options));
+  add("fromMarkdownExtensions", gfmFromMarkdown());
+  add("toMarkdownExtensions", gfmToMarkdown(options));
+  function add(field, value) {
+    const list = data[field] ? data[field] : data[field] = [];
+    list.push(value);
+  }
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {});

--- a/jest/vendor/remark-mdx@2.1.5.js
+++ b/jest/vendor/remark-mdx@2.1.5.js
@@ -1,0 +1,14938 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/acorn-jsx/xhtml.js
+var require_xhtml = __commonJS({
+  "node_modules/acorn-jsx/xhtml.js"(exports, module2) {
+    module2.exports = {
+      quot: '"',
+      amp: "&",
+      apos: "'",
+      lt: "<",
+      gt: ">",
+      nbsp: "\xA0",
+      iexcl: "\xA1",
+      cent: "\xA2",
+      pound: "\xA3",
+      curren: "\xA4",
+      yen: "\xA5",
+      brvbar: "\xA6",
+      sect: "\xA7",
+      uml: "\xA8",
+      copy: "\xA9",
+      ordf: "\xAA",
+      laquo: "\xAB",
+      not: "\xAC",
+      shy: "\xAD",
+      reg: "\xAE",
+      macr: "\xAF",
+      deg: "\xB0",
+      plusmn: "\xB1",
+      sup2: "\xB2",
+      sup3: "\xB3",
+      acute: "\xB4",
+      micro: "\xB5",
+      para: "\xB6",
+      middot: "\xB7",
+      cedil: "\xB8",
+      sup1: "\xB9",
+      ordm: "\xBA",
+      raquo: "\xBB",
+      frac14: "\xBC",
+      frac12: "\xBD",
+      frac34: "\xBE",
+      iquest: "\xBF",
+      Agrave: "\xC0",
+      Aacute: "\xC1",
+      Acirc: "\xC2",
+      Atilde: "\xC3",
+      Auml: "\xC4",
+      Aring: "\xC5",
+      AElig: "\xC6",
+      Ccedil: "\xC7",
+      Egrave: "\xC8",
+      Eacute: "\xC9",
+      Ecirc: "\xCA",
+      Euml: "\xCB",
+      Igrave: "\xCC",
+      Iacute: "\xCD",
+      Icirc: "\xCE",
+      Iuml: "\xCF",
+      ETH: "\xD0",
+      Ntilde: "\xD1",
+      Ograve: "\xD2",
+      Oacute: "\xD3",
+      Ocirc: "\xD4",
+      Otilde: "\xD5",
+      Ouml: "\xD6",
+      times: "\xD7",
+      Oslash: "\xD8",
+      Ugrave: "\xD9",
+      Uacute: "\xDA",
+      Ucirc: "\xDB",
+      Uuml: "\xDC",
+      Yacute: "\xDD",
+      THORN: "\xDE",
+      szlig: "\xDF",
+      agrave: "\xE0",
+      aacute: "\xE1",
+      acirc: "\xE2",
+      atilde: "\xE3",
+      auml: "\xE4",
+      aring: "\xE5",
+      aelig: "\xE6",
+      ccedil: "\xE7",
+      egrave: "\xE8",
+      eacute: "\xE9",
+      ecirc: "\xEA",
+      euml: "\xEB",
+      igrave: "\xEC",
+      iacute: "\xED",
+      icirc: "\xEE",
+      iuml: "\xEF",
+      eth: "\xF0",
+      ntilde: "\xF1",
+      ograve: "\xF2",
+      oacute: "\xF3",
+      ocirc: "\xF4",
+      otilde: "\xF5",
+      ouml: "\xF6",
+      divide: "\xF7",
+      oslash: "\xF8",
+      ugrave: "\xF9",
+      uacute: "\xFA",
+      ucirc: "\xFB",
+      uuml: "\xFC",
+      yacute: "\xFD",
+      thorn: "\xFE",
+      yuml: "\xFF",
+      OElig: "\u0152",
+      oelig: "\u0153",
+      Scaron: "\u0160",
+      scaron: "\u0161",
+      Yuml: "\u0178",
+      fnof: "\u0192",
+      circ: "\u02C6",
+      tilde: "\u02DC",
+      Alpha: "\u0391",
+      Beta: "\u0392",
+      Gamma: "\u0393",
+      Delta: "\u0394",
+      Epsilon: "\u0395",
+      Zeta: "\u0396",
+      Eta: "\u0397",
+      Theta: "\u0398",
+      Iota: "\u0399",
+      Kappa: "\u039A",
+      Lambda: "\u039B",
+      Mu: "\u039C",
+      Nu: "\u039D",
+      Xi: "\u039E",
+      Omicron: "\u039F",
+      Pi: "\u03A0",
+      Rho: "\u03A1",
+      Sigma: "\u03A3",
+      Tau: "\u03A4",
+      Upsilon: "\u03A5",
+      Phi: "\u03A6",
+      Chi: "\u03A7",
+      Psi: "\u03A8",
+      Omega: "\u03A9",
+      alpha: "\u03B1",
+      beta: "\u03B2",
+      gamma: "\u03B3",
+      delta: "\u03B4",
+      epsilon: "\u03B5",
+      zeta: "\u03B6",
+      eta: "\u03B7",
+      theta: "\u03B8",
+      iota: "\u03B9",
+      kappa: "\u03BA",
+      lambda: "\u03BB",
+      mu: "\u03BC",
+      nu: "\u03BD",
+      xi: "\u03BE",
+      omicron: "\u03BF",
+      pi: "\u03C0",
+      rho: "\u03C1",
+      sigmaf: "\u03C2",
+      sigma: "\u03C3",
+      tau: "\u03C4",
+      upsilon: "\u03C5",
+      phi: "\u03C6",
+      chi: "\u03C7",
+      psi: "\u03C8",
+      omega: "\u03C9",
+      thetasym: "\u03D1",
+      upsih: "\u03D2",
+      piv: "\u03D6",
+      ensp: "\u2002",
+      emsp: "\u2003",
+      thinsp: "\u2009",
+      zwnj: "\u200C",
+      zwj: "\u200D",
+      lrm: "\u200E",
+      rlm: "\u200F",
+      ndash: "\u2013",
+      mdash: "\u2014",
+      lsquo: "\u2018",
+      rsquo: "\u2019",
+      sbquo: "\u201A",
+      ldquo: "\u201C",
+      rdquo: "\u201D",
+      bdquo: "\u201E",
+      dagger: "\u2020",
+      Dagger: "\u2021",
+      bull: "\u2022",
+      hellip: "\u2026",
+      permil: "\u2030",
+      prime: "\u2032",
+      Prime: "\u2033",
+      lsaquo: "\u2039",
+      rsaquo: "\u203A",
+      oline: "\u203E",
+      frasl: "\u2044",
+      euro: "\u20AC",
+      image: "\u2111",
+      weierp: "\u2118",
+      real: "\u211C",
+      trade: "\u2122",
+      alefsym: "\u2135",
+      larr: "\u2190",
+      uarr: "\u2191",
+      rarr: "\u2192",
+      darr: "\u2193",
+      harr: "\u2194",
+      crarr: "\u21B5",
+      lArr: "\u21D0",
+      uArr: "\u21D1",
+      rArr: "\u21D2",
+      dArr: "\u21D3",
+      hArr: "\u21D4",
+      forall: "\u2200",
+      part: "\u2202",
+      exist: "\u2203",
+      empty: "\u2205",
+      nabla: "\u2207",
+      isin: "\u2208",
+      notin: "\u2209",
+      ni: "\u220B",
+      prod: "\u220F",
+      sum: "\u2211",
+      minus: "\u2212",
+      lowast: "\u2217",
+      radic: "\u221A",
+      prop: "\u221D",
+      infin: "\u221E",
+      ang: "\u2220",
+      and: "\u2227",
+      or: "\u2228",
+      cap: "\u2229",
+      cup: "\u222A",
+      "int": "\u222B",
+      there4: "\u2234",
+      sim: "\u223C",
+      cong: "\u2245",
+      asymp: "\u2248",
+      ne: "\u2260",
+      equiv: "\u2261",
+      le: "\u2264",
+      ge: "\u2265",
+      sub: "\u2282",
+      sup: "\u2283",
+      nsub: "\u2284",
+      sube: "\u2286",
+      supe: "\u2287",
+      oplus: "\u2295",
+      otimes: "\u2297",
+      perp: "\u22A5",
+      sdot: "\u22C5",
+      lceil: "\u2308",
+      rceil: "\u2309",
+      lfloor: "\u230A",
+      rfloor: "\u230B",
+      lang: "\u2329",
+      rang: "\u232A",
+      loz: "\u25CA",
+      spades: "\u2660",
+      clubs: "\u2663",
+      hearts: "\u2665",
+      diams: "\u2666"
+    };
+  }
+});
+
+// node_modules/acorn/dist/acorn.js
+var require_acorn = __commonJS({
+  "node_modules/acorn/dist/acorn.js"(exports, module2) {
+    (function(global, factory) {
+      typeof exports === "object" && typeof module2 !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, factory(global.acorn = {}));
+    })(exports, function(exports2) {
+      "use strict";
+      var astralIdentifierCodes2 = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 370, 1, 154, 10, 50, 3, 123, 2, 54, 14, 32, 10, 3, 1, 11, 3, 46, 10, 8, 0, 46, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 161, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 193, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 84, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 406, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 19306, 9, 87, 9, 39, 4, 60, 6, 26, 9, 1014, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 4706, 45, 3, 22, 543, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 262, 6, 10, 9, 357, 0, 62, 13, 1495, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
+      var astralIdentifierStartCodes2 = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 13, 10, 2, 14, 2, 6, 2, 1, 2, 10, 2, 14, 2, 6, 2, 1, 68, 310, 10, 21, 11, 7, 25, 5, 2, 41, 2, 8, 70, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 349, 41, 7, 1, 79, 28, 11, 0, 9, 21, 43, 17, 47, 20, 28, 22, 13, 52, 58, 1, 3, 0, 14, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 85, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 159, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 38, 6, 186, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 19, 72, 264, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 190, 0, 80, 921, 103, 110, 18, 195, 2637, 96, 16, 1070, 4050, 582, 8634, 568, 8, 30, 18, 78, 18, 29, 19, 47, 17, 3, 32, 20, 6, 18, 689, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 43, 8, 8936, 3, 2, 6, 2, 1, 2, 290, 46, 2, 18, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 1845, 30, 482, 44, 11, 6, 17, 0, 322, 29, 19, 43, 1269, 6, 2, 3, 2, 1, 2, 14, 2, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42719, 33, 4152, 8, 221, 3, 5761, 15, 7472, 3104, 541, 1507, 4938];
+      var nonASCIIidentifierChars2 = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u0898-\u089F\u08CA-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3C\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1715\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u180F-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF-\u1ACE\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DFF\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F";
+      var nonASCIIidentifierStartChars2 = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u0870-\u0887\u0889-\u088E\u08A0-\u08C9\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C5D\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u1711\u171F-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4C\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7CA\uA7D0\uA7D1\uA7D3\uA7D5-\uA7D9\uA7F2-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
+      var reservedWords2 = {
+        3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
+        5: "class enum extends super const export import",
+        6: "enum",
+        strict: "implements interface let package private protected public static yield",
+        strictBind: "eval arguments"
+      };
+      var ecma5AndLessKeywords2 = "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this";
+      var keywords$12 = {
+        5: ecma5AndLessKeywords2,
+        "5module": ecma5AndLessKeywords2 + " export import",
+        6: ecma5AndLessKeywords2 + " const class extends export import super"
+      };
+      var keywordRelationalOperator2 = /^in(stanceof)?$/;
+      var nonASCIIidentifierStart2 = new RegExp("[" + nonASCIIidentifierStartChars2 + "]");
+      var nonASCIIidentifier2 = new RegExp("[" + nonASCIIidentifierStartChars2 + nonASCIIidentifierChars2 + "]");
+      function isInAstralSet2(code, set) {
+        var pos = 65536;
+        for (var i2 = 0; i2 < set.length; i2 += 2) {
+          pos += set[i2];
+          if (pos > code) {
+            return false;
+          }
+          pos += set[i2 + 1];
+          if (pos >= code) {
+            return true;
+          }
+        }
+      }
+      function isIdentifierStart2(code, astral) {
+        if (code < 65) {
+          return code === 36;
+        }
+        if (code < 91) {
+          return true;
+        }
+        if (code < 97) {
+          return code === 95;
+        }
+        if (code < 123) {
+          return true;
+        }
+        if (code <= 65535) {
+          return code >= 170 && nonASCIIidentifierStart2.test(String.fromCharCode(code));
+        }
+        if (astral === false) {
+          return false;
+        }
+        return isInAstralSet2(code, astralIdentifierStartCodes2);
+      }
+      function isIdentifierChar2(code, astral) {
+        if (code < 48) {
+          return code === 36;
+        }
+        if (code < 58) {
+          return true;
+        }
+        if (code < 65) {
+          return false;
+        }
+        if (code < 91) {
+          return true;
+        }
+        if (code < 97) {
+          return code === 95;
+        }
+        if (code < 123) {
+          return true;
+        }
+        if (code <= 65535) {
+          return code >= 170 && nonASCIIidentifier2.test(String.fromCharCode(code));
+        }
+        if (astral === false) {
+          return false;
+        }
+        return isInAstralSet2(code, astralIdentifierStartCodes2) || isInAstralSet2(code, astralIdentifierCodes2);
+      }
+      var TokenType3 = function TokenType4(label, conf) {
+        if (conf === void 0)
+          conf = {};
+        this.label = label;
+        this.keyword = conf.keyword;
+        this.beforeExpr = !!conf.beforeExpr;
+        this.startsExpr = !!conf.startsExpr;
+        this.isLoop = !!conf.isLoop;
+        this.isAssign = !!conf.isAssign;
+        this.prefix = !!conf.prefix;
+        this.postfix = !!conf.postfix;
+        this.binop = conf.binop || null;
+        this.updateContext = null;
+      };
+      function binop2(name, prec) {
+        return new TokenType3(name, { beforeExpr: true, binop: prec });
+      }
+      var beforeExpr2 = { beforeExpr: true }, startsExpr2 = { startsExpr: true };
+      var keywords2 = {};
+      function kw2(name, options) {
+        if (options === void 0)
+          options = {};
+        options.keyword = name;
+        return keywords2[name] = new TokenType3(name, options);
+      }
+      var types$12 = {
+        num: new TokenType3("num", startsExpr2),
+        regexp: new TokenType3("regexp", startsExpr2),
+        string: new TokenType3("string", startsExpr2),
+        name: new TokenType3("name", startsExpr2),
+        privateId: new TokenType3("privateId", startsExpr2),
+        eof: new TokenType3("eof"),
+        bracketL: new TokenType3("[", { beforeExpr: true, startsExpr: true }),
+        bracketR: new TokenType3("]"),
+        braceL: new TokenType3("{", { beforeExpr: true, startsExpr: true }),
+        braceR: new TokenType3("}"),
+        parenL: new TokenType3("(", { beforeExpr: true, startsExpr: true }),
+        parenR: new TokenType3(")"),
+        comma: new TokenType3(",", beforeExpr2),
+        semi: new TokenType3(";", beforeExpr2),
+        colon: new TokenType3(":", beforeExpr2),
+        dot: new TokenType3("."),
+        question: new TokenType3("?", beforeExpr2),
+        questionDot: new TokenType3("?."),
+        arrow: new TokenType3("=>", beforeExpr2),
+        template: new TokenType3("template"),
+        invalidTemplate: new TokenType3("invalidTemplate"),
+        ellipsis: new TokenType3("...", beforeExpr2),
+        backQuote: new TokenType3("`", startsExpr2),
+        dollarBraceL: new TokenType3("${", { beforeExpr: true, startsExpr: true }),
+        eq: new TokenType3("=", { beforeExpr: true, isAssign: true }),
+        assign: new TokenType3("_=", { beforeExpr: true, isAssign: true }),
+        incDec: new TokenType3("++/--", { prefix: true, postfix: true, startsExpr: true }),
+        prefix: new TokenType3("!/~", { beforeExpr: true, prefix: true, startsExpr: true }),
+        logicalOR: binop2("||", 1),
+        logicalAND: binop2("&&", 2),
+        bitwiseOR: binop2("|", 3),
+        bitwiseXOR: binop2("^", 4),
+        bitwiseAND: binop2("&", 5),
+        equality: binop2("==/!=/===/!==", 6),
+        relational: binop2("</>/<=/>=", 7),
+        bitShift: binop2("<</>>/>>>", 8),
+        plusMin: new TokenType3("+/-", { beforeExpr: true, binop: 9, prefix: true, startsExpr: true }),
+        modulo: binop2("%", 10),
+        star: binop2("*", 10),
+        slash: binop2("/", 10),
+        starstar: new TokenType3("**", { beforeExpr: true }),
+        coalesce: binop2("??", 1),
+        _break: kw2("break"),
+        _case: kw2("case", beforeExpr2),
+        _catch: kw2("catch"),
+        _continue: kw2("continue"),
+        _debugger: kw2("debugger"),
+        _default: kw2("default", beforeExpr2),
+        _do: kw2("do", { isLoop: true, beforeExpr: true }),
+        _else: kw2("else", beforeExpr2),
+        _finally: kw2("finally"),
+        _for: kw2("for", { isLoop: true }),
+        _function: kw2("function", startsExpr2),
+        _if: kw2("if"),
+        _return: kw2("return", beforeExpr2),
+        _switch: kw2("switch"),
+        _throw: kw2("throw", beforeExpr2),
+        _try: kw2("try"),
+        _var: kw2("var"),
+        _const: kw2("const"),
+        _while: kw2("while", { isLoop: true }),
+        _with: kw2("with"),
+        _new: kw2("new", { beforeExpr: true, startsExpr: true }),
+        _this: kw2("this", startsExpr2),
+        _super: kw2("super", startsExpr2),
+        _class: kw2("class", startsExpr2),
+        _extends: kw2("extends", beforeExpr2),
+        _export: kw2("export"),
+        _import: kw2("import", startsExpr2),
+        _null: kw2("null", startsExpr2),
+        _true: kw2("true", startsExpr2),
+        _false: kw2("false", startsExpr2),
+        _in: kw2("in", { beforeExpr: true, binop: 7 }),
+        _instanceof: kw2("instanceof", { beforeExpr: true, binop: 7 }),
+        _typeof: kw2("typeof", { beforeExpr: true, prefix: true, startsExpr: true }),
+        _void: kw2("void", { beforeExpr: true, prefix: true, startsExpr: true }),
+        _delete: kw2("delete", { beforeExpr: true, prefix: true, startsExpr: true })
+      };
+      var lineBreak2 = /\r\n?|\n|\u2028|\u2029/;
+      var lineBreakG2 = new RegExp(lineBreak2.source, "g");
+      function isNewLine2(code) {
+        return code === 10 || code === 13 || code === 8232 || code === 8233;
+      }
+      function nextLineBreak2(code, from, end) {
+        if (end === void 0)
+          end = code.length;
+        for (var i2 = from; i2 < end; i2++) {
+          var next = code.charCodeAt(i2);
+          if (isNewLine2(next)) {
+            return i2 < end - 1 && next === 13 && code.charCodeAt(i2 + 1) === 10 ? i2 + 2 : i2 + 1;
+          }
+        }
+        return -1;
+      }
+      var nonASCIIwhitespace2 = /[\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
+      var skipWhiteSpace2 = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
+      var ref2 = Object.prototype;
+      var hasOwnProperty3 = ref2.hasOwnProperty;
+      var toString2 = ref2.toString;
+      var hasOwn2 = Object.hasOwn || function(obj, propName) {
+        return hasOwnProperty3.call(obj, propName);
+      };
+      var isArray2 = Array.isArray || function(obj) {
+        return toString2.call(obj) === "[object Array]";
+      };
+      function wordsRegexp2(words) {
+        return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+      }
+      function codePointToString2(code) {
+        if (code <= 65535) {
+          return String.fromCharCode(code);
+        }
+        code -= 65536;
+        return String.fromCharCode((code >> 10) + 55296, (code & 1023) + 56320);
+      }
+      var loneSurrogate2 = /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/;
+      var Position3 = function Position4(line, col) {
+        this.line = line;
+        this.column = col;
+      };
+      Position3.prototype.offset = function offset2(n) {
+        return new Position3(this.line, this.column + n);
+      };
+      var SourceLocation3 = function SourceLocation4(p, start3, end) {
+        this.start = start3;
+        this.end = end;
+        if (p.sourceFile !== null) {
+          this.source = p.sourceFile;
+        }
+      };
+      function getLineInfo2(input, offset2) {
+        for (var line = 1, cur = 0; ; ) {
+          var nextBreak = nextLineBreak2(input, cur, offset2);
+          if (nextBreak < 0) {
+            return new Position3(line, offset2 - cur);
+          }
+          ++line;
+          cur = nextBreak;
+        }
+      }
+      var defaultOptions2 = {
+        ecmaVersion: null,
+        sourceType: "script",
+        onInsertedSemicolon: null,
+        onTrailingComma: null,
+        allowReserved: null,
+        allowReturnOutsideFunction: false,
+        allowImportExportEverywhere: false,
+        allowAwaitOutsideFunction: null,
+        allowSuperOutsideMethod: null,
+        allowHashBang: false,
+        locations: false,
+        onToken: null,
+        onComment: null,
+        ranges: false,
+        program: null,
+        sourceFile: null,
+        directSourceFile: null,
+        preserveParens: false
+      };
+      var warnedAboutEcmaVersion2 = false;
+      function getOptions2(opts) {
+        var options = {};
+        for (var opt in defaultOptions2) {
+          options[opt] = opts && hasOwn2(opts, opt) ? opts[opt] : defaultOptions2[opt];
+        }
+        if (options.ecmaVersion === "latest") {
+          options.ecmaVersion = 1e8;
+        } else if (options.ecmaVersion == null) {
+          if (!warnedAboutEcmaVersion2 && typeof console === "object" && console.warn) {
+            warnedAboutEcmaVersion2 = true;
+            console.warn("Since Acorn 8.0.0, options.ecmaVersion is required.\nDefaulting to 2020, but this will stop working in the future.");
+          }
+          options.ecmaVersion = 11;
+        } else if (options.ecmaVersion >= 2015) {
+          options.ecmaVersion -= 2009;
+        }
+        if (options.allowReserved == null) {
+          options.allowReserved = options.ecmaVersion < 5;
+        }
+        if (opts.allowHashBang == null) {
+          options.allowHashBang = options.ecmaVersion >= 14;
+        }
+        if (isArray2(options.onToken)) {
+          var tokens = options.onToken;
+          options.onToken = function(token) {
+            return tokens.push(token);
+          };
+        }
+        if (isArray2(options.onComment)) {
+          options.onComment = pushComment2(options, options.onComment);
+        }
+        return options;
+      }
+      function pushComment2(options, array) {
+        return function(block, text, start3, end, startLoc, endLoc) {
+          var comment = {
+            type: block ? "Block" : "Line",
+            value: text,
+            start: start3,
+            end
+          };
+          if (options.locations) {
+            comment.loc = new SourceLocation3(this, startLoc, endLoc);
+          }
+          if (options.ranges) {
+            comment.range = [start3, end];
+          }
+          array.push(comment);
+        };
+      }
+      var SCOPE_TOP2 = 1, SCOPE_FUNCTION2 = 2, SCOPE_ASYNC2 = 4, SCOPE_GENERATOR2 = 8, SCOPE_ARROW2 = 16, SCOPE_SIMPLE_CATCH2 = 32, SCOPE_SUPER2 = 64, SCOPE_DIRECT_SUPER2 = 128, SCOPE_CLASS_STATIC_BLOCK2 = 256, SCOPE_VAR2 = SCOPE_TOP2 | SCOPE_FUNCTION2 | SCOPE_CLASS_STATIC_BLOCK2;
+      function functionFlags2(async, generator) {
+        return SCOPE_FUNCTION2 | (async ? SCOPE_ASYNC2 : 0) | (generator ? SCOPE_GENERATOR2 : 0);
+      }
+      var BIND_NONE2 = 0, BIND_VAR2 = 1, BIND_LEXICAL2 = 2, BIND_FUNCTION2 = 3, BIND_SIMPLE_CATCH2 = 4, BIND_OUTSIDE2 = 5;
+      var Parser3 = function Parser4(options, input, startPos) {
+        this.options = options = getOptions2(options);
+        this.sourceFile = options.sourceFile;
+        this.keywords = wordsRegexp2(keywords$12[options.ecmaVersion >= 6 ? 6 : options.sourceType === "module" ? "5module" : 5]);
+        var reserved = "";
+        if (options.allowReserved !== true) {
+          reserved = reservedWords2[options.ecmaVersion >= 6 ? 6 : options.ecmaVersion === 5 ? 5 : 3];
+          if (options.sourceType === "module") {
+            reserved += " await";
+          }
+        }
+        this.reservedWords = wordsRegexp2(reserved);
+        var reservedStrict = (reserved ? reserved + " " : "") + reservedWords2.strict;
+        this.reservedWordsStrict = wordsRegexp2(reservedStrict);
+        this.reservedWordsStrictBind = wordsRegexp2(reservedStrict + " " + reservedWords2.strictBind);
+        this.input = String(input);
+        this.containsEsc = false;
+        if (startPos) {
+          this.pos = startPos;
+          this.lineStart = this.input.lastIndexOf("\n", startPos - 1) + 1;
+          this.curLine = this.input.slice(0, this.lineStart).split(lineBreak2).length;
+        } else {
+          this.pos = this.lineStart = 0;
+          this.curLine = 1;
+        }
+        this.type = types$12.eof;
+        this.value = null;
+        this.start = this.end = this.pos;
+        this.startLoc = this.endLoc = this.curPosition();
+        this.lastTokEndLoc = this.lastTokStartLoc = null;
+        this.lastTokStart = this.lastTokEnd = this.pos;
+        this.context = this.initialContext();
+        this.exprAllowed = true;
+        this.inModule = options.sourceType === "module";
+        this.strict = this.inModule || this.strictDirective(this.pos);
+        this.potentialArrowAt = -1;
+        this.potentialArrowInForAwait = false;
+        this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
+        this.labels = [];
+        this.undefinedExports = /* @__PURE__ */ Object.create(null);
+        if (this.pos === 0 && options.allowHashBang && this.input.slice(0, 2) === "#!") {
+          this.skipLineComment(2);
+        }
+        this.scopeStack = [];
+        this.enterScope(SCOPE_TOP2);
+        this.regexpState = null;
+        this.privateNameStack = [];
+      };
+      var prototypeAccessors2 = { inFunction: { configurable: true }, inGenerator: { configurable: true }, inAsync: { configurable: true }, canAwait: { configurable: true }, allowSuper: { configurable: true }, allowDirectSuper: { configurable: true }, treatFunctionsAsVar: { configurable: true }, allowNewDotTarget: { configurable: true }, inClassStaticBlock: { configurable: true } };
+      Parser3.prototype.parse = function parse4() {
+        var node = this.options.program || this.startNode();
+        this.nextToken();
+        return this.parseTopLevel(node);
+      };
+      prototypeAccessors2.inFunction.get = function() {
+        return (this.currentVarScope().flags & SCOPE_FUNCTION2) > 0;
+      };
+      prototypeAccessors2.inGenerator.get = function() {
+        return (this.currentVarScope().flags & SCOPE_GENERATOR2) > 0 && !this.currentVarScope().inClassFieldInit;
+      };
+      prototypeAccessors2.inAsync.get = function() {
+        return (this.currentVarScope().flags & SCOPE_ASYNC2) > 0 && !this.currentVarScope().inClassFieldInit;
+      };
+      prototypeAccessors2.canAwait.get = function() {
+        for (var i2 = this.scopeStack.length - 1; i2 >= 0; i2--) {
+          var scope = this.scopeStack[i2];
+          if (scope.inClassFieldInit || scope.flags & SCOPE_CLASS_STATIC_BLOCK2) {
+            return false;
+          }
+          if (scope.flags & SCOPE_FUNCTION2) {
+            return (scope.flags & SCOPE_ASYNC2) > 0;
+          }
+        }
+        return this.inModule && this.options.ecmaVersion >= 13 || this.options.allowAwaitOutsideFunction;
+      };
+      prototypeAccessors2.allowSuper.get = function() {
+        var ref3 = this.currentThisScope();
+        var flags = ref3.flags;
+        var inClassFieldInit = ref3.inClassFieldInit;
+        return (flags & SCOPE_SUPER2) > 0 || inClassFieldInit || this.options.allowSuperOutsideMethod;
+      };
+      prototypeAccessors2.allowDirectSuper.get = function() {
+        return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER2) > 0;
+      };
+      prototypeAccessors2.treatFunctionsAsVar.get = function() {
+        return this.treatFunctionsAsVarInScope(this.currentScope());
+      };
+      prototypeAccessors2.allowNewDotTarget.get = function() {
+        var ref3 = this.currentThisScope();
+        var flags = ref3.flags;
+        var inClassFieldInit = ref3.inClassFieldInit;
+        return (flags & (SCOPE_FUNCTION2 | SCOPE_CLASS_STATIC_BLOCK2)) > 0 || inClassFieldInit;
+      };
+      prototypeAccessors2.inClassStaticBlock.get = function() {
+        return (this.currentVarScope().flags & SCOPE_CLASS_STATIC_BLOCK2) > 0;
+      };
+      Parser3.extend = function extend2() {
+        var plugins = [], len = arguments.length;
+        while (len--)
+          plugins[len] = arguments[len];
+        var cls = this;
+        for (var i2 = 0; i2 < plugins.length; i2++) {
+          cls = plugins[i2](cls);
+        }
+        return cls;
+      };
+      Parser3.parse = function parse4(input, options) {
+        return new this(options, input).parse();
+      };
+      Parser3.parseExpressionAt = function parseExpressionAt3(input, pos, options) {
+        var parser = new this(options, input, pos);
+        parser.nextToken();
+        return parser.parseExpression();
+      };
+      Parser3.tokenizer = function tokenizer3(input, options) {
+        return new this(options, input);
+      };
+      Object.defineProperties(Parser3.prototype, prototypeAccessors2);
+      var pp$92 = Parser3.prototype;
+      var literal2 = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/;
+      pp$92.strictDirective = function(start3) {
+        if (this.options.ecmaVersion < 5) {
+          return false;
+        }
+        for (; ; ) {
+          skipWhiteSpace2.lastIndex = start3;
+          start3 += skipWhiteSpace2.exec(this.input)[0].length;
+          var match = literal2.exec(this.input.slice(start3));
+          if (!match) {
+            return false;
+          }
+          if ((match[1] || match[2]) === "use strict") {
+            skipWhiteSpace2.lastIndex = start3 + match[0].length;
+            var spaceAfter = skipWhiteSpace2.exec(this.input), end = spaceAfter.index + spaceAfter[0].length;
+            var next = this.input.charAt(end);
+            return next === ";" || next === "}" || lineBreak2.test(spaceAfter[0]) && !(/[(`.[+\-/*%<>=,?^&]/.test(next) || next === "!" && this.input.charAt(end + 1) === "=");
+          }
+          start3 += match[0].length;
+          skipWhiteSpace2.lastIndex = start3;
+          start3 += skipWhiteSpace2.exec(this.input)[0].length;
+          if (this.input[start3] === ";") {
+            start3++;
+          }
+        }
+      };
+      pp$92.eat = function(type) {
+        if (this.type === type) {
+          this.next();
+          return true;
+        } else {
+          return false;
+        }
+      };
+      pp$92.isContextual = function(name) {
+        return this.type === types$12.name && this.value === name && !this.containsEsc;
+      };
+      pp$92.eatContextual = function(name) {
+        if (!this.isContextual(name)) {
+          return false;
+        }
+        this.next();
+        return true;
+      };
+      pp$92.expectContextual = function(name) {
+        if (!this.eatContextual(name)) {
+          this.unexpected();
+        }
+      };
+      pp$92.canInsertSemicolon = function() {
+        return this.type === types$12.eof || this.type === types$12.braceR || lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+      };
+      pp$92.insertSemicolon = function() {
+        if (this.canInsertSemicolon()) {
+          if (this.options.onInsertedSemicolon) {
+            this.options.onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+          }
+          return true;
+        }
+      };
+      pp$92.semicolon = function() {
+        if (!this.eat(types$12.semi) && !this.insertSemicolon()) {
+          this.unexpected();
+        }
+      };
+      pp$92.afterTrailingComma = function(tokType, notNext) {
+        if (this.type === tokType) {
+          if (this.options.onTrailingComma) {
+            this.options.onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+          }
+          if (!notNext) {
+            this.next();
+          }
+          return true;
+        }
+      };
+      pp$92.expect = function(type) {
+        this.eat(type) || this.unexpected();
+      };
+      pp$92.unexpected = function(pos) {
+        this.raise(pos != null ? pos : this.start, "Unexpected token");
+      };
+      var DestructuringErrors3 = function DestructuringErrors4() {
+        this.shorthandAssign = this.trailingComma = this.parenthesizedAssign = this.parenthesizedBind = this.doubleProto = -1;
+      };
+      pp$92.checkPatternErrors = function(refDestructuringErrors, isAssign) {
+        if (!refDestructuringErrors) {
+          return;
+        }
+        if (refDestructuringErrors.trailingComma > -1) {
+          this.raiseRecoverable(refDestructuringErrors.trailingComma, "Comma is not permitted after the rest element");
+        }
+        var parens = isAssign ? refDestructuringErrors.parenthesizedAssign : refDestructuringErrors.parenthesizedBind;
+        if (parens > -1) {
+          this.raiseRecoverable(parens, isAssign ? "Assigning to rvalue" : "Parenthesized pattern");
+        }
+      };
+      pp$92.checkExpressionErrors = function(refDestructuringErrors, andThrow) {
+        if (!refDestructuringErrors) {
+          return false;
+        }
+        var shorthandAssign = refDestructuringErrors.shorthandAssign;
+        var doubleProto = refDestructuringErrors.doubleProto;
+        if (!andThrow) {
+          return shorthandAssign >= 0 || doubleProto >= 0;
+        }
+        if (shorthandAssign >= 0) {
+          this.raise(shorthandAssign, "Shorthand property assignments are valid only in destructuring patterns");
+        }
+        if (doubleProto >= 0) {
+          this.raiseRecoverable(doubleProto, "Redefinition of __proto__ property");
+        }
+      };
+      pp$92.checkYieldAwaitInDefaultParams = function() {
+        if (this.yieldPos && (!this.awaitPos || this.yieldPos < this.awaitPos)) {
+          this.raise(this.yieldPos, "Yield expression cannot be a default value");
+        }
+        if (this.awaitPos) {
+          this.raise(this.awaitPos, "Await expression cannot be a default value");
+        }
+      };
+      pp$92.isSimpleAssignTarget = function(expr) {
+        if (expr.type === "ParenthesizedExpression") {
+          return this.isSimpleAssignTarget(expr.expression);
+        }
+        return expr.type === "Identifier" || expr.type === "MemberExpression";
+      };
+      var pp$82 = Parser3.prototype;
+      pp$82.parseTopLevel = function(node) {
+        var exports3 = /* @__PURE__ */ Object.create(null);
+        if (!node.body) {
+          node.body = [];
+        }
+        while (this.type !== types$12.eof) {
+          var stmt = this.parseStatement(null, true, exports3);
+          node.body.push(stmt);
+        }
+        if (this.inModule) {
+          for (var i2 = 0, list2 = Object.keys(this.undefinedExports); i2 < list2.length; i2 += 1) {
+            var name = list2[i2];
+            this.raiseRecoverable(this.undefinedExports[name].start, "Export '" + name + "' is not defined");
+          }
+        }
+        this.adaptDirectivePrologue(node.body);
+        this.next();
+        node.sourceType = this.options.sourceType;
+        return this.finishNode(node, "Program");
+      };
+      var loopLabel2 = { kind: "loop" }, switchLabel2 = { kind: "switch" };
+      pp$82.isLet = function(context) {
+        if (this.options.ecmaVersion < 6 || !this.isContextual("let")) {
+          return false;
+        }
+        skipWhiteSpace2.lastIndex = this.pos;
+        var skip = skipWhiteSpace2.exec(this.input);
+        var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+        if (nextCh === 91 || nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+          return true;
+        }
+        if (context) {
+          return false;
+        }
+        if (nextCh === 123) {
+          return true;
+        }
+        if (isIdentifierStart2(nextCh, true)) {
+          var pos = next + 1;
+          while (isIdentifierChar2(nextCh = this.input.charCodeAt(pos), true)) {
+            ++pos;
+          }
+          if (nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+            return true;
+          }
+          var ident = this.input.slice(next, pos);
+          if (!keywordRelationalOperator2.test(ident)) {
+            return true;
+          }
+        }
+        return false;
+      };
+      pp$82.isAsyncFunction = function() {
+        if (this.options.ecmaVersion < 8 || !this.isContextual("async")) {
+          return false;
+        }
+        skipWhiteSpace2.lastIndex = this.pos;
+        var skip = skipWhiteSpace2.exec(this.input);
+        var next = this.pos + skip[0].length, after;
+        return !lineBreak2.test(this.input.slice(this.pos, next)) && this.input.slice(next, next + 8) === "function" && (next + 8 === this.input.length || !(isIdentifierChar2(after = this.input.charCodeAt(next + 8)) || after > 55295 && after < 56320));
+      };
+      pp$82.parseStatement = function(context, topLevel, exports3) {
+        var starttype = this.type, node = this.startNode(), kind;
+        if (this.isLet(context)) {
+          starttype = types$12._var;
+          kind = "let";
+        }
+        switch (starttype) {
+          case types$12._break:
+          case types$12._continue:
+            return this.parseBreakContinueStatement(node, starttype.keyword);
+          case types$12._debugger:
+            return this.parseDebuggerStatement(node);
+          case types$12._do:
+            return this.parseDoStatement(node);
+          case types$12._for:
+            return this.parseForStatement(node);
+          case types$12._function:
+            if (context && (this.strict || context !== "if" && context !== "label") && this.options.ecmaVersion >= 6) {
+              this.unexpected();
+            }
+            return this.parseFunctionStatement(node, false, !context);
+          case types$12._class:
+            if (context) {
+              this.unexpected();
+            }
+            return this.parseClass(node, true);
+          case types$12._if:
+            return this.parseIfStatement(node);
+          case types$12._return:
+            return this.parseReturnStatement(node);
+          case types$12._switch:
+            return this.parseSwitchStatement(node);
+          case types$12._throw:
+            return this.parseThrowStatement(node);
+          case types$12._try:
+            return this.parseTryStatement(node);
+          case types$12._const:
+          case types$12._var:
+            kind = kind || this.value;
+            if (context && kind !== "var") {
+              this.unexpected();
+            }
+            return this.parseVarStatement(node, kind);
+          case types$12._while:
+            return this.parseWhileStatement(node);
+          case types$12._with:
+            return this.parseWithStatement(node);
+          case types$12.braceL:
+            return this.parseBlock(true, node);
+          case types$12.semi:
+            return this.parseEmptyStatement(node);
+          case types$12._export:
+          case types$12._import:
+            if (this.options.ecmaVersion > 10 && starttype === types$12._import) {
+              skipWhiteSpace2.lastIndex = this.pos;
+              var skip = skipWhiteSpace2.exec(this.input);
+              var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+              if (nextCh === 40 || nextCh === 46) {
+                return this.parseExpressionStatement(node, this.parseExpression());
+              }
+            }
+            if (!this.options.allowImportExportEverywhere) {
+              if (!topLevel) {
+                this.raise(this.start, "'import' and 'export' may only appear at the top level");
+              }
+              if (!this.inModule) {
+                this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'");
+              }
+            }
+            return starttype === types$12._import ? this.parseImport(node) : this.parseExport(node, exports3);
+          default:
+            if (this.isAsyncFunction()) {
+              if (context) {
+                this.unexpected();
+              }
+              this.next();
+              return this.parseFunctionStatement(node, true, !context);
+            }
+            var maybeName = this.value, expr = this.parseExpression();
+            if (starttype === types$12.name && expr.type === "Identifier" && this.eat(types$12.colon)) {
+              return this.parseLabeledStatement(node, maybeName, expr, context);
+            } else {
+              return this.parseExpressionStatement(node, expr);
+            }
+        }
+      };
+      pp$82.parseBreakContinueStatement = function(node, keyword) {
+        var isBreak = keyword === "break";
+        this.next();
+        if (this.eat(types$12.semi) || this.insertSemicolon()) {
+          node.label = null;
+        } else if (this.type !== types$12.name) {
+          this.unexpected();
+        } else {
+          node.label = this.parseIdent();
+          this.semicolon();
+        }
+        var i2 = 0;
+        for (; i2 < this.labels.length; ++i2) {
+          var lab = this.labels[i2];
+          if (node.label == null || lab.name === node.label.name) {
+            if (lab.kind != null && (isBreak || lab.kind === "loop")) {
+              break;
+            }
+            if (node.label && isBreak) {
+              break;
+            }
+          }
+        }
+        if (i2 === this.labels.length) {
+          this.raise(node.start, "Unsyntactic " + keyword);
+        }
+        return this.finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+      };
+      pp$82.parseDebuggerStatement = function(node) {
+        this.next();
+        this.semicolon();
+        return this.finishNode(node, "DebuggerStatement");
+      };
+      pp$82.parseDoStatement = function(node) {
+        this.next();
+        this.labels.push(loopLabel2);
+        node.body = this.parseStatement("do");
+        this.labels.pop();
+        this.expect(types$12._while);
+        node.test = this.parseParenExpression();
+        if (this.options.ecmaVersion >= 6) {
+          this.eat(types$12.semi);
+        } else {
+          this.semicolon();
+        }
+        return this.finishNode(node, "DoWhileStatement");
+      };
+      pp$82.parseForStatement = function(node) {
+        this.next();
+        var awaitAt = this.options.ecmaVersion >= 9 && this.canAwait && this.eatContextual("await") ? this.lastTokStart : -1;
+        this.labels.push(loopLabel2);
+        this.enterScope(0);
+        this.expect(types$12.parenL);
+        if (this.type === types$12.semi) {
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+          return this.parseFor(node, null);
+        }
+        var isLet = this.isLet();
+        if (this.type === types$12._var || this.type === types$12._const || isLet) {
+          var init$1 = this.startNode(), kind = isLet ? "let" : this.value;
+          this.next();
+          this.parseVar(init$1, true, kind);
+          this.finishNode(init$1, "VariableDeclaration");
+          if ((this.type === types$12._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) && init$1.declarations.length === 1) {
+            if (this.options.ecmaVersion >= 9) {
+              if (this.type === types$12._in) {
+                if (awaitAt > -1) {
+                  this.unexpected(awaitAt);
+                }
+              } else {
+                node.await = awaitAt > -1;
+              }
+            }
+            return this.parseForIn(node, init$1);
+          }
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+          return this.parseFor(node, init$1);
+        }
+        var startsWithLet = this.isContextual("let"), isForOf = false;
+        var refDestructuringErrors = new DestructuringErrors3();
+        var init = this.parseExpression(awaitAt > -1 ? "await" : true, refDestructuringErrors);
+        if (this.type === types$12._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+          if (this.options.ecmaVersion >= 9) {
+            if (this.type === types$12._in) {
+              if (awaitAt > -1) {
+                this.unexpected(awaitAt);
+              }
+            } else {
+              node.await = awaitAt > -1;
+            }
+          }
+          if (startsWithLet && isForOf) {
+            this.raise(init.start, "The left-hand side of a for-of loop may not start with 'let'.");
+          }
+          this.toAssignable(init, false, refDestructuringErrors);
+          this.checkLValPattern(init);
+          return this.parseForIn(node, init);
+        } else {
+          this.checkExpressionErrors(refDestructuringErrors, true);
+        }
+        if (awaitAt > -1) {
+          this.unexpected(awaitAt);
+        }
+        return this.parseFor(node, init);
+      };
+      pp$82.parseFunctionStatement = function(node, isAsync, declarationPosition) {
+        this.next();
+        return this.parseFunction(node, FUNC_STATEMENT2 | (declarationPosition ? 0 : FUNC_HANGING_STATEMENT2), false, isAsync);
+      };
+      pp$82.parseIfStatement = function(node) {
+        this.next();
+        node.test = this.parseParenExpression();
+        node.consequent = this.parseStatement("if");
+        node.alternate = this.eat(types$12._else) ? this.parseStatement("if") : null;
+        return this.finishNode(node, "IfStatement");
+      };
+      pp$82.parseReturnStatement = function(node) {
+        if (!this.inFunction && !this.options.allowReturnOutsideFunction) {
+          this.raise(this.start, "'return' outside of function");
+        }
+        this.next();
+        if (this.eat(types$12.semi) || this.insertSemicolon()) {
+          node.argument = null;
+        } else {
+          node.argument = this.parseExpression();
+          this.semicolon();
+        }
+        return this.finishNode(node, "ReturnStatement");
+      };
+      pp$82.parseSwitchStatement = function(node) {
+        this.next();
+        node.discriminant = this.parseParenExpression();
+        node.cases = [];
+        this.expect(types$12.braceL);
+        this.labels.push(switchLabel2);
+        this.enterScope(0);
+        var cur;
+        for (var sawDefault = false; this.type !== types$12.braceR; ) {
+          if (this.type === types$12._case || this.type === types$12._default) {
+            var isCase = this.type === types$12._case;
+            if (cur) {
+              this.finishNode(cur, "SwitchCase");
+            }
+            node.cases.push(cur = this.startNode());
+            cur.consequent = [];
+            this.next();
+            if (isCase) {
+              cur.test = this.parseExpression();
+            } else {
+              if (sawDefault) {
+                this.raiseRecoverable(this.lastTokStart, "Multiple default clauses");
+              }
+              sawDefault = true;
+              cur.test = null;
+            }
+            this.expect(types$12.colon);
+          } else {
+            if (!cur) {
+              this.unexpected();
+            }
+            cur.consequent.push(this.parseStatement(null));
+          }
+        }
+        this.exitScope();
+        if (cur) {
+          this.finishNode(cur, "SwitchCase");
+        }
+        this.next();
+        this.labels.pop();
+        return this.finishNode(node, "SwitchStatement");
+      };
+      pp$82.parseThrowStatement = function(node) {
+        this.next();
+        if (lineBreak2.test(this.input.slice(this.lastTokEnd, this.start))) {
+          this.raise(this.lastTokEnd, "Illegal newline after throw");
+        }
+        node.argument = this.parseExpression();
+        this.semicolon();
+        return this.finishNode(node, "ThrowStatement");
+      };
+      var empty$12 = [];
+      pp$82.parseTryStatement = function(node) {
+        this.next();
+        node.block = this.parseBlock();
+        node.handler = null;
+        if (this.type === types$12._catch) {
+          var clause = this.startNode();
+          this.next();
+          if (this.eat(types$12.parenL)) {
+            clause.param = this.parseBindingAtom();
+            var simple = clause.param.type === "Identifier";
+            this.enterScope(simple ? SCOPE_SIMPLE_CATCH2 : 0);
+            this.checkLValPattern(clause.param, simple ? BIND_SIMPLE_CATCH2 : BIND_LEXICAL2);
+            this.expect(types$12.parenR);
+          } else {
+            if (this.options.ecmaVersion < 10) {
+              this.unexpected();
+            }
+            clause.param = null;
+            this.enterScope(0);
+          }
+          clause.body = this.parseBlock(false);
+          this.exitScope();
+          node.handler = this.finishNode(clause, "CatchClause");
+        }
+        node.finalizer = this.eat(types$12._finally) ? this.parseBlock() : null;
+        if (!node.handler && !node.finalizer) {
+          this.raise(node.start, "Missing catch or finally clause");
+        }
+        return this.finishNode(node, "TryStatement");
+      };
+      pp$82.parseVarStatement = function(node, kind) {
+        this.next();
+        this.parseVar(node, false, kind);
+        this.semicolon();
+        return this.finishNode(node, "VariableDeclaration");
+      };
+      pp$82.parseWhileStatement = function(node) {
+        this.next();
+        node.test = this.parseParenExpression();
+        this.labels.push(loopLabel2);
+        node.body = this.parseStatement("while");
+        this.labels.pop();
+        return this.finishNode(node, "WhileStatement");
+      };
+      pp$82.parseWithStatement = function(node) {
+        if (this.strict) {
+          this.raise(this.start, "'with' in strict mode");
+        }
+        this.next();
+        node.object = this.parseParenExpression();
+        node.body = this.parseStatement("with");
+        return this.finishNode(node, "WithStatement");
+      };
+      pp$82.parseEmptyStatement = function(node) {
+        this.next();
+        return this.finishNode(node, "EmptyStatement");
+      };
+      pp$82.parseLabeledStatement = function(node, maybeName, expr, context) {
+        for (var i$1 = 0, list2 = this.labels; i$1 < list2.length; i$1 += 1) {
+          var label = list2[i$1];
+          if (label.name === maybeName) {
+            this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+          }
+        }
+        var kind = this.type.isLoop ? "loop" : this.type === types$12._switch ? "switch" : null;
+        for (var i2 = this.labels.length - 1; i2 >= 0; i2--) {
+          var label$1 = this.labels[i2];
+          if (label$1.statementStart === node.start) {
+            label$1.statementStart = this.start;
+            label$1.kind = kind;
+          } else {
+            break;
+          }
+        }
+        this.labels.push({ name: maybeName, kind, statementStart: this.start });
+        node.body = this.parseStatement(context ? context.indexOf("label") === -1 ? context + "label" : context : "label");
+        this.labels.pop();
+        node.label = expr;
+        return this.finishNode(node, "LabeledStatement");
+      };
+      pp$82.parseExpressionStatement = function(node, expr) {
+        node.expression = expr;
+        this.semicolon();
+        return this.finishNode(node, "ExpressionStatement");
+      };
+      pp$82.parseBlock = function(createNewLexicalScope, node, exitStrict) {
+        if (createNewLexicalScope === void 0)
+          createNewLexicalScope = true;
+        if (node === void 0)
+          node = this.startNode();
+        node.body = [];
+        this.expect(types$12.braceL);
+        if (createNewLexicalScope) {
+          this.enterScope(0);
+        }
+        while (this.type !== types$12.braceR) {
+          var stmt = this.parseStatement(null);
+          node.body.push(stmt);
+        }
+        if (exitStrict) {
+          this.strict = false;
+        }
+        this.next();
+        if (createNewLexicalScope) {
+          this.exitScope();
+        }
+        return this.finishNode(node, "BlockStatement");
+      };
+      pp$82.parseFor = function(node, init) {
+        node.init = init;
+        this.expect(types$12.semi);
+        node.test = this.type === types$12.semi ? null : this.parseExpression();
+        this.expect(types$12.semi);
+        node.update = this.type === types$12.parenR ? null : this.parseExpression();
+        this.expect(types$12.parenR);
+        node.body = this.parseStatement("for");
+        this.exitScope();
+        this.labels.pop();
+        return this.finishNode(node, "ForStatement");
+      };
+      pp$82.parseForIn = function(node, init) {
+        var isForIn = this.type === types$12._in;
+        this.next();
+        if (init.type === "VariableDeclaration" && init.declarations[0].init != null && (!isForIn || this.options.ecmaVersion < 8 || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")) {
+          this.raise(
+            init.start,
+            (isForIn ? "for-in" : "for-of") + " loop variable declaration may not have an initializer"
+          );
+        }
+        node.left = init;
+        node.right = isForIn ? this.parseExpression() : this.parseMaybeAssign();
+        this.expect(types$12.parenR);
+        node.body = this.parseStatement("for");
+        this.exitScope();
+        this.labels.pop();
+        return this.finishNode(node, isForIn ? "ForInStatement" : "ForOfStatement");
+      };
+      pp$82.parseVar = function(node, isFor, kind) {
+        node.declarations = [];
+        node.kind = kind;
+        for (; ; ) {
+          var decl = this.startNode();
+          this.parseVarId(decl, kind);
+          if (this.eat(types$12.eq)) {
+            decl.init = this.parseMaybeAssign(isFor);
+          } else if (kind === "const" && !(this.type === types$12._in || this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+            this.unexpected();
+          } else if (decl.id.type !== "Identifier" && !(isFor && (this.type === types$12._in || this.isContextual("of")))) {
+            this.raise(this.lastTokEnd, "Complex binding patterns require an initialization value");
+          } else {
+            decl.init = null;
+          }
+          node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+          if (!this.eat(types$12.comma)) {
+            break;
+          }
+        }
+        return node;
+      };
+      pp$82.parseVarId = function(decl, kind) {
+        decl.id = this.parseBindingAtom();
+        this.checkLValPattern(decl.id, kind === "var" ? BIND_VAR2 : BIND_LEXICAL2, false);
+      };
+      var FUNC_STATEMENT2 = 1, FUNC_HANGING_STATEMENT2 = 2, FUNC_NULLABLE_ID2 = 4;
+      pp$82.parseFunction = function(node, statement, allowExpressionBody, isAsync, forInit) {
+        this.initFunction(node);
+        if (this.options.ecmaVersion >= 9 || this.options.ecmaVersion >= 6 && !isAsync) {
+          if (this.type === types$12.star && statement & FUNC_HANGING_STATEMENT2) {
+            this.unexpected();
+          }
+          node.generator = this.eat(types$12.star);
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node.async = !!isAsync;
+        }
+        if (statement & FUNC_STATEMENT2) {
+          node.id = statement & FUNC_NULLABLE_ID2 && this.type !== types$12.name ? null : this.parseIdent();
+          if (node.id && !(statement & FUNC_HANGING_STATEMENT2)) {
+            this.checkLValSimple(node.id, this.strict || node.generator || node.async ? this.treatFunctionsAsVar ? BIND_VAR2 : BIND_LEXICAL2 : BIND_FUNCTION2);
+          }
+        }
+        var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        this.enterScope(functionFlags2(node.async, node.generator));
+        if (!(statement & FUNC_STATEMENT2)) {
+          node.id = this.type === types$12.name ? this.parseIdent() : null;
+        }
+        this.parseFunctionParams(node);
+        this.parseFunctionBody(node, allowExpressionBody, false, forInit);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node, statement & FUNC_STATEMENT2 ? "FunctionDeclaration" : "FunctionExpression");
+      };
+      pp$82.parseFunctionParams = function(node) {
+        this.expect(types$12.parenL);
+        node.params = this.parseBindingList(types$12.parenR, false, this.options.ecmaVersion >= 8);
+        this.checkYieldAwaitInDefaultParams();
+      };
+      pp$82.parseClass = function(node, isStatement) {
+        this.next();
+        var oldStrict = this.strict;
+        this.strict = true;
+        this.parseClassId(node, isStatement);
+        this.parseClassSuper(node);
+        var privateNameMap = this.enterClassBody();
+        var classBody = this.startNode();
+        var hadConstructor = false;
+        classBody.body = [];
+        this.expect(types$12.braceL);
+        while (this.type !== types$12.braceR) {
+          var element = this.parseClassElement(node.superClass !== null);
+          if (element) {
+            classBody.body.push(element);
+            if (element.type === "MethodDefinition" && element.kind === "constructor") {
+              if (hadConstructor) {
+                this.raise(element.start, "Duplicate constructor in the same class");
+              }
+              hadConstructor = true;
+            } else if (element.key && element.key.type === "PrivateIdentifier" && isPrivateNameConflicted2(privateNameMap, element)) {
+              this.raiseRecoverable(element.key.start, "Identifier '#" + element.key.name + "' has already been declared");
+            }
+          }
+        }
+        this.strict = oldStrict;
+        this.next();
+        node.body = this.finishNode(classBody, "ClassBody");
+        this.exitClassBody();
+        return this.finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
+      };
+      pp$82.parseClassElement = function(constructorAllowsSuper) {
+        if (this.eat(types$12.semi)) {
+          return null;
+        }
+        var ecmaVersion2 = this.options.ecmaVersion;
+        var node = this.startNode();
+        var keyName = "";
+        var isGenerator = false;
+        var isAsync = false;
+        var kind = "method";
+        var isStatic = false;
+        if (this.eatContextual("static")) {
+          if (ecmaVersion2 >= 13 && this.eat(types$12.braceL)) {
+            this.parseClassStaticBlock(node);
+            return node;
+          }
+          if (this.isClassElementNameStart() || this.type === types$12.star) {
+            isStatic = true;
+          } else {
+            keyName = "static";
+          }
+        }
+        node.static = isStatic;
+        if (!keyName && ecmaVersion2 >= 8 && this.eatContextual("async")) {
+          if ((this.isClassElementNameStart() || this.type === types$12.star) && !this.canInsertSemicolon()) {
+            isAsync = true;
+          } else {
+            keyName = "async";
+          }
+        }
+        if (!keyName && (ecmaVersion2 >= 9 || !isAsync) && this.eat(types$12.star)) {
+          isGenerator = true;
+        }
+        if (!keyName && !isAsync && !isGenerator) {
+          var lastValue = this.value;
+          if (this.eatContextual("get") || this.eatContextual("set")) {
+            if (this.isClassElementNameStart()) {
+              kind = lastValue;
+            } else {
+              keyName = lastValue;
+            }
+          }
+        }
+        if (keyName) {
+          node.computed = false;
+          node.key = this.startNodeAt(this.lastTokStart, this.lastTokStartLoc);
+          node.key.name = keyName;
+          this.finishNode(node.key, "Identifier");
+        } else {
+          this.parseClassElementName(node);
+        }
+        if (ecmaVersion2 < 13 || this.type === types$12.parenL || kind !== "method" || isGenerator || isAsync) {
+          var isConstructor = !node.static && checkKeyName2(node, "constructor");
+          var allowsDirectSuper = isConstructor && constructorAllowsSuper;
+          if (isConstructor && kind !== "method") {
+            this.raise(node.key.start, "Constructor can't have get/set modifier");
+          }
+          node.kind = isConstructor ? "constructor" : kind;
+          this.parseClassMethod(node, isGenerator, isAsync, allowsDirectSuper);
+        } else {
+          this.parseClassField(node);
+        }
+        return node;
+      };
+      pp$82.isClassElementNameStart = function() {
+        return this.type === types$12.name || this.type === types$12.privateId || this.type === types$12.num || this.type === types$12.string || this.type === types$12.bracketL || this.type.keyword;
+      };
+      pp$82.parseClassElementName = function(element) {
+        if (this.type === types$12.privateId) {
+          if (this.value === "constructor") {
+            this.raise(this.start, "Classes can't have an element named '#constructor'");
+          }
+          element.computed = false;
+          element.key = this.parsePrivateIdent();
+        } else {
+          this.parsePropertyName(element);
+        }
+      };
+      pp$82.parseClassMethod = function(method, isGenerator, isAsync, allowsDirectSuper) {
+        var key = method.key;
+        if (method.kind === "constructor") {
+          if (isGenerator) {
+            this.raise(key.start, "Constructor can't be a generator");
+          }
+          if (isAsync) {
+            this.raise(key.start, "Constructor can't be an async method");
+          }
+        } else if (method.static && checkKeyName2(method, "prototype")) {
+          this.raise(key.start, "Classes may not have a static property named prototype");
+        }
+        var value = method.value = this.parseMethod(isGenerator, isAsync, allowsDirectSuper);
+        if (method.kind === "get" && value.params.length !== 0) {
+          this.raiseRecoverable(value.start, "getter should have no params");
+        }
+        if (method.kind === "set" && value.params.length !== 1) {
+          this.raiseRecoverable(value.start, "setter should have exactly one param");
+        }
+        if (method.kind === "set" && value.params[0].type === "RestElement") {
+          this.raiseRecoverable(value.params[0].start, "Setter cannot use rest params");
+        }
+        return this.finishNode(method, "MethodDefinition");
+      };
+      pp$82.parseClassField = function(field) {
+        if (checkKeyName2(field, "constructor")) {
+          this.raise(field.key.start, "Classes can't have a field named 'constructor'");
+        } else if (field.static && checkKeyName2(field, "prototype")) {
+          this.raise(field.key.start, "Classes can't have a static field named 'prototype'");
+        }
+        if (this.eat(types$12.eq)) {
+          var scope = this.currentThisScope();
+          var inClassFieldInit = scope.inClassFieldInit;
+          scope.inClassFieldInit = true;
+          field.value = this.parseMaybeAssign();
+          scope.inClassFieldInit = inClassFieldInit;
+        } else {
+          field.value = null;
+        }
+        this.semicolon();
+        return this.finishNode(field, "PropertyDefinition");
+      };
+      pp$82.parseClassStaticBlock = function(node) {
+        node.body = [];
+        var oldLabels = this.labels;
+        this.labels = [];
+        this.enterScope(SCOPE_CLASS_STATIC_BLOCK2 | SCOPE_SUPER2);
+        while (this.type !== types$12.braceR) {
+          var stmt = this.parseStatement(null);
+          node.body.push(stmt);
+        }
+        this.next();
+        this.exitScope();
+        this.labels = oldLabels;
+        return this.finishNode(node, "StaticBlock");
+      };
+      pp$82.parseClassId = function(node, isStatement) {
+        if (this.type === types$12.name) {
+          node.id = this.parseIdent();
+          if (isStatement) {
+            this.checkLValSimple(node.id, BIND_LEXICAL2, false);
+          }
+        } else {
+          if (isStatement === true) {
+            this.unexpected();
+          }
+          node.id = null;
+        }
+      };
+      pp$82.parseClassSuper = function(node) {
+        node.superClass = this.eat(types$12._extends) ? this.parseExprSubscripts(false) : null;
+      };
+      pp$82.enterClassBody = function() {
+        var element = { declared: /* @__PURE__ */ Object.create(null), used: [] };
+        this.privateNameStack.push(element);
+        return element.declared;
+      };
+      pp$82.exitClassBody = function() {
+        var ref3 = this.privateNameStack.pop();
+        var declared = ref3.declared;
+        var used = ref3.used;
+        var len = this.privateNameStack.length;
+        var parent = len === 0 ? null : this.privateNameStack[len - 1];
+        for (var i2 = 0; i2 < used.length; ++i2) {
+          var id = used[i2];
+          if (!hasOwn2(declared, id.name)) {
+            if (parent) {
+              parent.used.push(id);
+            } else {
+              this.raiseRecoverable(id.start, "Private field '#" + id.name + "' must be declared in an enclosing class");
+            }
+          }
+        }
+      };
+      function isPrivateNameConflicted2(privateNameMap, element) {
+        var name = element.key.name;
+        var curr = privateNameMap[name];
+        var next = "true";
+        if (element.type === "MethodDefinition" && (element.kind === "get" || element.kind === "set")) {
+          next = (element.static ? "s" : "i") + element.kind;
+        }
+        if (curr === "iget" && next === "iset" || curr === "iset" && next === "iget" || curr === "sget" && next === "sset" || curr === "sset" && next === "sget") {
+          privateNameMap[name] = "true";
+          return false;
+        } else if (!curr) {
+          privateNameMap[name] = next;
+          return false;
+        } else {
+          return true;
+        }
+      }
+      function checkKeyName2(node, name) {
+        var computed = node.computed;
+        var key = node.key;
+        return !computed && (key.type === "Identifier" && key.name === name || key.type === "Literal" && key.value === name);
+      }
+      pp$82.parseExport = function(node, exports3) {
+        this.next();
+        if (this.eat(types$12.star)) {
+          if (this.options.ecmaVersion >= 11) {
+            if (this.eatContextual("as")) {
+              node.exported = this.parseModuleExportName();
+              this.checkExport(exports3, node.exported, this.lastTokStart);
+            } else {
+              node.exported = null;
+            }
+          }
+          this.expectContextual("from");
+          if (this.type !== types$12.string) {
+            this.unexpected();
+          }
+          node.source = this.parseExprAtom();
+          this.semicolon();
+          return this.finishNode(node, "ExportAllDeclaration");
+        }
+        if (this.eat(types$12._default)) {
+          this.checkExport(exports3, "default", this.lastTokStart);
+          var isAsync;
+          if (this.type === types$12._function || (isAsync = this.isAsyncFunction())) {
+            var fNode = this.startNode();
+            this.next();
+            if (isAsync) {
+              this.next();
+            }
+            node.declaration = this.parseFunction(fNode, FUNC_STATEMENT2 | FUNC_NULLABLE_ID2, false, isAsync);
+          } else if (this.type === types$12._class) {
+            var cNode = this.startNode();
+            node.declaration = this.parseClass(cNode, "nullableID");
+          } else {
+            node.declaration = this.parseMaybeAssign();
+            this.semicolon();
+          }
+          return this.finishNode(node, "ExportDefaultDeclaration");
+        }
+        if (this.shouldParseExportStatement()) {
+          node.declaration = this.parseStatement(null);
+          if (node.declaration.type === "VariableDeclaration") {
+            this.checkVariableExport(exports3, node.declaration.declarations);
+          } else {
+            this.checkExport(exports3, node.declaration.id, node.declaration.id.start);
+          }
+          node.specifiers = [];
+          node.source = null;
+        } else {
+          node.declaration = null;
+          node.specifiers = this.parseExportSpecifiers(exports3);
+          if (this.eatContextual("from")) {
+            if (this.type !== types$12.string) {
+              this.unexpected();
+            }
+            node.source = this.parseExprAtom();
+          } else {
+            for (var i2 = 0, list2 = node.specifiers; i2 < list2.length; i2 += 1) {
+              var spec = list2[i2];
+              this.checkUnreserved(spec.local);
+              this.checkLocalExport(spec.local);
+              if (spec.local.type === "Literal") {
+                this.raise(spec.local.start, "A string literal cannot be used as an exported binding without `from`.");
+              }
+            }
+            node.source = null;
+          }
+          this.semicolon();
+        }
+        return this.finishNode(node, "ExportNamedDeclaration");
+      };
+      pp$82.checkExport = function(exports3, name, pos) {
+        if (!exports3) {
+          return;
+        }
+        if (typeof name !== "string") {
+          name = name.type === "Identifier" ? name.name : name.value;
+        }
+        if (hasOwn2(exports3, name)) {
+          this.raiseRecoverable(pos, "Duplicate export '" + name + "'");
+        }
+        exports3[name] = true;
+      };
+      pp$82.checkPatternExport = function(exports3, pat) {
+        var type = pat.type;
+        if (type === "Identifier") {
+          this.checkExport(exports3, pat, pat.start);
+        } else if (type === "ObjectPattern") {
+          for (var i2 = 0, list2 = pat.properties; i2 < list2.length; i2 += 1) {
+            var prop = list2[i2];
+            this.checkPatternExport(exports3, prop);
+          }
+        } else if (type === "ArrayPattern") {
+          for (var i$1 = 0, list$1 = pat.elements; i$1 < list$1.length; i$1 += 1) {
+            var elt = list$1[i$1];
+            if (elt) {
+              this.checkPatternExport(exports3, elt);
+            }
+          }
+        } else if (type === "Property") {
+          this.checkPatternExport(exports3, pat.value);
+        } else if (type === "AssignmentPattern") {
+          this.checkPatternExport(exports3, pat.left);
+        } else if (type === "RestElement") {
+          this.checkPatternExport(exports3, pat.argument);
+        } else if (type === "ParenthesizedExpression") {
+          this.checkPatternExport(exports3, pat.expression);
+        }
+      };
+      pp$82.checkVariableExport = function(exports3, decls) {
+        if (!exports3) {
+          return;
+        }
+        for (var i2 = 0, list2 = decls; i2 < list2.length; i2 += 1) {
+          var decl = list2[i2];
+          this.checkPatternExport(exports3, decl.id);
+        }
+      };
+      pp$82.shouldParseExportStatement = function() {
+        return this.type.keyword === "var" || this.type.keyword === "const" || this.type.keyword === "class" || this.type.keyword === "function" || this.isLet() || this.isAsyncFunction();
+      };
+      pp$82.parseExportSpecifiers = function(exports3) {
+        var nodes = [], first = true;
+        this.expect(types$12.braceL);
+        while (!this.eat(types$12.braceR)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (this.afterTrailingComma(types$12.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var node = this.startNode();
+          node.local = this.parseModuleExportName();
+          node.exported = this.eatContextual("as") ? this.parseModuleExportName() : node.local;
+          this.checkExport(
+            exports3,
+            node.exported,
+            node.exported.start
+          );
+          nodes.push(this.finishNode(node, "ExportSpecifier"));
+        }
+        return nodes;
+      };
+      pp$82.parseImport = function(node) {
+        this.next();
+        if (this.type === types$12.string) {
+          node.specifiers = empty$12;
+          node.source = this.parseExprAtom();
+        } else {
+          node.specifiers = this.parseImportSpecifiers();
+          this.expectContextual("from");
+          node.source = this.type === types$12.string ? this.parseExprAtom() : this.unexpected();
+        }
+        this.semicolon();
+        return this.finishNode(node, "ImportDeclaration");
+      };
+      pp$82.parseImportSpecifiers = function() {
+        var nodes = [], first = true;
+        if (this.type === types$12.name) {
+          var node = this.startNode();
+          node.local = this.parseIdent();
+          this.checkLValSimple(node.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node, "ImportDefaultSpecifier"));
+          if (!this.eat(types$12.comma)) {
+            return nodes;
+          }
+        }
+        if (this.type === types$12.star) {
+          var node$1 = this.startNode();
+          this.next();
+          this.expectContextual("as");
+          node$1.local = this.parseIdent();
+          this.checkLValSimple(node$1.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node$1, "ImportNamespaceSpecifier"));
+          return nodes;
+        }
+        this.expect(types$12.braceL);
+        while (!this.eat(types$12.braceR)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (this.afterTrailingComma(types$12.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var node$2 = this.startNode();
+          node$2.imported = this.parseModuleExportName();
+          if (this.eatContextual("as")) {
+            node$2.local = this.parseIdent();
+          } else {
+            this.checkUnreserved(node$2.imported);
+            node$2.local = node$2.imported;
+          }
+          this.checkLValSimple(node$2.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node$2, "ImportSpecifier"));
+        }
+        return nodes;
+      };
+      pp$82.parseModuleExportName = function() {
+        if (this.options.ecmaVersion >= 13 && this.type === types$12.string) {
+          var stringLiteral = this.parseLiteral(this.value);
+          if (loneSurrogate2.test(stringLiteral.value)) {
+            this.raise(stringLiteral.start, "An export name cannot include a lone surrogate.");
+          }
+          return stringLiteral;
+        }
+        return this.parseIdent(true);
+      };
+      pp$82.adaptDirectivePrologue = function(statements) {
+        for (var i2 = 0; i2 < statements.length && this.isDirectiveCandidate(statements[i2]); ++i2) {
+          statements[i2].directive = statements[i2].expression.raw.slice(1, -1);
+        }
+      };
+      pp$82.isDirectiveCandidate = function(statement) {
+        return this.options.ecmaVersion >= 5 && statement.type === "ExpressionStatement" && statement.expression.type === "Literal" && typeof statement.expression.value === "string" && (this.input[statement.start] === '"' || this.input[statement.start] === "'");
+      };
+      var pp$72 = Parser3.prototype;
+      pp$72.toAssignable = function(node, isBinding, refDestructuringErrors) {
+        if (this.options.ecmaVersion >= 6 && node) {
+          switch (node.type) {
+            case "Identifier":
+              if (this.inAsync && node.name === "await") {
+                this.raise(node.start, "Cannot use 'await' as identifier inside an async function");
+              }
+              break;
+            case "ObjectPattern":
+            case "ArrayPattern":
+            case "AssignmentPattern":
+            case "RestElement":
+              break;
+            case "ObjectExpression":
+              node.type = "ObjectPattern";
+              if (refDestructuringErrors) {
+                this.checkPatternErrors(refDestructuringErrors, true);
+              }
+              for (var i2 = 0, list2 = node.properties; i2 < list2.length; i2 += 1) {
+                var prop = list2[i2];
+                this.toAssignable(prop, isBinding);
+                if (prop.type === "RestElement" && (prop.argument.type === "ArrayPattern" || prop.argument.type === "ObjectPattern")) {
+                  this.raise(prop.argument.start, "Unexpected token");
+                }
+              }
+              break;
+            case "Property":
+              if (node.kind !== "init") {
+                this.raise(node.key.start, "Object pattern can't contain getter or setter");
+              }
+              this.toAssignable(node.value, isBinding);
+              break;
+            case "ArrayExpression":
+              node.type = "ArrayPattern";
+              if (refDestructuringErrors) {
+                this.checkPatternErrors(refDestructuringErrors, true);
+              }
+              this.toAssignableList(node.elements, isBinding);
+              break;
+            case "SpreadElement":
+              node.type = "RestElement";
+              this.toAssignable(node.argument, isBinding);
+              if (node.argument.type === "AssignmentPattern") {
+                this.raise(node.argument.start, "Rest elements cannot have a default value");
+              }
+              break;
+            case "AssignmentExpression":
+              if (node.operator !== "=") {
+                this.raise(node.left.end, "Only '=' operator can be used for specifying default value.");
+              }
+              node.type = "AssignmentPattern";
+              delete node.operator;
+              this.toAssignable(node.left, isBinding);
+              break;
+            case "ParenthesizedExpression":
+              this.toAssignable(node.expression, isBinding, refDestructuringErrors);
+              break;
+            case "ChainExpression":
+              this.raiseRecoverable(node.start, "Optional chaining cannot appear in left-hand side");
+              break;
+            case "MemberExpression":
+              if (!isBinding) {
+                break;
+              }
+            default:
+              this.raise(node.start, "Assigning to rvalue");
+          }
+        } else if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        return node;
+      };
+      pp$72.toAssignableList = function(exprList, isBinding) {
+        var end = exprList.length;
+        for (var i2 = 0; i2 < end; i2++) {
+          var elt = exprList[i2];
+          if (elt) {
+            this.toAssignable(elt, isBinding);
+          }
+        }
+        if (end) {
+          var last = exprList[end - 1];
+          if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier") {
+            this.unexpected(last.argument.start);
+          }
+        }
+        return exprList;
+      };
+      pp$72.parseSpread = function(refDestructuringErrors) {
+        var node = this.startNode();
+        this.next();
+        node.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+        return this.finishNode(node, "SpreadElement");
+      };
+      pp$72.parseRestBinding = function() {
+        var node = this.startNode();
+        this.next();
+        if (this.options.ecmaVersion === 6 && this.type !== types$12.name) {
+          this.unexpected();
+        }
+        node.argument = this.parseBindingAtom();
+        return this.finishNode(node, "RestElement");
+      };
+      pp$72.parseBindingAtom = function() {
+        if (this.options.ecmaVersion >= 6) {
+          switch (this.type) {
+            case types$12.bracketL:
+              var node = this.startNode();
+              this.next();
+              node.elements = this.parseBindingList(types$12.bracketR, true, true);
+              return this.finishNode(node, "ArrayPattern");
+            case types$12.braceL:
+              return this.parseObj(true);
+          }
+        }
+        return this.parseIdent();
+      };
+      pp$72.parseBindingList = function(close, allowEmpty, allowTrailingComma) {
+        var elts = [], first = true;
+        while (!this.eat(close)) {
+          if (first) {
+            first = false;
+          } else {
+            this.expect(types$12.comma);
+          }
+          if (allowEmpty && this.type === types$12.comma) {
+            elts.push(null);
+          } else if (allowTrailingComma && this.afterTrailingComma(close)) {
+            break;
+          } else if (this.type === types$12.ellipsis) {
+            var rest = this.parseRestBinding();
+            this.parseBindingListItem(rest);
+            elts.push(rest);
+            if (this.type === types$12.comma) {
+              this.raise(this.start, "Comma is not permitted after the rest element");
+            }
+            this.expect(close);
+            break;
+          } else {
+            var elem = this.parseMaybeDefault(this.start, this.startLoc);
+            this.parseBindingListItem(elem);
+            elts.push(elem);
+          }
+        }
+        return elts;
+      };
+      pp$72.parseBindingListItem = function(param) {
+        return param;
+      };
+      pp$72.parseMaybeDefault = function(startPos, startLoc, left) {
+        left = left || this.parseBindingAtom();
+        if (this.options.ecmaVersion < 6 || !this.eat(types$12.eq)) {
+          return left;
+        }
+        var node = this.startNodeAt(startPos, startLoc);
+        node.left = left;
+        node.right = this.parseMaybeAssign();
+        return this.finishNode(node, "AssignmentPattern");
+      };
+      pp$72.checkLValSimple = function(expr, bindingType, checkClashes) {
+        if (bindingType === void 0)
+          bindingType = BIND_NONE2;
+        var isBind = bindingType !== BIND_NONE2;
+        switch (expr.type) {
+          case "Identifier":
+            if (this.strict && this.reservedWordsStrictBind.test(expr.name)) {
+              this.raiseRecoverable(expr.start, (isBind ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+            }
+            if (isBind) {
+              if (bindingType === BIND_LEXICAL2 && expr.name === "let") {
+                this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name");
+              }
+              if (checkClashes) {
+                if (hasOwn2(checkClashes, expr.name)) {
+                  this.raiseRecoverable(expr.start, "Argument name clash");
+                }
+                checkClashes[expr.name] = true;
+              }
+              if (bindingType !== BIND_OUTSIDE2) {
+                this.declareName(expr.name, bindingType, expr.start);
+              }
+            }
+            break;
+          case "ChainExpression":
+            this.raiseRecoverable(expr.start, "Optional chaining cannot appear in left-hand side");
+            break;
+          case "MemberExpression":
+            if (isBind) {
+              this.raiseRecoverable(expr.start, "Binding member expression");
+            }
+            break;
+          case "ParenthesizedExpression":
+            if (isBind) {
+              this.raiseRecoverable(expr.start, "Binding parenthesized expression");
+            }
+            return this.checkLValSimple(expr.expression, bindingType, checkClashes);
+          default:
+            this.raise(expr.start, (isBind ? "Binding" : "Assigning to") + " rvalue");
+        }
+      };
+      pp$72.checkLValPattern = function(expr, bindingType, checkClashes) {
+        if (bindingType === void 0)
+          bindingType = BIND_NONE2;
+        switch (expr.type) {
+          case "ObjectPattern":
+            for (var i2 = 0, list2 = expr.properties; i2 < list2.length; i2 += 1) {
+              var prop = list2[i2];
+              this.checkLValInnerPattern(prop, bindingType, checkClashes);
+            }
+            break;
+          case "ArrayPattern":
+            for (var i$1 = 0, list$1 = expr.elements; i$1 < list$1.length; i$1 += 1) {
+              var elem = list$1[i$1];
+              if (elem) {
+                this.checkLValInnerPattern(elem, bindingType, checkClashes);
+              }
+            }
+            break;
+          default:
+            this.checkLValSimple(expr, bindingType, checkClashes);
+        }
+      };
+      pp$72.checkLValInnerPattern = function(expr, bindingType, checkClashes) {
+        if (bindingType === void 0)
+          bindingType = BIND_NONE2;
+        switch (expr.type) {
+          case "Property":
+            this.checkLValInnerPattern(expr.value, bindingType, checkClashes);
+            break;
+          case "AssignmentPattern":
+            this.checkLValPattern(expr.left, bindingType, checkClashes);
+            break;
+          case "RestElement":
+            this.checkLValPattern(expr.argument, bindingType, checkClashes);
+            break;
+          default:
+            this.checkLValPattern(expr, bindingType, checkClashes);
+        }
+      };
+      var TokContext3 = function TokContext4(token, isExpr, preserveSpace, override, generator) {
+        this.token = token;
+        this.isExpr = !!isExpr;
+        this.preserveSpace = !!preserveSpace;
+        this.override = override;
+        this.generator = !!generator;
+      };
+      var types2 = {
+        b_stat: new TokContext3("{", false),
+        b_expr: new TokContext3("{", true),
+        b_tmpl: new TokContext3("${", false),
+        p_stat: new TokContext3("(", false),
+        p_expr: new TokContext3("(", true),
+        q_tmpl: new TokContext3("`", true, true, function(p) {
+          return p.tryReadTemplateToken();
+        }),
+        f_stat: new TokContext3("function", false),
+        f_expr: new TokContext3("function", true),
+        f_expr_gen: new TokContext3("function", true, false, null, true),
+        f_gen: new TokContext3("function", false, false, null, true)
+      };
+      var pp$62 = Parser3.prototype;
+      pp$62.initialContext = function() {
+        return [types2.b_stat];
+      };
+      pp$62.curContext = function() {
+        return this.context[this.context.length - 1];
+      };
+      pp$62.braceIsBlock = function(prevType) {
+        var parent = this.curContext();
+        if (parent === types2.f_expr || parent === types2.f_stat) {
+          return true;
+        }
+        if (prevType === types$12.colon && (parent === types2.b_stat || parent === types2.b_expr)) {
+          return !parent.isExpr;
+        }
+        if (prevType === types$12._return || prevType === types$12.name && this.exprAllowed) {
+          return lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+        }
+        if (prevType === types$12._else || prevType === types$12.semi || prevType === types$12.eof || prevType === types$12.parenR || prevType === types$12.arrow) {
+          return true;
+        }
+        if (prevType === types$12.braceL) {
+          return parent === types2.b_stat;
+        }
+        if (prevType === types$12._var || prevType === types$12._const || prevType === types$12.name) {
+          return false;
+        }
+        return !this.exprAllowed;
+      };
+      pp$62.inGeneratorContext = function() {
+        for (var i2 = this.context.length - 1; i2 >= 1; i2--) {
+          var context = this.context[i2];
+          if (context.token === "function") {
+            return context.generator;
+          }
+        }
+        return false;
+      };
+      pp$62.updateContext = function(prevType) {
+        var update, type = this.type;
+        if (type.keyword && prevType === types$12.dot) {
+          this.exprAllowed = false;
+        } else if (update = type.updateContext) {
+          update.call(this, prevType);
+        } else {
+          this.exprAllowed = type.beforeExpr;
+        }
+      };
+      pp$62.overrideContext = function(tokenCtx) {
+        if (this.curContext() !== tokenCtx) {
+          this.context[this.context.length - 1] = tokenCtx;
+        }
+      };
+      types$12.parenR.updateContext = types$12.braceR.updateContext = function() {
+        if (this.context.length === 1) {
+          this.exprAllowed = true;
+          return;
+        }
+        var out = this.context.pop();
+        if (out === types2.b_stat && this.curContext().token === "function") {
+          out = this.context.pop();
+        }
+        this.exprAllowed = !out.isExpr;
+      };
+      types$12.braceL.updateContext = function(prevType) {
+        this.context.push(this.braceIsBlock(prevType) ? types2.b_stat : types2.b_expr);
+        this.exprAllowed = true;
+      };
+      types$12.dollarBraceL.updateContext = function() {
+        this.context.push(types2.b_tmpl);
+        this.exprAllowed = true;
+      };
+      types$12.parenL.updateContext = function(prevType) {
+        var statementParens = prevType === types$12._if || prevType === types$12._for || prevType === types$12._with || prevType === types$12._while;
+        this.context.push(statementParens ? types2.p_stat : types2.p_expr);
+        this.exprAllowed = true;
+      };
+      types$12.incDec.updateContext = function() {
+      };
+      types$12._function.updateContext = types$12._class.updateContext = function(prevType) {
+        if (prevType.beforeExpr && prevType !== types$12._else && !(prevType === types$12.semi && this.curContext() !== types2.p_stat) && !(prevType === types$12._return && lineBreak2.test(this.input.slice(this.lastTokEnd, this.start))) && !((prevType === types$12.colon || prevType === types$12.braceL) && this.curContext() === types2.b_stat)) {
+          this.context.push(types2.f_expr);
+        } else {
+          this.context.push(types2.f_stat);
+        }
+        this.exprAllowed = false;
+      };
+      types$12.backQuote.updateContext = function() {
+        if (this.curContext() === types2.q_tmpl) {
+          this.context.pop();
+        } else {
+          this.context.push(types2.q_tmpl);
+        }
+        this.exprAllowed = false;
+      };
+      types$12.star.updateContext = function(prevType) {
+        if (prevType === types$12._function) {
+          var index2 = this.context.length - 1;
+          if (this.context[index2] === types2.f_expr) {
+            this.context[index2] = types2.f_expr_gen;
+          } else {
+            this.context[index2] = types2.f_gen;
+          }
+        }
+        this.exprAllowed = true;
+      };
+      types$12.name.updateContext = function(prevType) {
+        var allowed = false;
+        if (this.options.ecmaVersion >= 6 && prevType !== types$12.dot) {
+          if (this.value === "of" && !this.exprAllowed || this.value === "yield" && this.inGeneratorContext()) {
+            allowed = true;
+          }
+        }
+        this.exprAllowed = allowed;
+      };
+      var pp$52 = Parser3.prototype;
+      pp$52.checkPropClash = function(prop, propHash, refDestructuringErrors) {
+        if (this.options.ecmaVersion >= 9 && prop.type === "SpreadElement") {
+          return;
+        }
+        if (this.options.ecmaVersion >= 6 && (prop.computed || prop.method || prop.shorthand)) {
+          return;
+        }
+        var key = prop.key;
+        var name;
+        switch (key.type) {
+          case "Identifier":
+            name = key.name;
+            break;
+          case "Literal":
+            name = String(key.value);
+            break;
+          default:
+            return;
+        }
+        var kind = prop.kind;
+        if (this.options.ecmaVersion >= 6) {
+          if (name === "__proto__" && kind === "init") {
+            if (propHash.proto) {
+              if (refDestructuringErrors) {
+                if (refDestructuringErrors.doubleProto < 0) {
+                  refDestructuringErrors.doubleProto = key.start;
+                }
+              } else {
+                this.raiseRecoverable(key.start, "Redefinition of __proto__ property");
+              }
+            }
+            propHash.proto = true;
+          }
+          return;
+        }
+        name = "$" + name;
+        var other = propHash[name];
+        if (other) {
+          var redefinition;
+          if (kind === "init") {
+            redefinition = this.strict && other.init || other.get || other.set;
+          } else {
+            redefinition = other.init || other[kind];
+          }
+          if (redefinition) {
+            this.raiseRecoverable(key.start, "Redefinition of property");
+          }
+        } else {
+          other = propHash[name] = {
+            init: false,
+            get: false,
+            set: false
+          };
+        }
+        other[kind] = true;
+      };
+      pp$52.parseExpression = function(forInit, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseMaybeAssign(forInit, refDestructuringErrors);
+        if (this.type === types$12.comma) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.expressions = [expr];
+          while (this.eat(types$12.comma)) {
+            node.expressions.push(this.parseMaybeAssign(forInit, refDestructuringErrors));
+          }
+          return this.finishNode(node, "SequenceExpression");
+        }
+        return expr;
+      };
+      pp$52.parseMaybeAssign = function(forInit, refDestructuringErrors, afterLeftParse) {
+        if (this.isContextual("yield")) {
+          if (this.inGenerator) {
+            return this.parseYield(forInit);
+          } else {
+            this.exprAllowed = false;
+          }
+        }
+        var ownDestructuringErrors = false, oldParenAssign = -1, oldTrailingComma = -1, oldDoubleProto = -1;
+        if (refDestructuringErrors) {
+          oldParenAssign = refDestructuringErrors.parenthesizedAssign;
+          oldTrailingComma = refDestructuringErrors.trailingComma;
+          oldDoubleProto = refDestructuringErrors.doubleProto;
+          refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = -1;
+        } else {
+          refDestructuringErrors = new DestructuringErrors3();
+          ownDestructuringErrors = true;
+        }
+        var startPos = this.start, startLoc = this.startLoc;
+        if (this.type === types$12.parenL || this.type === types$12.name) {
+          this.potentialArrowAt = this.start;
+          this.potentialArrowInForAwait = forInit === "await";
+        }
+        var left = this.parseMaybeConditional(forInit, refDestructuringErrors);
+        if (afterLeftParse) {
+          left = afterLeftParse.call(this, left, startPos, startLoc);
+        }
+        if (this.type.isAssign) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.operator = this.value;
+          if (this.type === types$12.eq) {
+            left = this.toAssignable(left, false, refDestructuringErrors);
+          }
+          if (!ownDestructuringErrors) {
+            refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = refDestructuringErrors.doubleProto = -1;
+          }
+          if (refDestructuringErrors.shorthandAssign >= left.start) {
+            refDestructuringErrors.shorthandAssign = -1;
+          }
+          if (this.type === types$12.eq) {
+            this.checkLValPattern(left);
+          } else {
+            this.checkLValSimple(left);
+          }
+          node.left = left;
+          this.next();
+          node.right = this.parseMaybeAssign(forInit);
+          if (oldDoubleProto > -1) {
+            refDestructuringErrors.doubleProto = oldDoubleProto;
+          }
+          return this.finishNode(node, "AssignmentExpression");
+        } else {
+          if (ownDestructuringErrors) {
+            this.checkExpressionErrors(refDestructuringErrors, true);
+          }
+        }
+        if (oldParenAssign > -1) {
+          refDestructuringErrors.parenthesizedAssign = oldParenAssign;
+        }
+        if (oldTrailingComma > -1) {
+          refDestructuringErrors.trailingComma = oldTrailingComma;
+        }
+        return left;
+      };
+      pp$52.parseMaybeConditional = function(forInit, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseExprOps(forInit, refDestructuringErrors);
+        if (this.checkExpressionErrors(refDestructuringErrors)) {
+          return expr;
+        }
+        if (this.eat(types$12.question)) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.test = expr;
+          node.consequent = this.parseMaybeAssign();
+          this.expect(types$12.colon);
+          node.alternate = this.parseMaybeAssign(forInit);
+          return this.finishNode(node, "ConditionalExpression");
+        }
+        return expr;
+      };
+      pp$52.parseExprOps = function(forInit, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseMaybeUnary(refDestructuringErrors, false, false, forInit);
+        if (this.checkExpressionErrors(refDestructuringErrors)) {
+          return expr;
+        }
+        return expr.start === startPos && expr.type === "ArrowFunctionExpression" ? expr : this.parseExprOp(expr, startPos, startLoc, -1, forInit);
+      };
+      pp$52.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, forInit) {
+        var prec = this.type.binop;
+        if (prec != null && (!forInit || this.type !== types$12._in)) {
+          if (prec > minPrec) {
+            var logical = this.type === types$12.logicalOR || this.type === types$12.logicalAND;
+            var coalesce = this.type === types$12.coalesce;
+            if (coalesce) {
+              prec = types$12.logicalAND.binop;
+            }
+            var op = this.value;
+            this.next();
+            var startPos = this.start, startLoc = this.startLoc;
+            var right = this.parseExprOp(this.parseMaybeUnary(null, false, false, forInit), startPos, startLoc, prec, forInit);
+            var node = this.buildBinary(leftStartPos, leftStartLoc, left, right, op, logical || coalesce);
+            if (logical && this.type === types$12.coalesce || coalesce && (this.type === types$12.logicalOR || this.type === types$12.logicalAND)) {
+              this.raiseRecoverable(this.start, "Logical expressions and coalesce expressions cannot be mixed. Wrap either by parentheses");
+            }
+            return this.parseExprOp(node, leftStartPos, leftStartLoc, minPrec, forInit);
+          }
+        }
+        return left;
+      };
+      pp$52.buildBinary = function(startPos, startLoc, left, right, op, logical) {
+        if (right.type === "PrivateIdentifier") {
+          this.raise(right.start, "Private identifier can only be left side of binary expression");
+        }
+        var node = this.startNodeAt(startPos, startLoc);
+        node.left = left;
+        node.operator = op;
+        node.right = right;
+        return this.finishNode(node, logical ? "LogicalExpression" : "BinaryExpression");
+      };
+      pp$52.parseMaybeUnary = function(refDestructuringErrors, sawUnary, incDec, forInit) {
+        var startPos = this.start, startLoc = this.startLoc, expr;
+        if (this.isContextual("await") && this.canAwait) {
+          expr = this.parseAwait(forInit);
+          sawUnary = true;
+        } else if (this.type.prefix) {
+          var node = this.startNode(), update = this.type === types$12.incDec;
+          node.operator = this.value;
+          node.prefix = true;
+          this.next();
+          node.argument = this.parseMaybeUnary(null, true, update, forInit);
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          if (update) {
+            this.checkLValSimple(node.argument);
+          } else if (this.strict && node.operator === "delete" && node.argument.type === "Identifier") {
+            this.raiseRecoverable(node.start, "Deleting local variable in strict mode");
+          } else if (node.operator === "delete" && isPrivateFieldAccess2(node.argument)) {
+            this.raiseRecoverable(node.start, "Private fields can not be deleted");
+          } else {
+            sawUnary = true;
+          }
+          expr = this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
+        } else if (!sawUnary && this.type === types$12.privateId) {
+          if (forInit || this.privateNameStack.length === 0) {
+            this.unexpected();
+          }
+          expr = this.parsePrivateIdent();
+          if (this.type !== types$12._in) {
+            this.unexpected();
+          }
+        } else {
+          expr = this.parseExprSubscripts(refDestructuringErrors, forInit);
+          if (this.checkExpressionErrors(refDestructuringErrors)) {
+            return expr;
+          }
+          while (this.type.postfix && !this.canInsertSemicolon()) {
+            var node$1 = this.startNodeAt(startPos, startLoc);
+            node$1.operator = this.value;
+            node$1.prefix = false;
+            node$1.argument = expr;
+            this.checkLValSimple(expr);
+            this.next();
+            expr = this.finishNode(node$1, "UpdateExpression");
+          }
+        }
+        if (!incDec && this.eat(types$12.starstar)) {
+          if (sawUnary) {
+            this.unexpected(this.lastTokStart);
+          } else {
+            return this.buildBinary(startPos, startLoc, expr, this.parseMaybeUnary(null, false, false, forInit), "**", false);
+          }
+        } else {
+          return expr;
+        }
+      };
+      function isPrivateFieldAccess2(node) {
+        return node.type === "MemberExpression" && node.property.type === "PrivateIdentifier" || node.type === "ChainExpression" && isPrivateFieldAccess2(node.expression);
+      }
+      pp$52.parseExprSubscripts = function(refDestructuringErrors, forInit) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseExprAtom(refDestructuringErrors, forInit);
+        if (expr.type === "ArrowFunctionExpression" && this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")") {
+          return expr;
+        }
+        var result = this.parseSubscripts(expr, startPos, startLoc, false, forInit);
+        if (refDestructuringErrors && result.type === "MemberExpression") {
+          if (refDestructuringErrors.parenthesizedAssign >= result.start) {
+            refDestructuringErrors.parenthesizedAssign = -1;
+          }
+          if (refDestructuringErrors.parenthesizedBind >= result.start) {
+            refDestructuringErrors.parenthesizedBind = -1;
+          }
+          if (refDestructuringErrors.trailingComma >= result.start) {
+            refDestructuringErrors.trailingComma = -1;
+          }
+        }
+        return result;
+      };
+      pp$52.parseSubscripts = function(base, startPos, startLoc, noCalls, forInit) {
+        var maybeAsyncArrow = this.options.ecmaVersion >= 8 && base.type === "Identifier" && base.name === "async" && this.lastTokEnd === base.end && !this.canInsertSemicolon() && base.end - base.start === 5 && this.potentialArrowAt === base.start;
+        var optionalChained = false;
+        while (true) {
+          var element = this.parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit);
+          if (element.optional) {
+            optionalChained = true;
+          }
+          if (element === base || element.type === "ArrowFunctionExpression") {
+            if (optionalChained) {
+              var chainNode = this.startNodeAt(startPos, startLoc);
+              chainNode.expression = element;
+              element = this.finishNode(chainNode, "ChainExpression");
+            }
+            return element;
+          }
+          base = element;
+        }
+      };
+      pp$52.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
+        var optionalSupported = this.options.ecmaVersion >= 11;
+        var optional = optionalSupported && this.eat(types$12.questionDot);
+        if (noCalls && optional) {
+          this.raise(this.lastTokStart, "Optional chaining cannot appear in the callee of new expressions");
+        }
+        var computed = this.eat(types$12.bracketL);
+        if (computed || optional && this.type !== types$12.parenL && this.type !== types$12.backQuote || this.eat(types$12.dot)) {
+          var node = this.startNodeAt(startPos, startLoc);
+          node.object = base;
+          if (computed) {
+            node.property = this.parseExpression();
+            this.expect(types$12.bracketR);
+          } else if (this.type === types$12.privateId && base.type !== "Super") {
+            node.property = this.parsePrivateIdent();
+          } else {
+            node.property = this.parseIdent(this.options.allowReserved !== "never");
+          }
+          node.computed = !!computed;
+          if (optionalSupported) {
+            node.optional = optional;
+          }
+          base = this.finishNode(node, "MemberExpression");
+        } else if (!noCalls && this.eat(types$12.parenL)) {
+          var refDestructuringErrors = new DestructuringErrors3(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+          this.yieldPos = 0;
+          this.awaitPos = 0;
+          this.awaitIdentPos = 0;
+          var exprList = this.parseExprList(types$12.parenR, this.options.ecmaVersion >= 8, false, refDestructuringErrors);
+          if (maybeAsyncArrow && !optional && !this.canInsertSemicolon() && this.eat(types$12.arrow)) {
+            this.checkPatternErrors(refDestructuringErrors, false);
+            this.checkYieldAwaitInDefaultParams();
+            if (this.awaitIdentPos > 0) {
+              this.raise(this.awaitIdentPos, "Cannot use 'await' as identifier inside an async function");
+            }
+            this.yieldPos = oldYieldPos;
+            this.awaitPos = oldAwaitPos;
+            this.awaitIdentPos = oldAwaitIdentPos;
+            return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, true, forInit);
+          }
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          this.yieldPos = oldYieldPos || this.yieldPos;
+          this.awaitPos = oldAwaitPos || this.awaitPos;
+          this.awaitIdentPos = oldAwaitIdentPos || this.awaitIdentPos;
+          var node$1 = this.startNodeAt(startPos, startLoc);
+          node$1.callee = base;
+          node$1.arguments = exprList;
+          if (optionalSupported) {
+            node$1.optional = optional;
+          }
+          base = this.finishNode(node$1, "CallExpression");
+        } else if (this.type === types$12.backQuote) {
+          if (optional || optionalChained) {
+            this.raise(this.start, "Optional chaining cannot appear in the tag of tagged template expressions");
+          }
+          var node$2 = this.startNodeAt(startPos, startLoc);
+          node$2.tag = base;
+          node$2.quasi = this.parseTemplate({ isTagged: true });
+          base = this.finishNode(node$2, "TaggedTemplateExpression");
+        }
+        return base;
+      };
+      pp$52.parseExprAtom = function(refDestructuringErrors, forInit) {
+        if (this.type === types$12.slash) {
+          this.readRegexp();
+        }
+        var node, canBeArrow = this.potentialArrowAt === this.start;
+        switch (this.type) {
+          case types$12._super:
+            if (!this.allowSuper) {
+              this.raise(this.start, "'super' keyword outside a method");
+            }
+            node = this.startNode();
+            this.next();
+            if (this.type === types$12.parenL && !this.allowDirectSuper) {
+              this.raise(node.start, "super() call outside constructor of a subclass");
+            }
+            if (this.type !== types$12.dot && this.type !== types$12.bracketL && this.type !== types$12.parenL) {
+              this.unexpected();
+            }
+            return this.finishNode(node, "Super");
+          case types$12._this:
+            node = this.startNode();
+            this.next();
+            return this.finishNode(node, "ThisExpression");
+          case types$12.name:
+            var startPos = this.start, startLoc = this.startLoc, containsEsc = this.containsEsc;
+            var id = this.parseIdent(false);
+            if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === "async" && !this.canInsertSemicolon() && this.eat(types$12._function)) {
+              this.overrideContext(types2.f_expr);
+              return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true, forInit);
+            }
+            if (canBeArrow && !this.canInsertSemicolon()) {
+              if (this.eat(types$12.arrow)) {
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false, forInit);
+              }
+              if (this.options.ecmaVersion >= 8 && id.name === "async" && this.type === types$12.name && !containsEsc && (!this.potentialArrowInForAwait || this.value !== "of" || this.containsEsc)) {
+                id = this.parseIdent(false);
+                if (this.canInsertSemicolon() || !this.eat(types$12.arrow)) {
+                  this.unexpected();
+                }
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true, forInit);
+              }
+            }
+            return id;
+          case types$12.regexp:
+            var value = this.value;
+            node = this.parseLiteral(value.value);
+            node.regex = { pattern: value.pattern, flags: value.flags };
+            return node;
+          case types$12.num:
+          case types$12.string:
+            return this.parseLiteral(this.value);
+          case types$12._null:
+          case types$12._true:
+          case types$12._false:
+            node = this.startNode();
+            node.value = this.type === types$12._null ? null : this.type === types$12._true;
+            node.raw = this.type.keyword;
+            this.next();
+            return this.finishNode(node, "Literal");
+          case types$12.parenL:
+            var start3 = this.start, expr = this.parseParenAndDistinguishExpression(canBeArrow, forInit);
+            if (refDestructuringErrors) {
+              if (refDestructuringErrors.parenthesizedAssign < 0 && !this.isSimpleAssignTarget(expr)) {
+                refDestructuringErrors.parenthesizedAssign = start3;
+              }
+              if (refDestructuringErrors.parenthesizedBind < 0) {
+                refDestructuringErrors.parenthesizedBind = start3;
+              }
+            }
+            return expr;
+          case types$12.bracketL:
+            node = this.startNode();
+            this.next();
+            node.elements = this.parseExprList(types$12.bracketR, true, true, refDestructuringErrors);
+            return this.finishNode(node, "ArrayExpression");
+          case types$12.braceL:
+            this.overrideContext(types2.b_expr);
+            return this.parseObj(false, refDestructuringErrors);
+          case types$12._function:
+            node = this.startNode();
+            this.next();
+            return this.parseFunction(node, 0);
+          case types$12._class:
+            return this.parseClass(this.startNode(), false);
+          case types$12._new:
+            return this.parseNew();
+          case types$12.backQuote:
+            return this.parseTemplate();
+          case types$12._import:
+            if (this.options.ecmaVersion >= 11) {
+              return this.parseExprImport();
+            } else {
+              return this.unexpected();
+            }
+          default:
+            this.unexpected();
+        }
+      };
+      pp$52.parseExprImport = function() {
+        var node = this.startNode();
+        if (this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword import");
+        }
+        var meta = this.parseIdent(true);
+        switch (this.type) {
+          case types$12.parenL:
+            return this.parseDynamicImport(node);
+          case types$12.dot:
+            node.meta = meta;
+            return this.parseImportMeta(node);
+          default:
+            this.unexpected();
+        }
+      };
+      pp$52.parseDynamicImport = function(node) {
+        this.next();
+        node.source = this.parseMaybeAssign();
+        if (!this.eat(types$12.parenR)) {
+          var errorPos = this.start;
+          if (this.eat(types$12.comma) && this.eat(types$12.parenR)) {
+            this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+          } else {
+            this.unexpected(errorPos);
+          }
+        }
+        return this.finishNode(node, "ImportExpression");
+      };
+      pp$52.parseImportMeta = function(node) {
+        this.next();
+        var containsEsc = this.containsEsc;
+        node.property = this.parseIdent(true);
+        if (node.property.name !== "meta") {
+          this.raiseRecoverable(node.property.start, "The only valid meta property for import is 'import.meta'");
+        }
+        if (containsEsc) {
+          this.raiseRecoverable(node.start, "'import.meta' must not contain escaped characters");
+        }
+        if (this.options.sourceType !== "module" && !this.options.allowImportExportEverywhere) {
+          this.raiseRecoverable(node.start, "Cannot use 'import.meta' outside a module");
+        }
+        return this.finishNode(node, "MetaProperty");
+      };
+      pp$52.parseLiteral = function(value) {
+        var node = this.startNode();
+        node.value = value;
+        node.raw = this.input.slice(this.start, this.end);
+        if (node.raw.charCodeAt(node.raw.length - 1) === 110) {
+          node.bigint = node.raw.slice(0, -1).replace(/_/g, "");
+        }
+        this.next();
+        return this.finishNode(node, "Literal");
+      };
+      pp$52.parseParenExpression = function() {
+        this.expect(types$12.parenL);
+        var val = this.parseExpression();
+        this.expect(types$12.parenR);
+        return val;
+      };
+      pp$52.parseParenAndDistinguishExpression = function(canBeArrow, forInit) {
+        var startPos = this.start, startLoc = this.startLoc, val, allowTrailingComma = this.options.ecmaVersion >= 8;
+        if (this.options.ecmaVersion >= 6) {
+          this.next();
+          var innerStartPos = this.start, innerStartLoc = this.startLoc;
+          var exprList = [], first = true, lastIsComma = false;
+          var refDestructuringErrors = new DestructuringErrors3(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, spreadStart;
+          this.yieldPos = 0;
+          this.awaitPos = 0;
+          while (this.type !== types$12.parenR) {
+            first ? first = false : this.expect(types$12.comma);
+            if (allowTrailingComma && this.afterTrailingComma(types$12.parenR, true)) {
+              lastIsComma = true;
+              break;
+            } else if (this.type === types$12.ellipsis) {
+              spreadStart = this.start;
+              exprList.push(this.parseParenItem(this.parseRestBinding()));
+              if (this.type === types$12.comma) {
+                this.raise(this.start, "Comma is not permitted after the rest element");
+              }
+              break;
+            } else {
+              exprList.push(this.parseMaybeAssign(false, refDestructuringErrors, this.parseParenItem));
+            }
+          }
+          var innerEndPos = this.lastTokEnd, innerEndLoc = this.lastTokEndLoc;
+          this.expect(types$12.parenR);
+          if (canBeArrow && !this.canInsertSemicolon() && this.eat(types$12.arrow)) {
+            this.checkPatternErrors(refDestructuringErrors, false);
+            this.checkYieldAwaitInDefaultParams();
+            this.yieldPos = oldYieldPos;
+            this.awaitPos = oldAwaitPos;
+            return this.parseParenArrowList(startPos, startLoc, exprList, forInit);
+          }
+          if (!exprList.length || lastIsComma) {
+            this.unexpected(this.lastTokStart);
+          }
+          if (spreadStart) {
+            this.unexpected(spreadStart);
+          }
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          this.yieldPos = oldYieldPos || this.yieldPos;
+          this.awaitPos = oldAwaitPos || this.awaitPos;
+          if (exprList.length > 1) {
+            val = this.startNodeAt(innerStartPos, innerStartLoc);
+            val.expressions = exprList;
+            this.finishNodeAt(val, "SequenceExpression", innerEndPos, innerEndLoc);
+          } else {
+            val = exprList[0];
+          }
+        } else {
+          val = this.parseParenExpression();
+        }
+        if (this.options.preserveParens) {
+          var par = this.startNodeAt(startPos, startLoc);
+          par.expression = val;
+          return this.finishNode(par, "ParenthesizedExpression");
+        } else {
+          return val;
+        }
+      };
+      pp$52.parseParenItem = function(item) {
+        return item;
+      };
+      pp$52.parseParenArrowList = function(startPos, startLoc, exprList, forInit) {
+        return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, false, forInit);
+      };
+      var empty3 = [];
+      pp$52.parseNew = function() {
+        if (this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword new");
+        }
+        var node = this.startNode();
+        var meta = this.parseIdent(true);
+        if (this.options.ecmaVersion >= 6 && this.eat(types$12.dot)) {
+          node.meta = meta;
+          var containsEsc = this.containsEsc;
+          node.property = this.parseIdent(true);
+          if (node.property.name !== "target") {
+            this.raiseRecoverable(node.property.start, "The only valid meta property for new is 'new.target'");
+          }
+          if (containsEsc) {
+            this.raiseRecoverable(node.start, "'new.target' must not contain escaped characters");
+          }
+          if (!this.allowNewDotTarget) {
+            this.raiseRecoverable(node.start, "'new.target' can only be used in functions and class static block");
+          }
+          return this.finishNode(node, "MetaProperty");
+        }
+        var startPos = this.start, startLoc = this.startLoc, isImport = this.type === types$12._import;
+        node.callee = this.parseSubscripts(this.parseExprAtom(), startPos, startLoc, true, false);
+        if (isImport && node.callee.type === "ImportExpression") {
+          this.raise(startPos, "Cannot use new with import()");
+        }
+        if (this.eat(types$12.parenL)) {
+          node.arguments = this.parseExprList(types$12.parenR, this.options.ecmaVersion >= 8, false);
+        } else {
+          node.arguments = empty3;
+        }
+        return this.finishNode(node, "NewExpression");
+      };
+      pp$52.parseTemplateElement = function(ref3) {
+        var isTagged = ref3.isTagged;
+        var elem = this.startNode();
+        if (this.type === types$12.invalidTemplate) {
+          if (!isTagged) {
+            this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal");
+          }
+          elem.value = {
+            raw: this.value,
+            cooked: null
+          };
+        } else {
+          elem.value = {
+            raw: this.input.slice(this.start, this.end).replace(/\r\n?/g, "\n"),
+            cooked: this.value
+          };
+        }
+        this.next();
+        elem.tail = this.type === types$12.backQuote;
+        return this.finishNode(elem, "TemplateElement");
+      };
+      pp$52.parseTemplate = function(ref3) {
+        if (ref3 === void 0)
+          ref3 = {};
+        var isTagged = ref3.isTagged;
+        if (isTagged === void 0)
+          isTagged = false;
+        var node = this.startNode();
+        this.next();
+        node.expressions = [];
+        var curElt = this.parseTemplateElement({ isTagged });
+        node.quasis = [curElt];
+        while (!curElt.tail) {
+          if (this.type === types$12.eof) {
+            this.raise(this.pos, "Unterminated template literal");
+          }
+          this.expect(types$12.dollarBraceL);
+          node.expressions.push(this.parseExpression());
+          this.expect(types$12.braceR);
+          node.quasis.push(curElt = this.parseTemplateElement({ isTagged }));
+        }
+        this.next();
+        return this.finishNode(node, "TemplateLiteral");
+      };
+      pp$52.isAsyncProp = function(prop) {
+        return !prop.computed && prop.key.type === "Identifier" && prop.key.name === "async" && (this.type === types$12.name || this.type === types$12.num || this.type === types$12.string || this.type === types$12.bracketL || this.type.keyword || this.options.ecmaVersion >= 9 && this.type === types$12.star) && !lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+      };
+      pp$52.parseObj = function(isPattern, refDestructuringErrors) {
+        var node = this.startNode(), first = true, propHash = {};
+        node.properties = [];
+        this.next();
+        while (!this.eat(types$12.braceR)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (this.options.ecmaVersion >= 5 && this.afterTrailingComma(types$12.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var prop = this.parseProperty(isPattern, refDestructuringErrors);
+          if (!isPattern) {
+            this.checkPropClash(prop, propHash, refDestructuringErrors);
+          }
+          node.properties.push(prop);
+        }
+        return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
+      };
+      pp$52.parseProperty = function(isPattern, refDestructuringErrors) {
+        var prop = this.startNode(), isGenerator, isAsync, startPos, startLoc;
+        if (this.options.ecmaVersion >= 9 && this.eat(types$12.ellipsis)) {
+          if (isPattern) {
+            prop.argument = this.parseIdent(false);
+            if (this.type === types$12.comma) {
+              this.raise(this.start, "Comma is not permitted after the rest element");
+            }
+            return this.finishNode(prop, "RestElement");
+          }
+          prop.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+          if (this.type === types$12.comma && refDestructuringErrors && refDestructuringErrors.trailingComma < 0) {
+            refDestructuringErrors.trailingComma = this.start;
+          }
+          return this.finishNode(prop, "SpreadElement");
+        }
+        if (this.options.ecmaVersion >= 6) {
+          prop.method = false;
+          prop.shorthand = false;
+          if (isPattern || refDestructuringErrors) {
+            startPos = this.start;
+            startLoc = this.startLoc;
+          }
+          if (!isPattern) {
+            isGenerator = this.eat(types$12.star);
+          }
+        }
+        var containsEsc = this.containsEsc;
+        this.parsePropertyName(prop);
+        if (!isPattern && !containsEsc && this.options.ecmaVersion >= 8 && !isGenerator && this.isAsyncProp(prop)) {
+          isAsync = true;
+          isGenerator = this.options.ecmaVersion >= 9 && this.eat(types$12.star);
+          this.parsePropertyName(prop, refDestructuringErrors);
+        } else {
+          isAsync = false;
+        }
+        this.parsePropertyValue(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc);
+        return this.finishNode(prop, "Property");
+      };
+      pp$52.parsePropertyValue = function(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc) {
+        if ((isGenerator || isAsync) && this.type === types$12.colon) {
+          this.unexpected();
+        }
+        if (this.eat(types$12.colon)) {
+          prop.value = isPattern ? this.parseMaybeDefault(this.start, this.startLoc) : this.parseMaybeAssign(false, refDestructuringErrors);
+          prop.kind = "init";
+        } else if (this.options.ecmaVersion >= 6 && this.type === types$12.parenL) {
+          if (isPattern) {
+            this.unexpected();
+          }
+          prop.kind = "init";
+          prop.method = true;
+          prop.value = this.parseMethod(isGenerator, isAsync);
+        } else if (!isPattern && !containsEsc && this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type !== types$12.comma && this.type !== types$12.braceR && this.type !== types$12.eq)) {
+          if (isGenerator || isAsync) {
+            this.unexpected();
+          }
+          prop.kind = prop.key.name;
+          this.parsePropertyName(prop);
+          prop.value = this.parseMethod(false);
+          var paramCount = prop.kind === "get" ? 0 : 1;
+          if (prop.value.params.length !== paramCount) {
+            var start3 = prop.value.start;
+            if (prop.kind === "get") {
+              this.raiseRecoverable(start3, "getter should have no params");
+            } else {
+              this.raiseRecoverable(start3, "setter should have exactly one param");
+            }
+          } else {
+            if (prop.kind === "set" && prop.value.params[0].type === "RestElement") {
+              this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params");
+            }
+          }
+        } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+          if (isGenerator || isAsync) {
+            this.unexpected();
+          }
+          this.checkUnreserved(prop.key);
+          if (prop.key.name === "await" && !this.awaitIdentPos) {
+            this.awaitIdentPos = startPos;
+          }
+          prop.kind = "init";
+          if (isPattern) {
+            prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+          } else if (this.type === types$12.eq && refDestructuringErrors) {
+            if (refDestructuringErrors.shorthandAssign < 0) {
+              refDestructuringErrors.shorthandAssign = this.start;
+            }
+            prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+          } else {
+            prop.value = this.copyNode(prop.key);
+          }
+          prop.shorthand = true;
+        } else {
+          this.unexpected();
+        }
+      };
+      pp$52.parsePropertyName = function(prop) {
+        if (this.options.ecmaVersion >= 6) {
+          if (this.eat(types$12.bracketL)) {
+            prop.computed = true;
+            prop.key = this.parseMaybeAssign();
+            this.expect(types$12.bracketR);
+            return prop.key;
+          } else {
+            prop.computed = false;
+          }
+        }
+        return prop.key = this.type === types$12.num || this.type === types$12.string ? this.parseExprAtom() : this.parseIdent(this.options.allowReserved !== "never");
+      };
+      pp$52.initFunction = function(node) {
+        node.id = null;
+        if (this.options.ecmaVersion >= 6) {
+          node.generator = node.expression = false;
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node.async = false;
+        }
+      };
+      pp$52.parseMethod = function(isGenerator, isAsync, allowDirectSuper) {
+        var node = this.startNode(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.initFunction(node);
+        if (this.options.ecmaVersion >= 6) {
+          node.generator = isGenerator;
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node.async = !!isAsync;
+        }
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        this.enterScope(functionFlags2(isAsync, node.generator) | SCOPE_SUPER2 | (allowDirectSuper ? SCOPE_DIRECT_SUPER2 : 0));
+        this.expect(types$12.parenL);
+        node.params = this.parseBindingList(types$12.parenR, false, this.options.ecmaVersion >= 8);
+        this.checkYieldAwaitInDefaultParams();
+        this.parseFunctionBody(node, false, true, false);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node, "FunctionExpression");
+      };
+      pp$52.parseArrowExpression = function(node, params, isAsync, forInit) {
+        var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.enterScope(functionFlags2(isAsync, false) | SCOPE_ARROW2);
+        this.initFunction(node);
+        if (this.options.ecmaVersion >= 8) {
+          node.async = !!isAsync;
+        }
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        node.params = this.toAssignableList(params, true);
+        this.parseFunctionBody(node, true, false, forInit);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node, "ArrowFunctionExpression");
+      };
+      pp$52.parseFunctionBody = function(node, isArrowFunction, isMethod, forInit) {
+        var isExpression = isArrowFunction && this.type !== types$12.braceL;
+        var oldStrict = this.strict, useStrict = false;
+        if (isExpression) {
+          node.body = this.parseMaybeAssign(forInit);
+          node.expression = true;
+          this.checkParams(node, false);
+        } else {
+          var nonSimple = this.options.ecmaVersion >= 7 && !this.isSimpleParamList(node.params);
+          if (!oldStrict || nonSimple) {
+            useStrict = this.strictDirective(this.end);
+            if (useStrict && nonSimple) {
+              this.raiseRecoverable(node.start, "Illegal 'use strict' directive in function with non-simple parameter list");
+            }
+          }
+          var oldLabels = this.labels;
+          this.labels = [];
+          if (useStrict) {
+            this.strict = true;
+          }
+          this.checkParams(node, !oldStrict && !useStrict && !isArrowFunction && !isMethod && this.isSimpleParamList(node.params));
+          if (this.strict && node.id) {
+            this.checkLValSimple(node.id, BIND_OUTSIDE2);
+          }
+          node.body = this.parseBlock(false, void 0, useStrict && !oldStrict);
+          node.expression = false;
+          this.adaptDirectivePrologue(node.body.body);
+          this.labels = oldLabels;
+        }
+        this.exitScope();
+      };
+      pp$52.isSimpleParamList = function(params) {
+        for (var i2 = 0, list2 = params; i2 < list2.length; i2 += 1) {
+          var param = list2[i2];
+          if (param.type !== "Identifier") {
+            return false;
+          }
+        }
+        return true;
+      };
+      pp$52.checkParams = function(node, allowDuplicates) {
+        var nameHash = /* @__PURE__ */ Object.create(null);
+        for (var i2 = 0, list2 = node.params; i2 < list2.length; i2 += 1) {
+          var param = list2[i2];
+          this.checkLValInnerPattern(param, BIND_VAR2, allowDuplicates ? null : nameHash);
+        }
+      };
+      pp$52.parseExprList = function(close, allowTrailingComma, allowEmpty, refDestructuringErrors) {
+        var elts = [], first = true;
+        while (!this.eat(close)) {
+          if (!first) {
+            this.expect(types$12.comma);
+            if (allowTrailingComma && this.afterTrailingComma(close)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var elt = void 0;
+          if (allowEmpty && this.type === types$12.comma) {
+            elt = null;
+          } else if (this.type === types$12.ellipsis) {
+            elt = this.parseSpread(refDestructuringErrors);
+            if (refDestructuringErrors && this.type === types$12.comma && refDestructuringErrors.trailingComma < 0) {
+              refDestructuringErrors.trailingComma = this.start;
+            }
+          } else {
+            elt = this.parseMaybeAssign(false, refDestructuringErrors);
+          }
+          elts.push(elt);
+        }
+        return elts;
+      };
+      pp$52.checkUnreserved = function(ref3) {
+        var start3 = ref3.start;
+        var end = ref3.end;
+        var name = ref3.name;
+        if (this.inGenerator && name === "yield") {
+          this.raiseRecoverable(start3, "Cannot use 'yield' as identifier inside a generator");
+        }
+        if (this.inAsync && name === "await") {
+          this.raiseRecoverable(start3, "Cannot use 'await' as identifier inside an async function");
+        }
+        if (this.currentThisScope().inClassFieldInit && name === "arguments") {
+          this.raiseRecoverable(start3, "Cannot use 'arguments' in class field initializer");
+        }
+        if (this.inClassStaticBlock && (name === "arguments" || name === "await")) {
+          this.raise(start3, "Cannot use " + name + " in class static initialization block");
+        }
+        if (this.keywords.test(name)) {
+          this.raise(start3, "Unexpected keyword '" + name + "'");
+        }
+        if (this.options.ecmaVersion < 6 && this.input.slice(start3, end).indexOf("\\") !== -1) {
+          return;
+        }
+        var re = this.strict ? this.reservedWordsStrict : this.reservedWords;
+        if (re.test(name)) {
+          if (!this.inAsync && name === "await") {
+            this.raiseRecoverable(start3, "Cannot use keyword 'await' outside an async function");
+          }
+          this.raiseRecoverable(start3, "The keyword '" + name + "' is reserved");
+        }
+      };
+      pp$52.parseIdent = function(liberal, isBinding) {
+        var node = this.startNode();
+        if (this.type === types$12.name) {
+          node.name = this.value;
+        } else if (this.type.keyword) {
+          node.name = this.type.keyword;
+          if ((node.name === "class" || node.name === "function") && (this.lastTokEnd !== this.lastTokStart + 1 || this.input.charCodeAt(this.lastTokStart) !== 46)) {
+            this.context.pop();
+          }
+        } else {
+          this.unexpected();
+        }
+        this.next(!!liberal);
+        this.finishNode(node, "Identifier");
+        if (!liberal) {
+          this.checkUnreserved(node);
+          if (node.name === "await" && !this.awaitIdentPos) {
+            this.awaitIdentPos = node.start;
+          }
+        }
+        return node;
+      };
+      pp$52.parsePrivateIdent = function() {
+        var node = this.startNode();
+        if (this.type === types$12.privateId) {
+          node.name = this.value;
+        } else {
+          this.unexpected();
+        }
+        this.next();
+        this.finishNode(node, "PrivateIdentifier");
+        if (this.privateNameStack.length === 0) {
+          this.raise(node.start, "Private field '#" + node.name + "' must be declared in an enclosing class");
+        } else {
+          this.privateNameStack[this.privateNameStack.length - 1].used.push(node);
+        }
+        return node;
+      };
+      pp$52.parseYield = function(forInit) {
+        if (!this.yieldPos) {
+          this.yieldPos = this.start;
+        }
+        var node = this.startNode();
+        this.next();
+        if (this.type === types$12.semi || this.canInsertSemicolon() || this.type !== types$12.star && !this.type.startsExpr) {
+          node.delegate = false;
+          node.argument = null;
+        } else {
+          node.delegate = this.eat(types$12.star);
+          node.argument = this.parseMaybeAssign(forInit);
+        }
+        return this.finishNode(node, "YieldExpression");
+      };
+      pp$52.parseAwait = function(forInit) {
+        if (!this.awaitPos) {
+          this.awaitPos = this.start;
+        }
+        var node = this.startNode();
+        this.next();
+        node.argument = this.parseMaybeUnary(null, true, false, forInit);
+        return this.finishNode(node, "AwaitExpression");
+      };
+      var pp$42 = Parser3.prototype;
+      pp$42.raise = function(pos, message) {
+        var loc = getLineInfo2(this.input, pos);
+        message += " (" + loc.line + ":" + loc.column + ")";
+        var err = new SyntaxError(message);
+        err.pos = pos;
+        err.loc = loc;
+        err.raisedAt = this.pos;
+        throw err;
+      };
+      pp$42.raiseRecoverable = pp$42.raise;
+      pp$42.curPosition = function() {
+        if (this.options.locations) {
+          return new Position3(this.curLine, this.pos - this.lineStart);
+        }
+      };
+      var pp$32 = Parser3.prototype;
+      var Scope3 = function Scope4(flags) {
+        this.flags = flags;
+        this.var = [];
+        this.lexical = [];
+        this.functions = [];
+        this.inClassFieldInit = false;
+      };
+      pp$32.enterScope = function(flags) {
+        this.scopeStack.push(new Scope3(flags));
+      };
+      pp$32.exitScope = function() {
+        this.scopeStack.pop();
+      };
+      pp$32.treatFunctionsAsVarInScope = function(scope) {
+        return scope.flags & SCOPE_FUNCTION2 || !this.inModule && scope.flags & SCOPE_TOP2;
+      };
+      pp$32.declareName = function(name, bindingType, pos) {
+        var redeclared = false;
+        if (bindingType === BIND_LEXICAL2) {
+          var scope = this.currentScope();
+          redeclared = scope.lexical.indexOf(name) > -1 || scope.functions.indexOf(name) > -1 || scope.var.indexOf(name) > -1;
+          scope.lexical.push(name);
+          if (this.inModule && scope.flags & SCOPE_TOP2) {
+            delete this.undefinedExports[name];
+          }
+        } else if (bindingType === BIND_SIMPLE_CATCH2) {
+          var scope$1 = this.currentScope();
+          scope$1.lexical.push(name);
+        } else if (bindingType === BIND_FUNCTION2) {
+          var scope$2 = this.currentScope();
+          if (this.treatFunctionsAsVar) {
+            redeclared = scope$2.lexical.indexOf(name) > -1;
+          } else {
+            redeclared = scope$2.lexical.indexOf(name) > -1 || scope$2.var.indexOf(name) > -1;
+          }
+          scope$2.functions.push(name);
+        } else {
+          for (var i2 = this.scopeStack.length - 1; i2 >= 0; --i2) {
+            var scope$3 = this.scopeStack[i2];
+            if (scope$3.lexical.indexOf(name) > -1 && !(scope$3.flags & SCOPE_SIMPLE_CATCH2 && scope$3.lexical[0] === name) || !this.treatFunctionsAsVarInScope(scope$3) && scope$3.functions.indexOf(name) > -1) {
+              redeclared = true;
+              break;
+            }
+            scope$3.var.push(name);
+            if (this.inModule && scope$3.flags & SCOPE_TOP2) {
+              delete this.undefinedExports[name];
+            }
+            if (scope$3.flags & SCOPE_VAR2) {
+              break;
+            }
+          }
+        }
+        if (redeclared) {
+          this.raiseRecoverable(pos, "Identifier '" + name + "' has already been declared");
+        }
+      };
+      pp$32.checkLocalExport = function(id) {
+        if (this.scopeStack[0].lexical.indexOf(id.name) === -1 && this.scopeStack[0].var.indexOf(id.name) === -1) {
+          this.undefinedExports[id.name] = id;
+        }
+      };
+      pp$32.currentScope = function() {
+        return this.scopeStack[this.scopeStack.length - 1];
+      };
+      pp$32.currentVarScope = function() {
+        for (var i2 = this.scopeStack.length - 1; ; i2--) {
+          var scope = this.scopeStack[i2];
+          if (scope.flags & SCOPE_VAR2) {
+            return scope;
+          }
+        }
+      };
+      pp$32.currentThisScope = function() {
+        for (var i2 = this.scopeStack.length - 1; ; i2--) {
+          var scope = this.scopeStack[i2];
+          if (scope.flags & SCOPE_VAR2 && !(scope.flags & SCOPE_ARROW2)) {
+            return scope;
+          }
+        }
+      };
+      var Node3 = function Node4(parser, pos, loc) {
+        this.type = "";
+        this.start = pos;
+        this.end = 0;
+        if (parser.options.locations) {
+          this.loc = new SourceLocation3(parser, loc);
+        }
+        if (parser.options.directSourceFile) {
+          this.sourceFile = parser.options.directSourceFile;
+        }
+        if (parser.options.ranges) {
+          this.range = [pos, 0];
+        }
+      };
+      var pp$22 = Parser3.prototype;
+      pp$22.startNode = function() {
+        return new Node3(this, this.start, this.startLoc);
+      };
+      pp$22.startNodeAt = function(pos, loc) {
+        return new Node3(this, pos, loc);
+      };
+      function finishNodeAt2(node, type, pos, loc) {
+        node.type = type;
+        node.end = pos;
+        if (this.options.locations) {
+          node.loc.end = loc;
+        }
+        if (this.options.ranges) {
+          node.range[1] = pos;
+        }
+        return node;
+      }
+      pp$22.finishNode = function(node, type) {
+        return finishNodeAt2.call(this, node, type, this.lastTokEnd, this.lastTokEndLoc);
+      };
+      pp$22.finishNodeAt = function(node, type, pos, loc) {
+        return finishNodeAt2.call(this, node, type, pos, loc);
+      };
+      pp$22.copyNode = function(node) {
+        var newNode = new Node3(this, node.start, this.startLoc);
+        for (var prop in node) {
+          newNode[prop] = node[prop];
+        }
+        return newNode;
+      };
+      var ecma9BinaryProperties2 = "ASCII ASCII_Hex_Digit AHex Alphabetic Alpha Any Assigned Bidi_Control Bidi_C Bidi_Mirrored Bidi_M Case_Ignorable CI Cased Changes_When_Casefolded CWCF Changes_When_Casemapped CWCM Changes_When_Lowercased CWL Changes_When_NFKC_Casefolded CWKCF Changes_When_Titlecased CWT Changes_When_Uppercased CWU Dash Default_Ignorable_Code_Point DI Deprecated Dep Diacritic Dia Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Extender Ext Grapheme_Base Gr_Base Grapheme_Extend Gr_Ext Hex_Digit Hex IDS_Binary_Operator IDSB IDS_Trinary_Operator IDST ID_Continue IDC ID_Start IDS Ideographic Ideo Join_Control Join_C Logical_Order_Exception LOE Lowercase Lower Math Noncharacter_Code_Point NChar Pattern_Syntax Pat_Syn Pattern_White_Space Pat_WS Quotation_Mark QMark Radical Regional_Indicator RI Sentence_Terminal STerm Soft_Dotted SD Terminal_Punctuation Term Unified_Ideograph UIdeo Uppercase Upper Variation_Selector VS White_Space space XID_Continue XIDC XID_Start XIDS";
+      var ecma10BinaryProperties2 = ecma9BinaryProperties2 + " Extended_Pictographic";
+      var ecma11BinaryProperties2 = ecma10BinaryProperties2;
+      var ecma12BinaryProperties2 = ecma11BinaryProperties2 + " EBase EComp EMod EPres ExtPict";
+      var ecma13BinaryProperties2 = ecma12BinaryProperties2;
+      var unicodeBinaryProperties2 = {
+        9: ecma9BinaryProperties2,
+        10: ecma10BinaryProperties2,
+        11: ecma11BinaryProperties2,
+        12: ecma12BinaryProperties2,
+        13: ecma13BinaryProperties2
+      };
+      var unicodeGeneralCategoryValues2 = "Cased_Letter LC Close_Punctuation Pe Connector_Punctuation Pc Control Cc cntrl Currency_Symbol Sc Dash_Punctuation Pd Decimal_Number Nd digit Enclosing_Mark Me Final_Punctuation Pf Format Cf Initial_Punctuation Pi Letter L Letter_Number Nl Line_Separator Zl Lowercase_Letter Ll Mark M Combining_Mark Math_Symbol Sm Modifier_Letter Lm Modifier_Symbol Sk Nonspacing_Mark Mn Number N Open_Punctuation Ps Other C Other_Letter Lo Other_Number No Other_Punctuation Po Other_Symbol So Paragraph_Separator Zp Private_Use Co Punctuation P punct Separator Z Space_Separator Zs Spacing_Mark Mc Surrogate Cs Symbol S Titlecase_Letter Lt Unassigned Cn Uppercase_Letter Lu";
+      var ecma9ScriptValues2 = "Adlam Adlm Ahom Anatolian_Hieroglyphs Hluw Arabic Arab Armenian Armn Avestan Avst Balinese Bali Bamum Bamu Bassa_Vah Bass Batak Batk Bengali Beng Bhaiksuki Bhks Bopomofo Bopo Brahmi Brah Braille Brai Buginese Bugi Buhid Buhd Canadian_Aboriginal Cans Carian Cari Caucasian_Albanian Aghb Chakma Cakm Cham Cham Cherokee Cher Common Zyyy Coptic Copt Qaac Cuneiform Xsux Cypriot Cprt Cyrillic Cyrl Deseret Dsrt Devanagari Deva Duployan Dupl Egyptian_Hieroglyphs Egyp Elbasan Elba Ethiopic Ethi Georgian Geor Glagolitic Glag Gothic Goth Grantha Gran Greek Grek Gujarati Gujr Gurmukhi Guru Han Hani Hangul Hang Hanunoo Hano Hatran Hatr Hebrew Hebr Hiragana Hira Imperial_Aramaic Armi Inherited Zinh Qaai Inscriptional_Pahlavi Phli Inscriptional_Parthian Prti Javanese Java Kaithi Kthi Kannada Knda Katakana Kana Kayah_Li Kali Kharoshthi Khar Khmer Khmr Khojki Khoj Khudawadi Sind Lao Laoo Latin Latn Lepcha Lepc Limbu Limb Linear_A Lina Linear_B Linb Lisu Lisu Lycian Lyci Lydian Lydi Mahajani Mahj Malayalam Mlym Mandaic Mand Manichaean Mani Marchen Marc Masaram_Gondi Gonm Meetei_Mayek Mtei Mende_Kikakui Mend Meroitic_Cursive Merc Meroitic_Hieroglyphs Mero Miao Plrd Modi Mongolian Mong Mro Mroo Multani Mult Myanmar Mymr Nabataean Nbat New_Tai_Lue Talu Newa Newa Nko Nkoo Nushu Nshu Ogham Ogam Ol_Chiki Olck Old_Hungarian Hung Old_Italic Ital Old_North_Arabian Narb Old_Permic Perm Old_Persian Xpeo Old_South_Arabian Sarb Old_Turkic Orkh Oriya Orya Osage Osge Osmanya Osma Pahawh_Hmong Hmng Palmyrene Palm Pau_Cin_Hau Pauc Phags_Pa Phag Phoenician Phnx Psalter_Pahlavi Phlp Rejang Rjng Runic Runr Samaritan Samr Saurashtra Saur Sharada Shrd Shavian Shaw Siddham Sidd SignWriting Sgnw Sinhala Sinh Sora_Sompeng Sora Soyombo Soyo Sundanese Sund Syloti_Nagri Sylo Syriac Syrc Tagalog Tglg Tagbanwa Tagb Tai_Le Tale Tai_Tham Lana Tai_Viet Tavt Takri Takr Tamil Taml Tangut Tang Telugu Telu Thaana Thaa Thai Thai Tibetan Tibt Tifinagh Tfng Tirhuta Tirh Ugaritic Ugar Vai Vaii Warang_Citi Wara Yi Yiii Zanabazar_Square Zanb";
+      var ecma10ScriptValues2 = ecma9ScriptValues2 + " Dogra Dogr Gunjala_Gondi Gong Hanifi_Rohingya Rohg Makasar Maka Medefaidrin Medf Old_Sogdian Sogo Sogdian Sogd";
+      var ecma11ScriptValues2 = ecma10ScriptValues2 + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho";
+      var ecma12ScriptValues2 = ecma11ScriptValues2 + " Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi";
+      var ecma13ScriptValues2 = ecma12ScriptValues2 + " Cypro_Minoan Cpmn Old_Uyghur Ougr Tangsa Tnsa Toto Vithkuqi Vith";
+      var unicodeScriptValues2 = {
+        9: ecma9ScriptValues2,
+        10: ecma10ScriptValues2,
+        11: ecma11ScriptValues2,
+        12: ecma12ScriptValues2,
+        13: ecma13ScriptValues2
+      };
+      var data2 = {};
+      function buildUnicodeData2(ecmaVersion2) {
+        var d = data2[ecmaVersion2] = {
+          binary: wordsRegexp2(unicodeBinaryProperties2[ecmaVersion2] + " " + unicodeGeneralCategoryValues2),
+          nonBinary: {
+            General_Category: wordsRegexp2(unicodeGeneralCategoryValues2),
+            Script: wordsRegexp2(unicodeScriptValues2[ecmaVersion2])
+          }
+        };
+        d.nonBinary.Script_Extensions = d.nonBinary.Script;
+        d.nonBinary.gc = d.nonBinary.General_Category;
+        d.nonBinary.sc = d.nonBinary.Script;
+        d.nonBinary.scx = d.nonBinary.Script_Extensions;
+      }
+      for (var i = 0, list = [9, 10, 11, 12, 13]; i < list.length; i += 1) {
+        var ecmaVersion = list[i];
+        buildUnicodeData2(ecmaVersion);
+      }
+      var pp$12 = Parser3.prototype;
+      var RegExpValidationState3 = function RegExpValidationState4(parser) {
+        this.parser = parser;
+        this.validFlags = "gim" + (parser.options.ecmaVersion >= 6 ? "uy" : "") + (parser.options.ecmaVersion >= 9 ? "s" : "") + (parser.options.ecmaVersion >= 13 ? "d" : "");
+        this.unicodeProperties = data2[parser.options.ecmaVersion >= 13 ? 13 : parser.options.ecmaVersion];
+        this.source = "";
+        this.flags = "";
+        this.start = 0;
+        this.switchU = false;
+        this.switchN = false;
+        this.pos = 0;
+        this.lastIntValue = 0;
+        this.lastStringValue = "";
+        this.lastAssertionIsQuantifiable = false;
+        this.numCapturingParens = 0;
+        this.maxBackReference = 0;
+        this.groupNames = [];
+        this.backReferenceNames = [];
+      };
+      RegExpValidationState3.prototype.reset = function reset2(start3, pattern, flags) {
+        var unicode = flags.indexOf("u") !== -1;
+        this.start = start3 | 0;
+        this.source = pattern + "";
+        this.flags = flags;
+        this.switchU = unicode && this.parser.options.ecmaVersion >= 6;
+        this.switchN = unicode && this.parser.options.ecmaVersion >= 9;
+      };
+      RegExpValidationState3.prototype.raise = function raise2(message) {
+        this.parser.raiseRecoverable(this.start, "Invalid regular expression: /" + this.source + "/: " + message);
+      };
+      RegExpValidationState3.prototype.at = function at2(i2, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        var s = this.source;
+        var l = s.length;
+        if (i2 >= l) {
+          return -1;
+        }
+        var c = s.charCodeAt(i2);
+        if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i2 + 1 >= l) {
+          return c;
+        }
+        var next = s.charCodeAt(i2 + 1);
+        return next >= 56320 && next <= 57343 ? (c << 10) + next - 56613888 : c;
+      };
+      RegExpValidationState3.prototype.nextIndex = function nextIndex2(i2, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        var s = this.source;
+        var l = s.length;
+        if (i2 >= l) {
+          return l;
+        }
+        var c = s.charCodeAt(i2), next;
+        if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i2 + 1 >= l || (next = s.charCodeAt(i2 + 1)) < 56320 || next > 57343) {
+          return i2 + 1;
+        }
+        return i2 + 2;
+      };
+      RegExpValidationState3.prototype.current = function current2(forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        return this.at(this.pos, forceU);
+      };
+      RegExpValidationState3.prototype.lookahead = function lookahead2(forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        return this.at(this.nextIndex(this.pos, forceU), forceU);
+      };
+      RegExpValidationState3.prototype.advance = function advance2(forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        this.pos = this.nextIndex(this.pos, forceU);
+      };
+      RegExpValidationState3.prototype.eat = function eat2(ch, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        if (this.current(forceU) === ch) {
+          this.advance(forceU);
+          return true;
+        }
+        return false;
+      };
+      pp$12.validateRegExpFlags = function(state) {
+        var validFlags = state.validFlags;
+        var flags = state.flags;
+        for (var i2 = 0; i2 < flags.length; i2++) {
+          var flag = flags.charAt(i2);
+          if (validFlags.indexOf(flag) === -1) {
+            this.raise(state.start, "Invalid regular expression flag");
+          }
+          if (flags.indexOf(flag, i2 + 1) > -1) {
+            this.raise(state.start, "Duplicate regular expression flag");
+          }
+        }
+      };
+      pp$12.validateRegExpPattern = function(state) {
+        this.regexp_pattern(state);
+        if (!state.switchN && this.options.ecmaVersion >= 9 && state.groupNames.length > 0) {
+          state.switchN = true;
+          this.regexp_pattern(state);
+        }
+      };
+      pp$12.regexp_pattern = function(state) {
+        state.pos = 0;
+        state.lastIntValue = 0;
+        state.lastStringValue = "";
+        state.lastAssertionIsQuantifiable = false;
+        state.numCapturingParens = 0;
+        state.maxBackReference = 0;
+        state.groupNames.length = 0;
+        state.backReferenceNames.length = 0;
+        this.regexp_disjunction(state);
+        if (state.pos !== state.source.length) {
+          if (state.eat(41)) {
+            state.raise("Unmatched ')'");
+          }
+          if (state.eat(93) || state.eat(125)) {
+            state.raise("Lone quantifier brackets");
+          }
+        }
+        if (state.maxBackReference > state.numCapturingParens) {
+          state.raise("Invalid escape");
+        }
+        for (var i2 = 0, list2 = state.backReferenceNames; i2 < list2.length; i2 += 1) {
+          var name = list2[i2];
+          if (state.groupNames.indexOf(name) === -1) {
+            state.raise("Invalid named capture referenced");
+          }
+        }
+      };
+      pp$12.regexp_disjunction = function(state) {
+        this.regexp_alternative(state);
+        while (state.eat(124)) {
+          this.regexp_alternative(state);
+        }
+        if (this.regexp_eatQuantifier(state, true)) {
+          state.raise("Nothing to repeat");
+        }
+        if (state.eat(123)) {
+          state.raise("Lone quantifier brackets");
+        }
+      };
+      pp$12.regexp_alternative = function(state) {
+        while (state.pos < state.source.length && this.regexp_eatTerm(state)) {
+        }
+      };
+      pp$12.regexp_eatTerm = function(state) {
+        if (this.regexp_eatAssertion(state)) {
+          if (state.lastAssertionIsQuantifiable && this.regexp_eatQuantifier(state)) {
+            if (state.switchU) {
+              state.raise("Invalid quantifier");
+            }
+          }
+          return true;
+        }
+        if (state.switchU ? this.regexp_eatAtom(state) : this.regexp_eatExtendedAtom(state)) {
+          this.regexp_eatQuantifier(state);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatAssertion = function(state) {
+        var start3 = state.pos;
+        state.lastAssertionIsQuantifiable = false;
+        if (state.eat(94) || state.eat(36)) {
+          return true;
+        }
+        if (state.eat(92)) {
+          if (state.eat(66) || state.eat(98)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        if (state.eat(40) && state.eat(63)) {
+          var lookbehind = false;
+          if (this.options.ecmaVersion >= 9) {
+            lookbehind = state.eat(60);
+          }
+          if (state.eat(61) || state.eat(33)) {
+            this.regexp_disjunction(state);
+            if (!state.eat(41)) {
+              state.raise("Unterminated group");
+            }
+            state.lastAssertionIsQuantifiable = !lookbehind;
+            return true;
+          }
+        }
+        state.pos = start3;
+        return false;
+      };
+      pp$12.regexp_eatQuantifier = function(state, noError) {
+        if (noError === void 0)
+          noError = false;
+        if (this.regexp_eatQuantifierPrefix(state, noError)) {
+          state.eat(63);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatQuantifierPrefix = function(state, noError) {
+        return state.eat(42) || state.eat(43) || state.eat(63) || this.regexp_eatBracedQuantifier(state, noError);
+      };
+      pp$12.regexp_eatBracedQuantifier = function(state, noError) {
+        var start3 = state.pos;
+        if (state.eat(123)) {
+          var min = 0, max = -1;
+          if (this.regexp_eatDecimalDigits(state)) {
+            min = state.lastIntValue;
+            if (state.eat(44) && this.regexp_eatDecimalDigits(state)) {
+              max = state.lastIntValue;
+            }
+            if (state.eat(125)) {
+              if (max !== -1 && max < min && !noError) {
+                state.raise("numbers out of order in {} quantifier");
+              }
+              return true;
+            }
+          }
+          if (state.switchU && !noError) {
+            state.raise("Incomplete quantifier");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatAtom = function(state) {
+        return this.regexp_eatPatternCharacters(state) || state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state);
+      };
+      pp$12.regexp_eatReverseSolidusAtomEscape = function(state) {
+        var start3 = state.pos;
+        if (state.eat(92)) {
+          if (this.regexp_eatAtomEscape(state)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatUncapturingGroup = function(state) {
+        var start3 = state.pos;
+        if (state.eat(40)) {
+          if (state.eat(63) && state.eat(58)) {
+            this.regexp_disjunction(state);
+            if (state.eat(41)) {
+              return true;
+            }
+            state.raise("Unterminated group");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatCapturingGroup = function(state) {
+        if (state.eat(40)) {
+          if (this.options.ecmaVersion >= 9) {
+            this.regexp_groupSpecifier(state);
+          } else if (state.current() === 63) {
+            state.raise("Invalid group");
+          }
+          this.regexp_disjunction(state);
+          if (state.eat(41)) {
+            state.numCapturingParens += 1;
+            return true;
+          }
+          state.raise("Unterminated group");
+        }
+        return false;
+      };
+      pp$12.regexp_eatExtendedAtom = function(state) {
+        return state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state) || this.regexp_eatInvalidBracedQuantifier(state) || this.regexp_eatExtendedPatternCharacter(state);
+      };
+      pp$12.regexp_eatInvalidBracedQuantifier = function(state) {
+        if (this.regexp_eatBracedQuantifier(state, true)) {
+          state.raise("Nothing to repeat");
+        }
+        return false;
+      };
+      pp$12.regexp_eatSyntaxCharacter = function(state) {
+        var ch = state.current();
+        if (isSyntaxCharacter2(ch)) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      function isSyntaxCharacter2(ch) {
+        return ch === 36 || ch >= 40 && ch <= 43 || ch === 46 || ch === 63 || ch >= 91 && ch <= 94 || ch >= 123 && ch <= 125;
+      }
+      pp$12.regexp_eatPatternCharacters = function(state) {
+        var start3 = state.pos;
+        var ch = 0;
+        while ((ch = state.current()) !== -1 && !isSyntaxCharacter2(ch)) {
+          state.advance();
+        }
+        return state.pos !== start3;
+      };
+      pp$12.regexp_eatExtendedPatternCharacter = function(state) {
+        var ch = state.current();
+        if (ch !== -1 && ch !== 36 && !(ch >= 40 && ch <= 43) && ch !== 46 && ch !== 63 && ch !== 91 && ch !== 94 && ch !== 124) {
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_groupSpecifier = function(state) {
+        if (state.eat(63)) {
+          if (this.regexp_eatGroupName(state)) {
+            if (state.groupNames.indexOf(state.lastStringValue) !== -1) {
+              state.raise("Duplicate capture group name");
+            }
+            state.groupNames.push(state.lastStringValue);
+            return;
+          }
+          state.raise("Invalid group");
+        }
+      };
+      pp$12.regexp_eatGroupName = function(state) {
+        state.lastStringValue = "";
+        if (state.eat(60)) {
+          if (this.regexp_eatRegExpIdentifierName(state) && state.eat(62)) {
+            return true;
+          }
+          state.raise("Invalid capture group name");
+        }
+        return false;
+      };
+      pp$12.regexp_eatRegExpIdentifierName = function(state) {
+        state.lastStringValue = "";
+        if (this.regexp_eatRegExpIdentifierStart(state)) {
+          state.lastStringValue += codePointToString2(state.lastIntValue);
+          while (this.regexp_eatRegExpIdentifierPart(state)) {
+            state.lastStringValue += codePointToString2(state.lastIntValue);
+          }
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatRegExpIdentifierStart = function(state) {
+        var start3 = state.pos;
+        var forceU = this.options.ecmaVersion >= 11;
+        var ch = state.current(forceU);
+        state.advance(forceU);
+        if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+          ch = state.lastIntValue;
+        }
+        if (isRegExpIdentifierStart2(ch)) {
+          state.lastIntValue = ch;
+          return true;
+        }
+        state.pos = start3;
+        return false;
+      };
+      function isRegExpIdentifierStart2(ch) {
+        return isIdentifierStart2(ch, true) || ch === 36 || ch === 95;
+      }
+      pp$12.regexp_eatRegExpIdentifierPart = function(state) {
+        var start3 = state.pos;
+        var forceU = this.options.ecmaVersion >= 11;
+        var ch = state.current(forceU);
+        state.advance(forceU);
+        if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+          ch = state.lastIntValue;
+        }
+        if (isRegExpIdentifierPart2(ch)) {
+          state.lastIntValue = ch;
+          return true;
+        }
+        state.pos = start3;
+        return false;
+      };
+      function isRegExpIdentifierPart2(ch) {
+        return isIdentifierChar2(ch, true) || ch === 36 || ch === 95 || ch === 8204 || ch === 8205;
+      }
+      pp$12.regexp_eatAtomEscape = function(state) {
+        if (this.regexp_eatBackReference(state) || this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state) || state.switchN && this.regexp_eatKGroupName(state)) {
+          return true;
+        }
+        if (state.switchU) {
+          if (state.current() === 99) {
+            state.raise("Invalid unicode escape");
+          }
+          state.raise("Invalid escape");
+        }
+        return false;
+      };
+      pp$12.regexp_eatBackReference = function(state) {
+        var start3 = state.pos;
+        if (this.regexp_eatDecimalEscape(state)) {
+          var n = state.lastIntValue;
+          if (state.switchU) {
+            if (n > state.maxBackReference) {
+              state.maxBackReference = n;
+            }
+            return true;
+          }
+          if (n <= state.numCapturingParens) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatKGroupName = function(state) {
+        if (state.eat(107)) {
+          if (this.regexp_eatGroupName(state)) {
+            state.backReferenceNames.push(state.lastStringValue);
+            return true;
+          }
+          state.raise("Invalid named reference");
+        }
+        return false;
+      };
+      pp$12.regexp_eatCharacterEscape = function(state) {
+        return this.regexp_eatControlEscape(state) || this.regexp_eatCControlLetter(state) || this.regexp_eatZero(state) || this.regexp_eatHexEscapeSequence(state) || this.regexp_eatRegExpUnicodeEscapeSequence(state, false) || !state.switchU && this.regexp_eatLegacyOctalEscapeSequence(state) || this.regexp_eatIdentityEscape(state);
+      };
+      pp$12.regexp_eatCControlLetter = function(state) {
+        var start3 = state.pos;
+        if (state.eat(99)) {
+          if (this.regexp_eatControlLetter(state)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatZero = function(state) {
+        if (state.current() === 48 && !isDecimalDigit2(state.lookahead())) {
+          state.lastIntValue = 0;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatControlEscape = function(state) {
+        var ch = state.current();
+        if (ch === 116) {
+          state.lastIntValue = 9;
+          state.advance();
+          return true;
+        }
+        if (ch === 110) {
+          state.lastIntValue = 10;
+          state.advance();
+          return true;
+        }
+        if (ch === 118) {
+          state.lastIntValue = 11;
+          state.advance();
+          return true;
+        }
+        if (ch === 102) {
+          state.lastIntValue = 12;
+          state.advance();
+          return true;
+        }
+        if (ch === 114) {
+          state.lastIntValue = 13;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatControlLetter = function(state) {
+        var ch = state.current();
+        if (isControlLetter2(ch)) {
+          state.lastIntValue = ch % 32;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      function isControlLetter2(ch) {
+        return ch >= 65 && ch <= 90 || ch >= 97 && ch <= 122;
+      }
+      pp$12.regexp_eatRegExpUnicodeEscapeSequence = function(state, forceU) {
+        if (forceU === void 0)
+          forceU = false;
+        var start3 = state.pos;
+        var switchU = forceU || state.switchU;
+        if (state.eat(117)) {
+          if (this.regexp_eatFixedHexDigits(state, 4)) {
+            var lead = state.lastIntValue;
+            if (switchU && lead >= 55296 && lead <= 56319) {
+              var leadSurrogateEnd = state.pos;
+              if (state.eat(92) && state.eat(117) && this.regexp_eatFixedHexDigits(state, 4)) {
+                var trail = state.lastIntValue;
+                if (trail >= 56320 && trail <= 57343) {
+                  state.lastIntValue = (lead - 55296) * 1024 + (trail - 56320) + 65536;
+                  return true;
+                }
+              }
+              state.pos = leadSurrogateEnd;
+              state.lastIntValue = lead;
+            }
+            return true;
+          }
+          if (switchU && state.eat(123) && this.regexp_eatHexDigits(state) && state.eat(125) && isValidUnicode2(state.lastIntValue)) {
+            return true;
+          }
+          if (switchU) {
+            state.raise("Invalid unicode escape");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      function isValidUnicode2(ch) {
+        return ch >= 0 && ch <= 1114111;
+      }
+      pp$12.regexp_eatIdentityEscape = function(state) {
+        if (state.switchU) {
+          if (this.regexp_eatSyntaxCharacter(state)) {
+            return true;
+          }
+          if (state.eat(47)) {
+            state.lastIntValue = 47;
+            return true;
+          }
+          return false;
+        }
+        var ch = state.current();
+        if (ch !== 99 && (!state.switchN || ch !== 107)) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatDecimalEscape = function(state) {
+        state.lastIntValue = 0;
+        var ch = state.current();
+        if (ch >= 49 && ch <= 57) {
+          do {
+            state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+            state.advance();
+          } while ((ch = state.current()) >= 48 && ch <= 57);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatCharacterClassEscape = function(state) {
+        var ch = state.current();
+        if (isCharacterClassEscape2(ch)) {
+          state.lastIntValue = -1;
+          state.advance();
+          return true;
+        }
+        if (state.switchU && this.options.ecmaVersion >= 9 && (ch === 80 || ch === 112)) {
+          state.lastIntValue = -1;
+          state.advance();
+          if (state.eat(123) && this.regexp_eatUnicodePropertyValueExpression(state) && state.eat(125)) {
+            return true;
+          }
+          state.raise("Invalid property name");
+        }
+        return false;
+      };
+      function isCharacterClassEscape2(ch) {
+        return ch === 100 || ch === 68 || ch === 115 || ch === 83 || ch === 119 || ch === 87;
+      }
+      pp$12.regexp_eatUnicodePropertyValueExpression = function(state) {
+        var start3 = state.pos;
+        if (this.regexp_eatUnicodePropertyName(state) && state.eat(61)) {
+          var name = state.lastStringValue;
+          if (this.regexp_eatUnicodePropertyValue(state)) {
+            var value = state.lastStringValue;
+            this.regexp_validateUnicodePropertyNameAndValue(state, name, value);
+            return true;
+          }
+        }
+        state.pos = start3;
+        if (this.regexp_eatLoneUnicodePropertyNameOrValue(state)) {
+          var nameOrValue = state.lastStringValue;
+          this.regexp_validateUnicodePropertyNameOrValue(state, nameOrValue);
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_validateUnicodePropertyNameAndValue = function(state, name, value) {
+        if (!hasOwn2(state.unicodeProperties.nonBinary, name)) {
+          state.raise("Invalid property name");
+        }
+        if (!state.unicodeProperties.nonBinary[name].test(value)) {
+          state.raise("Invalid property value");
+        }
+      };
+      pp$12.regexp_validateUnicodePropertyNameOrValue = function(state, nameOrValue) {
+        if (!state.unicodeProperties.binary.test(nameOrValue)) {
+          state.raise("Invalid property name");
+        }
+      };
+      pp$12.regexp_eatUnicodePropertyName = function(state) {
+        var ch = 0;
+        state.lastStringValue = "";
+        while (isUnicodePropertyNameCharacter2(ch = state.current())) {
+          state.lastStringValue += codePointToString2(ch);
+          state.advance();
+        }
+        return state.lastStringValue !== "";
+      };
+      function isUnicodePropertyNameCharacter2(ch) {
+        return isControlLetter2(ch) || ch === 95;
+      }
+      pp$12.regexp_eatUnicodePropertyValue = function(state) {
+        var ch = 0;
+        state.lastStringValue = "";
+        while (isUnicodePropertyValueCharacter2(ch = state.current())) {
+          state.lastStringValue += codePointToString2(ch);
+          state.advance();
+        }
+        return state.lastStringValue !== "";
+      };
+      function isUnicodePropertyValueCharacter2(ch) {
+        return isUnicodePropertyNameCharacter2(ch) || isDecimalDigit2(ch);
+      }
+      pp$12.regexp_eatLoneUnicodePropertyNameOrValue = function(state) {
+        return this.regexp_eatUnicodePropertyValue(state);
+      };
+      pp$12.regexp_eatCharacterClass = function(state) {
+        if (state.eat(91)) {
+          state.eat(94);
+          this.regexp_classRanges(state);
+          if (state.eat(93)) {
+            return true;
+          }
+          state.raise("Unterminated character class");
+        }
+        return false;
+      };
+      pp$12.regexp_classRanges = function(state) {
+        while (this.regexp_eatClassAtom(state)) {
+          var left = state.lastIntValue;
+          if (state.eat(45) && this.regexp_eatClassAtom(state)) {
+            var right = state.lastIntValue;
+            if (state.switchU && (left === -1 || right === -1)) {
+              state.raise("Invalid character class");
+            }
+            if (left !== -1 && right !== -1 && left > right) {
+              state.raise("Range out of order in character class");
+            }
+          }
+        }
+      };
+      pp$12.regexp_eatClassAtom = function(state) {
+        var start3 = state.pos;
+        if (state.eat(92)) {
+          if (this.regexp_eatClassEscape(state)) {
+            return true;
+          }
+          if (state.switchU) {
+            var ch$1 = state.current();
+            if (ch$1 === 99 || isOctalDigit2(ch$1)) {
+              state.raise("Invalid class escape");
+            }
+            state.raise("Invalid escape");
+          }
+          state.pos = start3;
+        }
+        var ch = state.current();
+        if (ch !== 93) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatClassEscape = function(state) {
+        var start3 = state.pos;
+        if (state.eat(98)) {
+          state.lastIntValue = 8;
+          return true;
+        }
+        if (state.switchU && state.eat(45)) {
+          state.lastIntValue = 45;
+          return true;
+        }
+        if (!state.switchU && state.eat(99)) {
+          if (this.regexp_eatClassControlLetter(state)) {
+            return true;
+          }
+          state.pos = start3;
+        }
+        return this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state);
+      };
+      pp$12.regexp_eatClassControlLetter = function(state) {
+        var ch = state.current();
+        if (isDecimalDigit2(ch) || ch === 95) {
+          state.lastIntValue = ch % 32;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatHexEscapeSequence = function(state) {
+        var start3 = state.pos;
+        if (state.eat(120)) {
+          if (this.regexp_eatFixedHexDigits(state, 2)) {
+            return true;
+          }
+          if (state.switchU) {
+            state.raise("Invalid escape");
+          }
+          state.pos = start3;
+        }
+        return false;
+      };
+      pp$12.regexp_eatDecimalDigits = function(state) {
+        var start3 = state.pos;
+        var ch = 0;
+        state.lastIntValue = 0;
+        while (isDecimalDigit2(ch = state.current())) {
+          state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+          state.advance();
+        }
+        return state.pos !== start3;
+      };
+      function isDecimalDigit2(ch) {
+        return ch >= 48 && ch <= 57;
+      }
+      pp$12.regexp_eatHexDigits = function(state) {
+        var start3 = state.pos;
+        var ch = 0;
+        state.lastIntValue = 0;
+        while (isHexDigit2(ch = state.current())) {
+          state.lastIntValue = 16 * state.lastIntValue + hexToInt2(ch);
+          state.advance();
+        }
+        return state.pos !== start3;
+      };
+      function isHexDigit2(ch) {
+        return ch >= 48 && ch <= 57 || ch >= 65 && ch <= 70 || ch >= 97 && ch <= 102;
+      }
+      function hexToInt2(ch) {
+        if (ch >= 65 && ch <= 70) {
+          return 10 + (ch - 65);
+        }
+        if (ch >= 97 && ch <= 102) {
+          return 10 + (ch - 97);
+        }
+        return ch - 48;
+      }
+      pp$12.regexp_eatLegacyOctalEscapeSequence = function(state) {
+        if (this.regexp_eatOctalDigit(state)) {
+          var n1 = state.lastIntValue;
+          if (this.regexp_eatOctalDigit(state)) {
+            var n2 = state.lastIntValue;
+            if (n1 <= 3 && this.regexp_eatOctalDigit(state)) {
+              state.lastIntValue = n1 * 64 + n2 * 8 + state.lastIntValue;
+            } else {
+              state.lastIntValue = n1 * 8 + n2;
+            }
+          } else {
+            state.lastIntValue = n1;
+          }
+          return true;
+        }
+        return false;
+      };
+      pp$12.regexp_eatOctalDigit = function(state) {
+        var ch = state.current();
+        if (isOctalDigit2(ch)) {
+          state.lastIntValue = ch - 48;
+          state.advance();
+          return true;
+        }
+        state.lastIntValue = 0;
+        return false;
+      };
+      function isOctalDigit2(ch) {
+        return ch >= 48 && ch <= 55;
+      }
+      pp$12.regexp_eatFixedHexDigits = function(state, length) {
+        var start3 = state.pos;
+        state.lastIntValue = 0;
+        for (var i2 = 0; i2 < length; ++i2) {
+          var ch = state.current();
+          if (!isHexDigit2(ch)) {
+            state.pos = start3;
+            return false;
+          }
+          state.lastIntValue = 16 * state.lastIntValue + hexToInt2(ch);
+          state.advance();
+        }
+        return true;
+      };
+      var Token3 = function Token4(p) {
+        this.type = p.type;
+        this.value = p.value;
+        this.start = p.start;
+        this.end = p.end;
+        if (p.options.locations) {
+          this.loc = new SourceLocation3(p, p.startLoc, p.endLoc);
+        }
+        if (p.options.ranges) {
+          this.range = [p.start, p.end];
+        }
+      };
+      var pp2 = Parser3.prototype;
+      pp2.next = function(ignoreEscapeSequenceInKeyword) {
+        if (!ignoreEscapeSequenceInKeyword && this.type.keyword && this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword " + this.type.keyword);
+        }
+        if (this.options.onToken) {
+          this.options.onToken(new Token3(this));
+        }
+        this.lastTokEnd = this.end;
+        this.lastTokStart = this.start;
+        this.lastTokEndLoc = this.endLoc;
+        this.lastTokStartLoc = this.startLoc;
+        this.nextToken();
+      };
+      pp2.getToken = function() {
+        this.next();
+        return new Token3(this);
+      };
+      if (typeof Symbol !== "undefined") {
+        pp2[Symbol.iterator] = function() {
+          var this$1$1 = this;
+          return {
+            next: function() {
+              var token = this$1$1.getToken();
+              return {
+                done: token.type === types$12.eof,
+                value: token
+              };
+            }
+          };
+        };
+      }
+      pp2.nextToken = function() {
+        var curContext = this.curContext();
+        if (!curContext || !curContext.preserveSpace) {
+          this.skipSpace();
+        }
+        this.start = this.pos;
+        if (this.options.locations) {
+          this.startLoc = this.curPosition();
+        }
+        if (this.pos >= this.input.length) {
+          return this.finishToken(types$12.eof);
+        }
+        if (curContext.override) {
+          return curContext.override(this);
+        } else {
+          this.readToken(this.fullCharCodeAtPos());
+        }
+      };
+      pp2.readToken = function(code) {
+        if (isIdentifierStart2(code, this.options.ecmaVersion >= 6) || code === 92) {
+          return this.readWord();
+        }
+        return this.getTokenFromCode(code);
+      };
+      pp2.fullCharCodeAtPos = function() {
+        var code = this.input.charCodeAt(this.pos);
+        if (code <= 55295 || code >= 56320) {
+          return code;
+        }
+        var next = this.input.charCodeAt(this.pos + 1);
+        return next <= 56319 || next >= 57344 ? code : (code << 10) + next - 56613888;
+      };
+      pp2.skipBlockComment = function() {
+        var startLoc = this.options.onComment && this.curPosition();
+        var start3 = this.pos, end = this.input.indexOf("*/", this.pos += 2);
+        if (end === -1) {
+          this.raise(this.pos - 2, "Unterminated comment");
+        }
+        this.pos = end + 2;
+        if (this.options.locations) {
+          for (var nextBreak = void 0, pos = start3; (nextBreak = nextLineBreak2(this.input, pos, this.pos)) > -1; ) {
+            ++this.curLine;
+            pos = this.lineStart = nextBreak;
+          }
+        }
+        if (this.options.onComment) {
+          this.options.onComment(
+            true,
+            this.input.slice(start3 + 2, end),
+            start3,
+            this.pos,
+            startLoc,
+            this.curPosition()
+          );
+        }
+      };
+      pp2.skipLineComment = function(startSkip) {
+        var start3 = this.pos;
+        var startLoc = this.options.onComment && this.curPosition();
+        var ch = this.input.charCodeAt(this.pos += startSkip);
+        while (this.pos < this.input.length && !isNewLine2(ch)) {
+          ch = this.input.charCodeAt(++this.pos);
+        }
+        if (this.options.onComment) {
+          this.options.onComment(
+            false,
+            this.input.slice(start3 + startSkip, this.pos),
+            start3,
+            this.pos,
+            startLoc,
+            this.curPosition()
+          );
+        }
+      };
+      pp2.skipSpace = function() {
+        loop:
+          while (this.pos < this.input.length) {
+            var ch = this.input.charCodeAt(this.pos);
+            switch (ch) {
+              case 32:
+              case 160:
+                ++this.pos;
+                break;
+              case 13:
+                if (this.input.charCodeAt(this.pos + 1) === 10) {
+                  ++this.pos;
+                }
+              case 10:
+              case 8232:
+              case 8233:
+                ++this.pos;
+                if (this.options.locations) {
+                  ++this.curLine;
+                  this.lineStart = this.pos;
+                }
+                break;
+              case 47:
+                switch (this.input.charCodeAt(this.pos + 1)) {
+                  case 42:
+                    this.skipBlockComment();
+                    break;
+                  case 47:
+                    this.skipLineComment(2);
+                    break;
+                  default:
+                    break loop;
+                }
+                break;
+              default:
+                if (ch > 8 && ch < 14 || ch >= 5760 && nonASCIIwhitespace2.test(String.fromCharCode(ch))) {
+                  ++this.pos;
+                } else {
+                  break loop;
+                }
+            }
+          }
+      };
+      pp2.finishToken = function(type, val) {
+        this.end = this.pos;
+        if (this.options.locations) {
+          this.endLoc = this.curPosition();
+        }
+        var prevType = this.type;
+        this.type = type;
+        this.value = val;
+        this.updateContext(prevType);
+      };
+      pp2.readToken_dot = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next >= 48 && next <= 57) {
+          return this.readNumber(true);
+        }
+        var next2 = this.input.charCodeAt(this.pos + 2);
+        if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) {
+          this.pos += 3;
+          return this.finishToken(types$12.ellipsis);
+        } else {
+          ++this.pos;
+          return this.finishToken(types$12.dot);
+        }
+      };
+      pp2.readToken_slash = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (this.exprAllowed) {
+          ++this.pos;
+          return this.readRegexp();
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(types$12.slash, 1);
+      };
+      pp2.readToken_mult_modulo_exp = function(code) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        var size = 1;
+        var tokentype = code === 42 ? types$12.star : types$12.modulo;
+        if (this.options.ecmaVersion >= 7 && code === 42 && next === 42) {
+          ++size;
+          tokentype = types$12.starstar;
+          next = this.input.charCodeAt(this.pos + 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, size + 1);
+        }
+        return this.finishOp(tokentype, size);
+      };
+      pp2.readToken_pipe_amp = function(code) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === code) {
+          if (this.options.ecmaVersion >= 12) {
+            var next2 = this.input.charCodeAt(this.pos + 2);
+            if (next2 === 61) {
+              return this.finishOp(types$12.assign, 3);
+            }
+          }
+          return this.finishOp(code === 124 ? types$12.logicalOR : types$12.logicalAND, 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(code === 124 ? types$12.bitwiseOR : types$12.bitwiseAND, 1);
+      };
+      pp2.readToken_caret = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(types$12.bitwiseXOR, 1);
+      };
+      pp2.readToken_plus_min = function(code) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === code) {
+          if (next === 45 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 62 && (this.lastTokEnd === 0 || lineBreak2.test(this.input.slice(this.lastTokEnd, this.pos)))) {
+            this.skipLineComment(3);
+            this.skipSpace();
+            return this.nextToken();
+          }
+          return this.finishOp(types$12.incDec, 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types$12.assign, 2);
+        }
+        return this.finishOp(types$12.plusMin, 1);
+      };
+      pp2.readToken_lt_gt = function(code) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        var size = 1;
+        if (next === code) {
+          size = code === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+          if (this.input.charCodeAt(this.pos + size) === 61) {
+            return this.finishOp(types$12.assign, size + 1);
+          }
+          return this.finishOp(types$12.bitShift, size);
+        }
+        if (next === 33 && code === 60 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 45 && this.input.charCodeAt(this.pos + 3) === 45) {
+          this.skipLineComment(4);
+          this.skipSpace();
+          return this.nextToken();
+        }
+        if (next === 61) {
+          size = 2;
+        }
+        return this.finishOp(types$12.relational, size);
+      };
+      pp2.readToken_eq_excl = function(code) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === 61) {
+          return this.finishOp(types$12.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+        }
+        if (code === 61 && next === 62 && this.options.ecmaVersion >= 6) {
+          this.pos += 2;
+          return this.finishToken(types$12.arrow);
+        }
+        return this.finishOp(code === 61 ? types$12.eq : types$12.prefix, 1);
+      };
+      pp2.readToken_question = function() {
+        var ecmaVersion2 = this.options.ecmaVersion;
+        if (ecmaVersion2 >= 11) {
+          var next = this.input.charCodeAt(this.pos + 1);
+          if (next === 46) {
+            var next2 = this.input.charCodeAt(this.pos + 2);
+            if (next2 < 48 || next2 > 57) {
+              return this.finishOp(types$12.questionDot, 2);
+            }
+          }
+          if (next === 63) {
+            if (ecmaVersion2 >= 12) {
+              var next2$1 = this.input.charCodeAt(this.pos + 2);
+              if (next2$1 === 61) {
+                return this.finishOp(types$12.assign, 3);
+              }
+            }
+            return this.finishOp(types$12.coalesce, 2);
+          }
+        }
+        return this.finishOp(types$12.question, 1);
+      };
+      pp2.readToken_numberSign = function() {
+        var ecmaVersion2 = this.options.ecmaVersion;
+        var code = 35;
+        if (ecmaVersion2 >= 13) {
+          ++this.pos;
+          code = this.fullCharCodeAtPos();
+          if (isIdentifierStart2(code, true) || code === 92) {
+            return this.finishToken(types$12.privateId, this.readWord1());
+          }
+        }
+        this.raise(this.pos, "Unexpected character '" + codePointToString2(code) + "'");
+      };
+      pp2.getTokenFromCode = function(code) {
+        switch (code) {
+          case 46:
+            return this.readToken_dot();
+          case 40:
+            ++this.pos;
+            return this.finishToken(types$12.parenL);
+          case 41:
+            ++this.pos;
+            return this.finishToken(types$12.parenR);
+          case 59:
+            ++this.pos;
+            return this.finishToken(types$12.semi);
+          case 44:
+            ++this.pos;
+            return this.finishToken(types$12.comma);
+          case 91:
+            ++this.pos;
+            return this.finishToken(types$12.bracketL);
+          case 93:
+            ++this.pos;
+            return this.finishToken(types$12.bracketR);
+          case 123:
+            ++this.pos;
+            return this.finishToken(types$12.braceL);
+          case 125:
+            ++this.pos;
+            return this.finishToken(types$12.braceR);
+          case 58:
+            ++this.pos;
+            return this.finishToken(types$12.colon);
+          case 96:
+            if (this.options.ecmaVersion < 6) {
+              break;
+            }
+            ++this.pos;
+            return this.finishToken(types$12.backQuote);
+          case 48:
+            var next = this.input.charCodeAt(this.pos + 1);
+            if (next === 120 || next === 88) {
+              return this.readRadixNumber(16);
+            }
+            if (this.options.ecmaVersion >= 6) {
+              if (next === 111 || next === 79) {
+                return this.readRadixNumber(8);
+              }
+              if (next === 98 || next === 66) {
+                return this.readRadixNumber(2);
+              }
+            }
+          case 49:
+          case 50:
+          case 51:
+          case 52:
+          case 53:
+          case 54:
+          case 55:
+          case 56:
+          case 57:
+            return this.readNumber(false);
+          case 34:
+          case 39:
+            return this.readString(code);
+          case 47:
+            return this.readToken_slash();
+          case 37:
+          case 42:
+            return this.readToken_mult_modulo_exp(code);
+          case 124:
+          case 38:
+            return this.readToken_pipe_amp(code);
+          case 94:
+            return this.readToken_caret();
+          case 43:
+          case 45:
+            return this.readToken_plus_min(code);
+          case 60:
+          case 62:
+            return this.readToken_lt_gt(code);
+          case 61:
+          case 33:
+            return this.readToken_eq_excl(code);
+          case 63:
+            return this.readToken_question();
+          case 126:
+            return this.finishOp(types$12.prefix, 1);
+          case 35:
+            return this.readToken_numberSign();
+        }
+        this.raise(this.pos, "Unexpected character '" + codePointToString2(code) + "'");
+      };
+      pp2.finishOp = function(type, size) {
+        var str = this.input.slice(this.pos, this.pos + size);
+        this.pos += size;
+        return this.finishToken(type, str);
+      };
+      pp2.readRegexp = function() {
+        var escaped, inClass, start3 = this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(start3, "Unterminated regular expression");
+          }
+          var ch = this.input.charAt(this.pos);
+          if (lineBreak2.test(ch)) {
+            this.raise(start3, "Unterminated regular expression");
+          }
+          if (!escaped) {
+            if (ch === "[") {
+              inClass = true;
+            } else if (ch === "]" && inClass) {
+              inClass = false;
+            } else if (ch === "/" && !inClass) {
+              break;
+            }
+            escaped = ch === "\\";
+          } else {
+            escaped = false;
+          }
+          ++this.pos;
+        }
+        var pattern = this.input.slice(start3, this.pos);
+        ++this.pos;
+        var flagsStart = this.pos;
+        var flags = this.readWord1();
+        if (this.containsEsc) {
+          this.unexpected(flagsStart);
+        }
+        var state = this.regexpState || (this.regexpState = new RegExpValidationState3(this));
+        state.reset(start3, pattern, flags);
+        this.validateRegExpFlags(state);
+        this.validateRegExpPattern(state);
+        var value = null;
+        try {
+          value = new RegExp(pattern, flags);
+        } catch (e) {
+        }
+        return this.finishToken(types$12.regexp, { pattern, flags, value });
+      };
+      pp2.readInt = function(radix, len, maybeLegacyOctalNumericLiteral) {
+        var allowSeparators = this.options.ecmaVersion >= 12 && len === void 0;
+        var isLegacyOctalNumericLiteral = maybeLegacyOctalNumericLiteral && this.input.charCodeAt(this.pos) === 48;
+        var start3 = this.pos, total = 0, lastCode = 0;
+        for (var i2 = 0, e = len == null ? Infinity : len; i2 < e; ++i2, ++this.pos) {
+          var code = this.input.charCodeAt(this.pos), val = void 0;
+          if (allowSeparators && code === 95) {
+            if (isLegacyOctalNumericLiteral) {
+              this.raiseRecoverable(this.pos, "Numeric separator is not allowed in legacy octal numeric literals");
+            }
+            if (lastCode === 95) {
+              this.raiseRecoverable(this.pos, "Numeric separator must be exactly one underscore");
+            }
+            if (i2 === 0) {
+              this.raiseRecoverable(this.pos, "Numeric separator is not allowed at the first of digits");
+            }
+            lastCode = code;
+            continue;
+          }
+          if (code >= 97) {
+            val = code - 97 + 10;
+          } else if (code >= 65) {
+            val = code - 65 + 10;
+          } else if (code >= 48 && code <= 57) {
+            val = code - 48;
+          } else {
+            val = Infinity;
+          }
+          if (val >= radix) {
+            break;
+          }
+          lastCode = code;
+          total = total * radix + val;
+        }
+        if (allowSeparators && lastCode === 95) {
+          this.raiseRecoverable(this.pos - 1, "Numeric separator is not allowed at the last of digits");
+        }
+        if (this.pos === start3 || len != null && this.pos - start3 !== len) {
+          return null;
+        }
+        return total;
+      };
+      function stringToNumber2(str, isLegacyOctalNumericLiteral) {
+        if (isLegacyOctalNumericLiteral) {
+          return parseInt(str, 8);
+        }
+        return parseFloat(str.replace(/_/g, ""));
+      }
+      function stringToBigInt2(str) {
+        if (typeof BigInt !== "function") {
+          return null;
+        }
+        return BigInt(str.replace(/_/g, ""));
+      }
+      pp2.readRadixNumber = function(radix) {
+        var start3 = this.pos;
+        this.pos += 2;
+        var val = this.readInt(radix);
+        if (val == null) {
+          this.raise(this.start + 2, "Expected number in radix " + radix);
+        }
+        if (this.options.ecmaVersion >= 11 && this.input.charCodeAt(this.pos) === 110) {
+          val = stringToBigInt2(this.input.slice(start3, this.pos));
+          ++this.pos;
+        } else if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+          this.raise(this.pos, "Identifier directly after number");
+        }
+        return this.finishToken(types$12.num, val);
+      };
+      pp2.readNumber = function(startsWithDot) {
+        var start3 = this.pos;
+        if (!startsWithDot && this.readInt(10, void 0, true) === null) {
+          this.raise(start3, "Invalid number");
+        }
+        var octal = this.pos - start3 >= 2 && this.input.charCodeAt(start3) === 48;
+        if (octal && this.strict) {
+          this.raise(start3, "Invalid number");
+        }
+        var next = this.input.charCodeAt(this.pos);
+        if (!octal && !startsWithDot && this.options.ecmaVersion >= 11 && next === 110) {
+          var val$1 = stringToBigInt2(this.input.slice(start3, this.pos));
+          ++this.pos;
+          if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+            this.raise(this.pos, "Identifier directly after number");
+          }
+          return this.finishToken(types$12.num, val$1);
+        }
+        if (octal && /[89]/.test(this.input.slice(start3, this.pos))) {
+          octal = false;
+        }
+        if (next === 46 && !octal) {
+          ++this.pos;
+          this.readInt(10);
+          next = this.input.charCodeAt(this.pos);
+        }
+        if ((next === 69 || next === 101) && !octal) {
+          next = this.input.charCodeAt(++this.pos);
+          if (next === 43 || next === 45) {
+            ++this.pos;
+          }
+          if (this.readInt(10) === null) {
+            this.raise(start3, "Invalid number");
+          }
+        }
+        if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+          this.raise(this.pos, "Identifier directly after number");
+        }
+        var val = stringToNumber2(this.input.slice(start3, this.pos), octal);
+        return this.finishToken(types$12.num, val);
+      };
+      pp2.readCodePoint = function() {
+        var ch = this.input.charCodeAt(this.pos), code;
+        if (ch === 123) {
+          if (this.options.ecmaVersion < 6) {
+            this.unexpected();
+          }
+          var codePos = ++this.pos;
+          code = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos);
+          ++this.pos;
+          if (code > 1114111) {
+            this.invalidStringToken(codePos, "Code point out of bounds");
+          }
+        } else {
+          code = this.readHexChar(4);
+        }
+        return code;
+      };
+      pp2.readString = function(quote) {
+        var out = "", chunkStart = ++this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(this.start, "Unterminated string constant");
+          }
+          var ch = this.input.charCodeAt(this.pos);
+          if (ch === quote) {
+            break;
+          }
+          if (ch === 92) {
+            out += this.input.slice(chunkStart, this.pos);
+            out += this.readEscapedChar(false);
+            chunkStart = this.pos;
+          } else if (ch === 8232 || ch === 8233) {
+            if (this.options.ecmaVersion < 10) {
+              this.raise(this.start, "Unterminated string constant");
+            }
+            ++this.pos;
+            if (this.options.locations) {
+              this.curLine++;
+              this.lineStart = this.pos;
+            }
+          } else {
+            if (isNewLine2(ch)) {
+              this.raise(this.start, "Unterminated string constant");
+            }
+            ++this.pos;
+          }
+        }
+        out += this.input.slice(chunkStart, this.pos++);
+        return this.finishToken(types$12.string, out);
+      };
+      var INVALID_TEMPLATE_ESCAPE_ERROR2 = {};
+      pp2.tryReadTemplateToken = function() {
+        this.inTemplateElement = true;
+        try {
+          this.readTmplToken();
+        } catch (err) {
+          if (err === INVALID_TEMPLATE_ESCAPE_ERROR2) {
+            this.readInvalidTemplateToken();
+          } else {
+            throw err;
+          }
+        }
+        this.inTemplateElement = false;
+      };
+      pp2.invalidStringToken = function(position2, message) {
+        if (this.inTemplateElement && this.options.ecmaVersion >= 9) {
+          throw INVALID_TEMPLATE_ESCAPE_ERROR2;
+        } else {
+          this.raise(position2, message);
+        }
+      };
+      pp2.readTmplToken = function() {
+        var out = "", chunkStart = this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(this.start, "Unterminated template");
+          }
+          var ch = this.input.charCodeAt(this.pos);
+          if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) {
+            if (this.pos === this.start && (this.type === types$12.template || this.type === types$12.invalidTemplate)) {
+              if (ch === 36) {
+                this.pos += 2;
+                return this.finishToken(types$12.dollarBraceL);
+              } else {
+                ++this.pos;
+                return this.finishToken(types$12.backQuote);
+              }
+            }
+            out += this.input.slice(chunkStart, this.pos);
+            return this.finishToken(types$12.template, out);
+          }
+          if (ch === 92) {
+            out += this.input.slice(chunkStart, this.pos);
+            out += this.readEscapedChar(true);
+            chunkStart = this.pos;
+          } else if (isNewLine2(ch)) {
+            out += this.input.slice(chunkStart, this.pos);
+            ++this.pos;
+            switch (ch) {
+              case 13:
+                if (this.input.charCodeAt(this.pos) === 10) {
+                  ++this.pos;
+                }
+              case 10:
+                out += "\n";
+                break;
+              default:
+                out += String.fromCharCode(ch);
+                break;
+            }
+            if (this.options.locations) {
+              ++this.curLine;
+              this.lineStart = this.pos;
+            }
+            chunkStart = this.pos;
+          } else {
+            ++this.pos;
+          }
+        }
+      };
+      pp2.readInvalidTemplateToken = function() {
+        for (; this.pos < this.input.length; this.pos++) {
+          switch (this.input[this.pos]) {
+            case "\\":
+              ++this.pos;
+              break;
+            case "$":
+              if (this.input[this.pos + 1] !== "{") {
+                break;
+              }
+            case "`":
+              return this.finishToken(types$12.invalidTemplate, this.input.slice(this.start, this.pos));
+          }
+        }
+        this.raise(this.start, "Unterminated template");
+      };
+      pp2.readEscapedChar = function(inTemplate) {
+        var ch = this.input.charCodeAt(++this.pos);
+        ++this.pos;
+        switch (ch) {
+          case 110:
+            return "\n";
+          case 114:
+            return "\r";
+          case 120:
+            return String.fromCharCode(this.readHexChar(2));
+          case 117:
+            return codePointToString2(this.readCodePoint());
+          case 116:
+            return "	";
+          case 98:
+            return "\b";
+          case 118:
+            return "\v";
+          case 102:
+            return "\f";
+          case 13:
+            if (this.input.charCodeAt(this.pos) === 10) {
+              ++this.pos;
+            }
+          case 10:
+            if (this.options.locations) {
+              this.lineStart = this.pos;
+              ++this.curLine;
+            }
+            return "";
+          case 56:
+          case 57:
+            if (this.strict) {
+              this.invalidStringToken(
+                this.pos - 1,
+                "Invalid escape sequence"
+              );
+            }
+            if (inTemplate) {
+              var codePos = this.pos - 1;
+              this.invalidStringToken(
+                codePos,
+                "Invalid escape sequence in template string"
+              );
+              return null;
+            }
+          default:
+            if (ch >= 48 && ch <= 55) {
+              var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+              var octal = parseInt(octalStr, 8);
+              if (octal > 255) {
+                octalStr = octalStr.slice(0, -1);
+                octal = parseInt(octalStr, 8);
+              }
+              this.pos += octalStr.length - 1;
+              ch = this.input.charCodeAt(this.pos);
+              if ((octalStr !== "0" || ch === 56 || ch === 57) && (this.strict || inTemplate)) {
+                this.invalidStringToken(
+                  this.pos - 1 - octalStr.length,
+                  inTemplate ? "Octal literal in template string" : "Octal literal in strict mode"
+                );
+              }
+              return String.fromCharCode(octal);
+            }
+            if (isNewLine2(ch)) {
+              return "";
+            }
+            return String.fromCharCode(ch);
+        }
+      };
+      pp2.readHexChar = function(len) {
+        var codePos = this.pos;
+        var n = this.readInt(16, len);
+        if (n === null) {
+          this.invalidStringToken(codePos, "Bad character escape sequence");
+        }
+        return n;
+      };
+      pp2.readWord1 = function() {
+        this.containsEsc = false;
+        var word = "", first = true, chunkStart = this.pos;
+        var astral = this.options.ecmaVersion >= 6;
+        while (this.pos < this.input.length) {
+          var ch = this.fullCharCodeAtPos();
+          if (isIdentifierChar2(ch, astral)) {
+            this.pos += ch <= 65535 ? 1 : 2;
+          } else if (ch === 92) {
+            this.containsEsc = true;
+            word += this.input.slice(chunkStart, this.pos);
+            var escStart = this.pos;
+            if (this.input.charCodeAt(++this.pos) !== 117) {
+              this.invalidStringToken(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+            }
+            ++this.pos;
+            var esc = this.readCodePoint();
+            if (!(first ? isIdentifierStart2 : isIdentifierChar2)(esc, astral)) {
+              this.invalidStringToken(escStart, "Invalid Unicode escape");
+            }
+            word += codePointToString2(esc);
+            chunkStart = this.pos;
+          } else {
+            break;
+          }
+          first = false;
+        }
+        return word + this.input.slice(chunkStart, this.pos);
+      };
+      pp2.readWord = function() {
+        var word = this.readWord1();
+        var type = types$12.name;
+        if (this.keywords.test(word)) {
+          type = keywords2[word];
+        }
+        return this.finishToken(type, word);
+      };
+      var version2 = "8.8.1";
+      Parser3.acorn = {
+        Parser: Parser3,
+        version: version2,
+        defaultOptions: defaultOptions2,
+        Position: Position3,
+        SourceLocation: SourceLocation3,
+        getLineInfo: getLineInfo2,
+        Node: Node3,
+        TokenType: TokenType3,
+        tokTypes: types$12,
+        keywordTypes: keywords2,
+        TokContext: TokContext3,
+        tokContexts: types2,
+        isIdentifierChar: isIdentifierChar2,
+        isIdentifierStart: isIdentifierStart2,
+        Token: Token3,
+        isNewLine: isNewLine2,
+        lineBreak: lineBreak2,
+        lineBreakG: lineBreakG2,
+        nonASCIIwhitespace: nonASCIIwhitespace2
+      };
+      function parse3(input, options) {
+        return Parser3.parse(input, options);
+      }
+      function parseExpressionAt2(input, pos, options) {
+        return Parser3.parseExpressionAt(input, pos, options);
+      }
+      function tokenizer2(input, options) {
+        return Parser3.tokenizer(input, options);
+      }
+      exports2.Node = Node3;
+      exports2.Parser = Parser3;
+      exports2.Position = Position3;
+      exports2.SourceLocation = SourceLocation3;
+      exports2.TokContext = TokContext3;
+      exports2.Token = Token3;
+      exports2.TokenType = TokenType3;
+      exports2.defaultOptions = defaultOptions2;
+      exports2.getLineInfo = getLineInfo2;
+      exports2.isIdentifierChar = isIdentifierChar2;
+      exports2.isIdentifierStart = isIdentifierStart2;
+      exports2.isNewLine = isNewLine2;
+      exports2.keywordTypes = keywords2;
+      exports2.lineBreak = lineBreak2;
+      exports2.lineBreakG = lineBreakG2;
+      exports2.nonASCIIwhitespace = nonASCIIwhitespace2;
+      exports2.parse = parse3;
+      exports2.parseExpressionAt = parseExpressionAt2;
+      exports2.tokContexts = types2;
+      exports2.tokTypes = types$12;
+      exports2.tokenizer = tokenizer2;
+      exports2.version = version2;
+      Object.defineProperty(exports2, "__esModule", { value: true });
+    });
+  }
+});
+
+// node_modules/acorn-jsx/index.js
+var require_acorn_jsx = __commonJS({
+  "node_modules/acorn-jsx/index.js"(exports, module2) {
+    "use strict";
+    var XHTMLEntities = require_xhtml();
+    var hexNumber = /^[\da-fA-F]+$/;
+    var decimalNumber = /^\d+$/;
+    var acornJsxMap = /* @__PURE__ */ new WeakMap();
+    function getJsxTokens(acorn) {
+      acorn = acorn.Parser.acorn || acorn;
+      let acornJsx2 = acornJsxMap.get(acorn);
+      if (!acornJsx2) {
+        const tt = acorn.tokTypes;
+        const TokContext3 = acorn.TokContext;
+        const TokenType3 = acorn.TokenType;
+        const tc_oTag = new TokContext3("<tag", false);
+        const tc_cTag = new TokContext3("</tag", false);
+        const tc_expr = new TokContext3("<tag>...</tag>", true, true);
+        const tokContexts = {
+          tc_oTag,
+          tc_cTag,
+          tc_expr
+        };
+        const tokTypes = {
+          jsxName: new TokenType3("jsxName"),
+          jsxText: new TokenType3("jsxText", { beforeExpr: true }),
+          jsxTagStart: new TokenType3("jsxTagStart", { startsExpr: true }),
+          jsxTagEnd: new TokenType3("jsxTagEnd")
+        };
+        tokTypes.jsxTagStart.updateContext = function() {
+          this.context.push(tc_expr);
+          this.context.push(tc_oTag);
+          this.exprAllowed = false;
+        };
+        tokTypes.jsxTagEnd.updateContext = function(prevType) {
+          let out = this.context.pop();
+          if (out === tc_oTag && prevType === tt.slash || out === tc_cTag) {
+            this.context.pop();
+            this.exprAllowed = this.curContext() === tc_expr;
+          } else {
+            this.exprAllowed = true;
+          }
+        };
+        acornJsx2 = { tokContexts, tokTypes };
+        acornJsxMap.set(acorn, acornJsx2);
+      }
+      return acornJsx2;
+    }
+    function getQualifiedJSXName(object) {
+      if (!object)
+        return object;
+      if (object.type === "JSXIdentifier")
+        return object.name;
+      if (object.type === "JSXNamespacedName")
+        return object.namespace.name + ":" + object.name.name;
+      if (object.type === "JSXMemberExpression")
+        return getQualifiedJSXName(object.object) + "." + getQualifiedJSXName(object.property);
+    }
+    module2.exports = function(options) {
+      options = options || {};
+      return function(Parser3) {
+        return plugin({
+          allowNamespaces: options.allowNamespaces !== false,
+          allowNamespacedObjects: !!options.allowNamespacedObjects
+        }, Parser3);
+      };
+    };
+    Object.defineProperty(module2.exports, "tokTypes", {
+      get: function get_tokTypes() {
+        return getJsxTokens(require_acorn()).tokTypes;
+      },
+      configurable: true,
+      enumerable: true
+    });
+    function plugin(options, Parser3) {
+      const acorn = Parser3.acorn || require_acorn();
+      const acornJsx2 = getJsxTokens(acorn);
+      const tt = acorn.tokTypes;
+      const tok = acornJsx2.tokTypes;
+      const tokContexts = acorn.tokContexts;
+      const tc_oTag = acornJsx2.tokContexts.tc_oTag;
+      const tc_cTag = acornJsx2.tokContexts.tc_cTag;
+      const tc_expr = acornJsx2.tokContexts.tc_expr;
+      const isNewLine2 = acorn.isNewLine;
+      const isIdentifierStart2 = acorn.isIdentifierStart;
+      const isIdentifierChar2 = acorn.isIdentifierChar;
+      return class extends Parser3 {
+        static get acornJsx() {
+          return acornJsx2;
+        }
+        jsx_readToken() {
+          let out = "", chunkStart = this.pos;
+          for (; ; ) {
+            if (this.pos >= this.input.length)
+              this.raise(this.start, "Unterminated JSX contents");
+            let ch = this.input.charCodeAt(this.pos);
+            switch (ch) {
+              case 60:
+              case 123:
+                if (this.pos === this.start) {
+                  if (ch === 60 && this.exprAllowed) {
+                    ++this.pos;
+                    return this.finishToken(tok.jsxTagStart);
+                  }
+                  return this.getTokenFromCode(ch);
+                }
+                out += this.input.slice(chunkStart, this.pos);
+                return this.finishToken(tok.jsxText, out);
+              case 38:
+                out += this.input.slice(chunkStart, this.pos);
+                out += this.jsx_readEntity();
+                chunkStart = this.pos;
+                break;
+              case 62:
+              case 125:
+                this.raise(
+                  this.pos,
+                  "Unexpected token `" + this.input[this.pos] + "`. Did you mean `" + (ch === 62 ? "&gt;" : "&rbrace;") + '` or `{"' + this.input[this.pos] + '"}`?'
+                );
+              default:
+                if (isNewLine2(ch)) {
+                  out += this.input.slice(chunkStart, this.pos);
+                  out += this.jsx_readNewLine(true);
+                  chunkStart = this.pos;
+                } else {
+                  ++this.pos;
+                }
+            }
+          }
+        }
+        jsx_readNewLine(normalizeCRLF) {
+          let ch = this.input.charCodeAt(this.pos);
+          let out;
+          ++this.pos;
+          if (ch === 13 && this.input.charCodeAt(this.pos) === 10) {
+            ++this.pos;
+            out = normalizeCRLF ? "\n" : "\r\n";
+          } else {
+            out = String.fromCharCode(ch);
+          }
+          if (this.options.locations) {
+            ++this.curLine;
+            this.lineStart = this.pos;
+          }
+          return out;
+        }
+        jsx_readString(quote) {
+          let out = "", chunkStart = ++this.pos;
+          for (; ; ) {
+            if (this.pos >= this.input.length)
+              this.raise(this.start, "Unterminated string constant");
+            let ch = this.input.charCodeAt(this.pos);
+            if (ch === quote)
+              break;
+            if (ch === 38) {
+              out += this.input.slice(chunkStart, this.pos);
+              out += this.jsx_readEntity();
+              chunkStart = this.pos;
+            } else if (isNewLine2(ch)) {
+              out += this.input.slice(chunkStart, this.pos);
+              out += this.jsx_readNewLine(false);
+              chunkStart = this.pos;
+            } else {
+              ++this.pos;
+            }
+          }
+          out += this.input.slice(chunkStart, this.pos++);
+          return this.finishToken(tt.string, out);
+        }
+        jsx_readEntity() {
+          let str = "", count = 0, entity;
+          let ch = this.input[this.pos];
+          if (ch !== "&")
+            this.raise(this.pos, "Entity must start with an ampersand");
+          let startPos = ++this.pos;
+          while (this.pos < this.input.length && count++ < 10) {
+            ch = this.input[this.pos++];
+            if (ch === ";") {
+              if (str[0] === "#") {
+                if (str[1] === "x") {
+                  str = str.substr(2);
+                  if (hexNumber.test(str))
+                    entity = String.fromCharCode(parseInt(str, 16));
+                } else {
+                  str = str.substr(1);
+                  if (decimalNumber.test(str))
+                    entity = String.fromCharCode(parseInt(str, 10));
+                }
+              } else {
+                entity = XHTMLEntities[str];
+              }
+              break;
+            }
+            str += ch;
+          }
+          if (!entity) {
+            this.pos = startPos;
+            return "&";
+          }
+          return entity;
+        }
+        jsx_readWord() {
+          let ch, start3 = this.pos;
+          do {
+            ch = this.input.charCodeAt(++this.pos);
+          } while (isIdentifierChar2(ch) || ch === 45);
+          return this.finishToken(tok.jsxName, this.input.slice(start3, this.pos));
+        }
+        jsx_parseIdentifier() {
+          let node = this.startNode();
+          if (this.type === tok.jsxName)
+            node.name = this.value;
+          else if (this.type.keyword)
+            node.name = this.type.keyword;
+          else
+            this.unexpected();
+          this.next();
+          return this.finishNode(node, "JSXIdentifier");
+        }
+        jsx_parseNamespacedName() {
+          let startPos = this.start, startLoc = this.startLoc;
+          let name = this.jsx_parseIdentifier();
+          if (!options.allowNamespaces || !this.eat(tt.colon))
+            return name;
+          var node = this.startNodeAt(startPos, startLoc);
+          node.namespace = name;
+          node.name = this.jsx_parseIdentifier();
+          return this.finishNode(node, "JSXNamespacedName");
+        }
+        jsx_parseElementName() {
+          if (this.type === tok.jsxTagEnd)
+            return "";
+          let startPos = this.start, startLoc = this.startLoc;
+          let node = this.jsx_parseNamespacedName();
+          if (this.type === tt.dot && node.type === "JSXNamespacedName" && !options.allowNamespacedObjects) {
+            this.unexpected();
+          }
+          while (this.eat(tt.dot)) {
+            let newNode = this.startNodeAt(startPos, startLoc);
+            newNode.object = node;
+            newNode.property = this.jsx_parseIdentifier();
+            node = this.finishNode(newNode, "JSXMemberExpression");
+          }
+          return node;
+        }
+        jsx_parseAttributeValue() {
+          switch (this.type) {
+            case tt.braceL:
+              let node = this.jsx_parseExpressionContainer();
+              if (node.expression.type === "JSXEmptyExpression")
+                this.raise(node.start, "JSX attributes must only be assigned a non-empty expression");
+              return node;
+            case tok.jsxTagStart:
+            case tt.string:
+              return this.parseExprAtom();
+            default:
+              this.raise(this.start, "JSX value should be either an expression or a quoted JSX text");
+          }
+        }
+        jsx_parseEmptyExpression() {
+          let node = this.startNodeAt(this.lastTokEnd, this.lastTokEndLoc);
+          return this.finishNodeAt(node, "JSXEmptyExpression", this.start, this.startLoc);
+        }
+        jsx_parseExpressionContainer() {
+          let node = this.startNode();
+          this.next();
+          node.expression = this.type === tt.braceR ? this.jsx_parseEmptyExpression() : this.parseExpression();
+          this.expect(tt.braceR);
+          return this.finishNode(node, "JSXExpressionContainer");
+        }
+        jsx_parseAttribute() {
+          let node = this.startNode();
+          if (this.eat(tt.braceL)) {
+            this.expect(tt.ellipsis);
+            node.argument = this.parseMaybeAssign();
+            this.expect(tt.braceR);
+            return this.finishNode(node, "JSXSpreadAttribute");
+          }
+          node.name = this.jsx_parseNamespacedName();
+          node.value = this.eat(tt.eq) ? this.jsx_parseAttributeValue() : null;
+          return this.finishNode(node, "JSXAttribute");
+        }
+        jsx_parseOpeningElementAt(startPos, startLoc) {
+          let node = this.startNodeAt(startPos, startLoc);
+          node.attributes = [];
+          let nodeName = this.jsx_parseElementName();
+          if (nodeName)
+            node.name = nodeName;
+          while (this.type !== tt.slash && this.type !== tok.jsxTagEnd)
+            node.attributes.push(this.jsx_parseAttribute());
+          node.selfClosing = this.eat(tt.slash);
+          this.expect(tok.jsxTagEnd);
+          return this.finishNode(node, nodeName ? "JSXOpeningElement" : "JSXOpeningFragment");
+        }
+        jsx_parseClosingElementAt(startPos, startLoc) {
+          let node = this.startNodeAt(startPos, startLoc);
+          let nodeName = this.jsx_parseElementName();
+          if (nodeName)
+            node.name = nodeName;
+          this.expect(tok.jsxTagEnd);
+          return this.finishNode(node, nodeName ? "JSXClosingElement" : "JSXClosingFragment");
+        }
+        jsx_parseElementAt(startPos, startLoc) {
+          let node = this.startNodeAt(startPos, startLoc);
+          let children = [];
+          let openingElement = this.jsx_parseOpeningElementAt(startPos, startLoc);
+          let closingElement = null;
+          if (!openingElement.selfClosing) {
+            contents:
+              for (; ; ) {
+                switch (this.type) {
+                  case tok.jsxTagStart:
+                    startPos = this.start;
+                    startLoc = this.startLoc;
+                    this.next();
+                    if (this.eat(tt.slash)) {
+                      closingElement = this.jsx_parseClosingElementAt(startPos, startLoc);
+                      break contents;
+                    }
+                    children.push(this.jsx_parseElementAt(startPos, startLoc));
+                    break;
+                  case tok.jsxText:
+                    children.push(this.parseExprAtom());
+                    break;
+                  case tt.braceL:
+                    children.push(this.jsx_parseExpressionContainer());
+                    break;
+                  default:
+                    this.unexpected();
+                }
+              }
+            if (getQualifiedJSXName(closingElement.name) !== getQualifiedJSXName(openingElement.name)) {
+              this.raise(
+                closingElement.start,
+                "Expected corresponding JSX closing tag for <" + getQualifiedJSXName(openingElement.name) + ">"
+              );
+            }
+          }
+          let fragmentOrElement = openingElement.name ? "Element" : "Fragment";
+          node["opening" + fragmentOrElement] = openingElement;
+          node["closing" + fragmentOrElement] = closingElement;
+          node.children = children;
+          if (this.type === tt.relational && this.value === "<") {
+            this.raise(this.start, "Adjacent JSX elements must be wrapped in an enclosing tag");
+          }
+          return this.finishNode(node, "JSX" + fragmentOrElement);
+        }
+        jsx_parseText() {
+          let node = this.parseLiteral(this.value);
+          node.type = "JSXText";
+          return node;
+        }
+        jsx_parseElement() {
+          let startPos = this.start, startLoc = this.startLoc;
+          this.next();
+          return this.jsx_parseElementAt(startPos, startLoc);
+        }
+        parseExprAtom(refShortHandDefaultPos) {
+          if (this.type === tok.jsxText)
+            return this.jsx_parseText();
+          else if (this.type === tok.jsxTagStart)
+            return this.jsx_parseElement();
+          else
+            return super.parseExprAtom(refShortHandDefaultPos);
+        }
+        readToken(code) {
+          let context = this.curContext();
+          if (context === tc_expr)
+            return this.jsx_readToken();
+          if (context === tc_oTag || context === tc_cTag) {
+            if (isIdentifierStart2(code))
+              return this.jsx_readWord();
+            if (code == 62) {
+              ++this.pos;
+              return this.finishToken(tok.jsxTagEnd);
+            }
+            if ((code === 34 || code === 39) && context == tc_oTag)
+              return this.jsx_readString(code);
+          }
+          if (code === 60 && this.exprAllowed && this.input.charCodeAt(this.pos + 1) !== 33) {
+            ++this.pos;
+            return this.finishToken(tok.jsxTagStart);
+          }
+          return super.readToken(code);
+        }
+        updateContext(prevType) {
+          if (this.type == tt.braceL) {
+            var curContext = this.curContext();
+            if (curContext == tc_oTag)
+              this.context.push(tokContexts.b_expr);
+            else if (curContext == tc_expr)
+              this.context.push(tokContexts.b_tmpl);
+            else
+              super.updateContext(prevType);
+            this.exprAllowed = true;
+          } else if (this.type === tt.slash && prevType === tok.jsxTagStart) {
+            this.context.length -= 2;
+            this.context.push(tc_cTag);
+            this.exprAllowed = false;
+          } else {
+            return super.updateContext(prevType);
+          }
+        }
+      };
+    }
+  }
+});
+
+// node_modules/remark-mdx/index.js
+var remark_mdx_exports = {};
+__export(remark_mdx_exports, {
+  default: () => remarkMdx
+});
+module.exports = __toCommonJS(remark_mdx_exports);
+
+// node_modules/acorn/dist/acorn.mjs
+var astralIdentifierCodes = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 370, 1, 154, 10, 50, 3, 123, 2, 54, 14, 32, 10, 3, 1, 11, 3, 46, 10, 8, 0, 46, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 161, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 193, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 84, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 406, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 19306, 9, 87, 9, 39, 4, 60, 6, 26, 9, 1014, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 4706, 45, 3, 22, 543, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 262, 6, 10, 9, 357, 0, 62, 13, 1495, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
+var astralIdentifierStartCodes = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 13, 10, 2, 14, 2, 6, 2, 1, 2, 10, 2, 14, 2, 6, 2, 1, 68, 310, 10, 21, 11, 7, 25, 5, 2, 41, 2, 8, 70, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 349, 41, 7, 1, 79, 28, 11, 0, 9, 21, 43, 17, 47, 20, 28, 22, 13, 52, 58, 1, 3, 0, 14, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 85, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 159, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 38, 6, 186, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 19, 72, 264, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 190, 0, 80, 921, 103, 110, 18, 195, 2637, 96, 16, 1070, 4050, 582, 8634, 568, 8, 30, 18, 78, 18, 29, 19, 47, 17, 3, 32, 20, 6, 18, 689, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 43, 8, 8936, 3, 2, 6, 2, 1, 2, 290, 46, 2, 18, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 1845, 30, 482, 44, 11, 6, 17, 0, 322, 29, 19, 43, 1269, 6, 2, 3, 2, 1, 2, 14, 2, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42719, 33, 4152, 8, 221, 3, 5761, 15, 7472, 3104, 541, 1507, 4938];
+var nonASCIIidentifierChars = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u0898-\u089F\u08CA-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3C\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1715\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u180F-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF-\u1ACE\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DFF\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F";
+var nonASCIIidentifierStartChars = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u0870-\u0887\u0889-\u088E\u08A0-\u08C9\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C5D\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u1711\u171F-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4C\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7CA\uA7D0\uA7D1\uA7D3\uA7D5-\uA7D9\uA7F2-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
+var reservedWords = {
+  3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
+  5: "class enum extends super const export import",
+  6: "enum",
+  strict: "implements interface let package private protected public static yield",
+  strictBind: "eval arguments"
+};
+var ecma5AndLessKeywords = "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this";
+var keywords$1 = {
+  5: ecma5AndLessKeywords,
+  "5module": ecma5AndLessKeywords + " export import",
+  6: ecma5AndLessKeywords + " const class extends export import super"
+};
+var keywordRelationalOperator = /^in(stanceof)?$/;
+var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
+var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
+function isInAstralSet(code, set) {
+  var pos = 65536;
+  for (var i = 0; i < set.length; i += 2) {
+    pos += set[i];
+    if (pos > code) {
+      return false;
+    }
+    pos += set[i + 1];
+    if (pos >= code) {
+      return true;
+    }
+  }
+}
+function isIdentifierStart(code, astral) {
+  if (code < 65) {
+    return code === 36;
+  }
+  if (code < 91) {
+    return true;
+  }
+  if (code < 97) {
+    return code === 95;
+  }
+  if (code < 123) {
+    return true;
+  }
+  if (code <= 65535) {
+    return code >= 170 && nonASCIIidentifierStart.test(String.fromCharCode(code));
+  }
+  if (astral === false) {
+    return false;
+  }
+  return isInAstralSet(code, astralIdentifierStartCodes);
+}
+function isIdentifierChar(code, astral) {
+  if (code < 48) {
+    return code === 36;
+  }
+  if (code < 58) {
+    return true;
+  }
+  if (code < 65) {
+    return false;
+  }
+  if (code < 91) {
+    return true;
+  }
+  if (code < 97) {
+    return code === 95;
+  }
+  if (code < 123) {
+    return true;
+  }
+  if (code <= 65535) {
+    return code >= 170 && nonASCIIidentifier.test(String.fromCharCode(code));
+  }
+  if (astral === false) {
+    return false;
+  }
+  return isInAstralSet(code, astralIdentifierStartCodes) || isInAstralSet(code, astralIdentifierCodes);
+}
+var TokenType = function TokenType2(label, conf) {
+  if (conf === void 0)
+    conf = {};
+  this.label = label;
+  this.keyword = conf.keyword;
+  this.beforeExpr = !!conf.beforeExpr;
+  this.startsExpr = !!conf.startsExpr;
+  this.isLoop = !!conf.isLoop;
+  this.isAssign = !!conf.isAssign;
+  this.prefix = !!conf.prefix;
+  this.postfix = !!conf.postfix;
+  this.binop = conf.binop || null;
+  this.updateContext = null;
+};
+function binop(name, prec) {
+  return new TokenType(name, { beforeExpr: true, binop: prec });
+}
+var beforeExpr = { beforeExpr: true };
+var startsExpr = { startsExpr: true };
+var keywords = {};
+function kw(name, options) {
+  if (options === void 0)
+    options = {};
+  options.keyword = name;
+  return keywords[name] = new TokenType(name, options);
+}
+var types$1 = {
+  num: new TokenType("num", startsExpr),
+  regexp: new TokenType("regexp", startsExpr),
+  string: new TokenType("string", startsExpr),
+  name: new TokenType("name", startsExpr),
+  privateId: new TokenType("privateId", startsExpr),
+  eof: new TokenType("eof"),
+  bracketL: new TokenType("[", { beforeExpr: true, startsExpr: true }),
+  bracketR: new TokenType("]"),
+  braceL: new TokenType("{", { beforeExpr: true, startsExpr: true }),
+  braceR: new TokenType("}"),
+  parenL: new TokenType("(", { beforeExpr: true, startsExpr: true }),
+  parenR: new TokenType(")"),
+  comma: new TokenType(",", beforeExpr),
+  semi: new TokenType(";", beforeExpr),
+  colon: new TokenType(":", beforeExpr),
+  dot: new TokenType("."),
+  question: new TokenType("?", beforeExpr),
+  questionDot: new TokenType("?."),
+  arrow: new TokenType("=>", beforeExpr),
+  template: new TokenType("template"),
+  invalidTemplate: new TokenType("invalidTemplate"),
+  ellipsis: new TokenType("...", beforeExpr),
+  backQuote: new TokenType("`", startsExpr),
+  dollarBraceL: new TokenType("${", { beforeExpr: true, startsExpr: true }),
+  eq: new TokenType("=", { beforeExpr: true, isAssign: true }),
+  assign: new TokenType("_=", { beforeExpr: true, isAssign: true }),
+  incDec: new TokenType("++/--", { prefix: true, postfix: true, startsExpr: true }),
+  prefix: new TokenType("!/~", { beforeExpr: true, prefix: true, startsExpr: true }),
+  logicalOR: binop("||", 1),
+  logicalAND: binop("&&", 2),
+  bitwiseOR: binop("|", 3),
+  bitwiseXOR: binop("^", 4),
+  bitwiseAND: binop("&", 5),
+  equality: binop("==/!=/===/!==", 6),
+  relational: binop("</>/<=/>=", 7),
+  bitShift: binop("<</>>/>>>", 8),
+  plusMin: new TokenType("+/-", { beforeExpr: true, binop: 9, prefix: true, startsExpr: true }),
+  modulo: binop("%", 10),
+  star: binop("*", 10),
+  slash: binop("/", 10),
+  starstar: new TokenType("**", { beforeExpr: true }),
+  coalesce: binop("??", 1),
+  _break: kw("break"),
+  _case: kw("case", beforeExpr),
+  _catch: kw("catch"),
+  _continue: kw("continue"),
+  _debugger: kw("debugger"),
+  _default: kw("default", beforeExpr),
+  _do: kw("do", { isLoop: true, beforeExpr: true }),
+  _else: kw("else", beforeExpr),
+  _finally: kw("finally"),
+  _for: kw("for", { isLoop: true }),
+  _function: kw("function", startsExpr),
+  _if: kw("if"),
+  _return: kw("return", beforeExpr),
+  _switch: kw("switch"),
+  _throw: kw("throw", beforeExpr),
+  _try: kw("try"),
+  _var: kw("var"),
+  _const: kw("const"),
+  _while: kw("while", { isLoop: true }),
+  _with: kw("with"),
+  _new: kw("new", { beforeExpr: true, startsExpr: true }),
+  _this: kw("this", startsExpr),
+  _super: kw("super", startsExpr),
+  _class: kw("class", startsExpr),
+  _extends: kw("extends", beforeExpr),
+  _export: kw("export"),
+  _import: kw("import", startsExpr),
+  _null: kw("null", startsExpr),
+  _true: kw("true", startsExpr),
+  _false: kw("false", startsExpr),
+  _in: kw("in", { beforeExpr: true, binop: 7 }),
+  _instanceof: kw("instanceof", { beforeExpr: true, binop: 7 }),
+  _typeof: kw("typeof", { beforeExpr: true, prefix: true, startsExpr: true }),
+  _void: kw("void", { beforeExpr: true, prefix: true, startsExpr: true }),
+  _delete: kw("delete", { beforeExpr: true, prefix: true, startsExpr: true })
+};
+var lineBreak = /\r\n?|\n|\u2028|\u2029/;
+var lineBreakG = new RegExp(lineBreak.source, "g");
+function isNewLine(code) {
+  return code === 10 || code === 13 || code === 8232 || code === 8233;
+}
+function nextLineBreak(code, from, end) {
+  if (end === void 0)
+    end = code.length;
+  for (var i = from; i < end; i++) {
+    var next = code.charCodeAt(i);
+    if (isNewLine(next)) {
+      return i < end - 1 && next === 13 && code.charCodeAt(i + 1) === 10 ? i + 2 : i + 1;
+    }
+  }
+  return -1;
+}
+var nonASCIIwhitespace = /[\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
+var skipWhiteSpace = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
+var ref = Object.prototype;
+var hasOwnProperty = ref.hasOwnProperty;
+var toString = ref.toString;
+var hasOwn = Object.hasOwn || function(obj, propName) {
+  return hasOwnProperty.call(obj, propName);
+};
+var isArray = Array.isArray || function(obj) {
+  return toString.call(obj) === "[object Array]";
+};
+function wordsRegexp(words) {
+  return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+}
+function codePointToString(code) {
+  if (code <= 65535) {
+    return String.fromCharCode(code);
+  }
+  code -= 65536;
+  return String.fromCharCode((code >> 10) + 55296, (code & 1023) + 56320);
+}
+var loneSurrogate = /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/;
+var Position = function Position2(line, col) {
+  this.line = line;
+  this.column = col;
+};
+Position.prototype.offset = function offset(n) {
+  return new Position(this.line, this.column + n);
+};
+var SourceLocation = function SourceLocation2(p, start3, end) {
+  this.start = start3;
+  this.end = end;
+  if (p.sourceFile !== null) {
+    this.source = p.sourceFile;
+  }
+};
+function getLineInfo(input, offset2) {
+  for (var line = 1, cur = 0; ; ) {
+    var nextBreak = nextLineBreak(input, cur, offset2);
+    if (nextBreak < 0) {
+      return new Position(line, offset2 - cur);
+    }
+    ++line;
+    cur = nextBreak;
+  }
+}
+var defaultOptions = {
+  ecmaVersion: null,
+  sourceType: "script",
+  onInsertedSemicolon: null,
+  onTrailingComma: null,
+  allowReserved: null,
+  allowReturnOutsideFunction: false,
+  allowImportExportEverywhere: false,
+  allowAwaitOutsideFunction: null,
+  allowSuperOutsideMethod: null,
+  allowHashBang: false,
+  locations: false,
+  onToken: null,
+  onComment: null,
+  ranges: false,
+  program: null,
+  sourceFile: null,
+  directSourceFile: null,
+  preserveParens: false
+};
+var warnedAboutEcmaVersion = false;
+function getOptions(opts) {
+  var options = {};
+  for (var opt in defaultOptions) {
+    options[opt] = opts && hasOwn(opts, opt) ? opts[opt] : defaultOptions[opt];
+  }
+  if (options.ecmaVersion === "latest") {
+    options.ecmaVersion = 1e8;
+  } else if (options.ecmaVersion == null) {
+    if (!warnedAboutEcmaVersion && typeof console === "object" && console.warn) {
+      warnedAboutEcmaVersion = true;
+      console.warn("Since Acorn 8.0.0, options.ecmaVersion is required.\nDefaulting to 2020, but this will stop working in the future.");
+    }
+    options.ecmaVersion = 11;
+  } else if (options.ecmaVersion >= 2015) {
+    options.ecmaVersion -= 2009;
+  }
+  if (options.allowReserved == null) {
+    options.allowReserved = options.ecmaVersion < 5;
+  }
+  if (opts.allowHashBang == null) {
+    options.allowHashBang = options.ecmaVersion >= 14;
+  }
+  if (isArray(options.onToken)) {
+    var tokens = options.onToken;
+    options.onToken = function(token) {
+      return tokens.push(token);
+    };
+  }
+  if (isArray(options.onComment)) {
+    options.onComment = pushComment(options, options.onComment);
+  }
+  return options;
+}
+function pushComment(options, array) {
+  return function(block, text, start3, end, startLoc, endLoc) {
+    var comment = {
+      type: block ? "Block" : "Line",
+      value: text,
+      start: start3,
+      end
+    };
+    if (options.locations) {
+      comment.loc = new SourceLocation(this, startLoc, endLoc);
+    }
+    if (options.ranges) {
+      comment.range = [start3, end];
+    }
+    array.push(comment);
+  };
+}
+var SCOPE_TOP = 1;
+var SCOPE_FUNCTION = 2;
+var SCOPE_ASYNC = 4;
+var SCOPE_GENERATOR = 8;
+var SCOPE_ARROW = 16;
+var SCOPE_SIMPLE_CATCH = 32;
+var SCOPE_SUPER = 64;
+var SCOPE_DIRECT_SUPER = 128;
+var SCOPE_CLASS_STATIC_BLOCK = 256;
+var SCOPE_VAR = SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK;
+function functionFlags(async, generator) {
+  return SCOPE_FUNCTION | (async ? SCOPE_ASYNC : 0) | (generator ? SCOPE_GENERATOR : 0);
+}
+var BIND_NONE = 0;
+var BIND_VAR = 1;
+var BIND_LEXICAL = 2;
+var BIND_FUNCTION = 3;
+var BIND_SIMPLE_CATCH = 4;
+var BIND_OUTSIDE = 5;
+var Parser = function Parser2(options, input, startPos) {
+  this.options = options = getOptions(options);
+  this.sourceFile = options.sourceFile;
+  this.keywords = wordsRegexp(keywords$1[options.ecmaVersion >= 6 ? 6 : options.sourceType === "module" ? "5module" : 5]);
+  var reserved = "";
+  if (options.allowReserved !== true) {
+    reserved = reservedWords[options.ecmaVersion >= 6 ? 6 : options.ecmaVersion === 5 ? 5 : 3];
+    if (options.sourceType === "module") {
+      reserved += " await";
+    }
+  }
+  this.reservedWords = wordsRegexp(reserved);
+  var reservedStrict = (reserved ? reserved + " " : "") + reservedWords.strict;
+  this.reservedWordsStrict = wordsRegexp(reservedStrict);
+  this.reservedWordsStrictBind = wordsRegexp(reservedStrict + " " + reservedWords.strictBind);
+  this.input = String(input);
+  this.containsEsc = false;
+  if (startPos) {
+    this.pos = startPos;
+    this.lineStart = this.input.lastIndexOf("\n", startPos - 1) + 1;
+    this.curLine = this.input.slice(0, this.lineStart).split(lineBreak).length;
+  } else {
+    this.pos = this.lineStart = 0;
+    this.curLine = 1;
+  }
+  this.type = types$1.eof;
+  this.value = null;
+  this.start = this.end = this.pos;
+  this.startLoc = this.endLoc = this.curPosition();
+  this.lastTokEndLoc = this.lastTokStartLoc = null;
+  this.lastTokStart = this.lastTokEnd = this.pos;
+  this.context = this.initialContext();
+  this.exprAllowed = true;
+  this.inModule = options.sourceType === "module";
+  this.strict = this.inModule || this.strictDirective(this.pos);
+  this.potentialArrowAt = -1;
+  this.potentialArrowInForAwait = false;
+  this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
+  this.labels = [];
+  this.undefinedExports = /* @__PURE__ */ Object.create(null);
+  if (this.pos === 0 && options.allowHashBang && this.input.slice(0, 2) === "#!") {
+    this.skipLineComment(2);
+  }
+  this.scopeStack = [];
+  this.enterScope(SCOPE_TOP);
+  this.regexpState = null;
+  this.privateNameStack = [];
+};
+var prototypeAccessors = { inFunction: { configurable: true }, inGenerator: { configurable: true }, inAsync: { configurable: true }, canAwait: { configurable: true }, allowSuper: { configurable: true }, allowDirectSuper: { configurable: true }, treatFunctionsAsVar: { configurable: true }, allowNewDotTarget: { configurable: true }, inClassStaticBlock: { configurable: true } };
+Parser.prototype.parse = function parse() {
+  var node = this.options.program || this.startNode();
+  this.nextToken();
+  return this.parseTopLevel(node);
+};
+prototypeAccessors.inFunction.get = function() {
+  return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
+};
+prototypeAccessors.inGenerator.get = function() {
+  return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0 && !this.currentVarScope().inClassFieldInit;
+};
+prototypeAccessors.inAsync.get = function() {
+  return (this.currentVarScope().flags & SCOPE_ASYNC) > 0 && !this.currentVarScope().inClassFieldInit;
+};
+prototypeAccessors.canAwait.get = function() {
+  for (var i = this.scopeStack.length - 1; i >= 0; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.inClassFieldInit || scope.flags & SCOPE_CLASS_STATIC_BLOCK) {
+      return false;
+    }
+    if (scope.flags & SCOPE_FUNCTION) {
+      return (scope.flags & SCOPE_ASYNC) > 0;
+    }
+  }
+  return this.inModule && this.options.ecmaVersion >= 13 || this.options.allowAwaitOutsideFunction;
+};
+prototypeAccessors.allowSuper.get = function() {
+  var ref2 = this.currentThisScope();
+  var flags = ref2.flags;
+  var inClassFieldInit = ref2.inClassFieldInit;
+  return (flags & SCOPE_SUPER) > 0 || inClassFieldInit || this.options.allowSuperOutsideMethod;
+};
+prototypeAccessors.allowDirectSuper.get = function() {
+  return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER) > 0;
+};
+prototypeAccessors.treatFunctionsAsVar.get = function() {
+  return this.treatFunctionsAsVarInScope(this.currentScope());
+};
+prototypeAccessors.allowNewDotTarget.get = function() {
+  var ref2 = this.currentThisScope();
+  var flags = ref2.flags;
+  var inClassFieldInit = ref2.inClassFieldInit;
+  return (flags & (SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK)) > 0 || inClassFieldInit;
+};
+prototypeAccessors.inClassStaticBlock.get = function() {
+  return (this.currentVarScope().flags & SCOPE_CLASS_STATIC_BLOCK) > 0;
+};
+Parser.extend = function extend() {
+  var plugins = [], len = arguments.length;
+  while (len--)
+    plugins[len] = arguments[len];
+  var cls = this;
+  for (var i = 0; i < plugins.length; i++) {
+    cls = plugins[i](cls);
+  }
+  return cls;
+};
+Parser.parse = function parse2(input, options) {
+  return new this(options, input).parse();
+};
+Parser.parseExpressionAt = function parseExpressionAt(input, pos, options) {
+  var parser = new this(options, input, pos);
+  parser.nextToken();
+  return parser.parseExpression();
+};
+Parser.tokenizer = function tokenizer(input, options) {
+  return new this(options, input);
+};
+Object.defineProperties(Parser.prototype, prototypeAccessors);
+var pp$9 = Parser.prototype;
+var literal = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/;
+pp$9.strictDirective = function(start3) {
+  if (this.options.ecmaVersion < 5) {
+    return false;
+  }
+  for (; ; ) {
+    skipWhiteSpace.lastIndex = start3;
+    start3 += skipWhiteSpace.exec(this.input)[0].length;
+    var match = literal.exec(this.input.slice(start3));
+    if (!match) {
+      return false;
+    }
+    if ((match[1] || match[2]) === "use strict") {
+      skipWhiteSpace.lastIndex = start3 + match[0].length;
+      var spaceAfter = skipWhiteSpace.exec(this.input), end = spaceAfter.index + spaceAfter[0].length;
+      var next = this.input.charAt(end);
+      return next === ";" || next === "}" || lineBreak.test(spaceAfter[0]) && !(/[(`.[+\-/*%<>=,?^&]/.test(next) || next === "!" && this.input.charAt(end + 1) === "=");
+    }
+    start3 += match[0].length;
+    skipWhiteSpace.lastIndex = start3;
+    start3 += skipWhiteSpace.exec(this.input)[0].length;
+    if (this.input[start3] === ";") {
+      start3++;
+    }
+  }
+};
+pp$9.eat = function(type) {
+  if (this.type === type) {
+    this.next();
+    return true;
+  } else {
+    return false;
+  }
+};
+pp$9.isContextual = function(name) {
+  return this.type === types$1.name && this.value === name && !this.containsEsc;
+};
+pp$9.eatContextual = function(name) {
+  if (!this.isContextual(name)) {
+    return false;
+  }
+  this.next();
+  return true;
+};
+pp$9.expectContextual = function(name) {
+  if (!this.eatContextual(name)) {
+    this.unexpected();
+  }
+};
+pp$9.canInsertSemicolon = function() {
+  return this.type === types$1.eof || this.type === types$1.braceR || lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+};
+pp$9.insertSemicolon = function() {
+  if (this.canInsertSemicolon()) {
+    if (this.options.onInsertedSemicolon) {
+      this.options.onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+    }
+    return true;
+  }
+};
+pp$9.semicolon = function() {
+  if (!this.eat(types$1.semi) && !this.insertSemicolon()) {
+    this.unexpected();
+  }
+};
+pp$9.afterTrailingComma = function(tokType, notNext) {
+  if (this.type === tokType) {
+    if (this.options.onTrailingComma) {
+      this.options.onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+    }
+    if (!notNext) {
+      this.next();
+    }
+    return true;
+  }
+};
+pp$9.expect = function(type) {
+  this.eat(type) || this.unexpected();
+};
+pp$9.unexpected = function(pos) {
+  this.raise(pos != null ? pos : this.start, "Unexpected token");
+};
+var DestructuringErrors = function DestructuringErrors2() {
+  this.shorthandAssign = this.trailingComma = this.parenthesizedAssign = this.parenthesizedBind = this.doubleProto = -1;
+};
+pp$9.checkPatternErrors = function(refDestructuringErrors, isAssign) {
+  if (!refDestructuringErrors) {
+    return;
+  }
+  if (refDestructuringErrors.trailingComma > -1) {
+    this.raiseRecoverable(refDestructuringErrors.trailingComma, "Comma is not permitted after the rest element");
+  }
+  var parens = isAssign ? refDestructuringErrors.parenthesizedAssign : refDestructuringErrors.parenthesizedBind;
+  if (parens > -1) {
+    this.raiseRecoverable(parens, isAssign ? "Assigning to rvalue" : "Parenthesized pattern");
+  }
+};
+pp$9.checkExpressionErrors = function(refDestructuringErrors, andThrow) {
+  if (!refDestructuringErrors) {
+    return false;
+  }
+  var shorthandAssign = refDestructuringErrors.shorthandAssign;
+  var doubleProto = refDestructuringErrors.doubleProto;
+  if (!andThrow) {
+    return shorthandAssign >= 0 || doubleProto >= 0;
+  }
+  if (shorthandAssign >= 0) {
+    this.raise(shorthandAssign, "Shorthand property assignments are valid only in destructuring patterns");
+  }
+  if (doubleProto >= 0) {
+    this.raiseRecoverable(doubleProto, "Redefinition of __proto__ property");
+  }
+};
+pp$9.checkYieldAwaitInDefaultParams = function() {
+  if (this.yieldPos && (!this.awaitPos || this.yieldPos < this.awaitPos)) {
+    this.raise(this.yieldPos, "Yield expression cannot be a default value");
+  }
+  if (this.awaitPos) {
+    this.raise(this.awaitPos, "Await expression cannot be a default value");
+  }
+};
+pp$9.isSimpleAssignTarget = function(expr) {
+  if (expr.type === "ParenthesizedExpression") {
+    return this.isSimpleAssignTarget(expr.expression);
+  }
+  return expr.type === "Identifier" || expr.type === "MemberExpression";
+};
+var pp$8 = Parser.prototype;
+pp$8.parseTopLevel = function(node) {
+  var exports = /* @__PURE__ */ Object.create(null);
+  if (!node.body) {
+    node.body = [];
+  }
+  while (this.type !== types$1.eof) {
+    var stmt = this.parseStatement(null, true, exports);
+    node.body.push(stmt);
+  }
+  if (this.inModule) {
+    for (var i = 0, list = Object.keys(this.undefinedExports); i < list.length; i += 1) {
+      var name = list[i];
+      this.raiseRecoverable(this.undefinedExports[name].start, "Export '" + name + "' is not defined");
+    }
+  }
+  this.adaptDirectivePrologue(node.body);
+  this.next();
+  node.sourceType = this.options.sourceType;
+  return this.finishNode(node, "Program");
+};
+var loopLabel = { kind: "loop" };
+var switchLabel = { kind: "switch" };
+pp$8.isLet = function(context) {
+  if (this.options.ecmaVersion < 6 || !this.isContextual("let")) {
+    return false;
+  }
+  skipWhiteSpace.lastIndex = this.pos;
+  var skip = skipWhiteSpace.exec(this.input);
+  var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+  if (nextCh === 91 || nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+    return true;
+  }
+  if (context) {
+    return false;
+  }
+  if (nextCh === 123) {
+    return true;
+  }
+  if (isIdentifierStart(nextCh, true)) {
+    var pos = next + 1;
+    while (isIdentifierChar(nextCh = this.input.charCodeAt(pos), true)) {
+      ++pos;
+    }
+    if (nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+      return true;
+    }
+    var ident = this.input.slice(next, pos);
+    if (!keywordRelationalOperator.test(ident)) {
+      return true;
+    }
+  }
+  return false;
+};
+pp$8.isAsyncFunction = function() {
+  if (this.options.ecmaVersion < 8 || !this.isContextual("async")) {
+    return false;
+  }
+  skipWhiteSpace.lastIndex = this.pos;
+  var skip = skipWhiteSpace.exec(this.input);
+  var next = this.pos + skip[0].length, after;
+  return !lineBreak.test(this.input.slice(this.pos, next)) && this.input.slice(next, next + 8) === "function" && (next + 8 === this.input.length || !(isIdentifierChar(after = this.input.charCodeAt(next + 8)) || after > 55295 && after < 56320));
+};
+pp$8.parseStatement = function(context, topLevel, exports) {
+  var starttype = this.type, node = this.startNode(), kind;
+  if (this.isLet(context)) {
+    starttype = types$1._var;
+    kind = "let";
+  }
+  switch (starttype) {
+    case types$1._break:
+    case types$1._continue:
+      return this.parseBreakContinueStatement(node, starttype.keyword);
+    case types$1._debugger:
+      return this.parseDebuggerStatement(node);
+    case types$1._do:
+      return this.parseDoStatement(node);
+    case types$1._for:
+      return this.parseForStatement(node);
+    case types$1._function:
+      if (context && (this.strict || context !== "if" && context !== "label") && this.options.ecmaVersion >= 6) {
+        this.unexpected();
+      }
+      return this.parseFunctionStatement(node, false, !context);
+    case types$1._class:
+      if (context) {
+        this.unexpected();
+      }
+      return this.parseClass(node, true);
+    case types$1._if:
+      return this.parseIfStatement(node);
+    case types$1._return:
+      return this.parseReturnStatement(node);
+    case types$1._switch:
+      return this.parseSwitchStatement(node);
+    case types$1._throw:
+      return this.parseThrowStatement(node);
+    case types$1._try:
+      return this.parseTryStatement(node);
+    case types$1._const:
+    case types$1._var:
+      kind = kind || this.value;
+      if (context && kind !== "var") {
+        this.unexpected();
+      }
+      return this.parseVarStatement(node, kind);
+    case types$1._while:
+      return this.parseWhileStatement(node);
+    case types$1._with:
+      return this.parseWithStatement(node);
+    case types$1.braceL:
+      return this.parseBlock(true, node);
+    case types$1.semi:
+      return this.parseEmptyStatement(node);
+    case types$1._export:
+    case types$1._import:
+      if (this.options.ecmaVersion > 10 && starttype === types$1._import) {
+        skipWhiteSpace.lastIndex = this.pos;
+        var skip = skipWhiteSpace.exec(this.input);
+        var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+        if (nextCh === 40 || nextCh === 46) {
+          return this.parseExpressionStatement(node, this.parseExpression());
+        }
+      }
+      if (!this.options.allowImportExportEverywhere) {
+        if (!topLevel) {
+          this.raise(this.start, "'import' and 'export' may only appear at the top level");
+        }
+        if (!this.inModule) {
+          this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'");
+        }
+      }
+      return starttype === types$1._import ? this.parseImport(node) : this.parseExport(node, exports);
+    default:
+      if (this.isAsyncFunction()) {
+        if (context) {
+          this.unexpected();
+        }
+        this.next();
+        return this.parseFunctionStatement(node, true, !context);
+      }
+      var maybeName = this.value, expr = this.parseExpression();
+      if (starttype === types$1.name && expr.type === "Identifier" && this.eat(types$1.colon)) {
+        return this.parseLabeledStatement(node, maybeName, expr, context);
+      } else {
+        return this.parseExpressionStatement(node, expr);
+      }
+  }
+};
+pp$8.parseBreakContinueStatement = function(node, keyword) {
+  var isBreak = keyword === "break";
+  this.next();
+  if (this.eat(types$1.semi) || this.insertSemicolon()) {
+    node.label = null;
+  } else if (this.type !== types$1.name) {
+    this.unexpected();
+  } else {
+    node.label = this.parseIdent();
+    this.semicolon();
+  }
+  var i = 0;
+  for (; i < this.labels.length; ++i) {
+    var lab = this.labels[i];
+    if (node.label == null || lab.name === node.label.name) {
+      if (lab.kind != null && (isBreak || lab.kind === "loop")) {
+        break;
+      }
+      if (node.label && isBreak) {
+        break;
+      }
+    }
+  }
+  if (i === this.labels.length) {
+    this.raise(node.start, "Unsyntactic " + keyword);
+  }
+  return this.finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+};
+pp$8.parseDebuggerStatement = function(node) {
+  this.next();
+  this.semicolon();
+  return this.finishNode(node, "DebuggerStatement");
+};
+pp$8.parseDoStatement = function(node) {
+  this.next();
+  this.labels.push(loopLabel);
+  node.body = this.parseStatement("do");
+  this.labels.pop();
+  this.expect(types$1._while);
+  node.test = this.parseParenExpression();
+  if (this.options.ecmaVersion >= 6) {
+    this.eat(types$1.semi);
+  } else {
+    this.semicolon();
+  }
+  return this.finishNode(node, "DoWhileStatement");
+};
+pp$8.parseForStatement = function(node) {
+  this.next();
+  var awaitAt = this.options.ecmaVersion >= 9 && this.canAwait && this.eatContextual("await") ? this.lastTokStart : -1;
+  this.labels.push(loopLabel);
+  this.enterScope(0);
+  this.expect(types$1.parenL);
+  if (this.type === types$1.semi) {
+    if (awaitAt > -1) {
+      this.unexpected(awaitAt);
+    }
+    return this.parseFor(node, null);
+  }
+  var isLet = this.isLet();
+  if (this.type === types$1._var || this.type === types$1._const || isLet) {
+    var init$1 = this.startNode(), kind = isLet ? "let" : this.value;
+    this.next();
+    this.parseVar(init$1, true, kind);
+    this.finishNode(init$1, "VariableDeclaration");
+    if ((this.type === types$1._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) && init$1.declarations.length === 1) {
+      if (this.options.ecmaVersion >= 9) {
+        if (this.type === types$1._in) {
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+        } else {
+          node.await = awaitAt > -1;
+        }
+      }
+      return this.parseForIn(node, init$1);
+    }
+    if (awaitAt > -1) {
+      this.unexpected(awaitAt);
+    }
+    return this.parseFor(node, init$1);
+  }
+  var startsWithLet = this.isContextual("let"), isForOf = false;
+  var refDestructuringErrors = new DestructuringErrors();
+  var init = this.parseExpression(awaitAt > -1 ? "await" : true, refDestructuringErrors);
+  if (this.type === types$1._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+    if (this.options.ecmaVersion >= 9) {
+      if (this.type === types$1._in) {
+        if (awaitAt > -1) {
+          this.unexpected(awaitAt);
+        }
+      } else {
+        node.await = awaitAt > -1;
+      }
+    }
+    if (startsWithLet && isForOf) {
+      this.raise(init.start, "The left-hand side of a for-of loop may not start with 'let'.");
+    }
+    this.toAssignable(init, false, refDestructuringErrors);
+    this.checkLValPattern(init);
+    return this.parseForIn(node, init);
+  } else {
+    this.checkExpressionErrors(refDestructuringErrors, true);
+  }
+  if (awaitAt > -1) {
+    this.unexpected(awaitAt);
+  }
+  return this.parseFor(node, init);
+};
+pp$8.parseFunctionStatement = function(node, isAsync, declarationPosition) {
+  this.next();
+  return this.parseFunction(node, FUNC_STATEMENT | (declarationPosition ? 0 : FUNC_HANGING_STATEMENT), false, isAsync);
+};
+pp$8.parseIfStatement = function(node) {
+  this.next();
+  node.test = this.parseParenExpression();
+  node.consequent = this.parseStatement("if");
+  node.alternate = this.eat(types$1._else) ? this.parseStatement("if") : null;
+  return this.finishNode(node, "IfStatement");
+};
+pp$8.parseReturnStatement = function(node) {
+  if (!this.inFunction && !this.options.allowReturnOutsideFunction) {
+    this.raise(this.start, "'return' outside of function");
+  }
+  this.next();
+  if (this.eat(types$1.semi) || this.insertSemicolon()) {
+    node.argument = null;
+  } else {
+    node.argument = this.parseExpression();
+    this.semicolon();
+  }
+  return this.finishNode(node, "ReturnStatement");
+};
+pp$8.parseSwitchStatement = function(node) {
+  this.next();
+  node.discriminant = this.parseParenExpression();
+  node.cases = [];
+  this.expect(types$1.braceL);
+  this.labels.push(switchLabel);
+  this.enterScope(0);
+  var cur;
+  for (var sawDefault = false; this.type !== types$1.braceR; ) {
+    if (this.type === types$1._case || this.type === types$1._default) {
+      var isCase = this.type === types$1._case;
+      if (cur) {
+        this.finishNode(cur, "SwitchCase");
+      }
+      node.cases.push(cur = this.startNode());
+      cur.consequent = [];
+      this.next();
+      if (isCase) {
+        cur.test = this.parseExpression();
+      } else {
+        if (sawDefault) {
+          this.raiseRecoverable(this.lastTokStart, "Multiple default clauses");
+        }
+        sawDefault = true;
+        cur.test = null;
+      }
+      this.expect(types$1.colon);
+    } else {
+      if (!cur) {
+        this.unexpected();
+      }
+      cur.consequent.push(this.parseStatement(null));
+    }
+  }
+  this.exitScope();
+  if (cur) {
+    this.finishNode(cur, "SwitchCase");
+  }
+  this.next();
+  this.labels.pop();
+  return this.finishNode(node, "SwitchStatement");
+};
+pp$8.parseThrowStatement = function(node) {
+  this.next();
+  if (lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) {
+    this.raise(this.lastTokEnd, "Illegal newline after throw");
+  }
+  node.argument = this.parseExpression();
+  this.semicolon();
+  return this.finishNode(node, "ThrowStatement");
+};
+var empty$1 = [];
+pp$8.parseTryStatement = function(node) {
+  this.next();
+  node.block = this.parseBlock();
+  node.handler = null;
+  if (this.type === types$1._catch) {
+    var clause = this.startNode();
+    this.next();
+    if (this.eat(types$1.parenL)) {
+      clause.param = this.parseBindingAtom();
+      var simple = clause.param.type === "Identifier";
+      this.enterScope(simple ? SCOPE_SIMPLE_CATCH : 0);
+      this.checkLValPattern(clause.param, simple ? BIND_SIMPLE_CATCH : BIND_LEXICAL);
+      this.expect(types$1.parenR);
+    } else {
+      if (this.options.ecmaVersion < 10) {
+        this.unexpected();
+      }
+      clause.param = null;
+      this.enterScope(0);
+    }
+    clause.body = this.parseBlock(false);
+    this.exitScope();
+    node.handler = this.finishNode(clause, "CatchClause");
+  }
+  node.finalizer = this.eat(types$1._finally) ? this.parseBlock() : null;
+  if (!node.handler && !node.finalizer) {
+    this.raise(node.start, "Missing catch or finally clause");
+  }
+  return this.finishNode(node, "TryStatement");
+};
+pp$8.parseVarStatement = function(node, kind) {
+  this.next();
+  this.parseVar(node, false, kind);
+  this.semicolon();
+  return this.finishNode(node, "VariableDeclaration");
+};
+pp$8.parseWhileStatement = function(node) {
+  this.next();
+  node.test = this.parseParenExpression();
+  this.labels.push(loopLabel);
+  node.body = this.parseStatement("while");
+  this.labels.pop();
+  return this.finishNode(node, "WhileStatement");
+};
+pp$8.parseWithStatement = function(node) {
+  if (this.strict) {
+    this.raise(this.start, "'with' in strict mode");
+  }
+  this.next();
+  node.object = this.parseParenExpression();
+  node.body = this.parseStatement("with");
+  return this.finishNode(node, "WithStatement");
+};
+pp$8.parseEmptyStatement = function(node) {
+  this.next();
+  return this.finishNode(node, "EmptyStatement");
+};
+pp$8.parseLabeledStatement = function(node, maybeName, expr, context) {
+  for (var i$1 = 0, list = this.labels; i$1 < list.length; i$1 += 1) {
+    var label = list[i$1];
+    if (label.name === maybeName) {
+      this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+    }
+  }
+  var kind = this.type.isLoop ? "loop" : this.type === types$1._switch ? "switch" : null;
+  for (var i = this.labels.length - 1; i >= 0; i--) {
+    var label$1 = this.labels[i];
+    if (label$1.statementStart === node.start) {
+      label$1.statementStart = this.start;
+      label$1.kind = kind;
+    } else {
+      break;
+    }
+  }
+  this.labels.push({ name: maybeName, kind, statementStart: this.start });
+  node.body = this.parseStatement(context ? context.indexOf("label") === -1 ? context + "label" : context : "label");
+  this.labels.pop();
+  node.label = expr;
+  return this.finishNode(node, "LabeledStatement");
+};
+pp$8.parseExpressionStatement = function(node, expr) {
+  node.expression = expr;
+  this.semicolon();
+  return this.finishNode(node, "ExpressionStatement");
+};
+pp$8.parseBlock = function(createNewLexicalScope, node, exitStrict) {
+  if (createNewLexicalScope === void 0)
+    createNewLexicalScope = true;
+  if (node === void 0)
+    node = this.startNode();
+  node.body = [];
+  this.expect(types$1.braceL);
+  if (createNewLexicalScope) {
+    this.enterScope(0);
+  }
+  while (this.type !== types$1.braceR) {
+    var stmt = this.parseStatement(null);
+    node.body.push(stmt);
+  }
+  if (exitStrict) {
+    this.strict = false;
+  }
+  this.next();
+  if (createNewLexicalScope) {
+    this.exitScope();
+  }
+  return this.finishNode(node, "BlockStatement");
+};
+pp$8.parseFor = function(node, init) {
+  node.init = init;
+  this.expect(types$1.semi);
+  node.test = this.type === types$1.semi ? null : this.parseExpression();
+  this.expect(types$1.semi);
+  node.update = this.type === types$1.parenR ? null : this.parseExpression();
+  this.expect(types$1.parenR);
+  node.body = this.parseStatement("for");
+  this.exitScope();
+  this.labels.pop();
+  return this.finishNode(node, "ForStatement");
+};
+pp$8.parseForIn = function(node, init) {
+  var isForIn = this.type === types$1._in;
+  this.next();
+  if (init.type === "VariableDeclaration" && init.declarations[0].init != null && (!isForIn || this.options.ecmaVersion < 8 || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")) {
+    this.raise(
+      init.start,
+      (isForIn ? "for-in" : "for-of") + " loop variable declaration may not have an initializer"
+    );
+  }
+  node.left = init;
+  node.right = isForIn ? this.parseExpression() : this.parseMaybeAssign();
+  this.expect(types$1.parenR);
+  node.body = this.parseStatement("for");
+  this.exitScope();
+  this.labels.pop();
+  return this.finishNode(node, isForIn ? "ForInStatement" : "ForOfStatement");
+};
+pp$8.parseVar = function(node, isFor, kind) {
+  node.declarations = [];
+  node.kind = kind;
+  for (; ; ) {
+    var decl = this.startNode();
+    this.parseVarId(decl, kind);
+    if (this.eat(types$1.eq)) {
+      decl.init = this.parseMaybeAssign(isFor);
+    } else if (kind === "const" && !(this.type === types$1._in || this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+      this.unexpected();
+    } else if (decl.id.type !== "Identifier" && !(isFor && (this.type === types$1._in || this.isContextual("of")))) {
+      this.raise(this.lastTokEnd, "Complex binding patterns require an initialization value");
+    } else {
+      decl.init = null;
+    }
+    node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+    if (!this.eat(types$1.comma)) {
+      break;
+    }
+  }
+  return node;
+};
+pp$8.parseVarId = function(decl, kind) {
+  decl.id = this.parseBindingAtom();
+  this.checkLValPattern(decl.id, kind === "var" ? BIND_VAR : BIND_LEXICAL, false);
+};
+var FUNC_STATEMENT = 1;
+var FUNC_HANGING_STATEMENT = 2;
+var FUNC_NULLABLE_ID = 4;
+pp$8.parseFunction = function(node, statement, allowExpressionBody, isAsync, forInit) {
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 9 || this.options.ecmaVersion >= 6 && !isAsync) {
+    if (this.type === types$1.star && statement & FUNC_HANGING_STATEMENT) {
+      this.unexpected();
+    }
+    node.generator = this.eat(types$1.star);
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node.async = !!isAsync;
+  }
+  if (statement & FUNC_STATEMENT) {
+    node.id = statement & FUNC_NULLABLE_ID && this.type !== types$1.name ? null : this.parseIdent();
+    if (node.id && !(statement & FUNC_HANGING_STATEMENT)) {
+      this.checkLValSimple(node.id, this.strict || node.generator || node.async ? this.treatFunctionsAsVar ? BIND_VAR : BIND_LEXICAL : BIND_FUNCTION);
+    }
+  }
+  var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  this.enterScope(functionFlags(node.async, node.generator));
+  if (!(statement & FUNC_STATEMENT)) {
+    node.id = this.type === types$1.name ? this.parseIdent() : null;
+  }
+  this.parseFunctionParams(node);
+  this.parseFunctionBody(node, allowExpressionBody, false, forInit);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node, statement & FUNC_STATEMENT ? "FunctionDeclaration" : "FunctionExpression");
+};
+pp$8.parseFunctionParams = function(node) {
+  this.expect(types$1.parenL);
+  node.params = this.parseBindingList(types$1.parenR, false, this.options.ecmaVersion >= 8);
+  this.checkYieldAwaitInDefaultParams();
+};
+pp$8.parseClass = function(node, isStatement) {
+  this.next();
+  var oldStrict = this.strict;
+  this.strict = true;
+  this.parseClassId(node, isStatement);
+  this.parseClassSuper(node);
+  var privateNameMap = this.enterClassBody();
+  var classBody = this.startNode();
+  var hadConstructor = false;
+  classBody.body = [];
+  this.expect(types$1.braceL);
+  while (this.type !== types$1.braceR) {
+    var element = this.parseClassElement(node.superClass !== null);
+    if (element) {
+      classBody.body.push(element);
+      if (element.type === "MethodDefinition" && element.kind === "constructor") {
+        if (hadConstructor) {
+          this.raise(element.start, "Duplicate constructor in the same class");
+        }
+        hadConstructor = true;
+      } else if (element.key && element.key.type === "PrivateIdentifier" && isPrivateNameConflicted(privateNameMap, element)) {
+        this.raiseRecoverable(element.key.start, "Identifier '#" + element.key.name + "' has already been declared");
+      }
+    }
+  }
+  this.strict = oldStrict;
+  this.next();
+  node.body = this.finishNode(classBody, "ClassBody");
+  this.exitClassBody();
+  return this.finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
+};
+pp$8.parseClassElement = function(constructorAllowsSuper) {
+  if (this.eat(types$1.semi)) {
+    return null;
+  }
+  var ecmaVersion = this.options.ecmaVersion;
+  var node = this.startNode();
+  var keyName = "";
+  var isGenerator = false;
+  var isAsync = false;
+  var kind = "method";
+  var isStatic = false;
+  if (this.eatContextual("static")) {
+    if (ecmaVersion >= 13 && this.eat(types$1.braceL)) {
+      this.parseClassStaticBlock(node);
+      return node;
+    }
+    if (this.isClassElementNameStart() || this.type === types$1.star) {
+      isStatic = true;
+    } else {
+      keyName = "static";
+    }
+  }
+  node.static = isStatic;
+  if (!keyName && ecmaVersion >= 8 && this.eatContextual("async")) {
+    if ((this.isClassElementNameStart() || this.type === types$1.star) && !this.canInsertSemicolon()) {
+      isAsync = true;
+    } else {
+      keyName = "async";
+    }
+  }
+  if (!keyName && (ecmaVersion >= 9 || !isAsync) && this.eat(types$1.star)) {
+    isGenerator = true;
+  }
+  if (!keyName && !isAsync && !isGenerator) {
+    var lastValue = this.value;
+    if (this.eatContextual("get") || this.eatContextual("set")) {
+      if (this.isClassElementNameStart()) {
+        kind = lastValue;
+      } else {
+        keyName = lastValue;
+      }
+    }
+  }
+  if (keyName) {
+    node.computed = false;
+    node.key = this.startNodeAt(this.lastTokStart, this.lastTokStartLoc);
+    node.key.name = keyName;
+    this.finishNode(node.key, "Identifier");
+  } else {
+    this.parseClassElementName(node);
+  }
+  if (ecmaVersion < 13 || this.type === types$1.parenL || kind !== "method" || isGenerator || isAsync) {
+    var isConstructor = !node.static && checkKeyName(node, "constructor");
+    var allowsDirectSuper = isConstructor && constructorAllowsSuper;
+    if (isConstructor && kind !== "method") {
+      this.raise(node.key.start, "Constructor can't have get/set modifier");
+    }
+    node.kind = isConstructor ? "constructor" : kind;
+    this.parseClassMethod(node, isGenerator, isAsync, allowsDirectSuper);
+  } else {
+    this.parseClassField(node);
+  }
+  return node;
+};
+pp$8.isClassElementNameStart = function() {
+  return this.type === types$1.name || this.type === types$1.privateId || this.type === types$1.num || this.type === types$1.string || this.type === types$1.bracketL || this.type.keyword;
+};
+pp$8.parseClassElementName = function(element) {
+  if (this.type === types$1.privateId) {
+    if (this.value === "constructor") {
+      this.raise(this.start, "Classes can't have an element named '#constructor'");
+    }
+    element.computed = false;
+    element.key = this.parsePrivateIdent();
+  } else {
+    this.parsePropertyName(element);
+  }
+};
+pp$8.parseClassMethod = function(method, isGenerator, isAsync, allowsDirectSuper) {
+  var key = method.key;
+  if (method.kind === "constructor") {
+    if (isGenerator) {
+      this.raise(key.start, "Constructor can't be a generator");
+    }
+    if (isAsync) {
+      this.raise(key.start, "Constructor can't be an async method");
+    }
+  } else if (method.static && checkKeyName(method, "prototype")) {
+    this.raise(key.start, "Classes may not have a static property named prototype");
+  }
+  var value = method.value = this.parseMethod(isGenerator, isAsync, allowsDirectSuper);
+  if (method.kind === "get" && value.params.length !== 0) {
+    this.raiseRecoverable(value.start, "getter should have no params");
+  }
+  if (method.kind === "set" && value.params.length !== 1) {
+    this.raiseRecoverable(value.start, "setter should have exactly one param");
+  }
+  if (method.kind === "set" && value.params[0].type === "RestElement") {
+    this.raiseRecoverable(value.params[0].start, "Setter cannot use rest params");
+  }
+  return this.finishNode(method, "MethodDefinition");
+};
+pp$8.parseClassField = function(field) {
+  if (checkKeyName(field, "constructor")) {
+    this.raise(field.key.start, "Classes can't have a field named 'constructor'");
+  } else if (field.static && checkKeyName(field, "prototype")) {
+    this.raise(field.key.start, "Classes can't have a static field named 'prototype'");
+  }
+  if (this.eat(types$1.eq)) {
+    var scope = this.currentThisScope();
+    var inClassFieldInit = scope.inClassFieldInit;
+    scope.inClassFieldInit = true;
+    field.value = this.parseMaybeAssign();
+    scope.inClassFieldInit = inClassFieldInit;
+  } else {
+    field.value = null;
+  }
+  this.semicolon();
+  return this.finishNode(field, "PropertyDefinition");
+};
+pp$8.parseClassStaticBlock = function(node) {
+  node.body = [];
+  var oldLabels = this.labels;
+  this.labels = [];
+  this.enterScope(SCOPE_CLASS_STATIC_BLOCK | SCOPE_SUPER);
+  while (this.type !== types$1.braceR) {
+    var stmt = this.parseStatement(null);
+    node.body.push(stmt);
+  }
+  this.next();
+  this.exitScope();
+  this.labels = oldLabels;
+  return this.finishNode(node, "StaticBlock");
+};
+pp$8.parseClassId = function(node, isStatement) {
+  if (this.type === types$1.name) {
+    node.id = this.parseIdent();
+    if (isStatement) {
+      this.checkLValSimple(node.id, BIND_LEXICAL, false);
+    }
+  } else {
+    if (isStatement === true) {
+      this.unexpected();
+    }
+    node.id = null;
+  }
+};
+pp$8.parseClassSuper = function(node) {
+  node.superClass = this.eat(types$1._extends) ? this.parseExprSubscripts(false) : null;
+};
+pp$8.enterClassBody = function() {
+  var element = { declared: /* @__PURE__ */ Object.create(null), used: [] };
+  this.privateNameStack.push(element);
+  return element.declared;
+};
+pp$8.exitClassBody = function() {
+  var ref2 = this.privateNameStack.pop();
+  var declared = ref2.declared;
+  var used = ref2.used;
+  var len = this.privateNameStack.length;
+  var parent = len === 0 ? null : this.privateNameStack[len - 1];
+  for (var i = 0; i < used.length; ++i) {
+    var id = used[i];
+    if (!hasOwn(declared, id.name)) {
+      if (parent) {
+        parent.used.push(id);
+      } else {
+        this.raiseRecoverable(id.start, "Private field '#" + id.name + "' must be declared in an enclosing class");
+      }
+    }
+  }
+};
+function isPrivateNameConflicted(privateNameMap, element) {
+  var name = element.key.name;
+  var curr = privateNameMap[name];
+  var next = "true";
+  if (element.type === "MethodDefinition" && (element.kind === "get" || element.kind === "set")) {
+    next = (element.static ? "s" : "i") + element.kind;
+  }
+  if (curr === "iget" && next === "iset" || curr === "iset" && next === "iget" || curr === "sget" && next === "sset" || curr === "sset" && next === "sget") {
+    privateNameMap[name] = "true";
+    return false;
+  } else if (!curr) {
+    privateNameMap[name] = next;
+    return false;
+  } else {
+    return true;
+  }
+}
+function checkKeyName(node, name) {
+  var computed = node.computed;
+  var key = node.key;
+  return !computed && (key.type === "Identifier" && key.name === name || key.type === "Literal" && key.value === name);
+}
+pp$8.parseExport = function(node, exports) {
+  this.next();
+  if (this.eat(types$1.star)) {
+    if (this.options.ecmaVersion >= 11) {
+      if (this.eatContextual("as")) {
+        node.exported = this.parseModuleExportName();
+        this.checkExport(exports, node.exported, this.lastTokStart);
+      } else {
+        node.exported = null;
+      }
+    }
+    this.expectContextual("from");
+    if (this.type !== types$1.string) {
+      this.unexpected();
+    }
+    node.source = this.parseExprAtom();
+    this.semicolon();
+    return this.finishNode(node, "ExportAllDeclaration");
+  }
+  if (this.eat(types$1._default)) {
+    this.checkExport(exports, "default", this.lastTokStart);
+    var isAsync;
+    if (this.type === types$1._function || (isAsync = this.isAsyncFunction())) {
+      var fNode = this.startNode();
+      this.next();
+      if (isAsync) {
+        this.next();
+      }
+      node.declaration = this.parseFunction(fNode, FUNC_STATEMENT | FUNC_NULLABLE_ID, false, isAsync);
+    } else if (this.type === types$1._class) {
+      var cNode = this.startNode();
+      node.declaration = this.parseClass(cNode, "nullableID");
+    } else {
+      node.declaration = this.parseMaybeAssign();
+      this.semicolon();
+    }
+    return this.finishNode(node, "ExportDefaultDeclaration");
+  }
+  if (this.shouldParseExportStatement()) {
+    node.declaration = this.parseStatement(null);
+    if (node.declaration.type === "VariableDeclaration") {
+      this.checkVariableExport(exports, node.declaration.declarations);
+    } else {
+      this.checkExport(exports, node.declaration.id, node.declaration.id.start);
+    }
+    node.specifiers = [];
+    node.source = null;
+  } else {
+    node.declaration = null;
+    node.specifiers = this.parseExportSpecifiers(exports);
+    if (this.eatContextual("from")) {
+      if (this.type !== types$1.string) {
+        this.unexpected();
+      }
+      node.source = this.parseExprAtom();
+    } else {
+      for (var i = 0, list = node.specifiers; i < list.length; i += 1) {
+        var spec = list[i];
+        this.checkUnreserved(spec.local);
+        this.checkLocalExport(spec.local);
+        if (spec.local.type === "Literal") {
+          this.raise(spec.local.start, "A string literal cannot be used as an exported binding without `from`.");
+        }
+      }
+      node.source = null;
+    }
+    this.semicolon();
+  }
+  return this.finishNode(node, "ExportNamedDeclaration");
+};
+pp$8.checkExport = function(exports, name, pos) {
+  if (!exports) {
+    return;
+  }
+  if (typeof name !== "string") {
+    name = name.type === "Identifier" ? name.name : name.value;
+  }
+  if (hasOwn(exports, name)) {
+    this.raiseRecoverable(pos, "Duplicate export '" + name + "'");
+  }
+  exports[name] = true;
+};
+pp$8.checkPatternExport = function(exports, pat) {
+  var type = pat.type;
+  if (type === "Identifier") {
+    this.checkExport(exports, pat, pat.start);
+  } else if (type === "ObjectPattern") {
+    for (var i = 0, list = pat.properties; i < list.length; i += 1) {
+      var prop = list[i];
+      this.checkPatternExport(exports, prop);
+    }
+  } else if (type === "ArrayPattern") {
+    for (var i$1 = 0, list$1 = pat.elements; i$1 < list$1.length; i$1 += 1) {
+      var elt = list$1[i$1];
+      if (elt) {
+        this.checkPatternExport(exports, elt);
+      }
+    }
+  } else if (type === "Property") {
+    this.checkPatternExport(exports, pat.value);
+  } else if (type === "AssignmentPattern") {
+    this.checkPatternExport(exports, pat.left);
+  } else if (type === "RestElement") {
+    this.checkPatternExport(exports, pat.argument);
+  } else if (type === "ParenthesizedExpression") {
+    this.checkPatternExport(exports, pat.expression);
+  }
+};
+pp$8.checkVariableExport = function(exports, decls) {
+  if (!exports) {
+    return;
+  }
+  for (var i = 0, list = decls; i < list.length; i += 1) {
+    var decl = list[i];
+    this.checkPatternExport(exports, decl.id);
+  }
+};
+pp$8.shouldParseExportStatement = function() {
+  return this.type.keyword === "var" || this.type.keyword === "const" || this.type.keyword === "class" || this.type.keyword === "function" || this.isLet() || this.isAsyncFunction();
+};
+pp$8.parseExportSpecifiers = function(exports) {
+  var nodes = [], first = true;
+  this.expect(types$1.braceL);
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var node = this.startNode();
+    node.local = this.parseModuleExportName();
+    node.exported = this.eatContextual("as") ? this.parseModuleExportName() : node.local;
+    this.checkExport(
+      exports,
+      node.exported,
+      node.exported.start
+    );
+    nodes.push(this.finishNode(node, "ExportSpecifier"));
+  }
+  return nodes;
+};
+pp$8.parseImport = function(node) {
+  this.next();
+  if (this.type === types$1.string) {
+    node.specifiers = empty$1;
+    node.source = this.parseExprAtom();
+  } else {
+    node.specifiers = this.parseImportSpecifiers();
+    this.expectContextual("from");
+    node.source = this.type === types$1.string ? this.parseExprAtom() : this.unexpected();
+  }
+  this.semicolon();
+  return this.finishNode(node, "ImportDeclaration");
+};
+pp$8.parseImportSpecifiers = function() {
+  var nodes = [], first = true;
+  if (this.type === types$1.name) {
+    var node = this.startNode();
+    node.local = this.parseIdent();
+    this.checkLValSimple(node.local, BIND_LEXICAL);
+    nodes.push(this.finishNode(node, "ImportDefaultSpecifier"));
+    if (!this.eat(types$1.comma)) {
+      return nodes;
+    }
+  }
+  if (this.type === types$1.star) {
+    var node$1 = this.startNode();
+    this.next();
+    this.expectContextual("as");
+    node$1.local = this.parseIdent();
+    this.checkLValSimple(node$1.local, BIND_LEXICAL);
+    nodes.push(this.finishNode(node$1, "ImportNamespaceSpecifier"));
+    return nodes;
+  }
+  this.expect(types$1.braceL);
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var node$2 = this.startNode();
+    node$2.imported = this.parseModuleExportName();
+    if (this.eatContextual("as")) {
+      node$2.local = this.parseIdent();
+    } else {
+      this.checkUnreserved(node$2.imported);
+      node$2.local = node$2.imported;
+    }
+    this.checkLValSimple(node$2.local, BIND_LEXICAL);
+    nodes.push(this.finishNode(node$2, "ImportSpecifier"));
+  }
+  return nodes;
+};
+pp$8.parseModuleExportName = function() {
+  if (this.options.ecmaVersion >= 13 && this.type === types$1.string) {
+    var stringLiteral = this.parseLiteral(this.value);
+    if (loneSurrogate.test(stringLiteral.value)) {
+      this.raise(stringLiteral.start, "An export name cannot include a lone surrogate.");
+    }
+    return stringLiteral;
+  }
+  return this.parseIdent(true);
+};
+pp$8.adaptDirectivePrologue = function(statements) {
+  for (var i = 0; i < statements.length && this.isDirectiveCandidate(statements[i]); ++i) {
+    statements[i].directive = statements[i].expression.raw.slice(1, -1);
+  }
+};
+pp$8.isDirectiveCandidate = function(statement) {
+  return this.options.ecmaVersion >= 5 && statement.type === "ExpressionStatement" && statement.expression.type === "Literal" && typeof statement.expression.value === "string" && (this.input[statement.start] === '"' || this.input[statement.start] === "'");
+};
+var pp$7 = Parser.prototype;
+pp$7.toAssignable = function(node, isBinding, refDestructuringErrors) {
+  if (this.options.ecmaVersion >= 6 && node) {
+    switch (node.type) {
+      case "Identifier":
+        if (this.inAsync && node.name === "await") {
+          this.raise(node.start, "Cannot use 'await' as identifier inside an async function");
+        }
+        break;
+      case "ObjectPattern":
+      case "ArrayPattern":
+      case "AssignmentPattern":
+      case "RestElement":
+        break;
+      case "ObjectExpression":
+        node.type = "ObjectPattern";
+        if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        for (var i = 0, list = node.properties; i < list.length; i += 1) {
+          var prop = list[i];
+          this.toAssignable(prop, isBinding);
+          if (prop.type === "RestElement" && (prop.argument.type === "ArrayPattern" || prop.argument.type === "ObjectPattern")) {
+            this.raise(prop.argument.start, "Unexpected token");
+          }
+        }
+        break;
+      case "Property":
+        if (node.kind !== "init") {
+          this.raise(node.key.start, "Object pattern can't contain getter or setter");
+        }
+        this.toAssignable(node.value, isBinding);
+        break;
+      case "ArrayExpression":
+        node.type = "ArrayPattern";
+        if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        this.toAssignableList(node.elements, isBinding);
+        break;
+      case "SpreadElement":
+        node.type = "RestElement";
+        this.toAssignable(node.argument, isBinding);
+        if (node.argument.type === "AssignmentPattern") {
+          this.raise(node.argument.start, "Rest elements cannot have a default value");
+        }
+        break;
+      case "AssignmentExpression":
+        if (node.operator !== "=") {
+          this.raise(node.left.end, "Only '=' operator can be used for specifying default value.");
+        }
+        node.type = "AssignmentPattern";
+        delete node.operator;
+        this.toAssignable(node.left, isBinding);
+        break;
+      case "ParenthesizedExpression":
+        this.toAssignable(node.expression, isBinding, refDestructuringErrors);
+        break;
+      case "ChainExpression":
+        this.raiseRecoverable(node.start, "Optional chaining cannot appear in left-hand side");
+        break;
+      case "MemberExpression":
+        if (!isBinding) {
+          break;
+        }
+      default:
+        this.raise(node.start, "Assigning to rvalue");
+    }
+  } else if (refDestructuringErrors) {
+    this.checkPatternErrors(refDestructuringErrors, true);
+  }
+  return node;
+};
+pp$7.toAssignableList = function(exprList, isBinding) {
+  var end = exprList.length;
+  for (var i = 0; i < end; i++) {
+    var elt = exprList[i];
+    if (elt) {
+      this.toAssignable(elt, isBinding);
+    }
+  }
+  if (end) {
+    var last = exprList[end - 1];
+    if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier") {
+      this.unexpected(last.argument.start);
+    }
+  }
+  return exprList;
+};
+pp$7.parseSpread = function(refDestructuringErrors) {
+  var node = this.startNode();
+  this.next();
+  node.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+  return this.finishNode(node, "SpreadElement");
+};
+pp$7.parseRestBinding = function() {
+  var node = this.startNode();
+  this.next();
+  if (this.options.ecmaVersion === 6 && this.type !== types$1.name) {
+    this.unexpected();
+  }
+  node.argument = this.parseBindingAtom();
+  return this.finishNode(node, "RestElement");
+};
+pp$7.parseBindingAtom = function() {
+  if (this.options.ecmaVersion >= 6) {
+    switch (this.type) {
+      case types$1.bracketL:
+        var node = this.startNode();
+        this.next();
+        node.elements = this.parseBindingList(types$1.bracketR, true, true);
+        return this.finishNode(node, "ArrayPattern");
+      case types$1.braceL:
+        return this.parseObj(true);
+    }
+  }
+  return this.parseIdent();
+};
+pp$7.parseBindingList = function(close, allowEmpty, allowTrailingComma) {
+  var elts = [], first = true;
+  while (!this.eat(close)) {
+    if (first) {
+      first = false;
+    } else {
+      this.expect(types$1.comma);
+    }
+    if (allowEmpty && this.type === types$1.comma) {
+      elts.push(null);
+    } else if (allowTrailingComma && this.afterTrailingComma(close)) {
+      break;
+    } else if (this.type === types$1.ellipsis) {
+      var rest = this.parseRestBinding();
+      this.parseBindingListItem(rest);
+      elts.push(rest);
+      if (this.type === types$1.comma) {
+        this.raise(this.start, "Comma is not permitted after the rest element");
+      }
+      this.expect(close);
+      break;
+    } else {
+      var elem = this.parseMaybeDefault(this.start, this.startLoc);
+      this.parseBindingListItem(elem);
+      elts.push(elem);
+    }
+  }
+  return elts;
+};
+pp$7.parseBindingListItem = function(param) {
+  return param;
+};
+pp$7.parseMaybeDefault = function(startPos, startLoc, left) {
+  left = left || this.parseBindingAtom();
+  if (this.options.ecmaVersion < 6 || !this.eat(types$1.eq)) {
+    return left;
+  }
+  var node = this.startNodeAt(startPos, startLoc);
+  node.left = left;
+  node.right = this.parseMaybeAssign();
+  return this.finishNode(node, "AssignmentPattern");
+};
+pp$7.checkLValSimple = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0)
+    bindingType = BIND_NONE;
+  var isBind = bindingType !== BIND_NONE;
+  switch (expr.type) {
+    case "Identifier":
+      if (this.strict && this.reservedWordsStrictBind.test(expr.name)) {
+        this.raiseRecoverable(expr.start, (isBind ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+      }
+      if (isBind) {
+        if (bindingType === BIND_LEXICAL && expr.name === "let") {
+          this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name");
+        }
+        if (checkClashes) {
+          if (hasOwn(checkClashes, expr.name)) {
+            this.raiseRecoverable(expr.start, "Argument name clash");
+          }
+          checkClashes[expr.name] = true;
+        }
+        if (bindingType !== BIND_OUTSIDE) {
+          this.declareName(expr.name, bindingType, expr.start);
+        }
+      }
+      break;
+    case "ChainExpression":
+      this.raiseRecoverable(expr.start, "Optional chaining cannot appear in left-hand side");
+      break;
+    case "MemberExpression":
+      if (isBind) {
+        this.raiseRecoverable(expr.start, "Binding member expression");
+      }
+      break;
+    case "ParenthesizedExpression":
+      if (isBind) {
+        this.raiseRecoverable(expr.start, "Binding parenthesized expression");
+      }
+      return this.checkLValSimple(expr.expression, bindingType, checkClashes);
+    default:
+      this.raise(expr.start, (isBind ? "Binding" : "Assigning to") + " rvalue");
+  }
+};
+pp$7.checkLValPattern = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0)
+    bindingType = BIND_NONE;
+  switch (expr.type) {
+    case "ObjectPattern":
+      for (var i = 0, list = expr.properties; i < list.length; i += 1) {
+        var prop = list[i];
+        this.checkLValInnerPattern(prop, bindingType, checkClashes);
+      }
+      break;
+    case "ArrayPattern":
+      for (var i$1 = 0, list$1 = expr.elements; i$1 < list$1.length; i$1 += 1) {
+        var elem = list$1[i$1];
+        if (elem) {
+          this.checkLValInnerPattern(elem, bindingType, checkClashes);
+        }
+      }
+      break;
+    default:
+      this.checkLValSimple(expr, bindingType, checkClashes);
+  }
+};
+pp$7.checkLValInnerPattern = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0)
+    bindingType = BIND_NONE;
+  switch (expr.type) {
+    case "Property":
+      this.checkLValInnerPattern(expr.value, bindingType, checkClashes);
+      break;
+    case "AssignmentPattern":
+      this.checkLValPattern(expr.left, bindingType, checkClashes);
+      break;
+    case "RestElement":
+      this.checkLValPattern(expr.argument, bindingType, checkClashes);
+      break;
+    default:
+      this.checkLValPattern(expr, bindingType, checkClashes);
+  }
+};
+var TokContext = function TokContext2(token, isExpr, preserveSpace, override, generator) {
+  this.token = token;
+  this.isExpr = !!isExpr;
+  this.preserveSpace = !!preserveSpace;
+  this.override = override;
+  this.generator = !!generator;
+};
+var types = {
+  b_stat: new TokContext("{", false),
+  b_expr: new TokContext("{", true),
+  b_tmpl: new TokContext("${", false),
+  p_stat: new TokContext("(", false),
+  p_expr: new TokContext("(", true),
+  q_tmpl: new TokContext("`", true, true, function(p) {
+    return p.tryReadTemplateToken();
+  }),
+  f_stat: new TokContext("function", false),
+  f_expr: new TokContext("function", true),
+  f_expr_gen: new TokContext("function", true, false, null, true),
+  f_gen: new TokContext("function", false, false, null, true)
+};
+var pp$6 = Parser.prototype;
+pp$6.initialContext = function() {
+  return [types.b_stat];
+};
+pp$6.curContext = function() {
+  return this.context[this.context.length - 1];
+};
+pp$6.braceIsBlock = function(prevType) {
+  var parent = this.curContext();
+  if (parent === types.f_expr || parent === types.f_stat) {
+    return true;
+  }
+  if (prevType === types$1.colon && (parent === types.b_stat || parent === types.b_expr)) {
+    return !parent.isExpr;
+  }
+  if (prevType === types$1._return || prevType === types$1.name && this.exprAllowed) {
+    return lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+  }
+  if (prevType === types$1._else || prevType === types$1.semi || prevType === types$1.eof || prevType === types$1.parenR || prevType === types$1.arrow) {
+    return true;
+  }
+  if (prevType === types$1.braceL) {
+    return parent === types.b_stat;
+  }
+  if (prevType === types$1._var || prevType === types$1._const || prevType === types$1.name) {
+    return false;
+  }
+  return !this.exprAllowed;
+};
+pp$6.inGeneratorContext = function() {
+  for (var i = this.context.length - 1; i >= 1; i--) {
+    var context = this.context[i];
+    if (context.token === "function") {
+      return context.generator;
+    }
+  }
+  return false;
+};
+pp$6.updateContext = function(prevType) {
+  var update, type = this.type;
+  if (type.keyword && prevType === types$1.dot) {
+    this.exprAllowed = false;
+  } else if (update = type.updateContext) {
+    update.call(this, prevType);
+  } else {
+    this.exprAllowed = type.beforeExpr;
+  }
+};
+pp$6.overrideContext = function(tokenCtx) {
+  if (this.curContext() !== tokenCtx) {
+    this.context[this.context.length - 1] = tokenCtx;
+  }
+};
+types$1.parenR.updateContext = types$1.braceR.updateContext = function() {
+  if (this.context.length === 1) {
+    this.exprAllowed = true;
+    return;
+  }
+  var out = this.context.pop();
+  if (out === types.b_stat && this.curContext().token === "function") {
+    out = this.context.pop();
+  }
+  this.exprAllowed = !out.isExpr;
+};
+types$1.braceL.updateContext = function(prevType) {
+  this.context.push(this.braceIsBlock(prevType) ? types.b_stat : types.b_expr);
+  this.exprAllowed = true;
+};
+types$1.dollarBraceL.updateContext = function() {
+  this.context.push(types.b_tmpl);
+  this.exprAllowed = true;
+};
+types$1.parenL.updateContext = function(prevType) {
+  var statementParens = prevType === types$1._if || prevType === types$1._for || prevType === types$1._with || prevType === types$1._while;
+  this.context.push(statementParens ? types.p_stat : types.p_expr);
+  this.exprAllowed = true;
+};
+types$1.incDec.updateContext = function() {
+};
+types$1._function.updateContext = types$1._class.updateContext = function(prevType) {
+  if (prevType.beforeExpr && prevType !== types$1._else && !(prevType === types$1.semi && this.curContext() !== types.p_stat) && !(prevType === types$1._return && lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) && !((prevType === types$1.colon || prevType === types$1.braceL) && this.curContext() === types.b_stat)) {
+    this.context.push(types.f_expr);
+  } else {
+    this.context.push(types.f_stat);
+  }
+  this.exprAllowed = false;
+};
+types$1.backQuote.updateContext = function() {
+  if (this.curContext() === types.q_tmpl) {
+    this.context.pop();
+  } else {
+    this.context.push(types.q_tmpl);
+  }
+  this.exprAllowed = false;
+};
+types$1.star.updateContext = function(prevType) {
+  if (prevType === types$1._function) {
+    var index2 = this.context.length - 1;
+    if (this.context[index2] === types.f_expr) {
+      this.context[index2] = types.f_expr_gen;
+    } else {
+      this.context[index2] = types.f_gen;
+    }
+  }
+  this.exprAllowed = true;
+};
+types$1.name.updateContext = function(prevType) {
+  var allowed = false;
+  if (this.options.ecmaVersion >= 6 && prevType !== types$1.dot) {
+    if (this.value === "of" && !this.exprAllowed || this.value === "yield" && this.inGeneratorContext()) {
+      allowed = true;
+    }
+  }
+  this.exprAllowed = allowed;
+};
+var pp$5 = Parser.prototype;
+pp$5.checkPropClash = function(prop, propHash, refDestructuringErrors) {
+  if (this.options.ecmaVersion >= 9 && prop.type === "SpreadElement") {
+    return;
+  }
+  if (this.options.ecmaVersion >= 6 && (prop.computed || prop.method || prop.shorthand)) {
+    return;
+  }
+  var key = prop.key;
+  var name;
+  switch (key.type) {
+    case "Identifier":
+      name = key.name;
+      break;
+    case "Literal":
+      name = String(key.value);
+      break;
+    default:
+      return;
+  }
+  var kind = prop.kind;
+  if (this.options.ecmaVersion >= 6) {
+    if (name === "__proto__" && kind === "init") {
+      if (propHash.proto) {
+        if (refDestructuringErrors) {
+          if (refDestructuringErrors.doubleProto < 0) {
+            refDestructuringErrors.doubleProto = key.start;
+          }
+        } else {
+          this.raiseRecoverable(key.start, "Redefinition of __proto__ property");
+        }
+      }
+      propHash.proto = true;
+    }
+    return;
+  }
+  name = "$" + name;
+  var other = propHash[name];
+  if (other) {
+    var redefinition;
+    if (kind === "init") {
+      redefinition = this.strict && other.init || other.get || other.set;
+    } else {
+      redefinition = other.init || other[kind];
+    }
+    if (redefinition) {
+      this.raiseRecoverable(key.start, "Redefinition of property");
+    }
+  } else {
+    other = propHash[name] = {
+      init: false,
+      get: false,
+      set: false
+    };
+  }
+  other[kind] = true;
+};
+pp$5.parseExpression = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseMaybeAssign(forInit, refDestructuringErrors);
+  if (this.type === types$1.comma) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.expressions = [expr];
+    while (this.eat(types$1.comma)) {
+      node.expressions.push(this.parseMaybeAssign(forInit, refDestructuringErrors));
+    }
+    return this.finishNode(node, "SequenceExpression");
+  }
+  return expr;
+};
+pp$5.parseMaybeAssign = function(forInit, refDestructuringErrors, afterLeftParse) {
+  if (this.isContextual("yield")) {
+    if (this.inGenerator) {
+      return this.parseYield(forInit);
+    } else {
+      this.exprAllowed = false;
+    }
+  }
+  var ownDestructuringErrors = false, oldParenAssign = -1, oldTrailingComma = -1, oldDoubleProto = -1;
+  if (refDestructuringErrors) {
+    oldParenAssign = refDestructuringErrors.parenthesizedAssign;
+    oldTrailingComma = refDestructuringErrors.trailingComma;
+    oldDoubleProto = refDestructuringErrors.doubleProto;
+    refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = -1;
+  } else {
+    refDestructuringErrors = new DestructuringErrors();
+    ownDestructuringErrors = true;
+  }
+  var startPos = this.start, startLoc = this.startLoc;
+  if (this.type === types$1.parenL || this.type === types$1.name) {
+    this.potentialArrowAt = this.start;
+    this.potentialArrowInForAwait = forInit === "await";
+  }
+  var left = this.parseMaybeConditional(forInit, refDestructuringErrors);
+  if (afterLeftParse) {
+    left = afterLeftParse.call(this, left, startPos, startLoc);
+  }
+  if (this.type.isAssign) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.operator = this.value;
+    if (this.type === types$1.eq) {
+      left = this.toAssignable(left, false, refDestructuringErrors);
+    }
+    if (!ownDestructuringErrors) {
+      refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = refDestructuringErrors.doubleProto = -1;
+    }
+    if (refDestructuringErrors.shorthandAssign >= left.start) {
+      refDestructuringErrors.shorthandAssign = -1;
+    }
+    if (this.type === types$1.eq) {
+      this.checkLValPattern(left);
+    } else {
+      this.checkLValSimple(left);
+    }
+    node.left = left;
+    this.next();
+    node.right = this.parseMaybeAssign(forInit);
+    if (oldDoubleProto > -1) {
+      refDestructuringErrors.doubleProto = oldDoubleProto;
+    }
+    return this.finishNode(node, "AssignmentExpression");
+  } else {
+    if (ownDestructuringErrors) {
+      this.checkExpressionErrors(refDestructuringErrors, true);
+    }
+  }
+  if (oldParenAssign > -1) {
+    refDestructuringErrors.parenthesizedAssign = oldParenAssign;
+  }
+  if (oldTrailingComma > -1) {
+    refDestructuringErrors.trailingComma = oldTrailingComma;
+  }
+  return left;
+};
+pp$5.parseMaybeConditional = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseExprOps(forInit, refDestructuringErrors);
+  if (this.checkExpressionErrors(refDestructuringErrors)) {
+    return expr;
+  }
+  if (this.eat(types$1.question)) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.test = expr;
+    node.consequent = this.parseMaybeAssign();
+    this.expect(types$1.colon);
+    node.alternate = this.parseMaybeAssign(forInit);
+    return this.finishNode(node, "ConditionalExpression");
+  }
+  return expr;
+};
+pp$5.parseExprOps = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseMaybeUnary(refDestructuringErrors, false, false, forInit);
+  if (this.checkExpressionErrors(refDestructuringErrors)) {
+    return expr;
+  }
+  return expr.start === startPos && expr.type === "ArrowFunctionExpression" ? expr : this.parseExprOp(expr, startPos, startLoc, -1, forInit);
+};
+pp$5.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, forInit) {
+  var prec = this.type.binop;
+  if (prec != null && (!forInit || this.type !== types$1._in)) {
+    if (prec > minPrec) {
+      var logical = this.type === types$1.logicalOR || this.type === types$1.logicalAND;
+      var coalesce = this.type === types$1.coalesce;
+      if (coalesce) {
+        prec = types$1.logicalAND.binop;
+      }
+      var op = this.value;
+      this.next();
+      var startPos = this.start, startLoc = this.startLoc;
+      var right = this.parseExprOp(this.parseMaybeUnary(null, false, false, forInit), startPos, startLoc, prec, forInit);
+      var node = this.buildBinary(leftStartPos, leftStartLoc, left, right, op, logical || coalesce);
+      if (logical && this.type === types$1.coalesce || coalesce && (this.type === types$1.logicalOR || this.type === types$1.logicalAND)) {
+        this.raiseRecoverable(this.start, "Logical expressions and coalesce expressions cannot be mixed. Wrap either by parentheses");
+      }
+      return this.parseExprOp(node, leftStartPos, leftStartLoc, minPrec, forInit);
+    }
+  }
+  return left;
+};
+pp$5.buildBinary = function(startPos, startLoc, left, right, op, logical) {
+  if (right.type === "PrivateIdentifier") {
+    this.raise(right.start, "Private identifier can only be left side of binary expression");
+  }
+  var node = this.startNodeAt(startPos, startLoc);
+  node.left = left;
+  node.operator = op;
+  node.right = right;
+  return this.finishNode(node, logical ? "LogicalExpression" : "BinaryExpression");
+};
+pp$5.parseMaybeUnary = function(refDestructuringErrors, sawUnary, incDec, forInit) {
+  var startPos = this.start, startLoc = this.startLoc, expr;
+  if (this.isContextual("await") && this.canAwait) {
+    expr = this.parseAwait(forInit);
+    sawUnary = true;
+  } else if (this.type.prefix) {
+    var node = this.startNode(), update = this.type === types$1.incDec;
+    node.operator = this.value;
+    node.prefix = true;
+    this.next();
+    node.argument = this.parseMaybeUnary(null, true, update, forInit);
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    if (update) {
+      this.checkLValSimple(node.argument);
+    } else if (this.strict && node.operator === "delete" && node.argument.type === "Identifier") {
+      this.raiseRecoverable(node.start, "Deleting local variable in strict mode");
+    } else if (node.operator === "delete" && isPrivateFieldAccess(node.argument)) {
+      this.raiseRecoverable(node.start, "Private fields can not be deleted");
+    } else {
+      sawUnary = true;
+    }
+    expr = this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
+  } else if (!sawUnary && this.type === types$1.privateId) {
+    if (forInit || this.privateNameStack.length === 0) {
+      this.unexpected();
+    }
+    expr = this.parsePrivateIdent();
+    if (this.type !== types$1._in) {
+      this.unexpected();
+    }
+  } else {
+    expr = this.parseExprSubscripts(refDestructuringErrors, forInit);
+    if (this.checkExpressionErrors(refDestructuringErrors)) {
+      return expr;
+    }
+    while (this.type.postfix && !this.canInsertSemicolon()) {
+      var node$1 = this.startNodeAt(startPos, startLoc);
+      node$1.operator = this.value;
+      node$1.prefix = false;
+      node$1.argument = expr;
+      this.checkLValSimple(expr);
+      this.next();
+      expr = this.finishNode(node$1, "UpdateExpression");
+    }
+  }
+  if (!incDec && this.eat(types$1.starstar)) {
+    if (sawUnary) {
+      this.unexpected(this.lastTokStart);
+    } else {
+      return this.buildBinary(startPos, startLoc, expr, this.parseMaybeUnary(null, false, false, forInit), "**", false);
+    }
+  } else {
+    return expr;
+  }
+};
+function isPrivateFieldAccess(node) {
+  return node.type === "MemberExpression" && node.property.type === "PrivateIdentifier" || node.type === "ChainExpression" && isPrivateFieldAccess(node.expression);
+}
+pp$5.parseExprSubscripts = function(refDestructuringErrors, forInit) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseExprAtom(refDestructuringErrors, forInit);
+  if (expr.type === "ArrowFunctionExpression" && this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")") {
+    return expr;
+  }
+  var result = this.parseSubscripts(expr, startPos, startLoc, false, forInit);
+  if (refDestructuringErrors && result.type === "MemberExpression") {
+    if (refDestructuringErrors.parenthesizedAssign >= result.start) {
+      refDestructuringErrors.parenthesizedAssign = -1;
+    }
+    if (refDestructuringErrors.parenthesizedBind >= result.start) {
+      refDestructuringErrors.parenthesizedBind = -1;
+    }
+    if (refDestructuringErrors.trailingComma >= result.start) {
+      refDestructuringErrors.trailingComma = -1;
+    }
+  }
+  return result;
+};
+pp$5.parseSubscripts = function(base, startPos, startLoc, noCalls, forInit) {
+  var maybeAsyncArrow = this.options.ecmaVersion >= 8 && base.type === "Identifier" && base.name === "async" && this.lastTokEnd === base.end && !this.canInsertSemicolon() && base.end - base.start === 5 && this.potentialArrowAt === base.start;
+  var optionalChained = false;
+  while (true) {
+    var element = this.parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit);
+    if (element.optional) {
+      optionalChained = true;
+    }
+    if (element === base || element.type === "ArrowFunctionExpression") {
+      if (optionalChained) {
+        var chainNode = this.startNodeAt(startPos, startLoc);
+        chainNode.expression = element;
+        element = this.finishNode(chainNode, "ChainExpression");
+      }
+      return element;
+    }
+    base = element;
+  }
+};
+pp$5.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
+  var optionalSupported = this.options.ecmaVersion >= 11;
+  var optional = optionalSupported && this.eat(types$1.questionDot);
+  if (noCalls && optional) {
+    this.raise(this.lastTokStart, "Optional chaining cannot appear in the callee of new expressions");
+  }
+  var computed = this.eat(types$1.bracketL);
+  if (computed || optional && this.type !== types$1.parenL && this.type !== types$1.backQuote || this.eat(types$1.dot)) {
+    var node = this.startNodeAt(startPos, startLoc);
+    node.object = base;
+    if (computed) {
+      node.property = this.parseExpression();
+      this.expect(types$1.bracketR);
+    } else if (this.type === types$1.privateId && base.type !== "Super") {
+      node.property = this.parsePrivateIdent();
+    } else {
+      node.property = this.parseIdent(this.options.allowReserved !== "never");
+    }
+    node.computed = !!computed;
+    if (optionalSupported) {
+      node.optional = optional;
+    }
+    base = this.finishNode(node, "MemberExpression");
+  } else if (!noCalls && this.eat(types$1.parenL)) {
+    var refDestructuringErrors = new DestructuringErrors(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+    this.yieldPos = 0;
+    this.awaitPos = 0;
+    this.awaitIdentPos = 0;
+    var exprList = this.parseExprList(types$1.parenR, this.options.ecmaVersion >= 8, false, refDestructuringErrors);
+    if (maybeAsyncArrow && !optional && !this.canInsertSemicolon() && this.eat(types$1.arrow)) {
+      this.checkPatternErrors(refDestructuringErrors, false);
+      this.checkYieldAwaitInDefaultParams();
+      if (this.awaitIdentPos > 0) {
+        this.raise(this.awaitIdentPos, "Cannot use 'await' as identifier inside an async function");
+      }
+      this.yieldPos = oldYieldPos;
+      this.awaitPos = oldAwaitPos;
+      this.awaitIdentPos = oldAwaitIdentPos;
+      return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, true, forInit);
+    }
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    this.yieldPos = oldYieldPos || this.yieldPos;
+    this.awaitPos = oldAwaitPos || this.awaitPos;
+    this.awaitIdentPos = oldAwaitIdentPos || this.awaitIdentPos;
+    var node$1 = this.startNodeAt(startPos, startLoc);
+    node$1.callee = base;
+    node$1.arguments = exprList;
+    if (optionalSupported) {
+      node$1.optional = optional;
+    }
+    base = this.finishNode(node$1, "CallExpression");
+  } else if (this.type === types$1.backQuote) {
+    if (optional || optionalChained) {
+      this.raise(this.start, "Optional chaining cannot appear in the tag of tagged template expressions");
+    }
+    var node$2 = this.startNodeAt(startPos, startLoc);
+    node$2.tag = base;
+    node$2.quasi = this.parseTemplate({ isTagged: true });
+    base = this.finishNode(node$2, "TaggedTemplateExpression");
+  }
+  return base;
+};
+pp$5.parseExprAtom = function(refDestructuringErrors, forInit) {
+  if (this.type === types$1.slash) {
+    this.readRegexp();
+  }
+  var node, canBeArrow = this.potentialArrowAt === this.start;
+  switch (this.type) {
+    case types$1._super:
+      if (!this.allowSuper) {
+        this.raise(this.start, "'super' keyword outside a method");
+      }
+      node = this.startNode();
+      this.next();
+      if (this.type === types$1.parenL && !this.allowDirectSuper) {
+        this.raise(node.start, "super() call outside constructor of a subclass");
+      }
+      if (this.type !== types$1.dot && this.type !== types$1.bracketL && this.type !== types$1.parenL) {
+        this.unexpected();
+      }
+      return this.finishNode(node, "Super");
+    case types$1._this:
+      node = this.startNode();
+      this.next();
+      return this.finishNode(node, "ThisExpression");
+    case types$1.name:
+      var startPos = this.start, startLoc = this.startLoc, containsEsc = this.containsEsc;
+      var id = this.parseIdent(false);
+      if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === "async" && !this.canInsertSemicolon() && this.eat(types$1._function)) {
+        this.overrideContext(types.f_expr);
+        return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true, forInit);
+      }
+      if (canBeArrow && !this.canInsertSemicolon()) {
+        if (this.eat(types$1.arrow)) {
+          return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false, forInit);
+        }
+        if (this.options.ecmaVersion >= 8 && id.name === "async" && this.type === types$1.name && !containsEsc && (!this.potentialArrowInForAwait || this.value !== "of" || this.containsEsc)) {
+          id = this.parseIdent(false);
+          if (this.canInsertSemicolon() || !this.eat(types$1.arrow)) {
+            this.unexpected();
+          }
+          return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true, forInit);
+        }
+      }
+      return id;
+    case types$1.regexp:
+      var value = this.value;
+      node = this.parseLiteral(value.value);
+      node.regex = { pattern: value.pattern, flags: value.flags };
+      return node;
+    case types$1.num:
+    case types$1.string:
+      return this.parseLiteral(this.value);
+    case types$1._null:
+    case types$1._true:
+    case types$1._false:
+      node = this.startNode();
+      node.value = this.type === types$1._null ? null : this.type === types$1._true;
+      node.raw = this.type.keyword;
+      this.next();
+      return this.finishNode(node, "Literal");
+    case types$1.parenL:
+      var start3 = this.start, expr = this.parseParenAndDistinguishExpression(canBeArrow, forInit);
+      if (refDestructuringErrors) {
+        if (refDestructuringErrors.parenthesizedAssign < 0 && !this.isSimpleAssignTarget(expr)) {
+          refDestructuringErrors.parenthesizedAssign = start3;
+        }
+        if (refDestructuringErrors.parenthesizedBind < 0) {
+          refDestructuringErrors.parenthesizedBind = start3;
+        }
+      }
+      return expr;
+    case types$1.bracketL:
+      node = this.startNode();
+      this.next();
+      node.elements = this.parseExprList(types$1.bracketR, true, true, refDestructuringErrors);
+      return this.finishNode(node, "ArrayExpression");
+    case types$1.braceL:
+      this.overrideContext(types.b_expr);
+      return this.parseObj(false, refDestructuringErrors);
+    case types$1._function:
+      node = this.startNode();
+      this.next();
+      return this.parseFunction(node, 0);
+    case types$1._class:
+      return this.parseClass(this.startNode(), false);
+    case types$1._new:
+      return this.parseNew();
+    case types$1.backQuote:
+      return this.parseTemplate();
+    case types$1._import:
+      if (this.options.ecmaVersion >= 11) {
+        return this.parseExprImport();
+      } else {
+        return this.unexpected();
+      }
+    default:
+      this.unexpected();
+  }
+};
+pp$5.parseExprImport = function() {
+  var node = this.startNode();
+  if (this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword import");
+  }
+  var meta = this.parseIdent(true);
+  switch (this.type) {
+    case types$1.parenL:
+      return this.parseDynamicImport(node);
+    case types$1.dot:
+      node.meta = meta;
+      return this.parseImportMeta(node);
+    default:
+      this.unexpected();
+  }
+};
+pp$5.parseDynamicImport = function(node) {
+  this.next();
+  node.source = this.parseMaybeAssign();
+  if (!this.eat(types$1.parenR)) {
+    var errorPos = this.start;
+    if (this.eat(types$1.comma) && this.eat(types$1.parenR)) {
+      this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+    } else {
+      this.unexpected(errorPos);
+    }
+  }
+  return this.finishNode(node, "ImportExpression");
+};
+pp$5.parseImportMeta = function(node) {
+  this.next();
+  var containsEsc = this.containsEsc;
+  node.property = this.parseIdent(true);
+  if (node.property.name !== "meta") {
+    this.raiseRecoverable(node.property.start, "The only valid meta property for import is 'import.meta'");
+  }
+  if (containsEsc) {
+    this.raiseRecoverable(node.start, "'import.meta' must not contain escaped characters");
+  }
+  if (this.options.sourceType !== "module" && !this.options.allowImportExportEverywhere) {
+    this.raiseRecoverable(node.start, "Cannot use 'import.meta' outside a module");
+  }
+  return this.finishNode(node, "MetaProperty");
+};
+pp$5.parseLiteral = function(value) {
+  var node = this.startNode();
+  node.value = value;
+  node.raw = this.input.slice(this.start, this.end);
+  if (node.raw.charCodeAt(node.raw.length - 1) === 110) {
+    node.bigint = node.raw.slice(0, -1).replace(/_/g, "");
+  }
+  this.next();
+  return this.finishNode(node, "Literal");
+};
+pp$5.parseParenExpression = function() {
+  this.expect(types$1.parenL);
+  var val = this.parseExpression();
+  this.expect(types$1.parenR);
+  return val;
+};
+pp$5.parseParenAndDistinguishExpression = function(canBeArrow, forInit) {
+  var startPos = this.start, startLoc = this.startLoc, val, allowTrailingComma = this.options.ecmaVersion >= 8;
+  if (this.options.ecmaVersion >= 6) {
+    this.next();
+    var innerStartPos = this.start, innerStartLoc = this.startLoc;
+    var exprList = [], first = true, lastIsComma = false;
+    var refDestructuringErrors = new DestructuringErrors(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, spreadStart;
+    this.yieldPos = 0;
+    this.awaitPos = 0;
+    while (this.type !== types$1.parenR) {
+      first ? first = false : this.expect(types$1.comma);
+      if (allowTrailingComma && this.afterTrailingComma(types$1.parenR, true)) {
+        lastIsComma = true;
+        break;
+      } else if (this.type === types$1.ellipsis) {
+        spreadStart = this.start;
+        exprList.push(this.parseParenItem(this.parseRestBinding()));
+        if (this.type === types$1.comma) {
+          this.raise(this.start, "Comma is not permitted after the rest element");
+        }
+        break;
+      } else {
+        exprList.push(this.parseMaybeAssign(false, refDestructuringErrors, this.parseParenItem));
+      }
+    }
+    var innerEndPos = this.lastTokEnd, innerEndLoc = this.lastTokEndLoc;
+    this.expect(types$1.parenR);
+    if (canBeArrow && !this.canInsertSemicolon() && this.eat(types$1.arrow)) {
+      this.checkPatternErrors(refDestructuringErrors, false);
+      this.checkYieldAwaitInDefaultParams();
+      this.yieldPos = oldYieldPos;
+      this.awaitPos = oldAwaitPos;
+      return this.parseParenArrowList(startPos, startLoc, exprList, forInit);
+    }
+    if (!exprList.length || lastIsComma) {
+      this.unexpected(this.lastTokStart);
+    }
+    if (spreadStart) {
+      this.unexpected(spreadStart);
+    }
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    this.yieldPos = oldYieldPos || this.yieldPos;
+    this.awaitPos = oldAwaitPos || this.awaitPos;
+    if (exprList.length > 1) {
+      val = this.startNodeAt(innerStartPos, innerStartLoc);
+      val.expressions = exprList;
+      this.finishNodeAt(val, "SequenceExpression", innerEndPos, innerEndLoc);
+    } else {
+      val = exprList[0];
+    }
+  } else {
+    val = this.parseParenExpression();
+  }
+  if (this.options.preserveParens) {
+    var par = this.startNodeAt(startPos, startLoc);
+    par.expression = val;
+    return this.finishNode(par, "ParenthesizedExpression");
+  } else {
+    return val;
+  }
+};
+pp$5.parseParenItem = function(item) {
+  return item;
+};
+pp$5.parseParenArrowList = function(startPos, startLoc, exprList, forInit) {
+  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, false, forInit);
+};
+var empty = [];
+pp$5.parseNew = function() {
+  if (this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword new");
+  }
+  var node = this.startNode();
+  var meta = this.parseIdent(true);
+  if (this.options.ecmaVersion >= 6 && this.eat(types$1.dot)) {
+    node.meta = meta;
+    var containsEsc = this.containsEsc;
+    node.property = this.parseIdent(true);
+    if (node.property.name !== "target") {
+      this.raiseRecoverable(node.property.start, "The only valid meta property for new is 'new.target'");
+    }
+    if (containsEsc) {
+      this.raiseRecoverable(node.start, "'new.target' must not contain escaped characters");
+    }
+    if (!this.allowNewDotTarget) {
+      this.raiseRecoverable(node.start, "'new.target' can only be used in functions and class static block");
+    }
+    return this.finishNode(node, "MetaProperty");
+  }
+  var startPos = this.start, startLoc = this.startLoc, isImport = this.type === types$1._import;
+  node.callee = this.parseSubscripts(this.parseExprAtom(), startPos, startLoc, true, false);
+  if (isImport && node.callee.type === "ImportExpression") {
+    this.raise(startPos, "Cannot use new with import()");
+  }
+  if (this.eat(types$1.parenL)) {
+    node.arguments = this.parseExprList(types$1.parenR, this.options.ecmaVersion >= 8, false);
+  } else {
+    node.arguments = empty;
+  }
+  return this.finishNode(node, "NewExpression");
+};
+pp$5.parseTemplateElement = function(ref2) {
+  var isTagged = ref2.isTagged;
+  var elem = this.startNode();
+  if (this.type === types$1.invalidTemplate) {
+    if (!isTagged) {
+      this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal");
+    }
+    elem.value = {
+      raw: this.value,
+      cooked: null
+    };
+  } else {
+    elem.value = {
+      raw: this.input.slice(this.start, this.end).replace(/\r\n?/g, "\n"),
+      cooked: this.value
+    };
+  }
+  this.next();
+  elem.tail = this.type === types$1.backQuote;
+  return this.finishNode(elem, "TemplateElement");
+};
+pp$5.parseTemplate = function(ref2) {
+  if (ref2 === void 0)
+    ref2 = {};
+  var isTagged = ref2.isTagged;
+  if (isTagged === void 0)
+    isTagged = false;
+  var node = this.startNode();
+  this.next();
+  node.expressions = [];
+  var curElt = this.parseTemplateElement({ isTagged });
+  node.quasis = [curElt];
+  while (!curElt.tail) {
+    if (this.type === types$1.eof) {
+      this.raise(this.pos, "Unterminated template literal");
+    }
+    this.expect(types$1.dollarBraceL);
+    node.expressions.push(this.parseExpression());
+    this.expect(types$1.braceR);
+    node.quasis.push(curElt = this.parseTemplateElement({ isTagged }));
+  }
+  this.next();
+  return this.finishNode(node, "TemplateLiteral");
+};
+pp$5.isAsyncProp = function(prop) {
+  return !prop.computed && prop.key.type === "Identifier" && prop.key.name === "async" && (this.type === types$1.name || this.type === types$1.num || this.type === types$1.string || this.type === types$1.bracketL || this.type.keyword || this.options.ecmaVersion >= 9 && this.type === types$1.star) && !lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+};
+pp$5.parseObj = function(isPattern, refDestructuringErrors) {
+  var node = this.startNode(), first = true, propHash = {};
+  node.properties = [];
+  this.next();
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.options.ecmaVersion >= 5 && this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var prop = this.parseProperty(isPattern, refDestructuringErrors);
+    if (!isPattern) {
+      this.checkPropClash(prop, propHash, refDestructuringErrors);
+    }
+    node.properties.push(prop);
+  }
+  return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
+};
+pp$5.parseProperty = function(isPattern, refDestructuringErrors) {
+  var prop = this.startNode(), isGenerator, isAsync, startPos, startLoc;
+  if (this.options.ecmaVersion >= 9 && this.eat(types$1.ellipsis)) {
+    if (isPattern) {
+      prop.argument = this.parseIdent(false);
+      if (this.type === types$1.comma) {
+        this.raise(this.start, "Comma is not permitted after the rest element");
+      }
+      return this.finishNode(prop, "RestElement");
+    }
+    prop.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+    if (this.type === types$1.comma && refDestructuringErrors && refDestructuringErrors.trailingComma < 0) {
+      refDestructuringErrors.trailingComma = this.start;
+    }
+    return this.finishNode(prop, "SpreadElement");
+  }
+  if (this.options.ecmaVersion >= 6) {
+    prop.method = false;
+    prop.shorthand = false;
+    if (isPattern || refDestructuringErrors) {
+      startPos = this.start;
+      startLoc = this.startLoc;
+    }
+    if (!isPattern) {
+      isGenerator = this.eat(types$1.star);
+    }
+  }
+  var containsEsc = this.containsEsc;
+  this.parsePropertyName(prop);
+  if (!isPattern && !containsEsc && this.options.ecmaVersion >= 8 && !isGenerator && this.isAsyncProp(prop)) {
+    isAsync = true;
+    isGenerator = this.options.ecmaVersion >= 9 && this.eat(types$1.star);
+    this.parsePropertyName(prop, refDestructuringErrors);
+  } else {
+    isAsync = false;
+  }
+  this.parsePropertyValue(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc);
+  return this.finishNode(prop, "Property");
+};
+pp$5.parsePropertyValue = function(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc) {
+  if ((isGenerator || isAsync) && this.type === types$1.colon) {
+    this.unexpected();
+  }
+  if (this.eat(types$1.colon)) {
+    prop.value = isPattern ? this.parseMaybeDefault(this.start, this.startLoc) : this.parseMaybeAssign(false, refDestructuringErrors);
+    prop.kind = "init";
+  } else if (this.options.ecmaVersion >= 6 && this.type === types$1.parenL) {
+    if (isPattern) {
+      this.unexpected();
+    }
+    prop.kind = "init";
+    prop.method = true;
+    prop.value = this.parseMethod(isGenerator, isAsync);
+  } else if (!isPattern && !containsEsc && this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type !== types$1.comma && this.type !== types$1.braceR && this.type !== types$1.eq)) {
+    if (isGenerator || isAsync) {
+      this.unexpected();
+    }
+    prop.kind = prop.key.name;
+    this.parsePropertyName(prop);
+    prop.value = this.parseMethod(false);
+    var paramCount = prop.kind === "get" ? 0 : 1;
+    if (prop.value.params.length !== paramCount) {
+      var start3 = prop.value.start;
+      if (prop.kind === "get") {
+        this.raiseRecoverable(start3, "getter should have no params");
+      } else {
+        this.raiseRecoverable(start3, "setter should have exactly one param");
+      }
+    } else {
+      if (prop.kind === "set" && prop.value.params[0].type === "RestElement") {
+        this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params");
+      }
+    }
+  } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+    if (isGenerator || isAsync) {
+      this.unexpected();
+    }
+    this.checkUnreserved(prop.key);
+    if (prop.key.name === "await" && !this.awaitIdentPos) {
+      this.awaitIdentPos = startPos;
+    }
+    prop.kind = "init";
+    if (isPattern) {
+      prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+    } else if (this.type === types$1.eq && refDestructuringErrors) {
+      if (refDestructuringErrors.shorthandAssign < 0) {
+        refDestructuringErrors.shorthandAssign = this.start;
+      }
+      prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+    } else {
+      prop.value = this.copyNode(prop.key);
+    }
+    prop.shorthand = true;
+  } else {
+    this.unexpected();
+  }
+};
+pp$5.parsePropertyName = function(prop) {
+  if (this.options.ecmaVersion >= 6) {
+    if (this.eat(types$1.bracketL)) {
+      prop.computed = true;
+      prop.key = this.parseMaybeAssign();
+      this.expect(types$1.bracketR);
+      return prop.key;
+    } else {
+      prop.computed = false;
+    }
+  }
+  return prop.key = this.type === types$1.num || this.type === types$1.string ? this.parseExprAtom() : this.parseIdent(this.options.allowReserved !== "never");
+};
+pp$5.initFunction = function(node) {
+  node.id = null;
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = node.expression = false;
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node.async = false;
+  }
+};
+pp$5.parseMethod = function(isGenerator, isAsync, allowDirectSuper) {
+  var node = this.startNode(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 6) {
+    node.generator = isGenerator;
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node.async = !!isAsync;
+  }
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  this.enterScope(functionFlags(isAsync, node.generator) | SCOPE_SUPER | (allowDirectSuper ? SCOPE_DIRECT_SUPER : 0));
+  this.expect(types$1.parenL);
+  node.params = this.parseBindingList(types$1.parenR, false, this.options.ecmaVersion >= 8);
+  this.checkYieldAwaitInDefaultParams();
+  this.parseFunctionBody(node, false, true, false);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node, "FunctionExpression");
+};
+pp$5.parseArrowExpression = function(node, params, isAsync, forInit) {
+  var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.enterScope(functionFlags(isAsync, false) | SCOPE_ARROW);
+  this.initFunction(node);
+  if (this.options.ecmaVersion >= 8) {
+    node.async = !!isAsync;
+  }
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  node.params = this.toAssignableList(params, true);
+  this.parseFunctionBody(node, true, false, forInit);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node, "ArrowFunctionExpression");
+};
+pp$5.parseFunctionBody = function(node, isArrowFunction, isMethod, forInit) {
+  var isExpression = isArrowFunction && this.type !== types$1.braceL;
+  var oldStrict = this.strict, useStrict = false;
+  if (isExpression) {
+    node.body = this.parseMaybeAssign(forInit);
+    node.expression = true;
+    this.checkParams(node, false);
+  } else {
+    var nonSimple = this.options.ecmaVersion >= 7 && !this.isSimpleParamList(node.params);
+    if (!oldStrict || nonSimple) {
+      useStrict = this.strictDirective(this.end);
+      if (useStrict && nonSimple) {
+        this.raiseRecoverable(node.start, "Illegal 'use strict' directive in function with non-simple parameter list");
+      }
+    }
+    var oldLabels = this.labels;
+    this.labels = [];
+    if (useStrict) {
+      this.strict = true;
+    }
+    this.checkParams(node, !oldStrict && !useStrict && !isArrowFunction && !isMethod && this.isSimpleParamList(node.params));
+    if (this.strict && node.id) {
+      this.checkLValSimple(node.id, BIND_OUTSIDE);
+    }
+    node.body = this.parseBlock(false, void 0, useStrict && !oldStrict);
+    node.expression = false;
+    this.adaptDirectivePrologue(node.body.body);
+    this.labels = oldLabels;
+  }
+  this.exitScope();
+};
+pp$5.isSimpleParamList = function(params) {
+  for (var i = 0, list = params; i < list.length; i += 1) {
+    var param = list[i];
+    if (param.type !== "Identifier") {
+      return false;
+    }
+  }
+  return true;
+};
+pp$5.checkParams = function(node, allowDuplicates) {
+  var nameHash = /* @__PURE__ */ Object.create(null);
+  for (var i = 0, list = node.params; i < list.length; i += 1) {
+    var param = list[i];
+    this.checkLValInnerPattern(param, BIND_VAR, allowDuplicates ? null : nameHash);
+  }
+};
+pp$5.parseExprList = function(close, allowTrailingComma, allowEmpty, refDestructuringErrors) {
+  var elts = [], first = true;
+  while (!this.eat(close)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (allowTrailingComma && this.afterTrailingComma(close)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var elt = void 0;
+    if (allowEmpty && this.type === types$1.comma) {
+      elt = null;
+    } else if (this.type === types$1.ellipsis) {
+      elt = this.parseSpread(refDestructuringErrors);
+      if (refDestructuringErrors && this.type === types$1.comma && refDestructuringErrors.trailingComma < 0) {
+        refDestructuringErrors.trailingComma = this.start;
+      }
+    } else {
+      elt = this.parseMaybeAssign(false, refDestructuringErrors);
+    }
+    elts.push(elt);
+  }
+  return elts;
+};
+pp$5.checkUnreserved = function(ref2) {
+  var start3 = ref2.start;
+  var end = ref2.end;
+  var name = ref2.name;
+  if (this.inGenerator && name === "yield") {
+    this.raiseRecoverable(start3, "Cannot use 'yield' as identifier inside a generator");
+  }
+  if (this.inAsync && name === "await") {
+    this.raiseRecoverable(start3, "Cannot use 'await' as identifier inside an async function");
+  }
+  if (this.currentThisScope().inClassFieldInit && name === "arguments") {
+    this.raiseRecoverable(start3, "Cannot use 'arguments' in class field initializer");
+  }
+  if (this.inClassStaticBlock && (name === "arguments" || name === "await")) {
+    this.raise(start3, "Cannot use " + name + " in class static initialization block");
+  }
+  if (this.keywords.test(name)) {
+    this.raise(start3, "Unexpected keyword '" + name + "'");
+  }
+  if (this.options.ecmaVersion < 6 && this.input.slice(start3, end).indexOf("\\") !== -1) {
+    return;
+  }
+  var re = this.strict ? this.reservedWordsStrict : this.reservedWords;
+  if (re.test(name)) {
+    if (!this.inAsync && name === "await") {
+      this.raiseRecoverable(start3, "Cannot use keyword 'await' outside an async function");
+    }
+    this.raiseRecoverable(start3, "The keyword '" + name + "' is reserved");
+  }
+};
+pp$5.parseIdent = function(liberal, isBinding) {
+  var node = this.startNode();
+  if (this.type === types$1.name) {
+    node.name = this.value;
+  } else if (this.type.keyword) {
+    node.name = this.type.keyword;
+    if ((node.name === "class" || node.name === "function") && (this.lastTokEnd !== this.lastTokStart + 1 || this.input.charCodeAt(this.lastTokStart) !== 46)) {
+      this.context.pop();
+    }
+  } else {
+    this.unexpected();
+  }
+  this.next(!!liberal);
+  this.finishNode(node, "Identifier");
+  if (!liberal) {
+    this.checkUnreserved(node);
+    if (node.name === "await" && !this.awaitIdentPos) {
+      this.awaitIdentPos = node.start;
+    }
+  }
+  return node;
+};
+pp$5.parsePrivateIdent = function() {
+  var node = this.startNode();
+  if (this.type === types$1.privateId) {
+    node.name = this.value;
+  } else {
+    this.unexpected();
+  }
+  this.next();
+  this.finishNode(node, "PrivateIdentifier");
+  if (this.privateNameStack.length === 0) {
+    this.raise(node.start, "Private field '#" + node.name + "' must be declared in an enclosing class");
+  } else {
+    this.privateNameStack[this.privateNameStack.length - 1].used.push(node);
+  }
+  return node;
+};
+pp$5.parseYield = function(forInit) {
+  if (!this.yieldPos) {
+    this.yieldPos = this.start;
+  }
+  var node = this.startNode();
+  this.next();
+  if (this.type === types$1.semi || this.canInsertSemicolon() || this.type !== types$1.star && !this.type.startsExpr) {
+    node.delegate = false;
+    node.argument = null;
+  } else {
+    node.delegate = this.eat(types$1.star);
+    node.argument = this.parseMaybeAssign(forInit);
+  }
+  return this.finishNode(node, "YieldExpression");
+};
+pp$5.parseAwait = function(forInit) {
+  if (!this.awaitPos) {
+    this.awaitPos = this.start;
+  }
+  var node = this.startNode();
+  this.next();
+  node.argument = this.parseMaybeUnary(null, true, false, forInit);
+  return this.finishNode(node, "AwaitExpression");
+};
+var pp$4 = Parser.prototype;
+pp$4.raise = function(pos, message) {
+  var loc = getLineInfo(this.input, pos);
+  message += " (" + loc.line + ":" + loc.column + ")";
+  var err = new SyntaxError(message);
+  err.pos = pos;
+  err.loc = loc;
+  err.raisedAt = this.pos;
+  throw err;
+};
+pp$4.raiseRecoverable = pp$4.raise;
+pp$4.curPosition = function() {
+  if (this.options.locations) {
+    return new Position(this.curLine, this.pos - this.lineStart);
+  }
+};
+var pp$3 = Parser.prototype;
+var Scope = function Scope2(flags) {
+  this.flags = flags;
+  this.var = [];
+  this.lexical = [];
+  this.functions = [];
+  this.inClassFieldInit = false;
+};
+pp$3.enterScope = function(flags) {
+  this.scopeStack.push(new Scope(flags));
+};
+pp$3.exitScope = function() {
+  this.scopeStack.pop();
+};
+pp$3.treatFunctionsAsVarInScope = function(scope) {
+  return scope.flags & SCOPE_FUNCTION || !this.inModule && scope.flags & SCOPE_TOP;
+};
+pp$3.declareName = function(name, bindingType, pos) {
+  var redeclared = false;
+  if (bindingType === BIND_LEXICAL) {
+    var scope = this.currentScope();
+    redeclared = scope.lexical.indexOf(name) > -1 || scope.functions.indexOf(name) > -1 || scope.var.indexOf(name) > -1;
+    scope.lexical.push(name);
+    if (this.inModule && scope.flags & SCOPE_TOP) {
+      delete this.undefinedExports[name];
+    }
+  } else if (bindingType === BIND_SIMPLE_CATCH) {
+    var scope$1 = this.currentScope();
+    scope$1.lexical.push(name);
+  } else if (bindingType === BIND_FUNCTION) {
+    var scope$2 = this.currentScope();
+    if (this.treatFunctionsAsVar) {
+      redeclared = scope$2.lexical.indexOf(name) > -1;
+    } else {
+      redeclared = scope$2.lexical.indexOf(name) > -1 || scope$2.var.indexOf(name) > -1;
+    }
+    scope$2.functions.push(name);
+  } else {
+    for (var i = this.scopeStack.length - 1; i >= 0; --i) {
+      var scope$3 = this.scopeStack[i];
+      if (scope$3.lexical.indexOf(name) > -1 && !(scope$3.flags & SCOPE_SIMPLE_CATCH && scope$3.lexical[0] === name) || !this.treatFunctionsAsVarInScope(scope$3) && scope$3.functions.indexOf(name) > -1) {
+        redeclared = true;
+        break;
+      }
+      scope$3.var.push(name);
+      if (this.inModule && scope$3.flags & SCOPE_TOP) {
+        delete this.undefinedExports[name];
+      }
+      if (scope$3.flags & SCOPE_VAR) {
+        break;
+      }
+    }
+  }
+  if (redeclared) {
+    this.raiseRecoverable(pos, "Identifier '" + name + "' has already been declared");
+  }
+};
+pp$3.checkLocalExport = function(id) {
+  if (this.scopeStack[0].lexical.indexOf(id.name) === -1 && this.scopeStack[0].var.indexOf(id.name) === -1) {
+    this.undefinedExports[id.name] = id;
+  }
+};
+pp$3.currentScope = function() {
+  return this.scopeStack[this.scopeStack.length - 1];
+};
+pp$3.currentVarScope = function() {
+  for (var i = this.scopeStack.length - 1; ; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.flags & SCOPE_VAR) {
+      return scope;
+    }
+  }
+};
+pp$3.currentThisScope = function() {
+  for (var i = this.scopeStack.length - 1; ; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.flags & SCOPE_VAR && !(scope.flags & SCOPE_ARROW)) {
+      return scope;
+    }
+  }
+};
+var Node = function Node2(parser, pos, loc) {
+  this.type = "";
+  this.start = pos;
+  this.end = 0;
+  if (parser.options.locations) {
+    this.loc = new SourceLocation(parser, loc);
+  }
+  if (parser.options.directSourceFile) {
+    this.sourceFile = parser.options.directSourceFile;
+  }
+  if (parser.options.ranges) {
+    this.range = [pos, 0];
+  }
+};
+var pp$2 = Parser.prototype;
+pp$2.startNode = function() {
+  return new Node(this, this.start, this.startLoc);
+};
+pp$2.startNodeAt = function(pos, loc) {
+  return new Node(this, pos, loc);
+};
+function finishNodeAt(node, type, pos, loc) {
+  node.type = type;
+  node.end = pos;
+  if (this.options.locations) {
+    node.loc.end = loc;
+  }
+  if (this.options.ranges) {
+    node.range[1] = pos;
+  }
+  return node;
+}
+pp$2.finishNode = function(node, type) {
+  return finishNodeAt.call(this, node, type, this.lastTokEnd, this.lastTokEndLoc);
+};
+pp$2.finishNodeAt = function(node, type, pos, loc) {
+  return finishNodeAt.call(this, node, type, pos, loc);
+};
+pp$2.copyNode = function(node) {
+  var newNode = new Node(this, node.start, this.startLoc);
+  for (var prop in node) {
+    newNode[prop] = node[prop];
+  }
+  return newNode;
+};
+var ecma9BinaryProperties = "ASCII ASCII_Hex_Digit AHex Alphabetic Alpha Any Assigned Bidi_Control Bidi_C Bidi_Mirrored Bidi_M Case_Ignorable CI Cased Changes_When_Casefolded CWCF Changes_When_Casemapped CWCM Changes_When_Lowercased CWL Changes_When_NFKC_Casefolded CWKCF Changes_When_Titlecased CWT Changes_When_Uppercased CWU Dash Default_Ignorable_Code_Point DI Deprecated Dep Diacritic Dia Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Extender Ext Grapheme_Base Gr_Base Grapheme_Extend Gr_Ext Hex_Digit Hex IDS_Binary_Operator IDSB IDS_Trinary_Operator IDST ID_Continue IDC ID_Start IDS Ideographic Ideo Join_Control Join_C Logical_Order_Exception LOE Lowercase Lower Math Noncharacter_Code_Point NChar Pattern_Syntax Pat_Syn Pattern_White_Space Pat_WS Quotation_Mark QMark Radical Regional_Indicator RI Sentence_Terminal STerm Soft_Dotted SD Terminal_Punctuation Term Unified_Ideograph UIdeo Uppercase Upper Variation_Selector VS White_Space space XID_Continue XIDC XID_Start XIDS";
+var ecma10BinaryProperties = ecma9BinaryProperties + " Extended_Pictographic";
+var ecma11BinaryProperties = ecma10BinaryProperties;
+var ecma12BinaryProperties = ecma11BinaryProperties + " EBase EComp EMod EPres ExtPict";
+var ecma13BinaryProperties = ecma12BinaryProperties;
+var unicodeBinaryProperties = {
+  9: ecma9BinaryProperties,
+  10: ecma10BinaryProperties,
+  11: ecma11BinaryProperties,
+  12: ecma12BinaryProperties,
+  13: ecma13BinaryProperties
+};
+var unicodeGeneralCategoryValues = "Cased_Letter LC Close_Punctuation Pe Connector_Punctuation Pc Control Cc cntrl Currency_Symbol Sc Dash_Punctuation Pd Decimal_Number Nd digit Enclosing_Mark Me Final_Punctuation Pf Format Cf Initial_Punctuation Pi Letter L Letter_Number Nl Line_Separator Zl Lowercase_Letter Ll Mark M Combining_Mark Math_Symbol Sm Modifier_Letter Lm Modifier_Symbol Sk Nonspacing_Mark Mn Number N Open_Punctuation Ps Other C Other_Letter Lo Other_Number No Other_Punctuation Po Other_Symbol So Paragraph_Separator Zp Private_Use Co Punctuation P punct Separator Z Space_Separator Zs Spacing_Mark Mc Surrogate Cs Symbol S Titlecase_Letter Lt Unassigned Cn Uppercase_Letter Lu";
+var ecma9ScriptValues = "Adlam Adlm Ahom Anatolian_Hieroglyphs Hluw Arabic Arab Armenian Armn Avestan Avst Balinese Bali Bamum Bamu Bassa_Vah Bass Batak Batk Bengali Beng Bhaiksuki Bhks Bopomofo Bopo Brahmi Brah Braille Brai Buginese Bugi Buhid Buhd Canadian_Aboriginal Cans Carian Cari Caucasian_Albanian Aghb Chakma Cakm Cham Cham Cherokee Cher Common Zyyy Coptic Copt Qaac Cuneiform Xsux Cypriot Cprt Cyrillic Cyrl Deseret Dsrt Devanagari Deva Duployan Dupl Egyptian_Hieroglyphs Egyp Elbasan Elba Ethiopic Ethi Georgian Geor Glagolitic Glag Gothic Goth Grantha Gran Greek Grek Gujarati Gujr Gurmukhi Guru Han Hani Hangul Hang Hanunoo Hano Hatran Hatr Hebrew Hebr Hiragana Hira Imperial_Aramaic Armi Inherited Zinh Qaai Inscriptional_Pahlavi Phli Inscriptional_Parthian Prti Javanese Java Kaithi Kthi Kannada Knda Katakana Kana Kayah_Li Kali Kharoshthi Khar Khmer Khmr Khojki Khoj Khudawadi Sind Lao Laoo Latin Latn Lepcha Lepc Limbu Limb Linear_A Lina Linear_B Linb Lisu Lisu Lycian Lyci Lydian Lydi Mahajani Mahj Malayalam Mlym Mandaic Mand Manichaean Mani Marchen Marc Masaram_Gondi Gonm Meetei_Mayek Mtei Mende_Kikakui Mend Meroitic_Cursive Merc Meroitic_Hieroglyphs Mero Miao Plrd Modi Mongolian Mong Mro Mroo Multani Mult Myanmar Mymr Nabataean Nbat New_Tai_Lue Talu Newa Newa Nko Nkoo Nushu Nshu Ogham Ogam Ol_Chiki Olck Old_Hungarian Hung Old_Italic Ital Old_North_Arabian Narb Old_Permic Perm Old_Persian Xpeo Old_South_Arabian Sarb Old_Turkic Orkh Oriya Orya Osage Osge Osmanya Osma Pahawh_Hmong Hmng Palmyrene Palm Pau_Cin_Hau Pauc Phags_Pa Phag Phoenician Phnx Psalter_Pahlavi Phlp Rejang Rjng Runic Runr Samaritan Samr Saurashtra Saur Sharada Shrd Shavian Shaw Siddham Sidd SignWriting Sgnw Sinhala Sinh Sora_Sompeng Sora Soyombo Soyo Sundanese Sund Syloti_Nagri Sylo Syriac Syrc Tagalog Tglg Tagbanwa Tagb Tai_Le Tale Tai_Tham Lana Tai_Viet Tavt Takri Takr Tamil Taml Tangut Tang Telugu Telu Thaana Thaa Thai Thai Tibetan Tibt Tifinagh Tfng Tirhuta Tirh Ugaritic Ugar Vai Vaii Warang_Citi Wara Yi Yiii Zanabazar_Square Zanb";
+var ecma10ScriptValues = ecma9ScriptValues + " Dogra Dogr Gunjala_Gondi Gong Hanifi_Rohingya Rohg Makasar Maka Medefaidrin Medf Old_Sogdian Sogo Sogdian Sogd";
+var ecma11ScriptValues = ecma10ScriptValues + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho";
+var ecma12ScriptValues = ecma11ScriptValues + " Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi";
+var ecma13ScriptValues = ecma12ScriptValues + " Cypro_Minoan Cpmn Old_Uyghur Ougr Tangsa Tnsa Toto Vithkuqi Vith";
+var unicodeScriptValues = {
+  9: ecma9ScriptValues,
+  10: ecma10ScriptValues,
+  11: ecma11ScriptValues,
+  12: ecma12ScriptValues,
+  13: ecma13ScriptValues
+};
+var data = {};
+function buildUnicodeData(ecmaVersion) {
+  var d = data[ecmaVersion] = {
+    binary: wordsRegexp(unicodeBinaryProperties[ecmaVersion] + " " + unicodeGeneralCategoryValues),
+    nonBinary: {
+      General_Category: wordsRegexp(unicodeGeneralCategoryValues),
+      Script: wordsRegexp(unicodeScriptValues[ecmaVersion])
+    }
+  };
+  d.nonBinary.Script_Extensions = d.nonBinary.Script;
+  d.nonBinary.gc = d.nonBinary.General_Category;
+  d.nonBinary.sc = d.nonBinary.Script;
+  d.nonBinary.scx = d.nonBinary.Script_Extensions;
+}
+for (i = 0, list = [9, 10, 11, 12, 13]; i < list.length; i += 1) {
+  ecmaVersion = list[i];
+  buildUnicodeData(ecmaVersion);
+}
+var ecmaVersion;
+var i;
+var list;
+var pp$1 = Parser.prototype;
+var RegExpValidationState = function RegExpValidationState2(parser) {
+  this.parser = parser;
+  this.validFlags = "gim" + (parser.options.ecmaVersion >= 6 ? "uy" : "") + (parser.options.ecmaVersion >= 9 ? "s" : "") + (parser.options.ecmaVersion >= 13 ? "d" : "");
+  this.unicodeProperties = data[parser.options.ecmaVersion >= 13 ? 13 : parser.options.ecmaVersion];
+  this.source = "";
+  this.flags = "";
+  this.start = 0;
+  this.switchU = false;
+  this.switchN = false;
+  this.pos = 0;
+  this.lastIntValue = 0;
+  this.lastStringValue = "";
+  this.lastAssertionIsQuantifiable = false;
+  this.numCapturingParens = 0;
+  this.maxBackReference = 0;
+  this.groupNames = [];
+  this.backReferenceNames = [];
+};
+RegExpValidationState.prototype.reset = function reset(start3, pattern, flags) {
+  var unicode = flags.indexOf("u") !== -1;
+  this.start = start3 | 0;
+  this.source = pattern + "";
+  this.flags = flags;
+  this.switchU = unicode && this.parser.options.ecmaVersion >= 6;
+  this.switchN = unicode && this.parser.options.ecmaVersion >= 9;
+};
+RegExpValidationState.prototype.raise = function raise(message) {
+  this.parser.raiseRecoverable(this.start, "Invalid regular expression: /" + this.source + "/: " + message);
+};
+RegExpValidationState.prototype.at = function at(i, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  var s = this.source;
+  var l = s.length;
+  if (i >= l) {
+    return -1;
+  }
+  var c = s.charCodeAt(i);
+  if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l) {
+    return c;
+  }
+  var next = s.charCodeAt(i + 1);
+  return next >= 56320 && next <= 57343 ? (c << 10) + next - 56613888 : c;
+};
+RegExpValidationState.prototype.nextIndex = function nextIndex(i, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  var s = this.source;
+  var l = s.length;
+  if (i >= l) {
+    return l;
+  }
+  var c = s.charCodeAt(i), next;
+  if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l || (next = s.charCodeAt(i + 1)) < 56320 || next > 57343) {
+    return i + 1;
+  }
+  return i + 2;
+};
+RegExpValidationState.prototype.current = function current(forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  return this.at(this.pos, forceU);
+};
+RegExpValidationState.prototype.lookahead = function lookahead(forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  return this.at(this.nextIndex(this.pos, forceU), forceU);
+};
+RegExpValidationState.prototype.advance = function advance(forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  this.pos = this.nextIndex(this.pos, forceU);
+};
+RegExpValidationState.prototype.eat = function eat(ch, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  if (this.current(forceU) === ch) {
+    this.advance(forceU);
+    return true;
+  }
+  return false;
+};
+pp$1.validateRegExpFlags = function(state) {
+  var validFlags = state.validFlags;
+  var flags = state.flags;
+  for (var i = 0; i < flags.length; i++) {
+    var flag = flags.charAt(i);
+    if (validFlags.indexOf(flag) === -1) {
+      this.raise(state.start, "Invalid regular expression flag");
+    }
+    if (flags.indexOf(flag, i + 1) > -1) {
+      this.raise(state.start, "Duplicate regular expression flag");
+    }
+  }
+};
+pp$1.validateRegExpPattern = function(state) {
+  this.regexp_pattern(state);
+  if (!state.switchN && this.options.ecmaVersion >= 9 && state.groupNames.length > 0) {
+    state.switchN = true;
+    this.regexp_pattern(state);
+  }
+};
+pp$1.regexp_pattern = function(state) {
+  state.pos = 0;
+  state.lastIntValue = 0;
+  state.lastStringValue = "";
+  state.lastAssertionIsQuantifiable = false;
+  state.numCapturingParens = 0;
+  state.maxBackReference = 0;
+  state.groupNames.length = 0;
+  state.backReferenceNames.length = 0;
+  this.regexp_disjunction(state);
+  if (state.pos !== state.source.length) {
+    if (state.eat(41)) {
+      state.raise("Unmatched ')'");
+    }
+    if (state.eat(93) || state.eat(125)) {
+      state.raise("Lone quantifier brackets");
+    }
+  }
+  if (state.maxBackReference > state.numCapturingParens) {
+    state.raise("Invalid escape");
+  }
+  for (var i = 0, list = state.backReferenceNames; i < list.length; i += 1) {
+    var name = list[i];
+    if (state.groupNames.indexOf(name) === -1) {
+      state.raise("Invalid named capture referenced");
+    }
+  }
+};
+pp$1.regexp_disjunction = function(state) {
+  this.regexp_alternative(state);
+  while (state.eat(124)) {
+    this.regexp_alternative(state);
+  }
+  if (this.regexp_eatQuantifier(state, true)) {
+    state.raise("Nothing to repeat");
+  }
+  if (state.eat(123)) {
+    state.raise("Lone quantifier brackets");
+  }
+};
+pp$1.regexp_alternative = function(state) {
+  while (state.pos < state.source.length && this.regexp_eatTerm(state)) {
+  }
+};
+pp$1.regexp_eatTerm = function(state) {
+  if (this.regexp_eatAssertion(state)) {
+    if (state.lastAssertionIsQuantifiable && this.regexp_eatQuantifier(state)) {
+      if (state.switchU) {
+        state.raise("Invalid quantifier");
+      }
+    }
+    return true;
+  }
+  if (state.switchU ? this.regexp_eatAtom(state) : this.regexp_eatExtendedAtom(state)) {
+    this.regexp_eatQuantifier(state);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatAssertion = function(state) {
+  var start3 = state.pos;
+  state.lastAssertionIsQuantifiable = false;
+  if (state.eat(94) || state.eat(36)) {
+    return true;
+  }
+  if (state.eat(92)) {
+    if (state.eat(66) || state.eat(98)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  if (state.eat(40) && state.eat(63)) {
+    var lookbehind = false;
+    if (this.options.ecmaVersion >= 9) {
+      lookbehind = state.eat(60);
+    }
+    if (state.eat(61) || state.eat(33)) {
+      this.regexp_disjunction(state);
+      if (!state.eat(41)) {
+        state.raise("Unterminated group");
+      }
+      state.lastAssertionIsQuantifiable = !lookbehind;
+      return true;
+    }
+  }
+  state.pos = start3;
+  return false;
+};
+pp$1.regexp_eatQuantifier = function(state, noError) {
+  if (noError === void 0)
+    noError = false;
+  if (this.regexp_eatQuantifierPrefix(state, noError)) {
+    state.eat(63);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatQuantifierPrefix = function(state, noError) {
+  return state.eat(42) || state.eat(43) || state.eat(63) || this.regexp_eatBracedQuantifier(state, noError);
+};
+pp$1.regexp_eatBracedQuantifier = function(state, noError) {
+  var start3 = state.pos;
+  if (state.eat(123)) {
+    var min = 0, max = -1;
+    if (this.regexp_eatDecimalDigits(state)) {
+      min = state.lastIntValue;
+      if (state.eat(44) && this.regexp_eatDecimalDigits(state)) {
+        max = state.lastIntValue;
+      }
+      if (state.eat(125)) {
+        if (max !== -1 && max < min && !noError) {
+          state.raise("numbers out of order in {} quantifier");
+        }
+        return true;
+      }
+    }
+    if (state.switchU && !noError) {
+      state.raise("Incomplete quantifier");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatAtom = function(state) {
+  return this.regexp_eatPatternCharacters(state) || state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state);
+};
+pp$1.regexp_eatReverseSolidusAtomEscape = function(state) {
+  var start3 = state.pos;
+  if (state.eat(92)) {
+    if (this.regexp_eatAtomEscape(state)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatUncapturingGroup = function(state) {
+  var start3 = state.pos;
+  if (state.eat(40)) {
+    if (state.eat(63) && state.eat(58)) {
+      this.regexp_disjunction(state);
+      if (state.eat(41)) {
+        return true;
+      }
+      state.raise("Unterminated group");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatCapturingGroup = function(state) {
+  if (state.eat(40)) {
+    if (this.options.ecmaVersion >= 9) {
+      this.regexp_groupSpecifier(state);
+    } else if (state.current() === 63) {
+      state.raise("Invalid group");
+    }
+    this.regexp_disjunction(state);
+    if (state.eat(41)) {
+      state.numCapturingParens += 1;
+      return true;
+    }
+    state.raise("Unterminated group");
+  }
+  return false;
+};
+pp$1.regexp_eatExtendedAtom = function(state) {
+  return state.eat(46) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state) || this.regexp_eatInvalidBracedQuantifier(state) || this.regexp_eatExtendedPatternCharacter(state);
+};
+pp$1.regexp_eatInvalidBracedQuantifier = function(state) {
+  if (this.regexp_eatBracedQuantifier(state, true)) {
+    state.raise("Nothing to repeat");
+  }
+  return false;
+};
+pp$1.regexp_eatSyntaxCharacter = function(state) {
+  var ch = state.current();
+  if (isSyntaxCharacter(ch)) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+function isSyntaxCharacter(ch) {
+  return ch === 36 || ch >= 40 && ch <= 43 || ch === 46 || ch === 63 || ch >= 91 && ch <= 94 || ch >= 123 && ch <= 125;
+}
+pp$1.regexp_eatPatternCharacters = function(state) {
+  var start3 = state.pos;
+  var ch = 0;
+  while ((ch = state.current()) !== -1 && !isSyntaxCharacter(ch)) {
+    state.advance();
+  }
+  return state.pos !== start3;
+};
+pp$1.regexp_eatExtendedPatternCharacter = function(state) {
+  var ch = state.current();
+  if (ch !== -1 && ch !== 36 && !(ch >= 40 && ch <= 43) && ch !== 46 && ch !== 63 && ch !== 91 && ch !== 94 && ch !== 124) {
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_groupSpecifier = function(state) {
+  if (state.eat(63)) {
+    if (this.regexp_eatGroupName(state)) {
+      if (state.groupNames.indexOf(state.lastStringValue) !== -1) {
+        state.raise("Duplicate capture group name");
+      }
+      state.groupNames.push(state.lastStringValue);
+      return;
+    }
+    state.raise("Invalid group");
+  }
+};
+pp$1.regexp_eatGroupName = function(state) {
+  state.lastStringValue = "";
+  if (state.eat(60)) {
+    if (this.regexp_eatRegExpIdentifierName(state) && state.eat(62)) {
+      return true;
+    }
+    state.raise("Invalid capture group name");
+  }
+  return false;
+};
+pp$1.regexp_eatRegExpIdentifierName = function(state) {
+  state.lastStringValue = "";
+  if (this.regexp_eatRegExpIdentifierStart(state)) {
+    state.lastStringValue += codePointToString(state.lastIntValue);
+    while (this.regexp_eatRegExpIdentifierPart(state)) {
+      state.lastStringValue += codePointToString(state.lastIntValue);
+    }
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatRegExpIdentifierStart = function(state) {
+  var start3 = state.pos;
+  var forceU = this.options.ecmaVersion >= 11;
+  var ch = state.current(forceU);
+  state.advance(forceU);
+  if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+    ch = state.lastIntValue;
+  }
+  if (isRegExpIdentifierStart(ch)) {
+    state.lastIntValue = ch;
+    return true;
+  }
+  state.pos = start3;
+  return false;
+};
+function isRegExpIdentifierStart(ch) {
+  return isIdentifierStart(ch, true) || ch === 36 || ch === 95;
+}
+pp$1.regexp_eatRegExpIdentifierPart = function(state) {
+  var start3 = state.pos;
+  var forceU = this.options.ecmaVersion >= 11;
+  var ch = state.current(forceU);
+  state.advance(forceU);
+  if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+    ch = state.lastIntValue;
+  }
+  if (isRegExpIdentifierPart(ch)) {
+    state.lastIntValue = ch;
+    return true;
+  }
+  state.pos = start3;
+  return false;
+};
+function isRegExpIdentifierPart(ch) {
+  return isIdentifierChar(ch, true) || ch === 36 || ch === 95 || ch === 8204 || ch === 8205;
+}
+pp$1.regexp_eatAtomEscape = function(state) {
+  if (this.regexp_eatBackReference(state) || this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state) || state.switchN && this.regexp_eatKGroupName(state)) {
+    return true;
+  }
+  if (state.switchU) {
+    if (state.current() === 99) {
+      state.raise("Invalid unicode escape");
+    }
+    state.raise("Invalid escape");
+  }
+  return false;
+};
+pp$1.regexp_eatBackReference = function(state) {
+  var start3 = state.pos;
+  if (this.regexp_eatDecimalEscape(state)) {
+    var n = state.lastIntValue;
+    if (state.switchU) {
+      if (n > state.maxBackReference) {
+        state.maxBackReference = n;
+      }
+      return true;
+    }
+    if (n <= state.numCapturingParens) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatKGroupName = function(state) {
+  if (state.eat(107)) {
+    if (this.regexp_eatGroupName(state)) {
+      state.backReferenceNames.push(state.lastStringValue);
+      return true;
+    }
+    state.raise("Invalid named reference");
+  }
+  return false;
+};
+pp$1.regexp_eatCharacterEscape = function(state) {
+  return this.regexp_eatControlEscape(state) || this.regexp_eatCControlLetter(state) || this.regexp_eatZero(state) || this.regexp_eatHexEscapeSequence(state) || this.regexp_eatRegExpUnicodeEscapeSequence(state, false) || !state.switchU && this.regexp_eatLegacyOctalEscapeSequence(state) || this.regexp_eatIdentityEscape(state);
+};
+pp$1.regexp_eatCControlLetter = function(state) {
+  var start3 = state.pos;
+  if (state.eat(99)) {
+    if (this.regexp_eatControlLetter(state)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatZero = function(state) {
+  if (state.current() === 48 && !isDecimalDigit(state.lookahead())) {
+    state.lastIntValue = 0;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatControlEscape = function(state) {
+  var ch = state.current();
+  if (ch === 116) {
+    state.lastIntValue = 9;
+    state.advance();
+    return true;
+  }
+  if (ch === 110) {
+    state.lastIntValue = 10;
+    state.advance();
+    return true;
+  }
+  if (ch === 118) {
+    state.lastIntValue = 11;
+    state.advance();
+    return true;
+  }
+  if (ch === 102) {
+    state.lastIntValue = 12;
+    state.advance();
+    return true;
+  }
+  if (ch === 114) {
+    state.lastIntValue = 13;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatControlLetter = function(state) {
+  var ch = state.current();
+  if (isControlLetter(ch)) {
+    state.lastIntValue = ch % 32;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+function isControlLetter(ch) {
+  return ch >= 65 && ch <= 90 || ch >= 97 && ch <= 122;
+}
+pp$1.regexp_eatRegExpUnicodeEscapeSequence = function(state, forceU) {
+  if (forceU === void 0)
+    forceU = false;
+  var start3 = state.pos;
+  var switchU = forceU || state.switchU;
+  if (state.eat(117)) {
+    if (this.regexp_eatFixedHexDigits(state, 4)) {
+      var lead = state.lastIntValue;
+      if (switchU && lead >= 55296 && lead <= 56319) {
+        var leadSurrogateEnd = state.pos;
+        if (state.eat(92) && state.eat(117) && this.regexp_eatFixedHexDigits(state, 4)) {
+          var trail = state.lastIntValue;
+          if (trail >= 56320 && trail <= 57343) {
+            state.lastIntValue = (lead - 55296) * 1024 + (trail - 56320) + 65536;
+            return true;
+          }
+        }
+        state.pos = leadSurrogateEnd;
+        state.lastIntValue = lead;
+      }
+      return true;
+    }
+    if (switchU && state.eat(123) && this.regexp_eatHexDigits(state) && state.eat(125) && isValidUnicode(state.lastIntValue)) {
+      return true;
+    }
+    if (switchU) {
+      state.raise("Invalid unicode escape");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+function isValidUnicode(ch) {
+  return ch >= 0 && ch <= 1114111;
+}
+pp$1.regexp_eatIdentityEscape = function(state) {
+  if (state.switchU) {
+    if (this.regexp_eatSyntaxCharacter(state)) {
+      return true;
+    }
+    if (state.eat(47)) {
+      state.lastIntValue = 47;
+      return true;
+    }
+    return false;
+  }
+  var ch = state.current();
+  if (ch !== 99 && (!state.switchN || ch !== 107)) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatDecimalEscape = function(state) {
+  state.lastIntValue = 0;
+  var ch = state.current();
+  if (ch >= 49 && ch <= 57) {
+    do {
+      state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+      state.advance();
+    } while ((ch = state.current()) >= 48 && ch <= 57);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatCharacterClassEscape = function(state) {
+  var ch = state.current();
+  if (isCharacterClassEscape(ch)) {
+    state.lastIntValue = -1;
+    state.advance();
+    return true;
+  }
+  if (state.switchU && this.options.ecmaVersion >= 9 && (ch === 80 || ch === 112)) {
+    state.lastIntValue = -1;
+    state.advance();
+    if (state.eat(123) && this.regexp_eatUnicodePropertyValueExpression(state) && state.eat(125)) {
+      return true;
+    }
+    state.raise("Invalid property name");
+  }
+  return false;
+};
+function isCharacterClassEscape(ch) {
+  return ch === 100 || ch === 68 || ch === 115 || ch === 83 || ch === 119 || ch === 87;
+}
+pp$1.regexp_eatUnicodePropertyValueExpression = function(state) {
+  var start3 = state.pos;
+  if (this.regexp_eatUnicodePropertyName(state) && state.eat(61)) {
+    var name = state.lastStringValue;
+    if (this.regexp_eatUnicodePropertyValue(state)) {
+      var value = state.lastStringValue;
+      this.regexp_validateUnicodePropertyNameAndValue(state, name, value);
+      return true;
+    }
+  }
+  state.pos = start3;
+  if (this.regexp_eatLoneUnicodePropertyNameOrValue(state)) {
+    var nameOrValue = state.lastStringValue;
+    this.regexp_validateUnicodePropertyNameOrValue(state, nameOrValue);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_validateUnicodePropertyNameAndValue = function(state, name, value) {
+  if (!hasOwn(state.unicodeProperties.nonBinary, name)) {
+    state.raise("Invalid property name");
+  }
+  if (!state.unicodeProperties.nonBinary[name].test(value)) {
+    state.raise("Invalid property value");
+  }
+};
+pp$1.regexp_validateUnicodePropertyNameOrValue = function(state, nameOrValue) {
+  if (!state.unicodeProperties.binary.test(nameOrValue)) {
+    state.raise("Invalid property name");
+  }
+};
+pp$1.regexp_eatUnicodePropertyName = function(state) {
+  var ch = 0;
+  state.lastStringValue = "";
+  while (isUnicodePropertyNameCharacter(ch = state.current())) {
+    state.lastStringValue += codePointToString(ch);
+    state.advance();
+  }
+  return state.lastStringValue !== "";
+};
+function isUnicodePropertyNameCharacter(ch) {
+  return isControlLetter(ch) || ch === 95;
+}
+pp$1.regexp_eatUnicodePropertyValue = function(state) {
+  var ch = 0;
+  state.lastStringValue = "";
+  while (isUnicodePropertyValueCharacter(ch = state.current())) {
+    state.lastStringValue += codePointToString(ch);
+    state.advance();
+  }
+  return state.lastStringValue !== "";
+};
+function isUnicodePropertyValueCharacter(ch) {
+  return isUnicodePropertyNameCharacter(ch) || isDecimalDigit(ch);
+}
+pp$1.regexp_eatLoneUnicodePropertyNameOrValue = function(state) {
+  return this.regexp_eatUnicodePropertyValue(state);
+};
+pp$1.regexp_eatCharacterClass = function(state) {
+  if (state.eat(91)) {
+    state.eat(94);
+    this.regexp_classRanges(state);
+    if (state.eat(93)) {
+      return true;
+    }
+    state.raise("Unterminated character class");
+  }
+  return false;
+};
+pp$1.regexp_classRanges = function(state) {
+  while (this.regexp_eatClassAtom(state)) {
+    var left = state.lastIntValue;
+    if (state.eat(45) && this.regexp_eatClassAtom(state)) {
+      var right = state.lastIntValue;
+      if (state.switchU && (left === -1 || right === -1)) {
+        state.raise("Invalid character class");
+      }
+      if (left !== -1 && right !== -1 && left > right) {
+        state.raise("Range out of order in character class");
+      }
+    }
+  }
+};
+pp$1.regexp_eatClassAtom = function(state) {
+  var start3 = state.pos;
+  if (state.eat(92)) {
+    if (this.regexp_eatClassEscape(state)) {
+      return true;
+    }
+    if (state.switchU) {
+      var ch$1 = state.current();
+      if (ch$1 === 99 || isOctalDigit(ch$1)) {
+        state.raise("Invalid class escape");
+      }
+      state.raise("Invalid escape");
+    }
+    state.pos = start3;
+  }
+  var ch = state.current();
+  if (ch !== 93) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatClassEscape = function(state) {
+  var start3 = state.pos;
+  if (state.eat(98)) {
+    state.lastIntValue = 8;
+    return true;
+  }
+  if (state.switchU && state.eat(45)) {
+    state.lastIntValue = 45;
+    return true;
+  }
+  if (!state.switchU && state.eat(99)) {
+    if (this.regexp_eatClassControlLetter(state)) {
+      return true;
+    }
+    state.pos = start3;
+  }
+  return this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state);
+};
+pp$1.regexp_eatClassControlLetter = function(state) {
+  var ch = state.current();
+  if (isDecimalDigit(ch) || ch === 95) {
+    state.lastIntValue = ch % 32;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatHexEscapeSequence = function(state) {
+  var start3 = state.pos;
+  if (state.eat(120)) {
+    if (this.regexp_eatFixedHexDigits(state, 2)) {
+      return true;
+    }
+    if (state.switchU) {
+      state.raise("Invalid escape");
+    }
+    state.pos = start3;
+  }
+  return false;
+};
+pp$1.regexp_eatDecimalDigits = function(state) {
+  var start3 = state.pos;
+  var ch = 0;
+  state.lastIntValue = 0;
+  while (isDecimalDigit(ch = state.current())) {
+    state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+    state.advance();
+  }
+  return state.pos !== start3;
+};
+function isDecimalDigit(ch) {
+  return ch >= 48 && ch <= 57;
+}
+pp$1.regexp_eatHexDigits = function(state) {
+  var start3 = state.pos;
+  var ch = 0;
+  state.lastIntValue = 0;
+  while (isHexDigit(ch = state.current())) {
+    state.lastIntValue = 16 * state.lastIntValue + hexToInt(ch);
+    state.advance();
+  }
+  return state.pos !== start3;
+};
+function isHexDigit(ch) {
+  return ch >= 48 && ch <= 57 || ch >= 65 && ch <= 70 || ch >= 97 && ch <= 102;
+}
+function hexToInt(ch) {
+  if (ch >= 65 && ch <= 70) {
+    return 10 + (ch - 65);
+  }
+  if (ch >= 97 && ch <= 102) {
+    return 10 + (ch - 97);
+  }
+  return ch - 48;
+}
+pp$1.regexp_eatLegacyOctalEscapeSequence = function(state) {
+  if (this.regexp_eatOctalDigit(state)) {
+    var n1 = state.lastIntValue;
+    if (this.regexp_eatOctalDigit(state)) {
+      var n2 = state.lastIntValue;
+      if (n1 <= 3 && this.regexp_eatOctalDigit(state)) {
+        state.lastIntValue = n1 * 64 + n2 * 8 + state.lastIntValue;
+      } else {
+        state.lastIntValue = n1 * 8 + n2;
+      }
+    } else {
+      state.lastIntValue = n1;
+    }
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatOctalDigit = function(state) {
+  var ch = state.current();
+  if (isOctalDigit(ch)) {
+    state.lastIntValue = ch - 48;
+    state.advance();
+    return true;
+  }
+  state.lastIntValue = 0;
+  return false;
+};
+function isOctalDigit(ch) {
+  return ch >= 48 && ch <= 55;
+}
+pp$1.regexp_eatFixedHexDigits = function(state, length) {
+  var start3 = state.pos;
+  state.lastIntValue = 0;
+  for (var i = 0; i < length; ++i) {
+    var ch = state.current();
+    if (!isHexDigit(ch)) {
+      state.pos = start3;
+      return false;
+    }
+    state.lastIntValue = 16 * state.lastIntValue + hexToInt(ch);
+    state.advance();
+  }
+  return true;
+};
+var Token = function Token2(p) {
+  this.type = p.type;
+  this.value = p.value;
+  this.start = p.start;
+  this.end = p.end;
+  if (p.options.locations) {
+    this.loc = new SourceLocation(p, p.startLoc, p.endLoc);
+  }
+  if (p.options.ranges) {
+    this.range = [p.start, p.end];
+  }
+};
+var pp = Parser.prototype;
+pp.next = function(ignoreEscapeSequenceInKeyword) {
+  if (!ignoreEscapeSequenceInKeyword && this.type.keyword && this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword " + this.type.keyword);
+  }
+  if (this.options.onToken) {
+    this.options.onToken(new Token(this));
+  }
+  this.lastTokEnd = this.end;
+  this.lastTokStart = this.start;
+  this.lastTokEndLoc = this.endLoc;
+  this.lastTokStartLoc = this.startLoc;
+  this.nextToken();
+};
+pp.getToken = function() {
+  this.next();
+  return new Token(this);
+};
+if (typeof Symbol !== "undefined") {
+  pp[Symbol.iterator] = function() {
+    var this$1$1 = this;
+    return {
+      next: function() {
+        var token = this$1$1.getToken();
+        return {
+          done: token.type === types$1.eof,
+          value: token
+        };
+      }
+    };
+  };
+}
+pp.nextToken = function() {
+  var curContext = this.curContext();
+  if (!curContext || !curContext.preserveSpace) {
+    this.skipSpace();
+  }
+  this.start = this.pos;
+  if (this.options.locations) {
+    this.startLoc = this.curPosition();
+  }
+  if (this.pos >= this.input.length) {
+    return this.finishToken(types$1.eof);
+  }
+  if (curContext.override) {
+    return curContext.override(this);
+  } else {
+    this.readToken(this.fullCharCodeAtPos());
+  }
+};
+pp.readToken = function(code) {
+  if (isIdentifierStart(code, this.options.ecmaVersion >= 6) || code === 92) {
+    return this.readWord();
+  }
+  return this.getTokenFromCode(code);
+};
+pp.fullCharCodeAtPos = function() {
+  var code = this.input.charCodeAt(this.pos);
+  if (code <= 55295 || code >= 56320) {
+    return code;
+  }
+  var next = this.input.charCodeAt(this.pos + 1);
+  return next <= 56319 || next >= 57344 ? code : (code << 10) + next - 56613888;
+};
+pp.skipBlockComment = function() {
+  var startLoc = this.options.onComment && this.curPosition();
+  var start3 = this.pos, end = this.input.indexOf("*/", this.pos += 2);
+  if (end === -1) {
+    this.raise(this.pos - 2, "Unterminated comment");
+  }
+  this.pos = end + 2;
+  if (this.options.locations) {
+    for (var nextBreak = void 0, pos = start3; (nextBreak = nextLineBreak(this.input, pos, this.pos)) > -1; ) {
+      ++this.curLine;
+      pos = this.lineStart = nextBreak;
+    }
+  }
+  if (this.options.onComment) {
+    this.options.onComment(
+      true,
+      this.input.slice(start3 + 2, end),
+      start3,
+      this.pos,
+      startLoc,
+      this.curPosition()
+    );
+  }
+};
+pp.skipLineComment = function(startSkip) {
+  var start3 = this.pos;
+  var startLoc = this.options.onComment && this.curPosition();
+  var ch = this.input.charCodeAt(this.pos += startSkip);
+  while (this.pos < this.input.length && !isNewLine(ch)) {
+    ch = this.input.charCodeAt(++this.pos);
+  }
+  if (this.options.onComment) {
+    this.options.onComment(
+      false,
+      this.input.slice(start3 + startSkip, this.pos),
+      start3,
+      this.pos,
+      startLoc,
+      this.curPosition()
+    );
+  }
+};
+pp.skipSpace = function() {
+  loop:
+    while (this.pos < this.input.length) {
+      var ch = this.input.charCodeAt(this.pos);
+      switch (ch) {
+        case 32:
+        case 160:
+          ++this.pos;
+          break;
+        case 13:
+          if (this.input.charCodeAt(this.pos + 1) === 10) {
+            ++this.pos;
+          }
+        case 10:
+        case 8232:
+        case 8233:
+          ++this.pos;
+          if (this.options.locations) {
+            ++this.curLine;
+            this.lineStart = this.pos;
+          }
+          break;
+        case 47:
+          switch (this.input.charCodeAt(this.pos + 1)) {
+            case 42:
+              this.skipBlockComment();
+              break;
+            case 47:
+              this.skipLineComment(2);
+              break;
+            default:
+              break loop;
+          }
+          break;
+        default:
+          if (ch > 8 && ch < 14 || ch >= 5760 && nonASCIIwhitespace.test(String.fromCharCode(ch))) {
+            ++this.pos;
+          } else {
+            break loop;
+          }
+      }
+    }
+};
+pp.finishToken = function(type, val) {
+  this.end = this.pos;
+  if (this.options.locations) {
+    this.endLoc = this.curPosition();
+  }
+  var prevType = this.type;
+  this.type = type;
+  this.value = val;
+  this.updateContext(prevType);
+};
+pp.readToken_dot = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next >= 48 && next <= 57) {
+    return this.readNumber(true);
+  }
+  var next2 = this.input.charCodeAt(this.pos + 2);
+  if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) {
+    this.pos += 3;
+    return this.finishToken(types$1.ellipsis);
+  } else {
+    ++this.pos;
+    return this.finishToken(types$1.dot);
+  }
+};
+pp.readToken_slash = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (this.exprAllowed) {
+    ++this.pos;
+    return this.readRegexp();
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.slash, 1);
+};
+pp.readToken_mult_modulo_exp = function(code) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  var size = 1;
+  var tokentype = code === 42 ? types$1.star : types$1.modulo;
+  if (this.options.ecmaVersion >= 7 && code === 42 && next === 42) {
+    ++size;
+    tokentype = types$1.starstar;
+    next = this.input.charCodeAt(this.pos + 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, size + 1);
+  }
+  return this.finishOp(tokentype, size);
+};
+pp.readToken_pipe_amp = function(code) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code) {
+    if (this.options.ecmaVersion >= 12) {
+      var next2 = this.input.charCodeAt(this.pos + 2);
+      if (next2 === 61) {
+        return this.finishOp(types$1.assign, 3);
+      }
+    }
+    return this.finishOp(code === 124 ? types$1.logicalOR : types$1.logicalAND, 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(code === 124 ? types$1.bitwiseOR : types$1.bitwiseAND, 1);
+};
+pp.readToken_caret = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.bitwiseXOR, 1);
+};
+pp.readToken_plus_min = function(code) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code) {
+    if (next === 45 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 62 && (this.lastTokEnd === 0 || lineBreak.test(this.input.slice(this.lastTokEnd, this.pos)))) {
+      this.skipLineComment(3);
+      this.skipSpace();
+      return this.nextToken();
+    }
+    return this.finishOp(types$1.incDec, 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.plusMin, 1);
+};
+pp.readToken_lt_gt = function(code) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  var size = 1;
+  if (next === code) {
+    size = code === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+    if (this.input.charCodeAt(this.pos + size) === 61) {
+      return this.finishOp(types$1.assign, size + 1);
+    }
+    return this.finishOp(types$1.bitShift, size);
+  }
+  if (next === 33 && code === 60 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 45 && this.input.charCodeAt(this.pos + 3) === 45) {
+    this.skipLineComment(4);
+    this.skipSpace();
+    return this.nextToken();
+  }
+  if (next === 61) {
+    size = 2;
+  }
+  return this.finishOp(types$1.relational, size);
+};
+pp.readToken_eq_excl = function(code) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) {
+    return this.finishOp(types$1.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+  }
+  if (code === 61 && next === 62 && this.options.ecmaVersion >= 6) {
+    this.pos += 2;
+    return this.finishToken(types$1.arrow);
+  }
+  return this.finishOp(code === 61 ? types$1.eq : types$1.prefix, 1);
+};
+pp.readToken_question = function() {
+  var ecmaVersion = this.options.ecmaVersion;
+  if (ecmaVersion >= 11) {
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === 46) {
+      var next2 = this.input.charCodeAt(this.pos + 2);
+      if (next2 < 48 || next2 > 57) {
+        return this.finishOp(types$1.questionDot, 2);
+      }
+    }
+    if (next === 63) {
+      if (ecmaVersion >= 12) {
+        var next2$1 = this.input.charCodeAt(this.pos + 2);
+        if (next2$1 === 61) {
+          return this.finishOp(types$1.assign, 3);
+        }
+      }
+      return this.finishOp(types$1.coalesce, 2);
+    }
+  }
+  return this.finishOp(types$1.question, 1);
+};
+pp.readToken_numberSign = function() {
+  var ecmaVersion = this.options.ecmaVersion;
+  var code = 35;
+  if (ecmaVersion >= 13) {
+    ++this.pos;
+    code = this.fullCharCodeAtPos();
+    if (isIdentifierStart(code, true) || code === 92) {
+      return this.finishToken(types$1.privateId, this.readWord1());
+    }
+  }
+  this.raise(this.pos, "Unexpected character '" + codePointToString(code) + "'");
+};
+pp.getTokenFromCode = function(code) {
+  switch (code) {
+    case 46:
+      return this.readToken_dot();
+    case 40:
+      ++this.pos;
+      return this.finishToken(types$1.parenL);
+    case 41:
+      ++this.pos;
+      return this.finishToken(types$1.parenR);
+    case 59:
+      ++this.pos;
+      return this.finishToken(types$1.semi);
+    case 44:
+      ++this.pos;
+      return this.finishToken(types$1.comma);
+    case 91:
+      ++this.pos;
+      return this.finishToken(types$1.bracketL);
+    case 93:
+      ++this.pos;
+      return this.finishToken(types$1.bracketR);
+    case 123:
+      ++this.pos;
+      return this.finishToken(types$1.braceL);
+    case 125:
+      ++this.pos;
+      return this.finishToken(types$1.braceR);
+    case 58:
+      ++this.pos;
+      return this.finishToken(types$1.colon);
+    case 96:
+      if (this.options.ecmaVersion < 6) {
+        break;
+      }
+      ++this.pos;
+      return this.finishToken(types$1.backQuote);
+    case 48:
+      var next = this.input.charCodeAt(this.pos + 1);
+      if (next === 120 || next === 88) {
+        return this.readRadixNumber(16);
+      }
+      if (this.options.ecmaVersion >= 6) {
+        if (next === 111 || next === 79) {
+          return this.readRadixNumber(8);
+        }
+        if (next === 98 || next === 66) {
+          return this.readRadixNumber(2);
+        }
+      }
+    case 49:
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 55:
+    case 56:
+    case 57:
+      return this.readNumber(false);
+    case 34:
+    case 39:
+      return this.readString(code);
+    case 47:
+      return this.readToken_slash();
+    case 37:
+    case 42:
+      return this.readToken_mult_modulo_exp(code);
+    case 124:
+    case 38:
+      return this.readToken_pipe_amp(code);
+    case 94:
+      return this.readToken_caret();
+    case 43:
+    case 45:
+      return this.readToken_plus_min(code);
+    case 60:
+    case 62:
+      return this.readToken_lt_gt(code);
+    case 61:
+    case 33:
+      return this.readToken_eq_excl(code);
+    case 63:
+      return this.readToken_question();
+    case 126:
+      return this.finishOp(types$1.prefix, 1);
+    case 35:
+      return this.readToken_numberSign();
+  }
+  this.raise(this.pos, "Unexpected character '" + codePointToString(code) + "'");
+};
+pp.finishOp = function(type, size) {
+  var str = this.input.slice(this.pos, this.pos + size);
+  this.pos += size;
+  return this.finishToken(type, str);
+};
+pp.readRegexp = function() {
+  var escaped, inClass, start3 = this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(start3, "Unterminated regular expression");
+    }
+    var ch = this.input.charAt(this.pos);
+    if (lineBreak.test(ch)) {
+      this.raise(start3, "Unterminated regular expression");
+    }
+    if (!escaped) {
+      if (ch === "[") {
+        inClass = true;
+      } else if (ch === "]" && inClass) {
+        inClass = false;
+      } else if (ch === "/" && !inClass) {
+        break;
+      }
+      escaped = ch === "\\";
+    } else {
+      escaped = false;
+    }
+    ++this.pos;
+  }
+  var pattern = this.input.slice(start3, this.pos);
+  ++this.pos;
+  var flagsStart = this.pos;
+  var flags = this.readWord1();
+  if (this.containsEsc) {
+    this.unexpected(flagsStart);
+  }
+  var state = this.regexpState || (this.regexpState = new RegExpValidationState(this));
+  state.reset(start3, pattern, flags);
+  this.validateRegExpFlags(state);
+  this.validateRegExpPattern(state);
+  var value = null;
+  try {
+    value = new RegExp(pattern, flags);
+  } catch (e) {
+  }
+  return this.finishToken(types$1.regexp, { pattern, flags, value });
+};
+pp.readInt = function(radix, len, maybeLegacyOctalNumericLiteral) {
+  var allowSeparators = this.options.ecmaVersion >= 12 && len === void 0;
+  var isLegacyOctalNumericLiteral = maybeLegacyOctalNumericLiteral && this.input.charCodeAt(this.pos) === 48;
+  var start3 = this.pos, total = 0, lastCode = 0;
+  for (var i = 0, e = len == null ? Infinity : len; i < e; ++i, ++this.pos) {
+    var code = this.input.charCodeAt(this.pos), val = void 0;
+    if (allowSeparators && code === 95) {
+      if (isLegacyOctalNumericLiteral) {
+        this.raiseRecoverable(this.pos, "Numeric separator is not allowed in legacy octal numeric literals");
+      }
+      if (lastCode === 95) {
+        this.raiseRecoverable(this.pos, "Numeric separator must be exactly one underscore");
+      }
+      if (i === 0) {
+        this.raiseRecoverable(this.pos, "Numeric separator is not allowed at the first of digits");
+      }
+      lastCode = code;
+      continue;
+    }
+    if (code >= 97) {
+      val = code - 97 + 10;
+    } else if (code >= 65) {
+      val = code - 65 + 10;
+    } else if (code >= 48 && code <= 57) {
+      val = code - 48;
+    } else {
+      val = Infinity;
+    }
+    if (val >= radix) {
+      break;
+    }
+    lastCode = code;
+    total = total * radix + val;
+  }
+  if (allowSeparators && lastCode === 95) {
+    this.raiseRecoverable(this.pos - 1, "Numeric separator is not allowed at the last of digits");
+  }
+  if (this.pos === start3 || len != null && this.pos - start3 !== len) {
+    return null;
+  }
+  return total;
+};
+function stringToNumber(str, isLegacyOctalNumericLiteral) {
+  if (isLegacyOctalNumericLiteral) {
+    return parseInt(str, 8);
+  }
+  return parseFloat(str.replace(/_/g, ""));
+}
+function stringToBigInt(str) {
+  if (typeof BigInt !== "function") {
+    return null;
+  }
+  return BigInt(str.replace(/_/g, ""));
+}
+pp.readRadixNumber = function(radix) {
+  var start3 = this.pos;
+  this.pos += 2;
+  var val = this.readInt(radix);
+  if (val == null) {
+    this.raise(this.start + 2, "Expected number in radix " + radix);
+  }
+  if (this.options.ecmaVersion >= 11 && this.input.charCodeAt(this.pos) === 110) {
+    val = stringToBigInt(this.input.slice(start3, this.pos));
+    ++this.pos;
+  } else if (isIdentifierStart(this.fullCharCodeAtPos())) {
+    this.raise(this.pos, "Identifier directly after number");
+  }
+  return this.finishToken(types$1.num, val);
+};
+pp.readNumber = function(startsWithDot) {
+  var start3 = this.pos;
+  if (!startsWithDot && this.readInt(10, void 0, true) === null) {
+    this.raise(start3, "Invalid number");
+  }
+  var octal = this.pos - start3 >= 2 && this.input.charCodeAt(start3) === 48;
+  if (octal && this.strict) {
+    this.raise(start3, "Invalid number");
+  }
+  var next = this.input.charCodeAt(this.pos);
+  if (!octal && !startsWithDot && this.options.ecmaVersion >= 11 && next === 110) {
+    var val$1 = stringToBigInt(this.input.slice(start3, this.pos));
+    ++this.pos;
+    if (isIdentifierStart(this.fullCharCodeAtPos())) {
+      this.raise(this.pos, "Identifier directly after number");
+    }
+    return this.finishToken(types$1.num, val$1);
+  }
+  if (octal && /[89]/.test(this.input.slice(start3, this.pos))) {
+    octal = false;
+  }
+  if (next === 46 && !octal) {
+    ++this.pos;
+    this.readInt(10);
+    next = this.input.charCodeAt(this.pos);
+  }
+  if ((next === 69 || next === 101) && !octal) {
+    next = this.input.charCodeAt(++this.pos);
+    if (next === 43 || next === 45) {
+      ++this.pos;
+    }
+    if (this.readInt(10) === null) {
+      this.raise(start3, "Invalid number");
+    }
+  }
+  if (isIdentifierStart(this.fullCharCodeAtPos())) {
+    this.raise(this.pos, "Identifier directly after number");
+  }
+  var val = stringToNumber(this.input.slice(start3, this.pos), octal);
+  return this.finishToken(types$1.num, val);
+};
+pp.readCodePoint = function() {
+  var ch = this.input.charCodeAt(this.pos), code;
+  if (ch === 123) {
+    if (this.options.ecmaVersion < 6) {
+      this.unexpected();
+    }
+    var codePos = ++this.pos;
+    code = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos);
+    ++this.pos;
+    if (code > 1114111) {
+      this.invalidStringToken(codePos, "Code point out of bounds");
+    }
+  } else {
+    code = this.readHexChar(4);
+  }
+  return code;
+};
+pp.readString = function(quote) {
+  var out = "", chunkStart = ++this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(this.start, "Unterminated string constant");
+    }
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === quote) {
+      break;
+    }
+    if (ch === 92) {
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar(false);
+      chunkStart = this.pos;
+    } else if (ch === 8232 || ch === 8233) {
+      if (this.options.ecmaVersion < 10) {
+        this.raise(this.start, "Unterminated string constant");
+      }
+      ++this.pos;
+      if (this.options.locations) {
+        this.curLine++;
+        this.lineStart = this.pos;
+      }
+    } else {
+      if (isNewLine(ch)) {
+        this.raise(this.start, "Unterminated string constant");
+      }
+      ++this.pos;
+    }
+  }
+  out += this.input.slice(chunkStart, this.pos++);
+  return this.finishToken(types$1.string, out);
+};
+var INVALID_TEMPLATE_ESCAPE_ERROR = {};
+pp.tryReadTemplateToken = function() {
+  this.inTemplateElement = true;
+  try {
+    this.readTmplToken();
+  } catch (err) {
+    if (err === INVALID_TEMPLATE_ESCAPE_ERROR) {
+      this.readInvalidTemplateToken();
+    } else {
+      throw err;
+    }
+  }
+  this.inTemplateElement = false;
+};
+pp.invalidStringToken = function(position2, message) {
+  if (this.inTemplateElement && this.options.ecmaVersion >= 9) {
+    throw INVALID_TEMPLATE_ESCAPE_ERROR;
+  } else {
+    this.raise(position2, message);
+  }
+};
+pp.readTmplToken = function() {
+  var out = "", chunkStart = this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(this.start, "Unterminated template");
+    }
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) {
+      if (this.pos === this.start && (this.type === types$1.template || this.type === types$1.invalidTemplate)) {
+        if (ch === 36) {
+          this.pos += 2;
+          return this.finishToken(types$1.dollarBraceL);
+        } else {
+          ++this.pos;
+          return this.finishToken(types$1.backQuote);
+        }
+      }
+      out += this.input.slice(chunkStart, this.pos);
+      return this.finishToken(types$1.template, out);
+    }
+    if (ch === 92) {
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar(true);
+      chunkStart = this.pos;
+    } else if (isNewLine(ch)) {
+      out += this.input.slice(chunkStart, this.pos);
+      ++this.pos;
+      switch (ch) {
+        case 13:
+          if (this.input.charCodeAt(this.pos) === 10) {
+            ++this.pos;
+          }
+        case 10:
+          out += "\n";
+          break;
+        default:
+          out += String.fromCharCode(ch);
+          break;
+      }
+      if (this.options.locations) {
+        ++this.curLine;
+        this.lineStart = this.pos;
+      }
+      chunkStart = this.pos;
+    } else {
+      ++this.pos;
+    }
+  }
+};
+pp.readInvalidTemplateToken = function() {
+  for (; this.pos < this.input.length; this.pos++) {
+    switch (this.input[this.pos]) {
+      case "\\":
+        ++this.pos;
+        break;
+      case "$":
+        if (this.input[this.pos + 1] !== "{") {
+          break;
+        }
+      case "`":
+        return this.finishToken(types$1.invalidTemplate, this.input.slice(this.start, this.pos));
+    }
+  }
+  this.raise(this.start, "Unterminated template");
+};
+pp.readEscapedChar = function(inTemplate) {
+  var ch = this.input.charCodeAt(++this.pos);
+  ++this.pos;
+  switch (ch) {
+    case 110:
+      return "\n";
+    case 114:
+      return "\r";
+    case 120:
+      return String.fromCharCode(this.readHexChar(2));
+    case 117:
+      return codePointToString(this.readCodePoint());
+    case 116:
+      return "	";
+    case 98:
+      return "\b";
+    case 118:
+      return "\v";
+    case 102:
+      return "\f";
+    case 13:
+      if (this.input.charCodeAt(this.pos) === 10) {
+        ++this.pos;
+      }
+    case 10:
+      if (this.options.locations) {
+        this.lineStart = this.pos;
+        ++this.curLine;
+      }
+      return "";
+    case 56:
+    case 57:
+      if (this.strict) {
+        this.invalidStringToken(
+          this.pos - 1,
+          "Invalid escape sequence"
+        );
+      }
+      if (inTemplate) {
+        var codePos = this.pos - 1;
+        this.invalidStringToken(
+          codePos,
+          "Invalid escape sequence in template string"
+        );
+        return null;
+      }
+    default:
+      if (ch >= 48 && ch <= 55) {
+        var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+        var octal = parseInt(octalStr, 8);
+        if (octal > 255) {
+          octalStr = octalStr.slice(0, -1);
+          octal = parseInt(octalStr, 8);
+        }
+        this.pos += octalStr.length - 1;
+        ch = this.input.charCodeAt(this.pos);
+        if ((octalStr !== "0" || ch === 56 || ch === 57) && (this.strict || inTemplate)) {
+          this.invalidStringToken(
+            this.pos - 1 - octalStr.length,
+            inTemplate ? "Octal literal in template string" : "Octal literal in strict mode"
+          );
+        }
+        return String.fromCharCode(octal);
+      }
+      if (isNewLine(ch)) {
+        return "";
+      }
+      return String.fromCharCode(ch);
+  }
+};
+pp.readHexChar = function(len) {
+  var codePos = this.pos;
+  var n = this.readInt(16, len);
+  if (n === null) {
+    this.invalidStringToken(codePos, "Bad character escape sequence");
+  }
+  return n;
+};
+pp.readWord1 = function() {
+  this.containsEsc = false;
+  var word = "", first = true, chunkStart = this.pos;
+  var astral = this.options.ecmaVersion >= 6;
+  while (this.pos < this.input.length) {
+    var ch = this.fullCharCodeAtPos();
+    if (isIdentifierChar(ch, astral)) {
+      this.pos += ch <= 65535 ? 1 : 2;
+    } else if (ch === 92) {
+      this.containsEsc = true;
+      word += this.input.slice(chunkStart, this.pos);
+      var escStart = this.pos;
+      if (this.input.charCodeAt(++this.pos) !== 117) {
+        this.invalidStringToken(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+      }
+      ++this.pos;
+      var esc = this.readCodePoint();
+      if (!(first ? isIdentifierStart : isIdentifierChar)(esc, astral)) {
+        this.invalidStringToken(escStart, "Invalid Unicode escape");
+      }
+      word += codePointToString(esc);
+      chunkStart = this.pos;
+    } else {
+      break;
+    }
+    first = false;
+  }
+  return word + this.input.slice(chunkStart, this.pos);
+};
+pp.readWord = function() {
+  var word = this.readWord1();
+  var type = types$1.name;
+  if (this.keywords.test(word)) {
+    type = keywords[word];
+  }
+  return this.finishToken(type, word);
+};
+var version = "8.8.1";
+Parser.acorn = {
+  Parser,
+  version,
+  defaultOptions,
+  Position,
+  SourceLocation,
+  getLineInfo,
+  Node,
+  TokenType,
+  tokTypes: types$1,
+  keywordTypes: keywords,
+  TokContext,
+  tokContexts: types,
+  isIdentifierChar,
+  isIdentifierStart,
+  Token,
+  isNewLine,
+  lineBreak,
+  lineBreakG,
+  nonASCIIwhitespace
+};
+
+// node_modules/micromark-extension-mdxjs/index.js
+var import_acorn_jsx = __toESM(require_acorn_jsx(), 1);
+
+// node_modules/micromark-util-chunked/index.js
+function splice(list, start3, remove, items) {
+  const end = list.length;
+  let chunkStart = 0;
+  let parameters;
+  if (start3 < 0) {
+    start3 = -start3 > end ? 0 : end + start3;
+  } else {
+    start3 = start3 > end ? end : start3;
+  }
+  remove = remove > 0 ? remove : 0;
+  if (items.length < 1e4) {
+    parameters = Array.from(items);
+    parameters.unshift(start3, remove);
+    [].splice.apply(list, parameters);
+  } else {
+    if (remove)
+      [].splice.apply(list, [start3, remove]);
+    while (chunkStart < items.length) {
+      parameters = items.slice(chunkStart, chunkStart + 1e4);
+      parameters.unshift(start3, 0);
+      [].splice.apply(list, parameters);
+      chunkStart += 1e4;
+      start3 += 1e4;
+    }
+  }
+}
+
+// node_modules/micromark-util-combine-extensions/index.js
+var hasOwnProperty2 = {}.hasOwnProperty;
+function combineExtensions(extensions) {
+  const all = {};
+  let index2 = -1;
+  while (++index2 < extensions.length) {
+    syntaxExtension(all, extensions[index2]);
+  }
+  return all;
+}
+function syntaxExtension(all, extension) {
+  let hook;
+  for (hook in extension) {
+    const maybe = hasOwnProperty2.call(all, hook) ? all[hook] : void 0;
+    const left = maybe || (all[hook] = {});
+    const right = extension[hook];
+    let code;
+    for (code in right) {
+      if (!hasOwnProperty2.call(left, code))
+        left[code] = [];
+      const value = right[code];
+      constructs(
+        left[code],
+        Array.isArray(value) ? value : value ? [value] : []
+      );
+    }
+  }
+}
+function constructs(existing, list) {
+  let index2 = -1;
+  const before = [];
+  while (++index2 < list.length) {
+    ;
+    (list[index2].add === "after" ? existing : before).push(list[index2]);
+  }
+  splice(existing, 0, 0, before);
+}
+
+// node_modules/micromark-util-character/lib/unicode-punctuation-regex.js
+var unicodePunctuationRegex = /[!-/:-@[-`{-~\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0A76\u0AF0\u0C77\u0C84\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E4F\u2E52\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]/;
+
+// node_modules/micromark-util-character/index.js
+var asciiAlpha = regexCheck(/[A-Za-z]/);
+var asciiDigit = regexCheck(/\d/);
+var asciiHexDigit = regexCheck(/[\dA-Fa-f]/);
+var asciiAlphanumeric = regexCheck(/[\dA-Za-z]/);
+var asciiPunctuation = regexCheck(/[!-/:-@[-`{-~]/);
+var asciiAtext = regexCheck(/[#-'*+\--9=?A-Z^-~]/);
+function markdownLineEndingOrSpace(code) {
+  return code !== null && (code < 0 || code === 32);
+}
+function markdownLineEnding(code) {
+  return code !== null && code < -2;
+}
+function markdownSpace(code) {
+  return code === -2 || code === -1 || code === 32;
+}
+var unicodeWhitespace = regexCheck(/\s/);
+var unicodePunctuation = regexCheck(unicodePunctuationRegex);
+function regexCheck(regex) {
+  return check;
+  function check(code) {
+    return code !== null && regex.test(String.fromCharCode(code));
+  }
+}
+
+// node_modules/micromark-factory-space/index.js
+function factorySpace(effects, ok, type, max) {
+  const limit = max ? max - 1 : Number.POSITIVE_INFINITY;
+  let size = 0;
+  return start3;
+  function start3(code) {
+    if (markdownSpace(code)) {
+      effects.enter(type);
+      return prefix(code);
+    }
+    return ok(code);
+  }
+  function prefix(code) {
+    if (markdownSpace(code) && size++ < limit) {
+      effects.consume(code);
+      return prefix;
+    }
+    effects.exit(type);
+    return ok(code);
+  }
+}
+
+// node_modules/unist-util-position-from-estree/index.js
+function positionFromEstree(value) {
+  const node = value || {};
+  const loc = node.loc || {};
+  const range = node.range || [0, 0];
+  const startOffset = range[0] || node.start;
+  const endOffset = range[1] || node.end;
+  return {
+    start: {
+      line: loc.start && typeof loc.start.line === "number" && loc.start.line > -1 ? loc.start.line : void 0,
+      column: loc.start && typeof loc.start.column === "number" && loc.start.column > -1 ? loc.start.column + 1 : void 0,
+      offset: typeof startOffset === "number" && startOffset > -1 ? startOffset : void 0
+    },
+    end: {
+      line: loc.end && typeof loc.end.line === "number" && loc.end.line > -1 ? loc.end.line : void 0,
+      column: loc.end && typeof loc.end.column === "number" && loc.end.column > -1 ? loc.end.column + 1 : void 0,
+      offset: typeof endOffset === "number" && endOffset > -1 ? endOffset : void 0
+    }
+  };
+}
+
+// node_modules/unist-util-stringify-position/index.js
+function stringifyPosition(value) {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  if ("position" in value || "type" in value) {
+    return position(value.position);
+  }
+  if ("start" in value || "end" in value) {
+    return position(value);
+  }
+  if ("line" in value || "column" in value) {
+    return point(value);
+  }
+  return "";
+}
+function point(point2) {
+  return index(point2 && point2.line) + ":" + index(point2 && point2.column);
+}
+function position(pos) {
+  return point(pos && pos.start) + "-" + point(pos && pos.end);
+}
+function index(value) {
+  return value && typeof value === "number" ? value : 1;
+}
+
+// node_modules/vfile-message/index.js
+var VFileMessage = class extends Error {
+  constructor(reason, place, origin) {
+    const parts = [null, null];
+    let position2 = {
+      start: { line: null, column: null },
+      end: { line: null, column: null }
+    };
+    super();
+    if (typeof place === "string") {
+      origin = place;
+      place = void 0;
+    }
+    if (typeof origin === "string") {
+      const index2 = origin.indexOf(":");
+      if (index2 === -1) {
+        parts[1] = origin;
+      } else {
+        parts[0] = origin.slice(0, index2);
+        parts[1] = origin.slice(index2 + 1);
+      }
+    }
+    if (place) {
+      if ("type" in place || "position" in place) {
+        if (place.position) {
+          position2 = place.position;
+        }
+      } else if ("start" in place || "end" in place) {
+        position2 = place;
+      } else if ("line" in place || "column" in place) {
+        position2.start = place;
+      }
+    }
+    this.name = stringifyPosition(place) || "1:1";
+    this.message = typeof reason === "object" ? reason.message : reason;
+    this.stack = typeof reason === "object" ? reason.stack : "";
+    this.reason = this.message;
+    this.fatal;
+    this.line = position2.start.line;
+    this.column = position2.start.column;
+    this.source = parts[0];
+    this.ruleId = parts[1];
+    this.position = position2;
+    this.actual;
+    this.expected;
+    this.file;
+    this.url;
+    this.note;
+  }
+};
+VFileMessage.prototype.file = "";
+VFileMessage.prototype.name = "";
+VFileMessage.prototype.reason = "";
+VFileMessage.prototype.message = "";
+VFileMessage.prototype.stack = "";
+VFileMessage.prototype.fatal = null;
+VFileMessage.prototype.column = null;
+VFileMessage.prototype.line = null;
+VFileMessage.prototype.source = null;
+VFileMessage.prototype.ruleId = null;
+VFileMessage.prototype.position = null;
+
+// node_modules/estree-util-visit/color.js
+function color(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/estree-util-visit/index.js
+var own = {}.hasOwnProperty;
+var CONTINUE = Symbol("continue");
+var SKIP = Symbol("skip");
+var EXIT = Symbol("exit");
+function visit(tree, visitor) {
+  let enter;
+  let leave;
+  if (typeof visitor === "function") {
+    enter = visitor;
+  } else if (visitor && typeof visitor === "object") {
+    enter = visitor.enter;
+    leave = visitor.leave;
+  }
+  build(tree, null, null, [])();
+  function build(node, key, index2, parents) {
+    if (nodelike(node)) {
+      visit2.displayName = "node (" + color(node.type) + ")";
+    }
+    return visit2;
+    function visit2() {
+      const result = enter ? toResult(enter(node, key, index2, parents)) : [];
+      if (result[0] === EXIT) {
+        return result;
+      }
+      if (result[0] !== SKIP) {
+        let cKey;
+        for (cKey in node) {
+          if (own.call(node, cKey) && node[cKey] && typeof node[cKey] === "object" && cKey !== "data" && cKey !== "position") {
+            const value = node[cKey];
+            const grandparents = parents.concat(node);
+            if (Array.isArray(value)) {
+              let cIndex = 0;
+              while (cIndex > -1 && cIndex < value.length) {
+                const subvalue = value[cIndex];
+                if (nodelike(subvalue)) {
+                  const subresult = build(
+                    subvalue,
+                    cKey,
+                    cIndex,
+                    grandparents
+                  )();
+                  if (subresult[0] === EXIT)
+                    return subresult;
+                  cIndex = typeof subresult[1] === "number" ? subresult[1] : cIndex + 1;
+                } else {
+                  cIndex++;
+                }
+              }
+            } else if (nodelike(value)) {
+              const subresult = build(value, cKey, null, grandparents)();
+              if (subresult[0] === EXIT)
+                return subresult;
+            }
+          }
+        }
+      }
+      return leave ? toResult(leave(node, key, index2, parents)) : result;
+    }
+  }
+}
+function toResult(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE, value];
+  }
+  return [value];
+}
+function nodelike(value) {
+  return Boolean(
+    value && typeof value === "object" && typeof value.type === "string" && value.type.length > 0
+  );
+}
+
+// node_modules/micromark-util-events-to-acorn/node_modules/vfile-location/index.js
+function location(file) {
+  var value = String(file);
+  var indices = [];
+  var search = /\r?\n|\r/g;
+  while (search.test(value)) {
+    indices.push(search.lastIndex);
+  }
+  indices.push(value.length + 1);
+  return { toPoint, toOffset };
+  function toPoint(offset2) {
+    var index2 = -1;
+    if (offset2 > -1 && offset2 < indices[indices.length - 1]) {
+      while (++index2 < indices.length) {
+        if (indices[index2] > offset2) {
+          return {
+            line: index2 + 1,
+            column: offset2 - (indices[index2 - 1] || 0) + 1,
+            offset: offset2
+          };
+        }
+      }
+    }
+    return { line: void 0, column: void 0, offset: void 0 };
+  }
+  function toOffset(point2) {
+    var line = point2 && point2.line;
+    var column = point2 && point2.column;
+    var offset2;
+    if (typeof line === "number" && typeof column === "number" && !Number.isNaN(line) && !Number.isNaN(column) && line - 1 in indices) {
+      offset2 = (indices[line - 2] || 0) + column - 1 || 0;
+    }
+    return offset2 > -1 && offset2 < indices[indices.length - 1] ? offset2 : -1;
+  }
+}
+
+// node_modules/micromark-util-events-to-acorn/index.js
+function eventsToAcorn(events, options) {
+  const { prefix = "", suffix = "" } = options;
+  const acornOptions = Object.assign({}, options.acornOptions);
+  const comments = [];
+  const tokens = [];
+  const onComment = acornOptions.onComment;
+  const onToken = acornOptions.onToken;
+  const acornConfig = Object.assign({}, acornOptions, {
+    onComment: comments,
+    onToken: onToken ? tokens : void 0,
+    preserveParens: true
+  });
+  const chunks = [];
+  const lines = {};
+  let index2 = -1;
+  let swallow = false;
+  let estree;
+  let exception;
+  let startLine;
+  if (options.start) {
+    startLine = options.start.line;
+    lines[startLine] = options.start;
+  }
+  while (++index2 < events.length) {
+    const [kind, token, context] = events[index2];
+    if (kind === "exit") {
+      chunks.push(context.sliceSerialize(token));
+      setPoint(token.start);
+      setPoint(token.end);
+    }
+  }
+  const source = chunks.join("");
+  const value = prefix + source + suffix;
+  const isEmptyExpression = options.expression && empty2(source);
+  const place = location(source);
+  if (isEmptyExpression && !options.allowEmpty) {
+    throw new VFileMessage(
+      "Unexpected empty expression",
+      parseOffsetToUnistPoint(0),
+      "micromark-extension-mdx-expression:unexpected-empty-expression"
+    );
+  }
+  try {
+    estree = options.expression && !isEmptyExpression ? options.acorn.parseExpressionAt(value, 0, acornConfig) : options.acorn.parse(value, acornConfig);
+  } catch (error_) {
+    const error = error_;
+    const point2 = parseOffsetToUnistPoint(error.pos);
+    error.message = String(error.message).replace(/ \(\d+:\d+\)$/, "");
+    error.pos = point2.offset;
+    error.loc = {
+      line: point2.line,
+      column: point2.column - 1
+    };
+    exception = error;
+    swallow = error.raisedAt >= prefix.length + source.length || error.message === "Unterminated comment";
+  }
+  if (estree && options.expression && !isEmptyExpression) {
+    if (empty2(value.slice(estree.end, value.length - suffix.length))) {
+      estree = {
+        type: "Program",
+        start: 0,
+        end: prefix.length + source.length,
+        body: [
+          {
+            type: "ExpressionStatement",
+            expression: estree,
+            start: 0,
+            end: prefix.length + source.length
+          }
+        ],
+        sourceType: "module",
+        comments: []
+      };
+    } else {
+      const point2 = parseOffsetToUnistPoint(estree.end);
+      exception = new Error("Unexpected content after expression");
+      exception.pos = point2.offset;
+      exception.loc = {
+        line: point2.line,
+        column: point2.column - 1
+      };
+      estree = void 0;
+    }
+  }
+  if (estree) {
+    estree.comments = comments;
+    visit(estree, (esnode, field, index3, parents) => {
+      let context = parents[parents.length - 1];
+      let prop = field;
+      if (esnode.type === "ParenthesizedExpression" && context && prop) {
+        if (typeof index3 === "number") {
+          context = context[prop];
+          prop = index3;
+        }
+        context[prop] = esnode.expression;
+      }
+      fixPosition(esnode);
+    });
+    if (Array.isArray(onComment)) {
+      onComment.push(...comments);
+    } else if (typeof onComment === "function") {
+      for (const comment of comments) {
+        onComment(
+          comment.type === "Block",
+          comment.value,
+          comment.start,
+          comment.end,
+          comment.loc.start,
+          comment.loc.end
+        );
+      }
+    }
+    for (const token of tokens) {
+      fixPosition(token);
+      if (Array.isArray(onToken)) {
+        onToken.push(token);
+      } else {
+        onToken(token);
+      }
+    }
+  }
+  return {
+    estree,
+    error: exception,
+    swallow
+  };
+  function fixPosition(nodeOrToken) {
+    const pointStart = parseOffsetToUnistPoint(nodeOrToken.start);
+    const pointEnd = parseOffsetToUnistPoint(nodeOrToken.end);
+    nodeOrToken.start = pointStart.offset;
+    nodeOrToken.end = pointEnd.offset;
+    nodeOrToken.loc = {
+      start: {
+        line: pointStart.line,
+        column: pointStart.column - 1,
+        offset: pointStart.offset
+      },
+      end: {
+        line: pointEnd.line,
+        column: pointEnd.column - 1,
+        offset: pointEnd.offset
+      }
+    };
+    nodeOrToken.range = [nodeOrToken.start, nodeOrToken.end];
+  }
+  function parseOffsetToUnistPoint(acornOffset) {
+    let sourceOffset = acornOffset - prefix.length;
+    if (sourceOffset < 0) {
+      sourceOffset = 0;
+    } else if (sourceOffset > source.length) {
+      sourceOffset = source.length;
+    }
+    const pointInSource = place.toPoint(sourceOffset);
+    const line = startLine + (pointInSource.line - 1);
+    const column = lines[line].column + (pointInSource.column - 1);
+    const offset2 = lines[line].offset + (pointInSource.column - 1);
+    return {
+      line,
+      column,
+      offset: offset2
+    };
+  }
+  function setPoint(point2) {
+    if (!startLine || point2.line < startLine) {
+      startLine = point2.line;
+    }
+    if (!(point2.line in lines) || lines[point2.line].offset > point2.offset) {
+      lines[point2.line] = point2;
+    }
+  }
+}
+function empty2(value) {
+  return /^\s*$/.test(
+    value.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\r\n]*(\r\n|\n|\r)/g, "")
+  );
+}
+
+// node_modules/micromark-factory-mdx-expression/index.js
+function factoryMdxExpression(effects, ok, type, markerType, chunkType, acorn, acornOptions, addResult, spread, allowEmpty, allowLazy, startColumn) {
+  const self2 = this;
+  const eventStart = this.events.length + 3;
+  const tail = this.events[this.events.length - 1];
+  const initialPrefix = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  const prefixExpressionIndent = initialPrefix ? initialPrefix + 1 : 0;
+  let balance = 1;
+  let startPosition;
+  let lastCrash;
+  return start3;
+  function start3(code) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code);
+    effects.exit(markerType);
+    startPosition = self2.now();
+    return atBreak;
+  }
+  function atBreak(code) {
+    if (code === null) {
+      throw lastCrash || new VFileMessage(
+        "Unexpected end of file in expression, expected a corresponding closing brace for `{`",
+        self2.now(),
+        "micromark-extension-mdx-expression:unexpected-eof"
+      );
+    }
+    if (code === 125) {
+      return atClosingBrace(code);
+    }
+    if (markdownLineEnding(code)) {
+      effects.enter("lineEnding");
+      effects.consume(code);
+      effects.exit("lineEnding");
+      const prefixTagIndent = startColumn ? startColumn + 4 - self2.now().column : 0;
+      const indent = Math.max(prefixExpressionIndent, prefixTagIndent);
+      return indent ? factorySpace(effects, atBreak, "linePrefix", indent) : atBreak;
+    }
+    const now = self2.now();
+    if (now.line !== startPosition.line && !allowLazy && self2.parser.lazy[now.line]) {
+      throw new VFileMessage(
+        "Unexpected end of file in expression, expected a corresponding closing brace for `{`",
+        self2.now(),
+        "micromark-extension-mdx-expression:unexpected-eof"
+      );
+    }
+    effects.enter(chunkType);
+    return inside(code);
+  }
+  function inside(code) {
+    if (code === null || code === 125 || markdownLineEnding(code)) {
+      effects.exit(chunkType);
+      return atBreak(code);
+    }
+    if (code === 123 && !acorn) {
+      effects.consume(code);
+      balance++;
+      return inside;
+    }
+    effects.consume(code);
+    return inside;
+  }
+  function atClosingBrace(code) {
+    balance--;
+    if (!acorn) {
+      if (balance) {
+        effects.enter(chunkType);
+        effects.consume(code);
+        return inside;
+      }
+      effects.enter(markerType);
+      effects.consume(code);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok;
+    }
+    const result = eventsToAcorn(self2.events.slice(eventStart), {
+      acorn,
+      acornOptions,
+      start: startPosition,
+      expression: true,
+      allowEmpty,
+      prefix: spread ? "({" : "",
+      suffix: spread ? "})" : ""
+    });
+    const estree = result.estree;
+    if (spread && estree) {
+      const head = estree.body[0];
+      if (head.type !== "ExpressionStatement" || head.expression.type !== "ObjectExpression") {
+        throw new VFileMessage(
+          "Unexpected `" + head.type + "` in code: expected an object spread (`{...spread}`)",
+          positionFromEstree(head).start,
+          "micromark-extension-mdx-expression:non-spread"
+        );
+      } else if (head.expression.properties[1]) {
+        throw new VFileMessage(
+          "Unexpected extra content in spread: only a single spread is supported",
+          positionFromEstree(head.expression.properties[1]).start,
+          "micromark-extension-mdx-expression:spread-extra"
+        );
+      } else if (head.expression.properties[0] && head.expression.properties[0].type !== "SpreadElement") {
+        throw new VFileMessage(
+          "Unexpected `" + head.expression.properties[0].type + "` in code: only spread elements are supported",
+          positionFromEstree(head.expression.properties[0]).start,
+          "micromark-extension-mdx-expression:non-spread"
+        );
+      }
+    }
+    if (result.error) {
+      lastCrash = new VFileMessage(
+        "Could not parse expression with acorn: " + result.error.message,
+        {
+          line: result.error.loc.line,
+          column: result.error.loc.column + 1,
+          offset: result.error.pos
+        },
+        "micromark-extension-mdx-expression:acorn"
+      );
+      if (code !== null && result.swallow) {
+        effects.enter(chunkType);
+        effects.consume(code);
+        return inside;
+      }
+      throw lastCrash;
+    }
+    effects.enter(markerType);
+    effects.consume(code);
+    effects.exit(markerType);
+    Object.assign(
+      effects.exit(type),
+      addResult ? {
+        estree
+      } : void 0
+    );
+    return ok;
+  }
+}
+
+// node_modules/micromark-extension-mdx-expression/lib/syntax.js
+function mdxExpression(options = {}) {
+  const addResult = options.addResult;
+  const acorn = options.acorn;
+  const spread = options.spread;
+  let allowEmpty = options.allowEmpty;
+  let acornOptions;
+  if (allowEmpty === null || allowEmpty === void 0) {
+    allowEmpty = true;
+  }
+  if (acorn) {
+    if (!acorn.parseExpressionAt) {
+      throw new Error(
+        "Expected a proper `acorn` instance passed in as `options.acorn`"
+      );
+    }
+    acornOptions = Object.assign(
+      {
+        ecmaVersion: 2020,
+        sourceType: "module"
+      },
+      options.acornOptions
+    );
+  } else if (options.acornOptions || options.addResult) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  return {
+    flow: {
+      [123]: {
+        tokenize: tokenizeFlowExpression,
+        concrete: true
+      }
+    },
+    text: {
+      [123]: {
+        tokenize: tokenizeTextExpression
+      }
+    }
+  };
+  function tokenizeFlowExpression(effects, ok, nok) {
+    const self2 = this;
+    return start3;
+    function start3(code) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        factorySpace(effects, after, "whitespace"),
+        "mdxFlowExpression",
+        "mdxFlowExpressionMarker",
+        "mdxFlowExpressionChunk",
+        acorn,
+        acornOptions,
+        addResult,
+        spread,
+        allowEmpty
+      )(code);
+    }
+    function after(code) {
+      return code === null || markdownLineEnding(code) ? ok(code) : nok(code);
+    }
+  }
+  function tokenizeTextExpression(effects, ok) {
+    const self2 = this;
+    return start3;
+    function start3(code) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        ok,
+        "mdxTextExpression",
+        "mdxTextExpressionMarker",
+        "mdxTextExpressionChunk",
+        acorn,
+        acornOptions,
+        addResult,
+        spread,
+        allowEmpty,
+        true
+      )(code);
+    }
+  }
+}
+
+// node_modules/estree-util-is-identifier-name/regex.js
+var start = /[$A-Z_a-z\u00AA\u00B5\u00BA\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u08A0-\u08B4\u08B6-\u08C7\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2C2E\u2C30-\u2C5E\u2C60-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFC\uA000-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7BF\uA7C2-\uA7CA\uA7F5-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/;
+var cont = /[\d\u00B7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1714\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u1810-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF\u1AC0\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u200C\u200D\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F]/;
+
+// node_modules/estree-util-is-identifier-name/index.js
+function start2(code) {
+  return start.test(String.fromCharCode(code));
+}
+function cont2(code) {
+  const character = String.fromCharCode(code);
+  return start.test(character) || cont.test(character);
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/factory-tag.js
+var lazyLineEnd = {
+  tokenize: tokenizeLazyLineEnd,
+  partial: true
+};
+function factoryTag(effects, ok, nok, acorn, acornOptions, addResult, allowLazy, tagType, tagMarkerType, tagClosingMarkerType, tagSelfClosingMarker, tagNameType, tagNamePrimaryType, tagNameMemberMarkerType, tagNameMemberType, tagNamePrefixMarkerType, tagNameLocalType, tagExpressionAttributeType, tagExpressionAttributeMarkerType, tagExpressionAttributeValueType, tagAttributeType, tagAttributeNameType, tagAttributeNamePrimaryType, tagAttributeNamePrefixMarkerType, tagAttributeNameLocalType, tagAttributeInitializerMarkerType, tagAttributeValueLiteralType, tagAttributeValueLiteralMarkerType, tagAttributeValueLiteralValueType, tagAttributeValueExpressionType, tagAttributeValueExpressionMarkerType, tagAttributeValueExpressionValueType) {
+  const self2 = this;
+  let returnState;
+  let marker;
+  let startPoint;
+  return start3;
+  function start3(code) {
+    startPoint = self2.now();
+    effects.enter(tagType);
+    effects.enter(tagMarkerType);
+    effects.consume(code);
+    effects.exit(tagMarkerType);
+    return afterStart;
+  }
+  function afterStart(code) {
+    if (markdownLineEnding(code) || markdownSpace(code)) {
+      return nok(code);
+    }
+    returnState = beforeName;
+    return optionalEsWhitespace(code);
+  }
+  function beforeName(code) {
+    if (code === 47) {
+      effects.enter(tagClosingMarkerType);
+      effects.consume(code);
+      effects.exit(tagClosingMarkerType);
+      returnState = beforeClosingTagName;
+      return optionalEsWhitespace;
+    }
+    if (code === 62) {
+      return tagEnd(code);
+    }
+    if (code !== null && start2(code)) {
+      effects.enter(tagNameType);
+      effects.enter(tagNamePrimaryType);
+      effects.consume(code);
+      return primaryName;
+    }
+    crash(
+      code,
+      "before name",
+      "a character that can start a name, such as a letter, `$`, or `_`" + (code === 33 ? " (note: to create a comment in MDX, use `{/* text */}`)" : "")
+    );
+  }
+  function beforeClosingTagName(code) {
+    if (code === 62) {
+      return tagEnd(code);
+    }
+    if (code !== null && start2(code)) {
+      effects.enter(tagNameType);
+      effects.enter(tagNamePrimaryType);
+      effects.consume(code);
+      return primaryName;
+    }
+    crash(
+      code,
+      "before name",
+      "a character that can start a name, such as a letter, `$`, or `_`" + (code === 42 || code === 47 ? " (note: JS comments in JSX tags are not supported in MDX)" : "")
+    );
+  }
+  function primaryName(code) {
+    if (code === 45 || code !== null && cont2(code)) {
+      effects.consume(code);
+      return primaryName;
+    }
+    if (code === 46 || code === 47 || code === 58 || code === 62 || code === 123 || markdownLineEndingOrSpace(code) || unicodeWhitespace(code)) {
+      effects.exit(tagNamePrimaryType);
+      returnState = afterPrimaryName;
+      return optionalEsWhitespace(code);
+    }
+    crash(
+      code,
+      "in name",
+      "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag" + (code === 64 ? " (note: to create a link in MDX, use `[text](url)`)" : "")
+    );
+  }
+  function afterPrimaryName(code) {
+    if (code === 46) {
+      effects.enter(tagNameMemberMarkerType);
+      effects.consume(code);
+      effects.exit(tagNameMemberMarkerType);
+      returnState = beforeMemberName;
+      return optionalEsWhitespace;
+    }
+    if (code === 58) {
+      effects.enter(tagNamePrefixMarkerType);
+      effects.consume(code);
+      effects.exit(tagNamePrefixMarkerType);
+      returnState = beforeLocalName;
+      return optionalEsWhitespace;
+    }
+    if (code === 47 || code === 62 || code === 123 || code !== null && start2(code)) {
+      effects.exit(tagNameType);
+      return beforeAttribute(code);
+    }
+    crash(
+      code,
+      "after name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function beforeMemberName(code) {
+    if (code !== null && start2(code)) {
+      effects.enter(tagNameMemberType);
+      effects.consume(code);
+      return memberName;
+    }
+    crash(
+      code,
+      "before member name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function memberName(code) {
+    if (code === 45 || code !== null && cont2(code)) {
+      effects.consume(code);
+      return memberName;
+    }
+    if (code === 46 || code === 47 || code === 62 || code === 123 || markdownLineEndingOrSpace(code) || unicodeWhitespace(code)) {
+      effects.exit(tagNameMemberType);
+      returnState = afterMemberName;
+      return optionalEsWhitespace(code);
+    }
+    crash(
+      code,
+      "in member name",
+      "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag" + (code === 64 ? " (note: to create a link in MDX, use `[text](url)`)" : "")
+    );
+  }
+  function afterMemberName(code) {
+    if (code === 46) {
+      effects.enter(tagNameMemberMarkerType);
+      effects.consume(code);
+      effects.exit(tagNameMemberMarkerType);
+      returnState = beforeMemberName;
+      return optionalEsWhitespace;
+    }
+    if (code === 47 || code === 62 || code === 123 || code !== null && start2(code)) {
+      effects.exit(tagNameType);
+      return beforeAttribute(code);
+    }
+    crash(
+      code,
+      "after member name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function beforeLocalName(code) {
+    if (code !== null && start2(code)) {
+      effects.enter(tagNameLocalType);
+      effects.consume(code);
+      return localName;
+    }
+    crash(
+      code,
+      "before local name",
+      "a character that can start a name, such as a letter, `$`, or `_`" + (code === 43 || code !== null && code > 46 && code < 58 ? " (note: to create a link in MDX, use `[text](url)`)" : "")
+    );
+  }
+  function localName(code) {
+    if (code === 45 || code !== null && cont2(code)) {
+      effects.consume(code);
+      return localName;
+    }
+    if (code === 47 || code === 62 || code === 123 || markdownLineEndingOrSpace(code) || unicodeWhitespace(code)) {
+      effects.exit(tagNameLocalType);
+      returnState = afterLocalName;
+      return optionalEsWhitespace(code);
+    }
+    crash(
+      code,
+      "in local name",
+      "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterLocalName(code) {
+    if (code === 47 || code === 62 || code === 123 || code !== null && start2(code)) {
+      effects.exit(tagNameType);
+      return beforeAttribute(code);
+    }
+    crash(
+      code,
+      "after local name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function beforeAttribute(code) {
+    if (code === 47) {
+      effects.enter(tagSelfClosingMarker);
+      effects.consume(code);
+      effects.exit(tagSelfClosingMarker);
+      returnState = selfClosing;
+      return optionalEsWhitespace;
+    }
+    if (code === 62) {
+      return tagEnd(code);
+    }
+    if (code === 123) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        afterAttributeExpression,
+        tagExpressionAttributeType,
+        tagExpressionAttributeMarkerType,
+        tagExpressionAttributeValueType,
+        acorn,
+        acornOptions,
+        addResult,
+        true,
+        false,
+        allowLazy,
+        startPoint.column
+      )(code);
+    }
+    if (code !== null && start2(code)) {
+      effects.enter(tagAttributeType);
+      effects.enter(tagAttributeNameType);
+      effects.enter(tagAttributeNamePrimaryType);
+      effects.consume(code);
+      return attributePrimaryName;
+    }
+    crash(
+      code,
+      "before attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterAttributeExpression(code) {
+    returnState = beforeAttribute;
+    return optionalEsWhitespace(code);
+  }
+  function attributePrimaryName(code) {
+    if (code === 45 || code !== null && cont2(code)) {
+      effects.consume(code);
+      return attributePrimaryName;
+    }
+    if (code === 47 || code === 58 || code === 61 || code === 62 || code === 123 || markdownLineEndingOrSpace(code) || unicodeWhitespace(code)) {
+      effects.exit(tagAttributeNamePrimaryType);
+      returnState = afterAttributePrimaryName;
+      return optionalEsWhitespace(code);
+    }
+    crash(
+      code,
+      "in attribute name",
+      "an attribute name character such as letters, digits, `$`, or `_`; `=` to initialize a value; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterAttributePrimaryName(code) {
+    if (code === 58) {
+      effects.enter(tagAttributeNamePrefixMarkerType);
+      effects.consume(code);
+      effects.exit(tagAttributeNamePrefixMarkerType);
+      returnState = beforeAttributeLocalName;
+      return optionalEsWhitespace;
+    }
+    if (code === 61) {
+      effects.exit(tagAttributeNameType);
+      effects.enter(tagAttributeInitializerMarkerType);
+      effects.consume(code);
+      effects.exit(tagAttributeInitializerMarkerType);
+      returnState = beforeAttributeValue;
+      return optionalEsWhitespace;
+    }
+    if (code === 47 || code === 62 || code === 123 || markdownLineEndingOrSpace(code) || unicodeWhitespace(code) || code !== null && start2(code)) {
+      effects.exit(tagAttributeNameType);
+      effects.exit(tagAttributeType);
+      returnState = beforeAttribute;
+      return optionalEsWhitespace(code);
+    }
+    crash(
+      code,
+      "after attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag"
+    );
+  }
+  function beforeAttributeLocalName(code) {
+    if (code !== null && start2(code)) {
+      effects.enter(tagAttributeNameLocalType);
+      effects.consume(code);
+      return attributeLocalName;
+    }
+    crash(
+      code,
+      "before local attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag"
+    );
+  }
+  function attributeLocalName(code) {
+    if (code === 45 || code !== null && cont2(code)) {
+      effects.consume(code);
+      return attributeLocalName;
+    }
+    if (code === 47 || code === 61 || code === 62 || code === 123 || markdownLineEndingOrSpace(code) || unicodeWhitespace(code)) {
+      effects.exit(tagAttributeNameLocalType);
+      effects.exit(tagAttributeNameType);
+      returnState = afterAttributeLocalName;
+      return optionalEsWhitespace(code);
+    }
+    crash(
+      code,
+      "in local attribute name",
+      "an attribute name character such as letters, digits, `$`, or `_`; `=` to initialize a value; whitespace before attributes; or the end of the tag"
+    );
+  }
+  function afterAttributeLocalName(code) {
+    if (code === 61) {
+      effects.enter(tagAttributeInitializerMarkerType);
+      effects.consume(code);
+      effects.exit(tagAttributeInitializerMarkerType);
+      returnState = beforeAttributeValue;
+      return optionalEsWhitespace;
+    }
+    if (code === 47 || code === 62 || code === 123 || code !== null && start2(code)) {
+      effects.exit(tagAttributeType);
+      return beforeAttribute(code);
+    }
+    crash(
+      code,
+      "after local attribute name",
+      "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag"
+    );
+  }
+  function beforeAttributeValue(code) {
+    if (code === 34 || code === 39) {
+      effects.enter(tagAttributeValueLiteralType);
+      effects.enter(tagAttributeValueLiteralMarkerType);
+      effects.consume(code);
+      effects.exit(tagAttributeValueLiteralMarkerType);
+      marker = code;
+      return attributeValueQuotedStart;
+    }
+    if (code === 123) {
+      return factoryMdxExpression.call(
+        self2,
+        effects,
+        afterAttributeValueExpression,
+        tagAttributeValueExpressionType,
+        tagAttributeValueExpressionMarkerType,
+        tagAttributeValueExpressionValueType,
+        acorn,
+        acornOptions,
+        addResult,
+        false,
+        false,
+        allowLazy,
+        startPoint.column
+      )(code);
+    }
+    crash(
+      code,
+      "before attribute value",
+      "a character that can start an attribute value, such as `\"`, `'`, or `{`" + (code === 60 ? " (note: to use an element or fragment as a prop value in MDX, use `{<element />}`)" : "")
+    );
+  }
+  function afterAttributeValueExpression(code) {
+    effects.exit(tagAttributeType);
+    returnState = beforeAttribute;
+    return optionalEsWhitespace(code);
+  }
+  function attributeValueQuotedStart(code) {
+    if (code === null) {
+      crash(
+        code,
+        "in attribute value",
+        "a corresponding closing quote `" + String.fromCharCode(marker) + "`"
+      );
+    }
+    if (code === marker) {
+      effects.enter(tagAttributeValueLiteralMarkerType);
+      effects.consume(code);
+      effects.exit(tagAttributeValueLiteralMarkerType);
+      effects.exit(tagAttributeValueLiteralType);
+      effects.exit(tagAttributeType);
+      marker = void 0;
+      returnState = beforeAttribute;
+      return optionalEsWhitespace;
+    }
+    if (markdownLineEnding(code)) {
+      returnState = attributeValueQuotedStart;
+      return optionalEsWhitespace(code);
+    }
+    effects.enter(tagAttributeValueLiteralValueType);
+    return attributeValueQuoted(code);
+  }
+  function attributeValueQuoted(code) {
+    if (code === null || code === marker || markdownLineEnding(code)) {
+      effects.exit(tagAttributeValueLiteralValueType);
+      return attributeValueQuotedStart(code);
+    }
+    effects.consume(code);
+    return attributeValueQuoted;
+  }
+  function selfClosing(code) {
+    if (code === 62) {
+      return tagEnd(code);
+    }
+    crash(
+      code,
+      "after self-closing slash",
+      "`>` to end the tag" + (code === 42 || code === 47 ? " (note: JS comments in JSX tags are not supported in MDX)" : "")
+    );
+  }
+  function tagEnd(code) {
+    effects.enter(tagMarkerType);
+    effects.consume(code);
+    effects.exit(tagMarkerType);
+    effects.exit(tagType);
+    return ok;
+  }
+  function optionalEsWhitespace(code) {
+    if (markdownLineEnding(code)) {
+      if (allowLazy) {
+        effects.enter("lineEnding");
+        effects.consume(code);
+        effects.exit("lineEnding");
+        return factorySpace(effects, optionalEsWhitespace, "linePrefix", 4);
+      }
+      return effects.attempt(
+        lazyLineEnd,
+        factorySpace(effects, optionalEsWhitespace, "linePrefix", 4),
+        crashEol
+      )(code);
+    }
+    if (markdownSpace(code) || unicodeWhitespace(code)) {
+      effects.enter("esWhitespace");
+      return optionalEsWhitespaceContinue(code);
+    }
+    return returnState(code);
+  }
+  function optionalEsWhitespaceContinue(code) {
+    if (markdownLineEnding(code) || !(markdownSpace(code) || unicodeWhitespace(code))) {
+      effects.exit("esWhitespace");
+      return optionalEsWhitespace(code);
+    }
+    effects.consume(code);
+    return optionalEsWhitespaceContinue;
+  }
+  function crashEol() {
+    throw new VFileMessage(
+      "Unexpected lazy line in container, expected line to be prefixed with `>` when in a block quote, whitespace when in a list, etc",
+      self2.now(),
+      "micromark-extension-mdx-jsx:unexpected-eof"
+    );
+  }
+  function crash(code, at2, expect) {
+    throw new VFileMessage(
+      "Unexpected " + (code === null ? "end of file" : "character `" + (code === 96 ? "` ` `" : String.fromCharCode(code)) + "` (" + serializeCharCode(code) + ")") + " " + at2 + ", expected " + expect,
+      self2.now(),
+      "micromark-extension-mdx-jsx:unexpected-" + (code === null ? "eof" : "character")
+    );
+  }
+}
+function tokenizeLazyLineEnd(effects, ok, nok) {
+  const self2 = this;
+  return start3;
+  function start3(code) {
+    effects.enter("lineEnding");
+    effects.consume(code);
+    effects.exit("lineEnding");
+    return lineStart;
+  }
+  function lineStart(code) {
+    return self2.parser.lazy[self2.now().line] ? nok(code) : ok(code);
+  }
+}
+function serializeCharCode(code) {
+  return "U+" + code.toString(16).toUpperCase().padStart(4, "0");
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/jsx-text.js
+function jsxText(acorn, acornOptions, addResult) {
+  return {
+    tokenize: tokenizeJsxText
+  };
+  function tokenizeJsxText(effects, ok, nok) {
+    return factoryTag.call(
+      this,
+      effects,
+      ok,
+      nok,
+      acorn,
+      acornOptions,
+      addResult,
+      true,
+      "mdxJsxTextTag",
+      "mdxJsxTextTagMarker",
+      "mdxJsxTextTagClosingMarker",
+      "mdxJsxTextTagSelfClosingMarker",
+      "mdxJsxTextTagName",
+      "mdxJsxTextTagNamePrimary",
+      "mdxJsxTextTagNameMemberMarker",
+      "mdxJsxTextTagNameMember",
+      "mdxJsxTextTagNamePrefixMarker",
+      "mdxJsxTextTagNameLocal",
+      "mdxJsxTextTagExpressionAttribute",
+      "mdxJsxTextTagExpressionAttributeMarker",
+      "mdxJsxTextTagExpressionAttributeValue",
+      "mdxJsxTextTagAttribute",
+      "mdxJsxTextTagAttributeName",
+      "mdxJsxTextTagAttributeNamePrimary",
+      "mdxJsxTextTagAttributeNamePrefixMarker",
+      "mdxJsxTextTagAttributeNameLocal",
+      "mdxJsxTextTagAttributeInitializerMarker",
+      "mdxJsxTextTagAttributeValueLiteral",
+      "mdxJsxTextTagAttributeValueLiteralMarker",
+      "mdxJsxTextTagAttributeValueLiteralValue",
+      "mdxJsxTextTagAttributeValueExpression",
+      "mdxJsxTextTagAttributeValueExpressionMarker",
+      "mdxJsxTextTagAttributeValueExpressionValue"
+    );
+  }
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/jsx-flow.js
+function jsxFlow(acorn, acornOptions, addResult) {
+  return {
+    tokenize: tokenizeJsxFlow,
+    concrete: true
+  };
+  function tokenizeJsxFlow(effects, ok, nok) {
+    const self2 = this;
+    return start3;
+    function start3(code) {
+      return factoryTag.call(
+        self2,
+        effects,
+        factorySpace(effects, after, "whitespace"),
+        nok,
+        acorn,
+        acornOptions,
+        addResult,
+        false,
+        "mdxJsxFlowTag",
+        "mdxJsxFlowTagMarker",
+        "mdxJsxFlowTagClosingMarker",
+        "mdxJsxFlowTagSelfClosingMarker",
+        "mdxJsxFlowTagName",
+        "mdxJsxFlowTagNamePrimary",
+        "mdxJsxFlowTagNameMemberMarker",
+        "mdxJsxFlowTagNameMember",
+        "mdxJsxFlowTagNamePrefixMarker",
+        "mdxJsxFlowTagNameLocal",
+        "mdxJsxFlowTagExpressionAttribute",
+        "mdxJsxFlowTagExpressionAttributeMarker",
+        "mdxJsxFlowTagExpressionAttributeValue",
+        "mdxJsxFlowTagAttribute",
+        "mdxJsxFlowTagAttributeName",
+        "mdxJsxFlowTagAttributeNamePrimary",
+        "mdxJsxFlowTagAttributeNamePrefixMarker",
+        "mdxJsxFlowTagAttributeNameLocal",
+        "mdxJsxFlowTagAttributeInitializerMarker",
+        "mdxJsxFlowTagAttributeValueLiteral",
+        "mdxJsxFlowTagAttributeValueLiteralMarker",
+        "mdxJsxFlowTagAttributeValueLiteralValue",
+        "mdxJsxFlowTagAttributeValueExpression",
+        "mdxJsxFlowTagAttributeValueExpressionMarker",
+        "mdxJsxFlowTagAttributeValueExpressionValue"
+      )(code);
+    }
+    function after(code) {
+      return code === 60 ? start3(code) : code === null || markdownLineEnding(code) ? ok(code) : nok(code);
+    }
+  }
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/syntax.js
+function mdxJsx(options = {}) {
+  const acorn = options.acorn;
+  let acornOptions;
+  if (acorn) {
+    if (!acorn.parse || !acorn.parseExpressionAt) {
+      throw new Error(
+        "Expected a proper `acorn` instance passed in as `options.acorn`"
+      );
+    }
+    acornOptions = Object.assign(
+      {
+        ecmaVersion: 2020,
+        sourceType: "module"
+      },
+      options.acornOptions,
+      {
+        locations: true
+      }
+    );
+  } else if (options.acornOptions || options.addResult) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  return {
+    flow: {
+      [60]: jsxFlow(acorn, acornOptions, options.addResult)
+    },
+    text: {
+      [60]: jsxText(acorn, acornOptions, options.addResult)
+    }
+  };
+}
+
+// node_modules/micromark-extension-mdx-md/index.js
+var mdxMd = {
+  disable: { null: ["autolink", "codeIndented", "htmlFlow", "htmlText"] }
+};
+
+// node_modules/micromark-core-commonmark/lib/blank-line.js
+var blankLine = {
+  tokenize: tokenizeBlankLine,
+  partial: true
+};
+function tokenizeBlankLine(effects, ok, nok) {
+  return factorySpace(effects, afterWhitespace, "linePrefix");
+  function afterWhitespace(code) {
+    return code === null || markdownLineEnding(code) ? ok(code) : nok(code);
+  }
+}
+
+// node_modules/character-entities/index.js
+var characterEntities = {
+  AElig: "\xC6",
+  AMP: "&",
+  Aacute: "\xC1",
+  Abreve: "\u0102",
+  Acirc: "\xC2",
+  Acy: "\u0410",
+  Afr: "\u{1D504}",
+  Agrave: "\xC0",
+  Alpha: "\u0391",
+  Amacr: "\u0100",
+  And: "\u2A53",
+  Aogon: "\u0104",
+  Aopf: "\u{1D538}",
+  ApplyFunction: "\u2061",
+  Aring: "\xC5",
+  Ascr: "\u{1D49C}",
+  Assign: "\u2254",
+  Atilde: "\xC3",
+  Auml: "\xC4",
+  Backslash: "\u2216",
+  Barv: "\u2AE7",
+  Barwed: "\u2306",
+  Bcy: "\u0411",
+  Because: "\u2235",
+  Bernoullis: "\u212C",
+  Beta: "\u0392",
+  Bfr: "\u{1D505}",
+  Bopf: "\u{1D539}",
+  Breve: "\u02D8",
+  Bscr: "\u212C",
+  Bumpeq: "\u224E",
+  CHcy: "\u0427",
+  COPY: "\xA9",
+  Cacute: "\u0106",
+  Cap: "\u22D2",
+  CapitalDifferentialD: "\u2145",
+  Cayleys: "\u212D",
+  Ccaron: "\u010C",
+  Ccedil: "\xC7",
+  Ccirc: "\u0108",
+  Cconint: "\u2230",
+  Cdot: "\u010A",
+  Cedilla: "\xB8",
+  CenterDot: "\xB7",
+  Cfr: "\u212D",
+  Chi: "\u03A7",
+  CircleDot: "\u2299",
+  CircleMinus: "\u2296",
+  CirclePlus: "\u2295",
+  CircleTimes: "\u2297",
+  ClockwiseContourIntegral: "\u2232",
+  CloseCurlyDoubleQuote: "\u201D",
+  CloseCurlyQuote: "\u2019",
+  Colon: "\u2237",
+  Colone: "\u2A74",
+  Congruent: "\u2261",
+  Conint: "\u222F",
+  ContourIntegral: "\u222E",
+  Copf: "\u2102",
+  Coproduct: "\u2210",
+  CounterClockwiseContourIntegral: "\u2233",
+  Cross: "\u2A2F",
+  Cscr: "\u{1D49E}",
+  Cup: "\u22D3",
+  CupCap: "\u224D",
+  DD: "\u2145",
+  DDotrahd: "\u2911",
+  DJcy: "\u0402",
+  DScy: "\u0405",
+  DZcy: "\u040F",
+  Dagger: "\u2021",
+  Darr: "\u21A1",
+  Dashv: "\u2AE4",
+  Dcaron: "\u010E",
+  Dcy: "\u0414",
+  Del: "\u2207",
+  Delta: "\u0394",
+  Dfr: "\u{1D507}",
+  DiacriticalAcute: "\xB4",
+  DiacriticalDot: "\u02D9",
+  DiacriticalDoubleAcute: "\u02DD",
+  DiacriticalGrave: "`",
+  DiacriticalTilde: "\u02DC",
+  Diamond: "\u22C4",
+  DifferentialD: "\u2146",
+  Dopf: "\u{1D53B}",
+  Dot: "\xA8",
+  DotDot: "\u20DC",
+  DotEqual: "\u2250",
+  DoubleContourIntegral: "\u222F",
+  DoubleDot: "\xA8",
+  DoubleDownArrow: "\u21D3",
+  DoubleLeftArrow: "\u21D0",
+  DoubleLeftRightArrow: "\u21D4",
+  DoubleLeftTee: "\u2AE4",
+  DoubleLongLeftArrow: "\u27F8",
+  DoubleLongLeftRightArrow: "\u27FA",
+  DoubleLongRightArrow: "\u27F9",
+  DoubleRightArrow: "\u21D2",
+  DoubleRightTee: "\u22A8",
+  DoubleUpArrow: "\u21D1",
+  DoubleUpDownArrow: "\u21D5",
+  DoubleVerticalBar: "\u2225",
+  DownArrow: "\u2193",
+  DownArrowBar: "\u2913",
+  DownArrowUpArrow: "\u21F5",
+  DownBreve: "\u0311",
+  DownLeftRightVector: "\u2950",
+  DownLeftTeeVector: "\u295E",
+  DownLeftVector: "\u21BD",
+  DownLeftVectorBar: "\u2956",
+  DownRightTeeVector: "\u295F",
+  DownRightVector: "\u21C1",
+  DownRightVectorBar: "\u2957",
+  DownTee: "\u22A4",
+  DownTeeArrow: "\u21A7",
+  Downarrow: "\u21D3",
+  Dscr: "\u{1D49F}",
+  Dstrok: "\u0110",
+  ENG: "\u014A",
+  ETH: "\xD0",
+  Eacute: "\xC9",
+  Ecaron: "\u011A",
+  Ecirc: "\xCA",
+  Ecy: "\u042D",
+  Edot: "\u0116",
+  Efr: "\u{1D508}",
+  Egrave: "\xC8",
+  Element: "\u2208",
+  Emacr: "\u0112",
+  EmptySmallSquare: "\u25FB",
+  EmptyVerySmallSquare: "\u25AB",
+  Eogon: "\u0118",
+  Eopf: "\u{1D53C}",
+  Epsilon: "\u0395",
+  Equal: "\u2A75",
+  EqualTilde: "\u2242",
+  Equilibrium: "\u21CC",
+  Escr: "\u2130",
+  Esim: "\u2A73",
+  Eta: "\u0397",
+  Euml: "\xCB",
+  Exists: "\u2203",
+  ExponentialE: "\u2147",
+  Fcy: "\u0424",
+  Ffr: "\u{1D509}",
+  FilledSmallSquare: "\u25FC",
+  FilledVerySmallSquare: "\u25AA",
+  Fopf: "\u{1D53D}",
+  ForAll: "\u2200",
+  Fouriertrf: "\u2131",
+  Fscr: "\u2131",
+  GJcy: "\u0403",
+  GT: ">",
+  Gamma: "\u0393",
+  Gammad: "\u03DC",
+  Gbreve: "\u011E",
+  Gcedil: "\u0122",
+  Gcirc: "\u011C",
+  Gcy: "\u0413",
+  Gdot: "\u0120",
+  Gfr: "\u{1D50A}",
+  Gg: "\u22D9",
+  Gopf: "\u{1D53E}",
+  GreaterEqual: "\u2265",
+  GreaterEqualLess: "\u22DB",
+  GreaterFullEqual: "\u2267",
+  GreaterGreater: "\u2AA2",
+  GreaterLess: "\u2277",
+  GreaterSlantEqual: "\u2A7E",
+  GreaterTilde: "\u2273",
+  Gscr: "\u{1D4A2}",
+  Gt: "\u226B",
+  HARDcy: "\u042A",
+  Hacek: "\u02C7",
+  Hat: "^",
+  Hcirc: "\u0124",
+  Hfr: "\u210C",
+  HilbertSpace: "\u210B",
+  Hopf: "\u210D",
+  HorizontalLine: "\u2500",
+  Hscr: "\u210B",
+  Hstrok: "\u0126",
+  HumpDownHump: "\u224E",
+  HumpEqual: "\u224F",
+  IEcy: "\u0415",
+  IJlig: "\u0132",
+  IOcy: "\u0401",
+  Iacute: "\xCD",
+  Icirc: "\xCE",
+  Icy: "\u0418",
+  Idot: "\u0130",
+  Ifr: "\u2111",
+  Igrave: "\xCC",
+  Im: "\u2111",
+  Imacr: "\u012A",
+  ImaginaryI: "\u2148",
+  Implies: "\u21D2",
+  Int: "\u222C",
+  Integral: "\u222B",
+  Intersection: "\u22C2",
+  InvisibleComma: "\u2063",
+  InvisibleTimes: "\u2062",
+  Iogon: "\u012E",
+  Iopf: "\u{1D540}",
+  Iota: "\u0399",
+  Iscr: "\u2110",
+  Itilde: "\u0128",
+  Iukcy: "\u0406",
+  Iuml: "\xCF",
+  Jcirc: "\u0134",
+  Jcy: "\u0419",
+  Jfr: "\u{1D50D}",
+  Jopf: "\u{1D541}",
+  Jscr: "\u{1D4A5}",
+  Jsercy: "\u0408",
+  Jukcy: "\u0404",
+  KHcy: "\u0425",
+  KJcy: "\u040C",
+  Kappa: "\u039A",
+  Kcedil: "\u0136",
+  Kcy: "\u041A",
+  Kfr: "\u{1D50E}",
+  Kopf: "\u{1D542}",
+  Kscr: "\u{1D4A6}",
+  LJcy: "\u0409",
+  LT: "<",
+  Lacute: "\u0139",
+  Lambda: "\u039B",
+  Lang: "\u27EA",
+  Laplacetrf: "\u2112",
+  Larr: "\u219E",
+  Lcaron: "\u013D",
+  Lcedil: "\u013B",
+  Lcy: "\u041B",
+  LeftAngleBracket: "\u27E8",
+  LeftArrow: "\u2190",
+  LeftArrowBar: "\u21E4",
+  LeftArrowRightArrow: "\u21C6",
+  LeftCeiling: "\u2308",
+  LeftDoubleBracket: "\u27E6",
+  LeftDownTeeVector: "\u2961",
+  LeftDownVector: "\u21C3",
+  LeftDownVectorBar: "\u2959",
+  LeftFloor: "\u230A",
+  LeftRightArrow: "\u2194",
+  LeftRightVector: "\u294E",
+  LeftTee: "\u22A3",
+  LeftTeeArrow: "\u21A4",
+  LeftTeeVector: "\u295A",
+  LeftTriangle: "\u22B2",
+  LeftTriangleBar: "\u29CF",
+  LeftTriangleEqual: "\u22B4",
+  LeftUpDownVector: "\u2951",
+  LeftUpTeeVector: "\u2960",
+  LeftUpVector: "\u21BF",
+  LeftUpVectorBar: "\u2958",
+  LeftVector: "\u21BC",
+  LeftVectorBar: "\u2952",
+  Leftarrow: "\u21D0",
+  Leftrightarrow: "\u21D4",
+  LessEqualGreater: "\u22DA",
+  LessFullEqual: "\u2266",
+  LessGreater: "\u2276",
+  LessLess: "\u2AA1",
+  LessSlantEqual: "\u2A7D",
+  LessTilde: "\u2272",
+  Lfr: "\u{1D50F}",
+  Ll: "\u22D8",
+  Lleftarrow: "\u21DA",
+  Lmidot: "\u013F",
+  LongLeftArrow: "\u27F5",
+  LongLeftRightArrow: "\u27F7",
+  LongRightArrow: "\u27F6",
+  Longleftarrow: "\u27F8",
+  Longleftrightarrow: "\u27FA",
+  Longrightarrow: "\u27F9",
+  Lopf: "\u{1D543}",
+  LowerLeftArrow: "\u2199",
+  LowerRightArrow: "\u2198",
+  Lscr: "\u2112",
+  Lsh: "\u21B0",
+  Lstrok: "\u0141",
+  Lt: "\u226A",
+  Map: "\u2905",
+  Mcy: "\u041C",
+  MediumSpace: "\u205F",
+  Mellintrf: "\u2133",
+  Mfr: "\u{1D510}",
+  MinusPlus: "\u2213",
+  Mopf: "\u{1D544}",
+  Mscr: "\u2133",
+  Mu: "\u039C",
+  NJcy: "\u040A",
+  Nacute: "\u0143",
+  Ncaron: "\u0147",
+  Ncedil: "\u0145",
+  Ncy: "\u041D",
+  NegativeMediumSpace: "\u200B",
+  NegativeThickSpace: "\u200B",
+  NegativeThinSpace: "\u200B",
+  NegativeVeryThinSpace: "\u200B",
+  NestedGreaterGreater: "\u226B",
+  NestedLessLess: "\u226A",
+  NewLine: "\n",
+  Nfr: "\u{1D511}",
+  NoBreak: "\u2060",
+  NonBreakingSpace: "\xA0",
+  Nopf: "\u2115",
+  Not: "\u2AEC",
+  NotCongruent: "\u2262",
+  NotCupCap: "\u226D",
+  NotDoubleVerticalBar: "\u2226",
+  NotElement: "\u2209",
+  NotEqual: "\u2260",
+  NotEqualTilde: "\u2242\u0338",
+  NotExists: "\u2204",
+  NotGreater: "\u226F",
+  NotGreaterEqual: "\u2271",
+  NotGreaterFullEqual: "\u2267\u0338",
+  NotGreaterGreater: "\u226B\u0338",
+  NotGreaterLess: "\u2279",
+  NotGreaterSlantEqual: "\u2A7E\u0338",
+  NotGreaterTilde: "\u2275",
+  NotHumpDownHump: "\u224E\u0338",
+  NotHumpEqual: "\u224F\u0338",
+  NotLeftTriangle: "\u22EA",
+  NotLeftTriangleBar: "\u29CF\u0338",
+  NotLeftTriangleEqual: "\u22EC",
+  NotLess: "\u226E",
+  NotLessEqual: "\u2270",
+  NotLessGreater: "\u2278",
+  NotLessLess: "\u226A\u0338",
+  NotLessSlantEqual: "\u2A7D\u0338",
+  NotLessTilde: "\u2274",
+  NotNestedGreaterGreater: "\u2AA2\u0338",
+  NotNestedLessLess: "\u2AA1\u0338",
+  NotPrecedes: "\u2280",
+  NotPrecedesEqual: "\u2AAF\u0338",
+  NotPrecedesSlantEqual: "\u22E0",
+  NotReverseElement: "\u220C",
+  NotRightTriangle: "\u22EB",
+  NotRightTriangleBar: "\u29D0\u0338",
+  NotRightTriangleEqual: "\u22ED",
+  NotSquareSubset: "\u228F\u0338",
+  NotSquareSubsetEqual: "\u22E2",
+  NotSquareSuperset: "\u2290\u0338",
+  NotSquareSupersetEqual: "\u22E3",
+  NotSubset: "\u2282\u20D2",
+  NotSubsetEqual: "\u2288",
+  NotSucceeds: "\u2281",
+  NotSucceedsEqual: "\u2AB0\u0338",
+  NotSucceedsSlantEqual: "\u22E1",
+  NotSucceedsTilde: "\u227F\u0338",
+  NotSuperset: "\u2283\u20D2",
+  NotSupersetEqual: "\u2289",
+  NotTilde: "\u2241",
+  NotTildeEqual: "\u2244",
+  NotTildeFullEqual: "\u2247",
+  NotTildeTilde: "\u2249",
+  NotVerticalBar: "\u2224",
+  Nscr: "\u{1D4A9}",
+  Ntilde: "\xD1",
+  Nu: "\u039D",
+  OElig: "\u0152",
+  Oacute: "\xD3",
+  Ocirc: "\xD4",
+  Ocy: "\u041E",
+  Odblac: "\u0150",
+  Ofr: "\u{1D512}",
+  Ograve: "\xD2",
+  Omacr: "\u014C",
+  Omega: "\u03A9",
+  Omicron: "\u039F",
+  Oopf: "\u{1D546}",
+  OpenCurlyDoubleQuote: "\u201C",
+  OpenCurlyQuote: "\u2018",
+  Or: "\u2A54",
+  Oscr: "\u{1D4AA}",
+  Oslash: "\xD8",
+  Otilde: "\xD5",
+  Otimes: "\u2A37",
+  Ouml: "\xD6",
+  OverBar: "\u203E",
+  OverBrace: "\u23DE",
+  OverBracket: "\u23B4",
+  OverParenthesis: "\u23DC",
+  PartialD: "\u2202",
+  Pcy: "\u041F",
+  Pfr: "\u{1D513}",
+  Phi: "\u03A6",
+  Pi: "\u03A0",
+  PlusMinus: "\xB1",
+  Poincareplane: "\u210C",
+  Popf: "\u2119",
+  Pr: "\u2ABB",
+  Precedes: "\u227A",
+  PrecedesEqual: "\u2AAF",
+  PrecedesSlantEqual: "\u227C",
+  PrecedesTilde: "\u227E",
+  Prime: "\u2033",
+  Product: "\u220F",
+  Proportion: "\u2237",
+  Proportional: "\u221D",
+  Pscr: "\u{1D4AB}",
+  Psi: "\u03A8",
+  QUOT: '"',
+  Qfr: "\u{1D514}",
+  Qopf: "\u211A",
+  Qscr: "\u{1D4AC}",
+  RBarr: "\u2910",
+  REG: "\xAE",
+  Racute: "\u0154",
+  Rang: "\u27EB",
+  Rarr: "\u21A0",
+  Rarrtl: "\u2916",
+  Rcaron: "\u0158",
+  Rcedil: "\u0156",
+  Rcy: "\u0420",
+  Re: "\u211C",
+  ReverseElement: "\u220B",
+  ReverseEquilibrium: "\u21CB",
+  ReverseUpEquilibrium: "\u296F",
+  Rfr: "\u211C",
+  Rho: "\u03A1",
+  RightAngleBracket: "\u27E9",
+  RightArrow: "\u2192",
+  RightArrowBar: "\u21E5",
+  RightArrowLeftArrow: "\u21C4",
+  RightCeiling: "\u2309",
+  RightDoubleBracket: "\u27E7",
+  RightDownTeeVector: "\u295D",
+  RightDownVector: "\u21C2",
+  RightDownVectorBar: "\u2955",
+  RightFloor: "\u230B",
+  RightTee: "\u22A2",
+  RightTeeArrow: "\u21A6",
+  RightTeeVector: "\u295B",
+  RightTriangle: "\u22B3",
+  RightTriangleBar: "\u29D0",
+  RightTriangleEqual: "\u22B5",
+  RightUpDownVector: "\u294F",
+  RightUpTeeVector: "\u295C",
+  RightUpVector: "\u21BE",
+  RightUpVectorBar: "\u2954",
+  RightVector: "\u21C0",
+  RightVectorBar: "\u2953",
+  Rightarrow: "\u21D2",
+  Ropf: "\u211D",
+  RoundImplies: "\u2970",
+  Rrightarrow: "\u21DB",
+  Rscr: "\u211B",
+  Rsh: "\u21B1",
+  RuleDelayed: "\u29F4",
+  SHCHcy: "\u0429",
+  SHcy: "\u0428",
+  SOFTcy: "\u042C",
+  Sacute: "\u015A",
+  Sc: "\u2ABC",
+  Scaron: "\u0160",
+  Scedil: "\u015E",
+  Scirc: "\u015C",
+  Scy: "\u0421",
+  Sfr: "\u{1D516}",
+  ShortDownArrow: "\u2193",
+  ShortLeftArrow: "\u2190",
+  ShortRightArrow: "\u2192",
+  ShortUpArrow: "\u2191",
+  Sigma: "\u03A3",
+  SmallCircle: "\u2218",
+  Sopf: "\u{1D54A}",
+  Sqrt: "\u221A",
+  Square: "\u25A1",
+  SquareIntersection: "\u2293",
+  SquareSubset: "\u228F",
+  SquareSubsetEqual: "\u2291",
+  SquareSuperset: "\u2290",
+  SquareSupersetEqual: "\u2292",
+  SquareUnion: "\u2294",
+  Sscr: "\u{1D4AE}",
+  Star: "\u22C6",
+  Sub: "\u22D0",
+  Subset: "\u22D0",
+  SubsetEqual: "\u2286",
+  Succeeds: "\u227B",
+  SucceedsEqual: "\u2AB0",
+  SucceedsSlantEqual: "\u227D",
+  SucceedsTilde: "\u227F",
+  SuchThat: "\u220B",
+  Sum: "\u2211",
+  Sup: "\u22D1",
+  Superset: "\u2283",
+  SupersetEqual: "\u2287",
+  Supset: "\u22D1",
+  THORN: "\xDE",
+  TRADE: "\u2122",
+  TSHcy: "\u040B",
+  TScy: "\u0426",
+  Tab: "	",
+  Tau: "\u03A4",
+  Tcaron: "\u0164",
+  Tcedil: "\u0162",
+  Tcy: "\u0422",
+  Tfr: "\u{1D517}",
+  Therefore: "\u2234",
+  Theta: "\u0398",
+  ThickSpace: "\u205F\u200A",
+  ThinSpace: "\u2009",
+  Tilde: "\u223C",
+  TildeEqual: "\u2243",
+  TildeFullEqual: "\u2245",
+  TildeTilde: "\u2248",
+  Topf: "\u{1D54B}",
+  TripleDot: "\u20DB",
+  Tscr: "\u{1D4AF}",
+  Tstrok: "\u0166",
+  Uacute: "\xDA",
+  Uarr: "\u219F",
+  Uarrocir: "\u2949",
+  Ubrcy: "\u040E",
+  Ubreve: "\u016C",
+  Ucirc: "\xDB",
+  Ucy: "\u0423",
+  Udblac: "\u0170",
+  Ufr: "\u{1D518}",
+  Ugrave: "\xD9",
+  Umacr: "\u016A",
+  UnderBar: "_",
+  UnderBrace: "\u23DF",
+  UnderBracket: "\u23B5",
+  UnderParenthesis: "\u23DD",
+  Union: "\u22C3",
+  UnionPlus: "\u228E",
+  Uogon: "\u0172",
+  Uopf: "\u{1D54C}",
+  UpArrow: "\u2191",
+  UpArrowBar: "\u2912",
+  UpArrowDownArrow: "\u21C5",
+  UpDownArrow: "\u2195",
+  UpEquilibrium: "\u296E",
+  UpTee: "\u22A5",
+  UpTeeArrow: "\u21A5",
+  Uparrow: "\u21D1",
+  Updownarrow: "\u21D5",
+  UpperLeftArrow: "\u2196",
+  UpperRightArrow: "\u2197",
+  Upsi: "\u03D2",
+  Upsilon: "\u03A5",
+  Uring: "\u016E",
+  Uscr: "\u{1D4B0}",
+  Utilde: "\u0168",
+  Uuml: "\xDC",
+  VDash: "\u22AB",
+  Vbar: "\u2AEB",
+  Vcy: "\u0412",
+  Vdash: "\u22A9",
+  Vdashl: "\u2AE6",
+  Vee: "\u22C1",
+  Verbar: "\u2016",
+  Vert: "\u2016",
+  VerticalBar: "\u2223",
+  VerticalLine: "|",
+  VerticalSeparator: "\u2758",
+  VerticalTilde: "\u2240",
+  VeryThinSpace: "\u200A",
+  Vfr: "\u{1D519}",
+  Vopf: "\u{1D54D}",
+  Vscr: "\u{1D4B1}",
+  Vvdash: "\u22AA",
+  Wcirc: "\u0174",
+  Wedge: "\u22C0",
+  Wfr: "\u{1D51A}",
+  Wopf: "\u{1D54E}",
+  Wscr: "\u{1D4B2}",
+  Xfr: "\u{1D51B}",
+  Xi: "\u039E",
+  Xopf: "\u{1D54F}",
+  Xscr: "\u{1D4B3}",
+  YAcy: "\u042F",
+  YIcy: "\u0407",
+  YUcy: "\u042E",
+  Yacute: "\xDD",
+  Ycirc: "\u0176",
+  Ycy: "\u042B",
+  Yfr: "\u{1D51C}",
+  Yopf: "\u{1D550}",
+  Yscr: "\u{1D4B4}",
+  Yuml: "\u0178",
+  ZHcy: "\u0416",
+  Zacute: "\u0179",
+  Zcaron: "\u017D",
+  Zcy: "\u0417",
+  Zdot: "\u017B",
+  ZeroWidthSpace: "\u200B",
+  Zeta: "\u0396",
+  Zfr: "\u2128",
+  Zopf: "\u2124",
+  Zscr: "\u{1D4B5}",
+  aacute: "\xE1",
+  abreve: "\u0103",
+  ac: "\u223E",
+  acE: "\u223E\u0333",
+  acd: "\u223F",
+  acirc: "\xE2",
+  acute: "\xB4",
+  acy: "\u0430",
+  aelig: "\xE6",
+  af: "\u2061",
+  afr: "\u{1D51E}",
+  agrave: "\xE0",
+  alefsym: "\u2135",
+  aleph: "\u2135",
+  alpha: "\u03B1",
+  amacr: "\u0101",
+  amalg: "\u2A3F",
+  amp: "&",
+  and: "\u2227",
+  andand: "\u2A55",
+  andd: "\u2A5C",
+  andslope: "\u2A58",
+  andv: "\u2A5A",
+  ang: "\u2220",
+  ange: "\u29A4",
+  angle: "\u2220",
+  angmsd: "\u2221",
+  angmsdaa: "\u29A8",
+  angmsdab: "\u29A9",
+  angmsdac: "\u29AA",
+  angmsdad: "\u29AB",
+  angmsdae: "\u29AC",
+  angmsdaf: "\u29AD",
+  angmsdag: "\u29AE",
+  angmsdah: "\u29AF",
+  angrt: "\u221F",
+  angrtvb: "\u22BE",
+  angrtvbd: "\u299D",
+  angsph: "\u2222",
+  angst: "\xC5",
+  angzarr: "\u237C",
+  aogon: "\u0105",
+  aopf: "\u{1D552}",
+  ap: "\u2248",
+  apE: "\u2A70",
+  apacir: "\u2A6F",
+  ape: "\u224A",
+  apid: "\u224B",
+  apos: "'",
+  approx: "\u2248",
+  approxeq: "\u224A",
+  aring: "\xE5",
+  ascr: "\u{1D4B6}",
+  ast: "*",
+  asymp: "\u2248",
+  asympeq: "\u224D",
+  atilde: "\xE3",
+  auml: "\xE4",
+  awconint: "\u2233",
+  awint: "\u2A11",
+  bNot: "\u2AED",
+  backcong: "\u224C",
+  backepsilon: "\u03F6",
+  backprime: "\u2035",
+  backsim: "\u223D",
+  backsimeq: "\u22CD",
+  barvee: "\u22BD",
+  barwed: "\u2305",
+  barwedge: "\u2305",
+  bbrk: "\u23B5",
+  bbrktbrk: "\u23B6",
+  bcong: "\u224C",
+  bcy: "\u0431",
+  bdquo: "\u201E",
+  becaus: "\u2235",
+  because: "\u2235",
+  bemptyv: "\u29B0",
+  bepsi: "\u03F6",
+  bernou: "\u212C",
+  beta: "\u03B2",
+  beth: "\u2136",
+  between: "\u226C",
+  bfr: "\u{1D51F}",
+  bigcap: "\u22C2",
+  bigcirc: "\u25EF",
+  bigcup: "\u22C3",
+  bigodot: "\u2A00",
+  bigoplus: "\u2A01",
+  bigotimes: "\u2A02",
+  bigsqcup: "\u2A06",
+  bigstar: "\u2605",
+  bigtriangledown: "\u25BD",
+  bigtriangleup: "\u25B3",
+  biguplus: "\u2A04",
+  bigvee: "\u22C1",
+  bigwedge: "\u22C0",
+  bkarow: "\u290D",
+  blacklozenge: "\u29EB",
+  blacksquare: "\u25AA",
+  blacktriangle: "\u25B4",
+  blacktriangledown: "\u25BE",
+  blacktriangleleft: "\u25C2",
+  blacktriangleright: "\u25B8",
+  blank: "\u2423",
+  blk12: "\u2592",
+  blk14: "\u2591",
+  blk34: "\u2593",
+  block: "\u2588",
+  bne: "=\u20E5",
+  bnequiv: "\u2261\u20E5",
+  bnot: "\u2310",
+  bopf: "\u{1D553}",
+  bot: "\u22A5",
+  bottom: "\u22A5",
+  bowtie: "\u22C8",
+  boxDL: "\u2557",
+  boxDR: "\u2554",
+  boxDl: "\u2556",
+  boxDr: "\u2553",
+  boxH: "\u2550",
+  boxHD: "\u2566",
+  boxHU: "\u2569",
+  boxHd: "\u2564",
+  boxHu: "\u2567",
+  boxUL: "\u255D",
+  boxUR: "\u255A",
+  boxUl: "\u255C",
+  boxUr: "\u2559",
+  boxV: "\u2551",
+  boxVH: "\u256C",
+  boxVL: "\u2563",
+  boxVR: "\u2560",
+  boxVh: "\u256B",
+  boxVl: "\u2562",
+  boxVr: "\u255F",
+  boxbox: "\u29C9",
+  boxdL: "\u2555",
+  boxdR: "\u2552",
+  boxdl: "\u2510",
+  boxdr: "\u250C",
+  boxh: "\u2500",
+  boxhD: "\u2565",
+  boxhU: "\u2568",
+  boxhd: "\u252C",
+  boxhu: "\u2534",
+  boxminus: "\u229F",
+  boxplus: "\u229E",
+  boxtimes: "\u22A0",
+  boxuL: "\u255B",
+  boxuR: "\u2558",
+  boxul: "\u2518",
+  boxur: "\u2514",
+  boxv: "\u2502",
+  boxvH: "\u256A",
+  boxvL: "\u2561",
+  boxvR: "\u255E",
+  boxvh: "\u253C",
+  boxvl: "\u2524",
+  boxvr: "\u251C",
+  bprime: "\u2035",
+  breve: "\u02D8",
+  brvbar: "\xA6",
+  bscr: "\u{1D4B7}",
+  bsemi: "\u204F",
+  bsim: "\u223D",
+  bsime: "\u22CD",
+  bsol: "\\",
+  bsolb: "\u29C5",
+  bsolhsub: "\u27C8",
+  bull: "\u2022",
+  bullet: "\u2022",
+  bump: "\u224E",
+  bumpE: "\u2AAE",
+  bumpe: "\u224F",
+  bumpeq: "\u224F",
+  cacute: "\u0107",
+  cap: "\u2229",
+  capand: "\u2A44",
+  capbrcup: "\u2A49",
+  capcap: "\u2A4B",
+  capcup: "\u2A47",
+  capdot: "\u2A40",
+  caps: "\u2229\uFE00",
+  caret: "\u2041",
+  caron: "\u02C7",
+  ccaps: "\u2A4D",
+  ccaron: "\u010D",
+  ccedil: "\xE7",
+  ccirc: "\u0109",
+  ccups: "\u2A4C",
+  ccupssm: "\u2A50",
+  cdot: "\u010B",
+  cedil: "\xB8",
+  cemptyv: "\u29B2",
+  cent: "\xA2",
+  centerdot: "\xB7",
+  cfr: "\u{1D520}",
+  chcy: "\u0447",
+  check: "\u2713",
+  checkmark: "\u2713",
+  chi: "\u03C7",
+  cir: "\u25CB",
+  cirE: "\u29C3",
+  circ: "\u02C6",
+  circeq: "\u2257",
+  circlearrowleft: "\u21BA",
+  circlearrowright: "\u21BB",
+  circledR: "\xAE",
+  circledS: "\u24C8",
+  circledast: "\u229B",
+  circledcirc: "\u229A",
+  circleddash: "\u229D",
+  cire: "\u2257",
+  cirfnint: "\u2A10",
+  cirmid: "\u2AEF",
+  cirscir: "\u29C2",
+  clubs: "\u2663",
+  clubsuit: "\u2663",
+  colon: ":",
+  colone: "\u2254",
+  coloneq: "\u2254",
+  comma: ",",
+  commat: "@",
+  comp: "\u2201",
+  compfn: "\u2218",
+  complement: "\u2201",
+  complexes: "\u2102",
+  cong: "\u2245",
+  congdot: "\u2A6D",
+  conint: "\u222E",
+  copf: "\u{1D554}",
+  coprod: "\u2210",
+  copy: "\xA9",
+  copysr: "\u2117",
+  crarr: "\u21B5",
+  cross: "\u2717",
+  cscr: "\u{1D4B8}",
+  csub: "\u2ACF",
+  csube: "\u2AD1",
+  csup: "\u2AD0",
+  csupe: "\u2AD2",
+  ctdot: "\u22EF",
+  cudarrl: "\u2938",
+  cudarrr: "\u2935",
+  cuepr: "\u22DE",
+  cuesc: "\u22DF",
+  cularr: "\u21B6",
+  cularrp: "\u293D",
+  cup: "\u222A",
+  cupbrcap: "\u2A48",
+  cupcap: "\u2A46",
+  cupcup: "\u2A4A",
+  cupdot: "\u228D",
+  cupor: "\u2A45",
+  cups: "\u222A\uFE00",
+  curarr: "\u21B7",
+  curarrm: "\u293C",
+  curlyeqprec: "\u22DE",
+  curlyeqsucc: "\u22DF",
+  curlyvee: "\u22CE",
+  curlywedge: "\u22CF",
+  curren: "\xA4",
+  curvearrowleft: "\u21B6",
+  curvearrowright: "\u21B7",
+  cuvee: "\u22CE",
+  cuwed: "\u22CF",
+  cwconint: "\u2232",
+  cwint: "\u2231",
+  cylcty: "\u232D",
+  dArr: "\u21D3",
+  dHar: "\u2965",
+  dagger: "\u2020",
+  daleth: "\u2138",
+  darr: "\u2193",
+  dash: "\u2010",
+  dashv: "\u22A3",
+  dbkarow: "\u290F",
+  dblac: "\u02DD",
+  dcaron: "\u010F",
+  dcy: "\u0434",
+  dd: "\u2146",
+  ddagger: "\u2021",
+  ddarr: "\u21CA",
+  ddotseq: "\u2A77",
+  deg: "\xB0",
+  delta: "\u03B4",
+  demptyv: "\u29B1",
+  dfisht: "\u297F",
+  dfr: "\u{1D521}",
+  dharl: "\u21C3",
+  dharr: "\u21C2",
+  diam: "\u22C4",
+  diamond: "\u22C4",
+  diamondsuit: "\u2666",
+  diams: "\u2666",
+  die: "\xA8",
+  digamma: "\u03DD",
+  disin: "\u22F2",
+  div: "\xF7",
+  divide: "\xF7",
+  divideontimes: "\u22C7",
+  divonx: "\u22C7",
+  djcy: "\u0452",
+  dlcorn: "\u231E",
+  dlcrop: "\u230D",
+  dollar: "$",
+  dopf: "\u{1D555}",
+  dot: "\u02D9",
+  doteq: "\u2250",
+  doteqdot: "\u2251",
+  dotminus: "\u2238",
+  dotplus: "\u2214",
+  dotsquare: "\u22A1",
+  doublebarwedge: "\u2306",
+  downarrow: "\u2193",
+  downdownarrows: "\u21CA",
+  downharpoonleft: "\u21C3",
+  downharpoonright: "\u21C2",
+  drbkarow: "\u2910",
+  drcorn: "\u231F",
+  drcrop: "\u230C",
+  dscr: "\u{1D4B9}",
+  dscy: "\u0455",
+  dsol: "\u29F6",
+  dstrok: "\u0111",
+  dtdot: "\u22F1",
+  dtri: "\u25BF",
+  dtrif: "\u25BE",
+  duarr: "\u21F5",
+  duhar: "\u296F",
+  dwangle: "\u29A6",
+  dzcy: "\u045F",
+  dzigrarr: "\u27FF",
+  eDDot: "\u2A77",
+  eDot: "\u2251",
+  eacute: "\xE9",
+  easter: "\u2A6E",
+  ecaron: "\u011B",
+  ecir: "\u2256",
+  ecirc: "\xEA",
+  ecolon: "\u2255",
+  ecy: "\u044D",
+  edot: "\u0117",
+  ee: "\u2147",
+  efDot: "\u2252",
+  efr: "\u{1D522}",
+  eg: "\u2A9A",
+  egrave: "\xE8",
+  egs: "\u2A96",
+  egsdot: "\u2A98",
+  el: "\u2A99",
+  elinters: "\u23E7",
+  ell: "\u2113",
+  els: "\u2A95",
+  elsdot: "\u2A97",
+  emacr: "\u0113",
+  empty: "\u2205",
+  emptyset: "\u2205",
+  emptyv: "\u2205",
+  emsp13: "\u2004",
+  emsp14: "\u2005",
+  emsp: "\u2003",
+  eng: "\u014B",
+  ensp: "\u2002",
+  eogon: "\u0119",
+  eopf: "\u{1D556}",
+  epar: "\u22D5",
+  eparsl: "\u29E3",
+  eplus: "\u2A71",
+  epsi: "\u03B5",
+  epsilon: "\u03B5",
+  epsiv: "\u03F5",
+  eqcirc: "\u2256",
+  eqcolon: "\u2255",
+  eqsim: "\u2242",
+  eqslantgtr: "\u2A96",
+  eqslantless: "\u2A95",
+  equals: "=",
+  equest: "\u225F",
+  equiv: "\u2261",
+  equivDD: "\u2A78",
+  eqvparsl: "\u29E5",
+  erDot: "\u2253",
+  erarr: "\u2971",
+  escr: "\u212F",
+  esdot: "\u2250",
+  esim: "\u2242",
+  eta: "\u03B7",
+  eth: "\xF0",
+  euml: "\xEB",
+  euro: "\u20AC",
+  excl: "!",
+  exist: "\u2203",
+  expectation: "\u2130",
+  exponentiale: "\u2147",
+  fallingdotseq: "\u2252",
+  fcy: "\u0444",
+  female: "\u2640",
+  ffilig: "\uFB03",
+  fflig: "\uFB00",
+  ffllig: "\uFB04",
+  ffr: "\u{1D523}",
+  filig: "\uFB01",
+  fjlig: "fj",
+  flat: "\u266D",
+  fllig: "\uFB02",
+  fltns: "\u25B1",
+  fnof: "\u0192",
+  fopf: "\u{1D557}",
+  forall: "\u2200",
+  fork: "\u22D4",
+  forkv: "\u2AD9",
+  fpartint: "\u2A0D",
+  frac12: "\xBD",
+  frac13: "\u2153",
+  frac14: "\xBC",
+  frac15: "\u2155",
+  frac16: "\u2159",
+  frac18: "\u215B",
+  frac23: "\u2154",
+  frac25: "\u2156",
+  frac34: "\xBE",
+  frac35: "\u2157",
+  frac38: "\u215C",
+  frac45: "\u2158",
+  frac56: "\u215A",
+  frac58: "\u215D",
+  frac78: "\u215E",
+  frasl: "\u2044",
+  frown: "\u2322",
+  fscr: "\u{1D4BB}",
+  gE: "\u2267",
+  gEl: "\u2A8C",
+  gacute: "\u01F5",
+  gamma: "\u03B3",
+  gammad: "\u03DD",
+  gap: "\u2A86",
+  gbreve: "\u011F",
+  gcirc: "\u011D",
+  gcy: "\u0433",
+  gdot: "\u0121",
+  ge: "\u2265",
+  gel: "\u22DB",
+  geq: "\u2265",
+  geqq: "\u2267",
+  geqslant: "\u2A7E",
+  ges: "\u2A7E",
+  gescc: "\u2AA9",
+  gesdot: "\u2A80",
+  gesdoto: "\u2A82",
+  gesdotol: "\u2A84",
+  gesl: "\u22DB\uFE00",
+  gesles: "\u2A94",
+  gfr: "\u{1D524}",
+  gg: "\u226B",
+  ggg: "\u22D9",
+  gimel: "\u2137",
+  gjcy: "\u0453",
+  gl: "\u2277",
+  glE: "\u2A92",
+  gla: "\u2AA5",
+  glj: "\u2AA4",
+  gnE: "\u2269",
+  gnap: "\u2A8A",
+  gnapprox: "\u2A8A",
+  gne: "\u2A88",
+  gneq: "\u2A88",
+  gneqq: "\u2269",
+  gnsim: "\u22E7",
+  gopf: "\u{1D558}",
+  grave: "`",
+  gscr: "\u210A",
+  gsim: "\u2273",
+  gsime: "\u2A8E",
+  gsiml: "\u2A90",
+  gt: ">",
+  gtcc: "\u2AA7",
+  gtcir: "\u2A7A",
+  gtdot: "\u22D7",
+  gtlPar: "\u2995",
+  gtquest: "\u2A7C",
+  gtrapprox: "\u2A86",
+  gtrarr: "\u2978",
+  gtrdot: "\u22D7",
+  gtreqless: "\u22DB",
+  gtreqqless: "\u2A8C",
+  gtrless: "\u2277",
+  gtrsim: "\u2273",
+  gvertneqq: "\u2269\uFE00",
+  gvnE: "\u2269\uFE00",
+  hArr: "\u21D4",
+  hairsp: "\u200A",
+  half: "\xBD",
+  hamilt: "\u210B",
+  hardcy: "\u044A",
+  harr: "\u2194",
+  harrcir: "\u2948",
+  harrw: "\u21AD",
+  hbar: "\u210F",
+  hcirc: "\u0125",
+  hearts: "\u2665",
+  heartsuit: "\u2665",
+  hellip: "\u2026",
+  hercon: "\u22B9",
+  hfr: "\u{1D525}",
+  hksearow: "\u2925",
+  hkswarow: "\u2926",
+  hoarr: "\u21FF",
+  homtht: "\u223B",
+  hookleftarrow: "\u21A9",
+  hookrightarrow: "\u21AA",
+  hopf: "\u{1D559}",
+  horbar: "\u2015",
+  hscr: "\u{1D4BD}",
+  hslash: "\u210F",
+  hstrok: "\u0127",
+  hybull: "\u2043",
+  hyphen: "\u2010",
+  iacute: "\xED",
+  ic: "\u2063",
+  icirc: "\xEE",
+  icy: "\u0438",
+  iecy: "\u0435",
+  iexcl: "\xA1",
+  iff: "\u21D4",
+  ifr: "\u{1D526}",
+  igrave: "\xEC",
+  ii: "\u2148",
+  iiiint: "\u2A0C",
+  iiint: "\u222D",
+  iinfin: "\u29DC",
+  iiota: "\u2129",
+  ijlig: "\u0133",
+  imacr: "\u012B",
+  image: "\u2111",
+  imagline: "\u2110",
+  imagpart: "\u2111",
+  imath: "\u0131",
+  imof: "\u22B7",
+  imped: "\u01B5",
+  in: "\u2208",
+  incare: "\u2105",
+  infin: "\u221E",
+  infintie: "\u29DD",
+  inodot: "\u0131",
+  int: "\u222B",
+  intcal: "\u22BA",
+  integers: "\u2124",
+  intercal: "\u22BA",
+  intlarhk: "\u2A17",
+  intprod: "\u2A3C",
+  iocy: "\u0451",
+  iogon: "\u012F",
+  iopf: "\u{1D55A}",
+  iota: "\u03B9",
+  iprod: "\u2A3C",
+  iquest: "\xBF",
+  iscr: "\u{1D4BE}",
+  isin: "\u2208",
+  isinE: "\u22F9",
+  isindot: "\u22F5",
+  isins: "\u22F4",
+  isinsv: "\u22F3",
+  isinv: "\u2208",
+  it: "\u2062",
+  itilde: "\u0129",
+  iukcy: "\u0456",
+  iuml: "\xEF",
+  jcirc: "\u0135",
+  jcy: "\u0439",
+  jfr: "\u{1D527}",
+  jmath: "\u0237",
+  jopf: "\u{1D55B}",
+  jscr: "\u{1D4BF}",
+  jsercy: "\u0458",
+  jukcy: "\u0454",
+  kappa: "\u03BA",
+  kappav: "\u03F0",
+  kcedil: "\u0137",
+  kcy: "\u043A",
+  kfr: "\u{1D528}",
+  kgreen: "\u0138",
+  khcy: "\u0445",
+  kjcy: "\u045C",
+  kopf: "\u{1D55C}",
+  kscr: "\u{1D4C0}",
+  lAarr: "\u21DA",
+  lArr: "\u21D0",
+  lAtail: "\u291B",
+  lBarr: "\u290E",
+  lE: "\u2266",
+  lEg: "\u2A8B",
+  lHar: "\u2962",
+  lacute: "\u013A",
+  laemptyv: "\u29B4",
+  lagran: "\u2112",
+  lambda: "\u03BB",
+  lang: "\u27E8",
+  langd: "\u2991",
+  langle: "\u27E8",
+  lap: "\u2A85",
+  laquo: "\xAB",
+  larr: "\u2190",
+  larrb: "\u21E4",
+  larrbfs: "\u291F",
+  larrfs: "\u291D",
+  larrhk: "\u21A9",
+  larrlp: "\u21AB",
+  larrpl: "\u2939",
+  larrsim: "\u2973",
+  larrtl: "\u21A2",
+  lat: "\u2AAB",
+  latail: "\u2919",
+  late: "\u2AAD",
+  lates: "\u2AAD\uFE00",
+  lbarr: "\u290C",
+  lbbrk: "\u2772",
+  lbrace: "{",
+  lbrack: "[",
+  lbrke: "\u298B",
+  lbrksld: "\u298F",
+  lbrkslu: "\u298D",
+  lcaron: "\u013E",
+  lcedil: "\u013C",
+  lceil: "\u2308",
+  lcub: "{",
+  lcy: "\u043B",
+  ldca: "\u2936",
+  ldquo: "\u201C",
+  ldquor: "\u201E",
+  ldrdhar: "\u2967",
+  ldrushar: "\u294B",
+  ldsh: "\u21B2",
+  le: "\u2264",
+  leftarrow: "\u2190",
+  leftarrowtail: "\u21A2",
+  leftharpoondown: "\u21BD",
+  leftharpoonup: "\u21BC",
+  leftleftarrows: "\u21C7",
+  leftrightarrow: "\u2194",
+  leftrightarrows: "\u21C6",
+  leftrightharpoons: "\u21CB",
+  leftrightsquigarrow: "\u21AD",
+  leftthreetimes: "\u22CB",
+  leg: "\u22DA",
+  leq: "\u2264",
+  leqq: "\u2266",
+  leqslant: "\u2A7D",
+  les: "\u2A7D",
+  lescc: "\u2AA8",
+  lesdot: "\u2A7F",
+  lesdoto: "\u2A81",
+  lesdotor: "\u2A83",
+  lesg: "\u22DA\uFE00",
+  lesges: "\u2A93",
+  lessapprox: "\u2A85",
+  lessdot: "\u22D6",
+  lesseqgtr: "\u22DA",
+  lesseqqgtr: "\u2A8B",
+  lessgtr: "\u2276",
+  lesssim: "\u2272",
+  lfisht: "\u297C",
+  lfloor: "\u230A",
+  lfr: "\u{1D529}",
+  lg: "\u2276",
+  lgE: "\u2A91",
+  lhard: "\u21BD",
+  lharu: "\u21BC",
+  lharul: "\u296A",
+  lhblk: "\u2584",
+  ljcy: "\u0459",
+  ll: "\u226A",
+  llarr: "\u21C7",
+  llcorner: "\u231E",
+  llhard: "\u296B",
+  lltri: "\u25FA",
+  lmidot: "\u0140",
+  lmoust: "\u23B0",
+  lmoustache: "\u23B0",
+  lnE: "\u2268",
+  lnap: "\u2A89",
+  lnapprox: "\u2A89",
+  lne: "\u2A87",
+  lneq: "\u2A87",
+  lneqq: "\u2268",
+  lnsim: "\u22E6",
+  loang: "\u27EC",
+  loarr: "\u21FD",
+  lobrk: "\u27E6",
+  longleftarrow: "\u27F5",
+  longleftrightarrow: "\u27F7",
+  longmapsto: "\u27FC",
+  longrightarrow: "\u27F6",
+  looparrowleft: "\u21AB",
+  looparrowright: "\u21AC",
+  lopar: "\u2985",
+  lopf: "\u{1D55D}",
+  loplus: "\u2A2D",
+  lotimes: "\u2A34",
+  lowast: "\u2217",
+  lowbar: "_",
+  loz: "\u25CA",
+  lozenge: "\u25CA",
+  lozf: "\u29EB",
+  lpar: "(",
+  lparlt: "\u2993",
+  lrarr: "\u21C6",
+  lrcorner: "\u231F",
+  lrhar: "\u21CB",
+  lrhard: "\u296D",
+  lrm: "\u200E",
+  lrtri: "\u22BF",
+  lsaquo: "\u2039",
+  lscr: "\u{1D4C1}",
+  lsh: "\u21B0",
+  lsim: "\u2272",
+  lsime: "\u2A8D",
+  lsimg: "\u2A8F",
+  lsqb: "[",
+  lsquo: "\u2018",
+  lsquor: "\u201A",
+  lstrok: "\u0142",
+  lt: "<",
+  ltcc: "\u2AA6",
+  ltcir: "\u2A79",
+  ltdot: "\u22D6",
+  lthree: "\u22CB",
+  ltimes: "\u22C9",
+  ltlarr: "\u2976",
+  ltquest: "\u2A7B",
+  ltrPar: "\u2996",
+  ltri: "\u25C3",
+  ltrie: "\u22B4",
+  ltrif: "\u25C2",
+  lurdshar: "\u294A",
+  luruhar: "\u2966",
+  lvertneqq: "\u2268\uFE00",
+  lvnE: "\u2268\uFE00",
+  mDDot: "\u223A",
+  macr: "\xAF",
+  male: "\u2642",
+  malt: "\u2720",
+  maltese: "\u2720",
+  map: "\u21A6",
+  mapsto: "\u21A6",
+  mapstodown: "\u21A7",
+  mapstoleft: "\u21A4",
+  mapstoup: "\u21A5",
+  marker: "\u25AE",
+  mcomma: "\u2A29",
+  mcy: "\u043C",
+  mdash: "\u2014",
+  measuredangle: "\u2221",
+  mfr: "\u{1D52A}",
+  mho: "\u2127",
+  micro: "\xB5",
+  mid: "\u2223",
+  midast: "*",
+  midcir: "\u2AF0",
+  middot: "\xB7",
+  minus: "\u2212",
+  minusb: "\u229F",
+  minusd: "\u2238",
+  minusdu: "\u2A2A",
+  mlcp: "\u2ADB",
+  mldr: "\u2026",
+  mnplus: "\u2213",
+  models: "\u22A7",
+  mopf: "\u{1D55E}",
+  mp: "\u2213",
+  mscr: "\u{1D4C2}",
+  mstpos: "\u223E",
+  mu: "\u03BC",
+  multimap: "\u22B8",
+  mumap: "\u22B8",
+  nGg: "\u22D9\u0338",
+  nGt: "\u226B\u20D2",
+  nGtv: "\u226B\u0338",
+  nLeftarrow: "\u21CD",
+  nLeftrightarrow: "\u21CE",
+  nLl: "\u22D8\u0338",
+  nLt: "\u226A\u20D2",
+  nLtv: "\u226A\u0338",
+  nRightarrow: "\u21CF",
+  nVDash: "\u22AF",
+  nVdash: "\u22AE",
+  nabla: "\u2207",
+  nacute: "\u0144",
+  nang: "\u2220\u20D2",
+  nap: "\u2249",
+  napE: "\u2A70\u0338",
+  napid: "\u224B\u0338",
+  napos: "\u0149",
+  napprox: "\u2249",
+  natur: "\u266E",
+  natural: "\u266E",
+  naturals: "\u2115",
+  nbsp: "\xA0",
+  nbump: "\u224E\u0338",
+  nbumpe: "\u224F\u0338",
+  ncap: "\u2A43",
+  ncaron: "\u0148",
+  ncedil: "\u0146",
+  ncong: "\u2247",
+  ncongdot: "\u2A6D\u0338",
+  ncup: "\u2A42",
+  ncy: "\u043D",
+  ndash: "\u2013",
+  ne: "\u2260",
+  neArr: "\u21D7",
+  nearhk: "\u2924",
+  nearr: "\u2197",
+  nearrow: "\u2197",
+  nedot: "\u2250\u0338",
+  nequiv: "\u2262",
+  nesear: "\u2928",
+  nesim: "\u2242\u0338",
+  nexist: "\u2204",
+  nexists: "\u2204",
+  nfr: "\u{1D52B}",
+  ngE: "\u2267\u0338",
+  nge: "\u2271",
+  ngeq: "\u2271",
+  ngeqq: "\u2267\u0338",
+  ngeqslant: "\u2A7E\u0338",
+  nges: "\u2A7E\u0338",
+  ngsim: "\u2275",
+  ngt: "\u226F",
+  ngtr: "\u226F",
+  nhArr: "\u21CE",
+  nharr: "\u21AE",
+  nhpar: "\u2AF2",
+  ni: "\u220B",
+  nis: "\u22FC",
+  nisd: "\u22FA",
+  niv: "\u220B",
+  njcy: "\u045A",
+  nlArr: "\u21CD",
+  nlE: "\u2266\u0338",
+  nlarr: "\u219A",
+  nldr: "\u2025",
+  nle: "\u2270",
+  nleftarrow: "\u219A",
+  nleftrightarrow: "\u21AE",
+  nleq: "\u2270",
+  nleqq: "\u2266\u0338",
+  nleqslant: "\u2A7D\u0338",
+  nles: "\u2A7D\u0338",
+  nless: "\u226E",
+  nlsim: "\u2274",
+  nlt: "\u226E",
+  nltri: "\u22EA",
+  nltrie: "\u22EC",
+  nmid: "\u2224",
+  nopf: "\u{1D55F}",
+  not: "\xAC",
+  notin: "\u2209",
+  notinE: "\u22F9\u0338",
+  notindot: "\u22F5\u0338",
+  notinva: "\u2209",
+  notinvb: "\u22F7",
+  notinvc: "\u22F6",
+  notni: "\u220C",
+  notniva: "\u220C",
+  notnivb: "\u22FE",
+  notnivc: "\u22FD",
+  npar: "\u2226",
+  nparallel: "\u2226",
+  nparsl: "\u2AFD\u20E5",
+  npart: "\u2202\u0338",
+  npolint: "\u2A14",
+  npr: "\u2280",
+  nprcue: "\u22E0",
+  npre: "\u2AAF\u0338",
+  nprec: "\u2280",
+  npreceq: "\u2AAF\u0338",
+  nrArr: "\u21CF",
+  nrarr: "\u219B",
+  nrarrc: "\u2933\u0338",
+  nrarrw: "\u219D\u0338",
+  nrightarrow: "\u219B",
+  nrtri: "\u22EB",
+  nrtrie: "\u22ED",
+  nsc: "\u2281",
+  nsccue: "\u22E1",
+  nsce: "\u2AB0\u0338",
+  nscr: "\u{1D4C3}",
+  nshortmid: "\u2224",
+  nshortparallel: "\u2226",
+  nsim: "\u2241",
+  nsime: "\u2244",
+  nsimeq: "\u2244",
+  nsmid: "\u2224",
+  nspar: "\u2226",
+  nsqsube: "\u22E2",
+  nsqsupe: "\u22E3",
+  nsub: "\u2284",
+  nsubE: "\u2AC5\u0338",
+  nsube: "\u2288",
+  nsubset: "\u2282\u20D2",
+  nsubseteq: "\u2288",
+  nsubseteqq: "\u2AC5\u0338",
+  nsucc: "\u2281",
+  nsucceq: "\u2AB0\u0338",
+  nsup: "\u2285",
+  nsupE: "\u2AC6\u0338",
+  nsupe: "\u2289",
+  nsupset: "\u2283\u20D2",
+  nsupseteq: "\u2289",
+  nsupseteqq: "\u2AC6\u0338",
+  ntgl: "\u2279",
+  ntilde: "\xF1",
+  ntlg: "\u2278",
+  ntriangleleft: "\u22EA",
+  ntrianglelefteq: "\u22EC",
+  ntriangleright: "\u22EB",
+  ntrianglerighteq: "\u22ED",
+  nu: "\u03BD",
+  num: "#",
+  numero: "\u2116",
+  numsp: "\u2007",
+  nvDash: "\u22AD",
+  nvHarr: "\u2904",
+  nvap: "\u224D\u20D2",
+  nvdash: "\u22AC",
+  nvge: "\u2265\u20D2",
+  nvgt: ">\u20D2",
+  nvinfin: "\u29DE",
+  nvlArr: "\u2902",
+  nvle: "\u2264\u20D2",
+  nvlt: "<\u20D2",
+  nvltrie: "\u22B4\u20D2",
+  nvrArr: "\u2903",
+  nvrtrie: "\u22B5\u20D2",
+  nvsim: "\u223C\u20D2",
+  nwArr: "\u21D6",
+  nwarhk: "\u2923",
+  nwarr: "\u2196",
+  nwarrow: "\u2196",
+  nwnear: "\u2927",
+  oS: "\u24C8",
+  oacute: "\xF3",
+  oast: "\u229B",
+  ocir: "\u229A",
+  ocirc: "\xF4",
+  ocy: "\u043E",
+  odash: "\u229D",
+  odblac: "\u0151",
+  odiv: "\u2A38",
+  odot: "\u2299",
+  odsold: "\u29BC",
+  oelig: "\u0153",
+  ofcir: "\u29BF",
+  ofr: "\u{1D52C}",
+  ogon: "\u02DB",
+  ograve: "\xF2",
+  ogt: "\u29C1",
+  ohbar: "\u29B5",
+  ohm: "\u03A9",
+  oint: "\u222E",
+  olarr: "\u21BA",
+  olcir: "\u29BE",
+  olcross: "\u29BB",
+  oline: "\u203E",
+  olt: "\u29C0",
+  omacr: "\u014D",
+  omega: "\u03C9",
+  omicron: "\u03BF",
+  omid: "\u29B6",
+  ominus: "\u2296",
+  oopf: "\u{1D560}",
+  opar: "\u29B7",
+  operp: "\u29B9",
+  oplus: "\u2295",
+  or: "\u2228",
+  orarr: "\u21BB",
+  ord: "\u2A5D",
+  order: "\u2134",
+  orderof: "\u2134",
+  ordf: "\xAA",
+  ordm: "\xBA",
+  origof: "\u22B6",
+  oror: "\u2A56",
+  orslope: "\u2A57",
+  orv: "\u2A5B",
+  oscr: "\u2134",
+  oslash: "\xF8",
+  osol: "\u2298",
+  otilde: "\xF5",
+  otimes: "\u2297",
+  otimesas: "\u2A36",
+  ouml: "\xF6",
+  ovbar: "\u233D",
+  par: "\u2225",
+  para: "\xB6",
+  parallel: "\u2225",
+  parsim: "\u2AF3",
+  parsl: "\u2AFD",
+  part: "\u2202",
+  pcy: "\u043F",
+  percnt: "%",
+  period: ".",
+  permil: "\u2030",
+  perp: "\u22A5",
+  pertenk: "\u2031",
+  pfr: "\u{1D52D}",
+  phi: "\u03C6",
+  phiv: "\u03D5",
+  phmmat: "\u2133",
+  phone: "\u260E",
+  pi: "\u03C0",
+  pitchfork: "\u22D4",
+  piv: "\u03D6",
+  planck: "\u210F",
+  planckh: "\u210E",
+  plankv: "\u210F",
+  plus: "+",
+  plusacir: "\u2A23",
+  plusb: "\u229E",
+  pluscir: "\u2A22",
+  plusdo: "\u2214",
+  plusdu: "\u2A25",
+  pluse: "\u2A72",
+  plusmn: "\xB1",
+  plussim: "\u2A26",
+  plustwo: "\u2A27",
+  pm: "\xB1",
+  pointint: "\u2A15",
+  popf: "\u{1D561}",
+  pound: "\xA3",
+  pr: "\u227A",
+  prE: "\u2AB3",
+  prap: "\u2AB7",
+  prcue: "\u227C",
+  pre: "\u2AAF",
+  prec: "\u227A",
+  precapprox: "\u2AB7",
+  preccurlyeq: "\u227C",
+  preceq: "\u2AAF",
+  precnapprox: "\u2AB9",
+  precneqq: "\u2AB5",
+  precnsim: "\u22E8",
+  precsim: "\u227E",
+  prime: "\u2032",
+  primes: "\u2119",
+  prnE: "\u2AB5",
+  prnap: "\u2AB9",
+  prnsim: "\u22E8",
+  prod: "\u220F",
+  profalar: "\u232E",
+  profline: "\u2312",
+  profsurf: "\u2313",
+  prop: "\u221D",
+  propto: "\u221D",
+  prsim: "\u227E",
+  prurel: "\u22B0",
+  pscr: "\u{1D4C5}",
+  psi: "\u03C8",
+  puncsp: "\u2008",
+  qfr: "\u{1D52E}",
+  qint: "\u2A0C",
+  qopf: "\u{1D562}",
+  qprime: "\u2057",
+  qscr: "\u{1D4C6}",
+  quaternions: "\u210D",
+  quatint: "\u2A16",
+  quest: "?",
+  questeq: "\u225F",
+  quot: '"',
+  rAarr: "\u21DB",
+  rArr: "\u21D2",
+  rAtail: "\u291C",
+  rBarr: "\u290F",
+  rHar: "\u2964",
+  race: "\u223D\u0331",
+  racute: "\u0155",
+  radic: "\u221A",
+  raemptyv: "\u29B3",
+  rang: "\u27E9",
+  rangd: "\u2992",
+  range: "\u29A5",
+  rangle: "\u27E9",
+  raquo: "\xBB",
+  rarr: "\u2192",
+  rarrap: "\u2975",
+  rarrb: "\u21E5",
+  rarrbfs: "\u2920",
+  rarrc: "\u2933",
+  rarrfs: "\u291E",
+  rarrhk: "\u21AA",
+  rarrlp: "\u21AC",
+  rarrpl: "\u2945",
+  rarrsim: "\u2974",
+  rarrtl: "\u21A3",
+  rarrw: "\u219D",
+  ratail: "\u291A",
+  ratio: "\u2236",
+  rationals: "\u211A",
+  rbarr: "\u290D",
+  rbbrk: "\u2773",
+  rbrace: "}",
+  rbrack: "]",
+  rbrke: "\u298C",
+  rbrksld: "\u298E",
+  rbrkslu: "\u2990",
+  rcaron: "\u0159",
+  rcedil: "\u0157",
+  rceil: "\u2309",
+  rcub: "}",
+  rcy: "\u0440",
+  rdca: "\u2937",
+  rdldhar: "\u2969",
+  rdquo: "\u201D",
+  rdquor: "\u201D",
+  rdsh: "\u21B3",
+  real: "\u211C",
+  realine: "\u211B",
+  realpart: "\u211C",
+  reals: "\u211D",
+  rect: "\u25AD",
+  reg: "\xAE",
+  rfisht: "\u297D",
+  rfloor: "\u230B",
+  rfr: "\u{1D52F}",
+  rhard: "\u21C1",
+  rharu: "\u21C0",
+  rharul: "\u296C",
+  rho: "\u03C1",
+  rhov: "\u03F1",
+  rightarrow: "\u2192",
+  rightarrowtail: "\u21A3",
+  rightharpoondown: "\u21C1",
+  rightharpoonup: "\u21C0",
+  rightleftarrows: "\u21C4",
+  rightleftharpoons: "\u21CC",
+  rightrightarrows: "\u21C9",
+  rightsquigarrow: "\u219D",
+  rightthreetimes: "\u22CC",
+  ring: "\u02DA",
+  risingdotseq: "\u2253",
+  rlarr: "\u21C4",
+  rlhar: "\u21CC",
+  rlm: "\u200F",
+  rmoust: "\u23B1",
+  rmoustache: "\u23B1",
+  rnmid: "\u2AEE",
+  roang: "\u27ED",
+  roarr: "\u21FE",
+  robrk: "\u27E7",
+  ropar: "\u2986",
+  ropf: "\u{1D563}",
+  roplus: "\u2A2E",
+  rotimes: "\u2A35",
+  rpar: ")",
+  rpargt: "\u2994",
+  rppolint: "\u2A12",
+  rrarr: "\u21C9",
+  rsaquo: "\u203A",
+  rscr: "\u{1D4C7}",
+  rsh: "\u21B1",
+  rsqb: "]",
+  rsquo: "\u2019",
+  rsquor: "\u2019",
+  rthree: "\u22CC",
+  rtimes: "\u22CA",
+  rtri: "\u25B9",
+  rtrie: "\u22B5",
+  rtrif: "\u25B8",
+  rtriltri: "\u29CE",
+  ruluhar: "\u2968",
+  rx: "\u211E",
+  sacute: "\u015B",
+  sbquo: "\u201A",
+  sc: "\u227B",
+  scE: "\u2AB4",
+  scap: "\u2AB8",
+  scaron: "\u0161",
+  sccue: "\u227D",
+  sce: "\u2AB0",
+  scedil: "\u015F",
+  scirc: "\u015D",
+  scnE: "\u2AB6",
+  scnap: "\u2ABA",
+  scnsim: "\u22E9",
+  scpolint: "\u2A13",
+  scsim: "\u227F",
+  scy: "\u0441",
+  sdot: "\u22C5",
+  sdotb: "\u22A1",
+  sdote: "\u2A66",
+  seArr: "\u21D8",
+  searhk: "\u2925",
+  searr: "\u2198",
+  searrow: "\u2198",
+  sect: "\xA7",
+  semi: ";",
+  seswar: "\u2929",
+  setminus: "\u2216",
+  setmn: "\u2216",
+  sext: "\u2736",
+  sfr: "\u{1D530}",
+  sfrown: "\u2322",
+  sharp: "\u266F",
+  shchcy: "\u0449",
+  shcy: "\u0448",
+  shortmid: "\u2223",
+  shortparallel: "\u2225",
+  shy: "\xAD",
+  sigma: "\u03C3",
+  sigmaf: "\u03C2",
+  sigmav: "\u03C2",
+  sim: "\u223C",
+  simdot: "\u2A6A",
+  sime: "\u2243",
+  simeq: "\u2243",
+  simg: "\u2A9E",
+  simgE: "\u2AA0",
+  siml: "\u2A9D",
+  simlE: "\u2A9F",
+  simne: "\u2246",
+  simplus: "\u2A24",
+  simrarr: "\u2972",
+  slarr: "\u2190",
+  smallsetminus: "\u2216",
+  smashp: "\u2A33",
+  smeparsl: "\u29E4",
+  smid: "\u2223",
+  smile: "\u2323",
+  smt: "\u2AAA",
+  smte: "\u2AAC",
+  smtes: "\u2AAC\uFE00",
+  softcy: "\u044C",
+  sol: "/",
+  solb: "\u29C4",
+  solbar: "\u233F",
+  sopf: "\u{1D564}",
+  spades: "\u2660",
+  spadesuit: "\u2660",
+  spar: "\u2225",
+  sqcap: "\u2293",
+  sqcaps: "\u2293\uFE00",
+  sqcup: "\u2294",
+  sqcups: "\u2294\uFE00",
+  sqsub: "\u228F",
+  sqsube: "\u2291",
+  sqsubset: "\u228F",
+  sqsubseteq: "\u2291",
+  sqsup: "\u2290",
+  sqsupe: "\u2292",
+  sqsupset: "\u2290",
+  sqsupseteq: "\u2292",
+  squ: "\u25A1",
+  square: "\u25A1",
+  squarf: "\u25AA",
+  squf: "\u25AA",
+  srarr: "\u2192",
+  sscr: "\u{1D4C8}",
+  ssetmn: "\u2216",
+  ssmile: "\u2323",
+  sstarf: "\u22C6",
+  star: "\u2606",
+  starf: "\u2605",
+  straightepsilon: "\u03F5",
+  straightphi: "\u03D5",
+  strns: "\xAF",
+  sub: "\u2282",
+  subE: "\u2AC5",
+  subdot: "\u2ABD",
+  sube: "\u2286",
+  subedot: "\u2AC3",
+  submult: "\u2AC1",
+  subnE: "\u2ACB",
+  subne: "\u228A",
+  subplus: "\u2ABF",
+  subrarr: "\u2979",
+  subset: "\u2282",
+  subseteq: "\u2286",
+  subseteqq: "\u2AC5",
+  subsetneq: "\u228A",
+  subsetneqq: "\u2ACB",
+  subsim: "\u2AC7",
+  subsub: "\u2AD5",
+  subsup: "\u2AD3",
+  succ: "\u227B",
+  succapprox: "\u2AB8",
+  succcurlyeq: "\u227D",
+  succeq: "\u2AB0",
+  succnapprox: "\u2ABA",
+  succneqq: "\u2AB6",
+  succnsim: "\u22E9",
+  succsim: "\u227F",
+  sum: "\u2211",
+  sung: "\u266A",
+  sup1: "\xB9",
+  sup2: "\xB2",
+  sup3: "\xB3",
+  sup: "\u2283",
+  supE: "\u2AC6",
+  supdot: "\u2ABE",
+  supdsub: "\u2AD8",
+  supe: "\u2287",
+  supedot: "\u2AC4",
+  suphsol: "\u27C9",
+  suphsub: "\u2AD7",
+  suplarr: "\u297B",
+  supmult: "\u2AC2",
+  supnE: "\u2ACC",
+  supne: "\u228B",
+  supplus: "\u2AC0",
+  supset: "\u2283",
+  supseteq: "\u2287",
+  supseteqq: "\u2AC6",
+  supsetneq: "\u228B",
+  supsetneqq: "\u2ACC",
+  supsim: "\u2AC8",
+  supsub: "\u2AD4",
+  supsup: "\u2AD6",
+  swArr: "\u21D9",
+  swarhk: "\u2926",
+  swarr: "\u2199",
+  swarrow: "\u2199",
+  swnwar: "\u292A",
+  szlig: "\xDF",
+  target: "\u2316",
+  tau: "\u03C4",
+  tbrk: "\u23B4",
+  tcaron: "\u0165",
+  tcedil: "\u0163",
+  tcy: "\u0442",
+  tdot: "\u20DB",
+  telrec: "\u2315",
+  tfr: "\u{1D531}",
+  there4: "\u2234",
+  therefore: "\u2234",
+  theta: "\u03B8",
+  thetasym: "\u03D1",
+  thetav: "\u03D1",
+  thickapprox: "\u2248",
+  thicksim: "\u223C",
+  thinsp: "\u2009",
+  thkap: "\u2248",
+  thksim: "\u223C",
+  thorn: "\xFE",
+  tilde: "\u02DC",
+  times: "\xD7",
+  timesb: "\u22A0",
+  timesbar: "\u2A31",
+  timesd: "\u2A30",
+  tint: "\u222D",
+  toea: "\u2928",
+  top: "\u22A4",
+  topbot: "\u2336",
+  topcir: "\u2AF1",
+  topf: "\u{1D565}",
+  topfork: "\u2ADA",
+  tosa: "\u2929",
+  tprime: "\u2034",
+  trade: "\u2122",
+  triangle: "\u25B5",
+  triangledown: "\u25BF",
+  triangleleft: "\u25C3",
+  trianglelefteq: "\u22B4",
+  triangleq: "\u225C",
+  triangleright: "\u25B9",
+  trianglerighteq: "\u22B5",
+  tridot: "\u25EC",
+  trie: "\u225C",
+  triminus: "\u2A3A",
+  triplus: "\u2A39",
+  trisb: "\u29CD",
+  tritime: "\u2A3B",
+  trpezium: "\u23E2",
+  tscr: "\u{1D4C9}",
+  tscy: "\u0446",
+  tshcy: "\u045B",
+  tstrok: "\u0167",
+  twixt: "\u226C",
+  twoheadleftarrow: "\u219E",
+  twoheadrightarrow: "\u21A0",
+  uArr: "\u21D1",
+  uHar: "\u2963",
+  uacute: "\xFA",
+  uarr: "\u2191",
+  ubrcy: "\u045E",
+  ubreve: "\u016D",
+  ucirc: "\xFB",
+  ucy: "\u0443",
+  udarr: "\u21C5",
+  udblac: "\u0171",
+  udhar: "\u296E",
+  ufisht: "\u297E",
+  ufr: "\u{1D532}",
+  ugrave: "\xF9",
+  uharl: "\u21BF",
+  uharr: "\u21BE",
+  uhblk: "\u2580",
+  ulcorn: "\u231C",
+  ulcorner: "\u231C",
+  ulcrop: "\u230F",
+  ultri: "\u25F8",
+  umacr: "\u016B",
+  uml: "\xA8",
+  uogon: "\u0173",
+  uopf: "\u{1D566}",
+  uparrow: "\u2191",
+  updownarrow: "\u2195",
+  upharpoonleft: "\u21BF",
+  upharpoonright: "\u21BE",
+  uplus: "\u228E",
+  upsi: "\u03C5",
+  upsih: "\u03D2",
+  upsilon: "\u03C5",
+  upuparrows: "\u21C8",
+  urcorn: "\u231D",
+  urcorner: "\u231D",
+  urcrop: "\u230E",
+  uring: "\u016F",
+  urtri: "\u25F9",
+  uscr: "\u{1D4CA}",
+  utdot: "\u22F0",
+  utilde: "\u0169",
+  utri: "\u25B5",
+  utrif: "\u25B4",
+  uuarr: "\u21C8",
+  uuml: "\xFC",
+  uwangle: "\u29A7",
+  vArr: "\u21D5",
+  vBar: "\u2AE8",
+  vBarv: "\u2AE9",
+  vDash: "\u22A8",
+  vangrt: "\u299C",
+  varepsilon: "\u03F5",
+  varkappa: "\u03F0",
+  varnothing: "\u2205",
+  varphi: "\u03D5",
+  varpi: "\u03D6",
+  varpropto: "\u221D",
+  varr: "\u2195",
+  varrho: "\u03F1",
+  varsigma: "\u03C2",
+  varsubsetneq: "\u228A\uFE00",
+  varsubsetneqq: "\u2ACB\uFE00",
+  varsupsetneq: "\u228B\uFE00",
+  varsupsetneqq: "\u2ACC\uFE00",
+  vartheta: "\u03D1",
+  vartriangleleft: "\u22B2",
+  vartriangleright: "\u22B3",
+  vcy: "\u0432",
+  vdash: "\u22A2",
+  vee: "\u2228",
+  veebar: "\u22BB",
+  veeeq: "\u225A",
+  vellip: "\u22EE",
+  verbar: "|",
+  vert: "|",
+  vfr: "\u{1D533}",
+  vltri: "\u22B2",
+  vnsub: "\u2282\u20D2",
+  vnsup: "\u2283\u20D2",
+  vopf: "\u{1D567}",
+  vprop: "\u221D",
+  vrtri: "\u22B3",
+  vscr: "\u{1D4CB}",
+  vsubnE: "\u2ACB\uFE00",
+  vsubne: "\u228A\uFE00",
+  vsupnE: "\u2ACC\uFE00",
+  vsupne: "\u228B\uFE00",
+  vzigzag: "\u299A",
+  wcirc: "\u0175",
+  wedbar: "\u2A5F",
+  wedge: "\u2227",
+  wedgeq: "\u2259",
+  weierp: "\u2118",
+  wfr: "\u{1D534}",
+  wopf: "\u{1D568}",
+  wp: "\u2118",
+  wr: "\u2240",
+  wreath: "\u2240",
+  wscr: "\u{1D4CC}",
+  xcap: "\u22C2",
+  xcirc: "\u25EF",
+  xcup: "\u22C3",
+  xdtri: "\u25BD",
+  xfr: "\u{1D535}",
+  xhArr: "\u27FA",
+  xharr: "\u27F7",
+  xi: "\u03BE",
+  xlArr: "\u27F8",
+  xlarr: "\u27F5",
+  xmap: "\u27FC",
+  xnis: "\u22FB",
+  xodot: "\u2A00",
+  xopf: "\u{1D569}",
+  xoplus: "\u2A01",
+  xotime: "\u2A02",
+  xrArr: "\u27F9",
+  xrarr: "\u27F6",
+  xscr: "\u{1D4CD}",
+  xsqcup: "\u2A06",
+  xuplus: "\u2A04",
+  xutri: "\u25B3",
+  xvee: "\u22C1",
+  xwedge: "\u22C0",
+  yacute: "\xFD",
+  yacy: "\u044F",
+  ycirc: "\u0177",
+  ycy: "\u044B",
+  yen: "\xA5",
+  yfr: "\u{1D536}",
+  yicy: "\u0457",
+  yopf: "\u{1D56A}",
+  yscr: "\u{1D4CE}",
+  yucy: "\u044E",
+  yuml: "\xFF",
+  zacute: "\u017A",
+  zcaron: "\u017E",
+  zcy: "\u0437",
+  zdot: "\u017C",
+  zeetrf: "\u2128",
+  zeta: "\u03B6",
+  zfr: "\u{1D537}",
+  zhcy: "\u0436",
+  zigrarr: "\u21DD",
+  zopf: "\u{1D56B}",
+  zscr: "\u{1D4CF}",
+  zwj: "\u200D",
+  zwnj: "\u200C"
+};
+
+// node_modules/decode-named-character-reference/index.js
+var own2 = {}.hasOwnProperty;
+function decodeNamedCharacterReference(value) {
+  return own2.call(characterEntities, value) ? characterEntities[value] : false;
+}
+
+// node_modules/micromark-extension-mdxjs-esm/lib/syntax.js
+var nextBlankConstruct = {
+  tokenize: tokenizeNextBlank,
+  partial: true
+};
+var allowedAcornTypes = /* @__PURE__ */ new Set([
+  "ExportAllDeclaration",
+  "ExportDefaultDeclaration",
+  "ExportNamedDeclaration",
+  "ImportDeclaration"
+]);
+function mdxjsEsm(options) {
+  const exportImportConstruct = {
+    tokenize: tokenizeExportImport,
+    concrete: true
+  };
+  if (!options || !options.acorn || !options.acorn.parse) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  const acorn = options.acorn;
+  const acornOptions = Object.assign(
+    {
+      ecmaVersion: 2020,
+      sourceType: "module"
+    },
+    options.acornOptions
+  );
+  return {
+    flow: {
+      [101]: exportImportConstruct,
+      [105]: exportImportConstruct
+    }
+  };
+  function tokenizeExportImport(effects, ok, nok) {
+    const self2 = this;
+    const definedModuleSpecifiers = self2.parser.definedModuleSpecifiers || (self2.parser.definedModuleSpecifiers = []);
+    const eventStart = this.events.length + 1;
+    let index2 = 0;
+    let buffer;
+    return self2.interrupt ? nok : start3;
+    function start3(code) {
+      if (self2.now().column > 1)
+        return nok(code);
+      buffer = code === 101 ? "export" : "import";
+      effects.enter("mdxjsEsm");
+      effects.enter("mdxjsEsmData");
+      return keyword(code);
+    }
+    function keyword(code) {
+      if (code === buffer.charCodeAt(index2++)) {
+        effects.consume(code);
+        return index2 === buffer.length ? after : keyword;
+      }
+      return nok(code);
+    }
+    function after(code) {
+      if (unicodeWhitespace(code)) {
+        effects.consume(code);
+        return rest;
+      }
+      return nok(code);
+    }
+    function rest(code) {
+      if (code === null) {
+        return atEndOfData(code);
+      }
+      if (markdownLineEnding(code)) {
+        return effects.check(nextBlankConstruct, atEndOfData, atEol)(code);
+      }
+      effects.consume(code);
+      return rest;
+    }
+    function atEol(code) {
+      effects.exit("mdxjsEsmData");
+      return lineStart(code);
+    }
+    function lineStart(code) {
+      if (markdownLineEnding(code)) {
+        effects.enter("lineEnding");
+        effects.consume(code);
+        effects.exit("lineEnding");
+        return lineStart;
+      }
+      if (code === null) {
+        return atEnd(code);
+      }
+      effects.enter("mdxjsEsmData");
+      return rest(code);
+    }
+    function atEndOfData(code) {
+      effects.exit("mdxjsEsmData");
+      return atEnd(code);
+    }
+    function atEnd(code) {
+      let index3 = -1;
+      const result = eventsToAcorn(self2.events.slice(eventStart), {
+        acorn,
+        acornOptions,
+        prefix: definedModuleSpecifiers.length > 0 ? "var " + definedModuleSpecifiers.join(",") + "\n" : ""
+      });
+      if (code !== null && result.swallow) {
+        return lineStart(code);
+      }
+      if (result.error) {
+        throw new VFileMessage(
+          "Could not parse import/exports with acorn: " + String(result.error),
+          {
+            line: result.error.loc.line,
+            column: result.error.loc.column + 1,
+            offset: result.error.pos
+          },
+          "micromark-extension-mdxjs-esm:acorn"
+        );
+      }
+      if (definedModuleSpecifiers.length > 0) {
+        result.estree.body.shift();
+      }
+      while (++index3 < result.estree.body.length) {
+        const node = result.estree.body[index3];
+        if (!allowedAcornTypes.has(node.type)) {
+          throw new VFileMessage(
+            "Unexpected `" + node.type + "` in code: only import/exports are supported",
+            positionFromEstree(node),
+            "micromark-extension-mdxjs-esm:non-esm"
+          );
+        }
+        if (node.type === "ImportDeclaration" && !self2.interrupt) {
+          let index4 = -1;
+          while (++index4 < node.specifiers.length) {
+            definedModuleSpecifiers.push(node.specifiers[index4].local.name);
+          }
+        }
+      }
+      Object.assign(
+        effects.exit("mdxjsEsm"),
+        options.addResult ? {
+          estree: result.estree
+        } : void 0
+      );
+      return ok(code);
+    }
+  }
+}
+function tokenizeNextBlank(effects, ok, nok) {
+  return start3;
+  function start3(code) {
+    effects.exit("mdxjsEsmData");
+    effects.enter("lineEndingBlank");
+    effects.consume(code);
+    effects.exit("lineEndingBlank");
+    return effects.attempt(blankLine, ok, nok);
+  }
+}
+
+// node_modules/micromark-extension-mdxjs/index.js
+function mdxjs(options) {
+  const settings = Object.assign(
+    {
+      acorn: Parser.extend((0, import_acorn_jsx.default)()),
+      acornOptions: { ecmaVersion: 2020, sourceType: "module" },
+      addResult: true
+    },
+    options
+  );
+  return combineExtensions([
+    mdxjsEsm(settings),
+    mdxExpression(settings),
+    mdxJsx(settings),
+    mdxMd
+  ]);
+}
+
+// node_modules/mdast-util-mdx-expression/index.js
+var mdxExpressionFromMarkdown = {
+  enter: {
+    mdxFlowExpression: enterMdxFlowExpression,
+    mdxTextExpression: enterMdxTextExpression
+  },
+  exit: {
+    mdxFlowExpression: exitMdxExpression,
+    mdxFlowExpressionChunk: exitMdxExpressionData,
+    mdxTextExpression: exitMdxExpression,
+    mdxTextExpressionChunk: exitMdxExpressionData
+  }
+};
+var mdxExpressionToMarkdown = {
+  handlers: {
+    mdxFlowExpression: handleMdxExpression,
+    mdxTextExpression: handleMdxExpression
+  },
+  unsafe: [
+    { character: "{", inConstruct: ["phrasing"] },
+    { atBreak: true, character: "{" }
+  ]
+};
+function enterMdxFlowExpression(token) {
+  this.enter({ type: "mdxFlowExpression", value: "" }, token);
+  this.buffer();
+}
+function enterMdxTextExpression(token) {
+  this.enter({ type: "mdxTextExpression", value: "" }, token);
+  this.buffer();
+}
+function exitMdxExpression(token) {
+  const value = this.resume();
+  const estree = token.estree;
+  const node = this.exit(token);
+  node.value = value;
+  if (estree) {
+    node.data = { estree };
+  }
+}
+function exitMdxExpressionData(token) {
+  this.config.enter.data.call(this, token);
+  this.config.exit.data.call(this, token);
+}
+function handleMdxExpression(node) {
+  const value = node.value || "";
+  return "{" + value + "}";
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/ccount/index.js
+function ccount(value, character) {
+  const source = String(value);
+  if (typeof character !== "string") {
+    throw new TypeError("Expected character");
+  }
+  let count = 0;
+  let index2 = source.indexOf(character);
+  while (index2 !== -1) {
+    count++;
+    index2 = source.indexOf(character, index2 + character.length);
+  }
+  return count;
+}
+
+// node_modules/parse-entities/node_modules/character-entities-legacy/index.js
+var characterEntitiesLegacy = [
+  "AElig",
+  "AMP",
+  "Aacute",
+  "Acirc",
+  "Agrave",
+  "Aring",
+  "Atilde",
+  "Auml",
+  "COPY",
+  "Ccedil",
+  "ETH",
+  "Eacute",
+  "Ecirc",
+  "Egrave",
+  "Euml",
+  "GT",
+  "Iacute",
+  "Icirc",
+  "Igrave",
+  "Iuml",
+  "LT",
+  "Ntilde",
+  "Oacute",
+  "Ocirc",
+  "Ograve",
+  "Oslash",
+  "Otilde",
+  "Ouml",
+  "QUOT",
+  "REG",
+  "THORN",
+  "Uacute",
+  "Ucirc",
+  "Ugrave",
+  "Uuml",
+  "Yacute",
+  "aacute",
+  "acirc",
+  "acute",
+  "aelig",
+  "agrave",
+  "amp",
+  "aring",
+  "atilde",
+  "auml",
+  "brvbar",
+  "ccedil",
+  "cedil",
+  "cent",
+  "copy",
+  "curren",
+  "deg",
+  "divide",
+  "eacute",
+  "ecirc",
+  "egrave",
+  "eth",
+  "euml",
+  "frac12",
+  "frac14",
+  "frac34",
+  "gt",
+  "iacute",
+  "icirc",
+  "iexcl",
+  "igrave",
+  "iquest",
+  "iuml",
+  "laquo",
+  "lt",
+  "macr",
+  "micro",
+  "middot",
+  "nbsp",
+  "not",
+  "ntilde",
+  "oacute",
+  "ocirc",
+  "ograve",
+  "ordf",
+  "ordm",
+  "oslash",
+  "otilde",
+  "ouml",
+  "para",
+  "plusmn",
+  "pound",
+  "quot",
+  "raquo",
+  "reg",
+  "sect",
+  "shy",
+  "sup1",
+  "sup2",
+  "sup3",
+  "szlig",
+  "thorn",
+  "times",
+  "uacute",
+  "ucirc",
+  "ugrave",
+  "uml",
+  "uuml",
+  "yacute",
+  "yen",
+  "yuml"
+];
+
+// node_modules/character-reference-invalid/index.js
+var characterReferenceInvalid = {
+  0: "\uFFFD",
+  128: "\u20AC",
+  130: "\u201A",
+  131: "\u0192",
+  132: "\u201E",
+  133: "\u2026",
+  134: "\u2020",
+  135: "\u2021",
+  136: "\u02C6",
+  137: "\u2030",
+  138: "\u0160",
+  139: "\u2039",
+  140: "\u0152",
+  142: "\u017D",
+  145: "\u2018",
+  146: "\u2019",
+  147: "\u201C",
+  148: "\u201D",
+  149: "\u2022",
+  150: "\u2013",
+  151: "\u2014",
+  152: "\u02DC",
+  153: "\u2122",
+  154: "\u0161",
+  155: "\u203A",
+  156: "\u0153",
+  158: "\u017E",
+  159: "\u0178"
+};
+
+// node_modules/parse-entities/node_modules/is-decimal/index.js
+function isDecimal(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 48 && code <= 57;
+}
+
+// node_modules/is-hexadecimal/index.js
+function isHexadecimal(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 97 && code <= 102 || code >= 65 && code <= 70 || code >= 48 && code <= 57;
+}
+
+// node_modules/is-alphanumerical/node_modules/is-alphabetical/index.js
+function isAlphabetical(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 97 && code <= 122 || code >= 65 && code <= 90;
+}
+
+// node_modules/is-alphanumerical/node_modules/is-decimal/index.js
+function isDecimal2(character) {
+  const code = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code >= 48 && code <= 57;
+}
+
+// node_modules/is-alphanumerical/index.js
+function isAlphanumerical(character) {
+  return isAlphabetical(character) || isDecimal2(character);
+}
+
+// node_modules/parse-entities/lib/index.js
+var fromCharCode = String.fromCharCode;
+var messages = [
+  "",
+  "Named character references must be terminated by a semicolon",
+  "Numeric character references must be terminated by a semicolon",
+  "Named character references cannot be empty",
+  "Numeric character references cannot be empty",
+  "Named character references must be known",
+  "Numeric character references cannot be disallowed",
+  "Numeric character references cannot be outside the permissible Unicode range"
+];
+function parseEntities(value, options = {}) {
+  const additional = typeof options.additional === "string" ? options.additional.charCodeAt(0) : options.additional;
+  const result = [];
+  let index2 = 0;
+  let lines = -1;
+  let queue = "";
+  let point2;
+  let indent;
+  if (options.position) {
+    if ("start" in options.position || "indent" in options.position) {
+      indent = options.position.indent;
+      point2 = options.position.start;
+    } else {
+      point2 = options.position;
+    }
+  }
+  let line = (point2 ? point2.line : 0) || 1;
+  let column = (point2 ? point2.column : 0) || 1;
+  let previous = now();
+  let character;
+  index2--;
+  while (++index2 <= value.length) {
+    if (character === 10) {
+      column = (indent ? indent[lines] : 0) || 1;
+    }
+    character = value.charCodeAt(index2);
+    if (character === 38) {
+      const following = value.charCodeAt(index2 + 1);
+      if (following === 9 || following === 10 || following === 12 || following === 32 || following === 38 || following === 60 || Number.isNaN(following) || additional && following === additional) {
+        queue += fromCharCode(character);
+        column++;
+        continue;
+      }
+      const start3 = index2 + 1;
+      let begin = start3;
+      let end = start3;
+      let type;
+      if (following === 35) {
+        end = ++begin;
+        const following2 = value.charCodeAt(end);
+        if (following2 === 88 || following2 === 120) {
+          type = "hexadecimal";
+          end = ++begin;
+        } else {
+          type = "decimal";
+        }
+      } else {
+        type = "named";
+      }
+      let characterReferenceCharacters = "";
+      let characterReference = "";
+      let characters = "";
+      const test = type === "named" ? isAlphanumerical : type === "decimal" ? isDecimal : isHexadecimal;
+      end--;
+      while (++end <= value.length) {
+        const following2 = value.charCodeAt(end);
+        if (!test(following2)) {
+          break;
+        }
+        characters += fromCharCode(following2);
+        if (type === "named" && characterEntitiesLegacy.includes(characters)) {
+          characterReferenceCharacters = characters;
+          characterReference = decodeNamedCharacterReference(characters);
+        }
+      }
+      let terminated = value.charCodeAt(end) === 59;
+      if (terminated) {
+        end++;
+        const namedReference = type === "named" ? decodeNamedCharacterReference(characters) : false;
+        if (namedReference) {
+          characterReferenceCharacters = characters;
+          characterReference = namedReference;
+        }
+      }
+      let diff = 1 + end - start3;
+      let reference = "";
+      if (!terminated && options.nonTerminated === false) {
+      } else if (!characters) {
+        if (type !== "named") {
+          warning(4, diff);
+        }
+      } else if (type === "named") {
+        if (terminated && !characterReference) {
+          warning(5, 1);
+        } else {
+          if (characterReferenceCharacters !== characters) {
+            end = begin + characterReferenceCharacters.length;
+            diff = 1 + end - begin;
+            terminated = false;
+          }
+          if (!terminated) {
+            const reason = characterReferenceCharacters ? 1 : 3;
+            if (options.attribute) {
+              const following2 = value.charCodeAt(end);
+              if (following2 === 61) {
+                warning(reason, diff);
+                characterReference = "";
+              } else if (isAlphanumerical(following2)) {
+                characterReference = "";
+              } else {
+                warning(reason, diff);
+              }
+            } else {
+              warning(reason, diff);
+            }
+          }
+        }
+        reference = characterReference;
+      } else {
+        if (!terminated) {
+          warning(2, diff);
+        }
+        let referenceCode = Number.parseInt(
+          characters,
+          type === "hexadecimal" ? 16 : 10
+        );
+        if (prohibited(referenceCode)) {
+          warning(7, diff);
+          reference = fromCharCode(65533);
+        } else if (referenceCode in characterReferenceInvalid) {
+          warning(6, diff);
+          reference = characterReferenceInvalid[referenceCode];
+        } else {
+          let output = "";
+          if (disallowed(referenceCode)) {
+            warning(6, diff);
+          }
+          if (referenceCode > 65535) {
+            referenceCode -= 65536;
+            output += fromCharCode(referenceCode >>> (10 & 1023) | 55296);
+            referenceCode = 56320 | referenceCode & 1023;
+          }
+          reference = output + fromCharCode(referenceCode);
+        }
+      }
+      if (reference) {
+        flush();
+        previous = now();
+        index2 = end - 1;
+        column += end - start3 + 1;
+        result.push(reference);
+        const next = now();
+        next.offset++;
+        if (options.reference) {
+          options.reference.call(
+            options.referenceContext,
+            reference,
+            { start: previous, end: next },
+            value.slice(start3 - 1, end)
+          );
+        }
+        previous = next;
+      } else {
+        characters = value.slice(start3 - 1, end);
+        queue += characters;
+        column += characters.length;
+        index2 = end - 1;
+      }
+    } else {
+      if (character === 10) {
+        line++;
+        lines++;
+        column = 0;
+      }
+      if (Number.isNaN(character)) {
+        flush();
+      } else {
+        queue += fromCharCode(character);
+        column++;
+      }
+    }
+  }
+  return result.join("");
+  function now() {
+    return {
+      line,
+      column,
+      offset: index2 + ((point2 ? point2.offset : 0) || 0)
+    };
+  }
+  function warning(code, offset2) {
+    let position2;
+    if (options.warning) {
+      position2 = now();
+      position2.column += offset2;
+      position2.offset += offset2;
+      options.warning.call(
+        options.warningContext,
+        messages[code],
+        position2,
+        code
+      );
+    }
+  }
+  function flush() {
+    if (queue) {
+      result.push(queue);
+      if (options.text) {
+        options.text.call(options.textContext, queue, {
+          start: previous,
+          end: now()
+        });
+      }
+      queue = "";
+    }
+  }
+}
+function prohibited(code) {
+  return code >= 55296 && code <= 57343 || code > 1114111;
+}
+function disallowed(code) {
+  return code >= 1 && code <= 8 || code === 11 || code >= 13 && code <= 31 || code >= 127 && code <= 159 || code >= 64976 && code <= 65007 || (code & 65535) === 65535 || (code & 65535) === 65534;
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/stringify-entities/lib/core.js
+function core(value, options) {
+  value = value.replace(
+    options.subset ? charactersToExpression(options.subset) : /["&'<>`]/g,
+    basic
+  );
+  if (options.subset || options.escapeOnly) {
+    return value;
+  }
+  return value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, surrogate).replace(
+    /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g,
+    basic
+  );
+  function surrogate(pair, index2, all) {
+    return options.format(
+      (pair.charCodeAt(0) - 55296) * 1024 + pair.charCodeAt(1) - 56320 + 65536,
+      all.charCodeAt(index2 + 2),
+      options
+    );
+  }
+  function basic(character, index2, all) {
+    return options.format(
+      character.charCodeAt(0),
+      all.charCodeAt(index2 + 1),
+      options
+    );
+  }
+}
+function charactersToExpression(subset) {
+  const groups = [];
+  let index2 = -1;
+  while (++index2 < subset.length) {
+    groups.push(subset[index2].replace(/[|\\{}()[\]^$+*?.]/g, "\\$&"));
+  }
+  return new RegExp("(?:" + groups.join("|") + ")", "g");
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/stringify-entities/lib/util/format-basic.js
+function formatBasic(code) {
+  return "&#x" + code.toString(16).toUpperCase() + ";";
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/stringify-entities/lib/index.js
+function stringifyEntitiesLight(value, options) {
+  return core(value, Object.assign({ format: formatBasic }, options));
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/track.js
+function track(options_) {
+  const options = options_ || {};
+  const now = options.now || {};
+  let lineShift = options.lineShift || 0;
+  let line = now.line || 1;
+  let column = now.column || 1;
+  return { move, current: current2, shift };
+  function current2() {
+    return { now: { line, column }, lineShift };
+  }
+  function shift(value) {
+    lineShift += value;
+  }
+  function move(value = "") {
+    const chunks = value.split(/\r?\n|\r/g);
+    const tail = chunks[chunks.length - 1];
+    line += chunks.length - 1;
+    column = chunks.length === 1 ? column + tail.length : 1 + tail.length + lineShift;
+    return value;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-flow.js
+function containerFlow(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const tracker = track(safeOptions);
+  const results = [];
+  let index2 = -1;
+  indexStack.push(-1);
+  while (++index2 < children.length) {
+    const child = children[index2];
+    indexStack[indexStack.length - 1] = index2;
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          before: "\n",
+          after: "\n",
+          ...tracker.current()
+        })
+      )
+    );
+    if (child.type !== "list") {
+      context.bulletLastUsed = void 0;
+    }
+    if (index2 < children.length - 1) {
+      results.push(tracker.move(between(child, children[index2 + 1])));
+    }
+  }
+  indexStack.pop();
+  return results.join("");
+  function between(left, right) {
+    let index3 = context.join.length;
+    while (index3--) {
+      const result = context.join[index3](left, right, parent, context);
+      if (result === true || result === 1) {
+        break;
+      }
+      if (typeof result === "number") {
+        return "\n".repeat(1 + result);
+      }
+      if (result === false) {
+        return "\n\n<!---->\n\n";
+      }
+    }
+    return "\n\n";
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-phrasing.js
+function containerPhrasing(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const results = [];
+  let index2 = -1;
+  let before = safeOptions.before;
+  indexStack.push(-1);
+  let tracker = track(safeOptions);
+  while (++index2 < children.length) {
+    const child = children[index2];
+    let after;
+    indexStack[indexStack.length - 1] = index2;
+    if (index2 + 1 < children.length) {
+      let handle = context.handle.handlers[children[index2 + 1].type];
+      if (handle && handle.peek)
+        handle = handle.peek;
+      after = handle ? handle(children[index2 + 1], parent, context, {
+        before: "",
+        after: "",
+        ...tracker.current()
+      }).charAt(0) : "";
+    } else {
+      after = safeOptions.after;
+    }
+    if (results.length > 0 && (before === "\r" || before === "\n") && child.type === "html") {
+      results[results.length - 1] = results[results.length - 1].replace(
+        /(\r?\n|\r)$/,
+        " "
+      );
+      before = " ";
+      tracker = track(safeOptions);
+      tracker.move(results.join(""));
+    }
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          ...tracker.current(),
+          before,
+          after
+        })
+      )
+    );
+    before = results[results.length - 1].slice(-1);
+  }
+  indexStack.pop();
+  return results.join("");
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/indent-lines.js
+var eol = /\r?\n|\r/g;
+function indentLines(value, map) {
+  const result = [];
+  let start3 = 0;
+  let line = 0;
+  let match;
+  while (match = eol.exec(value)) {
+    one(value.slice(start3, match.index));
+    result.push(match[0]);
+    start3 = match.index + match[0].length;
+    line++;
+  }
+  one(value.slice(start3));
+  return result.join("");
+  function one(value2) {
+    result.push(map(value2, line, !value2));
+  }
+}
+
+// node_modules/mdast-util-mdx-jsx/lib/index.js
+function mdxJsxFromMarkdown() {
+  return {
+    canContainEols: ["mdxJsxTextElement"],
+    enter: {
+      mdxJsxFlowTag: enterMdxJsxTag,
+      mdxJsxFlowTagClosingMarker: enterMdxJsxTagClosingMarker,
+      mdxJsxFlowTagAttribute: enterMdxJsxTagAttribute,
+      mdxJsxFlowTagExpressionAttribute: enterMdxJsxTagExpressionAttribute,
+      mdxJsxFlowTagAttributeValueLiteral: buffer,
+      mdxJsxFlowTagAttributeValueExpression: buffer,
+      mdxJsxFlowTagSelfClosingMarker: enterMdxJsxTagSelfClosingMarker,
+      mdxJsxTextTag: enterMdxJsxTag,
+      mdxJsxTextTagClosingMarker: enterMdxJsxTagClosingMarker,
+      mdxJsxTextTagAttribute: enterMdxJsxTagAttribute,
+      mdxJsxTextTagExpressionAttribute: enterMdxJsxTagExpressionAttribute,
+      mdxJsxTextTagAttributeValueLiteral: buffer,
+      mdxJsxTextTagAttributeValueExpression: buffer,
+      mdxJsxTextTagSelfClosingMarker: enterMdxJsxTagSelfClosingMarker
+    },
+    exit: {
+      mdxJsxFlowTagClosingMarker: exitMdxJsxTagClosingMarker,
+      mdxJsxFlowTagNamePrimary: exitMdxJsxTagNamePrimary,
+      mdxJsxFlowTagNameMember: exitMdxJsxTagNameMember,
+      mdxJsxFlowTagNameLocal: exitMdxJsxTagNameLocal,
+      mdxJsxFlowTagExpressionAttribute: exitMdxJsxTagExpressionAttribute,
+      mdxJsxFlowTagExpressionAttributeValue: data2,
+      mdxJsxFlowTagAttributeNamePrimary: exitMdxJsxTagAttributeNamePrimary,
+      mdxJsxFlowTagAttributeNameLocal: exitMdxJsxTagAttributeNameLocal,
+      mdxJsxFlowTagAttributeValueLiteral: exitMdxJsxTagAttributeValueLiteral,
+      mdxJsxFlowTagAttributeValueLiteralValue: data2,
+      mdxJsxFlowTagAttributeValueExpression: exitMdxJsxTagAttributeValueExpression,
+      mdxJsxFlowTagAttributeValueExpressionValue: data2,
+      mdxJsxFlowTagSelfClosingMarker: exitMdxJsxTagSelfClosingMarker,
+      mdxJsxFlowTag: exitMdxJsxTag,
+      mdxJsxTextTagClosingMarker: exitMdxJsxTagClosingMarker,
+      mdxJsxTextTagNamePrimary: exitMdxJsxTagNamePrimary,
+      mdxJsxTextTagNameMember: exitMdxJsxTagNameMember,
+      mdxJsxTextTagNameLocal: exitMdxJsxTagNameLocal,
+      mdxJsxTextTagExpressionAttribute: exitMdxJsxTagExpressionAttribute,
+      mdxJsxTextTagExpressionAttributeValue: data2,
+      mdxJsxTextTagAttributeNamePrimary: exitMdxJsxTagAttributeNamePrimary,
+      mdxJsxTextTagAttributeNameLocal: exitMdxJsxTagAttributeNameLocal,
+      mdxJsxTextTagAttributeValueLiteral: exitMdxJsxTagAttributeValueLiteral,
+      mdxJsxTextTagAttributeValueLiteralValue: data2,
+      mdxJsxTextTagAttributeValueExpression: exitMdxJsxTagAttributeValueExpression,
+      mdxJsxTextTagAttributeValueExpressionValue: data2,
+      mdxJsxTextTagSelfClosingMarker: exitMdxJsxTagSelfClosingMarker,
+      mdxJsxTextTag: exitMdxJsxTag
+    }
+  };
+  function buffer() {
+    this.buffer();
+  }
+  function data2(token) {
+    this.config.enter.data.call(this, token);
+    this.config.exit.data.call(this, token);
+  }
+  function enterMdxJsxTag(token) {
+    const tag = { name: null, attributes: [], start: token.start, end: token.end };
+    if (!this.getData("mdxJsxTagStack"))
+      this.setData("mdxJsxTagStack", []);
+    this.setData("mdxJsxTag", tag);
+    this.buffer();
+  }
+  function enterMdxJsxTagClosingMarker(token) {
+    const stack = this.getData("mdxJsxTagStack");
+    if (stack.length === 0) {
+      throw new VFileMessage(
+        "Unexpected closing slash `/` in tag, expected an open tag first",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-closing-slash"
+      );
+    }
+  }
+  function enterMdxJsxTagAnyAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    if (tag.close) {
+      throw new VFileMessage(
+        "Unexpected attribute in closing tag, expected the end of the tag",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-attribute"
+      );
+    }
+  }
+  function enterMdxJsxTagSelfClosingMarker(token) {
+    const tag = this.getData("mdxJsxTag");
+    if (tag.close) {
+      throw new VFileMessage(
+        "Unexpected self-closing slash `/` in closing tag, expected the end of the tag",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-self-closing-slash"
+      );
+    }
+  }
+  function exitMdxJsxTagClosingMarker() {
+    const tag = this.getData("mdxJsxTag");
+    tag.close = true;
+  }
+  function exitMdxJsxTagNamePrimary(token) {
+    const tag = this.getData("mdxJsxTag");
+    tag.name = this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagNameMember(token) {
+    const tag = this.getData("mdxJsxTag");
+    tag.name += "." + this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagNameLocal(token) {
+    const tag = this.getData("mdxJsxTag");
+    tag.name += ":" + this.sliceSerialize(token);
+  }
+  function enterMdxJsxTagAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    enterMdxJsxTagAnyAttribute.call(this, token);
+    tag.attributes.push({ type: "mdxJsxAttribute", name: "", value: null });
+  }
+  function enterMdxJsxTagExpressionAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    enterMdxJsxTagAnyAttribute.call(this, token);
+    tag.attributes.push({ type: "mdxJsxExpressionAttribute", value: "" });
+    this.buffer();
+  }
+  function exitMdxJsxTagExpressionAttribute(token) {
+    const tag = this.getData("mdxJsxTag");
+    const tail = tag.attributes[tag.attributes.length - 1];
+    const estree = token.estree;
+    tail.value = this.resume();
+    if (estree) {
+      tail.data = { estree };
+    }
+  }
+  function exitMdxJsxTagAttributeNamePrimary(token) {
+    const tag = this.getData("mdxJsxTag");
+    const node = tag.attributes[tag.attributes.length - 1];
+    node.name = this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagAttributeNameLocal(token) {
+    const tag = this.getData("mdxJsxTag");
+    const node = tag.attributes[tag.attributes.length - 1];
+    node.name += ":" + this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagAttributeValueLiteral() {
+    const tag = this.getData("mdxJsxTag");
+    tag.attributes[tag.attributes.length - 1].value = parseEntities(
+      this.resume(),
+      { nonTerminated: false }
+    );
+  }
+  function exitMdxJsxTagAttributeValueExpression(token) {
+    const tag = this.getData("mdxJsxTag");
+    const tail = tag.attributes[tag.attributes.length - 1];
+    const node = { type: "mdxJsxAttributeValueExpression", value: this.resume() };
+    const estree = token.estree;
+    if (estree) {
+      node.data = { estree };
+    }
+    tail.value = node;
+  }
+  function exitMdxJsxTagSelfClosingMarker() {
+    const tag = this.getData("mdxJsxTag");
+    tag.selfClosing = true;
+  }
+  function exitMdxJsxTag(token) {
+    const tag = this.getData("mdxJsxTag");
+    const stack = this.getData("mdxJsxTagStack");
+    const tail = stack[stack.length - 1];
+    if (tag.close && tail.name !== tag.name) {
+      throw new VFileMessage(
+        "Unexpected closing tag `" + serializeAbbreviatedTag(tag) + "`, expected corresponding closing tag for `" + serializeAbbreviatedTag(tail) + "` (" + stringifyPosition(tail) + ")",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:end-tag-mismatch"
+      );
+    }
+    this.resume();
+    if (tag.close) {
+      stack.pop();
+    } else {
+      this.enter(
+        {
+          type: token.type === "mdxJsxTextTag" ? "mdxJsxTextElement" : "mdxJsxFlowElement",
+          name: tag.name,
+          attributes: tag.attributes,
+          children: []
+        },
+        token,
+        onErrorRightIsTag
+      );
+    }
+    if (tag.selfClosing || tag.close) {
+      this.exit(token, onErrorLeftIsTag);
+    } else {
+      stack.push(tag);
+    }
+  }
+  function onErrorRightIsTag(closing, open) {
+    const tag = this.getData("mdxJsxTag");
+    const place = closing ? " before the end of `" + closing.type + "`" : "";
+    const position2 = closing ? { start: closing.start, end: closing.end } : void 0;
+    throw new VFileMessage(
+      "Expected a closing tag for `" + serializeAbbreviatedTag(tag) + "` (" + stringifyPosition({ start: open.start, end: open.end }) + ")" + place,
+      position2,
+      "mdast-util-mdx-jsx:end-tag-mismatch"
+    );
+  }
+  function onErrorLeftIsTag(a, b) {
+    const tag = this.getData("mdxJsxTag");
+    throw new VFileMessage(
+      "Expected the closing tag `" + serializeAbbreviatedTag(tag) + "` either after the end of `" + b.type + "` (" + stringifyPosition(b.end) + ") or another opening tag after the start of `" + b.type + "` (" + stringifyPosition(b.start) + ")",
+      { start: a.start, end: a.end },
+      "mdast-util-mdx-jsx:end-tag-mismatch"
+    );
+  }
+  function serializeAbbreviatedTag(tag) {
+    return "<" + (tag.close ? "/" : "") + (tag.name || "") + ">";
+  }
+}
+function mdxJsxToMarkdown(options = {}) {
+  const {
+    quote = '"',
+    quoteSmart,
+    tightSelfClosing,
+    printWidth = Number.POSITIVE_INFINITY
+  } = options;
+  const alternative = quote === '"' ? "'" : '"';
+  if (quote !== '"' && quote !== "'") {
+    throw new Error(
+      "Cannot serialize attribute values with `" + quote + "` for `options.quote`, expected `\"`, or `'`"
+    );
+  }
+  mdxElement.peek = peekElement;
+  return {
+    handlers: {
+      mdxJsxFlowElement: mdxElement,
+      mdxJsxTextElement: mdxElement
+    },
+    unsafe: [
+      { character: "<", inConstruct: ["phrasing"] },
+      { atBreak: true, character: "<" }
+    ],
+    fences: true,
+    resourceLink: true
+  };
+  function mdxElement(node, _, context, safeOptions) {
+    const tracker = track(safeOptions);
+    const selfClosing = node.name && (!node.children || node.children.length === 0);
+    const exit = context.enter(node.type);
+    let index2 = -1;
+    const serializedAttributes = [];
+    let value = tracker.move("<" + (node.name || ""));
+    if (node.attributes && node.attributes.length > 0) {
+      if (!node.name) {
+        throw new Error("Cannot serialize fragment w/ attributes");
+      }
+      while (++index2 < node.attributes.length) {
+        const attribute = node.attributes[index2];
+        let result;
+        if (attribute.type === "mdxJsxExpressionAttribute") {
+          result = "{" + (attribute.value || "") + "}";
+        } else {
+          if (!attribute.name) {
+            throw new Error("Cannot serialize attribute w/o name");
+          }
+          const value2 = attribute.value;
+          const left = attribute.name;
+          let right = "";
+          if (value2 === void 0 || value2 === null) {
+          } else if (typeof value2 === "object") {
+            right = "{" + (value2.value || "") + "}";
+          } else {
+            const appliedQuote = quoteSmart && ccount(value2, quote) > ccount(value2, alternative) ? alternative : quote;
+            right = appliedQuote + stringifyEntitiesLight(value2, { subset: [appliedQuote] }) + appliedQuote;
+          }
+          result = left + (right ? "=" : "") + right;
+        }
+        serializedAttributes.push(result);
+      }
+    }
+    let attributesOnTheirOwnLine = false;
+    const attributesOnOneLine = serializedAttributes.join(" ");
+    if (node.type === "mdxJsxFlowElement" && (/\r?\n|\r/.test(attributesOnOneLine) || tracker.current().now.column + attributesOnOneLine.length + (selfClosing ? tightSelfClosing ? 2 : 3 : 1) > printWidth)) {
+      attributesOnTheirOwnLine = true;
+    }
+    if (attributesOnTheirOwnLine) {
+      value += tracker.move(
+        "\n" + indentLines(serializedAttributes.join("\n"), map)
+      );
+    } else if (attributesOnOneLine) {
+      value += tracker.move(" " + attributesOnOneLine);
+    }
+    if (attributesOnTheirOwnLine) {
+      value += tracker.move("\n");
+    }
+    if (selfClosing) {
+      value += tracker.move(
+        (tightSelfClosing || attributesOnTheirOwnLine ? "" : " ") + "/"
+      );
+    }
+    value += tracker.move(">");
+    if (node.children && node.children.length > 0) {
+      if (node.type === "mdxJsxFlowElement") {
+        tracker.shift(2);
+        value += tracker.move("\n");
+        value += tracker.move(
+          indentLines(containerFlow(node, context, tracker.current()), map)
+        );
+        value += tracker.move("\n");
+      } else {
+        value += tracker.move(
+          containerPhrasing(node, context, {
+            ...tracker.current(),
+            before: "<",
+            after: ">"
+          })
+        );
+      }
+    }
+    if (!selfClosing) {
+      value += tracker.move("</" + (node.name || "") + ">");
+    }
+    exit();
+    return value;
+  }
+  function map(line, _, blank) {
+    return (blank ? "" : "  ") + line;
+  }
+  function peekElement() {
+    return "<";
+  }
+}
+
+// node_modules/mdast-util-mdxjs-esm/index.js
+var mdxjsEsmFromMarkdown = {
+  enter: { mdxjsEsm: enterMdxjsEsm },
+  exit: { mdxjsEsm: exitMdxjsEsm, mdxjsEsmData: exitMdxjsEsmData }
+};
+var mdxjsEsmToMarkdown = { handlers: { mdxjsEsm: handleMdxjsEsm } };
+function enterMdxjsEsm(token) {
+  this.enter({ type: "mdxjsEsm", value: "" }, token);
+  this.buffer();
+}
+function exitMdxjsEsm(token) {
+  const value = this.resume();
+  const node = this.exit(token);
+  const estree = token.estree;
+  node.value = value;
+  if (estree) {
+    node.data = { estree };
+  }
+}
+function exitMdxjsEsmData(token) {
+  this.config.enter.data.call(this, token);
+  this.config.exit.data.call(this, token);
+}
+function handleMdxjsEsm(node) {
+  return node.value || "";
+}
+
+// node_modules/mdast-util-mdx/index.js
+function mdxFromMarkdown() {
+  return [mdxExpressionFromMarkdown, mdxJsxFromMarkdown(), mdxjsEsmFromMarkdown];
+}
+function mdxToMarkdown(options) {
+  return {
+    extensions: [
+      mdxExpressionToMarkdown,
+      mdxJsxToMarkdown(options),
+      mdxjsEsmToMarkdown
+    ]
+  };
+}
+
+// node_modules/remark-mdx/index.js
+function remarkMdx(options = {}) {
+  const data2 = this.data();
+  add("micromarkExtensions", mdxjs(options));
+  add("fromMarkdownExtensions", mdxFromMarkdown());
+  add("toMarkdownExtensions", mdxToMarkdown(options));
+  function add(field, value) {
+    const list = data2[field] ? data2[field] : data2[field] = [];
+    list.push(value);
+  }
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {});

--- a/jest/vendor/remark@14.0.2.js
+++ b/jest/vendor/remark@14.0.2.js
@@ -1,0 +1,8908 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all2) => {
+  for (var name in all2)
+    __defProp(target, name, { get: all2[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/is-buffer/index.js
+var require_is_buffer = __commonJS({
+  "node_modules/is-buffer/index.js"(exports, module2) {
+    module2.exports = function isBuffer2(obj) {
+      return obj != null && obj.constructor != null && typeof obj.constructor.isBuffer === "function" && obj.constructor.isBuffer(obj);
+    };
+  }
+});
+
+// node_modules/extend/index.js
+var require_extend = __commonJS({
+  "node_modules/extend/index.js"(exports, module2) {
+    "use strict";
+    var hasOwn = Object.prototype.hasOwnProperty;
+    var toStr = Object.prototype.toString;
+    var defineProperty = Object.defineProperty;
+    var gOPD = Object.getOwnPropertyDescriptor;
+    var isArray = function isArray2(arr) {
+      if (typeof Array.isArray === "function") {
+        return Array.isArray(arr);
+      }
+      return toStr.call(arr) === "[object Array]";
+    };
+    var isPlainObject2 = function isPlainObject3(obj) {
+      if (!obj || toStr.call(obj) !== "[object Object]") {
+        return false;
+      }
+      var hasOwnConstructor = hasOwn.call(obj, "constructor");
+      var hasIsPrototypeOf = obj.constructor && obj.constructor.prototype && hasOwn.call(obj.constructor.prototype, "isPrototypeOf");
+      if (obj.constructor && !hasOwnConstructor && !hasIsPrototypeOf) {
+        return false;
+      }
+      var key;
+      for (key in obj) {
+      }
+      return typeof key === "undefined" || hasOwn.call(obj, key);
+    };
+    var setProperty = function setProperty2(target, options) {
+      if (defineProperty && options.name === "__proto__") {
+        defineProperty(target, options.name, {
+          enumerable: true,
+          configurable: true,
+          value: options.newValue,
+          writable: true
+        });
+      } else {
+        target[options.name] = options.newValue;
+      }
+    };
+    var getProperty = function getProperty2(obj, name) {
+      if (name === "__proto__") {
+        if (!hasOwn.call(obj, name)) {
+          return void 0;
+        } else if (gOPD) {
+          return gOPD(obj, name).value;
+        }
+      }
+      return obj[name];
+    };
+    module2.exports = function extend2() {
+      var options, name, src, copy, copyIsArray, clone;
+      var target = arguments[0];
+      var i = 1;
+      var length = arguments.length;
+      var deep = false;
+      if (typeof target === "boolean") {
+        deep = target;
+        target = arguments[1] || {};
+        i = 2;
+      }
+      if (target == null || typeof target !== "object" && typeof target !== "function") {
+        target = {};
+      }
+      for (; i < length; ++i) {
+        options = arguments[i];
+        if (options != null) {
+          for (name in options) {
+            src = getProperty(target, name);
+            copy = getProperty(options, name);
+            if (target !== copy) {
+              if (deep && copy && (isPlainObject2(copy) || (copyIsArray = isArray(copy)))) {
+                if (copyIsArray) {
+                  copyIsArray = false;
+                  clone = src && isArray(src) ? src : [];
+                } else {
+                  clone = src && isPlainObject2(src) ? src : {};
+                }
+                setProperty(target, { name, newValue: extend2(deep, clone, copy) });
+              } else if (typeof copy !== "undefined") {
+                setProperty(target, { name, newValue: copy });
+              }
+            }
+          }
+        }
+      }
+      return target;
+    };
+  }
+});
+
+// node_modules/remark/index.js
+var remark_exports = {};
+__export(remark_exports, {
+  remark: () => remark1402
+});
+module.exports = __toCommonJS(remark_exports);
+
+// node_modules/remark/node_modules/bail/index.js
+function bail(error) {
+  if (error) {
+    throw error;
+  }
+}
+
+// node_modules/remark/node_modules/unified/lib/index.js
+var import_is_buffer2 = __toESM(require_is_buffer(), 1);
+var import_extend = __toESM(require_extend(), 1);
+
+// node_modules/remark/node_modules/is-plain-obj/index.js
+function isPlainObject(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in value) && !(Symbol.iterator in value);
+}
+
+// node_modules/remark/node_modules/trough/index.js
+function trough() {
+  const fns = [];
+  const pipeline = { run, use };
+  return pipeline;
+  function run(...values) {
+    let middlewareIndex = -1;
+    const callback = values.pop();
+    if (typeof callback !== "function") {
+      throw new TypeError("Expected function as last argument, not " + callback);
+    }
+    next(null, ...values);
+    function next(error, ...output) {
+      const fn = fns[++middlewareIndex];
+      let index2 = -1;
+      if (error) {
+        callback(error);
+        return;
+      }
+      while (++index2 < values.length) {
+        if (output[index2] === null || output[index2] === void 0) {
+          output[index2] = values[index2];
+        }
+      }
+      values = output;
+      if (fn) {
+        wrap(fn, next)(...output);
+      } else {
+        callback(null, ...output);
+      }
+    }
+  }
+  function use(middelware) {
+    if (typeof middelware !== "function") {
+      throw new TypeError(
+        "Expected `middelware` to be a function, not " + middelware
+      );
+    }
+    fns.push(middelware);
+    return pipeline;
+  }
+}
+function wrap(middleware, callback) {
+  let called;
+  return wrapped;
+  function wrapped(...parameters) {
+    const fnExpectsCallback = middleware.length > parameters.length;
+    let result;
+    if (fnExpectsCallback) {
+      parameters.push(done);
+    }
+    try {
+      result = middleware.apply(this, parameters);
+    } catch (error) {
+      const exception = error;
+      if (fnExpectsCallback && called) {
+        throw exception;
+      }
+      return done(exception);
+    }
+    if (!fnExpectsCallback) {
+      if (result instanceof Promise) {
+        result.then(then, done);
+      } else if (result instanceof Error) {
+        done(result);
+      } else {
+        then(result);
+      }
+    }
+  }
+  function done(error, ...output) {
+    if (!called) {
+      called = true;
+      callback(error, ...output);
+    }
+  }
+  function then(value) {
+    done(null, value);
+  }
+}
+
+// node_modules/vfile/lib/index.js
+var import_is_buffer = __toESM(require_is_buffer(), 1);
+
+// node_modules/unist-util-stringify-position/index.js
+function stringifyPosition(value) {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  if ("position" in value || "type" in value) {
+    return position(value.position);
+  }
+  if ("start" in value || "end" in value) {
+    return position(value);
+  }
+  if ("line" in value || "column" in value) {
+    return point(value);
+  }
+  return "";
+}
+function point(point2) {
+  return index(point2 && point2.line) + ":" + index(point2 && point2.column);
+}
+function position(pos) {
+  return point(pos && pos.start) + "-" + point(pos && pos.end);
+}
+function index(value) {
+  return value && typeof value === "number" ? value : 1;
+}
+
+// node_modules/vfile-message/index.js
+var VFileMessage = class extends Error {
+  constructor(reason, place, origin) {
+    const parts = [null, null];
+    let position2 = {
+      start: { line: null, column: null },
+      end: { line: null, column: null }
+    };
+    super();
+    if (typeof place === "string") {
+      origin = place;
+      place = void 0;
+    }
+    if (typeof origin === "string") {
+      const index2 = origin.indexOf(":");
+      if (index2 === -1) {
+        parts[1] = origin;
+      } else {
+        parts[0] = origin.slice(0, index2);
+        parts[1] = origin.slice(index2 + 1);
+      }
+    }
+    if (place) {
+      if ("type" in place || "position" in place) {
+        if (place.position) {
+          position2 = place.position;
+        }
+      } else if ("start" in place || "end" in place) {
+        position2 = place;
+      } else if ("line" in place || "column" in place) {
+        position2.start = place;
+      }
+    }
+    this.name = stringifyPosition(place) || "1:1";
+    this.message = typeof reason === "object" ? reason.message : reason;
+    this.stack = typeof reason === "object" ? reason.stack : "";
+    this.reason = this.message;
+    this.fatal;
+    this.line = position2.start.line;
+    this.column = position2.start.column;
+    this.source = parts[0];
+    this.ruleId = parts[1];
+    this.position = position2;
+    this.actual;
+    this.expected;
+    this.file;
+    this.url;
+    this.note;
+  }
+};
+VFileMessage.prototype.file = "";
+VFileMessage.prototype.name = "";
+VFileMessage.prototype.reason = "";
+VFileMessage.prototype.message = "";
+VFileMessage.prototype.stack = "";
+VFileMessage.prototype.fatal = null;
+VFileMessage.prototype.column = null;
+VFileMessage.prototype.line = null;
+VFileMessage.prototype.source = null;
+VFileMessage.prototype.ruleId = null;
+VFileMessage.prototype.position = null;
+
+// node_modules/vfile/lib/minpath.js
+var import_path = __toESM(require("path"), 1);
+
+// node_modules/vfile/lib/minproc.js
+var import_process = __toESM(require("process"), 1);
+
+// node_modules/vfile/lib/minurl.js
+var import_url = require("url");
+
+// node_modules/vfile/lib/minurl.shared.js
+function isUrl(fileURLOrPath) {
+  return fileURLOrPath !== null && typeof fileURLOrPath === "object" && fileURLOrPath.href && fileURLOrPath.origin;
+}
+
+// node_modules/vfile/lib/index.js
+var order = ["history", "path", "basename", "stem", "extname", "dirname"];
+var VFile = class {
+  constructor(value) {
+    let options;
+    if (!value) {
+      options = {};
+    } else if (typeof value === "string" || (0, import_is_buffer.default)(value)) {
+      options = { value };
+    } else if (isUrl(value)) {
+      options = { path: value };
+    } else {
+      options = value;
+    }
+    this.data = {};
+    this.messages = [];
+    this.history = [];
+    this.cwd = import_process.default.cwd();
+    this.value;
+    this.stored;
+    this.result;
+    this.map;
+    let index2 = -1;
+    while (++index2 < order.length) {
+      const prop2 = order[index2];
+      if (prop2 in options && options[prop2] !== void 0) {
+        this[prop2] = prop2 === "history" ? [...options[prop2]] : options[prop2];
+      }
+    }
+    let prop;
+    for (prop in options) {
+      if (!order.includes(prop))
+        this[prop] = options[prop];
+    }
+  }
+  get path() {
+    return this.history[this.history.length - 1];
+  }
+  set path(path) {
+    if (isUrl(path)) {
+      path = (0, import_url.fileURLToPath)(path);
+    }
+    assertNonEmpty(path, "path");
+    if (this.path !== path) {
+      this.history.push(path);
+    }
+  }
+  get dirname() {
+    return typeof this.path === "string" ? import_path.default.dirname(this.path) : void 0;
+  }
+  set dirname(dirname) {
+    assertPath(this.basename, "dirname");
+    this.path = import_path.default.join(dirname || "", this.basename);
+  }
+  get basename() {
+    return typeof this.path === "string" ? import_path.default.basename(this.path) : void 0;
+  }
+  set basename(basename) {
+    assertNonEmpty(basename, "basename");
+    assertPart(basename, "basename");
+    this.path = import_path.default.join(this.dirname || "", basename);
+  }
+  get extname() {
+    return typeof this.path === "string" ? import_path.default.extname(this.path) : void 0;
+  }
+  set extname(extname) {
+    assertPart(extname, "extname");
+    assertPath(this.dirname, "extname");
+    if (extname) {
+      if (extname.charCodeAt(0) !== 46) {
+        throw new Error("`extname` must start with `.`");
+      }
+      if (extname.includes(".", 1)) {
+        throw new Error("`extname` cannot contain multiple dots");
+      }
+    }
+    this.path = import_path.default.join(this.dirname, this.stem + (extname || ""));
+  }
+  get stem() {
+    return typeof this.path === "string" ? import_path.default.basename(this.path, this.extname) : void 0;
+  }
+  set stem(stem) {
+    assertNonEmpty(stem, "stem");
+    assertPart(stem, "stem");
+    this.path = import_path.default.join(this.dirname || "", stem + (this.extname || ""));
+  }
+  toString(encoding) {
+    return (this.value || "").toString(encoding);
+  }
+  message(reason, place, origin) {
+    const message = new VFileMessage(reason, place, origin);
+    if (this.path) {
+      message.name = this.path + ":" + message.name;
+      message.file = this.path;
+    }
+    message.fatal = false;
+    this.messages.push(message);
+    return message;
+  }
+  info(reason, place, origin) {
+    const message = this.message(reason, place, origin);
+    message.fatal = null;
+    return message;
+  }
+  fail(reason, place, origin) {
+    const message = this.message(reason, place, origin);
+    message.fatal = true;
+    throw message;
+  }
+};
+function assertPart(part, name) {
+  if (part && part.includes(import_path.default.sep)) {
+    throw new Error(
+      "`" + name + "` cannot be a path: did not expect `" + import_path.default.sep + "`"
+    );
+  }
+}
+function assertNonEmpty(part, name) {
+  if (!part) {
+    throw new Error("`" + name + "` cannot be empty");
+  }
+}
+function assertPath(path, name) {
+  if (!path) {
+    throw new Error("Setting `" + name + "` requires `path` to be set too");
+  }
+}
+
+// node_modules/remark/node_modules/unified/lib/index.js
+var unified = base().freeze();
+var own = {}.hasOwnProperty;
+function base() {
+  const transformers = trough();
+  const attachers = [];
+  let namespace = {};
+  let frozen;
+  let freezeIndex = -1;
+  processor.data = data;
+  processor.Parser = void 0;
+  processor.Compiler = void 0;
+  processor.freeze = freeze;
+  processor.attachers = attachers;
+  processor.use = use;
+  processor.parse = parse2;
+  processor.stringify = stringify;
+  processor.run = run;
+  processor.runSync = runSync;
+  processor.process = process;
+  processor.processSync = processSync;
+  return processor;
+  function processor() {
+    const destination = base();
+    let index2 = -1;
+    while (++index2 < attachers.length) {
+      destination.use(...attachers[index2]);
+    }
+    destination.data((0, import_extend.default)(true, {}, namespace));
+    return destination;
+  }
+  function data(key, value) {
+    if (typeof key === "string") {
+      if (arguments.length === 2) {
+        assertUnfrozen("data", frozen);
+        namespace[key] = value;
+        return processor;
+      }
+      return own.call(namespace, key) && namespace[key] || null;
+    }
+    if (key) {
+      assertUnfrozen("data", frozen);
+      namespace = key;
+      return processor;
+    }
+    return namespace;
+  }
+  function freeze() {
+    if (frozen) {
+      return processor;
+    }
+    while (++freezeIndex < attachers.length) {
+      const [attacher, ...options] = attachers[freezeIndex];
+      if (options[0] === false) {
+        continue;
+      }
+      if (options[0] === true) {
+        options[0] = void 0;
+      }
+      const transformer = attacher.call(processor, ...options);
+      if (typeof transformer === "function") {
+        transformers.use(transformer);
+      }
+    }
+    frozen = true;
+    freezeIndex = Number.POSITIVE_INFINITY;
+    return processor;
+  }
+  function use(value, ...options) {
+    let settings;
+    assertUnfrozen("use", frozen);
+    if (value === null || value === void 0) {
+    } else if (typeof value === "function") {
+      addPlugin(value, ...options);
+    } else if (typeof value === "object") {
+      if (Array.isArray(value)) {
+        addList(value);
+      } else {
+        addPreset(value);
+      }
+    } else {
+      throw new TypeError("Expected usable value, not `" + value + "`");
+    }
+    if (settings) {
+      namespace.settings = Object.assign(namespace.settings || {}, settings);
+    }
+    return processor;
+    function add(value2) {
+      if (typeof value2 === "function") {
+        addPlugin(value2);
+      } else if (typeof value2 === "object") {
+        if (Array.isArray(value2)) {
+          const [plugin, ...options2] = value2;
+          addPlugin(plugin, ...options2);
+        } else {
+          addPreset(value2);
+        }
+      } else {
+        throw new TypeError("Expected usable value, not `" + value2 + "`");
+      }
+    }
+    function addPreset(result) {
+      addList(result.plugins);
+      if (result.settings) {
+        settings = Object.assign(settings || {}, result.settings);
+      }
+    }
+    function addList(plugins) {
+      let index2 = -1;
+      if (plugins === null || plugins === void 0) {
+      } else if (Array.isArray(plugins)) {
+        while (++index2 < plugins.length) {
+          const thing = plugins[index2];
+          add(thing);
+        }
+      } else {
+        throw new TypeError("Expected a list of plugins, not `" + plugins + "`");
+      }
+    }
+    function addPlugin(plugin, value2) {
+      let index2 = -1;
+      let entry;
+      while (++index2 < attachers.length) {
+        if (attachers[index2][0] === plugin) {
+          entry = attachers[index2];
+          break;
+        }
+      }
+      if (entry) {
+        if (isPlainObject(entry[1]) && isPlainObject(value2)) {
+          value2 = (0, import_extend.default)(true, entry[1], value2);
+        }
+        entry[1] = value2;
+      } else {
+        attachers.push([...arguments]);
+      }
+    }
+  }
+  function parse2(doc) {
+    processor.freeze();
+    const file = vfile(doc);
+    const Parser = processor.Parser;
+    assertParser("parse", Parser);
+    if (newable(Parser, "parse")) {
+      return new Parser(String(file), file).parse();
+    }
+    return Parser(String(file), file);
+  }
+  function stringify(node, doc) {
+    processor.freeze();
+    const file = vfile(doc);
+    const Compiler = processor.Compiler;
+    assertCompiler("stringify", Compiler);
+    assertNode(node);
+    if (newable(Compiler, "compile")) {
+      return new Compiler(node, file).compile();
+    }
+    return Compiler(node, file);
+  }
+  function run(node, doc, callback) {
+    assertNode(node);
+    processor.freeze();
+    if (!callback && typeof doc === "function") {
+      callback = doc;
+      doc = void 0;
+    }
+    if (!callback) {
+      return new Promise(executor);
+    }
+    executor(null, callback);
+    function executor(resolve, reject) {
+      transformers.run(node, vfile(doc), done);
+      function done(error, tree, file) {
+        tree = tree || node;
+        if (error) {
+          reject(error);
+        } else if (resolve) {
+          resolve(tree);
+        } else {
+          callback(null, tree, file);
+        }
+      }
+    }
+  }
+  function runSync(node, file) {
+    let result;
+    let complete;
+    processor.run(node, file, done);
+    assertDone("runSync", "run", complete);
+    return result;
+    function done(error, tree) {
+      bail(error);
+      result = tree;
+      complete = true;
+    }
+  }
+  function process(doc, callback) {
+    processor.freeze();
+    assertParser("process", processor.Parser);
+    assertCompiler("process", processor.Compiler);
+    if (!callback) {
+      return new Promise(executor);
+    }
+    executor(null, callback);
+    function executor(resolve, reject) {
+      const file = vfile(doc);
+      processor.run(processor.parse(file), file, (error, tree, file2) => {
+        if (error || !tree || !file2) {
+          done(error);
+        } else {
+          const result = processor.stringify(tree, file2);
+          if (result === void 0 || result === null) {
+          } else if (looksLikeAVFileValue(result)) {
+            file2.value = result;
+          } else {
+            file2.result = result;
+          }
+          done(error, file2);
+        }
+      });
+      function done(error, file2) {
+        if (error || !file2) {
+          reject(error);
+        } else if (resolve) {
+          resolve(file2);
+        } else {
+          callback(null, file2);
+        }
+      }
+    }
+  }
+  function processSync(doc) {
+    let complete;
+    processor.freeze();
+    assertParser("processSync", processor.Parser);
+    assertCompiler("processSync", processor.Compiler);
+    const file = vfile(doc);
+    processor.process(file, done);
+    assertDone("processSync", "process", complete);
+    return file;
+    function done(error) {
+      complete = true;
+      bail(error);
+    }
+  }
+}
+function newable(value, name) {
+  return typeof value === "function" && value.prototype && (keys(value.prototype) || name in value.prototype);
+}
+function keys(value) {
+  let key;
+  for (key in value) {
+    if (own.call(value, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+function assertParser(name, value) {
+  if (typeof value !== "function") {
+    throw new TypeError("Cannot `" + name + "` without `Parser`");
+  }
+}
+function assertCompiler(name, value) {
+  if (typeof value !== "function") {
+    throw new TypeError("Cannot `" + name + "` without `Compiler`");
+  }
+}
+function assertUnfrozen(name, frozen) {
+  if (frozen) {
+    throw new Error(
+      "Cannot call `" + name + "` on a frozen processor.\nCreate a new processor first, by calling it: use `processor()` instead of `processor`."
+    );
+  }
+}
+function assertNode(node) {
+  if (!isPlainObject(node) || typeof node.type !== "string") {
+    throw new TypeError("Expected node, got `" + node + "`");
+  }
+}
+function assertDone(name, asyncName, complete) {
+  if (!complete) {
+    throw new Error(
+      "`" + name + "` finished async. Use `" + asyncName + "` instead"
+    );
+  }
+}
+function vfile(value) {
+  return looksLikeAVFile(value) ? value : new VFile(value);
+}
+function looksLikeAVFile(value) {
+  return Boolean(
+    value && typeof value === "object" && "message" in value && "messages" in value
+  );
+}
+function looksLikeAVFileValue(value) {
+  return typeof value === "string" || (0, import_is_buffer2.default)(value);
+}
+
+// node_modules/mdast-util-to-string/index.js
+function toString(node, options) {
+  var { includeImageAlt = true } = options || {};
+  return one(node, includeImageAlt);
+}
+function one(node, includeImageAlt) {
+  return node && typeof node === "object" && (node.value || (includeImageAlt ? node.alt : "") || "children" in node && all(node.children, includeImageAlt) || Array.isArray(node) && all(node, includeImageAlt)) || "";
+}
+function all(values, includeImageAlt) {
+  var result = [];
+  var index2 = -1;
+  while (++index2 < values.length) {
+    result[index2] = one(values[index2], includeImageAlt);
+  }
+  return result.join("");
+}
+
+// node_modules/micromark-util-chunked/index.js
+function splice(list3, start, remove, items) {
+  const end = list3.length;
+  let chunkStart = 0;
+  let parameters;
+  if (start < 0) {
+    start = -start > end ? 0 : end + start;
+  } else {
+    start = start > end ? end : start;
+  }
+  remove = remove > 0 ? remove : 0;
+  if (items.length < 1e4) {
+    parameters = Array.from(items);
+    parameters.unshift(start, remove);
+    [].splice.apply(list3, parameters);
+  } else {
+    if (remove)
+      [].splice.apply(list3, [start, remove]);
+    while (chunkStart < items.length) {
+      parameters = items.slice(chunkStart, chunkStart + 1e4);
+      parameters.unshift(start, 0);
+      [].splice.apply(list3, parameters);
+      chunkStart += 1e4;
+      start += 1e4;
+    }
+  }
+}
+function push(list3, items) {
+  if (list3.length > 0) {
+    splice(list3, list3.length, 0, items);
+    return list3;
+  }
+  return items;
+}
+
+// node_modules/micromark-util-combine-extensions/index.js
+var hasOwnProperty = {}.hasOwnProperty;
+function combineExtensions(extensions) {
+  const all2 = {};
+  let index2 = -1;
+  while (++index2 < extensions.length) {
+    syntaxExtension(all2, extensions[index2]);
+  }
+  return all2;
+}
+function syntaxExtension(all2, extension2) {
+  let hook;
+  for (hook in extension2) {
+    const maybe = hasOwnProperty.call(all2, hook) ? all2[hook] : void 0;
+    const left = maybe || (all2[hook] = {});
+    const right = extension2[hook];
+    let code2;
+    for (code2 in right) {
+      if (!hasOwnProperty.call(left, code2))
+        left[code2] = [];
+      const value = right[code2];
+      constructs(
+        left[code2],
+        Array.isArray(value) ? value : value ? [value] : []
+      );
+    }
+  }
+}
+function constructs(existing, list3) {
+  let index2 = -1;
+  const before = [];
+  while (++index2 < list3.length) {
+    ;
+    (list3[index2].add === "after" ? existing : before).push(list3[index2]);
+  }
+  splice(existing, 0, 0, before);
+}
+
+// node_modules/micromark-util-character/lib/unicode-punctuation-regex.js
+var unicodePunctuationRegex = /[!-/:-@[-`{-~\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0A76\u0AF0\u0C77\u0C84\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E4F\u2E52\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]/;
+
+// node_modules/micromark-util-character/index.js
+var asciiAlpha = regexCheck(/[A-Za-z]/);
+var asciiDigit = regexCheck(/\d/);
+var asciiHexDigit = regexCheck(/[\dA-Fa-f]/);
+var asciiAlphanumeric = regexCheck(/[\dA-Za-z]/);
+var asciiPunctuation = regexCheck(/[!-/:-@[-`{-~]/);
+var asciiAtext = regexCheck(/[#-'*+\--9=?A-Z^-~]/);
+function asciiControl(code2) {
+  return code2 !== null && (code2 < 32 || code2 === 127);
+}
+function markdownLineEndingOrSpace(code2) {
+  return code2 !== null && (code2 < 0 || code2 === 32);
+}
+function markdownLineEnding(code2) {
+  return code2 !== null && code2 < -2;
+}
+function markdownSpace(code2) {
+  return code2 === -2 || code2 === -1 || code2 === 32;
+}
+var unicodeWhitespace = regexCheck(/\s/);
+var unicodePunctuation = regexCheck(unicodePunctuationRegex);
+function regexCheck(regex) {
+  return check;
+  function check(code2) {
+    return code2 !== null && regex.test(String.fromCharCode(code2));
+  }
+}
+
+// node_modules/micromark-factory-space/index.js
+function factorySpace(effects, ok2, type, max) {
+  const limit = max ? max - 1 : Number.POSITIVE_INFINITY;
+  let size = 0;
+  return start;
+  function start(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter(type);
+      return prefix(code2);
+    }
+    return ok2(code2);
+  }
+  function prefix(code2) {
+    if (markdownSpace(code2) && size++ < limit) {
+      effects.consume(code2);
+      return prefix;
+    }
+    effects.exit(type);
+    return ok2(code2);
+  }
+}
+
+// node_modules/micromark/lib/initialize/content.js
+var content = {
+  tokenize: initializeContent
+};
+function initializeContent(effects) {
+  const contentStart = effects.attempt(
+    this.parser.constructs.contentInitial,
+    afterContentStartConstruct,
+    paragraphInitial
+  );
+  let previous2;
+  return contentStart;
+  function afterContentStartConstruct(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, contentStart, "linePrefix");
+  }
+  function paragraphInitial(code2) {
+    effects.enter("paragraph");
+    return lineStart(code2);
+  }
+  function lineStart(code2) {
+    const token = effects.enter("chunkText", {
+      contentType: "text",
+      previous: previous2
+    });
+    if (previous2) {
+      previous2.next = token;
+    }
+    previous2 = token;
+    return data(code2);
+  }
+  function data(code2) {
+    if (code2 === null) {
+      effects.exit("chunkText");
+      effects.exit("paragraph");
+      effects.consume(code2);
+      return;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.consume(code2);
+      effects.exit("chunkText");
+      return lineStart;
+    }
+    effects.consume(code2);
+    return data;
+  }
+}
+
+// node_modules/micromark/lib/initialize/document.js
+var document = {
+  tokenize: initializeDocument
+};
+var containerConstruct = {
+  tokenize: tokenizeContainer
+};
+function initializeDocument(effects) {
+  const self = this;
+  const stack = [];
+  let continued = 0;
+  let childFlow;
+  let childToken;
+  let lineStartOffset;
+  return start;
+  function start(code2) {
+    if (continued < stack.length) {
+      const item = stack[continued];
+      self.containerState = item[1];
+      return effects.attempt(
+        item[0].continuation,
+        documentContinue,
+        checkNewContainers
+      )(code2);
+    }
+    return checkNewContainers(code2);
+  }
+  function documentContinue(code2) {
+    continued++;
+    if (self.containerState._closeFlow) {
+      self.containerState._closeFlow = void 0;
+      if (childFlow) {
+        closeFlow();
+      }
+      const indexBeforeExits = self.events.length;
+      let indexBeforeFlow = indexBeforeExits;
+      let point2;
+      while (indexBeforeFlow--) {
+        if (self.events[indexBeforeFlow][0] === "exit" && self.events[indexBeforeFlow][1].type === "chunkFlow") {
+          point2 = self.events[indexBeforeFlow][1].end;
+          break;
+        }
+      }
+      exitContainers(continued);
+      let index2 = indexBeforeExits;
+      while (index2 < self.events.length) {
+        self.events[index2][1].end = Object.assign({}, point2);
+        index2++;
+      }
+      splice(
+        self.events,
+        indexBeforeFlow + 1,
+        0,
+        self.events.slice(indexBeforeExits)
+      );
+      self.events.length = index2;
+      return checkNewContainers(code2);
+    }
+    return start(code2);
+  }
+  function checkNewContainers(code2) {
+    if (continued === stack.length) {
+      if (!childFlow) {
+        return documentContinued(code2);
+      }
+      if (childFlow.currentConstruct && childFlow.currentConstruct.concrete) {
+        return flowStart(code2);
+      }
+      self.interrupt = Boolean(
+        childFlow.currentConstruct && !childFlow._gfmTableDynamicInterruptHack
+      );
+    }
+    self.containerState = {};
+    return effects.check(
+      containerConstruct,
+      thereIsANewContainer,
+      thereIsNoNewContainer
+    )(code2);
+  }
+  function thereIsANewContainer(code2) {
+    if (childFlow)
+      closeFlow();
+    exitContainers(continued);
+    return documentContinued(code2);
+  }
+  function thereIsNoNewContainer(code2) {
+    self.parser.lazy[self.now().line] = continued !== stack.length;
+    lineStartOffset = self.now().offset;
+    return flowStart(code2);
+  }
+  function documentContinued(code2) {
+    self.containerState = {};
+    return effects.attempt(
+      containerConstruct,
+      containerContinue,
+      flowStart
+    )(code2);
+  }
+  function containerContinue(code2) {
+    continued++;
+    stack.push([self.currentConstruct, self.containerState]);
+    return documentContinued(code2);
+  }
+  function flowStart(code2) {
+    if (code2 === null) {
+      if (childFlow)
+        closeFlow();
+      exitContainers(0);
+      effects.consume(code2);
+      return;
+    }
+    childFlow = childFlow || self.parser.flow(self.now());
+    effects.enter("chunkFlow", {
+      contentType: "flow",
+      previous: childToken,
+      _tokenizer: childFlow
+    });
+    return flowContinue(code2);
+  }
+  function flowContinue(code2) {
+    if (code2 === null) {
+      writeToChild(effects.exit("chunkFlow"), true);
+      exitContainers(0);
+      effects.consume(code2);
+      return;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.consume(code2);
+      writeToChild(effects.exit("chunkFlow"));
+      continued = 0;
+      self.interrupt = void 0;
+      return start;
+    }
+    effects.consume(code2);
+    return flowContinue;
+  }
+  function writeToChild(token, eof) {
+    const stream = self.sliceStream(token);
+    if (eof)
+      stream.push(null);
+    token.previous = childToken;
+    if (childToken)
+      childToken.next = token;
+    childToken = token;
+    childFlow.defineSkip(token.start);
+    childFlow.write(stream);
+    if (self.parser.lazy[token.start.line]) {
+      let index2 = childFlow.events.length;
+      while (index2--) {
+        if (childFlow.events[index2][1].start.offset < lineStartOffset && (!childFlow.events[index2][1].end || childFlow.events[index2][1].end.offset > lineStartOffset)) {
+          return;
+        }
+      }
+      const indexBeforeExits = self.events.length;
+      let indexBeforeFlow = indexBeforeExits;
+      let seen;
+      let point2;
+      while (indexBeforeFlow--) {
+        if (self.events[indexBeforeFlow][0] === "exit" && self.events[indexBeforeFlow][1].type === "chunkFlow") {
+          if (seen) {
+            point2 = self.events[indexBeforeFlow][1].end;
+            break;
+          }
+          seen = true;
+        }
+      }
+      exitContainers(continued);
+      index2 = indexBeforeExits;
+      while (index2 < self.events.length) {
+        self.events[index2][1].end = Object.assign({}, point2);
+        index2++;
+      }
+      splice(
+        self.events,
+        indexBeforeFlow + 1,
+        0,
+        self.events.slice(indexBeforeExits)
+      );
+      self.events.length = index2;
+    }
+  }
+  function exitContainers(size) {
+    let index2 = stack.length;
+    while (index2-- > size) {
+      const entry = stack[index2];
+      self.containerState = entry[1];
+      entry[0].exit.call(self, effects);
+    }
+    stack.length = size;
+  }
+  function closeFlow() {
+    childFlow.write([null]);
+    childToken = void 0;
+    childFlow = void 0;
+    self.containerState._closeFlow = void 0;
+  }
+}
+function tokenizeContainer(effects, ok2, nok) {
+  return factorySpace(
+    effects,
+    effects.attempt(this.parser.constructs.document, ok2, nok),
+    "linePrefix",
+    this.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+  );
+}
+
+// node_modules/micromark-util-classify-character/index.js
+function classifyCharacter(code2) {
+  if (code2 === null || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+    return 1;
+  }
+  if (unicodePunctuation(code2)) {
+    return 2;
+  }
+}
+
+// node_modules/micromark-util-resolve-all/index.js
+function resolveAll(constructs2, events, context) {
+  const called = [];
+  let index2 = -1;
+  while (++index2 < constructs2.length) {
+    const resolve = constructs2[index2].resolveAll;
+    if (resolve && !called.includes(resolve)) {
+      events = resolve(events, context);
+      called.push(resolve);
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark-core-commonmark/lib/attention.js
+var attention = {
+  name: "attention",
+  tokenize: tokenizeAttention,
+  resolveAll: resolveAllAttention
+};
+function resolveAllAttention(events, context) {
+  let index2 = -1;
+  let open;
+  let group;
+  let text4;
+  let openingSequence;
+  let closingSequence;
+  let use;
+  let nextEvents;
+  let offset;
+  while (++index2 < events.length) {
+    if (events[index2][0] === "enter" && events[index2][1].type === "attentionSequence" && events[index2][1]._close) {
+      open = index2;
+      while (open--) {
+        if (events[open][0] === "exit" && events[open][1].type === "attentionSequence" && events[open][1]._open && context.sliceSerialize(events[open][1]).charCodeAt(0) === context.sliceSerialize(events[index2][1]).charCodeAt(0)) {
+          if ((events[open][1]._close || events[index2][1]._open) && (events[index2][1].end.offset - events[index2][1].start.offset) % 3 && !((events[open][1].end.offset - events[open][1].start.offset + events[index2][1].end.offset - events[index2][1].start.offset) % 3)) {
+            continue;
+          }
+          use = events[open][1].end.offset - events[open][1].start.offset > 1 && events[index2][1].end.offset - events[index2][1].start.offset > 1 ? 2 : 1;
+          const start = Object.assign({}, events[open][1].end);
+          const end = Object.assign({}, events[index2][1].start);
+          movePoint(start, -use);
+          movePoint(end, use);
+          openingSequence = {
+            type: use > 1 ? "strongSequence" : "emphasisSequence",
+            start,
+            end: Object.assign({}, events[open][1].end)
+          };
+          closingSequence = {
+            type: use > 1 ? "strongSequence" : "emphasisSequence",
+            start: Object.assign({}, events[index2][1].start),
+            end
+          };
+          text4 = {
+            type: use > 1 ? "strongText" : "emphasisText",
+            start: Object.assign({}, events[open][1].end),
+            end: Object.assign({}, events[index2][1].start)
+          };
+          group = {
+            type: use > 1 ? "strong" : "emphasis",
+            start: Object.assign({}, openingSequence.start),
+            end: Object.assign({}, closingSequence.end)
+          };
+          events[open][1].end = Object.assign({}, openingSequence.start);
+          events[index2][1].start = Object.assign({}, closingSequence.end);
+          nextEvents = [];
+          if (events[open][1].end.offset - events[open][1].start.offset) {
+            nextEvents = push(nextEvents, [
+              ["enter", events[open][1], context],
+              ["exit", events[open][1], context]
+            ]);
+          }
+          nextEvents = push(nextEvents, [
+            ["enter", group, context],
+            ["enter", openingSequence, context],
+            ["exit", openingSequence, context],
+            ["enter", text4, context]
+          ]);
+          nextEvents = push(
+            nextEvents,
+            resolveAll(
+              context.parser.constructs.insideSpan.null,
+              events.slice(open + 1, index2),
+              context
+            )
+          );
+          nextEvents = push(nextEvents, [
+            ["exit", text4, context],
+            ["enter", closingSequence, context],
+            ["exit", closingSequence, context],
+            ["exit", group, context]
+          ]);
+          if (events[index2][1].end.offset - events[index2][1].start.offset) {
+            offset = 2;
+            nextEvents = push(nextEvents, [
+              ["enter", events[index2][1], context],
+              ["exit", events[index2][1], context]
+            ]);
+          } else {
+            offset = 0;
+          }
+          splice(events, open - 1, index2 - open + 3, nextEvents);
+          index2 = open + nextEvents.length - offset - 2;
+          break;
+        }
+      }
+    }
+  }
+  index2 = -1;
+  while (++index2 < events.length) {
+    if (events[index2][1].type === "attentionSequence") {
+      events[index2][1].type = "data";
+    }
+  }
+  return events;
+}
+function tokenizeAttention(effects, ok2) {
+  const attentionMarkers2 = this.parser.constructs.attentionMarkers.null;
+  const previous2 = this.previous;
+  const before = classifyCharacter(previous2);
+  let marker;
+  return start;
+  function start(code2) {
+    effects.enter("attentionSequence");
+    marker = code2;
+    return sequence(code2);
+  }
+  function sequence(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return sequence;
+    }
+    const token = effects.exit("attentionSequence");
+    const after = classifyCharacter(code2);
+    const open = !after || after === 2 && before || attentionMarkers2.includes(code2);
+    const close = !before || before === 2 && after || attentionMarkers2.includes(previous2);
+    token._open = Boolean(marker === 42 ? open : open && (before || !close));
+    token._close = Boolean(marker === 42 ? close : close && (after || !open));
+    return ok2(code2);
+  }
+}
+function movePoint(point2, offset) {
+  point2.column += offset;
+  point2.offset += offset;
+  point2._bufferIndex += offset;
+}
+
+// node_modules/micromark-core-commonmark/lib/autolink.js
+var autolink = {
+  name: "autolink",
+  tokenize: tokenizeAutolink
+};
+function tokenizeAutolink(effects, ok2, nok) {
+  let size = 1;
+  return start;
+  function start(code2) {
+    effects.enter("autolink");
+    effects.enter("autolinkMarker");
+    effects.consume(code2);
+    effects.exit("autolinkMarker");
+    effects.enter("autolinkProtocol");
+    return open;
+  }
+  function open(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return schemeOrEmailAtext;
+    }
+    return asciiAtext(code2) ? emailAtext(code2) : nok(code2);
+  }
+  function schemeOrEmailAtext(code2) {
+    return code2 === 43 || code2 === 45 || code2 === 46 || asciiAlphanumeric(code2) ? schemeInsideOrEmailAtext(code2) : emailAtext(code2);
+  }
+  function schemeInsideOrEmailAtext(code2) {
+    if (code2 === 58) {
+      effects.consume(code2);
+      return urlInside;
+    }
+    if ((code2 === 43 || code2 === 45 || code2 === 46 || asciiAlphanumeric(code2)) && size++ < 32) {
+      effects.consume(code2);
+      return schemeInsideOrEmailAtext;
+    }
+    return emailAtext(code2);
+  }
+  function urlInside(code2) {
+    if (code2 === 62) {
+      effects.exit("autolinkProtocol");
+      return end(code2);
+    }
+    if (code2 === null || code2 === 32 || code2 === 60 || asciiControl(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return urlInside;
+  }
+  function emailAtext(code2) {
+    if (code2 === 64) {
+      effects.consume(code2);
+      size = 0;
+      return emailAtSignOrDot;
+    }
+    if (asciiAtext(code2)) {
+      effects.consume(code2);
+      return emailAtext;
+    }
+    return nok(code2);
+  }
+  function emailAtSignOrDot(code2) {
+    return asciiAlphanumeric(code2) ? emailLabel(code2) : nok(code2);
+  }
+  function emailLabel(code2) {
+    if (code2 === 46) {
+      effects.consume(code2);
+      size = 0;
+      return emailAtSignOrDot;
+    }
+    if (code2 === 62) {
+      effects.exit("autolinkProtocol").type = "autolinkEmail";
+      return end(code2);
+    }
+    return emailValue(code2);
+  }
+  function emailValue(code2) {
+    if ((code2 === 45 || asciiAlphanumeric(code2)) && size++ < 63) {
+      effects.consume(code2);
+      return code2 === 45 ? emailValue : emailLabel;
+    }
+    return nok(code2);
+  }
+  function end(code2) {
+    effects.enter("autolinkMarker");
+    effects.consume(code2);
+    effects.exit("autolinkMarker");
+    effects.exit("autolink");
+    return ok2;
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/blank-line.js
+var blankLine = {
+  tokenize: tokenizeBlankLine,
+  partial: true
+};
+function tokenizeBlankLine(effects, ok2, nok) {
+  return factorySpace(effects, afterWhitespace, "linePrefix");
+  function afterWhitespace(code2) {
+    return code2 === null || markdownLineEnding(code2) ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/block-quote.js
+var blockQuote = {
+  name: "blockQuote",
+  tokenize: tokenizeBlockQuoteStart,
+  continuation: {
+    tokenize: tokenizeBlockQuoteContinuation
+  },
+  exit
+};
+function tokenizeBlockQuoteStart(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    if (code2 === 62) {
+      const state = self.containerState;
+      if (!state.open) {
+        effects.enter("blockQuote", {
+          _container: true
+        });
+        state.open = true;
+      }
+      effects.enter("blockQuotePrefix");
+      effects.enter("blockQuoteMarker");
+      effects.consume(code2);
+      effects.exit("blockQuoteMarker");
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter("blockQuotePrefixWhitespace");
+      effects.consume(code2);
+      effects.exit("blockQuotePrefixWhitespace");
+      effects.exit("blockQuotePrefix");
+      return ok2;
+    }
+    effects.exit("blockQuotePrefix");
+    return ok2(code2);
+  }
+}
+function tokenizeBlockQuoteContinuation(effects, ok2, nok) {
+  return factorySpace(
+    effects,
+    effects.attempt(blockQuote, ok2, nok),
+    "linePrefix",
+    this.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+  );
+}
+function exit(effects) {
+  effects.exit("blockQuote");
+}
+
+// node_modules/micromark-core-commonmark/lib/character-escape.js
+var characterEscape = {
+  name: "characterEscape",
+  tokenize: tokenizeCharacterEscape
+};
+function tokenizeCharacterEscape(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.enter("characterEscape");
+    effects.enter("escapeMarker");
+    effects.consume(code2);
+    effects.exit("escapeMarker");
+    return open;
+  }
+  function open(code2) {
+    if (asciiPunctuation(code2)) {
+      effects.enter("characterEscapeValue");
+      effects.consume(code2);
+      effects.exit("characterEscapeValue");
+      effects.exit("characterEscape");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/character-entities/index.js
+var characterEntities = {
+  AElig: "\xC6",
+  AMP: "&",
+  Aacute: "\xC1",
+  Abreve: "\u0102",
+  Acirc: "\xC2",
+  Acy: "\u0410",
+  Afr: "\u{1D504}",
+  Agrave: "\xC0",
+  Alpha: "\u0391",
+  Amacr: "\u0100",
+  And: "\u2A53",
+  Aogon: "\u0104",
+  Aopf: "\u{1D538}",
+  ApplyFunction: "\u2061",
+  Aring: "\xC5",
+  Ascr: "\u{1D49C}",
+  Assign: "\u2254",
+  Atilde: "\xC3",
+  Auml: "\xC4",
+  Backslash: "\u2216",
+  Barv: "\u2AE7",
+  Barwed: "\u2306",
+  Bcy: "\u0411",
+  Because: "\u2235",
+  Bernoullis: "\u212C",
+  Beta: "\u0392",
+  Bfr: "\u{1D505}",
+  Bopf: "\u{1D539}",
+  Breve: "\u02D8",
+  Bscr: "\u212C",
+  Bumpeq: "\u224E",
+  CHcy: "\u0427",
+  COPY: "\xA9",
+  Cacute: "\u0106",
+  Cap: "\u22D2",
+  CapitalDifferentialD: "\u2145",
+  Cayleys: "\u212D",
+  Ccaron: "\u010C",
+  Ccedil: "\xC7",
+  Ccirc: "\u0108",
+  Cconint: "\u2230",
+  Cdot: "\u010A",
+  Cedilla: "\xB8",
+  CenterDot: "\xB7",
+  Cfr: "\u212D",
+  Chi: "\u03A7",
+  CircleDot: "\u2299",
+  CircleMinus: "\u2296",
+  CirclePlus: "\u2295",
+  CircleTimes: "\u2297",
+  ClockwiseContourIntegral: "\u2232",
+  CloseCurlyDoubleQuote: "\u201D",
+  CloseCurlyQuote: "\u2019",
+  Colon: "\u2237",
+  Colone: "\u2A74",
+  Congruent: "\u2261",
+  Conint: "\u222F",
+  ContourIntegral: "\u222E",
+  Copf: "\u2102",
+  Coproduct: "\u2210",
+  CounterClockwiseContourIntegral: "\u2233",
+  Cross: "\u2A2F",
+  Cscr: "\u{1D49E}",
+  Cup: "\u22D3",
+  CupCap: "\u224D",
+  DD: "\u2145",
+  DDotrahd: "\u2911",
+  DJcy: "\u0402",
+  DScy: "\u0405",
+  DZcy: "\u040F",
+  Dagger: "\u2021",
+  Darr: "\u21A1",
+  Dashv: "\u2AE4",
+  Dcaron: "\u010E",
+  Dcy: "\u0414",
+  Del: "\u2207",
+  Delta: "\u0394",
+  Dfr: "\u{1D507}",
+  DiacriticalAcute: "\xB4",
+  DiacriticalDot: "\u02D9",
+  DiacriticalDoubleAcute: "\u02DD",
+  DiacriticalGrave: "`",
+  DiacriticalTilde: "\u02DC",
+  Diamond: "\u22C4",
+  DifferentialD: "\u2146",
+  Dopf: "\u{1D53B}",
+  Dot: "\xA8",
+  DotDot: "\u20DC",
+  DotEqual: "\u2250",
+  DoubleContourIntegral: "\u222F",
+  DoubleDot: "\xA8",
+  DoubleDownArrow: "\u21D3",
+  DoubleLeftArrow: "\u21D0",
+  DoubleLeftRightArrow: "\u21D4",
+  DoubleLeftTee: "\u2AE4",
+  DoubleLongLeftArrow: "\u27F8",
+  DoubleLongLeftRightArrow: "\u27FA",
+  DoubleLongRightArrow: "\u27F9",
+  DoubleRightArrow: "\u21D2",
+  DoubleRightTee: "\u22A8",
+  DoubleUpArrow: "\u21D1",
+  DoubleUpDownArrow: "\u21D5",
+  DoubleVerticalBar: "\u2225",
+  DownArrow: "\u2193",
+  DownArrowBar: "\u2913",
+  DownArrowUpArrow: "\u21F5",
+  DownBreve: "\u0311",
+  DownLeftRightVector: "\u2950",
+  DownLeftTeeVector: "\u295E",
+  DownLeftVector: "\u21BD",
+  DownLeftVectorBar: "\u2956",
+  DownRightTeeVector: "\u295F",
+  DownRightVector: "\u21C1",
+  DownRightVectorBar: "\u2957",
+  DownTee: "\u22A4",
+  DownTeeArrow: "\u21A7",
+  Downarrow: "\u21D3",
+  Dscr: "\u{1D49F}",
+  Dstrok: "\u0110",
+  ENG: "\u014A",
+  ETH: "\xD0",
+  Eacute: "\xC9",
+  Ecaron: "\u011A",
+  Ecirc: "\xCA",
+  Ecy: "\u042D",
+  Edot: "\u0116",
+  Efr: "\u{1D508}",
+  Egrave: "\xC8",
+  Element: "\u2208",
+  Emacr: "\u0112",
+  EmptySmallSquare: "\u25FB",
+  EmptyVerySmallSquare: "\u25AB",
+  Eogon: "\u0118",
+  Eopf: "\u{1D53C}",
+  Epsilon: "\u0395",
+  Equal: "\u2A75",
+  EqualTilde: "\u2242",
+  Equilibrium: "\u21CC",
+  Escr: "\u2130",
+  Esim: "\u2A73",
+  Eta: "\u0397",
+  Euml: "\xCB",
+  Exists: "\u2203",
+  ExponentialE: "\u2147",
+  Fcy: "\u0424",
+  Ffr: "\u{1D509}",
+  FilledSmallSquare: "\u25FC",
+  FilledVerySmallSquare: "\u25AA",
+  Fopf: "\u{1D53D}",
+  ForAll: "\u2200",
+  Fouriertrf: "\u2131",
+  Fscr: "\u2131",
+  GJcy: "\u0403",
+  GT: ">",
+  Gamma: "\u0393",
+  Gammad: "\u03DC",
+  Gbreve: "\u011E",
+  Gcedil: "\u0122",
+  Gcirc: "\u011C",
+  Gcy: "\u0413",
+  Gdot: "\u0120",
+  Gfr: "\u{1D50A}",
+  Gg: "\u22D9",
+  Gopf: "\u{1D53E}",
+  GreaterEqual: "\u2265",
+  GreaterEqualLess: "\u22DB",
+  GreaterFullEqual: "\u2267",
+  GreaterGreater: "\u2AA2",
+  GreaterLess: "\u2277",
+  GreaterSlantEqual: "\u2A7E",
+  GreaterTilde: "\u2273",
+  Gscr: "\u{1D4A2}",
+  Gt: "\u226B",
+  HARDcy: "\u042A",
+  Hacek: "\u02C7",
+  Hat: "^",
+  Hcirc: "\u0124",
+  Hfr: "\u210C",
+  HilbertSpace: "\u210B",
+  Hopf: "\u210D",
+  HorizontalLine: "\u2500",
+  Hscr: "\u210B",
+  Hstrok: "\u0126",
+  HumpDownHump: "\u224E",
+  HumpEqual: "\u224F",
+  IEcy: "\u0415",
+  IJlig: "\u0132",
+  IOcy: "\u0401",
+  Iacute: "\xCD",
+  Icirc: "\xCE",
+  Icy: "\u0418",
+  Idot: "\u0130",
+  Ifr: "\u2111",
+  Igrave: "\xCC",
+  Im: "\u2111",
+  Imacr: "\u012A",
+  ImaginaryI: "\u2148",
+  Implies: "\u21D2",
+  Int: "\u222C",
+  Integral: "\u222B",
+  Intersection: "\u22C2",
+  InvisibleComma: "\u2063",
+  InvisibleTimes: "\u2062",
+  Iogon: "\u012E",
+  Iopf: "\u{1D540}",
+  Iota: "\u0399",
+  Iscr: "\u2110",
+  Itilde: "\u0128",
+  Iukcy: "\u0406",
+  Iuml: "\xCF",
+  Jcirc: "\u0134",
+  Jcy: "\u0419",
+  Jfr: "\u{1D50D}",
+  Jopf: "\u{1D541}",
+  Jscr: "\u{1D4A5}",
+  Jsercy: "\u0408",
+  Jukcy: "\u0404",
+  KHcy: "\u0425",
+  KJcy: "\u040C",
+  Kappa: "\u039A",
+  Kcedil: "\u0136",
+  Kcy: "\u041A",
+  Kfr: "\u{1D50E}",
+  Kopf: "\u{1D542}",
+  Kscr: "\u{1D4A6}",
+  LJcy: "\u0409",
+  LT: "<",
+  Lacute: "\u0139",
+  Lambda: "\u039B",
+  Lang: "\u27EA",
+  Laplacetrf: "\u2112",
+  Larr: "\u219E",
+  Lcaron: "\u013D",
+  Lcedil: "\u013B",
+  Lcy: "\u041B",
+  LeftAngleBracket: "\u27E8",
+  LeftArrow: "\u2190",
+  LeftArrowBar: "\u21E4",
+  LeftArrowRightArrow: "\u21C6",
+  LeftCeiling: "\u2308",
+  LeftDoubleBracket: "\u27E6",
+  LeftDownTeeVector: "\u2961",
+  LeftDownVector: "\u21C3",
+  LeftDownVectorBar: "\u2959",
+  LeftFloor: "\u230A",
+  LeftRightArrow: "\u2194",
+  LeftRightVector: "\u294E",
+  LeftTee: "\u22A3",
+  LeftTeeArrow: "\u21A4",
+  LeftTeeVector: "\u295A",
+  LeftTriangle: "\u22B2",
+  LeftTriangleBar: "\u29CF",
+  LeftTriangleEqual: "\u22B4",
+  LeftUpDownVector: "\u2951",
+  LeftUpTeeVector: "\u2960",
+  LeftUpVector: "\u21BF",
+  LeftUpVectorBar: "\u2958",
+  LeftVector: "\u21BC",
+  LeftVectorBar: "\u2952",
+  Leftarrow: "\u21D0",
+  Leftrightarrow: "\u21D4",
+  LessEqualGreater: "\u22DA",
+  LessFullEqual: "\u2266",
+  LessGreater: "\u2276",
+  LessLess: "\u2AA1",
+  LessSlantEqual: "\u2A7D",
+  LessTilde: "\u2272",
+  Lfr: "\u{1D50F}",
+  Ll: "\u22D8",
+  Lleftarrow: "\u21DA",
+  Lmidot: "\u013F",
+  LongLeftArrow: "\u27F5",
+  LongLeftRightArrow: "\u27F7",
+  LongRightArrow: "\u27F6",
+  Longleftarrow: "\u27F8",
+  Longleftrightarrow: "\u27FA",
+  Longrightarrow: "\u27F9",
+  Lopf: "\u{1D543}",
+  LowerLeftArrow: "\u2199",
+  LowerRightArrow: "\u2198",
+  Lscr: "\u2112",
+  Lsh: "\u21B0",
+  Lstrok: "\u0141",
+  Lt: "\u226A",
+  Map: "\u2905",
+  Mcy: "\u041C",
+  MediumSpace: "\u205F",
+  Mellintrf: "\u2133",
+  Mfr: "\u{1D510}",
+  MinusPlus: "\u2213",
+  Mopf: "\u{1D544}",
+  Mscr: "\u2133",
+  Mu: "\u039C",
+  NJcy: "\u040A",
+  Nacute: "\u0143",
+  Ncaron: "\u0147",
+  Ncedil: "\u0145",
+  Ncy: "\u041D",
+  NegativeMediumSpace: "\u200B",
+  NegativeThickSpace: "\u200B",
+  NegativeThinSpace: "\u200B",
+  NegativeVeryThinSpace: "\u200B",
+  NestedGreaterGreater: "\u226B",
+  NestedLessLess: "\u226A",
+  NewLine: "\n",
+  Nfr: "\u{1D511}",
+  NoBreak: "\u2060",
+  NonBreakingSpace: "\xA0",
+  Nopf: "\u2115",
+  Not: "\u2AEC",
+  NotCongruent: "\u2262",
+  NotCupCap: "\u226D",
+  NotDoubleVerticalBar: "\u2226",
+  NotElement: "\u2209",
+  NotEqual: "\u2260",
+  NotEqualTilde: "\u2242\u0338",
+  NotExists: "\u2204",
+  NotGreater: "\u226F",
+  NotGreaterEqual: "\u2271",
+  NotGreaterFullEqual: "\u2267\u0338",
+  NotGreaterGreater: "\u226B\u0338",
+  NotGreaterLess: "\u2279",
+  NotGreaterSlantEqual: "\u2A7E\u0338",
+  NotGreaterTilde: "\u2275",
+  NotHumpDownHump: "\u224E\u0338",
+  NotHumpEqual: "\u224F\u0338",
+  NotLeftTriangle: "\u22EA",
+  NotLeftTriangleBar: "\u29CF\u0338",
+  NotLeftTriangleEqual: "\u22EC",
+  NotLess: "\u226E",
+  NotLessEqual: "\u2270",
+  NotLessGreater: "\u2278",
+  NotLessLess: "\u226A\u0338",
+  NotLessSlantEqual: "\u2A7D\u0338",
+  NotLessTilde: "\u2274",
+  NotNestedGreaterGreater: "\u2AA2\u0338",
+  NotNestedLessLess: "\u2AA1\u0338",
+  NotPrecedes: "\u2280",
+  NotPrecedesEqual: "\u2AAF\u0338",
+  NotPrecedesSlantEqual: "\u22E0",
+  NotReverseElement: "\u220C",
+  NotRightTriangle: "\u22EB",
+  NotRightTriangleBar: "\u29D0\u0338",
+  NotRightTriangleEqual: "\u22ED",
+  NotSquareSubset: "\u228F\u0338",
+  NotSquareSubsetEqual: "\u22E2",
+  NotSquareSuperset: "\u2290\u0338",
+  NotSquareSupersetEqual: "\u22E3",
+  NotSubset: "\u2282\u20D2",
+  NotSubsetEqual: "\u2288",
+  NotSucceeds: "\u2281",
+  NotSucceedsEqual: "\u2AB0\u0338",
+  NotSucceedsSlantEqual: "\u22E1",
+  NotSucceedsTilde: "\u227F\u0338",
+  NotSuperset: "\u2283\u20D2",
+  NotSupersetEqual: "\u2289",
+  NotTilde: "\u2241",
+  NotTildeEqual: "\u2244",
+  NotTildeFullEqual: "\u2247",
+  NotTildeTilde: "\u2249",
+  NotVerticalBar: "\u2224",
+  Nscr: "\u{1D4A9}",
+  Ntilde: "\xD1",
+  Nu: "\u039D",
+  OElig: "\u0152",
+  Oacute: "\xD3",
+  Ocirc: "\xD4",
+  Ocy: "\u041E",
+  Odblac: "\u0150",
+  Ofr: "\u{1D512}",
+  Ograve: "\xD2",
+  Omacr: "\u014C",
+  Omega: "\u03A9",
+  Omicron: "\u039F",
+  Oopf: "\u{1D546}",
+  OpenCurlyDoubleQuote: "\u201C",
+  OpenCurlyQuote: "\u2018",
+  Or: "\u2A54",
+  Oscr: "\u{1D4AA}",
+  Oslash: "\xD8",
+  Otilde: "\xD5",
+  Otimes: "\u2A37",
+  Ouml: "\xD6",
+  OverBar: "\u203E",
+  OverBrace: "\u23DE",
+  OverBracket: "\u23B4",
+  OverParenthesis: "\u23DC",
+  PartialD: "\u2202",
+  Pcy: "\u041F",
+  Pfr: "\u{1D513}",
+  Phi: "\u03A6",
+  Pi: "\u03A0",
+  PlusMinus: "\xB1",
+  Poincareplane: "\u210C",
+  Popf: "\u2119",
+  Pr: "\u2ABB",
+  Precedes: "\u227A",
+  PrecedesEqual: "\u2AAF",
+  PrecedesSlantEqual: "\u227C",
+  PrecedesTilde: "\u227E",
+  Prime: "\u2033",
+  Product: "\u220F",
+  Proportion: "\u2237",
+  Proportional: "\u221D",
+  Pscr: "\u{1D4AB}",
+  Psi: "\u03A8",
+  QUOT: '"',
+  Qfr: "\u{1D514}",
+  Qopf: "\u211A",
+  Qscr: "\u{1D4AC}",
+  RBarr: "\u2910",
+  REG: "\xAE",
+  Racute: "\u0154",
+  Rang: "\u27EB",
+  Rarr: "\u21A0",
+  Rarrtl: "\u2916",
+  Rcaron: "\u0158",
+  Rcedil: "\u0156",
+  Rcy: "\u0420",
+  Re: "\u211C",
+  ReverseElement: "\u220B",
+  ReverseEquilibrium: "\u21CB",
+  ReverseUpEquilibrium: "\u296F",
+  Rfr: "\u211C",
+  Rho: "\u03A1",
+  RightAngleBracket: "\u27E9",
+  RightArrow: "\u2192",
+  RightArrowBar: "\u21E5",
+  RightArrowLeftArrow: "\u21C4",
+  RightCeiling: "\u2309",
+  RightDoubleBracket: "\u27E7",
+  RightDownTeeVector: "\u295D",
+  RightDownVector: "\u21C2",
+  RightDownVectorBar: "\u2955",
+  RightFloor: "\u230B",
+  RightTee: "\u22A2",
+  RightTeeArrow: "\u21A6",
+  RightTeeVector: "\u295B",
+  RightTriangle: "\u22B3",
+  RightTriangleBar: "\u29D0",
+  RightTriangleEqual: "\u22B5",
+  RightUpDownVector: "\u294F",
+  RightUpTeeVector: "\u295C",
+  RightUpVector: "\u21BE",
+  RightUpVectorBar: "\u2954",
+  RightVector: "\u21C0",
+  RightVectorBar: "\u2953",
+  Rightarrow: "\u21D2",
+  Ropf: "\u211D",
+  RoundImplies: "\u2970",
+  Rrightarrow: "\u21DB",
+  Rscr: "\u211B",
+  Rsh: "\u21B1",
+  RuleDelayed: "\u29F4",
+  SHCHcy: "\u0429",
+  SHcy: "\u0428",
+  SOFTcy: "\u042C",
+  Sacute: "\u015A",
+  Sc: "\u2ABC",
+  Scaron: "\u0160",
+  Scedil: "\u015E",
+  Scirc: "\u015C",
+  Scy: "\u0421",
+  Sfr: "\u{1D516}",
+  ShortDownArrow: "\u2193",
+  ShortLeftArrow: "\u2190",
+  ShortRightArrow: "\u2192",
+  ShortUpArrow: "\u2191",
+  Sigma: "\u03A3",
+  SmallCircle: "\u2218",
+  Sopf: "\u{1D54A}",
+  Sqrt: "\u221A",
+  Square: "\u25A1",
+  SquareIntersection: "\u2293",
+  SquareSubset: "\u228F",
+  SquareSubsetEqual: "\u2291",
+  SquareSuperset: "\u2290",
+  SquareSupersetEqual: "\u2292",
+  SquareUnion: "\u2294",
+  Sscr: "\u{1D4AE}",
+  Star: "\u22C6",
+  Sub: "\u22D0",
+  Subset: "\u22D0",
+  SubsetEqual: "\u2286",
+  Succeeds: "\u227B",
+  SucceedsEqual: "\u2AB0",
+  SucceedsSlantEqual: "\u227D",
+  SucceedsTilde: "\u227F",
+  SuchThat: "\u220B",
+  Sum: "\u2211",
+  Sup: "\u22D1",
+  Superset: "\u2283",
+  SupersetEqual: "\u2287",
+  Supset: "\u22D1",
+  THORN: "\xDE",
+  TRADE: "\u2122",
+  TSHcy: "\u040B",
+  TScy: "\u0426",
+  Tab: "	",
+  Tau: "\u03A4",
+  Tcaron: "\u0164",
+  Tcedil: "\u0162",
+  Tcy: "\u0422",
+  Tfr: "\u{1D517}",
+  Therefore: "\u2234",
+  Theta: "\u0398",
+  ThickSpace: "\u205F\u200A",
+  ThinSpace: "\u2009",
+  Tilde: "\u223C",
+  TildeEqual: "\u2243",
+  TildeFullEqual: "\u2245",
+  TildeTilde: "\u2248",
+  Topf: "\u{1D54B}",
+  TripleDot: "\u20DB",
+  Tscr: "\u{1D4AF}",
+  Tstrok: "\u0166",
+  Uacute: "\xDA",
+  Uarr: "\u219F",
+  Uarrocir: "\u2949",
+  Ubrcy: "\u040E",
+  Ubreve: "\u016C",
+  Ucirc: "\xDB",
+  Ucy: "\u0423",
+  Udblac: "\u0170",
+  Ufr: "\u{1D518}",
+  Ugrave: "\xD9",
+  Umacr: "\u016A",
+  UnderBar: "_",
+  UnderBrace: "\u23DF",
+  UnderBracket: "\u23B5",
+  UnderParenthesis: "\u23DD",
+  Union: "\u22C3",
+  UnionPlus: "\u228E",
+  Uogon: "\u0172",
+  Uopf: "\u{1D54C}",
+  UpArrow: "\u2191",
+  UpArrowBar: "\u2912",
+  UpArrowDownArrow: "\u21C5",
+  UpDownArrow: "\u2195",
+  UpEquilibrium: "\u296E",
+  UpTee: "\u22A5",
+  UpTeeArrow: "\u21A5",
+  Uparrow: "\u21D1",
+  Updownarrow: "\u21D5",
+  UpperLeftArrow: "\u2196",
+  UpperRightArrow: "\u2197",
+  Upsi: "\u03D2",
+  Upsilon: "\u03A5",
+  Uring: "\u016E",
+  Uscr: "\u{1D4B0}",
+  Utilde: "\u0168",
+  Uuml: "\xDC",
+  VDash: "\u22AB",
+  Vbar: "\u2AEB",
+  Vcy: "\u0412",
+  Vdash: "\u22A9",
+  Vdashl: "\u2AE6",
+  Vee: "\u22C1",
+  Verbar: "\u2016",
+  Vert: "\u2016",
+  VerticalBar: "\u2223",
+  VerticalLine: "|",
+  VerticalSeparator: "\u2758",
+  VerticalTilde: "\u2240",
+  VeryThinSpace: "\u200A",
+  Vfr: "\u{1D519}",
+  Vopf: "\u{1D54D}",
+  Vscr: "\u{1D4B1}",
+  Vvdash: "\u22AA",
+  Wcirc: "\u0174",
+  Wedge: "\u22C0",
+  Wfr: "\u{1D51A}",
+  Wopf: "\u{1D54E}",
+  Wscr: "\u{1D4B2}",
+  Xfr: "\u{1D51B}",
+  Xi: "\u039E",
+  Xopf: "\u{1D54F}",
+  Xscr: "\u{1D4B3}",
+  YAcy: "\u042F",
+  YIcy: "\u0407",
+  YUcy: "\u042E",
+  Yacute: "\xDD",
+  Ycirc: "\u0176",
+  Ycy: "\u042B",
+  Yfr: "\u{1D51C}",
+  Yopf: "\u{1D550}",
+  Yscr: "\u{1D4B4}",
+  Yuml: "\u0178",
+  ZHcy: "\u0416",
+  Zacute: "\u0179",
+  Zcaron: "\u017D",
+  Zcy: "\u0417",
+  Zdot: "\u017B",
+  ZeroWidthSpace: "\u200B",
+  Zeta: "\u0396",
+  Zfr: "\u2128",
+  Zopf: "\u2124",
+  Zscr: "\u{1D4B5}",
+  aacute: "\xE1",
+  abreve: "\u0103",
+  ac: "\u223E",
+  acE: "\u223E\u0333",
+  acd: "\u223F",
+  acirc: "\xE2",
+  acute: "\xB4",
+  acy: "\u0430",
+  aelig: "\xE6",
+  af: "\u2061",
+  afr: "\u{1D51E}",
+  agrave: "\xE0",
+  alefsym: "\u2135",
+  aleph: "\u2135",
+  alpha: "\u03B1",
+  amacr: "\u0101",
+  amalg: "\u2A3F",
+  amp: "&",
+  and: "\u2227",
+  andand: "\u2A55",
+  andd: "\u2A5C",
+  andslope: "\u2A58",
+  andv: "\u2A5A",
+  ang: "\u2220",
+  ange: "\u29A4",
+  angle: "\u2220",
+  angmsd: "\u2221",
+  angmsdaa: "\u29A8",
+  angmsdab: "\u29A9",
+  angmsdac: "\u29AA",
+  angmsdad: "\u29AB",
+  angmsdae: "\u29AC",
+  angmsdaf: "\u29AD",
+  angmsdag: "\u29AE",
+  angmsdah: "\u29AF",
+  angrt: "\u221F",
+  angrtvb: "\u22BE",
+  angrtvbd: "\u299D",
+  angsph: "\u2222",
+  angst: "\xC5",
+  angzarr: "\u237C",
+  aogon: "\u0105",
+  aopf: "\u{1D552}",
+  ap: "\u2248",
+  apE: "\u2A70",
+  apacir: "\u2A6F",
+  ape: "\u224A",
+  apid: "\u224B",
+  apos: "'",
+  approx: "\u2248",
+  approxeq: "\u224A",
+  aring: "\xE5",
+  ascr: "\u{1D4B6}",
+  ast: "*",
+  asymp: "\u2248",
+  asympeq: "\u224D",
+  atilde: "\xE3",
+  auml: "\xE4",
+  awconint: "\u2233",
+  awint: "\u2A11",
+  bNot: "\u2AED",
+  backcong: "\u224C",
+  backepsilon: "\u03F6",
+  backprime: "\u2035",
+  backsim: "\u223D",
+  backsimeq: "\u22CD",
+  barvee: "\u22BD",
+  barwed: "\u2305",
+  barwedge: "\u2305",
+  bbrk: "\u23B5",
+  bbrktbrk: "\u23B6",
+  bcong: "\u224C",
+  bcy: "\u0431",
+  bdquo: "\u201E",
+  becaus: "\u2235",
+  because: "\u2235",
+  bemptyv: "\u29B0",
+  bepsi: "\u03F6",
+  bernou: "\u212C",
+  beta: "\u03B2",
+  beth: "\u2136",
+  between: "\u226C",
+  bfr: "\u{1D51F}",
+  bigcap: "\u22C2",
+  bigcirc: "\u25EF",
+  bigcup: "\u22C3",
+  bigodot: "\u2A00",
+  bigoplus: "\u2A01",
+  bigotimes: "\u2A02",
+  bigsqcup: "\u2A06",
+  bigstar: "\u2605",
+  bigtriangledown: "\u25BD",
+  bigtriangleup: "\u25B3",
+  biguplus: "\u2A04",
+  bigvee: "\u22C1",
+  bigwedge: "\u22C0",
+  bkarow: "\u290D",
+  blacklozenge: "\u29EB",
+  blacksquare: "\u25AA",
+  blacktriangle: "\u25B4",
+  blacktriangledown: "\u25BE",
+  blacktriangleleft: "\u25C2",
+  blacktriangleright: "\u25B8",
+  blank: "\u2423",
+  blk12: "\u2592",
+  blk14: "\u2591",
+  blk34: "\u2593",
+  block: "\u2588",
+  bne: "=\u20E5",
+  bnequiv: "\u2261\u20E5",
+  bnot: "\u2310",
+  bopf: "\u{1D553}",
+  bot: "\u22A5",
+  bottom: "\u22A5",
+  bowtie: "\u22C8",
+  boxDL: "\u2557",
+  boxDR: "\u2554",
+  boxDl: "\u2556",
+  boxDr: "\u2553",
+  boxH: "\u2550",
+  boxHD: "\u2566",
+  boxHU: "\u2569",
+  boxHd: "\u2564",
+  boxHu: "\u2567",
+  boxUL: "\u255D",
+  boxUR: "\u255A",
+  boxUl: "\u255C",
+  boxUr: "\u2559",
+  boxV: "\u2551",
+  boxVH: "\u256C",
+  boxVL: "\u2563",
+  boxVR: "\u2560",
+  boxVh: "\u256B",
+  boxVl: "\u2562",
+  boxVr: "\u255F",
+  boxbox: "\u29C9",
+  boxdL: "\u2555",
+  boxdR: "\u2552",
+  boxdl: "\u2510",
+  boxdr: "\u250C",
+  boxh: "\u2500",
+  boxhD: "\u2565",
+  boxhU: "\u2568",
+  boxhd: "\u252C",
+  boxhu: "\u2534",
+  boxminus: "\u229F",
+  boxplus: "\u229E",
+  boxtimes: "\u22A0",
+  boxuL: "\u255B",
+  boxuR: "\u2558",
+  boxul: "\u2518",
+  boxur: "\u2514",
+  boxv: "\u2502",
+  boxvH: "\u256A",
+  boxvL: "\u2561",
+  boxvR: "\u255E",
+  boxvh: "\u253C",
+  boxvl: "\u2524",
+  boxvr: "\u251C",
+  bprime: "\u2035",
+  breve: "\u02D8",
+  brvbar: "\xA6",
+  bscr: "\u{1D4B7}",
+  bsemi: "\u204F",
+  bsim: "\u223D",
+  bsime: "\u22CD",
+  bsol: "\\",
+  bsolb: "\u29C5",
+  bsolhsub: "\u27C8",
+  bull: "\u2022",
+  bullet: "\u2022",
+  bump: "\u224E",
+  bumpE: "\u2AAE",
+  bumpe: "\u224F",
+  bumpeq: "\u224F",
+  cacute: "\u0107",
+  cap: "\u2229",
+  capand: "\u2A44",
+  capbrcup: "\u2A49",
+  capcap: "\u2A4B",
+  capcup: "\u2A47",
+  capdot: "\u2A40",
+  caps: "\u2229\uFE00",
+  caret: "\u2041",
+  caron: "\u02C7",
+  ccaps: "\u2A4D",
+  ccaron: "\u010D",
+  ccedil: "\xE7",
+  ccirc: "\u0109",
+  ccups: "\u2A4C",
+  ccupssm: "\u2A50",
+  cdot: "\u010B",
+  cedil: "\xB8",
+  cemptyv: "\u29B2",
+  cent: "\xA2",
+  centerdot: "\xB7",
+  cfr: "\u{1D520}",
+  chcy: "\u0447",
+  check: "\u2713",
+  checkmark: "\u2713",
+  chi: "\u03C7",
+  cir: "\u25CB",
+  cirE: "\u29C3",
+  circ: "\u02C6",
+  circeq: "\u2257",
+  circlearrowleft: "\u21BA",
+  circlearrowright: "\u21BB",
+  circledR: "\xAE",
+  circledS: "\u24C8",
+  circledast: "\u229B",
+  circledcirc: "\u229A",
+  circleddash: "\u229D",
+  cire: "\u2257",
+  cirfnint: "\u2A10",
+  cirmid: "\u2AEF",
+  cirscir: "\u29C2",
+  clubs: "\u2663",
+  clubsuit: "\u2663",
+  colon: ":",
+  colone: "\u2254",
+  coloneq: "\u2254",
+  comma: ",",
+  commat: "@",
+  comp: "\u2201",
+  compfn: "\u2218",
+  complement: "\u2201",
+  complexes: "\u2102",
+  cong: "\u2245",
+  congdot: "\u2A6D",
+  conint: "\u222E",
+  copf: "\u{1D554}",
+  coprod: "\u2210",
+  copy: "\xA9",
+  copysr: "\u2117",
+  crarr: "\u21B5",
+  cross: "\u2717",
+  cscr: "\u{1D4B8}",
+  csub: "\u2ACF",
+  csube: "\u2AD1",
+  csup: "\u2AD0",
+  csupe: "\u2AD2",
+  ctdot: "\u22EF",
+  cudarrl: "\u2938",
+  cudarrr: "\u2935",
+  cuepr: "\u22DE",
+  cuesc: "\u22DF",
+  cularr: "\u21B6",
+  cularrp: "\u293D",
+  cup: "\u222A",
+  cupbrcap: "\u2A48",
+  cupcap: "\u2A46",
+  cupcup: "\u2A4A",
+  cupdot: "\u228D",
+  cupor: "\u2A45",
+  cups: "\u222A\uFE00",
+  curarr: "\u21B7",
+  curarrm: "\u293C",
+  curlyeqprec: "\u22DE",
+  curlyeqsucc: "\u22DF",
+  curlyvee: "\u22CE",
+  curlywedge: "\u22CF",
+  curren: "\xA4",
+  curvearrowleft: "\u21B6",
+  curvearrowright: "\u21B7",
+  cuvee: "\u22CE",
+  cuwed: "\u22CF",
+  cwconint: "\u2232",
+  cwint: "\u2231",
+  cylcty: "\u232D",
+  dArr: "\u21D3",
+  dHar: "\u2965",
+  dagger: "\u2020",
+  daleth: "\u2138",
+  darr: "\u2193",
+  dash: "\u2010",
+  dashv: "\u22A3",
+  dbkarow: "\u290F",
+  dblac: "\u02DD",
+  dcaron: "\u010F",
+  dcy: "\u0434",
+  dd: "\u2146",
+  ddagger: "\u2021",
+  ddarr: "\u21CA",
+  ddotseq: "\u2A77",
+  deg: "\xB0",
+  delta: "\u03B4",
+  demptyv: "\u29B1",
+  dfisht: "\u297F",
+  dfr: "\u{1D521}",
+  dharl: "\u21C3",
+  dharr: "\u21C2",
+  diam: "\u22C4",
+  diamond: "\u22C4",
+  diamondsuit: "\u2666",
+  diams: "\u2666",
+  die: "\xA8",
+  digamma: "\u03DD",
+  disin: "\u22F2",
+  div: "\xF7",
+  divide: "\xF7",
+  divideontimes: "\u22C7",
+  divonx: "\u22C7",
+  djcy: "\u0452",
+  dlcorn: "\u231E",
+  dlcrop: "\u230D",
+  dollar: "$",
+  dopf: "\u{1D555}",
+  dot: "\u02D9",
+  doteq: "\u2250",
+  doteqdot: "\u2251",
+  dotminus: "\u2238",
+  dotplus: "\u2214",
+  dotsquare: "\u22A1",
+  doublebarwedge: "\u2306",
+  downarrow: "\u2193",
+  downdownarrows: "\u21CA",
+  downharpoonleft: "\u21C3",
+  downharpoonright: "\u21C2",
+  drbkarow: "\u2910",
+  drcorn: "\u231F",
+  drcrop: "\u230C",
+  dscr: "\u{1D4B9}",
+  dscy: "\u0455",
+  dsol: "\u29F6",
+  dstrok: "\u0111",
+  dtdot: "\u22F1",
+  dtri: "\u25BF",
+  dtrif: "\u25BE",
+  duarr: "\u21F5",
+  duhar: "\u296F",
+  dwangle: "\u29A6",
+  dzcy: "\u045F",
+  dzigrarr: "\u27FF",
+  eDDot: "\u2A77",
+  eDot: "\u2251",
+  eacute: "\xE9",
+  easter: "\u2A6E",
+  ecaron: "\u011B",
+  ecir: "\u2256",
+  ecirc: "\xEA",
+  ecolon: "\u2255",
+  ecy: "\u044D",
+  edot: "\u0117",
+  ee: "\u2147",
+  efDot: "\u2252",
+  efr: "\u{1D522}",
+  eg: "\u2A9A",
+  egrave: "\xE8",
+  egs: "\u2A96",
+  egsdot: "\u2A98",
+  el: "\u2A99",
+  elinters: "\u23E7",
+  ell: "\u2113",
+  els: "\u2A95",
+  elsdot: "\u2A97",
+  emacr: "\u0113",
+  empty: "\u2205",
+  emptyset: "\u2205",
+  emptyv: "\u2205",
+  emsp13: "\u2004",
+  emsp14: "\u2005",
+  emsp: "\u2003",
+  eng: "\u014B",
+  ensp: "\u2002",
+  eogon: "\u0119",
+  eopf: "\u{1D556}",
+  epar: "\u22D5",
+  eparsl: "\u29E3",
+  eplus: "\u2A71",
+  epsi: "\u03B5",
+  epsilon: "\u03B5",
+  epsiv: "\u03F5",
+  eqcirc: "\u2256",
+  eqcolon: "\u2255",
+  eqsim: "\u2242",
+  eqslantgtr: "\u2A96",
+  eqslantless: "\u2A95",
+  equals: "=",
+  equest: "\u225F",
+  equiv: "\u2261",
+  equivDD: "\u2A78",
+  eqvparsl: "\u29E5",
+  erDot: "\u2253",
+  erarr: "\u2971",
+  escr: "\u212F",
+  esdot: "\u2250",
+  esim: "\u2242",
+  eta: "\u03B7",
+  eth: "\xF0",
+  euml: "\xEB",
+  euro: "\u20AC",
+  excl: "!",
+  exist: "\u2203",
+  expectation: "\u2130",
+  exponentiale: "\u2147",
+  fallingdotseq: "\u2252",
+  fcy: "\u0444",
+  female: "\u2640",
+  ffilig: "\uFB03",
+  fflig: "\uFB00",
+  ffllig: "\uFB04",
+  ffr: "\u{1D523}",
+  filig: "\uFB01",
+  fjlig: "fj",
+  flat: "\u266D",
+  fllig: "\uFB02",
+  fltns: "\u25B1",
+  fnof: "\u0192",
+  fopf: "\u{1D557}",
+  forall: "\u2200",
+  fork: "\u22D4",
+  forkv: "\u2AD9",
+  fpartint: "\u2A0D",
+  frac12: "\xBD",
+  frac13: "\u2153",
+  frac14: "\xBC",
+  frac15: "\u2155",
+  frac16: "\u2159",
+  frac18: "\u215B",
+  frac23: "\u2154",
+  frac25: "\u2156",
+  frac34: "\xBE",
+  frac35: "\u2157",
+  frac38: "\u215C",
+  frac45: "\u2158",
+  frac56: "\u215A",
+  frac58: "\u215D",
+  frac78: "\u215E",
+  frasl: "\u2044",
+  frown: "\u2322",
+  fscr: "\u{1D4BB}",
+  gE: "\u2267",
+  gEl: "\u2A8C",
+  gacute: "\u01F5",
+  gamma: "\u03B3",
+  gammad: "\u03DD",
+  gap: "\u2A86",
+  gbreve: "\u011F",
+  gcirc: "\u011D",
+  gcy: "\u0433",
+  gdot: "\u0121",
+  ge: "\u2265",
+  gel: "\u22DB",
+  geq: "\u2265",
+  geqq: "\u2267",
+  geqslant: "\u2A7E",
+  ges: "\u2A7E",
+  gescc: "\u2AA9",
+  gesdot: "\u2A80",
+  gesdoto: "\u2A82",
+  gesdotol: "\u2A84",
+  gesl: "\u22DB\uFE00",
+  gesles: "\u2A94",
+  gfr: "\u{1D524}",
+  gg: "\u226B",
+  ggg: "\u22D9",
+  gimel: "\u2137",
+  gjcy: "\u0453",
+  gl: "\u2277",
+  glE: "\u2A92",
+  gla: "\u2AA5",
+  glj: "\u2AA4",
+  gnE: "\u2269",
+  gnap: "\u2A8A",
+  gnapprox: "\u2A8A",
+  gne: "\u2A88",
+  gneq: "\u2A88",
+  gneqq: "\u2269",
+  gnsim: "\u22E7",
+  gopf: "\u{1D558}",
+  grave: "`",
+  gscr: "\u210A",
+  gsim: "\u2273",
+  gsime: "\u2A8E",
+  gsiml: "\u2A90",
+  gt: ">",
+  gtcc: "\u2AA7",
+  gtcir: "\u2A7A",
+  gtdot: "\u22D7",
+  gtlPar: "\u2995",
+  gtquest: "\u2A7C",
+  gtrapprox: "\u2A86",
+  gtrarr: "\u2978",
+  gtrdot: "\u22D7",
+  gtreqless: "\u22DB",
+  gtreqqless: "\u2A8C",
+  gtrless: "\u2277",
+  gtrsim: "\u2273",
+  gvertneqq: "\u2269\uFE00",
+  gvnE: "\u2269\uFE00",
+  hArr: "\u21D4",
+  hairsp: "\u200A",
+  half: "\xBD",
+  hamilt: "\u210B",
+  hardcy: "\u044A",
+  harr: "\u2194",
+  harrcir: "\u2948",
+  harrw: "\u21AD",
+  hbar: "\u210F",
+  hcirc: "\u0125",
+  hearts: "\u2665",
+  heartsuit: "\u2665",
+  hellip: "\u2026",
+  hercon: "\u22B9",
+  hfr: "\u{1D525}",
+  hksearow: "\u2925",
+  hkswarow: "\u2926",
+  hoarr: "\u21FF",
+  homtht: "\u223B",
+  hookleftarrow: "\u21A9",
+  hookrightarrow: "\u21AA",
+  hopf: "\u{1D559}",
+  horbar: "\u2015",
+  hscr: "\u{1D4BD}",
+  hslash: "\u210F",
+  hstrok: "\u0127",
+  hybull: "\u2043",
+  hyphen: "\u2010",
+  iacute: "\xED",
+  ic: "\u2063",
+  icirc: "\xEE",
+  icy: "\u0438",
+  iecy: "\u0435",
+  iexcl: "\xA1",
+  iff: "\u21D4",
+  ifr: "\u{1D526}",
+  igrave: "\xEC",
+  ii: "\u2148",
+  iiiint: "\u2A0C",
+  iiint: "\u222D",
+  iinfin: "\u29DC",
+  iiota: "\u2129",
+  ijlig: "\u0133",
+  imacr: "\u012B",
+  image: "\u2111",
+  imagline: "\u2110",
+  imagpart: "\u2111",
+  imath: "\u0131",
+  imof: "\u22B7",
+  imped: "\u01B5",
+  in: "\u2208",
+  incare: "\u2105",
+  infin: "\u221E",
+  infintie: "\u29DD",
+  inodot: "\u0131",
+  int: "\u222B",
+  intcal: "\u22BA",
+  integers: "\u2124",
+  intercal: "\u22BA",
+  intlarhk: "\u2A17",
+  intprod: "\u2A3C",
+  iocy: "\u0451",
+  iogon: "\u012F",
+  iopf: "\u{1D55A}",
+  iota: "\u03B9",
+  iprod: "\u2A3C",
+  iquest: "\xBF",
+  iscr: "\u{1D4BE}",
+  isin: "\u2208",
+  isinE: "\u22F9",
+  isindot: "\u22F5",
+  isins: "\u22F4",
+  isinsv: "\u22F3",
+  isinv: "\u2208",
+  it: "\u2062",
+  itilde: "\u0129",
+  iukcy: "\u0456",
+  iuml: "\xEF",
+  jcirc: "\u0135",
+  jcy: "\u0439",
+  jfr: "\u{1D527}",
+  jmath: "\u0237",
+  jopf: "\u{1D55B}",
+  jscr: "\u{1D4BF}",
+  jsercy: "\u0458",
+  jukcy: "\u0454",
+  kappa: "\u03BA",
+  kappav: "\u03F0",
+  kcedil: "\u0137",
+  kcy: "\u043A",
+  kfr: "\u{1D528}",
+  kgreen: "\u0138",
+  khcy: "\u0445",
+  kjcy: "\u045C",
+  kopf: "\u{1D55C}",
+  kscr: "\u{1D4C0}",
+  lAarr: "\u21DA",
+  lArr: "\u21D0",
+  lAtail: "\u291B",
+  lBarr: "\u290E",
+  lE: "\u2266",
+  lEg: "\u2A8B",
+  lHar: "\u2962",
+  lacute: "\u013A",
+  laemptyv: "\u29B4",
+  lagran: "\u2112",
+  lambda: "\u03BB",
+  lang: "\u27E8",
+  langd: "\u2991",
+  langle: "\u27E8",
+  lap: "\u2A85",
+  laquo: "\xAB",
+  larr: "\u2190",
+  larrb: "\u21E4",
+  larrbfs: "\u291F",
+  larrfs: "\u291D",
+  larrhk: "\u21A9",
+  larrlp: "\u21AB",
+  larrpl: "\u2939",
+  larrsim: "\u2973",
+  larrtl: "\u21A2",
+  lat: "\u2AAB",
+  latail: "\u2919",
+  late: "\u2AAD",
+  lates: "\u2AAD\uFE00",
+  lbarr: "\u290C",
+  lbbrk: "\u2772",
+  lbrace: "{",
+  lbrack: "[",
+  lbrke: "\u298B",
+  lbrksld: "\u298F",
+  lbrkslu: "\u298D",
+  lcaron: "\u013E",
+  lcedil: "\u013C",
+  lceil: "\u2308",
+  lcub: "{",
+  lcy: "\u043B",
+  ldca: "\u2936",
+  ldquo: "\u201C",
+  ldquor: "\u201E",
+  ldrdhar: "\u2967",
+  ldrushar: "\u294B",
+  ldsh: "\u21B2",
+  le: "\u2264",
+  leftarrow: "\u2190",
+  leftarrowtail: "\u21A2",
+  leftharpoondown: "\u21BD",
+  leftharpoonup: "\u21BC",
+  leftleftarrows: "\u21C7",
+  leftrightarrow: "\u2194",
+  leftrightarrows: "\u21C6",
+  leftrightharpoons: "\u21CB",
+  leftrightsquigarrow: "\u21AD",
+  leftthreetimes: "\u22CB",
+  leg: "\u22DA",
+  leq: "\u2264",
+  leqq: "\u2266",
+  leqslant: "\u2A7D",
+  les: "\u2A7D",
+  lescc: "\u2AA8",
+  lesdot: "\u2A7F",
+  lesdoto: "\u2A81",
+  lesdotor: "\u2A83",
+  lesg: "\u22DA\uFE00",
+  lesges: "\u2A93",
+  lessapprox: "\u2A85",
+  lessdot: "\u22D6",
+  lesseqgtr: "\u22DA",
+  lesseqqgtr: "\u2A8B",
+  lessgtr: "\u2276",
+  lesssim: "\u2272",
+  lfisht: "\u297C",
+  lfloor: "\u230A",
+  lfr: "\u{1D529}",
+  lg: "\u2276",
+  lgE: "\u2A91",
+  lhard: "\u21BD",
+  lharu: "\u21BC",
+  lharul: "\u296A",
+  lhblk: "\u2584",
+  ljcy: "\u0459",
+  ll: "\u226A",
+  llarr: "\u21C7",
+  llcorner: "\u231E",
+  llhard: "\u296B",
+  lltri: "\u25FA",
+  lmidot: "\u0140",
+  lmoust: "\u23B0",
+  lmoustache: "\u23B0",
+  lnE: "\u2268",
+  lnap: "\u2A89",
+  lnapprox: "\u2A89",
+  lne: "\u2A87",
+  lneq: "\u2A87",
+  lneqq: "\u2268",
+  lnsim: "\u22E6",
+  loang: "\u27EC",
+  loarr: "\u21FD",
+  lobrk: "\u27E6",
+  longleftarrow: "\u27F5",
+  longleftrightarrow: "\u27F7",
+  longmapsto: "\u27FC",
+  longrightarrow: "\u27F6",
+  looparrowleft: "\u21AB",
+  looparrowright: "\u21AC",
+  lopar: "\u2985",
+  lopf: "\u{1D55D}",
+  loplus: "\u2A2D",
+  lotimes: "\u2A34",
+  lowast: "\u2217",
+  lowbar: "_",
+  loz: "\u25CA",
+  lozenge: "\u25CA",
+  lozf: "\u29EB",
+  lpar: "(",
+  lparlt: "\u2993",
+  lrarr: "\u21C6",
+  lrcorner: "\u231F",
+  lrhar: "\u21CB",
+  lrhard: "\u296D",
+  lrm: "\u200E",
+  lrtri: "\u22BF",
+  lsaquo: "\u2039",
+  lscr: "\u{1D4C1}",
+  lsh: "\u21B0",
+  lsim: "\u2272",
+  lsime: "\u2A8D",
+  lsimg: "\u2A8F",
+  lsqb: "[",
+  lsquo: "\u2018",
+  lsquor: "\u201A",
+  lstrok: "\u0142",
+  lt: "<",
+  ltcc: "\u2AA6",
+  ltcir: "\u2A79",
+  ltdot: "\u22D6",
+  lthree: "\u22CB",
+  ltimes: "\u22C9",
+  ltlarr: "\u2976",
+  ltquest: "\u2A7B",
+  ltrPar: "\u2996",
+  ltri: "\u25C3",
+  ltrie: "\u22B4",
+  ltrif: "\u25C2",
+  lurdshar: "\u294A",
+  luruhar: "\u2966",
+  lvertneqq: "\u2268\uFE00",
+  lvnE: "\u2268\uFE00",
+  mDDot: "\u223A",
+  macr: "\xAF",
+  male: "\u2642",
+  malt: "\u2720",
+  maltese: "\u2720",
+  map: "\u21A6",
+  mapsto: "\u21A6",
+  mapstodown: "\u21A7",
+  mapstoleft: "\u21A4",
+  mapstoup: "\u21A5",
+  marker: "\u25AE",
+  mcomma: "\u2A29",
+  mcy: "\u043C",
+  mdash: "\u2014",
+  measuredangle: "\u2221",
+  mfr: "\u{1D52A}",
+  mho: "\u2127",
+  micro: "\xB5",
+  mid: "\u2223",
+  midast: "*",
+  midcir: "\u2AF0",
+  middot: "\xB7",
+  minus: "\u2212",
+  minusb: "\u229F",
+  minusd: "\u2238",
+  minusdu: "\u2A2A",
+  mlcp: "\u2ADB",
+  mldr: "\u2026",
+  mnplus: "\u2213",
+  models: "\u22A7",
+  mopf: "\u{1D55E}",
+  mp: "\u2213",
+  mscr: "\u{1D4C2}",
+  mstpos: "\u223E",
+  mu: "\u03BC",
+  multimap: "\u22B8",
+  mumap: "\u22B8",
+  nGg: "\u22D9\u0338",
+  nGt: "\u226B\u20D2",
+  nGtv: "\u226B\u0338",
+  nLeftarrow: "\u21CD",
+  nLeftrightarrow: "\u21CE",
+  nLl: "\u22D8\u0338",
+  nLt: "\u226A\u20D2",
+  nLtv: "\u226A\u0338",
+  nRightarrow: "\u21CF",
+  nVDash: "\u22AF",
+  nVdash: "\u22AE",
+  nabla: "\u2207",
+  nacute: "\u0144",
+  nang: "\u2220\u20D2",
+  nap: "\u2249",
+  napE: "\u2A70\u0338",
+  napid: "\u224B\u0338",
+  napos: "\u0149",
+  napprox: "\u2249",
+  natur: "\u266E",
+  natural: "\u266E",
+  naturals: "\u2115",
+  nbsp: "\xA0",
+  nbump: "\u224E\u0338",
+  nbumpe: "\u224F\u0338",
+  ncap: "\u2A43",
+  ncaron: "\u0148",
+  ncedil: "\u0146",
+  ncong: "\u2247",
+  ncongdot: "\u2A6D\u0338",
+  ncup: "\u2A42",
+  ncy: "\u043D",
+  ndash: "\u2013",
+  ne: "\u2260",
+  neArr: "\u21D7",
+  nearhk: "\u2924",
+  nearr: "\u2197",
+  nearrow: "\u2197",
+  nedot: "\u2250\u0338",
+  nequiv: "\u2262",
+  nesear: "\u2928",
+  nesim: "\u2242\u0338",
+  nexist: "\u2204",
+  nexists: "\u2204",
+  nfr: "\u{1D52B}",
+  ngE: "\u2267\u0338",
+  nge: "\u2271",
+  ngeq: "\u2271",
+  ngeqq: "\u2267\u0338",
+  ngeqslant: "\u2A7E\u0338",
+  nges: "\u2A7E\u0338",
+  ngsim: "\u2275",
+  ngt: "\u226F",
+  ngtr: "\u226F",
+  nhArr: "\u21CE",
+  nharr: "\u21AE",
+  nhpar: "\u2AF2",
+  ni: "\u220B",
+  nis: "\u22FC",
+  nisd: "\u22FA",
+  niv: "\u220B",
+  njcy: "\u045A",
+  nlArr: "\u21CD",
+  nlE: "\u2266\u0338",
+  nlarr: "\u219A",
+  nldr: "\u2025",
+  nle: "\u2270",
+  nleftarrow: "\u219A",
+  nleftrightarrow: "\u21AE",
+  nleq: "\u2270",
+  nleqq: "\u2266\u0338",
+  nleqslant: "\u2A7D\u0338",
+  nles: "\u2A7D\u0338",
+  nless: "\u226E",
+  nlsim: "\u2274",
+  nlt: "\u226E",
+  nltri: "\u22EA",
+  nltrie: "\u22EC",
+  nmid: "\u2224",
+  nopf: "\u{1D55F}",
+  not: "\xAC",
+  notin: "\u2209",
+  notinE: "\u22F9\u0338",
+  notindot: "\u22F5\u0338",
+  notinva: "\u2209",
+  notinvb: "\u22F7",
+  notinvc: "\u22F6",
+  notni: "\u220C",
+  notniva: "\u220C",
+  notnivb: "\u22FE",
+  notnivc: "\u22FD",
+  npar: "\u2226",
+  nparallel: "\u2226",
+  nparsl: "\u2AFD\u20E5",
+  npart: "\u2202\u0338",
+  npolint: "\u2A14",
+  npr: "\u2280",
+  nprcue: "\u22E0",
+  npre: "\u2AAF\u0338",
+  nprec: "\u2280",
+  npreceq: "\u2AAF\u0338",
+  nrArr: "\u21CF",
+  nrarr: "\u219B",
+  nrarrc: "\u2933\u0338",
+  nrarrw: "\u219D\u0338",
+  nrightarrow: "\u219B",
+  nrtri: "\u22EB",
+  nrtrie: "\u22ED",
+  nsc: "\u2281",
+  nsccue: "\u22E1",
+  nsce: "\u2AB0\u0338",
+  nscr: "\u{1D4C3}",
+  nshortmid: "\u2224",
+  nshortparallel: "\u2226",
+  nsim: "\u2241",
+  nsime: "\u2244",
+  nsimeq: "\u2244",
+  nsmid: "\u2224",
+  nspar: "\u2226",
+  nsqsube: "\u22E2",
+  nsqsupe: "\u22E3",
+  nsub: "\u2284",
+  nsubE: "\u2AC5\u0338",
+  nsube: "\u2288",
+  nsubset: "\u2282\u20D2",
+  nsubseteq: "\u2288",
+  nsubseteqq: "\u2AC5\u0338",
+  nsucc: "\u2281",
+  nsucceq: "\u2AB0\u0338",
+  nsup: "\u2285",
+  nsupE: "\u2AC6\u0338",
+  nsupe: "\u2289",
+  nsupset: "\u2283\u20D2",
+  nsupseteq: "\u2289",
+  nsupseteqq: "\u2AC6\u0338",
+  ntgl: "\u2279",
+  ntilde: "\xF1",
+  ntlg: "\u2278",
+  ntriangleleft: "\u22EA",
+  ntrianglelefteq: "\u22EC",
+  ntriangleright: "\u22EB",
+  ntrianglerighteq: "\u22ED",
+  nu: "\u03BD",
+  num: "#",
+  numero: "\u2116",
+  numsp: "\u2007",
+  nvDash: "\u22AD",
+  nvHarr: "\u2904",
+  nvap: "\u224D\u20D2",
+  nvdash: "\u22AC",
+  nvge: "\u2265\u20D2",
+  nvgt: ">\u20D2",
+  nvinfin: "\u29DE",
+  nvlArr: "\u2902",
+  nvle: "\u2264\u20D2",
+  nvlt: "<\u20D2",
+  nvltrie: "\u22B4\u20D2",
+  nvrArr: "\u2903",
+  nvrtrie: "\u22B5\u20D2",
+  nvsim: "\u223C\u20D2",
+  nwArr: "\u21D6",
+  nwarhk: "\u2923",
+  nwarr: "\u2196",
+  nwarrow: "\u2196",
+  nwnear: "\u2927",
+  oS: "\u24C8",
+  oacute: "\xF3",
+  oast: "\u229B",
+  ocir: "\u229A",
+  ocirc: "\xF4",
+  ocy: "\u043E",
+  odash: "\u229D",
+  odblac: "\u0151",
+  odiv: "\u2A38",
+  odot: "\u2299",
+  odsold: "\u29BC",
+  oelig: "\u0153",
+  ofcir: "\u29BF",
+  ofr: "\u{1D52C}",
+  ogon: "\u02DB",
+  ograve: "\xF2",
+  ogt: "\u29C1",
+  ohbar: "\u29B5",
+  ohm: "\u03A9",
+  oint: "\u222E",
+  olarr: "\u21BA",
+  olcir: "\u29BE",
+  olcross: "\u29BB",
+  oline: "\u203E",
+  olt: "\u29C0",
+  omacr: "\u014D",
+  omega: "\u03C9",
+  omicron: "\u03BF",
+  omid: "\u29B6",
+  ominus: "\u2296",
+  oopf: "\u{1D560}",
+  opar: "\u29B7",
+  operp: "\u29B9",
+  oplus: "\u2295",
+  or: "\u2228",
+  orarr: "\u21BB",
+  ord: "\u2A5D",
+  order: "\u2134",
+  orderof: "\u2134",
+  ordf: "\xAA",
+  ordm: "\xBA",
+  origof: "\u22B6",
+  oror: "\u2A56",
+  orslope: "\u2A57",
+  orv: "\u2A5B",
+  oscr: "\u2134",
+  oslash: "\xF8",
+  osol: "\u2298",
+  otilde: "\xF5",
+  otimes: "\u2297",
+  otimesas: "\u2A36",
+  ouml: "\xF6",
+  ovbar: "\u233D",
+  par: "\u2225",
+  para: "\xB6",
+  parallel: "\u2225",
+  parsim: "\u2AF3",
+  parsl: "\u2AFD",
+  part: "\u2202",
+  pcy: "\u043F",
+  percnt: "%",
+  period: ".",
+  permil: "\u2030",
+  perp: "\u22A5",
+  pertenk: "\u2031",
+  pfr: "\u{1D52D}",
+  phi: "\u03C6",
+  phiv: "\u03D5",
+  phmmat: "\u2133",
+  phone: "\u260E",
+  pi: "\u03C0",
+  pitchfork: "\u22D4",
+  piv: "\u03D6",
+  planck: "\u210F",
+  planckh: "\u210E",
+  plankv: "\u210F",
+  plus: "+",
+  plusacir: "\u2A23",
+  plusb: "\u229E",
+  pluscir: "\u2A22",
+  plusdo: "\u2214",
+  plusdu: "\u2A25",
+  pluse: "\u2A72",
+  plusmn: "\xB1",
+  plussim: "\u2A26",
+  plustwo: "\u2A27",
+  pm: "\xB1",
+  pointint: "\u2A15",
+  popf: "\u{1D561}",
+  pound: "\xA3",
+  pr: "\u227A",
+  prE: "\u2AB3",
+  prap: "\u2AB7",
+  prcue: "\u227C",
+  pre: "\u2AAF",
+  prec: "\u227A",
+  precapprox: "\u2AB7",
+  preccurlyeq: "\u227C",
+  preceq: "\u2AAF",
+  precnapprox: "\u2AB9",
+  precneqq: "\u2AB5",
+  precnsim: "\u22E8",
+  precsim: "\u227E",
+  prime: "\u2032",
+  primes: "\u2119",
+  prnE: "\u2AB5",
+  prnap: "\u2AB9",
+  prnsim: "\u22E8",
+  prod: "\u220F",
+  profalar: "\u232E",
+  profline: "\u2312",
+  profsurf: "\u2313",
+  prop: "\u221D",
+  propto: "\u221D",
+  prsim: "\u227E",
+  prurel: "\u22B0",
+  pscr: "\u{1D4C5}",
+  psi: "\u03C8",
+  puncsp: "\u2008",
+  qfr: "\u{1D52E}",
+  qint: "\u2A0C",
+  qopf: "\u{1D562}",
+  qprime: "\u2057",
+  qscr: "\u{1D4C6}",
+  quaternions: "\u210D",
+  quatint: "\u2A16",
+  quest: "?",
+  questeq: "\u225F",
+  quot: '"',
+  rAarr: "\u21DB",
+  rArr: "\u21D2",
+  rAtail: "\u291C",
+  rBarr: "\u290F",
+  rHar: "\u2964",
+  race: "\u223D\u0331",
+  racute: "\u0155",
+  radic: "\u221A",
+  raemptyv: "\u29B3",
+  rang: "\u27E9",
+  rangd: "\u2992",
+  range: "\u29A5",
+  rangle: "\u27E9",
+  raquo: "\xBB",
+  rarr: "\u2192",
+  rarrap: "\u2975",
+  rarrb: "\u21E5",
+  rarrbfs: "\u2920",
+  rarrc: "\u2933",
+  rarrfs: "\u291E",
+  rarrhk: "\u21AA",
+  rarrlp: "\u21AC",
+  rarrpl: "\u2945",
+  rarrsim: "\u2974",
+  rarrtl: "\u21A3",
+  rarrw: "\u219D",
+  ratail: "\u291A",
+  ratio: "\u2236",
+  rationals: "\u211A",
+  rbarr: "\u290D",
+  rbbrk: "\u2773",
+  rbrace: "}",
+  rbrack: "]",
+  rbrke: "\u298C",
+  rbrksld: "\u298E",
+  rbrkslu: "\u2990",
+  rcaron: "\u0159",
+  rcedil: "\u0157",
+  rceil: "\u2309",
+  rcub: "}",
+  rcy: "\u0440",
+  rdca: "\u2937",
+  rdldhar: "\u2969",
+  rdquo: "\u201D",
+  rdquor: "\u201D",
+  rdsh: "\u21B3",
+  real: "\u211C",
+  realine: "\u211B",
+  realpart: "\u211C",
+  reals: "\u211D",
+  rect: "\u25AD",
+  reg: "\xAE",
+  rfisht: "\u297D",
+  rfloor: "\u230B",
+  rfr: "\u{1D52F}",
+  rhard: "\u21C1",
+  rharu: "\u21C0",
+  rharul: "\u296C",
+  rho: "\u03C1",
+  rhov: "\u03F1",
+  rightarrow: "\u2192",
+  rightarrowtail: "\u21A3",
+  rightharpoondown: "\u21C1",
+  rightharpoonup: "\u21C0",
+  rightleftarrows: "\u21C4",
+  rightleftharpoons: "\u21CC",
+  rightrightarrows: "\u21C9",
+  rightsquigarrow: "\u219D",
+  rightthreetimes: "\u22CC",
+  ring: "\u02DA",
+  risingdotseq: "\u2253",
+  rlarr: "\u21C4",
+  rlhar: "\u21CC",
+  rlm: "\u200F",
+  rmoust: "\u23B1",
+  rmoustache: "\u23B1",
+  rnmid: "\u2AEE",
+  roang: "\u27ED",
+  roarr: "\u21FE",
+  robrk: "\u27E7",
+  ropar: "\u2986",
+  ropf: "\u{1D563}",
+  roplus: "\u2A2E",
+  rotimes: "\u2A35",
+  rpar: ")",
+  rpargt: "\u2994",
+  rppolint: "\u2A12",
+  rrarr: "\u21C9",
+  rsaquo: "\u203A",
+  rscr: "\u{1D4C7}",
+  rsh: "\u21B1",
+  rsqb: "]",
+  rsquo: "\u2019",
+  rsquor: "\u2019",
+  rthree: "\u22CC",
+  rtimes: "\u22CA",
+  rtri: "\u25B9",
+  rtrie: "\u22B5",
+  rtrif: "\u25B8",
+  rtriltri: "\u29CE",
+  ruluhar: "\u2968",
+  rx: "\u211E",
+  sacute: "\u015B",
+  sbquo: "\u201A",
+  sc: "\u227B",
+  scE: "\u2AB4",
+  scap: "\u2AB8",
+  scaron: "\u0161",
+  sccue: "\u227D",
+  sce: "\u2AB0",
+  scedil: "\u015F",
+  scirc: "\u015D",
+  scnE: "\u2AB6",
+  scnap: "\u2ABA",
+  scnsim: "\u22E9",
+  scpolint: "\u2A13",
+  scsim: "\u227F",
+  scy: "\u0441",
+  sdot: "\u22C5",
+  sdotb: "\u22A1",
+  sdote: "\u2A66",
+  seArr: "\u21D8",
+  searhk: "\u2925",
+  searr: "\u2198",
+  searrow: "\u2198",
+  sect: "\xA7",
+  semi: ";",
+  seswar: "\u2929",
+  setminus: "\u2216",
+  setmn: "\u2216",
+  sext: "\u2736",
+  sfr: "\u{1D530}",
+  sfrown: "\u2322",
+  sharp: "\u266F",
+  shchcy: "\u0449",
+  shcy: "\u0448",
+  shortmid: "\u2223",
+  shortparallel: "\u2225",
+  shy: "\xAD",
+  sigma: "\u03C3",
+  sigmaf: "\u03C2",
+  sigmav: "\u03C2",
+  sim: "\u223C",
+  simdot: "\u2A6A",
+  sime: "\u2243",
+  simeq: "\u2243",
+  simg: "\u2A9E",
+  simgE: "\u2AA0",
+  siml: "\u2A9D",
+  simlE: "\u2A9F",
+  simne: "\u2246",
+  simplus: "\u2A24",
+  simrarr: "\u2972",
+  slarr: "\u2190",
+  smallsetminus: "\u2216",
+  smashp: "\u2A33",
+  smeparsl: "\u29E4",
+  smid: "\u2223",
+  smile: "\u2323",
+  smt: "\u2AAA",
+  smte: "\u2AAC",
+  smtes: "\u2AAC\uFE00",
+  softcy: "\u044C",
+  sol: "/",
+  solb: "\u29C4",
+  solbar: "\u233F",
+  sopf: "\u{1D564}",
+  spades: "\u2660",
+  spadesuit: "\u2660",
+  spar: "\u2225",
+  sqcap: "\u2293",
+  sqcaps: "\u2293\uFE00",
+  sqcup: "\u2294",
+  sqcups: "\u2294\uFE00",
+  sqsub: "\u228F",
+  sqsube: "\u2291",
+  sqsubset: "\u228F",
+  sqsubseteq: "\u2291",
+  sqsup: "\u2290",
+  sqsupe: "\u2292",
+  sqsupset: "\u2290",
+  sqsupseteq: "\u2292",
+  squ: "\u25A1",
+  square: "\u25A1",
+  squarf: "\u25AA",
+  squf: "\u25AA",
+  srarr: "\u2192",
+  sscr: "\u{1D4C8}",
+  ssetmn: "\u2216",
+  ssmile: "\u2323",
+  sstarf: "\u22C6",
+  star: "\u2606",
+  starf: "\u2605",
+  straightepsilon: "\u03F5",
+  straightphi: "\u03D5",
+  strns: "\xAF",
+  sub: "\u2282",
+  subE: "\u2AC5",
+  subdot: "\u2ABD",
+  sube: "\u2286",
+  subedot: "\u2AC3",
+  submult: "\u2AC1",
+  subnE: "\u2ACB",
+  subne: "\u228A",
+  subplus: "\u2ABF",
+  subrarr: "\u2979",
+  subset: "\u2282",
+  subseteq: "\u2286",
+  subseteqq: "\u2AC5",
+  subsetneq: "\u228A",
+  subsetneqq: "\u2ACB",
+  subsim: "\u2AC7",
+  subsub: "\u2AD5",
+  subsup: "\u2AD3",
+  succ: "\u227B",
+  succapprox: "\u2AB8",
+  succcurlyeq: "\u227D",
+  succeq: "\u2AB0",
+  succnapprox: "\u2ABA",
+  succneqq: "\u2AB6",
+  succnsim: "\u22E9",
+  succsim: "\u227F",
+  sum: "\u2211",
+  sung: "\u266A",
+  sup1: "\xB9",
+  sup2: "\xB2",
+  sup3: "\xB3",
+  sup: "\u2283",
+  supE: "\u2AC6",
+  supdot: "\u2ABE",
+  supdsub: "\u2AD8",
+  supe: "\u2287",
+  supedot: "\u2AC4",
+  suphsol: "\u27C9",
+  suphsub: "\u2AD7",
+  suplarr: "\u297B",
+  supmult: "\u2AC2",
+  supnE: "\u2ACC",
+  supne: "\u228B",
+  supplus: "\u2AC0",
+  supset: "\u2283",
+  supseteq: "\u2287",
+  supseteqq: "\u2AC6",
+  supsetneq: "\u228B",
+  supsetneqq: "\u2ACC",
+  supsim: "\u2AC8",
+  supsub: "\u2AD4",
+  supsup: "\u2AD6",
+  swArr: "\u21D9",
+  swarhk: "\u2926",
+  swarr: "\u2199",
+  swarrow: "\u2199",
+  swnwar: "\u292A",
+  szlig: "\xDF",
+  target: "\u2316",
+  tau: "\u03C4",
+  tbrk: "\u23B4",
+  tcaron: "\u0165",
+  tcedil: "\u0163",
+  tcy: "\u0442",
+  tdot: "\u20DB",
+  telrec: "\u2315",
+  tfr: "\u{1D531}",
+  there4: "\u2234",
+  therefore: "\u2234",
+  theta: "\u03B8",
+  thetasym: "\u03D1",
+  thetav: "\u03D1",
+  thickapprox: "\u2248",
+  thicksim: "\u223C",
+  thinsp: "\u2009",
+  thkap: "\u2248",
+  thksim: "\u223C",
+  thorn: "\xFE",
+  tilde: "\u02DC",
+  times: "\xD7",
+  timesb: "\u22A0",
+  timesbar: "\u2A31",
+  timesd: "\u2A30",
+  tint: "\u222D",
+  toea: "\u2928",
+  top: "\u22A4",
+  topbot: "\u2336",
+  topcir: "\u2AF1",
+  topf: "\u{1D565}",
+  topfork: "\u2ADA",
+  tosa: "\u2929",
+  tprime: "\u2034",
+  trade: "\u2122",
+  triangle: "\u25B5",
+  triangledown: "\u25BF",
+  triangleleft: "\u25C3",
+  trianglelefteq: "\u22B4",
+  triangleq: "\u225C",
+  triangleright: "\u25B9",
+  trianglerighteq: "\u22B5",
+  tridot: "\u25EC",
+  trie: "\u225C",
+  triminus: "\u2A3A",
+  triplus: "\u2A39",
+  trisb: "\u29CD",
+  tritime: "\u2A3B",
+  trpezium: "\u23E2",
+  tscr: "\u{1D4C9}",
+  tscy: "\u0446",
+  tshcy: "\u045B",
+  tstrok: "\u0167",
+  twixt: "\u226C",
+  twoheadleftarrow: "\u219E",
+  twoheadrightarrow: "\u21A0",
+  uArr: "\u21D1",
+  uHar: "\u2963",
+  uacute: "\xFA",
+  uarr: "\u2191",
+  ubrcy: "\u045E",
+  ubreve: "\u016D",
+  ucirc: "\xFB",
+  ucy: "\u0443",
+  udarr: "\u21C5",
+  udblac: "\u0171",
+  udhar: "\u296E",
+  ufisht: "\u297E",
+  ufr: "\u{1D532}",
+  ugrave: "\xF9",
+  uharl: "\u21BF",
+  uharr: "\u21BE",
+  uhblk: "\u2580",
+  ulcorn: "\u231C",
+  ulcorner: "\u231C",
+  ulcrop: "\u230F",
+  ultri: "\u25F8",
+  umacr: "\u016B",
+  uml: "\xA8",
+  uogon: "\u0173",
+  uopf: "\u{1D566}",
+  uparrow: "\u2191",
+  updownarrow: "\u2195",
+  upharpoonleft: "\u21BF",
+  upharpoonright: "\u21BE",
+  uplus: "\u228E",
+  upsi: "\u03C5",
+  upsih: "\u03D2",
+  upsilon: "\u03C5",
+  upuparrows: "\u21C8",
+  urcorn: "\u231D",
+  urcorner: "\u231D",
+  urcrop: "\u230E",
+  uring: "\u016F",
+  urtri: "\u25F9",
+  uscr: "\u{1D4CA}",
+  utdot: "\u22F0",
+  utilde: "\u0169",
+  utri: "\u25B5",
+  utrif: "\u25B4",
+  uuarr: "\u21C8",
+  uuml: "\xFC",
+  uwangle: "\u29A7",
+  vArr: "\u21D5",
+  vBar: "\u2AE8",
+  vBarv: "\u2AE9",
+  vDash: "\u22A8",
+  vangrt: "\u299C",
+  varepsilon: "\u03F5",
+  varkappa: "\u03F0",
+  varnothing: "\u2205",
+  varphi: "\u03D5",
+  varpi: "\u03D6",
+  varpropto: "\u221D",
+  varr: "\u2195",
+  varrho: "\u03F1",
+  varsigma: "\u03C2",
+  varsubsetneq: "\u228A\uFE00",
+  varsubsetneqq: "\u2ACB\uFE00",
+  varsupsetneq: "\u228B\uFE00",
+  varsupsetneqq: "\u2ACC\uFE00",
+  vartheta: "\u03D1",
+  vartriangleleft: "\u22B2",
+  vartriangleright: "\u22B3",
+  vcy: "\u0432",
+  vdash: "\u22A2",
+  vee: "\u2228",
+  veebar: "\u22BB",
+  veeeq: "\u225A",
+  vellip: "\u22EE",
+  verbar: "|",
+  vert: "|",
+  vfr: "\u{1D533}",
+  vltri: "\u22B2",
+  vnsub: "\u2282\u20D2",
+  vnsup: "\u2283\u20D2",
+  vopf: "\u{1D567}",
+  vprop: "\u221D",
+  vrtri: "\u22B3",
+  vscr: "\u{1D4CB}",
+  vsubnE: "\u2ACB\uFE00",
+  vsubne: "\u228A\uFE00",
+  vsupnE: "\u2ACC\uFE00",
+  vsupne: "\u228B\uFE00",
+  vzigzag: "\u299A",
+  wcirc: "\u0175",
+  wedbar: "\u2A5F",
+  wedge: "\u2227",
+  wedgeq: "\u2259",
+  weierp: "\u2118",
+  wfr: "\u{1D534}",
+  wopf: "\u{1D568}",
+  wp: "\u2118",
+  wr: "\u2240",
+  wreath: "\u2240",
+  wscr: "\u{1D4CC}",
+  xcap: "\u22C2",
+  xcirc: "\u25EF",
+  xcup: "\u22C3",
+  xdtri: "\u25BD",
+  xfr: "\u{1D535}",
+  xhArr: "\u27FA",
+  xharr: "\u27F7",
+  xi: "\u03BE",
+  xlArr: "\u27F8",
+  xlarr: "\u27F5",
+  xmap: "\u27FC",
+  xnis: "\u22FB",
+  xodot: "\u2A00",
+  xopf: "\u{1D569}",
+  xoplus: "\u2A01",
+  xotime: "\u2A02",
+  xrArr: "\u27F9",
+  xrarr: "\u27F6",
+  xscr: "\u{1D4CD}",
+  xsqcup: "\u2A06",
+  xuplus: "\u2A04",
+  xutri: "\u25B3",
+  xvee: "\u22C1",
+  xwedge: "\u22C0",
+  yacute: "\xFD",
+  yacy: "\u044F",
+  ycirc: "\u0177",
+  ycy: "\u044B",
+  yen: "\xA5",
+  yfr: "\u{1D536}",
+  yicy: "\u0457",
+  yopf: "\u{1D56A}",
+  yscr: "\u{1D4CE}",
+  yucy: "\u044E",
+  yuml: "\xFF",
+  zacute: "\u017A",
+  zcaron: "\u017E",
+  zcy: "\u0437",
+  zdot: "\u017C",
+  zeetrf: "\u2128",
+  zeta: "\u03B6",
+  zfr: "\u{1D537}",
+  zhcy: "\u0436",
+  zigrarr: "\u21DD",
+  zopf: "\u{1D56B}",
+  zscr: "\u{1D4CF}",
+  zwj: "\u200D",
+  zwnj: "\u200C"
+};
+
+// node_modules/decode-named-character-reference/index.js
+var own2 = {}.hasOwnProperty;
+function decodeNamedCharacterReference(value) {
+  return own2.call(characterEntities, value) ? characterEntities[value] : false;
+}
+
+// node_modules/micromark-core-commonmark/lib/character-reference.js
+var characterReference = {
+  name: "characterReference",
+  tokenize: tokenizeCharacterReference
+};
+function tokenizeCharacterReference(effects, ok2, nok) {
+  const self = this;
+  let size = 0;
+  let max;
+  let test;
+  return start;
+  function start(code2) {
+    effects.enter("characterReference");
+    effects.enter("characterReferenceMarker");
+    effects.consume(code2);
+    effects.exit("characterReferenceMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 35) {
+      effects.enter("characterReferenceMarkerNumeric");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarkerNumeric");
+      return numeric;
+    }
+    effects.enter("characterReferenceValue");
+    max = 31;
+    test = asciiAlphanumeric;
+    return value(code2);
+  }
+  function numeric(code2) {
+    if (code2 === 88 || code2 === 120) {
+      effects.enter("characterReferenceMarkerHexadecimal");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarkerHexadecimal");
+      effects.enter("characterReferenceValue");
+      max = 6;
+      test = asciiHexDigit;
+      return value;
+    }
+    effects.enter("characterReferenceValue");
+    max = 7;
+    test = asciiDigit;
+    return value(code2);
+  }
+  function value(code2) {
+    let token;
+    if (code2 === 59 && size) {
+      token = effects.exit("characterReferenceValue");
+      if (test === asciiAlphanumeric && !decodeNamedCharacterReference(self.sliceSerialize(token))) {
+        return nok(code2);
+      }
+      effects.enter("characterReferenceMarker");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarker");
+      effects.exit("characterReference");
+      return ok2;
+    }
+    if (test(code2) && size++ < max) {
+      effects.consume(code2);
+      return value;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-fenced.js
+var codeFenced = {
+  name: "codeFenced",
+  tokenize: tokenizeCodeFenced,
+  concrete: true
+};
+function tokenizeCodeFenced(effects, ok2, nok) {
+  const self = this;
+  const closingFenceConstruct = {
+    tokenize: tokenizeClosingFence,
+    partial: true
+  };
+  const nonLazyLine = {
+    tokenize: tokenizeNonLazyLine,
+    partial: true
+  };
+  const tail = this.events[this.events.length - 1];
+  const initialPrefix = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  let sizeOpen = 0;
+  let marker;
+  return start;
+  function start(code2) {
+    effects.enter("codeFenced");
+    effects.enter("codeFencedFence");
+    effects.enter("codeFencedFenceSequence");
+    marker = code2;
+    return sequenceOpen(code2);
+  }
+  function sequenceOpen(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      sizeOpen++;
+      return sequenceOpen;
+    }
+    effects.exit("codeFencedFenceSequence");
+    return sizeOpen < 3 ? nok(code2) : factorySpace(effects, infoOpen, "whitespace")(code2);
+  }
+  function infoOpen(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return openAfter(code2);
+    }
+    effects.enter("codeFencedFenceInfo");
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return info(code2);
+  }
+  function info(code2) {
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      effects.exit("chunkString");
+      effects.exit("codeFencedFenceInfo");
+      return factorySpace(effects, infoAfter, "whitespace")(code2);
+    }
+    if (code2 === 96 && code2 === marker)
+      return nok(code2);
+    effects.consume(code2);
+    return info;
+  }
+  function infoAfter(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return openAfter(code2);
+    }
+    effects.enter("codeFencedFenceMeta");
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return meta(code2);
+  }
+  function meta(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("chunkString");
+      effects.exit("codeFencedFenceMeta");
+      return openAfter(code2);
+    }
+    if (code2 === 96 && code2 === marker)
+      return nok(code2);
+    effects.consume(code2);
+    return meta;
+  }
+  function openAfter(code2) {
+    effects.exit("codeFencedFence");
+    return self.interrupt ? ok2(code2) : contentStart(code2);
+  }
+  function contentStart(code2) {
+    if (code2 === null) {
+      return after(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.attempt(
+        nonLazyLine,
+        effects.attempt(
+          closingFenceConstruct,
+          after,
+          initialPrefix ? factorySpace(
+            effects,
+            contentStart,
+            "linePrefix",
+            initialPrefix + 1
+          ) : contentStart
+        ),
+        after
+      )(code2);
+    }
+    effects.enter("codeFlowValue");
+    return contentContinue(code2);
+  }
+  function contentContinue(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("codeFlowValue");
+      return contentStart(code2);
+    }
+    effects.consume(code2);
+    return contentContinue;
+  }
+  function after(code2) {
+    effects.exit("codeFenced");
+    return ok2(code2);
+  }
+  function tokenizeNonLazyLine(effects2, ok3, nok2) {
+    const self2 = this;
+    return start2;
+    function start2(code2) {
+      effects2.enter("lineEnding");
+      effects2.consume(code2);
+      effects2.exit("lineEnding");
+      return lineStart;
+    }
+    function lineStart(code2) {
+      return self2.parser.lazy[self2.now().line] ? nok2(code2) : ok3(code2);
+    }
+  }
+  function tokenizeClosingFence(effects2, ok3, nok2) {
+    let size = 0;
+    return factorySpace(
+      effects2,
+      closingSequenceStart,
+      "linePrefix",
+      this.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+    );
+    function closingSequenceStart(code2) {
+      effects2.enter("codeFencedFence");
+      effects2.enter("codeFencedFenceSequence");
+      return closingSequence(code2);
+    }
+    function closingSequence(code2) {
+      if (code2 === marker) {
+        effects2.consume(code2);
+        size++;
+        return closingSequence;
+      }
+      if (size < sizeOpen)
+        return nok2(code2);
+      effects2.exit("codeFencedFenceSequence");
+      return factorySpace(effects2, closingSequenceEnd, "whitespace")(code2);
+    }
+    function closingSequenceEnd(code2) {
+      if (code2 === null || markdownLineEnding(code2)) {
+        effects2.exit("codeFencedFence");
+        return ok3(code2);
+      }
+      return nok2(code2);
+    }
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-indented.js
+var codeIndented = {
+  name: "codeIndented",
+  tokenize: tokenizeCodeIndented
+};
+var indentedContent = {
+  tokenize: tokenizeIndentedContent,
+  partial: true
+};
+function tokenizeCodeIndented(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    effects.enter("codeIndented");
+    return factorySpace(effects, afterStartPrefix, "linePrefix", 4 + 1)(code2);
+  }
+  function afterStartPrefix(code2) {
+    const tail = self.events[self.events.length - 1];
+    return tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4 ? afterPrefix(code2) : nok(code2);
+  }
+  function afterPrefix(code2) {
+    if (code2 === null) {
+      return after(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.attempt(indentedContent, afterPrefix, after)(code2);
+    }
+    effects.enter("codeFlowValue");
+    return content3(code2);
+  }
+  function content3(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("codeFlowValue");
+      return afterPrefix(code2);
+    }
+    effects.consume(code2);
+    return content3;
+  }
+  function after(code2) {
+    effects.exit("codeIndented");
+    return ok2(code2);
+  }
+}
+function tokenizeIndentedContent(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    if (self.parser.lazy[self.now().line]) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return start;
+    }
+    return factorySpace(effects, afterPrefix, "linePrefix", 4 + 1)(code2);
+  }
+  function afterPrefix(code2) {
+    const tail = self.events[self.events.length - 1];
+    return tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4 ? ok2(code2) : markdownLineEnding(code2) ? start(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-text.js
+var codeText = {
+  name: "codeText",
+  tokenize: tokenizeCodeText,
+  resolve: resolveCodeText,
+  previous
+};
+function resolveCodeText(events) {
+  let tailExitIndex = events.length - 4;
+  let headEnterIndex = 3;
+  let index2;
+  let enter;
+  if ((events[headEnterIndex][1].type === "lineEnding" || events[headEnterIndex][1].type === "space") && (events[tailExitIndex][1].type === "lineEnding" || events[tailExitIndex][1].type === "space")) {
+    index2 = headEnterIndex;
+    while (++index2 < tailExitIndex) {
+      if (events[index2][1].type === "codeTextData") {
+        events[headEnterIndex][1].type = "codeTextPadding";
+        events[tailExitIndex][1].type = "codeTextPadding";
+        headEnterIndex += 2;
+        tailExitIndex -= 2;
+        break;
+      }
+    }
+  }
+  index2 = headEnterIndex - 1;
+  tailExitIndex++;
+  while (++index2 <= tailExitIndex) {
+    if (enter === void 0) {
+      if (index2 !== tailExitIndex && events[index2][1].type !== "lineEnding") {
+        enter = index2;
+      }
+    } else if (index2 === tailExitIndex || events[index2][1].type === "lineEnding") {
+      events[enter][1].type = "codeTextData";
+      if (index2 !== enter + 2) {
+        events[enter][1].end = events[index2 - 1][1].end;
+        events.splice(enter + 2, index2 - enter - 2);
+        tailExitIndex -= index2 - enter - 2;
+        index2 = enter + 2;
+      }
+      enter = void 0;
+    }
+  }
+  return events;
+}
+function previous(code2) {
+  return code2 !== 96 || this.events[this.events.length - 1][1].type === "characterEscape";
+}
+function tokenizeCodeText(effects, ok2, nok) {
+  const self = this;
+  let sizeOpen = 0;
+  let size;
+  let token;
+  return start;
+  function start(code2) {
+    effects.enter("codeText");
+    effects.enter("codeTextSequence");
+    return openingSequence(code2);
+  }
+  function openingSequence(code2) {
+    if (code2 === 96) {
+      effects.consume(code2);
+      sizeOpen++;
+      return openingSequence;
+    }
+    effects.exit("codeTextSequence");
+    return gap(code2);
+  }
+  function gap(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 96) {
+      token = effects.enter("codeTextSequence");
+      size = 0;
+      return closingSequence(code2);
+    }
+    if (code2 === 32) {
+      effects.enter("space");
+      effects.consume(code2);
+      effects.exit("space");
+      return gap;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return gap;
+    }
+    effects.enter("codeTextData");
+    return data(code2);
+  }
+  function data(code2) {
+    if (code2 === null || code2 === 32 || code2 === 96 || markdownLineEnding(code2)) {
+      effects.exit("codeTextData");
+      return gap(code2);
+    }
+    effects.consume(code2);
+    return data;
+  }
+  function closingSequence(code2) {
+    if (code2 === 96) {
+      effects.consume(code2);
+      size++;
+      return closingSequence;
+    }
+    if (size === sizeOpen) {
+      effects.exit("codeTextSequence");
+      effects.exit("codeText");
+      return ok2(code2);
+    }
+    token.type = "codeTextData";
+    return data(code2);
+  }
+}
+
+// node_modules/micromark-util-subtokenize/index.js
+function subtokenize(events) {
+  const jumps = {};
+  let index2 = -1;
+  let event;
+  let lineIndex;
+  let otherIndex;
+  let otherEvent;
+  let parameters;
+  let subevents;
+  let more;
+  while (++index2 < events.length) {
+    while (index2 in jumps) {
+      index2 = jumps[index2];
+    }
+    event = events[index2];
+    if (index2 && event[1].type === "chunkFlow" && events[index2 - 1][1].type === "listItemPrefix") {
+      subevents = event[1]._tokenizer.events;
+      otherIndex = 0;
+      if (otherIndex < subevents.length && subevents[otherIndex][1].type === "lineEndingBlank") {
+        otherIndex += 2;
+      }
+      if (otherIndex < subevents.length && subevents[otherIndex][1].type === "content") {
+        while (++otherIndex < subevents.length) {
+          if (subevents[otherIndex][1].type === "content") {
+            break;
+          }
+          if (subevents[otherIndex][1].type === "chunkText") {
+            subevents[otherIndex][1]._isInFirstContentOfListItem = true;
+            otherIndex++;
+          }
+        }
+      }
+    }
+    if (event[0] === "enter") {
+      if (event[1].contentType) {
+        Object.assign(jumps, subcontent(events, index2));
+        index2 = jumps[index2];
+        more = true;
+      }
+    } else if (event[1]._container) {
+      otherIndex = index2;
+      lineIndex = void 0;
+      while (otherIndex--) {
+        otherEvent = events[otherIndex];
+        if (otherEvent[1].type === "lineEnding" || otherEvent[1].type === "lineEndingBlank") {
+          if (otherEvent[0] === "enter") {
+            if (lineIndex) {
+              events[lineIndex][1].type = "lineEndingBlank";
+            }
+            otherEvent[1].type = "lineEnding";
+            lineIndex = otherIndex;
+          }
+        } else {
+          break;
+        }
+      }
+      if (lineIndex) {
+        event[1].end = Object.assign({}, events[lineIndex][1].start);
+        parameters = events.slice(lineIndex, index2);
+        parameters.unshift(event);
+        splice(events, lineIndex, index2 - lineIndex + 1, parameters);
+      }
+    }
+  }
+  return !more;
+}
+function subcontent(events, eventIndex) {
+  const token = events[eventIndex][1];
+  const context = events[eventIndex][2];
+  let startPosition = eventIndex - 1;
+  const startPositions = [];
+  const tokenizer = token._tokenizer || context.parser[token.contentType](token.start);
+  const childEvents = tokenizer.events;
+  const jumps = [];
+  const gaps = {};
+  let stream;
+  let previous2;
+  let index2 = -1;
+  let current = token;
+  let adjust = 0;
+  let start = 0;
+  const breaks = [start];
+  while (current) {
+    while (events[++startPosition][1] !== current) {
+    }
+    startPositions.push(startPosition);
+    if (!current._tokenizer) {
+      stream = context.sliceStream(current);
+      if (!current.next) {
+        stream.push(null);
+      }
+      if (previous2) {
+        tokenizer.defineSkip(current.start);
+      }
+      if (current._isInFirstContentOfListItem) {
+        tokenizer._gfmTasklistFirstContentOfListItem = true;
+      }
+      tokenizer.write(stream);
+      if (current._isInFirstContentOfListItem) {
+        tokenizer._gfmTasklistFirstContentOfListItem = void 0;
+      }
+    }
+    previous2 = current;
+    current = current.next;
+  }
+  current = token;
+  while (++index2 < childEvents.length) {
+    if (childEvents[index2][0] === "exit" && childEvents[index2 - 1][0] === "enter" && childEvents[index2][1].type === childEvents[index2 - 1][1].type && childEvents[index2][1].start.line !== childEvents[index2][1].end.line) {
+      start = index2 + 1;
+      breaks.push(start);
+      current._tokenizer = void 0;
+      current.previous = void 0;
+      current = current.next;
+    }
+  }
+  tokenizer.events = [];
+  if (current) {
+    current._tokenizer = void 0;
+    current.previous = void 0;
+  } else {
+    breaks.pop();
+  }
+  index2 = breaks.length;
+  while (index2--) {
+    const slice = childEvents.slice(breaks[index2], breaks[index2 + 1]);
+    const start2 = startPositions.pop();
+    jumps.unshift([start2, start2 + slice.length - 1]);
+    splice(events, start2, 2, slice);
+  }
+  index2 = -1;
+  while (++index2 < jumps.length) {
+    gaps[adjust + jumps[index2][0]] = adjust + jumps[index2][1];
+    adjust += jumps[index2][1] - jumps[index2][0] - 1;
+  }
+  return gaps;
+}
+
+// node_modules/micromark-core-commonmark/lib/content.js
+var content2 = {
+  tokenize: tokenizeContent,
+  resolve: resolveContent
+};
+var continuationConstruct = {
+  tokenize: tokenizeContinuation,
+  partial: true
+};
+function resolveContent(events) {
+  subtokenize(events);
+  return events;
+}
+function tokenizeContent(effects, ok2) {
+  let previous2;
+  return start;
+  function start(code2) {
+    effects.enter("content");
+    previous2 = effects.enter("chunkContent", {
+      contentType: "content"
+    });
+    return data(code2);
+  }
+  function data(code2) {
+    if (code2 === null) {
+      return contentEnd(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.check(
+        continuationConstruct,
+        contentContinue,
+        contentEnd
+      )(code2);
+    }
+    effects.consume(code2);
+    return data;
+  }
+  function contentEnd(code2) {
+    effects.exit("chunkContent");
+    effects.exit("content");
+    return ok2(code2);
+  }
+  function contentContinue(code2) {
+    effects.consume(code2);
+    effects.exit("chunkContent");
+    previous2.next = effects.enter("chunkContent", {
+      contentType: "content",
+      previous: previous2
+    });
+    previous2 = previous2.next;
+    return data;
+  }
+}
+function tokenizeContinuation(effects, ok2, nok) {
+  const self = this;
+  return startLookahead;
+  function startLookahead(code2) {
+    effects.exit("chunkContent");
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, prefixed, "linePrefix");
+  }
+  function prefixed(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    const tail = self.events[self.events.length - 1];
+    if (!self.parser.constructs.disable.null.includes("codeIndented") && tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4) {
+      return ok2(code2);
+    }
+    return effects.interrupt(self.parser.constructs.flow, nok, ok2)(code2);
+  }
+}
+
+// node_modules/micromark-factory-destination/index.js
+function factoryDestination(effects, ok2, nok, type, literalType, literalMarkerType, rawType, stringType, max) {
+  const limit = max || Number.POSITIVE_INFINITY;
+  let balance = 0;
+  return start;
+  function start(code2) {
+    if (code2 === 60) {
+      effects.enter(type);
+      effects.enter(literalType);
+      effects.enter(literalMarkerType);
+      effects.consume(code2);
+      effects.exit(literalMarkerType);
+      return destinationEnclosedBefore;
+    }
+    if (code2 === null || code2 === 41 || asciiControl(code2)) {
+      return nok(code2);
+    }
+    effects.enter(type);
+    effects.enter(rawType);
+    effects.enter(stringType);
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return destinationRaw(code2);
+  }
+  function destinationEnclosedBefore(code2) {
+    if (code2 === 62) {
+      effects.enter(literalMarkerType);
+      effects.consume(code2);
+      effects.exit(literalMarkerType);
+      effects.exit(literalType);
+      effects.exit(type);
+      return ok2;
+    }
+    effects.enter(stringType);
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return destinationEnclosed(code2);
+  }
+  function destinationEnclosed(code2) {
+    if (code2 === 62) {
+      effects.exit("chunkString");
+      effects.exit(stringType);
+      return destinationEnclosedBefore(code2);
+    }
+    if (code2 === null || code2 === 60 || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? destinationEnclosedEscape : destinationEnclosed;
+  }
+  function destinationEnclosedEscape(code2) {
+    if (code2 === 60 || code2 === 62 || code2 === 92) {
+      effects.consume(code2);
+      return destinationEnclosed;
+    }
+    return destinationEnclosed(code2);
+  }
+  function destinationRaw(code2) {
+    if (code2 === 40) {
+      if (++balance > limit)
+        return nok(code2);
+      effects.consume(code2);
+      return destinationRaw;
+    }
+    if (code2 === 41) {
+      if (!balance--) {
+        effects.exit("chunkString");
+        effects.exit(stringType);
+        effects.exit(rawType);
+        effects.exit(type);
+        return ok2(code2);
+      }
+      effects.consume(code2);
+      return destinationRaw;
+    }
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      if (balance)
+        return nok(code2);
+      effects.exit("chunkString");
+      effects.exit(stringType);
+      effects.exit(rawType);
+      effects.exit(type);
+      return ok2(code2);
+    }
+    if (asciiControl(code2))
+      return nok(code2);
+    effects.consume(code2);
+    return code2 === 92 ? destinationRawEscape : destinationRaw;
+  }
+  function destinationRawEscape(code2) {
+    if (code2 === 40 || code2 === 41 || code2 === 92) {
+      effects.consume(code2);
+      return destinationRaw;
+    }
+    return destinationRaw(code2);
+  }
+}
+
+// node_modules/micromark-factory-label/index.js
+function factoryLabel(effects, ok2, nok, type, markerType, stringType) {
+  const self = this;
+  let size = 0;
+  let data;
+  return start;
+  function start(code2) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    effects.enter(stringType);
+    return atBreak;
+  }
+  function atBreak(code2) {
+    if (code2 === null || code2 === 91 || code2 === 93 && !data || code2 === 94 && !size && "_hiddenFootnoteSupport" in self.parser.constructs || size > 999) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      effects.exit(stringType);
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok2;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return atBreak;
+    }
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return label(code2);
+  }
+  function label(code2) {
+    if (code2 === null || code2 === 91 || code2 === 93 || markdownLineEnding(code2) || size++ > 999) {
+      effects.exit("chunkString");
+      return atBreak(code2);
+    }
+    effects.consume(code2);
+    data = data || !markdownSpace(code2);
+    return code2 === 92 ? labelEscape : label;
+  }
+  function labelEscape(code2) {
+    if (code2 === 91 || code2 === 92 || code2 === 93) {
+      effects.consume(code2);
+      size++;
+      return label;
+    }
+    return label(code2);
+  }
+}
+
+// node_modules/micromark-factory-title/index.js
+function factoryTitle(effects, ok2, nok, type, markerType, stringType) {
+  let marker;
+  return start;
+  function start(code2) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    marker = code2 === 40 ? 41 : code2;
+    return atFirstTitleBreak;
+  }
+  function atFirstTitleBreak(code2) {
+    if (code2 === marker) {
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok2;
+    }
+    effects.enter(stringType);
+    return atTitleBreak(code2);
+  }
+  function atTitleBreak(code2) {
+    if (code2 === marker) {
+      effects.exit(stringType);
+      return atFirstTitleBreak(marker);
+    }
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return factorySpace(effects, atTitleBreak, "linePrefix");
+    }
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return title(code2);
+  }
+  function title(code2) {
+    if (code2 === marker || code2 === null || markdownLineEnding(code2)) {
+      effects.exit("chunkString");
+      return atTitleBreak(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? titleEscape : title;
+  }
+  function titleEscape(code2) {
+    if (code2 === marker || code2 === 92) {
+      effects.consume(code2);
+      return title;
+    }
+    return title(code2);
+  }
+}
+
+// node_modules/micromark-factory-whitespace/index.js
+function factoryWhitespace(effects, ok2) {
+  let seen;
+  return start;
+  function start(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      seen = true;
+      return start;
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(
+        effects,
+        start,
+        seen ? "linePrefix" : "lineSuffix"
+      )(code2);
+    }
+    return ok2(code2);
+  }
+}
+
+// node_modules/micromark-util-normalize-identifier/index.js
+function normalizeIdentifier(value) {
+  return value.replace(/[\t\n\r ]+/g, " ").replace(/^ | $/g, "").toLowerCase().toUpperCase();
+}
+
+// node_modules/micromark-core-commonmark/lib/definition.js
+var definition = {
+  name: "definition",
+  tokenize: tokenizeDefinition
+};
+var titleConstruct = {
+  tokenize: tokenizeTitle,
+  partial: true
+};
+function tokenizeDefinition(effects, ok2, nok) {
+  const self = this;
+  let identifier;
+  return start;
+  function start(code2) {
+    effects.enter("definition");
+    return factoryLabel.call(
+      self,
+      effects,
+      labelAfter,
+      nok,
+      "definitionLabel",
+      "definitionLabelMarker",
+      "definitionLabelString"
+    )(code2);
+  }
+  function labelAfter(code2) {
+    identifier = normalizeIdentifier(
+      self.sliceSerialize(self.events[self.events.length - 1][1]).slice(1, -1)
+    );
+    if (code2 === 58) {
+      effects.enter("definitionMarker");
+      effects.consume(code2);
+      effects.exit("definitionMarker");
+      return factoryWhitespace(
+        effects,
+        factoryDestination(
+          effects,
+          effects.attempt(
+            titleConstruct,
+            factorySpace(effects, after, "whitespace"),
+            factorySpace(effects, after, "whitespace")
+          ),
+          nok,
+          "definitionDestination",
+          "definitionDestinationLiteral",
+          "definitionDestinationLiteralMarker",
+          "definitionDestinationRaw",
+          "definitionDestinationString"
+        )
+      );
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("definition");
+      if (!self.parser.defined.includes(identifier)) {
+        self.parser.defined.push(identifier);
+      }
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+function tokenizeTitle(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, before)(code2) : nok(code2);
+  }
+  function before(code2) {
+    if (code2 === 34 || code2 === 39 || code2 === 40) {
+      return factoryTitle(
+        effects,
+        factorySpace(effects, after, "whitespace"),
+        nok,
+        "definitionTitle",
+        "definitionTitleMarker",
+        "definitionTitleString"
+      )(code2);
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return code2 === null || markdownLineEnding(code2) ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/hard-break-escape.js
+var hardBreakEscape = {
+  name: "hardBreakEscape",
+  tokenize: tokenizeHardBreakEscape
+};
+function tokenizeHardBreakEscape(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.enter("hardBreakEscape");
+    effects.enter("escapeMarker");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.exit("escapeMarker");
+      effects.exit("hardBreakEscape");
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/heading-atx.js
+var headingAtx = {
+  name: "headingAtx",
+  tokenize: tokenizeHeadingAtx,
+  resolve: resolveHeadingAtx
+};
+function resolveHeadingAtx(events, context) {
+  let contentEnd = events.length - 2;
+  let contentStart = 3;
+  let content3;
+  let text4;
+  if (events[contentStart][1].type === "whitespace") {
+    contentStart += 2;
+  }
+  if (contentEnd - 2 > contentStart && events[contentEnd][1].type === "whitespace") {
+    contentEnd -= 2;
+  }
+  if (events[contentEnd][1].type === "atxHeadingSequence" && (contentStart === contentEnd - 1 || contentEnd - 4 > contentStart && events[contentEnd - 2][1].type === "whitespace")) {
+    contentEnd -= contentStart + 1 === contentEnd ? 2 : 4;
+  }
+  if (contentEnd > contentStart) {
+    content3 = {
+      type: "atxHeadingText",
+      start: events[contentStart][1].start,
+      end: events[contentEnd][1].end
+    };
+    text4 = {
+      type: "chunkText",
+      start: events[contentStart][1].start,
+      end: events[contentEnd][1].end,
+      contentType: "text"
+    };
+    splice(events, contentStart, contentEnd - contentStart + 1, [
+      ["enter", content3, context],
+      ["enter", text4, context],
+      ["exit", text4, context],
+      ["exit", content3, context]
+    ]);
+  }
+  return events;
+}
+function tokenizeHeadingAtx(effects, ok2, nok) {
+  const self = this;
+  let size = 0;
+  return start;
+  function start(code2) {
+    effects.enter("atxHeading");
+    effects.enter("atxHeadingSequence");
+    return fenceOpenInside(code2);
+  }
+  function fenceOpenInside(code2) {
+    if (code2 === 35 && size++ < 6) {
+      effects.consume(code2);
+      return fenceOpenInside;
+    }
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      effects.exit("atxHeadingSequence");
+      return self.interrupt ? ok2(code2) : headingBreak(code2);
+    }
+    return nok(code2);
+  }
+  function headingBreak(code2) {
+    if (code2 === 35) {
+      effects.enter("atxHeadingSequence");
+      return sequence(code2);
+    }
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("atxHeading");
+      return ok2(code2);
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(effects, headingBreak, "whitespace")(code2);
+    }
+    effects.enter("atxHeadingText");
+    return data(code2);
+  }
+  function sequence(code2) {
+    if (code2 === 35) {
+      effects.consume(code2);
+      return sequence;
+    }
+    effects.exit("atxHeadingSequence");
+    return headingBreak(code2);
+  }
+  function data(code2) {
+    if (code2 === null || code2 === 35 || markdownLineEndingOrSpace(code2)) {
+      effects.exit("atxHeadingText");
+      return headingBreak(code2);
+    }
+    effects.consume(code2);
+    return data;
+  }
+}
+
+// node_modules/micromark-util-html-tag-name/index.js
+var htmlBlockNames = [
+  "address",
+  "article",
+  "aside",
+  "base",
+  "basefont",
+  "blockquote",
+  "body",
+  "caption",
+  "center",
+  "col",
+  "colgroup",
+  "dd",
+  "details",
+  "dialog",
+  "dir",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hr",
+  "html",
+  "iframe",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "menu",
+  "menuitem",
+  "nav",
+  "noframes",
+  "ol",
+  "optgroup",
+  "option",
+  "p",
+  "param",
+  "section",
+  "summary",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "title",
+  "tr",
+  "track",
+  "ul"
+];
+var htmlRawNames = ["pre", "script", "style", "textarea"];
+
+// node_modules/micromark-core-commonmark/lib/html-flow.js
+var htmlFlow = {
+  name: "htmlFlow",
+  tokenize: tokenizeHtmlFlow,
+  resolveTo: resolveToHtmlFlow,
+  concrete: true
+};
+var nextBlankConstruct = {
+  tokenize: tokenizeNextBlank,
+  partial: true
+};
+function resolveToHtmlFlow(events) {
+  let index2 = events.length;
+  while (index2--) {
+    if (events[index2][0] === "enter" && events[index2][1].type === "htmlFlow") {
+      break;
+    }
+  }
+  if (index2 > 1 && events[index2 - 2][1].type === "linePrefix") {
+    events[index2][1].start = events[index2 - 2][1].start;
+    events[index2 + 1][1].start = events[index2 - 2][1].start;
+    events.splice(index2 - 2, 2);
+  }
+  return events;
+}
+function tokenizeHtmlFlow(effects, ok2, nok) {
+  const self = this;
+  let kind;
+  let startTag;
+  let buffer2;
+  let index2;
+  let marker;
+  return start;
+  function start(code2) {
+    effects.enter("htmlFlow");
+    effects.enter("htmlFlowData");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 33) {
+      effects.consume(code2);
+      return declarationStart;
+    }
+    if (code2 === 47) {
+      effects.consume(code2);
+      return tagCloseStart;
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      kind = 3;
+      return self.interrupt ? ok2 : continuationDeclarationInside;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      buffer2 = String.fromCharCode(code2);
+      startTag = true;
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function declarationStart(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      kind = 2;
+      return commentOpenInside;
+    }
+    if (code2 === 91) {
+      effects.consume(code2);
+      kind = 5;
+      buffer2 = "CDATA[";
+      index2 = 0;
+      return cdataOpenInside;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      kind = 4;
+      return self.interrupt ? ok2 : continuationDeclarationInside;
+    }
+    return nok(code2);
+  }
+  function commentOpenInside(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return self.interrupt ? ok2 : continuationDeclarationInside;
+    }
+    return nok(code2);
+  }
+  function cdataOpenInside(code2) {
+    if (code2 === buffer2.charCodeAt(index2++)) {
+      effects.consume(code2);
+      return index2 === buffer2.length ? self.interrupt ? ok2 : continuation : cdataOpenInside;
+    }
+    return nok(code2);
+  }
+  function tagCloseStart(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      buffer2 = String.fromCharCode(code2);
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function tagName(code2) {
+    if (code2 === null || code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      if (code2 !== 47 && startTag && htmlRawNames.includes(buffer2.toLowerCase())) {
+        kind = 1;
+        return self.interrupt ? ok2(code2) : continuation(code2);
+      }
+      if (htmlBlockNames.includes(buffer2.toLowerCase())) {
+        kind = 6;
+        if (code2 === 47) {
+          effects.consume(code2);
+          return basicSelfClosing;
+        }
+        return self.interrupt ? ok2(code2) : continuation(code2);
+      }
+      kind = 7;
+      return self.interrupt && !self.parser.lazy[self.now().line] ? nok(code2) : startTag ? completeAttributeNameBefore(code2) : completeClosingTagAfter(code2);
+    }
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      buffer2 += String.fromCharCode(code2);
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function basicSelfClosing(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return self.interrupt ? ok2 : continuation;
+    }
+    return nok(code2);
+  }
+  function completeClosingTagAfter(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeClosingTagAfter;
+    }
+    return completeEnd(code2);
+  }
+  function completeAttributeNameBefore(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return completeEnd;
+    }
+    if (code2 === 58 || code2 === 95 || asciiAlpha(code2)) {
+      effects.consume(code2);
+      return completeAttributeName;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeNameBefore;
+    }
+    return completeEnd(code2);
+  }
+  function completeAttributeName(code2) {
+    if (code2 === 45 || code2 === 46 || code2 === 58 || code2 === 95 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return completeAttributeName;
+    }
+    return completeAttributeNameAfter(code2);
+  }
+  function completeAttributeNameAfter(code2) {
+    if (code2 === 61) {
+      effects.consume(code2);
+      return completeAttributeValueBefore;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeNameAfter;
+    }
+    return completeAttributeNameBefore(code2);
+  }
+  function completeAttributeValueBefore(code2) {
+    if (code2 === null || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 34 || code2 === 39) {
+      effects.consume(code2);
+      marker = code2;
+      return completeAttributeValueQuoted;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeValueBefore;
+    }
+    marker = null;
+    return completeAttributeValueUnquoted(code2);
+  }
+  function completeAttributeValueQuoted(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    if (code2 === marker) {
+      effects.consume(code2);
+      return completeAttributeValueQuotedAfter;
+    }
+    effects.consume(code2);
+    return completeAttributeValueQuoted;
+  }
+  function completeAttributeValueUnquoted(code2) {
+    if (code2 === null || code2 === 34 || code2 === 39 || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96 || markdownLineEndingOrSpace(code2)) {
+      return completeAttributeNameAfter(code2);
+    }
+    effects.consume(code2);
+    return completeAttributeValueUnquoted;
+  }
+  function completeAttributeValueQuotedAfter(code2) {
+    if (code2 === 47 || code2 === 62 || markdownSpace(code2)) {
+      return completeAttributeNameBefore(code2);
+    }
+    return nok(code2);
+  }
+  function completeEnd(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return completeAfter;
+    }
+    return nok(code2);
+  }
+  function completeAfter(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAfter;
+    }
+    return code2 === null || markdownLineEnding(code2) ? continuation(code2) : nok(code2);
+  }
+  function continuation(code2) {
+    if (code2 === 45 && kind === 2) {
+      effects.consume(code2);
+      return continuationCommentInside;
+    }
+    if (code2 === 60 && kind === 1) {
+      effects.consume(code2);
+      return continuationRawTagOpen;
+    }
+    if (code2 === 62 && kind === 4) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (code2 === 63 && kind === 3) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    if (code2 === 93 && kind === 5) {
+      effects.consume(code2);
+      return continuationCharacterDataInside;
+    }
+    if (markdownLineEnding(code2) && (kind === 6 || kind === 7)) {
+      return effects.check(
+        nextBlankConstruct,
+        continuationClose,
+        continuationAtLineEnding
+      )(code2);
+    }
+    if (code2 === null || markdownLineEnding(code2)) {
+      return continuationAtLineEnding(code2);
+    }
+    effects.consume(code2);
+    return continuation;
+  }
+  function continuationAtLineEnding(code2) {
+    effects.exit("htmlFlowData");
+    return htmlContinueStart(code2);
+  }
+  function htmlContinueStart(code2) {
+    if (code2 === null) {
+      return done(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.attempt(
+        {
+          tokenize: htmlLineEnd,
+          partial: true
+        },
+        htmlContinueStart,
+        done
+      )(code2);
+    }
+    effects.enter("htmlFlowData");
+    return continuation(code2);
+  }
+  function htmlLineEnd(effects2, ok3, nok2) {
+    return start2;
+    function start2(code2) {
+      effects2.enter("lineEnding");
+      effects2.consume(code2);
+      effects2.exit("lineEnding");
+      return lineStart;
+    }
+    function lineStart(code2) {
+      return self.parser.lazy[self.now().line] ? nok2(code2) : ok3(code2);
+    }
+  }
+  function continuationCommentInside(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationRawTagOpen(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      buffer2 = "";
+      return continuationRawEndTag;
+    }
+    return continuation(code2);
+  }
+  function continuationRawEndTag(code2) {
+    if (code2 === 62 && htmlRawNames.includes(buffer2.toLowerCase())) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (asciiAlpha(code2) && buffer2.length < 8) {
+      effects.consume(code2);
+      buffer2 += String.fromCharCode(code2);
+      return continuationRawEndTag;
+    }
+    return continuation(code2);
+  }
+  function continuationCharacterDataInside(code2) {
+    if (code2 === 93) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationDeclarationInside(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (code2 === 45 && kind === 2) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationClose(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("htmlFlowData");
+      return done(code2);
+    }
+    effects.consume(code2);
+    return continuationClose;
+  }
+  function done(code2) {
+    effects.exit("htmlFlow");
+    return ok2(code2);
+  }
+}
+function tokenizeNextBlank(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.exit("htmlFlowData");
+    effects.enter("lineEndingBlank");
+    effects.consume(code2);
+    effects.exit("lineEndingBlank");
+    return effects.attempt(blankLine, ok2, nok);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/html-text.js
+var htmlText = {
+  name: "htmlText",
+  tokenize: tokenizeHtmlText
+};
+function tokenizeHtmlText(effects, ok2, nok) {
+  const self = this;
+  let marker;
+  let buffer2;
+  let index2;
+  let returnState;
+  return start;
+  function start(code2) {
+    effects.enter("htmlText");
+    effects.enter("htmlTextData");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 33) {
+      effects.consume(code2);
+      return declarationOpen;
+    }
+    if (code2 === 47) {
+      effects.consume(code2);
+      return tagCloseStart;
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      return instruction;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagOpen;
+    }
+    return nok(code2);
+  }
+  function declarationOpen(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentOpen;
+    }
+    if (code2 === 91) {
+      effects.consume(code2);
+      buffer2 = "CDATA[";
+      index2 = 0;
+      return cdataOpen;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return declaration;
+    }
+    return nok(code2);
+  }
+  function commentOpen(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentStart;
+    }
+    return nok(code2);
+  }
+  function commentStart(code2) {
+    if (code2 === null || code2 === 62) {
+      return nok(code2);
+    }
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentStartDash;
+    }
+    return comment(code2);
+  }
+  function commentStartDash(code2) {
+    if (code2 === null || code2 === 62) {
+      return nok(code2);
+    }
+    return comment(code2);
+  }
+  function comment(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = comment;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return comment;
+  }
+  function commentClose(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return end;
+    }
+    return comment(code2);
+  }
+  function cdataOpen(code2) {
+    if (code2 === buffer2.charCodeAt(index2++)) {
+      effects.consume(code2);
+      return index2 === buffer2.length ? cdata : cdataOpen;
+    }
+    return nok(code2);
+  }
+  function cdata(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = cdata;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return cdata;
+  }
+  function cdataClose(code2) {
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataEnd;
+    }
+    return cdata(code2);
+  }
+  function cdataEnd(code2) {
+    if (code2 === 62) {
+      return end(code2);
+    }
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataEnd;
+    }
+    return cdata(code2);
+  }
+  function declaration(code2) {
+    if (code2 === null || code2 === 62) {
+      return end(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = declaration;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return declaration;
+  }
+  function instruction(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      return instructionClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = instruction;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return instruction;
+  }
+  function instructionClose(code2) {
+    return code2 === 62 ? end(code2) : instruction(code2);
+  }
+  function tagCloseStart(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagClose;
+    }
+    return nok(code2);
+  }
+  function tagClose(code2) {
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagClose;
+    }
+    return tagCloseBetween(code2);
+  }
+  function tagCloseBetween(code2) {
+    if (markdownLineEnding(code2)) {
+      returnState = tagCloseBetween;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagCloseBetween;
+    }
+    return end(code2);
+  }
+  function tagOpen(code2) {
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagOpen;
+    }
+    if (code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    return nok(code2);
+  }
+  function tagOpenBetween(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return end;
+    }
+    if (code2 === 58 || code2 === 95 || asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeName;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenBetween;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenBetween;
+    }
+    return end(code2);
+  }
+  function tagOpenAttributeName(code2) {
+    if (code2 === 45 || code2 === 46 || code2 === 58 || code2 === 95 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeName;
+    }
+    return tagOpenAttributeNameAfter(code2);
+  }
+  function tagOpenAttributeNameAfter(code2) {
+    if (code2 === 61) {
+      effects.consume(code2);
+      return tagOpenAttributeValueBefore;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeNameAfter;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeNameAfter;
+    }
+    return tagOpenBetween(code2);
+  }
+  function tagOpenAttributeValueBefore(code2) {
+    if (code2 === null || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 34 || code2 === 39) {
+      effects.consume(code2);
+      marker = code2;
+      return tagOpenAttributeValueQuoted;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeValueBefore;
+      return atLineEnding(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeValueBefore;
+    }
+    effects.consume(code2);
+    marker = void 0;
+    return tagOpenAttributeValueUnquoted;
+  }
+  function tagOpenAttributeValueQuoted(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return tagOpenAttributeValueQuotedAfter;
+    }
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeValueQuoted;
+      return atLineEnding(code2);
+    }
+    effects.consume(code2);
+    return tagOpenAttributeValueQuoted;
+  }
+  function tagOpenAttributeValueQuotedAfter(code2) {
+    if (code2 === 62 || code2 === 47 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    return nok(code2);
+  }
+  function tagOpenAttributeValueUnquoted(code2) {
+    if (code2 === null || code2 === 34 || code2 === 39 || code2 === 60 || code2 === 61 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    effects.consume(code2);
+    return tagOpenAttributeValueUnquoted;
+  }
+  function atLineEnding(code2) {
+    effects.exit("htmlTextData");
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(
+      effects,
+      afterPrefix,
+      "linePrefix",
+      self.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+    );
+  }
+  function afterPrefix(code2) {
+    effects.enter("htmlTextData");
+    return returnState(code2);
+  }
+  function end(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      effects.exit("htmlTextData");
+      effects.exit("htmlText");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-end.js
+var labelEnd = {
+  name: "labelEnd",
+  tokenize: tokenizeLabelEnd,
+  resolveTo: resolveToLabelEnd,
+  resolveAll: resolveAllLabelEnd
+};
+var resourceConstruct = {
+  tokenize: tokenizeResource
+};
+var fullReferenceConstruct = {
+  tokenize: tokenizeFullReference
+};
+var collapsedReferenceConstruct = {
+  tokenize: tokenizeCollapsedReference
+};
+function resolveAllLabelEnd(events) {
+  let index2 = -1;
+  let token;
+  while (++index2 < events.length) {
+    token = events[index2][1];
+    if (token.type === "labelImage" || token.type === "labelLink" || token.type === "labelEnd") {
+      events.splice(index2 + 1, token.type === "labelImage" ? 4 : 2);
+      token.type = "data";
+      index2++;
+    }
+  }
+  return events;
+}
+function resolveToLabelEnd(events, context) {
+  let index2 = events.length;
+  let offset = 0;
+  let token;
+  let open;
+  let close;
+  let media;
+  while (index2--) {
+    token = events[index2][1];
+    if (open) {
+      if (token.type === "link" || token.type === "labelLink" && token._inactive) {
+        break;
+      }
+      if (events[index2][0] === "enter" && token.type === "labelLink") {
+        token._inactive = true;
+      }
+    } else if (close) {
+      if (events[index2][0] === "enter" && (token.type === "labelImage" || token.type === "labelLink") && !token._balanced) {
+        open = index2;
+        if (token.type !== "labelLink") {
+          offset = 2;
+          break;
+        }
+      }
+    } else if (token.type === "labelEnd") {
+      close = index2;
+    }
+  }
+  const group = {
+    type: events[open][1].type === "labelLink" ? "link" : "image",
+    start: Object.assign({}, events[open][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  const label = {
+    type: "label",
+    start: Object.assign({}, events[open][1].start),
+    end: Object.assign({}, events[close][1].end)
+  };
+  const text4 = {
+    type: "labelText",
+    start: Object.assign({}, events[open + offset + 2][1].end),
+    end: Object.assign({}, events[close - 2][1].start)
+  };
+  media = [
+    ["enter", group, context],
+    ["enter", label, context]
+  ];
+  media = push(media, events.slice(open + 1, open + offset + 3));
+  media = push(media, [["enter", text4, context]]);
+  media = push(
+    media,
+    resolveAll(
+      context.parser.constructs.insideSpan.null,
+      events.slice(open + offset + 4, close - 3),
+      context
+    )
+  );
+  media = push(media, [
+    ["exit", text4, context],
+    events[close - 2],
+    events[close - 1],
+    ["exit", label, context]
+  ]);
+  media = push(media, events.slice(close + 1));
+  media = push(media, [["exit", group, context]]);
+  splice(events, open, events.length, media);
+  return events;
+}
+function tokenizeLabelEnd(effects, ok2, nok) {
+  const self = this;
+  let index2 = self.events.length;
+  let labelStart;
+  let defined;
+  while (index2--) {
+    if ((self.events[index2][1].type === "labelImage" || self.events[index2][1].type === "labelLink") && !self.events[index2][1]._balanced) {
+      labelStart = self.events[index2][1];
+      break;
+    }
+  }
+  return start;
+  function start(code2) {
+    if (!labelStart) {
+      return nok(code2);
+    }
+    if (labelStart._inactive)
+      return balanced(code2);
+    defined = self.parser.defined.includes(
+      normalizeIdentifier(
+        self.sliceSerialize({
+          start: labelStart.end,
+          end: self.now()
+        })
+      )
+    );
+    effects.enter("labelEnd");
+    effects.enter("labelMarker");
+    effects.consume(code2);
+    effects.exit("labelMarker");
+    effects.exit("labelEnd");
+    return afterLabelEnd;
+  }
+  function afterLabelEnd(code2) {
+    if (code2 === 40) {
+      return effects.attempt(
+        resourceConstruct,
+        ok2,
+        defined ? ok2 : balanced
+      )(code2);
+    }
+    if (code2 === 91) {
+      return effects.attempt(
+        fullReferenceConstruct,
+        ok2,
+        defined ? effects.attempt(collapsedReferenceConstruct, ok2, balanced) : balanced
+      )(code2);
+    }
+    return defined ? ok2(code2) : balanced(code2);
+  }
+  function balanced(code2) {
+    labelStart._balanced = true;
+    return nok(code2);
+  }
+}
+function tokenizeResource(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.enter("resource");
+    effects.enter("resourceMarker");
+    effects.consume(code2);
+    effects.exit("resourceMarker");
+    return factoryWhitespace(effects, open);
+  }
+  function open(code2) {
+    if (code2 === 41) {
+      return end(code2);
+    }
+    return factoryDestination(
+      effects,
+      destinationAfter,
+      nok,
+      "resourceDestination",
+      "resourceDestinationLiteral",
+      "resourceDestinationLiteralMarker",
+      "resourceDestinationRaw",
+      "resourceDestinationString",
+      32
+    )(code2);
+  }
+  function destinationAfter(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, between)(code2) : end(code2);
+  }
+  function between(code2) {
+    if (code2 === 34 || code2 === 39 || code2 === 40) {
+      return factoryTitle(
+        effects,
+        factoryWhitespace(effects, end),
+        nok,
+        "resourceTitle",
+        "resourceTitleMarker",
+        "resourceTitleString"
+      )(code2);
+    }
+    return end(code2);
+  }
+  function end(code2) {
+    if (code2 === 41) {
+      effects.enter("resourceMarker");
+      effects.consume(code2);
+      effects.exit("resourceMarker");
+      effects.exit("resource");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+function tokenizeFullReference(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    return factoryLabel.call(
+      self,
+      effects,
+      afterLabel,
+      nok,
+      "reference",
+      "referenceMarker",
+      "referenceString"
+    )(code2);
+  }
+  function afterLabel(code2) {
+    return self.parser.defined.includes(
+      normalizeIdentifier(
+        self.sliceSerialize(self.events[self.events.length - 1][1]).slice(1, -1)
+      )
+    ) ? ok2(code2) : nok(code2);
+  }
+}
+function tokenizeCollapsedReference(effects, ok2, nok) {
+  return start;
+  function start(code2) {
+    effects.enter("reference");
+    effects.enter("referenceMarker");
+    effects.consume(code2);
+    effects.exit("referenceMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 93) {
+      effects.enter("referenceMarker");
+      effects.consume(code2);
+      effects.exit("referenceMarker");
+      effects.exit("reference");
+      return ok2;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-start-image.js
+var labelStartImage = {
+  name: "labelStartImage",
+  tokenize: tokenizeLabelStartImage,
+  resolveAll: labelEnd.resolveAll
+};
+function tokenizeLabelStartImage(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    effects.enter("labelImage");
+    effects.enter("labelImageMarker");
+    effects.consume(code2);
+    effects.exit("labelImageMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 91) {
+      effects.enter("labelMarker");
+      effects.consume(code2);
+      effects.exit("labelMarker");
+      effects.exit("labelImage");
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return code2 === 94 && "_hiddenFootnoteSupport" in self.parser.constructs ? nok(code2) : ok2(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-start-link.js
+var labelStartLink = {
+  name: "labelStartLink",
+  tokenize: tokenizeLabelStartLink,
+  resolveAll: labelEnd.resolveAll
+};
+function tokenizeLabelStartLink(effects, ok2, nok) {
+  const self = this;
+  return start;
+  function start(code2) {
+    effects.enter("labelLink");
+    effects.enter("labelMarker");
+    effects.consume(code2);
+    effects.exit("labelMarker");
+    effects.exit("labelLink");
+    return after;
+  }
+  function after(code2) {
+    return code2 === 94 && "_hiddenFootnoteSupport" in self.parser.constructs ? nok(code2) : ok2(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/line-ending.js
+var lineEnding = {
+  name: "lineEnding",
+  tokenize: tokenizeLineEnding
+};
+function tokenizeLineEnding(effects, ok2) {
+  return start;
+  function start(code2) {
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, ok2, "linePrefix");
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/thematic-break.js
+var thematicBreak = {
+  name: "thematicBreak",
+  tokenize: tokenizeThematicBreak
+};
+function tokenizeThematicBreak(effects, ok2, nok) {
+  let size = 0;
+  let marker;
+  return start;
+  function start(code2) {
+    effects.enter("thematicBreak");
+    marker = code2;
+    return atBreak(code2);
+  }
+  function atBreak(code2) {
+    if (code2 === marker) {
+      effects.enter("thematicBreakSequence");
+      return sequence(code2);
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(effects, atBreak, "whitespace")(code2);
+    }
+    if (size < 3 || code2 !== null && !markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    effects.exit("thematicBreak");
+    return ok2(code2);
+  }
+  function sequence(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      size++;
+      return sequence;
+    }
+    effects.exit("thematicBreakSequence");
+    return atBreak(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/list.js
+var list = {
+  name: "list",
+  tokenize: tokenizeListStart,
+  continuation: {
+    tokenize: tokenizeListContinuation
+  },
+  exit: tokenizeListEnd
+};
+var listItemPrefixWhitespaceConstruct = {
+  tokenize: tokenizeListItemPrefixWhitespace,
+  partial: true
+};
+var indentConstruct = {
+  tokenize: tokenizeIndent,
+  partial: true
+};
+function tokenizeListStart(effects, ok2, nok) {
+  const self = this;
+  const tail = self.events[self.events.length - 1];
+  let initialSize = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  let size = 0;
+  return start;
+  function start(code2) {
+    const kind = self.containerState.type || (code2 === 42 || code2 === 43 || code2 === 45 ? "listUnordered" : "listOrdered");
+    if (kind === "listUnordered" ? !self.containerState.marker || code2 === self.containerState.marker : asciiDigit(code2)) {
+      if (!self.containerState.type) {
+        self.containerState.type = kind;
+        effects.enter(kind, {
+          _container: true
+        });
+      }
+      if (kind === "listUnordered") {
+        effects.enter("listItemPrefix");
+        return code2 === 42 || code2 === 45 ? effects.check(thematicBreak, nok, atMarker)(code2) : atMarker(code2);
+      }
+      if (!self.interrupt || code2 === 49) {
+        effects.enter("listItemPrefix");
+        effects.enter("listItemValue");
+        return inside(code2);
+      }
+    }
+    return nok(code2);
+  }
+  function inside(code2) {
+    if (asciiDigit(code2) && ++size < 10) {
+      effects.consume(code2);
+      return inside;
+    }
+    if ((!self.interrupt || size < 2) && (self.containerState.marker ? code2 === self.containerState.marker : code2 === 41 || code2 === 46)) {
+      effects.exit("listItemValue");
+      return atMarker(code2);
+    }
+    return nok(code2);
+  }
+  function atMarker(code2) {
+    effects.enter("listItemMarker");
+    effects.consume(code2);
+    effects.exit("listItemMarker");
+    self.containerState.marker = self.containerState.marker || code2;
+    return effects.check(
+      blankLine,
+      self.interrupt ? nok : onBlank,
+      effects.attempt(
+        listItemPrefixWhitespaceConstruct,
+        endOfPrefix,
+        otherPrefix
+      )
+    );
+  }
+  function onBlank(code2) {
+    self.containerState.initialBlankLine = true;
+    initialSize++;
+    return endOfPrefix(code2);
+  }
+  function otherPrefix(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter("listItemPrefixWhitespace");
+      effects.consume(code2);
+      effects.exit("listItemPrefixWhitespace");
+      return endOfPrefix;
+    }
+    return nok(code2);
+  }
+  function endOfPrefix(code2) {
+    self.containerState.size = initialSize + self.sliceSerialize(effects.exit("listItemPrefix"), true).length;
+    return ok2(code2);
+  }
+}
+function tokenizeListContinuation(effects, ok2, nok) {
+  const self = this;
+  self.containerState._closeFlow = void 0;
+  return effects.check(blankLine, onBlank, notBlank);
+  function onBlank(code2) {
+    self.containerState.furtherBlankLines = self.containerState.furtherBlankLines || self.containerState.initialBlankLine;
+    return factorySpace(
+      effects,
+      ok2,
+      "listItemIndent",
+      self.containerState.size + 1
+    )(code2);
+  }
+  function notBlank(code2) {
+    if (self.containerState.furtherBlankLines || !markdownSpace(code2)) {
+      self.containerState.furtherBlankLines = void 0;
+      self.containerState.initialBlankLine = void 0;
+      return notInCurrentItem(code2);
+    }
+    self.containerState.furtherBlankLines = void 0;
+    self.containerState.initialBlankLine = void 0;
+    return effects.attempt(indentConstruct, ok2, notInCurrentItem)(code2);
+  }
+  function notInCurrentItem(code2) {
+    self.containerState._closeFlow = true;
+    self.interrupt = void 0;
+    return factorySpace(
+      effects,
+      effects.attempt(list, ok2, nok),
+      "linePrefix",
+      self.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+    )(code2);
+  }
+}
+function tokenizeIndent(effects, ok2, nok) {
+  const self = this;
+  return factorySpace(
+    effects,
+    afterPrefix,
+    "listItemIndent",
+    self.containerState.size + 1
+  );
+  function afterPrefix(code2) {
+    const tail = self.events[self.events.length - 1];
+    return tail && tail[1].type === "listItemIndent" && tail[2].sliceSerialize(tail[1], true).length === self.containerState.size ? ok2(code2) : nok(code2);
+  }
+}
+function tokenizeListEnd(effects) {
+  effects.exit(this.containerState.type);
+}
+function tokenizeListItemPrefixWhitespace(effects, ok2, nok) {
+  const self = this;
+  return factorySpace(
+    effects,
+    afterPrefix,
+    "listItemPrefixWhitespace",
+    self.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4 + 1
+  );
+  function afterPrefix(code2) {
+    const tail = self.events[self.events.length - 1];
+    return !markdownSpace(code2) && tail && tail[1].type === "listItemPrefixWhitespace" ? ok2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/setext-underline.js
+var setextUnderline = {
+  name: "setextUnderline",
+  tokenize: tokenizeSetextUnderline,
+  resolveTo: resolveToSetextUnderline
+};
+function resolveToSetextUnderline(events, context) {
+  let index2 = events.length;
+  let content3;
+  let text4;
+  let definition3;
+  while (index2--) {
+    if (events[index2][0] === "enter") {
+      if (events[index2][1].type === "content") {
+        content3 = index2;
+        break;
+      }
+      if (events[index2][1].type === "paragraph") {
+        text4 = index2;
+      }
+    } else {
+      if (events[index2][1].type === "content") {
+        events.splice(index2, 1);
+      }
+      if (!definition3 && events[index2][1].type === "definition") {
+        definition3 = index2;
+      }
+    }
+  }
+  const heading2 = {
+    type: "setextHeading",
+    start: Object.assign({}, events[text4][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  events[text4][1].type = "setextHeadingText";
+  if (definition3) {
+    events.splice(text4, 0, ["enter", heading2, context]);
+    events.splice(definition3 + 1, 0, ["exit", events[content3][1], context]);
+    events[content3][1].end = Object.assign({}, events[definition3][1].end);
+  } else {
+    events[content3][1] = heading2;
+  }
+  events.push(["exit", heading2, context]);
+  return events;
+}
+function tokenizeSetextUnderline(effects, ok2, nok) {
+  const self = this;
+  let index2 = self.events.length;
+  let marker;
+  let paragraph2;
+  while (index2--) {
+    if (self.events[index2][1].type !== "lineEnding" && self.events[index2][1].type !== "linePrefix" && self.events[index2][1].type !== "content") {
+      paragraph2 = self.events[index2][1].type === "paragraph";
+      break;
+    }
+  }
+  return start;
+  function start(code2) {
+    if (!self.parser.lazy[self.now().line] && (self.interrupt || paragraph2)) {
+      effects.enter("setextHeadingLine");
+      effects.enter("setextHeadingLineSequence");
+      marker = code2;
+      return closingSequence(code2);
+    }
+    return nok(code2);
+  }
+  function closingSequence(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return closingSequence;
+    }
+    effects.exit("setextHeadingLineSequence");
+    return factorySpace(effects, closingSequenceEnd, "lineSuffix")(code2);
+  }
+  function closingSequenceEnd(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("setextHeadingLine");
+      return ok2(code2);
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark/lib/initialize/flow.js
+var flow = {
+  tokenize: initializeFlow
+};
+function initializeFlow(effects) {
+  const self = this;
+  const initial = effects.attempt(
+    blankLine,
+    atBlankEnding,
+    effects.attempt(
+      this.parser.constructs.flowInitial,
+      afterConstruct,
+      factorySpace(
+        effects,
+        effects.attempt(
+          this.parser.constructs.flow,
+          afterConstruct,
+          effects.attempt(content2, afterConstruct)
+        ),
+        "linePrefix"
+      )
+    )
+  );
+  return initial;
+  function atBlankEnding(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEndingBlank");
+    effects.consume(code2);
+    effects.exit("lineEndingBlank");
+    self.currentConstruct = void 0;
+    return initial;
+  }
+  function afterConstruct(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    self.currentConstruct = void 0;
+    return initial;
+  }
+}
+
+// node_modules/micromark/lib/initialize/text.js
+var resolver = {
+  resolveAll: createResolver()
+};
+var string = initializeFactory("string");
+var text = initializeFactory("text");
+function initializeFactory(field) {
+  return {
+    tokenize: initializeText,
+    resolveAll: createResolver(
+      field === "text" ? resolveAllLineSuffixes : void 0
+    )
+  };
+  function initializeText(effects) {
+    const self = this;
+    const constructs2 = this.parser.constructs[field];
+    const text4 = effects.attempt(constructs2, start, notText);
+    return start;
+    function start(code2) {
+      return atBreak(code2) ? text4(code2) : notText(code2);
+    }
+    function notText(code2) {
+      if (code2 === null) {
+        effects.consume(code2);
+        return;
+      }
+      effects.enter("data");
+      effects.consume(code2);
+      return data;
+    }
+    function data(code2) {
+      if (atBreak(code2)) {
+        effects.exit("data");
+        return text4(code2);
+      }
+      effects.consume(code2);
+      return data;
+    }
+    function atBreak(code2) {
+      if (code2 === null) {
+        return true;
+      }
+      const list3 = constructs2[code2];
+      let index2 = -1;
+      if (list3) {
+        while (++index2 < list3.length) {
+          const item = list3[index2];
+          if (!item.previous || item.previous.call(self, self.previous)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+  }
+}
+function createResolver(extraResolver) {
+  return resolveAllText;
+  function resolveAllText(events, context) {
+    let index2 = -1;
+    let enter;
+    while (++index2 <= events.length) {
+      if (enter === void 0) {
+        if (events[index2] && events[index2][1].type === "data") {
+          enter = index2;
+          index2++;
+        }
+      } else if (!events[index2] || events[index2][1].type !== "data") {
+        if (index2 !== enter + 2) {
+          events[enter][1].end = events[index2 - 1][1].end;
+          events.splice(enter + 2, index2 - enter - 2);
+          index2 = enter + 2;
+        }
+        enter = void 0;
+      }
+    }
+    return extraResolver ? extraResolver(events, context) : events;
+  }
+}
+function resolveAllLineSuffixes(events, context) {
+  let eventIndex = 0;
+  while (++eventIndex <= events.length) {
+    if ((eventIndex === events.length || events[eventIndex][1].type === "lineEnding") && events[eventIndex - 1][1].type === "data") {
+      const data = events[eventIndex - 1][1];
+      const chunks = context.sliceStream(data);
+      let index2 = chunks.length;
+      let bufferIndex = -1;
+      let size = 0;
+      let tabs;
+      while (index2--) {
+        const chunk = chunks[index2];
+        if (typeof chunk === "string") {
+          bufferIndex = chunk.length;
+          while (chunk.charCodeAt(bufferIndex - 1) === 32) {
+            size++;
+            bufferIndex--;
+          }
+          if (bufferIndex)
+            break;
+          bufferIndex = -1;
+        } else if (chunk === -2) {
+          tabs = true;
+          size++;
+        } else if (chunk === -1) {
+        } else {
+          index2++;
+          break;
+        }
+      }
+      if (size) {
+        const token = {
+          type: eventIndex === events.length || tabs || size < 2 ? "lineSuffix" : "hardBreakTrailing",
+          start: {
+            line: data.end.line,
+            column: data.end.column - size,
+            offset: data.end.offset - size,
+            _index: data.start._index + index2,
+            _bufferIndex: index2 ? bufferIndex : data.start._bufferIndex + bufferIndex
+          },
+          end: Object.assign({}, data.end)
+        };
+        data.end = Object.assign({}, token.start);
+        if (data.start.offset === data.end.offset) {
+          Object.assign(data, token);
+        } else {
+          events.splice(
+            eventIndex,
+            0,
+            ["enter", token, context],
+            ["exit", token, context]
+          );
+          eventIndex += 2;
+        }
+      }
+      eventIndex++;
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark/lib/create-tokenizer.js
+function createTokenizer(parser, initialize, from) {
+  let point2 = Object.assign(
+    from ? Object.assign({}, from) : {
+      line: 1,
+      column: 1,
+      offset: 0
+    },
+    {
+      _index: 0,
+      _bufferIndex: -1
+    }
+  );
+  const columnStart = {};
+  const resolveAllConstructs = [];
+  let chunks = [];
+  let stack = [];
+  let consumed = true;
+  const effects = {
+    consume,
+    enter,
+    exit: exit2,
+    attempt: constructFactory(onsuccessfulconstruct),
+    check: constructFactory(onsuccessfulcheck),
+    interrupt: constructFactory(onsuccessfulcheck, {
+      interrupt: true
+    })
+  };
+  const context = {
+    previous: null,
+    code: null,
+    containerState: {},
+    events: [],
+    parser,
+    sliceStream,
+    sliceSerialize,
+    now,
+    defineSkip,
+    write
+  };
+  let state = initialize.tokenize.call(context, effects);
+  let expectedCode;
+  if (initialize.resolveAll) {
+    resolveAllConstructs.push(initialize);
+  }
+  return context;
+  function write(slice) {
+    chunks = push(chunks, slice);
+    main();
+    if (chunks[chunks.length - 1] !== null) {
+      return [];
+    }
+    addResult(initialize, 0);
+    context.events = resolveAll(resolveAllConstructs, context.events, context);
+    return context.events;
+  }
+  function sliceSerialize(token, expandTabs) {
+    return serializeChunks(sliceStream(token), expandTabs);
+  }
+  function sliceStream(token) {
+    return sliceChunks(chunks, token);
+  }
+  function now() {
+    return Object.assign({}, point2);
+  }
+  function defineSkip(value) {
+    columnStart[value.line] = value.column;
+    accountForPotentialSkip();
+  }
+  function main() {
+    let chunkIndex;
+    while (point2._index < chunks.length) {
+      const chunk = chunks[point2._index];
+      if (typeof chunk === "string") {
+        chunkIndex = point2._index;
+        if (point2._bufferIndex < 0) {
+          point2._bufferIndex = 0;
+        }
+        while (point2._index === chunkIndex && point2._bufferIndex < chunk.length) {
+          go(chunk.charCodeAt(point2._bufferIndex));
+        }
+      } else {
+        go(chunk);
+      }
+    }
+  }
+  function go(code2) {
+    consumed = void 0;
+    expectedCode = code2;
+    state = state(code2);
+  }
+  function consume(code2) {
+    if (markdownLineEnding(code2)) {
+      point2.line++;
+      point2.column = 1;
+      point2.offset += code2 === -3 ? 2 : 1;
+      accountForPotentialSkip();
+    } else if (code2 !== -1) {
+      point2.column++;
+      point2.offset++;
+    }
+    if (point2._bufferIndex < 0) {
+      point2._index++;
+    } else {
+      point2._bufferIndex++;
+      if (point2._bufferIndex === chunks[point2._index].length) {
+        point2._bufferIndex = -1;
+        point2._index++;
+      }
+    }
+    context.previous = code2;
+    consumed = true;
+  }
+  function enter(type, fields) {
+    const token = fields || {};
+    token.type = type;
+    token.start = now();
+    context.events.push(["enter", token, context]);
+    stack.push(token);
+    return token;
+  }
+  function exit2(type) {
+    const token = stack.pop();
+    token.end = now();
+    context.events.push(["exit", token, context]);
+    return token;
+  }
+  function onsuccessfulconstruct(construct, info) {
+    addResult(construct, info.from);
+  }
+  function onsuccessfulcheck(_, info) {
+    info.restore();
+  }
+  function constructFactory(onreturn, fields) {
+    return hook;
+    function hook(constructs2, returnState, bogusState) {
+      let listOfConstructs;
+      let constructIndex;
+      let currentConstruct;
+      let info;
+      return Array.isArray(constructs2) ? handleListOfConstructs(constructs2) : "tokenize" in constructs2 ? handleListOfConstructs([constructs2]) : handleMapOfConstructs(constructs2);
+      function handleMapOfConstructs(map3) {
+        return start;
+        function start(code2) {
+          const def = code2 !== null && map3[code2];
+          const all2 = code2 !== null && map3.null;
+          const list3 = [
+            ...Array.isArray(def) ? def : def ? [def] : [],
+            ...Array.isArray(all2) ? all2 : all2 ? [all2] : []
+          ];
+          return handleListOfConstructs(list3)(code2);
+        }
+      }
+      function handleListOfConstructs(list3) {
+        listOfConstructs = list3;
+        constructIndex = 0;
+        if (list3.length === 0) {
+          return bogusState;
+        }
+        return handleConstruct(list3[constructIndex]);
+      }
+      function handleConstruct(construct) {
+        return start;
+        function start(code2) {
+          info = store();
+          currentConstruct = construct;
+          if (!construct.partial) {
+            context.currentConstruct = construct;
+          }
+          if (construct.name && context.parser.constructs.disable.null.includes(construct.name)) {
+            return nok(code2);
+          }
+          return construct.tokenize.call(
+            fields ? Object.assign(Object.create(context), fields) : context,
+            effects,
+            ok2,
+            nok
+          )(code2);
+        }
+      }
+      function ok2(code2) {
+        consumed = true;
+        onreturn(currentConstruct, info);
+        return returnState;
+      }
+      function nok(code2) {
+        consumed = true;
+        info.restore();
+        if (++constructIndex < listOfConstructs.length) {
+          return handleConstruct(listOfConstructs[constructIndex]);
+        }
+        return bogusState;
+      }
+    }
+  }
+  function addResult(construct, from2) {
+    if (construct.resolveAll && !resolveAllConstructs.includes(construct)) {
+      resolveAllConstructs.push(construct);
+    }
+    if (construct.resolve) {
+      splice(
+        context.events,
+        from2,
+        context.events.length - from2,
+        construct.resolve(context.events.slice(from2), context)
+      );
+    }
+    if (construct.resolveTo) {
+      context.events = construct.resolveTo(context.events, context);
+    }
+  }
+  function store() {
+    const startPoint = now();
+    const startPrevious = context.previous;
+    const startCurrentConstruct = context.currentConstruct;
+    const startEventsIndex = context.events.length;
+    const startStack = Array.from(stack);
+    return {
+      restore,
+      from: startEventsIndex
+    };
+    function restore() {
+      point2 = startPoint;
+      context.previous = startPrevious;
+      context.currentConstruct = startCurrentConstruct;
+      context.events.length = startEventsIndex;
+      stack = startStack;
+      accountForPotentialSkip();
+    }
+  }
+  function accountForPotentialSkip() {
+    if (point2.line in columnStart && point2.column < 2) {
+      point2.column = columnStart[point2.line];
+      point2.offset += columnStart[point2.line] - 1;
+    }
+  }
+}
+function sliceChunks(chunks, token) {
+  const startIndex = token.start._index;
+  const startBufferIndex = token.start._bufferIndex;
+  const endIndex = token.end._index;
+  const endBufferIndex = token.end._bufferIndex;
+  let view;
+  if (startIndex === endIndex) {
+    view = [chunks[startIndex].slice(startBufferIndex, endBufferIndex)];
+  } else {
+    view = chunks.slice(startIndex, endIndex);
+    if (startBufferIndex > -1) {
+      view[0] = view[0].slice(startBufferIndex);
+    }
+    if (endBufferIndex > 0) {
+      view.push(chunks[endIndex].slice(0, endBufferIndex));
+    }
+  }
+  return view;
+}
+function serializeChunks(chunks, expandTabs) {
+  let index2 = -1;
+  const result = [];
+  let atTab;
+  while (++index2 < chunks.length) {
+    const chunk = chunks[index2];
+    let value;
+    if (typeof chunk === "string") {
+      value = chunk;
+    } else
+      switch (chunk) {
+        case -5: {
+          value = "\r";
+          break;
+        }
+        case -4: {
+          value = "\n";
+          break;
+        }
+        case -3: {
+          value = "\r\n";
+          break;
+        }
+        case -2: {
+          value = expandTabs ? " " : "	";
+          break;
+        }
+        case -1: {
+          if (!expandTabs && atTab)
+            continue;
+          value = " ";
+          break;
+        }
+        default: {
+          value = String.fromCharCode(chunk);
+        }
+      }
+    atTab = chunk === -2;
+    result.push(value);
+  }
+  return result.join("");
+}
+
+// node_modules/micromark/lib/constructs.js
+var constructs_exports = {};
+__export(constructs_exports, {
+  attentionMarkers: () => attentionMarkers,
+  contentInitial: () => contentInitial,
+  disable: () => disable,
+  document: () => document2,
+  flow: () => flow2,
+  flowInitial: () => flowInitial,
+  insideSpan: () => insideSpan,
+  string: () => string2,
+  text: () => text2
+});
+var document2 = {
+  [42]: list,
+  [43]: list,
+  [45]: list,
+  [48]: list,
+  [49]: list,
+  [50]: list,
+  [51]: list,
+  [52]: list,
+  [53]: list,
+  [54]: list,
+  [55]: list,
+  [56]: list,
+  [57]: list,
+  [62]: blockQuote
+};
+var contentInitial = {
+  [91]: definition
+};
+var flowInitial = {
+  [-2]: codeIndented,
+  [-1]: codeIndented,
+  [32]: codeIndented
+};
+var flow2 = {
+  [35]: headingAtx,
+  [42]: thematicBreak,
+  [45]: [setextUnderline, thematicBreak],
+  [60]: htmlFlow,
+  [61]: setextUnderline,
+  [95]: thematicBreak,
+  [96]: codeFenced,
+  [126]: codeFenced
+};
+var string2 = {
+  [38]: characterReference,
+  [92]: characterEscape
+};
+var text2 = {
+  [-5]: lineEnding,
+  [-4]: lineEnding,
+  [-3]: lineEnding,
+  [33]: labelStartImage,
+  [38]: characterReference,
+  [42]: attention,
+  [60]: [autolink, htmlText],
+  [91]: labelStartLink,
+  [92]: [hardBreakEscape, characterEscape],
+  [93]: labelEnd,
+  [95]: attention,
+  [96]: codeText
+};
+var insideSpan = {
+  null: [attention, resolver]
+};
+var attentionMarkers = {
+  null: [42, 95]
+};
+var disable = {
+  null: []
+};
+
+// node_modules/micromark/lib/parse.js
+function parse(options = {}) {
+  const constructs2 = combineExtensions(
+    [constructs_exports].concat(options.extensions || [])
+  );
+  const parser = {
+    defined: [],
+    lazy: {},
+    constructs: constructs2,
+    content: create(content),
+    document: create(document),
+    flow: create(flow),
+    string: create(string),
+    text: create(text)
+  };
+  return parser;
+  function create(initial) {
+    return creator;
+    function creator(from) {
+      return createTokenizer(parser, initial, from);
+    }
+  }
+}
+
+// node_modules/micromark/lib/preprocess.js
+var search = /[\0\t\n\r]/g;
+function preprocess() {
+  let column = 1;
+  let buffer2 = "";
+  let start = true;
+  let atCarriageReturn;
+  return preprocessor;
+  function preprocessor(value, encoding, end) {
+    const chunks = [];
+    let match;
+    let next;
+    let startPosition;
+    let endPosition;
+    let code2;
+    value = buffer2 + value.toString(encoding);
+    startPosition = 0;
+    buffer2 = "";
+    if (start) {
+      if (value.charCodeAt(0) === 65279) {
+        startPosition++;
+      }
+      start = void 0;
+    }
+    while (startPosition < value.length) {
+      search.lastIndex = startPosition;
+      match = search.exec(value);
+      endPosition = match && match.index !== void 0 ? match.index : value.length;
+      code2 = value.charCodeAt(endPosition);
+      if (!match) {
+        buffer2 = value.slice(startPosition);
+        break;
+      }
+      if (code2 === 10 && startPosition === endPosition && atCarriageReturn) {
+        chunks.push(-3);
+        atCarriageReturn = void 0;
+      } else {
+        if (atCarriageReturn) {
+          chunks.push(-5);
+          atCarriageReturn = void 0;
+        }
+        if (startPosition < endPosition) {
+          chunks.push(value.slice(startPosition, endPosition));
+          column += endPosition - startPosition;
+        }
+        switch (code2) {
+          case 0: {
+            chunks.push(65533);
+            column++;
+            break;
+          }
+          case 9: {
+            next = Math.ceil(column / 4) * 4;
+            chunks.push(-2);
+            while (column++ < next)
+              chunks.push(-1);
+            break;
+          }
+          case 10: {
+            chunks.push(-4);
+            column = 1;
+            break;
+          }
+          default: {
+            atCarriageReturn = true;
+            column = 1;
+          }
+        }
+      }
+      startPosition = endPosition + 1;
+    }
+    if (end) {
+      if (atCarriageReturn)
+        chunks.push(-5);
+      if (buffer2)
+        chunks.push(buffer2);
+      chunks.push(null);
+    }
+    return chunks;
+  }
+}
+
+// node_modules/micromark/lib/postprocess.js
+function postprocess(events) {
+  while (!subtokenize(events)) {
+  }
+  return events;
+}
+
+// node_modules/micromark-util-decode-numeric-character-reference/index.js
+function decodeNumericCharacterReference(value, base2) {
+  const code2 = Number.parseInt(value, base2);
+  if (code2 < 9 || code2 === 11 || code2 > 13 && code2 < 32 || code2 > 126 && code2 < 160 || code2 > 55295 && code2 < 57344 || code2 > 64975 && code2 < 65008 || (code2 & 65535) === 65535 || (code2 & 65535) === 65534 || code2 > 1114111) {
+    return "\uFFFD";
+  }
+  return String.fromCharCode(code2);
+}
+
+// node_modules/micromark-util-decode-string/index.js
+var characterEscapeOrReference = /\\([!-/:-@[-`{-~])|&(#(?:\d{1,7}|x[\da-f]{1,6})|[\da-z]{1,31});/gi;
+function decodeString(value) {
+  return value.replace(characterEscapeOrReference, decode);
+}
+function decode($0, $1, $2) {
+  if ($1) {
+    return $1;
+  }
+  const head = $2.charCodeAt(0);
+  if (head === 35) {
+    const head2 = $2.charCodeAt(1);
+    const hex = head2 === 120 || head2 === 88;
+    return decodeNumericCharacterReference($2.slice(hex ? 2 : 1), hex ? 16 : 10);
+  }
+  return decodeNamedCharacterReference($2) || $0;
+}
+
+// node_modules/mdast-util-from-markdown/lib/index.js
+var own3 = {}.hasOwnProperty;
+var fromMarkdown = function(value, encoding, options) {
+  if (typeof encoding !== "string") {
+    options = encoding;
+    encoding = void 0;
+  }
+  return compiler(options)(
+    postprocess(
+      parse(options).document().write(preprocess()(value, encoding, true))
+    )
+  );
+};
+function compiler(options = {}) {
+  const config = configure(
+    {
+      transforms: [],
+      canContainEols: [
+        "emphasis",
+        "fragment",
+        "heading",
+        "paragraph",
+        "strong"
+      ],
+      enter: {
+        autolink: opener(link2),
+        autolinkProtocol: onenterdata,
+        autolinkEmail: onenterdata,
+        atxHeading: opener(heading2),
+        blockQuote: opener(blockQuote2),
+        characterEscape: onenterdata,
+        characterReference: onenterdata,
+        codeFenced: opener(codeFlow),
+        codeFencedFenceInfo: buffer2,
+        codeFencedFenceMeta: buffer2,
+        codeIndented: opener(codeFlow, buffer2),
+        codeText: opener(codeText2, buffer2),
+        codeTextData: onenterdata,
+        data: onenterdata,
+        codeFlowValue: onenterdata,
+        definition: opener(definition3),
+        definitionDestinationString: buffer2,
+        definitionLabelString: buffer2,
+        definitionTitleString: buffer2,
+        emphasis: opener(emphasis2),
+        hardBreakEscape: opener(hardBreak2),
+        hardBreakTrailing: opener(hardBreak2),
+        htmlFlow: opener(html2, buffer2),
+        htmlFlowData: onenterdata,
+        htmlText: opener(html2, buffer2),
+        htmlTextData: onenterdata,
+        image: opener(image2),
+        label: buffer2,
+        link: opener(link2),
+        listItem: opener(listItem2),
+        listItemValue: onenterlistitemvalue,
+        listOrdered: opener(list3, onenterlistordered),
+        listUnordered: opener(list3),
+        paragraph: opener(paragraph2),
+        reference: onenterreference,
+        referenceString: buffer2,
+        resourceDestinationString: buffer2,
+        resourceTitleString: buffer2,
+        setextHeading: opener(heading2),
+        strong: opener(strong2),
+        thematicBreak: opener(thematicBreak3)
+      },
+      exit: {
+        atxHeading: closer(),
+        atxHeadingSequence: onexitatxheadingsequence,
+        autolink: closer(),
+        autolinkEmail: onexitautolinkemail,
+        autolinkProtocol: onexitautolinkprotocol,
+        blockQuote: closer(),
+        characterEscapeValue: onexitdata,
+        characterReferenceMarkerHexadecimal: onexitcharacterreferencemarker,
+        characterReferenceMarkerNumeric: onexitcharacterreferencemarker,
+        characterReferenceValue: onexitcharacterreferencevalue,
+        codeFenced: closer(onexitcodefenced),
+        codeFencedFence: onexitcodefencedfence,
+        codeFencedFenceInfo: onexitcodefencedfenceinfo,
+        codeFencedFenceMeta: onexitcodefencedfencemeta,
+        codeFlowValue: onexitdata,
+        codeIndented: closer(onexitcodeindented),
+        codeText: closer(onexitcodetext),
+        codeTextData: onexitdata,
+        data: onexitdata,
+        definition: closer(),
+        definitionDestinationString: onexitdefinitiondestinationstring,
+        definitionLabelString: onexitdefinitionlabelstring,
+        definitionTitleString: onexitdefinitiontitlestring,
+        emphasis: closer(),
+        hardBreakEscape: closer(onexithardbreak),
+        hardBreakTrailing: closer(onexithardbreak),
+        htmlFlow: closer(onexithtmlflow),
+        htmlFlowData: onexitdata,
+        htmlText: closer(onexithtmltext),
+        htmlTextData: onexitdata,
+        image: closer(onexitimage),
+        label: onexitlabel,
+        labelText: onexitlabeltext,
+        lineEnding: onexitlineending,
+        link: closer(onexitlink),
+        listItem: closer(),
+        listOrdered: closer(),
+        listUnordered: closer(),
+        paragraph: closer(),
+        referenceString: onexitreferencestring,
+        resourceDestinationString: onexitresourcedestinationstring,
+        resourceTitleString: onexitresourcetitlestring,
+        resource: onexitresource,
+        setextHeading: closer(onexitsetextheading),
+        setextHeadingLineSequence: onexitsetextheadinglinesequence,
+        setextHeadingText: onexitsetextheadingtext,
+        strong: closer(),
+        thematicBreak: closer()
+      }
+    },
+    options.mdastExtensions || []
+  );
+  const data = {};
+  return compile;
+  function compile(events) {
+    let tree = {
+      type: "root",
+      children: []
+    };
+    const stack = [tree];
+    const tokenStack = [];
+    const listStack = [];
+    const context = {
+      stack,
+      tokenStack,
+      config,
+      enter,
+      exit: exit2,
+      buffer: buffer2,
+      resume,
+      setData,
+      getData
+    };
+    let index2 = -1;
+    while (++index2 < events.length) {
+      if (events[index2][1].type === "listOrdered" || events[index2][1].type === "listUnordered") {
+        if (events[index2][0] === "enter") {
+          listStack.push(index2);
+        } else {
+          const tail = listStack.pop();
+          index2 = prepareList(events, tail, index2);
+        }
+      }
+    }
+    index2 = -1;
+    while (++index2 < events.length) {
+      const handler = config[events[index2][0]];
+      if (own3.call(handler, events[index2][1].type)) {
+        handler[events[index2][1].type].call(
+          Object.assign(
+            {
+              sliceSerialize: events[index2][2].sliceSerialize
+            },
+            context
+          ),
+          events[index2][1]
+        );
+      }
+    }
+    if (tokenStack.length > 0) {
+      const tail = tokenStack[tokenStack.length - 1];
+      const handler = tail[1] || defaultOnError;
+      handler.call(context, void 0, tail[0]);
+    }
+    tree.position = {
+      start: point2(
+        events.length > 0 ? events[0][1].start : {
+          line: 1,
+          column: 1,
+          offset: 0
+        }
+      ),
+      end: point2(
+        events.length > 0 ? events[events.length - 2][1].end : {
+          line: 1,
+          column: 1,
+          offset: 0
+        }
+      )
+    };
+    index2 = -1;
+    while (++index2 < config.transforms.length) {
+      tree = config.transforms[index2](tree) || tree;
+    }
+    return tree;
+  }
+  function prepareList(events, start, length) {
+    let index2 = start - 1;
+    let containerBalance = -1;
+    let listSpread = false;
+    let listItem3;
+    let lineIndex;
+    let firstBlankLineIndex;
+    let atMarker;
+    while (++index2 <= length) {
+      const event = events[index2];
+      if (event[1].type === "listUnordered" || event[1].type === "listOrdered" || event[1].type === "blockQuote") {
+        if (event[0] === "enter") {
+          containerBalance++;
+        } else {
+          containerBalance--;
+        }
+        atMarker = void 0;
+      } else if (event[1].type === "lineEndingBlank") {
+        if (event[0] === "enter") {
+          if (listItem3 && !atMarker && !containerBalance && !firstBlankLineIndex) {
+            firstBlankLineIndex = index2;
+          }
+          atMarker = void 0;
+        }
+      } else if (event[1].type === "linePrefix" || event[1].type === "listItemValue" || event[1].type === "listItemMarker" || event[1].type === "listItemPrefix" || event[1].type === "listItemPrefixWhitespace") {
+      } else {
+        atMarker = void 0;
+      }
+      if (!containerBalance && event[0] === "enter" && event[1].type === "listItemPrefix" || containerBalance === -1 && event[0] === "exit" && (event[1].type === "listUnordered" || event[1].type === "listOrdered")) {
+        if (listItem3) {
+          let tailIndex = index2;
+          lineIndex = void 0;
+          while (tailIndex--) {
+            const tailEvent = events[tailIndex];
+            if (tailEvent[1].type === "lineEnding" || tailEvent[1].type === "lineEndingBlank") {
+              if (tailEvent[0] === "exit")
+                continue;
+              if (lineIndex) {
+                events[lineIndex][1].type = "lineEndingBlank";
+                listSpread = true;
+              }
+              tailEvent[1].type = "lineEnding";
+              lineIndex = tailIndex;
+            } else if (tailEvent[1].type === "linePrefix" || tailEvent[1].type === "blockQuotePrefix" || tailEvent[1].type === "blockQuotePrefixWhitespace" || tailEvent[1].type === "blockQuoteMarker" || tailEvent[1].type === "listItemIndent") {
+            } else {
+              break;
+            }
+          }
+          if (firstBlankLineIndex && (!lineIndex || firstBlankLineIndex < lineIndex)) {
+            listItem3._spread = true;
+          }
+          listItem3.end = Object.assign(
+            {},
+            lineIndex ? events[lineIndex][1].start : event[1].end
+          );
+          events.splice(lineIndex || index2, 0, ["exit", listItem3, event[2]]);
+          index2++;
+          length++;
+        }
+        if (event[1].type === "listItemPrefix") {
+          listItem3 = {
+            type: "listItem",
+            _spread: false,
+            start: Object.assign({}, event[1].start)
+          };
+          events.splice(index2, 0, ["enter", listItem3, event[2]]);
+          index2++;
+          length++;
+          firstBlankLineIndex = void 0;
+          atMarker = true;
+        }
+      }
+    }
+    events[start][1]._spread = listSpread;
+    return length;
+  }
+  function setData(key, value) {
+    data[key] = value;
+  }
+  function getData(key) {
+    return data[key];
+  }
+  function point2(d) {
+    return {
+      line: d.line,
+      column: d.column,
+      offset: d.offset
+    };
+  }
+  function opener(create, and) {
+    return open;
+    function open(token) {
+      enter.call(this, create(token), token);
+      if (and)
+        and.call(this, token);
+    }
+  }
+  function buffer2() {
+    this.stack.push({
+      type: "fragment",
+      children: []
+    });
+  }
+  function enter(node, token, errorHandler) {
+    const parent = this.stack[this.stack.length - 1];
+    parent.children.push(node);
+    this.stack.push(node);
+    this.tokenStack.push([token, errorHandler]);
+    node.position = {
+      start: point2(token.start)
+    };
+    return node;
+  }
+  function closer(and) {
+    return close;
+    function close(token) {
+      if (and)
+        and.call(this, token);
+      exit2.call(this, token);
+    }
+  }
+  function exit2(token, onExitError) {
+    const node = this.stack.pop();
+    const open = this.tokenStack.pop();
+    if (!open) {
+      throw new Error(
+        "Cannot close `" + token.type + "` (" + stringifyPosition({
+          start: token.start,
+          end: token.end
+        }) + "): it\u2019s not open"
+      );
+    } else if (open[0].type !== token.type) {
+      if (onExitError) {
+        onExitError.call(this, token, open[0]);
+      } else {
+        const handler = open[1] || defaultOnError;
+        handler.call(this, token, open[0]);
+      }
+    }
+    node.position.end = point2(token.end);
+    return node;
+  }
+  function resume() {
+    return toString(this.stack.pop());
+  }
+  function onenterlistordered() {
+    setData("expectingFirstListItemValue", true);
+  }
+  function onenterlistitemvalue(token) {
+    if (getData("expectingFirstListItemValue")) {
+      const ancestor = this.stack[this.stack.length - 2];
+      ancestor.start = Number.parseInt(this.sliceSerialize(token), 10);
+      setData("expectingFirstListItemValue");
+    }
+  }
+  function onexitcodefencedfenceinfo() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.lang = data2;
+  }
+  function onexitcodefencedfencemeta() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.meta = data2;
+  }
+  function onexitcodefencedfence() {
+    if (getData("flowCodeInside"))
+      return;
+    this.buffer();
+    setData("flowCodeInside", true);
+  }
+  function onexitcodefenced() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data2.replace(/^(\r?\n|\r)|(\r?\n|\r)$/g, "");
+    setData("flowCodeInside");
+  }
+  function onexitcodeindented() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data2.replace(/(\r?\n|\r)$/g, "");
+  }
+  function onexitdefinitionlabelstring(token) {
+    const label = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.label = label;
+    node.identifier = normalizeIdentifier(
+      this.sliceSerialize(token)
+    ).toLowerCase();
+  }
+  function onexitdefinitiontitlestring() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.title = data2;
+  }
+  function onexitdefinitiondestinationstring() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.url = data2;
+  }
+  function onexitatxheadingsequence(token) {
+    const node = this.stack[this.stack.length - 1];
+    if (!node.depth) {
+      const depth = this.sliceSerialize(token).length;
+      node.depth = depth;
+    }
+  }
+  function onexitsetextheadingtext() {
+    setData("setextHeadingSlurpLineEnding", true);
+  }
+  function onexitsetextheadinglinesequence(token) {
+    const node = this.stack[this.stack.length - 1];
+    node.depth = this.sliceSerialize(token).charCodeAt(0) === 61 ? 1 : 2;
+  }
+  function onexitsetextheading() {
+    setData("setextHeadingSlurpLineEnding");
+  }
+  function onenterdata(token) {
+    const parent = this.stack[this.stack.length - 1];
+    let tail = parent.children[parent.children.length - 1];
+    if (!tail || tail.type !== "text") {
+      tail = text4();
+      tail.position = {
+        start: point2(token.start)
+      };
+      parent.children.push(tail);
+    }
+    this.stack.push(tail);
+  }
+  function onexitdata(token) {
+    const tail = this.stack.pop();
+    tail.value += this.sliceSerialize(token);
+    tail.position.end = point2(token.end);
+  }
+  function onexitlineending(token) {
+    const context = this.stack[this.stack.length - 1];
+    if (getData("atHardBreak")) {
+      const tail = context.children[context.children.length - 1];
+      tail.position.end = point2(token.end);
+      setData("atHardBreak");
+      return;
+    }
+    if (!getData("setextHeadingSlurpLineEnding") && config.canContainEols.includes(context.type)) {
+      onenterdata.call(this, token);
+      onexitdata.call(this, token);
+    }
+  }
+  function onexithardbreak() {
+    setData("atHardBreak", true);
+  }
+  function onexithtmlflow() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data2;
+  }
+  function onexithtmltext() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data2;
+  }
+  function onexitcodetext() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.value = data2;
+  }
+  function onexitlink() {
+    const context = this.stack[this.stack.length - 1];
+    if (getData("inReference")) {
+      context.type += "Reference";
+      context.referenceType = getData("referenceType") || "shortcut";
+      delete context.url;
+      delete context.title;
+    } else {
+      delete context.identifier;
+      delete context.label;
+    }
+    setData("referenceType");
+  }
+  function onexitimage() {
+    const context = this.stack[this.stack.length - 1];
+    if (getData("inReference")) {
+      context.type += "Reference";
+      context.referenceType = getData("referenceType") || "shortcut";
+      delete context.url;
+      delete context.title;
+    } else {
+      delete context.identifier;
+      delete context.label;
+    }
+    setData("referenceType");
+  }
+  function onexitlabeltext(token) {
+    const ancestor = this.stack[this.stack.length - 2];
+    const string3 = this.sliceSerialize(token);
+    ancestor.label = decodeString(string3);
+    ancestor.identifier = normalizeIdentifier(string3).toLowerCase();
+  }
+  function onexitlabel() {
+    const fragment = this.stack[this.stack.length - 1];
+    const value = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    setData("inReference", true);
+    if (node.type === "link") {
+      node.children = fragment.children;
+    } else {
+      node.alt = value;
+    }
+  }
+  function onexitresourcedestinationstring() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.url = data2;
+  }
+  function onexitresourcetitlestring() {
+    const data2 = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.title = data2;
+  }
+  function onexitresource() {
+    setData("inReference");
+  }
+  function onenterreference() {
+    setData("referenceType", "collapsed");
+  }
+  function onexitreferencestring(token) {
+    const label = this.resume();
+    const node = this.stack[this.stack.length - 1];
+    node.label = label;
+    node.identifier = normalizeIdentifier(
+      this.sliceSerialize(token)
+    ).toLowerCase();
+    setData("referenceType", "full");
+  }
+  function onexitcharacterreferencemarker(token) {
+    setData("characterReferenceType", token.type);
+  }
+  function onexitcharacterreferencevalue(token) {
+    const data2 = this.sliceSerialize(token);
+    const type = getData("characterReferenceType");
+    let value;
+    if (type) {
+      value = decodeNumericCharacterReference(
+        data2,
+        type === "characterReferenceMarkerNumeric" ? 10 : 16
+      );
+      setData("characterReferenceType");
+    } else {
+      value = decodeNamedCharacterReference(data2);
+    }
+    const tail = this.stack.pop();
+    tail.value += value;
+    tail.position.end = point2(token.end);
+  }
+  function onexitautolinkprotocol(token) {
+    onexitdata.call(this, token);
+    const node = this.stack[this.stack.length - 1];
+    node.url = this.sliceSerialize(token);
+  }
+  function onexitautolinkemail(token) {
+    onexitdata.call(this, token);
+    const node = this.stack[this.stack.length - 1];
+    node.url = "mailto:" + this.sliceSerialize(token);
+  }
+  function blockQuote2() {
+    return {
+      type: "blockquote",
+      children: []
+    };
+  }
+  function codeFlow() {
+    return {
+      type: "code",
+      lang: null,
+      meta: null,
+      value: ""
+    };
+  }
+  function codeText2() {
+    return {
+      type: "inlineCode",
+      value: ""
+    };
+  }
+  function definition3() {
+    return {
+      type: "definition",
+      identifier: "",
+      label: null,
+      title: null,
+      url: ""
+    };
+  }
+  function emphasis2() {
+    return {
+      type: "emphasis",
+      children: []
+    };
+  }
+  function heading2() {
+    return {
+      type: "heading",
+      depth: void 0,
+      children: []
+    };
+  }
+  function hardBreak2() {
+    return {
+      type: "break"
+    };
+  }
+  function html2() {
+    return {
+      type: "html",
+      value: ""
+    };
+  }
+  function image2() {
+    return {
+      type: "image",
+      title: null,
+      url: "",
+      alt: null
+    };
+  }
+  function link2() {
+    return {
+      type: "link",
+      title: null,
+      url: "",
+      children: []
+    };
+  }
+  function list3(token) {
+    return {
+      type: "list",
+      ordered: token.type === "listOrdered",
+      start: null,
+      spread: token._spread,
+      children: []
+    };
+  }
+  function listItem2(token) {
+    return {
+      type: "listItem",
+      spread: token._spread,
+      checked: null,
+      children: []
+    };
+  }
+  function paragraph2() {
+    return {
+      type: "paragraph",
+      children: []
+    };
+  }
+  function strong2() {
+    return {
+      type: "strong",
+      children: []
+    };
+  }
+  function text4() {
+    return {
+      type: "text",
+      value: ""
+    };
+  }
+  function thematicBreak3() {
+    return {
+      type: "thematicBreak"
+    };
+  }
+}
+function configure(combined, extensions) {
+  let index2 = -1;
+  while (++index2 < extensions.length) {
+    const value = extensions[index2];
+    if (Array.isArray(value)) {
+      configure(combined, value);
+    } else {
+      extension(combined, value);
+    }
+  }
+  return combined;
+}
+function extension(combined, extension2) {
+  let key;
+  for (key in extension2) {
+    if (own3.call(extension2, key)) {
+      const list3 = key === "canContainEols" || key === "transforms";
+      const maybe = own3.call(combined, key) ? combined[key] : void 0;
+      const left = maybe || (combined[key] = list3 ? [] : {});
+      const right = extension2[key];
+      if (right) {
+        if (list3) {
+          combined[key] = [...left, ...right];
+        } else {
+          Object.assign(left, right);
+        }
+      }
+    }
+  }
+}
+function defaultOnError(left, right) {
+  if (left) {
+    throw new Error(
+      "Cannot close `" + left.type + "` (" + stringifyPosition({
+        start: left.start,
+        end: left.end
+      }) + "): a different token (`" + right.type + "`, " + stringifyPosition({
+        start: right.start,
+        end: right.end
+      }) + ") is open"
+    );
+  } else {
+    throw new Error(
+      "Cannot close document, a token (`" + right.type + "`, " + stringifyPosition({
+        start: right.start,
+        end: right.end
+      }) + ") is still open"
+    );
+  }
+}
+
+// node_modules/remark/node_modules/remark-parse/lib/index.js
+function remarkParse(options) {
+  const parser = (doc) => {
+    const settings = this.data("settings");
+    return fromMarkdown(
+      doc,
+      Object.assign({}, settings, options, {
+        extensions: this.data("micromarkExtensions") || [],
+        mdastExtensions: this.data("fromMarkdownExtensions") || []
+      })
+    );
+  };
+  Object.assign(this, { Parser: parser });
+}
+
+// node_modules/remark/node_modules/remark-parse/index.js
+var remark_parse_default = remarkParse;
+
+// node_modules/zwitch/index.js
+var own4 = {}.hasOwnProperty;
+function zwitch(key, options) {
+  var settings = options || {};
+  function one2(value) {
+    var fn = one2.invalid;
+    var handlers = one2.handlers;
+    if (value && own4.call(value, key)) {
+      fn = own4.call(handlers, value[key]) ? handlers[value[key]] : one2.unknown;
+    }
+    if (fn) {
+      return fn.apply(this, arguments);
+    }
+  }
+  one2.handlers = settings.handlers || {};
+  one2.invalid = settings.invalid;
+  one2.unknown = settings.unknown;
+  return one2;
+}
+
+// node_modules/mdast-util-to-markdown/lib/configure.js
+function configure2(base2, extension2) {
+  let index2 = -1;
+  let key;
+  if (extension2.extensions) {
+    while (++index2 < extension2.extensions.length) {
+      configure2(base2, extension2.extensions[index2]);
+    }
+  }
+  for (key in extension2) {
+    if (key === "extensions") {
+    } else if (key === "unsafe" || key === "join") {
+      base2[key] = [...base2[key] || [], ...extension2[key] || []];
+    } else if (key === "handlers") {
+      base2[key] = Object.assign(base2[key], extension2[key] || {});
+    } else {
+      base2.options[key] = extension2[key];
+    }
+  }
+  return base2;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/track.js
+function track(options_) {
+  const options = options_ || {};
+  const now = options.now || {};
+  let lineShift = options.lineShift || 0;
+  let line = now.line || 1;
+  let column = now.column || 1;
+  return { move, current, shift };
+  function current() {
+    return { now: { line, column }, lineShift };
+  }
+  function shift(value) {
+    lineShift += value;
+  }
+  function move(value = "") {
+    const chunks = value.split(/\r?\n|\r/g);
+    const tail = chunks[chunks.length - 1];
+    line += chunks.length - 1;
+    column = chunks.length === 1 ? column + tail.length : 1 + tail.length + lineShift;
+    return value;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-flow.js
+function containerFlow(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const tracker = track(safeOptions);
+  const results = [];
+  let index2 = -1;
+  indexStack.push(-1);
+  while (++index2 < children.length) {
+    const child = children[index2];
+    indexStack[indexStack.length - 1] = index2;
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          before: "\n",
+          after: "\n",
+          ...tracker.current()
+        })
+      )
+    );
+    if (child.type !== "list") {
+      context.bulletLastUsed = void 0;
+    }
+    if (index2 < children.length - 1) {
+      results.push(tracker.move(between(child, children[index2 + 1])));
+    }
+  }
+  indexStack.pop();
+  return results.join("");
+  function between(left, right) {
+    let index3 = context.join.length;
+    while (index3--) {
+      const result = context.join[index3](left, right, parent, context);
+      if (result === true || result === 1) {
+        break;
+      }
+      if (typeof result === "number") {
+        return "\n".repeat(1 + result);
+      }
+      if (result === false) {
+        return "\n\n<!---->\n\n";
+      }
+    }
+    return "\n\n";
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/indent-lines.js
+var eol = /\r?\n|\r/g;
+function indentLines(value, map3) {
+  const result = [];
+  let start = 0;
+  let line = 0;
+  let match;
+  while (match = eol.exec(value)) {
+    one2(value.slice(start, match.index));
+    result.push(match[0]);
+    start = match.index + match[0].length;
+    line++;
+  }
+  one2(value.slice(start));
+  return result.join("");
+  function one2(value2) {
+    result.push(map3(value2, line, !value2));
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/blockquote.js
+function blockquote(node, _, context, safeOptions) {
+  const exit2 = context.enter("blockquote");
+  const tracker = track(safeOptions);
+  tracker.move("> ");
+  tracker.shift(2);
+  const value = indentLines(
+    containerFlow(node, context, tracker.current()),
+    map
+  );
+  exit2();
+  return value;
+}
+function map(line, _, blank) {
+  return ">" + (blank ? "" : " ") + line;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/pattern-in-scope.js
+function patternInScope(stack, pattern) {
+  return listInScope(stack, pattern.inConstruct, true) && !listInScope(stack, pattern.notInConstruct, false);
+}
+function listInScope(stack, list3, none) {
+  if (!list3) {
+    return none;
+  }
+  if (typeof list3 === "string") {
+    list3 = [list3];
+  }
+  let index2 = -1;
+  while (++index2 < list3.length) {
+    if (stack.includes(list3[index2])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/break.js
+function hardBreak(_, _1, context, safe2) {
+  let index2 = -1;
+  while (++index2 < context.unsafe.length) {
+    if (context.unsafe[index2].character === "\n" && patternInScope(context.stack, context.unsafe[index2])) {
+      return /[ \t]/.test(safe2.before) ? "" : " ";
+    }
+  }
+  return "\\\n";
+}
+
+// node_modules/mdast-util-to-markdown/node_modules/longest-streak/index.js
+function longestStreak(value, character) {
+  const source = String(value);
+  let index2 = source.indexOf(character);
+  let expected = index2;
+  let count = 0;
+  let max = 0;
+  if (typeof character !== "string" || character.length !== 1) {
+    throw new Error("Expected character");
+  }
+  while (index2 !== -1) {
+    if (index2 === expected) {
+      if (++count > max) {
+        max = count;
+      }
+    } else {
+      count = 1;
+    }
+    expected = index2 + 1;
+    index2 = source.indexOf(character, expected);
+  }
+  return max;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/format-code-as-indented.js
+function formatCodeAsIndented(node, context) {
+  return Boolean(
+    !context.options.fences && node.value && !node.lang && /[^ \r\n]/.test(node.value) && !/^[\t ]*(?:[\r\n]|$)|(?:^|[\r\n])[\t ]*$/.test(node.value)
+  );
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-fence.js
+function checkFence(context) {
+  const marker = context.options.fence || "`";
+  if (marker !== "`" && marker !== "~") {
+    throw new Error(
+      "Cannot serialize code with `" + marker + "` for `options.fence`, expected `` ` `` or `~`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/pattern-compile.js
+function patternCompile(pattern) {
+  if (!pattern._compiled) {
+    const before = (pattern.atBreak ? "[\\r\\n][\\t ]*" : "") + (pattern.before ? "(?:" + pattern.before + ")" : "");
+    pattern._compiled = new RegExp(
+      (before ? "(" + before + ")" : "") + (/[|\\{}()[\]^$+*?.-]/.test(pattern.character) ? "\\" : "") + pattern.character + (pattern.after ? "(?:" + pattern.after + ")" : ""),
+      "g"
+    );
+  }
+  return pattern._compiled;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/safe.js
+function safe(context, input, config) {
+  const value = (config.before || "") + (input || "") + (config.after || "");
+  const positions = [];
+  const result = [];
+  const infos = {};
+  let index2 = -1;
+  while (++index2 < context.unsafe.length) {
+    const pattern = context.unsafe[index2];
+    if (!patternInScope(context.stack, pattern)) {
+      continue;
+    }
+    const expression = patternCompile(pattern);
+    let match;
+    while (match = expression.exec(value)) {
+      const before = "before" in pattern || Boolean(pattern.atBreak);
+      const after = "after" in pattern;
+      const position2 = match.index + (before ? match[1].length : 0);
+      if (positions.includes(position2)) {
+        if (infos[position2].before && !before) {
+          infos[position2].before = false;
+        }
+        if (infos[position2].after && !after) {
+          infos[position2].after = false;
+        }
+      } else {
+        positions.push(position2);
+        infos[position2] = { before, after };
+      }
+    }
+  }
+  positions.sort(numerical);
+  let start = config.before ? config.before.length : 0;
+  const end = value.length - (config.after ? config.after.length : 0);
+  index2 = -1;
+  while (++index2 < positions.length) {
+    const position2 = positions[index2];
+    if (position2 < start || position2 >= end) {
+      continue;
+    }
+    if (position2 + 1 < end && positions[index2 + 1] === position2 + 1 && infos[position2].after && !infos[position2 + 1].before && !infos[position2 + 1].after || positions[index2 - 1] === position2 - 1 && infos[position2].before && !infos[position2 - 1].before && !infos[position2 - 1].after) {
+      continue;
+    }
+    if (start !== position2) {
+      result.push(escapeBackslashes(value.slice(start, position2), "\\"));
+    }
+    start = position2;
+    if (/[!-/:-@[-`{-~]/.test(value.charAt(position2)) && (!config.encode || !config.encode.includes(value.charAt(position2)))) {
+      result.push("\\");
+    } else {
+      result.push(
+        "&#x" + value.charCodeAt(position2).toString(16).toUpperCase() + ";"
+      );
+      start++;
+    }
+  }
+  result.push(escapeBackslashes(value.slice(start, end), config.after));
+  return result.join("");
+}
+function numerical(a, b) {
+  return a - b;
+}
+function escapeBackslashes(value, after) {
+  const expression = /\\(?=[!-/:-@[-`{-~])/g;
+  const positions = [];
+  const results = [];
+  const whole = value + after;
+  let index2 = -1;
+  let start = 0;
+  let match;
+  while (match = expression.exec(whole)) {
+    positions.push(match.index);
+  }
+  while (++index2 < positions.length) {
+    if (start !== positions[index2]) {
+      results.push(value.slice(start, positions[index2]));
+    }
+    results.push("\\");
+    start = positions[index2];
+  }
+  results.push(value.slice(start));
+  return results.join("");
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/code.js
+function code(node, _, context, safeOptions) {
+  const marker = checkFence(context);
+  const raw = node.value || "";
+  const suffix = marker === "`" ? "GraveAccent" : "Tilde";
+  if (formatCodeAsIndented(node, context)) {
+    const exit3 = context.enter("codeIndented");
+    const value2 = indentLines(raw, map2);
+    exit3();
+    return value2;
+  }
+  const tracker = track(safeOptions);
+  const sequence = marker.repeat(Math.max(longestStreak(raw, marker) + 1, 3));
+  const exit2 = context.enter("codeFenced");
+  let value = tracker.move(sequence);
+  if (node.lang) {
+    const subexit = context.enter("codeFencedLang" + suffix);
+    value += tracker.move(
+      safe(context, node.lang, {
+        before: value,
+        after: " ",
+        encode: ["`"],
+        ...tracker.current()
+      })
+    );
+    subexit();
+  }
+  if (node.lang && node.meta) {
+    const subexit = context.enter("codeFencedMeta" + suffix);
+    value += tracker.move(" ");
+    value += tracker.move(
+      safe(context, node.meta, {
+        before: value,
+        after: "\n",
+        encode: ["`"],
+        ...tracker.current()
+      })
+    );
+    subexit();
+  }
+  value += tracker.move("\n");
+  if (raw) {
+    value += tracker.move(raw + "\n");
+  }
+  value += tracker.move(sequence);
+  exit2();
+  return value;
+}
+function map2(line, _, blank) {
+  return (blank ? "" : "    ") + line;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/association.js
+function association(node) {
+  if (node.label || !node.identifier) {
+    return node.label || "";
+  }
+  return decodeString(node.identifier);
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-quote.js
+function checkQuote(context) {
+  const marker = context.options.quote || '"';
+  if (marker !== '"' && marker !== "'") {
+    throw new Error(
+      "Cannot serialize title with `" + marker + "` for `options.quote`, expected `\"`, or `'`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/definition.js
+function definition2(node, _, context, safeOptions) {
+  const quote = checkQuote(context);
+  const suffix = quote === '"' ? "Quote" : "Apostrophe";
+  const exit2 = context.enter("definition");
+  let subexit = context.enter("label");
+  const tracker = track(safeOptions);
+  let value = tracker.move("[");
+  value += tracker.move(
+    safe(context, association(node), {
+      before: value,
+      after: "]",
+      ...tracker.current()
+    })
+  );
+  value += tracker.move("]: ");
+  subexit();
+  if (!node.url || /[\0- \u007F]/.test(node.url)) {
+    subexit = context.enter("destinationLiteral");
+    value += tracker.move("<");
+    value += tracker.move(
+      safe(context, node.url, { before: value, after: ">", ...tracker.current() })
+    );
+    value += tracker.move(">");
+  } else {
+    subexit = context.enter("destinationRaw");
+    value += tracker.move(
+      safe(context, node.url, {
+        before: value,
+        after: node.title ? " " : "\n",
+        ...tracker.current()
+      })
+    );
+  }
+  subexit();
+  if (node.title) {
+    subexit = context.enter("title" + suffix);
+    value += tracker.move(" " + quote);
+    value += tracker.move(
+      safe(context, node.title, {
+        before: value,
+        after: quote,
+        ...tracker.current()
+      })
+    );
+    value += tracker.move(quote);
+    subexit();
+  }
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-emphasis.js
+function checkEmphasis(context) {
+  const marker = context.options.emphasis || "*";
+  if (marker !== "*" && marker !== "_") {
+    throw new Error(
+      "Cannot serialize emphasis with `" + marker + "` for `options.emphasis`, expected `*`, or `_`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/container-phrasing.js
+function containerPhrasing(parent, context, safeOptions) {
+  const indexStack = context.indexStack;
+  const children = parent.children || [];
+  const results = [];
+  let index2 = -1;
+  let before = safeOptions.before;
+  indexStack.push(-1);
+  let tracker = track(safeOptions);
+  while (++index2 < children.length) {
+    const child = children[index2];
+    let after;
+    indexStack[indexStack.length - 1] = index2;
+    if (index2 + 1 < children.length) {
+      let handle2 = context.handle.handlers[children[index2 + 1].type];
+      if (handle2 && handle2.peek)
+        handle2 = handle2.peek;
+      after = handle2 ? handle2(children[index2 + 1], parent, context, {
+        before: "",
+        after: "",
+        ...tracker.current()
+      }).charAt(0) : "";
+    } else {
+      after = safeOptions.after;
+    }
+    if (results.length > 0 && (before === "\r" || before === "\n") && child.type === "html") {
+      results[results.length - 1] = results[results.length - 1].replace(
+        /(\r?\n|\r)$/,
+        " "
+      );
+      before = " ";
+      tracker = track(safeOptions);
+      tracker.move(results.join(""));
+    }
+    results.push(
+      tracker.move(
+        context.handle(child, parent, context, {
+          ...tracker.current(),
+          before,
+          after
+        })
+      )
+    );
+    before = results[results.length - 1].slice(-1);
+  }
+  indexStack.pop();
+  return results.join("");
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/emphasis.js
+emphasis.peek = emphasisPeek;
+function emphasis(node, _, context, safeOptions) {
+  const marker = checkEmphasis(context);
+  const exit2 = context.enter("emphasis");
+  const tracker = track(safeOptions);
+  let value = tracker.move(marker);
+  value += tracker.move(
+    containerPhrasing(node, context, {
+      before: value,
+      after: marker,
+      ...tracker.current()
+    })
+  );
+  value += tracker.move(marker);
+  exit2();
+  return value;
+}
+function emphasisPeek(_, _1, context) {
+  return context.options.emphasis || "*";
+}
+
+// node_modules/unist-util-is/index.js
+var convert = function(test) {
+  if (test === void 0 || test === null) {
+    return ok;
+  }
+  if (typeof test === "string") {
+    return typeFactory(test);
+  }
+  if (typeof test === "object") {
+    return Array.isArray(test) ? anyFactory(test) : propsFactory(test);
+  }
+  if (typeof test === "function") {
+    return castFactory(test);
+  }
+  throw new Error("Expected function, string, or object as test");
+};
+function anyFactory(tests) {
+  const checks = [];
+  let index2 = -1;
+  while (++index2 < tests.length) {
+    checks[index2] = convert(tests[index2]);
+  }
+  return castFactory(any);
+  function any(...parameters) {
+    let index3 = -1;
+    while (++index3 < checks.length) {
+      if (checks[index3].call(this, ...parameters))
+        return true;
+    }
+    return false;
+  }
+}
+function propsFactory(check) {
+  return castFactory(all2);
+  function all2(node) {
+    let key;
+    for (key in check) {
+      if (node[key] !== check[key])
+        return false;
+    }
+    return true;
+  }
+}
+function typeFactory(check) {
+  return castFactory(type);
+  function type(node) {
+    return node && node.type === check;
+  }
+}
+function castFactory(check) {
+  return assertion;
+  function assertion(...parameters) {
+    return Boolean(check.call(this, ...parameters));
+  }
+}
+function ok() {
+  return true;
+}
+
+// node_modules/unist-util-visit-parents/color.js
+function color(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/unist-util-visit-parents/index.js
+var CONTINUE = true;
+var SKIP = "skip";
+var EXIT = false;
+var visitParents = function(tree, test, visitor, reverse) {
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+    test = null;
+  }
+  const is = convert(test);
+  const step = reverse ? -1 : 1;
+  factory(tree, null, [])();
+  function factory(node, index2, parents) {
+    const value = typeof node === "object" && node !== null ? node : {};
+    let name;
+    if (typeof value.type === "string") {
+      name = typeof value.tagName === "string" ? value.tagName : typeof value.name === "string" ? value.name : void 0;
+      Object.defineProperty(visit2, "name", {
+        value: "node (" + color(value.type + (name ? "<" + name + ">" : "")) + ")"
+      });
+    }
+    return visit2;
+    function visit2() {
+      let result = [];
+      let subresult;
+      let offset;
+      let grandparents;
+      if (!test || is(node, index2, parents[parents.length - 1] || null)) {
+        result = toResult(visitor(node, parents));
+        if (result[0] === EXIT) {
+          return result;
+        }
+      }
+      if (node.children && result[0] !== SKIP) {
+        offset = (reverse ? node.children.length : -1) + step;
+        grandparents = parents.concat(node);
+        while (offset > -1 && offset < node.children.length) {
+          subresult = factory(node.children[offset], offset, grandparents)();
+          if (subresult[0] === EXIT) {
+            return subresult;
+          }
+          offset = typeof subresult[1] === "number" ? subresult[1] : offset + step;
+        }
+      }
+      return result;
+    }
+  }
+};
+function toResult(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE, value];
+  }
+  return [value];
+}
+
+// node_modules/mdast-util-to-markdown/node_modules/unist-util-visit/index.js
+var visit = function(tree, test, visitor, reverse) {
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+    test = null;
+  }
+  visitParents(tree, test, overload, reverse);
+  function overload(node, parents) {
+    const parent = parents[parents.length - 1];
+    return visitor(
+      node,
+      parent ? parent.children.indexOf(node) : null,
+      parent
+    );
+  }
+};
+
+// node_modules/mdast-util-to-markdown/lib/util/format-heading-as-setext.js
+function formatHeadingAsSetext(node, context) {
+  let literalWithBreak = false;
+  visit(node, (node2) => {
+    if ("value" in node2 && /\r?\n|\r/.test(node2.value) || node2.type === "break") {
+      literalWithBreak = true;
+      return EXIT;
+    }
+  });
+  return Boolean(
+    (!node.depth || node.depth < 3) && toString(node) && (context.options.setext || literalWithBreak)
+  );
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/heading.js
+function heading(node, _, context, safeOptions) {
+  const rank = Math.max(Math.min(6, node.depth || 1), 1);
+  const tracker = track(safeOptions);
+  if (formatHeadingAsSetext(node, context)) {
+    const exit3 = context.enter("headingSetext");
+    const subexit2 = context.enter("phrasing");
+    const value2 = containerPhrasing(node, context, {
+      ...tracker.current(),
+      before: "\n",
+      after: "\n"
+    });
+    subexit2();
+    exit3();
+    return value2 + "\n" + (rank === 1 ? "=" : "-").repeat(
+      value2.length - (Math.max(value2.lastIndexOf("\r"), value2.lastIndexOf("\n")) + 1)
+    );
+  }
+  const sequence = "#".repeat(rank);
+  const exit2 = context.enter("headingAtx");
+  const subexit = context.enter("phrasing");
+  tracker.move(sequence + " ");
+  let value = containerPhrasing(node, context, {
+    before: "# ",
+    after: "\n",
+    ...tracker.current()
+  });
+  if (/^[\t ]/.test(value)) {
+    value = "&#x" + value.charCodeAt(0).toString(16).toUpperCase() + ";" + value.slice(1);
+  }
+  value = value ? sequence + " " + value : sequence;
+  if (context.options.closeAtx) {
+    value += " " + sequence;
+  }
+  subexit();
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/html.js
+html.peek = htmlPeek;
+function html(node) {
+  return node.value || "";
+}
+function htmlPeek() {
+  return "<";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/image.js
+image.peek = imagePeek;
+function image(node, _, context, safeOptions) {
+  const quote = checkQuote(context);
+  const suffix = quote === '"' ? "Quote" : "Apostrophe";
+  const exit2 = context.enter("image");
+  let subexit = context.enter("label");
+  const tracker = track(safeOptions);
+  let value = tracker.move("![");
+  value += tracker.move(
+    safe(context, node.alt, { before: value, after: "]", ...tracker.current() })
+  );
+  value += tracker.move("](");
+  subexit();
+  if (!node.url && node.title || /[\0- \u007F]/.test(node.url)) {
+    subexit = context.enter("destinationLiteral");
+    value += tracker.move("<");
+    value += tracker.move(
+      safe(context, node.url, { before: value, after: ">", ...tracker.current() })
+    );
+    value += tracker.move(">");
+  } else {
+    subexit = context.enter("destinationRaw");
+    value += tracker.move(
+      safe(context, node.url, {
+        before: value,
+        after: node.title ? " " : ")",
+        ...tracker.current()
+      })
+    );
+  }
+  subexit();
+  if (node.title) {
+    subexit = context.enter("title" + suffix);
+    value += tracker.move(" " + quote);
+    value += tracker.move(
+      safe(context, node.title, {
+        before: value,
+        after: quote,
+        ...tracker.current()
+      })
+    );
+    value += tracker.move(quote);
+    subexit();
+  }
+  value += tracker.move(")");
+  exit2();
+  return value;
+}
+function imagePeek() {
+  return "!";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/image-reference.js
+imageReference.peek = imageReferencePeek;
+function imageReference(node, _, context, safeOptions) {
+  const type = node.referenceType;
+  const exit2 = context.enter("imageReference");
+  let subexit = context.enter("label");
+  const tracker = track(safeOptions);
+  let value = tracker.move("![");
+  const alt = safe(context, node.alt, {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  value += tracker.move(alt + "][");
+  subexit();
+  const stack = context.stack;
+  context.stack = [];
+  subexit = context.enter("reference");
+  const reference = safe(context, association(node), {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  subexit();
+  context.stack = stack;
+  exit2();
+  if (type === "full" || !alt || alt !== reference) {
+    value += tracker.move(reference + "]");
+  } else if (type === "shortcut") {
+    value = value.slice(0, -1);
+  } else {
+    value += tracker.move("]");
+  }
+  return value;
+}
+function imageReferencePeek() {
+  return "!";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/inline-code.js
+inlineCode.peek = inlineCodePeek;
+function inlineCode(node, _, context) {
+  let value = node.value || "";
+  let sequence = "`";
+  let index2 = -1;
+  while (new RegExp("(^|[^`])" + sequence + "([^`]|$)").test(value)) {
+    sequence += "`";
+  }
+  if (/[^ \r\n]/.test(value) && (/^[ \r\n]/.test(value) && /[ \r\n]$/.test(value) || /^`|`$/.test(value))) {
+    value = " " + value + " ";
+  }
+  while (++index2 < context.unsafe.length) {
+    const pattern = context.unsafe[index2];
+    const expression = patternCompile(pattern);
+    let match;
+    if (!pattern.atBreak)
+      continue;
+    while (match = expression.exec(value)) {
+      let position2 = match.index;
+      if (value.charCodeAt(position2) === 10 && value.charCodeAt(position2 - 1) === 13) {
+        position2--;
+      }
+      value = value.slice(0, position2) + " " + value.slice(match.index + 1);
+    }
+  }
+  return sequence + value + sequence;
+}
+function inlineCodePeek() {
+  return "`";
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/format-link-as-autolink.js
+function formatLinkAsAutolink(node, context) {
+  const raw = toString(node);
+  return Boolean(
+    !context.options.resourceLink && node.url && !node.title && node.children && node.children.length === 1 && node.children[0].type === "text" && (raw === node.url || "mailto:" + raw === node.url) && /^[a-z][a-z+.-]+:/i.test(node.url) && !/[\0- <>\u007F]/.test(node.url)
+  );
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/link.js
+link.peek = linkPeek;
+function link(node, _, context, safeOptions) {
+  const quote = checkQuote(context);
+  const suffix = quote === '"' ? "Quote" : "Apostrophe";
+  const tracker = track(safeOptions);
+  let exit2;
+  let subexit;
+  if (formatLinkAsAutolink(node, context)) {
+    const stack = context.stack;
+    context.stack = [];
+    exit2 = context.enter("autolink");
+    let value2 = tracker.move("<");
+    value2 += tracker.move(
+      containerPhrasing(node, context, {
+        before: value2,
+        after: ">",
+        ...tracker.current()
+      })
+    );
+    value2 += tracker.move(">");
+    exit2();
+    context.stack = stack;
+    return value2;
+  }
+  exit2 = context.enter("link");
+  subexit = context.enter("label");
+  let value = tracker.move("[");
+  value += tracker.move(
+    containerPhrasing(node, context, {
+      before: value,
+      after: "](",
+      ...tracker.current()
+    })
+  );
+  value += tracker.move("](");
+  subexit();
+  if (!node.url && node.title || /[\0- \u007F]/.test(node.url)) {
+    subexit = context.enter("destinationLiteral");
+    value += tracker.move("<");
+    value += tracker.move(
+      safe(context, node.url, { before: value, after: ">", ...tracker.current() })
+    );
+    value += tracker.move(">");
+  } else {
+    subexit = context.enter("destinationRaw");
+    value += tracker.move(
+      safe(context, node.url, {
+        before: value,
+        after: node.title ? " " : ")",
+        ...tracker.current()
+      })
+    );
+  }
+  subexit();
+  if (node.title) {
+    subexit = context.enter("title" + suffix);
+    value += tracker.move(" " + quote);
+    value += tracker.move(
+      safe(context, node.title, {
+        before: value,
+        after: quote,
+        ...tracker.current()
+      })
+    );
+    value += tracker.move(quote);
+    subexit();
+  }
+  value += tracker.move(")");
+  exit2();
+  return value;
+}
+function linkPeek(node, _, context) {
+  return formatLinkAsAutolink(node, context) ? "<" : "[";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/link-reference.js
+linkReference.peek = linkReferencePeek;
+function linkReference(node, _, context, safeOptions) {
+  const type = node.referenceType;
+  const exit2 = context.enter("linkReference");
+  let subexit = context.enter("label");
+  const tracker = track(safeOptions);
+  let value = tracker.move("[");
+  const text4 = containerPhrasing(node, context, {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  value += tracker.move(text4 + "][");
+  subexit();
+  const stack = context.stack;
+  context.stack = [];
+  subexit = context.enter("reference");
+  const reference = safe(context, association(node), {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  subexit();
+  context.stack = stack;
+  exit2();
+  if (type === "full" || !text4 || text4 !== reference) {
+    value += tracker.move(reference + "]");
+  } else if (type === "shortcut") {
+    value = value.slice(0, -1);
+  } else {
+    value += tracker.move("]");
+  }
+  return value;
+}
+function linkReferencePeek() {
+  return "[";
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet.js
+function checkBullet(context) {
+  const marker = context.options.bullet || "*";
+  if (marker !== "*" && marker !== "+" && marker !== "-") {
+    throw new Error(
+      "Cannot serialize items with `" + marker + "` for `options.bullet`, expected `*`, `+`, or `-`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet-other.js
+function checkBulletOther(context) {
+  const bullet = checkBullet(context);
+  const bulletOther = context.options.bulletOther;
+  if (!bulletOther) {
+    return bullet === "*" ? "-" : "*";
+  }
+  if (bulletOther !== "*" && bulletOther !== "+" && bulletOther !== "-") {
+    throw new Error(
+      "Cannot serialize items with `" + bulletOther + "` for `options.bulletOther`, expected `*`, `+`, or `-`"
+    );
+  }
+  if (bulletOther === bullet) {
+    throw new Error(
+      "Expected `bullet` (`" + bullet + "`) and `bulletOther` (`" + bulletOther + "`) to be different"
+    );
+  }
+  return bulletOther;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet-ordered.js
+function checkBulletOrdered(context) {
+  const marker = context.options.bulletOrdered || ".";
+  if (marker !== "." && marker !== ")") {
+    throw new Error(
+      "Cannot serialize items with `" + marker + "` for `options.bulletOrdered`, expected `.` or `)`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet-ordered-other.js
+function checkBulletOrderedOther(context) {
+  const bulletOrdered = checkBulletOrdered(context);
+  const bulletOrderedOther = context.options.bulletOrderedOther;
+  if (!bulletOrderedOther) {
+    return bulletOrdered === "." ? ")" : ".";
+  }
+  if (bulletOrderedOther !== "." && bulletOrderedOther !== ")") {
+    throw new Error(
+      "Cannot serialize items with `" + bulletOrderedOther + "` for `options.bulletOrderedOther`, expected `*`, `+`, or `-`"
+    );
+  }
+  if (bulletOrderedOther === bulletOrdered) {
+    throw new Error(
+      "Expected `bulletOrdered` (`" + bulletOrdered + "`) and `bulletOrderedOther` (`" + bulletOrderedOther + "`) to be different"
+    );
+  }
+  return bulletOrderedOther;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-rule.js
+function checkRule(context) {
+  const marker = context.options.rule || "*";
+  if (marker !== "*" && marker !== "-" && marker !== "_") {
+    throw new Error(
+      "Cannot serialize rules with `" + marker + "` for `options.rule`, expected `*`, `-`, or `_`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/list.js
+function list2(node, parent, context, safeOptions) {
+  const exit2 = context.enter("list");
+  const bulletCurrent = context.bulletCurrent;
+  let bullet = node.ordered ? checkBulletOrdered(context) : checkBullet(context);
+  const bulletOther = node.ordered ? checkBulletOrderedOther(context) : checkBulletOther(context);
+  const bulletLastUsed = context.bulletLastUsed;
+  let useDifferentMarker = false;
+  if (parent && (node.ordered ? context.options.bulletOrderedOther : context.options.bulletOther) && bulletLastUsed && bullet === bulletLastUsed) {
+    useDifferentMarker = true;
+  }
+  if (!node.ordered) {
+    const firstListItem = node.children ? node.children[0] : void 0;
+    if ((bullet === "*" || bullet === "-") && firstListItem && (!firstListItem.children || !firstListItem.children[0]) && context.stack[context.stack.length - 1] === "list" && context.stack[context.stack.length - 2] === "listItem" && context.stack[context.stack.length - 3] === "list" && context.stack[context.stack.length - 4] === "listItem" && context.indexStack[context.indexStack.length - 1] === 0 && context.indexStack[context.indexStack.length - 2] === 0 && context.indexStack[context.indexStack.length - 3] === 0) {
+      useDifferentMarker = true;
+    }
+    if (checkRule(context) === bullet && firstListItem) {
+      let index2 = -1;
+      while (++index2 < node.children.length) {
+        const item = node.children[index2];
+        if (item && item.type === "listItem" && item.children && item.children[0] && item.children[0].type === "thematicBreak") {
+          useDifferentMarker = true;
+          break;
+        }
+      }
+    }
+  }
+  if (useDifferentMarker) {
+    bullet = bulletOther;
+  }
+  context.bulletCurrent = bullet;
+  const value = containerFlow(node, context, safeOptions);
+  context.bulletLastUsed = bullet;
+  context.bulletCurrent = bulletCurrent;
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-list-item-indent.js
+function checkListItemIndent(context) {
+  const style = context.options.listItemIndent || "tab";
+  if (style === 1 || style === "1") {
+    return "one";
+  }
+  if (style !== "tab" && style !== "one" && style !== "mixed") {
+    throw new Error(
+      "Cannot serialize items with `" + style + "` for `options.listItemIndent`, expected `tab`, `one`, or `mixed`"
+    );
+  }
+  return style;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/list-item.js
+function listItem(node, parent, context, safeOptions) {
+  const listItemIndent = checkListItemIndent(context);
+  let bullet = context.bulletCurrent || checkBullet(context);
+  if (parent && parent.type === "list" && parent.ordered) {
+    bullet = (typeof parent.start === "number" && parent.start > -1 ? parent.start : 1) + (context.options.incrementListMarker === false ? 0 : parent.children.indexOf(node)) + bullet;
+  }
+  let size = bullet.length + 1;
+  if (listItemIndent === "tab" || listItemIndent === "mixed" && (parent && parent.type === "list" && parent.spread || node.spread)) {
+    size = Math.ceil(size / 4) * 4;
+  }
+  const tracker = track(safeOptions);
+  tracker.move(bullet + " ".repeat(size - bullet.length));
+  tracker.shift(size);
+  const exit2 = context.enter("listItem");
+  const value = indentLines(
+    containerFlow(node, context, tracker.current()),
+    map3
+  );
+  exit2();
+  return value;
+  function map3(line, index2, blank) {
+    if (index2) {
+      return (blank ? "" : " ".repeat(size)) + line;
+    }
+    return (blank ? bullet : bullet + " ".repeat(size - bullet.length)) + line;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/paragraph.js
+function paragraph(node, _, context, safeOptions) {
+  const exit2 = context.enter("paragraph");
+  const subexit = context.enter("phrasing");
+  const value = containerPhrasing(node, context, safeOptions);
+  subexit();
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/root.js
+function root(node, _, context, safeOptions) {
+  return containerFlow(node, context, safeOptions);
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-strong.js
+function checkStrong(context) {
+  const marker = context.options.strong || "*";
+  if (marker !== "*" && marker !== "_") {
+    throw new Error(
+      "Cannot serialize strong with `" + marker + "` for `options.strong`, expected `*`, or `_`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/strong.js
+strong.peek = strongPeek;
+function strong(node, _, context, safeOptions) {
+  const marker = checkStrong(context);
+  const exit2 = context.enter("strong");
+  const tracker = track(safeOptions);
+  let value = tracker.move(marker + marker);
+  value += tracker.move(
+    containerPhrasing(node, context, {
+      before: value,
+      after: marker,
+      ...tracker.current()
+    })
+  );
+  value += tracker.move(marker + marker);
+  exit2();
+  return value;
+}
+function strongPeek(_, _1, context) {
+  return context.options.strong || "*";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/text.js
+function text3(node, _, context, safeOptions) {
+  return safe(context, node.value, safeOptions);
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-rule-repetition.js
+function checkRuleRepetition(context) {
+  const repetition = context.options.ruleRepetition || 3;
+  if (repetition < 3) {
+    throw new Error(
+      "Cannot serialize rules with repetition `" + repetition + "` for `options.ruleRepetition`, expected `3` or more"
+    );
+  }
+  return repetition;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/thematic-break.js
+function thematicBreak2(_, _1, context) {
+  const value = (checkRule(context) + (context.options.ruleSpaces ? " " : "")).repeat(checkRuleRepetition(context));
+  return context.options.ruleSpaces ? value.slice(0, -1) : value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/index.js
+var handle = {
+  blockquote,
+  break: hardBreak,
+  code,
+  definition: definition2,
+  emphasis,
+  hardBreak,
+  heading,
+  html,
+  image,
+  imageReference,
+  inlineCode,
+  link,
+  linkReference,
+  list: list2,
+  listItem,
+  paragraph,
+  root,
+  strong,
+  text: text3,
+  thematicBreak: thematicBreak2
+};
+
+// node_modules/mdast-util-to-markdown/lib/join.js
+var join = [joinDefaults];
+function joinDefaults(left, right, parent, context) {
+  if (right.type === "code" && formatCodeAsIndented(right, context) && (left.type === "list" || left.type === right.type && formatCodeAsIndented(left, context))) {
+    return false;
+  }
+  if (left.type === "list" && left.type === right.type && Boolean(left.ordered) === Boolean(right.ordered) && !(left.ordered ? context.options.bulletOrderedOther : context.options.bulletOther)) {
+    return false;
+  }
+  if ("spread" in parent && typeof parent.spread === "boolean") {
+    if (left.type === "paragraph" && (left.type === right.type || right.type === "definition" || right.type === "heading" && formatHeadingAsSetext(right, context))) {
+      return;
+    }
+    return parent.spread ? 1 : 0;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/unsafe.js
+var fullPhrasingSpans = [
+  "autolink",
+  "destinationLiteral",
+  "destinationRaw",
+  "reference",
+  "titleQuote",
+  "titleApostrophe"
+];
+var unsafe = [
+  { character: "	", after: "[\\r\\n]", inConstruct: "phrasing" },
+  { character: "	", before: "[\\r\\n]", inConstruct: "phrasing" },
+  {
+    character: "	",
+    inConstruct: ["codeFencedLangGraveAccent", "codeFencedLangTilde"]
+  },
+  {
+    character: "\r",
+    inConstruct: [
+      "codeFencedLangGraveAccent",
+      "codeFencedLangTilde",
+      "codeFencedMetaGraveAccent",
+      "codeFencedMetaTilde",
+      "destinationLiteral",
+      "headingAtx"
+    ]
+  },
+  {
+    character: "\n",
+    inConstruct: [
+      "codeFencedLangGraveAccent",
+      "codeFencedLangTilde",
+      "codeFencedMetaGraveAccent",
+      "codeFencedMetaTilde",
+      "destinationLiteral",
+      "headingAtx"
+    ]
+  },
+  { character: " ", after: "[\\r\\n]", inConstruct: "phrasing" },
+  { character: " ", before: "[\\r\\n]", inConstruct: "phrasing" },
+  {
+    character: " ",
+    inConstruct: ["codeFencedLangGraveAccent", "codeFencedLangTilde"]
+  },
+  {
+    character: "!",
+    after: "\\[",
+    inConstruct: "phrasing",
+    notInConstruct: fullPhrasingSpans
+  },
+  { character: '"', inConstruct: "titleQuote" },
+  { atBreak: true, character: "#" },
+  { character: "#", inConstruct: "headingAtx", after: "(?:[\r\n]|$)" },
+  { character: "&", after: "[#A-Za-z]", inConstruct: "phrasing" },
+  { character: "'", inConstruct: "titleApostrophe" },
+  { character: "(", inConstruct: "destinationRaw" },
+  {
+    before: "\\]",
+    character: "(",
+    inConstruct: "phrasing",
+    notInConstruct: fullPhrasingSpans
+  },
+  { atBreak: true, before: "\\d+", character: ")" },
+  { character: ")", inConstruct: "destinationRaw" },
+  { atBreak: true, character: "*" },
+  { character: "*", inConstruct: "phrasing", notInConstruct: fullPhrasingSpans },
+  { atBreak: true, character: "+" },
+  { atBreak: true, character: "-" },
+  { atBreak: true, before: "\\d+", character: ".", after: "(?:[ 	\r\n]|$)" },
+  { atBreak: true, character: "<", after: "[!/?A-Za-z]" },
+  {
+    character: "<",
+    after: "[!/?A-Za-z]",
+    inConstruct: "phrasing",
+    notInConstruct: fullPhrasingSpans
+  },
+  { character: "<", inConstruct: "destinationLiteral" },
+  { atBreak: true, character: "=" },
+  { atBreak: true, character: ">" },
+  { character: ">", inConstruct: "destinationLiteral" },
+  { atBreak: true, character: "[" },
+  { character: "[", inConstruct: "phrasing", notInConstruct: fullPhrasingSpans },
+  { character: "[", inConstruct: ["label", "reference"] },
+  { character: "\\", after: "[\\r\\n]", inConstruct: "phrasing" },
+  { character: "]", inConstruct: ["label", "reference"] },
+  { atBreak: true, character: "_" },
+  { character: "_", inConstruct: "phrasing", notInConstruct: fullPhrasingSpans },
+  { atBreak: true, character: "`" },
+  {
+    character: "`",
+    inConstruct: ["codeFencedLangGraveAccent", "codeFencedMetaGraveAccent"]
+  },
+  { character: "`", inConstruct: "phrasing", notInConstruct: fullPhrasingSpans },
+  { atBreak: true, character: "~" }
+];
+
+// node_modules/mdast-util-to-markdown/lib/index.js
+function toMarkdown(tree, options = {}) {
+  const context = {
+    enter,
+    stack: [],
+    unsafe: [],
+    join: [],
+    handlers: {},
+    options: {},
+    indexStack: []
+  };
+  configure2(context, { unsafe, join, handlers: handle });
+  configure2(context, options);
+  if (context.options.tightDefinitions) {
+    configure2(context, { join: [joinDefinition] });
+  }
+  context.handle = zwitch("type", {
+    invalid,
+    unknown,
+    handlers: context.handlers
+  });
+  let result = context.handle(tree, null, context, {
+    before: "\n",
+    after: "\n",
+    now: { line: 1, column: 1 },
+    lineShift: 0
+  });
+  if (result && result.charCodeAt(result.length - 1) !== 10 && result.charCodeAt(result.length - 1) !== 13) {
+    result += "\n";
+  }
+  return result;
+  function enter(name) {
+    context.stack.push(name);
+    return exit2;
+    function exit2() {
+      context.stack.pop();
+    }
+  }
+}
+function invalid(value) {
+  throw new Error("Cannot handle value `" + value + "`, expected node");
+}
+function unknown(node) {
+  throw new Error("Cannot handle unknown node `" + node.type + "`");
+}
+function joinDefinition(left, right) {
+  if (left.type === "definition" && left.type === right.type) {
+    return 0;
+  }
+}
+
+// node_modules/remark/node_modules/remark-stringify/lib/index.js
+function remarkStringify(options) {
+  const compiler2 = (tree) => {
+    const settings = this.data("settings");
+    return toMarkdown(
+      tree,
+      Object.assign({}, settings, options, {
+        extensions: this.data("toMarkdownExtensions") || []
+      })
+    );
+  };
+  Object.assign(this, { Compiler: compiler2 });
+}
+
+// node_modules/remark/node_modules/remark-stringify/index.js
+var remark_stringify_default = remarkStringify;
+
+// node_modules/remark/index.js
+var remark1402 = unified().use(remark_parse_default).use(remark_stringify_default).freeze();
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  remark: remark1402
+});
+/*!
+ * Determine if an object is a Buffer
+ *
+ * @author   Feross Aboukhadijeh <https://feross.org>
+ * @license  MIT
+ */


### PR DESCRIPTION
MDX 2 deps only support ESM so we need to vendor them as CJS to make them work in Jest unit tests.

This was initially made as part of the MDX 2 PR here: https://github.com/facebook/docusaurus/pull/8288

But I'm moving this in this separate PR and merging it earlier because otherwise, the MDX 2 PR (https://github.com/facebook/docusaurus/pull/8288/files) becomes hard to review (too much noise, GitHub review UI freezing...)
