### PR TITLE
docs(core): explaining the difference between "hydration completion" versus "actually being in the browser environment" in `useIsBrowser` hook

### DIFF
--- a/website/docs/advanced/ssg.mdx
+++ b/website/docs/advanced/ssg.mdx
@@ -177,17 +177,88 @@ While you may expect that `BrowserOnly` hides away the children during server-si
 
 ### `useIsBrowser` {#useisbrowser}
 
-You can also use the `useIsBrowser()` hook to test if the component is currently in a browser environment. It returns `false` in SSR and `true` is CSR, after first client render. Use this hook if you only need to perform certain conditional operations on client-side, but not render an entirely different UI.
+Returns `true` when the React app has successfully hydrated in the browser.
+
+:::caution
+
+Use this hook instead of `typeof windows !== 'undefined'` in React rendering logic.
+
+The first client-side render output (in the browser) **must be exactly the same** as the server-side render output (Node.js). Not following this rule can lead to unexpected hydration behaviors, as described in [The Perils of Rehydration](https://www.joshwcomeau.com/react/the-perils-of-rehydration/).
+
+:::
+
+Usage example:
 
 ```jsx
+import React from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
-function MyComponent() {
+const MyComponent = () => {
+  // highlight-start
   const isBrowser = useIsBrowser();
   const location = isBrowser ? window.location.href : 'fetching location...';
+  // highlight-end
   return <span>{location}</span>;
-}
+};
 ```
+
+#### A caveat to know when using `useIsBrowser`
+
+Because it does not do `typeof windows !== 'undefined'` check but rather checks if the React app has successfully hydrated, the following code will not work as intended:
+
+```jsx
+import React from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
+const MyComponent = () => {
+  // highlight-start
+  const isBrowser = useIsBrowser();
+  const url = isBrowser ? new URL(window.location.href) : undefined;
+  const someQueryParam = url?.searchParams.get('someParam');
+  const [someParam, setSomeParam] = useState(someQueryParam || 'fallbackValue');
+
+  // renders fallbackValue instead of the value of someParam query parameter
+  // because the component has already rendered but hydration has not completed
+  // useState references the fallbackValue
+  return <span>{someParam}</span>;
+  // highlight-end
+};
+```
+
+Adding `useIsBrowser()` checks to derived values will have no effect. Wrapping the `<span>` with `<BrowserOnly>` will also have no effect. To have `useState` reference the correct value, which is the value of the `someParam` query parameter, `MyComponent`'s first render should actually happen after `useIsBrowser` returns true. Because you cannot have if statements inside the component before any hooks, you need to resort to doing `useIsBrowser()` in the parent component as such:
+
+```jsx
+import React, {useState} from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
+const MyComponent = () => {
+  const isBrowser = useIsBrowser();
+  const url = isBrowser ? new URL(window.location.href) : undefined;
+  const someQueryParam = url?.searchParams.get('someParam');
+  const [someParam, setSomeParam] = useState(someQueryParam || 'fallbackValue');
+
+  return <span>{someParam}</span>;
+};
+
+// highlight-start
+const MyComponentParent = () => {
+  const isBrowser = useIsBrowser();
+
+  if (!isBrowser) {
+    return null;
+  }
+
+  return <MyComponent />;
+};
+// highlight-end
+
+export default MyComponentParent;
+```
+
+There are a couple more alternative solutions to this problem. However all of them require adding checks in **the parent component**:
+
+1. You can wrap `<MyComponent />` with [`BrowserOnly`](../docusaurus-core.mdx#browseronly)
+2. You can use `canUseDOM` from [`ExecutionEnvironment`](../docusaurus-core.mdx#executionenvironment) and `return null` when `canUseDOM` is `false`
 
 ### `useEffect` {#useeffect}
 

--- a/website/docs/docusaurus-core.mdx
+++ b/website/docs/docusaurus-core.mdx
@@ -433,6 +433,64 @@ const MyComponent = () => {
 };
 ```
 
+#### A caveat to know when using `useIsBrowser`
+
+Because it does not do `typeof windows !== 'undefined'` check but rather checks if the React app has successfully hydrated, the following code will not work as intended:
+
+```jsx
+import React from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
+const MyComponent = () => {
+  // highlight-start
+  const isBrowser = useIsBrowser();
+  const url = isBrowser ? new URL(window.location.href) : undefined;
+  const someQueryParam = url?.searchParams.get('someParam');
+  const [someParam, setSomeParam] = useState(someQueryParam || 'fallbackValue');
+
+  // renders fallbackValue instead of the value of someParam query parameter
+  // because the component has already rendered but hydration has not completed
+  // useState references the fallbackValue
+  return <span>{someParam}</span>;
+  // highlight-end
+};
+```
+
+Adding `useIsBrowser()` checks to derived values will have no effect. Wrapping the `<span>` with `<BrowserOnly>` will also have no effect. To have `useState` reference the correct value, which is the value of the `someParam` query parameter, `MyComponent`'s first render should actually happen after `useIsBrowser` returns true. Because you cannot have if statements inside the component before any hooks, you need to resort to doing `useIsBrowser()` in the parent component as such:
+
+```jsx
+import React, {useState} from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
+const MyComponent = () => {
+  const isBrowser = useIsBrowser();
+  const url = isBrowser ? new URL(window.location.href) : undefined;
+  const someQueryParam = url?.searchParams.get('someParam');
+  const [someParam, setSomeParam] = useState(someQueryParam || 'fallbackValue');
+
+  return <span>{someParam}</span>;
+};
+
+// highlight-start
+const MyComponentParent = () => {
+  const isBrowser = useIsBrowser();
+
+  if (!isBrowser) {
+    return null;
+  }
+
+  return <MyComponent />;
+};
+// highlight-end
+
+export default MyComponentParent;
+```
+
+There are a couple more alternative solutions to this problem. However all of them require adding checks in **the parent component**:
+
+1. You can wrap `<MyComponent />` with [`BrowserOnly`](../docusaurus-core.mdx#browseronly)
+2. You can use `canUseDOM` from [`ExecutionEnvironment`](../docusaurus-core.mdx#executionenvironment) and `return null` when `canUseDOM` is `false`
+
 ### `useBaseUrl` {#useBaseUrl}
 
 React hook to prepend your site `baseUrl` to a string.


### PR DESCRIPTION
## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Having read the Perils of Rehydration and having known why `useIsBrowser()` does not check the existence of the window, I found that it is helpful to the community by giving an example that explains "hydration completion" versus "is in browser environment" are two different things and their code may not work if they simply trust in the name of the hook which plainly states `useIsBrowser` while it actually acts as `useHasHydrationCompleted`.

As a developer trying to get a successful build and thanks to the error message shown while building for window being undefined, I was able to get a successful build however I ran into problems with some business logic not working as intended and spent some time on debugging and coming to a solution, I think this will help other community members better understand the problem.

The related issue, although long and may be confusing,  tries to explain some more fine-grained solutions than simply documenting an example for the issue.

Even if this PR gets merged, these problems will still remain:
- `useIsBrowser` will keep confusing people because the name of the function does not do what it does internally
- The fact that you cannot rely on `useIsBrowser` only; when you have reference variables derived from the variable that has the check, the values of the referenced variables will be wrong thus cause business logic problems
- The error message printed on the console does give links to the right areas but lacks the link to the `useIsBrowser`

Although this is issue is tiny and links to the Perils of Rehydration and there are more pressing concerns, it may deserve a bit more thought and discussion and maybe some refactoring/additions later.

## Related issues/PRs

Related issue: https://github.com/facebook/docusaurus/issues/8678
