### PR TITLE
feat(core): add script env variables: NODE_ENV + BABEL_ENV + DOCUSAURUS_CURRENT_LOCALE (temporary i18n workaround)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,6 +28,7 @@
     "__snapshots__",
     "website/src/data/users.tsx",
     "website/src/data/tweets.tsx",
+    "website/docusaurus.config.localized.json",
     "*.xyz",
     "*.docx",
     "versioned_docs",

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -25,7 +25,7 @@ import {
 import beforeCli from './beforeCli.mjs';
 
 // Env variables are initialized to dev, but can be overridden by each command
-// For example, "docusaurus build" overrides them to "prod
+// For example, "docusaurus build" overrides them to "production"
 // See also https://github.com/facebook/docusaurus/issues/8599
 process.env.BABEL_ENV ??= 'development';
 process.env.NODE_ENV ??= 'development';

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -24,6 +24,12 @@ import {
 } from '../lib/index.js';
 import beforeCli from './beforeCli.mjs';
 
+// Env variables are initialized to dev, but can be overridden by each command
+// For example, "docusaurus build" overrides them to "prod
+// See also https://github.com/facebook/docusaurus/issues/8599
+process.env.BABEL_ENV ??= 'development';
+process.env.NODE_ENV ??= 'development';
+
 await beforeCli();
 
 cli.version(DOCUSAURUS_VERSION).usage('<command> [options]');

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -46,6 +46,9 @@ export async function build(
   // See https://github.com/facebook/docusaurus/pull/2496
   forceTerminate: boolean = true,
 ): Promise<string> {
+  process.env.BABEL_ENV = 'production';
+  process.env.NODE_ENV = 'production';
+
   const siteDir = await fs.realpath(siteDirParam);
 
   ['SIGINT', 'SIGTERM'].forEach((sig) => {
@@ -117,8 +120,11 @@ async function buildLocale({
   forceTerminate: boolean;
   isLastLocale: boolean;
 }): Promise<string> {
-  process.env.BABEL_ENV = 'production';
-  process.env.NODE_ENV = 'production';
+  // Temporary workaround to unlock the ability to translate the site config
+  // We'll remove it if a better official API can be designed
+  // See https://github.com/facebook/docusaurus/issues/4542
+  process.env.DOCUSAURUS_CURRENT_LOCALE = locale;
+
   logger.info`name=${`[${locale}]`} Creating an optimized production build...`;
 
   const props: Props = await load({

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -48,6 +48,7 @@ export async function build(
 ): Promise<string> {
   process.env.BABEL_ENV = 'production';
   process.env.NODE_ENV = 'production';
+  process.env.DOCUSAURUS_CURRENT_LOCALE = cliOptions.locale;
 
   const siteDir = await fs.realpath(siteDirParam);
 

--- a/packages/docusaurus/src/commands/start.ts
+++ b/packages/docusaurus/src/commands/start.ts
@@ -39,10 +39,13 @@ export async function start(
   siteDirParam: string = '.',
   cliOptions: Partial<StartCLIOptions> = {},
 ): Promise<void> {
+  // Temporary workaround to unlock the ability to translate the site config
+  // We'll remove it if a better official API can be designed
+  // See https://github.com/facebook/docusaurus/issues/4542
+  process.env.DOCUSAURUS_CURRENT_LOCALE = cliOptions.locale;
+
   const siteDir = await fs.realpath(siteDirParam);
 
-  process.env.NODE_ENV = 'development';
-  process.env.BABEL_ENV = 'development';
   logger.info('Starting the development server...');
 
   function loadSite() {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,6 +16,9 @@ const {
   dogfoodingThemeInstances,
 } = require('./_dogfooding/dogfooding.config');
 
+/** @type {Record<string,Record<string,string>>} */
+const ConfigLocalized = require('./docusaurus.config.localized.json');
+
 const ArchivedVersionsDropdownItems = Object.entries(VersionsArchived).splice(
   0,
   5,
@@ -63,10 +66,27 @@ const isVersioningDisabled = !!process.env.DISABLE_VERSIONING || isI18nStaging;
 const TwitterSvg =
   '<svg style="fill: #1DA1F2; vertical-align: middle; margin-left: 3px;" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"></path></svg>';
 
+const defaultLocale = 'en';
+
+function getLocalizedConfigValue(/** @type {string} */ key) {
+  const currentLocale = process.env.DOCUSAURUS_CURRENT_LOCALE ?? defaultLocale;
+  const values = ConfigLocalized[key];
+  if (!values) {
+    throw new Error(`Localized config key=${key} not found`);
+  }
+  const value = values[currentLocale] ?? values[defaultLocale];
+  if (!value) {
+    throw new Error(
+      `Localized value for config key=${key} not found for both currentLocale=${currentLocale} or defaultLocale=${defaultLocale}`,
+    );
+  }
+  return value;
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Docusaurus',
-  tagline: 'Build optimized websites quickly, focus on your content',
+  tagline: getLocalizedConfigValue('tagline'),
   organizationName: 'facebook',
   projectName: 'docusaurus',
   baseUrl,
@@ -83,17 +103,17 @@ const config = {
     },
   ],
   i18n: {
-    defaultLocale: 'en',
+    defaultLocale,
 
     locales:
       isDeployPreview || isBranchDeploy
         ? // Deploy preview and branch deploys: keep them fast!
-          ['en']
+          [defaultLocale]
         : isI18nStaging
         ? // Staging locales: https://docusaurus-i18n-staging.netlify.app/
-          ['en', 'ja']
+          [defaultLocale, 'ja']
         : // Production locales
-          ['en', 'fr', 'pt-BR', 'ko', 'zh-CN'],
+          [defaultLocale, 'fr', 'pt-BR', 'ko', 'zh-CN'],
   },
   webpack: {
     jsLoader: (isServer) => ({
@@ -151,7 +171,7 @@ const config = {
           description:
             'Keep yourself up-to-date about new features in every release',
           copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
-          language: 'en',
+          language: defaultLocale,
         },
       },
     ],
@@ -163,7 +183,7 @@ const config = {
         path: 'community',
         routeBasePath: 'community',
         editUrl: ({locale, versionDocsDirPath, docPath}) => {
-          if (locale !== 'en') {
+          if (locale !== defaultLocale) {
             return `https://crowdin.com/project/docusaurus-v2/${locale}`;
           }
           return `https://github.com/facebook/docusaurus/edit/main/website/${versionDocsDirPath}/${docPath}`;
@@ -292,7 +312,7 @@ const config = {
           // sidebarCollapsible: false,
           // sidebarCollapsed: true,
           editUrl: ({locale, docPath}) => {
-            if (locale !== 'en') {
+            if (locale !== defaultLocale) {
               return `https://crowdin.com/project/docusaurus-v2/${locale}`;
             }
             // We want users to submit doc updates to the upstream/next version!
@@ -332,7 +352,7 @@ const config = {
           // routeBasePath: '/',
           path: 'blog',
           editUrl: ({locale, blogDirPath, blogPath}) => {
-            if (locale !== 'en') {
+            if (locale !== defaultLocale) {
               return `https://crowdin.com/project/docusaurus-v2/${locale}`;
             }
             return `https://github.com/facebook/docusaurus/edit/main/website/${blogDirPath}/${blogPath}`;

--- a/website/docusaurus.config.localized.json
+++ b/website/docusaurus.config.localized.json
@@ -1,0 +1,6 @@
+{
+  "tagline": {
+    "en": "Build optimized websites quickly, focus on your content",
+    "fr": "Construisez rapidement des sites web optimisés, concentrez-vous sur votre contenu"
+  }
+}


### PR DESCRIPTION
## Motivation

All Docusaurus scripts should fallback to "development" env:

```js
process.env.BABEL_ENV ??= 'development';
process.env.NODE_ENV ??= 'development';
```

It should remain possible to run something like `NODE_ENV=production docusaurus swizzle`, although I'm not sure why someone would want to do that, it could make sense for some plugin script use cases we didn't think of? 🤷‍♂️ 

`docusaurus build` should override those defaults and have:

```js
  process.env.BABEL_ENV = 'production';
  process.env.NODE_ENV = 'production';
```

---

When starting/building the site for a given locale, we should set a `process.env.DOCUSAURUS_CURRENT_LOCALE` variable.

 It is a temporary flexible workaround to solve the inability to translate site config attributes (https://github.com/facebook/docusaurus/issues/4542). 

**IMPORTANT**: the `docusaurus build` will first load the Docusaurus config with an **empty value** for `DOCUSAURUS_CURRENT_LOCALE`. This is because... the i18n config is in that file so we must first load it before being able to inject a value as an env variable.  For this reason this env variable is only a best-effort awkward temporary workaround to unlock users. It is undocumented on purpose, not part of the public API, and will likely be refactored some day.

If you decide to use this variable, you'd rather program defensively and assume the locale value might be absent, and fallback yourself to your defaultLocale.


2 possible defensive examples, assuming "en" is your default locale:

```
process.env.DOCUSAURUS_CURRENT_LOCALE ??= "en"
```

```js
function getSiteTagline() {
  switch(process.env.DOCUSAURUS_CURRENT_LOCALE) {
    case "fr": return "Mon site en Français";
    default: return "My English website";
  }
}
```


Some cases where `DOCUSAURUS_CURRENT_LOCALE` will be undefined:
- When Docusaurus first loads the config file on `docusaurus build` to get the i18n config
- When you run `docusaurus start` with no locale arg
- When you run any other docusaurus CLI script unrelated to i18n, that requires reading the config (`swizzle`, `docs:version`...)

The `DOCUSAURUS_CURRENT_LOCALE`  env variable will be provided when:
- You run `docusaurus build`, **only after the first load**, once we start iterating over locales
- You run `docusaurus build --locale fr`
- You run `docusaurus start --locale fr`

Note: `DOCUSAURUS_CURRENT_LOCALE` is not designed to be set "from the outside". Please don't set this value as an env variable in your CI or local computer, it will be ignored. 

I hope this makes sense and is not too confusing. Hopefully, we will provide a better way to translate the config later, but this should be good enough to unlock many use cases.


## Test Plan

dogfood on our own website (site meta SEO tagline translated)

### Test links

Deploy preview: https://deploy-preview-8677--docusaurus-2.netlify.app/

## Related issues/PRs

Fix https://github.com/facebook/docusaurus/issues/8599

i18n workaround for https://github.com/facebook/docusaurus/issues/4542
