### PR TITLE
chore: add "pr: dependencies" to lerna changelog labels

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -12,6 +12,7 @@
       "pr: performance": ":running_woman: Performance",
       "pr: polish": ":nail_care: Polish",
       "pr: documentation": ":memo: Documentation",
+      "pr: dependencies": ":robot: Dependencies",
       "pr: maintenance": ":wrench: Maintenance"
     },
     "cacheDir": ".changelog"


### PR DESCRIPTION
Our changelog does not include some deps upgrades currently, I think it's useful to have these entries:

---

#### :robot: Dependencies
* `docusaurus-plugin-client-redirects`, `docusaurus-theme-search-algolia`, `docusaurus`
  * [#8610](https://github.com/facebook/docusaurus/pull/8610) chore(deps): bump eta from 1.12.3 to 2.0.0 ([@dependabot[bot]](https://github.com/apps/dependabot))