### PR TITLE
fix(theme): emoji collide in DocCard

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -24,7 +24,7 @@ import type {
 import styles from './styles.module.css';
 
 function startWithEmoji(title: string): boolean {
-    return /^\p{S}/u.test(title);
+    return /^\p{So}/u.test(title);
 }
 
 function CardContainer({

--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -23,6 +23,10 @@ import type {
 
 import styles from './styles.module.css';
 
+function startWithEmoji(title: string): boolean {
+    return /^\p{S}/u.test(title);
+}
+
 function CardContainer({
   href,
   children,
@@ -53,7 +57,7 @@ function CardLayout({
   return (
     <CardContainer href={href}>
       <h2 className={clsx('text--truncate', styles.cardTitle)} title={title}>
-        {icon} {title}
+        {icon !== '' ? icon + ' ' : ''}{title}
       </h2>
       {description && (
         <p
@@ -81,7 +85,7 @@ function CardCategory({
   return (
     <CardLayout
       href={href}
-      icon="🗃️"
+      icon={startWithEmoji(item.label) ? "" : "🗃️"}
       title={item.label}
       description={translate(
         {
@@ -102,7 +106,7 @@ function CardLink({item}: {item: PropSidebarItemLink}): JSX.Element {
   return (
     <CardLayout
       href={item.href}
-      icon={icon}
+      icon={startWithEmoji(item.label) ? '' : icon}
       title={item.label}
       description={doc?.description}
     />


### PR DESCRIPTION
if the title already contains a starting emoji the default emoji is not displayed

before:
![image](https://user-images.githubusercontent.com/7063188/213420633-70e558f8-17ef-419b-9c0e-0017c1fe2a8d.png)

after the fix:
![image](https://user-images.githubusercontent.com/7063188/213420783-c3c23dc9-8a3d-4a95-ad50-c0ae732dfa85.png)

other overview without emojis(still working):
![image](https://user-images.githubusercontent.com/7063188/213420870-776ac583-fbcf-4cc1-a5e2-3afecea3e1e8.png)


## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

