### PR TITLE
fix: bad routing for docusaurus.new ts functions

### DIFF
--- a/admin/new.docusaurus.io/netlify.toml
+++ b/admin/new.docusaurus.io/netlify.toml
@@ -13,8 +13,18 @@ to      = "/.netlify/functions/codesandbox"
 status  = 200
 
 [[redirects]]
+from    = "/codesandbox-ts"
+to      = "/.netlify/functions/codesandbox-ts"
+status  = 200
+
+[[redirects]]
 from    = "/stackblitz"
 to      = "/.netlify/functions/stackblitz"
+status  = 200
+
+[[redirects]]
+from    = "/stackblitz-ts"
+to      = "/.netlify/functions/stackblitz-ts"
 status  = 200
 
 [[redirects]]


### PR DESCRIPTION
Missing serverless setup for https://github.com/facebook/docusaurus/pull/8723 to work as it should

These URLs should work:
- https://docusaurus.new/codesandbox-ts
- https://docusaurus.new/stackblitz-ts