### PR TITLE
Add support for alt text of logo for navbar & footer in translations builds

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/__snapshots__/translations.test.ts.snap
+++ b/packages/docusaurus-theme-classic/src/__tests__/__snapshots__/translations.test.ts.snap
@@ -16,6 +16,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 1`] = `
         "description": "Navbar item with label Dropdown item 2",
         "message": "Dropdown item 2",
       },
+      "logo.alt": {
+        "description": "The alt of navbar logo",
+        "message": "navbar alt logo",
+      },
       "title": {
         "description": "The title in the navbar",
         "message": "navbar title",
@@ -49,6 +53,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 1`] = `
         "description": "The title of the footer links column with title=Footer link column 2 in the footer",
         "message": "Footer link column 2",
       },
+      "logo.alt": {
+        "description": "The alt of footer logo",
+        "message": "footer alt logo",
+      },
     },
     "path": "footer",
   },
@@ -70,6 +78,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 2`] = `
       "item.label.Dropdown item 2": {
         "description": "Navbar item with label Dropdown item 2",
         "message": "Dropdown item 2",
+      },
+      "logo.alt": {
+        "description": "The alt of navbar logo",
+        "message": "navbar alt logo",
       },
       "title": {
         "description": "The title in the navbar",
@@ -131,6 +143,10 @@ exports[`translateThemeConfig returns translated themeConfig 1`] = `
         "title": "Footer link column 2 (translated)",
       },
     ],
+    "logo": {
+      "alt": "footer alt logo (translated)",
+      "src": "img/docusaurus.svg",
+    },
     "style": "light",
   },
   "navbar": {
@@ -150,6 +166,10 @@ exports[`translateThemeConfig returns translated themeConfig 1`] = `
         "label": "Dropdown (translated)",
       },
     ],
+    "logo": {
+      "alt": "navbar alt logo (translated)",
+      "src": "img/docusaurus.svg",
+    },
     "style": "dark",
     "title": "navbar title (translated)",
   },

--- a/packages/docusaurus-theme-classic/src/__tests__/__snapshots__/translations.test.ts.snap
+++ b/packages/docusaurus-theme-classic/src/__tests__/__snapshots__/translations.test.ts.snap
@@ -104,6 +104,10 @@ exports[`getTranslationFiles returns translation files matching snapshot 2`] = `
         "description": "The label of footer link with label=Link 2 linking to https://facebook.com",
         "message": "Link 2",
       },
+      "logo.alt": {
+        "description": "The alt of footer logo",
+        "message": "footer alt logo",
+      },
     },
     "path": "footer",
   },

--- a/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
@@ -60,6 +60,10 @@ const ThemeConfigSample = {
 const ThemeConfigSampleSimpleFooter: ThemeConfig = {
   ...ThemeConfigSample,
   footer: {
+    logo: {
+      alt: 'footer alt logo',
+      src: 'img/docusaurus.svg',
+    },
     copyright: 'Copyright FB',
     style: 'light',
     links: [

--- a/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/translations.test.ts
@@ -18,6 +18,10 @@ const ThemeConfigSample = {
   },
   navbar: {
     title: 'navbar title',
+    logo: {
+      alt: 'navbar alt logo',
+      src: 'img/docusaurus.svg',
+    },
     style: 'dark',
     hideOnScroll: false,
     items: [
@@ -31,6 +35,10 @@ const ThemeConfigSample = {
     ],
   },
   footer: {
+    logo: {
+      alt: 'footer alt logo',
+      src: 'img/docusaurus.svg',
+    },
     copyright: 'Copyright FB',
     style: 'light',
     links: [

--- a/packages/docusaurus-theme-classic/src/translations.ts
+++ b/packages/docusaurus-theme-classic/src/translations.ts
@@ -45,7 +45,20 @@ function getNavbarTranslationFile(navbar: Navbar): TranslationFileContent {
     ? {title: {message: navbar.title, description: 'The title in the navbar'}}
     : {};
 
-  return mergeTranslations([titleTranslations, navbarItemsTranslations]);
+  const logoAlt: TranslationFileContent = navbar.logo?.alt
+    ? {
+        'logo.alt': {
+          message: navbar.logo.alt,
+          description: 'The alt of navbar logo',
+        },
+      }
+    : {};
+
+  return mergeTranslations([
+    titleTranslations,
+    logoAlt,
+    navbarItemsTranslations,
+  ]);
 }
 function translateNavbar(
   navbar: Navbar,
@@ -54,9 +67,16 @@ function translateNavbar(
   if (!navbarTranslations) {
     return navbar;
   }
+
+  const {logo} = navbar;
+
+  if (logo)
+    {logo.alt = navbarTranslations[`logo.alt`]?.message ?? navbar.logo?.alt;}
+
   return {
     ...navbar,
     title: navbarTranslations.title?.message ?? navbar.title,
+    logo,
     //  TODO handle properly all the navbar item types here!
     items: navbar.items.map((item) => {
       const subItems = item.items?.map((subItem) => ({
@@ -119,7 +139,21 @@ function getFooterTranslationFile(footer: Footer): TranslationFileContent {
       }
     : {};
 
-  return mergeTranslations([footerLinkTitles, footerLinkLabels, copyright]);
+  const logoAlt: TranslationFileContent = footer.logo?.alt
+    ? {
+        'logo.alt': {
+          message: footer.logo.alt,
+          description: 'The alt of footer logo',
+        },
+      }
+    : {};
+
+  return mergeTranslations([
+    footerLinkTitles,
+    footerLinkLabels,
+    copyright,
+    logoAlt,
+  ]);
 }
 function translateFooter(
   footer: Footer,
@@ -149,10 +183,16 @@ function translateFooter(
 
   const copyright = footerTranslations.copyright?.message ?? footer.copyright;
 
+  const {logo} = footer;
+
+  if (logo)
+    {logo.alt = footerTranslations[`logo.alt`]?.message ?? footer.logo?.alt;}
+
   return {
     ...footer,
     links,
     copyright,
+    logo,
   };
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Remake of #8551 

This PR can allow more control for translations by the addition of footer & navbar alt text for logo.

It's a detail but that can be usefull to translate the alt text for footer Logo of docusaurus website (https://github.com/facebook/docusaurus/blob/main/website/docusaurus.config.js#L622) to be more consistent.

## Test Plan

Translations tests have been updated for the package `docusaurus-theme-classic` ^^.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/
