### PR TITLE
feat(theme): allow to load a Docusaurus page with theme from query-string: ?docusaurus-theme=dark

### DIFF
--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -26,6 +26,8 @@ const ContextReplacementPlugin = requireFromDocusaurusCore(
 // Need to be inlined to prevent dark mode FOUC
 // Make sure the key is the same as the one in `/theme/hooks/useTheme.js`
 const ThemeStorageKey = 'theme';
+const ThemeQueryStringKey = 'docusaurus-theme';
+
 const noFlashColorMode = ({
   defaultMode,
   respectPrefersColorScheme,
@@ -39,6 +41,14 @@ const noFlashColorMode = ({
     document.documentElement.setAttribute('data-theme', theme);
   }
 
+  function getQueryStringTheme() {
+    var theme = null;
+    try {
+      theme = new URLSearchParams(window.location.search).get('${ThemeQueryStringKey}')
+    } catch(e) {}
+    return theme;
+  }
+
   function getStoredTheme() {
     var theme = null;
     try {
@@ -47,9 +57,10 @@ const noFlashColorMode = ({
     return theme;
   }
 
-  var storedTheme = getStoredTheme();
-  if (storedTheme !== null) {
-    setDataThemeAttribute(storedTheme);
+  var initialTheme = getQueryStringTheme() || getStoredTheme();
+  console.log("initialTheme",initialTheme)
+  if (initialTheme !== null) {
+    setDataThemeAttribute(initialTheme);
   } else {
     if (
       respectPrefersColorScheme &&

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -58,7 +58,6 @@ const noFlashColorMode = ({
   }
 
   var initialTheme = getQueryStringTheme() || getStoredTheme();
-  console.log("initialTheme",initialTheme)
   if (initialTheme !== null) {
     setDataThemeAttribute(initialTheme);
   } else {

--- a/website/_dogfooding/_pages tests/embeds.tsx
+++ b/website/_dogfooding/_pages tests/embeds.tsx
@@ -12,9 +12,14 @@ import BrowserWindow from '@site/src/components/BrowserWindow';
 
 function IframeTest({url}: {url: string}) {
   return (
-    <BrowserWindow url={url} bodyStyle={{padding: 0, height: '100%'}}>
-      <iframe src={url} title={url} style={{width: '100%', height: 300}} />
-    </BrowserWindow>
+    <div style={{padding: 10}}>
+      <BrowserWindow
+        url={url}
+        style={{minWidth: '40vw', maxWidth: 400}}
+        bodyStyle={{padding: 0}}>
+        <iframe src={url} title={url} style={{width: '100%', height: 300}} />
+      </BrowserWindow>
+    </div>
   );
 }
 
@@ -24,10 +29,14 @@ export default function Embeds(): JSX.Element {
     <Layout>
       <div style={{padding: 10}}>
         <Heading as="h1">Test Embeds</Heading>
-        <IframeTest url="https://docusaurus.io/" />
-        <IframeTest url="https://tutorial.docusaurus.io/" />
-        <IframeTest url="https://deploy-preview-8708--docusaurus-2.netlify.app/" />
-        <IframeTest url="http://localhost:3000/" />
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
+          <IframeTest url="/?docusaurus-theme=light" />
+          <IframeTest url="/?docusaurus-theme=dark" />
+          <IframeTest url="/?docusaurus-theme=unexpected-value" />
+          <IframeTest url="/" />
+          <IframeTest url="https://docusaurus.io/" />
+          <IframeTest url="https://tutorial.docusaurus.io/" />
+        </div>
       </div>
     </Layout>
   );

--- a/website/_dogfooding/_pages tests/embeds.tsx
+++ b/website/_dogfooding/_pages tests/embeds.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
+import BrowserWindow from '@site/src/components/BrowserWindow';
+
+function IframeTest({url}: {url: string}) {
+  return (
+    <BrowserWindow url={url} bodyStyle={{padding: 0, height: '100%'}}>
+      <iframe src={url} title={url} style={{width: '100%', height: 300}} />
+    </BrowserWindow>
+  );
+}
+
+// See https://github.com/facebook/docusaurus/issues/8672
+export default function Embeds(): JSX.Element {
+  return (
+    <Layout>
+      <div style={{padding: 10}}>
+        <Heading as="h1">Test Embeds</Heading>
+        <IframeTest url="https://docusaurus.io/" />
+        <IframeTest url="https://tutorial.docusaurus.io/" />
+        <IframeTest url="https://deploy-preview-8708--docusaurus-2.netlify.app/" />
+        <IframeTest url="http://localhost:3000/" />
+      </div>
+    </Layout>
+  );
+}

--- a/website/_dogfooding/_pages tests/index.mdx
+++ b/website/_dogfooding/_pages tests/index.mdx
@@ -33,3 +33,4 @@ import Readme from "../README.mdx"
 - [Head metadata tests](/tests/pages/head-metadata)
 - [Unlisted page](/tests/pages/unlisted)
 - [Analytics](/tests/pages/analytics)
+- [Embeds](/tests/pages/embeds)

--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -127,6 +127,17 @@ In light mode, the `<html>` element has a `data-theme="light"` attribute; in dar
 }
 ```
 
+:::tip
+
+It is possible to initialize the Docusaurus theme directly from a `docusaurus-theme` query string parameter.
+
+Examples:
+
+- [`https://docusaurus.io/?docusaurus-theme=dark`](https://docusaurus.io/?docusaurus-theme=dark)
+- [`https://docusaurus.io/docs/configuration?docusaurus-theme=light`](https://docusaurus.io/docs/configuration?docusaurus-theme=light)
+
+:::
+
 ### Mobile View {#mobile-view}
 
 Docusaurus uses `996px` as the cutoff between mobile screen width and desktop. If you want your layout to be different in the mobile view, you can use media queries.

--- a/website/src/components/BrowserWindow/index.tsx
+++ b/website/src/components/BrowserWindow/index.tsx
@@ -5,21 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ReactNode} from 'react';
+import React, {type CSSProperties, type ReactNode} from 'react';
 import clsx from 'clsx';
 
 import styles from './styles.module.css';
 
 interface Props {
   children: ReactNode;
-  minHeight: number;
+  minHeight?: number;
   url: string;
+  bodyStyle?: CSSProperties;
 }
 
 export default function BrowserWindow({
   children,
   minHeight,
   url = 'http://localhost:3000',
+  bodyStyle,
 }: Props): JSX.Element {
   return (
     <div className={styles.browserWindow} style={{minHeight}}>
@@ -41,7 +43,9 @@ export default function BrowserWindow({
         </div>
       </div>
 
-      <div className={styles.browserWindowBody}>{children}</div>
+      <div className={styles.browserWindowBody} style={bodyStyle}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/website/src/components/BrowserWindow/index.tsx
+++ b/website/src/components/BrowserWindow/index.tsx
@@ -14,6 +14,7 @@ interface Props {
   children: ReactNode;
   minHeight?: number;
   url: string;
+  style?: CSSProperties;
   bodyStyle?: CSSProperties;
 }
 
@@ -21,10 +22,11 @@ export default function BrowserWindow({
   children,
   minHeight,
   url = 'http://localhost:3000',
+  style,
   bodyStyle,
 }: Props): JSX.Element {
   return (
-    <div className={styles.browserWindow} style={{minHeight}}>
+    <div className={styles.browserWindow} style={{...style, minHeight}}>
       <div className={styles.browserWindowHeader}>
         <div className={styles.buttons}>
           <span className={styles.dot} style={{background: '#f25f58'}} />


### PR DESCRIPTION
## Motivation

We should be able to force start a Docusaurus site on a given theme through a query-string param.

Examples:
- https://docusaurus.io/?docusaurus-theme=dark
- https://docusaurus.io/docs/configuration?docusaurus-theme=light

This is notably useful for embedding Docusaurus inside another system (WebView, iframe, Electron...) and ensuring the the Docusaurus theme matches the host theme (see https://github.com/facebook/docusaurus/issues/8672)

## Test Plan

preview

### Test links


https://deploy-preview-8708--docusaurus-2.netlify.app/tests/pages/embeds

## Related issues/PRs

fix https://github.com/facebook/docusaurus/issues/8672