### PR TITLE
fix(theme-common): prepare usage of useSyncExternalStore compatibility with React 18 

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/historyUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/historyUtils.ts
@@ -56,7 +56,11 @@ export function useHistorySelector<Value>(
   selector: (history: History<unknown>) => Value,
 ): Value {
   const history = useHistory();
-  return useSyncExternalStore(history.listen, () => selector(history));
+  return useSyncExternalStore(
+    history.listen,
+    () => selector(history),
+    () => selector(history),
+  );
 }
 
 /**


### PR DESCRIPTION
Under React 18 SSR, it will be required to provide `getServerSnapshot()` callback to `useSyncExternalStore`

Apparently, some users already run Docusaurus on React 18, and `useSyncExternalStore` throw more aggressively than the shim.

We don't officially support React 18 yet and don't recommend using it, but this fix should make it possible to use it if you really want to, at your own risk.

Fix https://github.com/facebook/docusaurus/issues/8592