### PR TITLE
Update favicon config to allow user to specify a specific favicon for dark theme (prefers-color-scheme)

### DIFF
--- a/examples/classic-typescript/docusaurus.config.js
+++ b/examples/classic-typescript/docusaurus.config.js
@@ -8,7 +8,9 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'My Site',
   tagline: 'Dinosaurs are cool',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 
   // Set the production url of your site here
   url: 'https://your-docusaurus-test-site.com',

--- a/examples/classic/docusaurus.config.js
+++ b/examples/classic/docusaurus.config.js
@@ -8,7 +8,9 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'My Site',
   tagline: 'Dinosaurs are cool',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 
   // Set the production url of your site here
   url: 'https://your-docusaurus-test-site.com',

--- a/examples/facebook/docusaurus.config.js
+++ b/examples/facebook/docusaurus.config.js
@@ -13,7 +13,9 @@
 const config = {
   title: 'My Site',
   tagline: 'The tagline of my site',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 
   // Set the production url of your site here
   url: 'https://your-docusaurus-test-site.com',

--- a/packages/create-docusaurus/templates/classic/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/classic/docusaurus.config.js
@@ -8,7 +8,9 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'My Site',
   tagline: 'Dinosaurs are cool',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 
   // Set the production url of your site here
   url: 'https://your-docusaurus-test-site.com',

--- a/packages/create-docusaurus/templates/facebook/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/facebook/docusaurus.config.js
@@ -13,7 +13,9 @@
 const config = {
   title: 'My Site',
   tagline: 'The tagline of my site',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 
   // Set the production url of your site here
   url: 'https://your-docusaurus-test-site.com',

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
@@ -71,7 +71,9 @@ describe.each(['atom', 'rss', 'json'])('%s', (feedType) => {
       title: 'Hello',
       baseUrl: '/',
       url: 'https://docusaurus.io',
-      favicon: 'image/favicon.ico',
+      favicon: {
+        src: 'image/favicon.ico',
+      },
     };
     const outDir = path.join(siteDir, 'build-snap');
 
@@ -109,7 +111,9 @@ describe.each(['atom', 'rss', 'json'])('%s', (feedType) => {
       title: 'Hello',
       baseUrl: '/myBaseUrl/',
       url: 'https://docusaurus.io',
-      favicon: 'image/favicon.ico',
+      favicon: {
+        src: 'image/favicon.ico',
+      },
     };
 
     // Build is quite difficult to mock, so we built the blog beforehand and
@@ -151,7 +155,9 @@ describe.each(['atom', 'rss', 'json'])('%s', (feedType) => {
       title: 'Hello',
       baseUrl: '/myBaseUrl/',
       url: 'https://docusaurus.io',
-      favicon: 'image/favicon.ico',
+      favicon: {
+        src: 'image/favicon.ico',
+      },
     };
 
     // Build is quite difficult to mock, so we built the blog beforehand and

--- a/packages/docusaurus-plugin-content-blog/src/feed.ts
+++ b/packages/docusaurus-plugin-content-blog/src/feed.ts
@@ -51,7 +51,9 @@ async function generateBlogFeed({
     language: feedOptions.language ?? locale,
     link: blogBaseUrl,
     description: feedOptions.description ?? `${siteConfig.title} Blog`,
-    favicon: favicon ? normalizeUrl([siteUrl, baseUrl, favicon]) : undefined,
+    favicon: favicon?.src
+      ? normalizeUrl([siteUrl, baseUrl, favicon?.src])
+      : undefined,
     copyright: feedOptions.copyright,
   });
 

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/empty-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/empty-site/docusaurus.config.js
@@ -10,7 +10,9 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
   organizationName: 'facebook', // Usually your GitHub org/user name.
   projectName: 'docusaurus', // Usually your repo name.
 };

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -10,5 +10,7 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 };

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-autogenerated-sidebar/docusaurus.config.js
@@ -10,5 +10,7 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 };

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-doc-label/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/site-with-doc-label/docusaurus.config.js
@@ -10,5 +10,7 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 };

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/docusaurus.config.js
@@ -10,7 +10,9 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'fr'],

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
@@ -10,5 +10,7 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
 };

