### PR TITLE
Add support for alt text of logo for navbar & footer in translations builds

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/__snapshots__/translations.test.ts.snap
+++ b/packages/docusaurus-theme-classic/src/__tests__/__snapshots__/translations.test.ts.snap
@@ -16,6 +16,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 1`] = `
         "description": "Navbar item with label Dropdown item 2",
         "message": "Dropdown item 2",
       },
+      "logo.alt": {
+        "description": "The alt of navbar logo",
+        "message": "Navbar alt Logo",
+      },
       "title": {
         "description": "The title in the navbar",
         "message": "navbar title",
@@ -49,6 +53,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 1`] = `
         "description": "The title of the footer links column with title=Footer link column 2 in the footer",
         "message": "Footer link column 2",
       },
+      "logo.alt": {
+        "description": "The alt of footer logo",
+        "message": "Footer alt Logo",
+      },
     },
     "path": "footer",
   },
@@ -71,6 +79,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 2`] = `
         "description": "Navbar item with label Dropdown item 2",
         "message": "Dropdown item 2",
       },
+      "logo.alt": {
+        "description": "The alt of navbar logo",
+        "message": "Navbar alt Logo",
+      },
       "title": {
         "description": "The title in the navbar",
         "message": "navbar title",
@@ -91,6 +103,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 2`] = `
       "link.item.label.Link 2": {
         "description": "The label of footer link with label=Link 2 linking to https://facebook.com",
         "message": "Link 2",
+      },
+      "logo.alt": {
+        "description": "The alt of footer logo",
+        "message": "Footer alt Logo",
       },
     },
     "path": "footer",
@@ -131,6 +147,10 @@ exports[`translateThemeConfig returns translated themeConfig 1`] = `
         "title": "Footer link column 2 (translated)",
       },
     ],
+    "logo": {
+      "alt": "Footer alt Logo",
+      "src": "/img/test_logo.svg",
+    },
     "style": "light",
   },
   "navbar": {
@@ -150,6 +170,10 @@ exports[`translateThemeConfig returns translated themeConfig 1`] = `
         "label": "Dropdown (translated)",
       },
     ],
+    "logo": {
+      "alt": "Navbar alt Logo",
+      "src": "/img/test_logo.svg",
+    },
     "style": "dark",
     "title": "navbar title (translated)",
   },

--- a/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
@@ -18,6 +18,10 @@ const ThemeConfigSample = {
   },
   navbar: {
     title: 'navbar title',
+    logo: {
+      alt: 'Navbar alt Logo',
+      src: '/img/test_logo.svg',
+    },
     style: 'dark',
     hideOnScroll: false,
     items: [
@@ -31,6 +35,10 @@ const ThemeConfigSample = {
     ],
   },
   footer: {
+    logo: {
+      alt: 'Footer alt Logo',
+      src: '/img/test_logo.svg',
+    },
     copyright: 'Copyright FB',
     style: 'light',
     links: [
@@ -52,6 +60,10 @@ const ThemeConfigSample = {
 const ThemeConfigSampleSimpleFooter: ThemeConfig = {
   ...ThemeConfigSample,
   footer: {
+    logo: {
+      alt: 'Footer alt Logo',
+      src: '/img/test_logo.svg',
+    },
     copyright: 'Copyright FB',
     style: 'light',
     links: [

--- a/packages/docusaurus-theme-classic/src/translations.ts
+++ b/packages/docusaurus-theme-classic/src/translations.ts
@@ -45,7 +45,20 @@ function getNavbarTranslationFile(navbar: Navbar): TranslationFileContent {
     ? {title: {message: navbar.title, description: 'The title in the navbar'}}
     : {};
 
-  return mergeTranslations([titleTranslations, navbarItemsTranslations]);
+  const logoAlt: TranslationFileContent = navbar.logo?.alt
+    ? {
+        'logo.alt': {
+          message: navbar.logo?.alt,
+          description: 'The alt of navbar logo',
+        },
+      }
+    : {};
+
+  return mergeTranslations([
+    titleTranslations,
+    logoAlt,
+    navbarItemsTranslations,
+  ]);
 }
 function translateNavbar(
   navbar: Navbar,
@@ -119,7 +132,21 @@ function getFooterTranslationFile(footer: Footer): TranslationFileContent {
       }
     : {};
 
-  return mergeTranslations([footerLinkTitles, footerLinkLabels, copyright]);
+  const logoAlt: TranslationFileContent = footer.logo?.alt
+    ? {
+        'logo.alt': {
+          message: footer.logo?.alt,
+          description: 'The alt of footer logo',
+        },
+      }
+    : {};
+
+  return mergeTranslations([
+    footerLinkTitles,
+    footerLinkLabels,
+    copyright,
+    logoAlt,
+  ]);
 }
 function translateFooter(
   footer: Footer,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR can allow more control for translations by the addition of footer & navbar alt text for logo.

It's a detail but that can be usefull to translate the alt text for footer Logo of docusaurus website (https://github.com/facebook/docusaurus/blob/main/website/docusaurus.config.js#L622) to be more consistent.

## Test Plan

Translations tests have been updated for the package `docusaurus-theme-classic` ^^.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8551--docusaurus-2.netlify.app/
