### PR TITLE
fix(utils): handle CRLF when parsing MDX imports

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -130,6 +130,26 @@ describe('createExcerpt', () => {
     );
   });
 
+  it('creates excerpt for content with imports/exports declarations, with CRLF line endings', () => {
+    expect(
+      createExcerpt(
+        dedent`
+          import Component from '@site/src/components/Component';
+
+          export function ItemCol(props) {
+            return <Item {...props} className={'col col--6 margin-bottom--lg'}/>
+          }
+
+          Lorem **ipsum** dolor sit \`amet\`[^1], consectetur _adipiscing_ elit. [**Vestibulum**](https://wiktionary.org/wiki/vestibulum) ex urna[^note], ~~molestie~~ et sagittis ut, varius ac justo :wink:.
+
+          Nunc porttitor libero nec vulputate venenatis. Nam nec rhoncus mauris. Morbi tempus est et nibh maximus, tempus venenatis arcu lobortis.
+        `.replace(/\n/g, '\r\n'),
+      ),
+    ).toBe(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ex urna, molestie et sagittis ut, varius ac justo.',
+    );
+  });
+
   it('creates excerpt for heading specified with anchor-id syntax', () => {
     expect(
       createExcerpt(dedent`

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -62,9 +62,11 @@ export function createExcerpt(fileString: string): string | undefined {
   let lastCodeFence = '';
 
   for (const fileLine of fileLines) {
-    if (fileLine === '' && inImport) {
+    // An empty line marks the end of imports
+    if (!fileLine.trim() && inImport) {
       inImport = false;
     }
+
     // Skip empty line.
     if (!fileLine.trim()) {
       continue;

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -55,8 +55,8 @@ export function createExcerpt(fileString: string): string | undefined {
   const fileLines = fileString
     .trimStart()
     // Remove Markdown alternate title
-    .replace(/^[^\n]*\n[=]+/g, '')
-    .split('\n');
+    .replace(/^[^\r\n]*\r?\n[=]+/g, '')
+    .split(/\r?\n/);
   let inCode = false;
   let inImport = false;
   let lastCodeFence = '';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [NA] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

On Windows, when CRLF line endings are used, there is an issue when parsing Markdown. More specifically, the generated excerpt might be empty when the Markdown content starts with some `import`.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I added a unit tests that demonstrates what the issue was, and shows that it is now fixed with the change.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8606--docusaurus-2.netlify.app/

## Related issues/PRs

None

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
