### PR TITLE
fix(theme-classic): fix docs layout issue

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocPage/Layout/styles.module.css
@@ -8,6 +8,7 @@
 .docPage {
   display: flex;
   width: 100%;
+  flex: 1 0;
 }
 
 .docsWrapper {


### PR DESCRIPTION

## Motivation

Little layout bug reported here, only affecting v2.x (already fixed in 3.x but not backportable)

https://github.com/facebook/docusaurus/issues/8369#issuecomment-1426838764

![image](https://user-images.githubusercontent.com/749374/221194526-f4c51c7c-1410-44e6-b679-ef7d627f999b.png)


## Test Plan

preview

### Test links


https://deploy-preview-8707--docusaurus-2.netlify.app/tests/docs/more-test

## Related issues/PRs

https://github.com/facebook/docusaurus/issues/8369
