### PR TITLE
feat(theme-classic): respect `prefers-reduced-motion: reduce` mediaquery, bump Infima to alpha.43

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -35,7 +35,7 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "copy-text-to-clipboard": "^3.0.1",
-    "infima": "0.2.0-alpha.42",
+    "infima": "0.2.0-alpha.43",
     "lodash": "^4.17.21",
     "nprogress": "^0.2.0",
     "postcss": "^8.4.21",

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/styles.module.css
@@ -72,7 +72,7 @@
   border-radius: var(--ifm-global-radius);
   padding: 0.4rem;
   line-height: 0;
-  transition: opacity 200ms ease-in-out;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
   opacity: 0;
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/styles.module.css
@@ -24,7 +24,7 @@
   opacity: inherit;
   width: inherit;
   height: inherit;
-  transition: all 0.15s ease;
+  transition: all var(--ifm-transition-fast) ease;
 }
 
 .copyButtonSuccessIcon {

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -65,6 +65,10 @@ function applyCollapsedStyle(el: HTMLElement, collapsed: boolean) {
   el.style.height = collapsedStyles.height;
 }
 
+function userPrefersReducedMotion(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
 /*
 Lex111: Dynamic transition duration is used in Material design, this technique
 is good for a large number of items.
@@ -72,6 +76,9 @@ https://material.io/archive/guidelines/motion/duration-easing.html#duration-easi
 https://github.com/mui-org/material-ui/blob/e724d98eba018e55e1a684236a2037e24bcf050c/packages/material-ui/src/styles/createTransitions.js#L40-L43
  */
 function getAutoHeightDuration(height: number) {
+  if (userPrefersReducedMotion()) {
+    return 0;
+  }
   const constant = height / 36;
   return Math.round((4 + 15 * constant ** 0.25 + constant / 5) * 10);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9009,10 +9009,10 @@ infer-owner@^1.0.4:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-infima@0.2.0-alpha.42:
-  version "0.2.0-alpha.42"
-  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.42.tgz#f6e86a655ad40877c6b4d11b2ede681eb5470aa5"
-  integrity sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==
+infima@0.2.0-alpha.43:
+  version "0.2.0-alpha.43"
+  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.43.tgz#f7aa1d7b30b6c08afef441c726bac6150228cbe0"
+  integrity sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION

## Motivation

Upgrade Infima version to alpha.43, now respecting the user intent of reducing browser motions through their OS / accessibility settings.

![CleanShot 2023-02-17 at 12 15 27@2x](https://user-images.githubusercontent.com/749374/219635519-1aa122a2-ce8d-4d58-90cb-c638e4296f3b.png)

Docusaurus should respect that as well and automatically disable most of its animated transitions.

Other animations disabled on the Docusaurus side:
- Collasible animations (JS-based, affects sidebar categories, mobile TOC, details/summary...)
- Code block buttons animations

## Test Plan

Browse preview with reduced motions

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8674--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebookincubator/infima/pull/281

