### PR TITLE
feat(theme-classic): Admonitions: hide header

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Layout/index.tsx
@@ -32,12 +32,12 @@ function AdmonitionContainer({
 }
 
 function AdmonitionHeading({icon, title}: Pick<Props, 'icon' | 'title'>) {
-  return (
+  return title !== 'NO_HEADER' ? (
     <div className={styles.admonitionHeading}>
       <span className={styles.admonitionIcon}>{icon}</span>
       {title}
     </div>
-  );
+    ) : null;
 }
 
 function AdmonitionContent({children}: Pick<Props, 'children'>) {

--- a/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-admonitions.mdx
@@ -129,6 +129,31 @@ Some **content** with _Markdown_ `syntax`.
 </BrowserWindow>
 ```
 
+## No header {#no header}
+
+You may also specify element without icon and title .
+
+```md
+:::note NO_HEADER
+
+Some **content** with _Markdown_ `syntax`.
+
+:::
+```
+
+```mdx-code-block
+<BrowserWindow>
+
+:::note NO_HEADER
+
+Some **content** with _Markdown_ `syntax`.
+
+:::
+
+</BrowserWindow>
+```
+
+
 ## Nested admonitions {#nested-admonitions}
 
 Admonitions can be nested. Use more colons `:` for each parent admonition level.


### PR DESCRIPTION
## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

It's good to have possibility to hide header in Admotions
Posible solution for #8568 

## Test Plan

Straightforward UI change, not sure if there is a need for tests here

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

#8568 