--- a/packages/docusaurus-theme-search-algolia/src/index.ts
+++ b/packages/docusaurus-theme-search-algolia/src/index.ts
@@ -81,7 +81,9 @@ export default function themeSearchAlgolia(context: LoadContext): Plugin<void> {
               title,
               siteUrl,
               searchUrl: normalizeUrl([siteUrl, searchPagePath]),
-              faviconUrl: favicon ? normalizeUrl([siteUrl, favicon]) : null,
+              faviconUrl: favicon?.src
+                ? normalizeUrl([siteUrl, favicon?.src])
+                : null,
             }),
           );
         } catch (err) {

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -30,6 +30,11 @@ export type MarkdownConfig = {
   mermaid?: boolean;
 };
 
+export type FaviconConfig = {
+  src?: string;
+  srcDark?: string;
+};
+
 /**
  * Docusaurus config, after validation/normalization.
  */
@@ -62,7 +67,7 @@ export type DocusaurusConfig = {
    *
    * @see https://docusaurus.io/docs/api/docusaurus-config#favicon
    */
-  favicon?: string;
+  favicon?: FaviconConfig;
   /**
    * Allow to customize the presence/absence of a trailing slash at the end of
    * URLs/links, and how static HTML files are generated:

--- a/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
+++ b/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
@@ -32,7 +32,14 @@ export default function SiteMetadataDefaults(): JSX.Element {
       <meta property="og:title" content={title} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       {noIndex && <meta name="robots" content="noindex, nofollow" />}
-      {favicon && <link rel="icon" href={faviconUrl} />}
+      {favicon && !faviconDarkUrl && <link rel="icon" href={faviconUrl} />}
+      {favicon && faviconDarkUrl && (
+        <link
+          rel="icon"
+          media="(prefers-color-scheme: light)"
+          href={faviconUrl}
+        />
+      )}
       {faviconDarkUrl && (
         <link
           rel="icon"

--- a/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
+++ b/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
@@ -33,20 +33,20 @@ export default function SiteMetadataDefaults(): JSX.Element {
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       {noIndex && <meta name="robots" content="noindex, nofollow" />}
       {favicon && !faviconDarkUrl && <link rel="icon" href={faviconUrl} />}
-      {favicon && faviconDarkUrl && (
-        <link
-          rel="icon"
-          media="(prefers-color-scheme: light)"
-          href={faviconUrl}
-        />
-      )}
-      {faviconDarkUrl && (
-        <link
-          rel="icon"
-          media="(prefers-color-scheme: dark)"
-          href={faviconDarkUrl}
-        />
-      )}
+      {favicon &&
+        faviconDarkUrl && (
+          <link
+            rel="icon"
+            media="(prefers-color-scheme: light)"
+            href={faviconUrl}
+          />
+        ) && (
+          <link
+            rel="icon"
+            media="(prefers-color-scheme: dark)"
+            href={faviconDarkUrl}
+          />
+        )}
     </Head>
   );
 }

--- a/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
+++ b/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
@@ -15,7 +15,8 @@ export default function SiteMetadataDefaults(): JSX.Element {
     siteConfig: {favicon, title, noIndex},
     i18n: {currentLocale, localeConfigs},
   } = useDocusaurusContext();
-  const faviconUrl = useBaseUrl(favicon);
+  const faviconUrl = useBaseUrl(favicon?.src);
+  const faviconDarkUrl = useBaseUrl(favicon?.srcDark);
   const {htmlLang, direction: htmlDir} = localeConfigs[currentLocale]!;
 
   return (
@@ -32,6 +33,13 @@ export default function SiteMetadataDefaults(): JSX.Element {
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       {noIndex && <meta name="robots" content="noindex, nofollow" />}
       {favicon && <link rel="icon" href={faviconUrl} />}
+      {faviconDarkUrl && (
+        <link
+          rel="icon"
+          media="(prefers-color-scheme: dark)"
+          href={faviconDarkUrl}
+        />
+      )}
     </Head>
   );
 }

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/custom-site/docusaurus.config.js
@@ -12,7 +12,9 @@ module.exports = {
   projectName: 'site',
   baseUrl: '/site/',
   url: 'https://docusaurus.io',
-  favicon: 'img/docusaurus.ico',
+  favicon: {
+    src: 'img/docusaurus.ico',
+  },
   plugins: [
     [
       '@docusaurus/plugin-content-docs',

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/simple-site/docusaurus.config.js
@@ -12,7 +12,9 @@ module.exports = {
   projectName: 'hello',
   baseUrl: '/',
   url: 'https://docusaurus.io',
-  favicon: 'img/docusaurus.ico',
+  favicon: {
+    src: 'img/docusaurus.ico',
+  },
   plugins: [
     [
       '@docusaurus/plugin-content-docs',

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -179,7 +179,9 @@ exports[`loadSiteConfig website with valid siteConfig 1`] = `
       "foo.js",
     ],
     "customFields": {},
-    "favicon": "img/docusaurus.ico",
+    "favicon": {
+      "src": "img/docusaurus.ico",
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -178,6 +178,11 @@ const SiteUrlSchema = Joi.string()
       'The url is not supposed to contain a sub-path like "{#pathname}". Please use the baseUrl field for sub-paths.',
   });
 
+const FaviconConfigSchema = Joi.object({
+  src: Joi.string(),
+  srcDark: Joi.string(),
+});
+
 // TODO move to @docusaurus/utils-validation
 export const ConfigSchema = Joi.object<DocusaurusConfig>({
   baseUrl: Joi
@@ -187,7 +192,7 @@ export const ConfigSchema = Joi.object<DocusaurusConfig>({
     .required()
     .custom((value: string) => addLeadingSlash(addTrailingSlash(value))),
   baseUrlIssueBanner: Joi.boolean().default(DEFAULT_CONFIG.baseUrlIssueBanner),
-  favicon: Joi.string().optional(),
+  favicon: FaviconConfigSchema,
   title: Joi.string().required(),
   url: SiteUrlSchema,
   trailingSlash: Joi.boolean(), // No default value! undefined = retrocompatible legacy behavior!

--- a/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/badPlugins.docusaurus.config.js
+++ b/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/badPlugins.docusaurus.config.js
@@ -10,6 +10,8 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico'
+  },
   plugins: [42, true],
 };

--- a/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/docusaurus.config.js
+++ b/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-plugin/docusaurus.config.js
@@ -10,7 +10,9 @@ module.exports = {
   tagline: 'The tagline of my site',
   url: 'https://your-docusaurus-test-site.com',
   baseUrl: '/',
-  favicon: 'img/favicon.ico',
+  favicon: {
+    src: 'img/favicon.ico',
+  },
   plugins: [
     function (context, options) {
       return {name: 'first-plugin'};

--- a/website/docs/api/docusaurus.config.js.mdx
+++ b/website/docs/api/docusaurus.config.js.mdx
@@ -6,6 +6,8 @@ slug: /api/docusaurus-config
 
 # `docusaurus.config.js`
 
+import APITable from '@site/src/components/APITable';
+
 ## Overview {#overview}
 
 `docusaurus.config.js` contains configurations for your site and is placed in the root directory of your site.
@@ -87,14 +89,29 @@ module.exports = {
 
 ### `favicon` {#favicon}
 
-- Type: `string | undefined`
+- Type: `object | undefined`
 
 Path to your site favicon; must be a URL that can be used in link's href. For example, if your favicon is in `static/img/favicon.ico`:
 
 ```js title="docusaurus.config.js"
 module.exports = {
-  favicon: '/img/favicon.ico',
+  favicon: {
+    src: '/img/favicon.ico',
+  },
 };
+```
+
+```mdx-code-block
+<APITable>
+```
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `src` | `string` | URL to the site favicon. Base URL is appended by default. |
+| `srcDark` | `string` | An alternative site favicon URL to use in dark mode. |
+
+```mdx-code-block
+</APITable>
 ```
 
 ### `trailingSlash` {#trailingSlash}

--- a/website/docusaurus.config-blog-only.js
+++ b/website/docusaurus.config-blog-only.js
@@ -15,7 +15,9 @@ module.exports = {
   // We can only warn now, since we have blog pages linking to non-blog pages...
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
-  favicon: 'img/docusaurus.ico',
+  favicon: {
+    src: 'img/docusaurus.ico',
+  },
   themes: ['live-codeblock'],
   plugins: ['ideal-image'],
   presets: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -119,7 +119,6 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   favicon: {
     src: 'img/docusaurus.ico',
-    srcDark: 'img/docusaurus.ico',
   },
   customFields: {
     isDeployPreview,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -117,7 +117,9 @@ const config = {
   },
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
-  favicon: 'img/docusaurus.ico',
+  favicon: {
+    src: 'img/docusaurus.ico',
+  },
   customFields: {
     isDeployPreview,
     description:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -119,6 +119,7 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   favicon: {
     src: 'img/docusaurus.ico',
+    srcDark: 'img/docusaurus.ico',
   },
   customFields: {
     isDeployPreview,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Like we have on Github, this change allow the specification of favicon for dark prefers-color-scheme.

To add that, there is a "breaking change", the `favicon` field becomes an object field with two properties (`src` & `srcDark`) and is therefore not considered like a string field.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8602--docusaurus-2.netlify.app/
