### PR TITLE
polish(create-docusaurus): the starter template should use a navbar item "docSidebar" instead of "doc" (less fragile on updates)

### DIFF
--- a/examples/facebook/docusaurus.config.js
+++ b/examples/facebook/docusaurus.config.js
@@ -67,8 +67,8 @@ const config = {
         },
         items: [
           {
-            type: 'doc',
-            docId: 'intro',
+            type: 'docSidebar',
+            sidebarName: 'tutorialSidebar',
             position: 'left',
             label: 'Tutorial',
           },

--- a/examples/facebook/docusaurus.config.js
+++ b/examples/facebook/docusaurus.config.js
@@ -67,8 +67,8 @@ const config = {
         },
         items: [
           {
-            type: 'docSidebar',
-            sidebarName: 'tutorialSidebar',
+            type: 'doc',
+            docId: 'intro',
             position: 'left',
             label: 'Tutorial',
           },

--- a/packages/create-docusaurus/templates/classic/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/classic/docusaurus.config.js
@@ -71,8 +71,8 @@ const config = {
         },
         items: [
           {
-            type: 'doc',
-            docId: 'intro',
+            type: 'docSidebar',
+            sidebarId: 'tutorialSidebar',
             position: 'left',
             label: 'Tutorial',
           },

--- a/packages/create-docusaurus/templates/facebook/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/facebook/docusaurus.config.js
@@ -67,8 +67,8 @@ const config = {
         },
         items: [
           {
-            type: 'doc',
-            docId: 'intro',
+            type: 'docSidebar',
+            sidebarId: 'tutorialSidebar',
             position: 'left',
             label: 'Tutorial',
           },


### PR DESCRIPTION


## Motivation

Fix https://github.com/facebook/docusaurus/issues/8696

Using a docSidebar item is less fragile for new Docusaurus users: they can delete/rename the intro doc without having an immediate error because the sidebar still exists



## Test Plan

locally + CI

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8712--docusaurus-2.netlify.app/


