### PR TITLE
fix(core): avoid hash collision when generating chunk names

### DIFF
--- a/packages/docusaurus/src/server/__tests__/routes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/routes.test.ts
@@ -64,12 +64,29 @@ describe('genChunkName', () => {
         '@site/blog/2022-11-18-bye-medium/index.mdx?truncated=true',
         'content',
         'blog',
+        false,
       ),
     ).not.toBe(
       genChunkName(
         '@site/blog/2019-10-05-react-nfc/index.mdx?truncated=true',
         'content',
         'blog',
+        false,
+      ),
+    );
+    expect(
+      genChunkName(
+        '@site/blog/2022-11-18-bye-medium/index.mdx?truncated=true',
+        'content',
+        'blog',
+        true,
+      ),
+    ).not.toBe(
+      genChunkName(
+        '@site/blog/2019-10-05-react-nfc/index.mdx?truncated=true',
+        'content',
+        'blog',
+        true,
       ),
     );
   });

--- a/packages/docusaurus/src/server/__tests__/routes.test.ts
+++ b/packages/docusaurus/src/server/__tests__/routes.test.ts
@@ -56,6 +56,23 @@ describe('genChunkName', () => {
     });
     expect(genChunkName('d', undefined, undefined, true)).toBe('8277e091');
   });
+
+  // https://github.com/facebook/docusaurus/issues/8536
+  it('avoids hash collisions', () => {
+    expect(
+      genChunkName(
+        '@site/blog/2022-11-18-bye-medium/index.mdx?truncated=true',
+        'content',
+        'blog',
+      ),
+    ).not.toBe(
+      genChunkName(
+        '@site/blog/2019-10-05-react-nfc/index.mdx?truncated=true',
+        'content',
+        'blog',
+      ),
+    );
+  });
 });
 
 describe('handleDuplicateRoutes', () => {

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -80,12 +80,12 @@ export function genChunkName(
         const shortHash = simpleHash(modulePath, 3);
         str = `${preferredName}${shortHash}`;
       }
-      const name = str === '/' ? 'index' : docuHash(str);
+      const name = docuHash(str);
       chunkName = prefix ? `${prefix}---${name}` : name;
     }
     const seenCount = (chunkNameCount.get(chunkName) ?? 0) + 1;
     if (seenCount > 1) {
-      chunkName += seenCount;
+      chunkName += seenCount.toString(36);
     }
     chunkNameCache.set(modulePath, chunkName);
     chunkNameCount.set(chunkName, seenCount);

--- a/packages/docusaurus/src/server/routes.ts
+++ b/packages/docusaurus/src/server/routes.ts
@@ -51,6 +51,7 @@ function indent(str: string) {
 }
 
 const chunkNameCache = new Map<string, string>();
+const chunkNameCount = new Map<string, number>();
 
 /**
  * Generates a unique chunk name that can be used in the chunk registry.
@@ -82,7 +83,12 @@ export function genChunkName(
       const name = str === '/' ? 'index' : docuHash(str);
       chunkName = prefix ? `${prefix}---${name}` : name;
     }
+    const seenCount = (chunkNameCount.get(chunkName) ?? 0) + 1;
+    if (seenCount > 1) {
+      chunkName += seenCount;
+    }
     chunkNameCache.set(modulePath, chunkName);
+    chunkNameCount.set(chunkName, seenCount);
   }
   return chunkName;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #8536) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

Added a unit test that didn't pass on master. Ideally we would have dogfooding as well, but this is hard because we have to make sure that (1) two blog posts have the same chunk name (2) they appear on the same page in the paginated view. It's possible if we create another blog plugin solely for this test, but that doesn't seem worthwhile.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
