### PR TITLE
fix(preset-classic): Pass Google Tag Manager configuration to correct plugin

### DIFF
--- a/packages/docusaurus-preset-classic/src/index.ts
+++ b/packages/docusaurus-preset-classic/src/index.ts
@@ -83,7 +83,7 @@ export default function preset(
   }
   if (googleTagManager) {
     plugins.push(
-      makePluginConfig('@docusaurus/plugin-google-gtag', googleTagManager),
+      makePluginConfig('@docusaurus/plugin-google-tag-manager', googleTagManager),
     );
   }
   if (isProd && sitemap !== false) {


### PR DESCRIPTION
The current implementation of the plugin configuration builder of preset-classic incorrectly sets the configuration for the `googleTagManager`-tag. It tries to pass the Google Tag Manager configuration to the legacy GTag plugin, instead of the new Google Tag Manager plugin.

This change routes the configuration to the correct plugin.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

The newly added plugin for Google Tag Manager isn't properly integrated with the `classic`-preset, as the `classic`-preset tries to route the newly added config for the GTM plugin to the legacy GTag plugin.

Therefore, preventing you from being able to confgure the GTM plugin from the `classic`-preset.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8600--docusaurus-2.netlify.app/

## Related issues/PRs

#8470 