### PR TITLE
feat(theme-classic): syntax-highlighting for inline code

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -354,6 +354,16 @@ declare module '@theme/CodeBlock' {
   export default function CodeBlock(props: Props): JSX.Element;
 }
 
+declare module '@theme/CodeInline' {
+  export interface Props {
+    readonly children: string;
+    readonly className?: string;
+    readonly language?: string;
+  }
+
+  export default function CodeInline(props: Props): JSX.Element;
+}
+
 declare module '@theme/CodeBlock/CopyButton' {
   export interface Props {
     readonly code: string;

--- a/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import {usePrismTheme, useThemeConfig} from '@docusaurus/theme-common';
+import Highlight, {defaultProps, type Language} from 'prism-react-renderer';
+import type {Props} from '@theme/CodeInline';
+
+export default function CodeInline({
+  language: languageProp,
+  className = '',
+  children,
+}: Props) {
+  const {
+    prism: {defaultLanguage},
+  } = useThemeConfig();
+  const language = languageProp ?? defaultLanguage ?? 'text';
+  const prismTheme = usePrismTheme();
+
+  return (
+    <code className={clsx(className, `language-${language}`)}>
+      <Highlight
+        {...defaultProps}
+        theme={prismTheme}
+        code={children}
+        language={language as Language}>
+        {({tokens, getTokenProps}) => {
+          if (tokens.length !== 1) {
+            // This is actually multi-line (or empty) code. Multi-line _should_ never happen. Just return the code without highlighting I guess?
+            return children;
+          }
+          return tokens[0]!.map((token, key) => (
+            <span key={key} {...getTokenProps({token, key})} />
+          ));
+        }}
+      </Highlight>
+    </code>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
@@ -9,6 +9,7 @@ import type {ComponentProps} from 'react';
 import React, {isValidElement} from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import type {Props} from '@theme/MDXComponents/Code';
+import CodeInline from '@theme/CodeInline';
 
 export default function MDXCode(props: Props): JSX.Element {
   const inlineElements: (string | undefined)[] = [
@@ -53,7 +54,7 @@ export default function MDXCode(props: Props): JSX.Element {
   );
 
   return shouldBeInline ? (
-    <code {...props} />
+    <CodeInline {...(props as ComponentProps<typeof CodeInline>)} />
   ) : (
     <CodeBlock {...(props as ComponentProps<typeof CodeBlock>)} />
   );

--- a/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -57,6 +57,20 @@ console.log('Every repo must come with a mascot.');
 
 </BrowserWindow>
 
+To use syntax-highlighting for inline code, you have to use the `code` tag:
+
+```md
+Some text with <code language="js">const i = 0 // inline JS</code>.
+```
+
+The same language strings have to be used for inline code as for code blocks.
+
+<BrowserWindow>
+
+Some text with <code language="js">const i = 0 // inline JS</code>.
+
+</BrowserWindow>
+
 ### Theming {#theming}
 
 By default, the Prism [syntax highlighting theme](https://github.com/FormidableLabs/prism-react-renderer#theming) we use is [Palenight](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/themes/palenight.js). You can change this to another theme by passing `theme` field in `prism` as `themeConfig` in your docusaurus.config.js.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Currently, there is no way to highlight the syntax in inline code.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I have added a section to the docs that uses the feature. I am not sure how to properly test this going further.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

![Screenshot from 2023-02-27 16-37-23](https://user-images.githubusercontent.com/5354445/221609810-0eef06cc-e9fd-430f-99b4-b2223257ca0f.png)

from http://localhost:3000/docs/markdown-features/code-blocks#syntax-highlighting

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

I did not really find any.