### PR TITLE
polish(core): better styling for error screens

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
@@ -7,7 +7,10 @@
 
 import React from 'react';
 import Translate from '@docusaurus/Translate';
-import {ErrorBoundaryTryAgainButton} from '@docusaurus/theme-common';
+import {
+  ErrorBoundaryError,
+  ErrorBoundaryTryAgainButton,
+} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Error';
 import Heading from '@theme/Heading';
 
@@ -26,9 +29,15 @@ export default function ErrorPageContent({
               This page crashed.
             </Translate>
           </Heading>
-          <p>{error.message}</p>
-          <div>
-            <ErrorBoundaryTryAgainButton onClick={tryAgain} />
+          <div className="margin-vert--lg">
+            <ErrorBoundaryTryAgainButton
+              onClick={tryAgain}
+              className="button button--primary shadow--lw"
+            />
+          </div>
+          <hr />
+          <div className="margin-vert--md">
+            <ErrorBoundaryError error={error} />
           </div>
         </div>
       </div>

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -96,4 +96,7 @@ export {
   UnlistedMetadata,
 } from './utils/unlistedUtils';
 
-export {ErrorBoundaryTryAgainButton} from './utils/errorBoundaryUtils';
+export {
+  ErrorBoundaryTryAgainButton,
+  ErrorBoundaryError,
+} from './utils/errorBoundaryUtils';

--- a/packages/docusaurus-theme-common/src/utils/errorBoundaryUtils.module.css
+++ b/packages/docusaurus-theme-common/src/utils/errorBoundaryUtils.module.css
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.errorBoundaryError {
+  white-space: pre-wrap;
+  color: red;
+}

--- a/packages/docusaurus-theme-common/src/utils/errorBoundaryUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/errorBoundaryUtils.tsx
@@ -7,6 +7,7 @@
 
 import React, {type ComponentProps} from 'react';
 import Translate from '@docusaurus/Translate';
+import styles from './errorBoundaryUtils.module.css';
 
 export function ErrorBoundaryTryAgainButton(
   props: ComponentProps<'button'>,
@@ -20,4 +21,8 @@ export function ErrorBoundaryTryAgainButton(
       </Translate>
     </button>
   );
+}
+
+export function ErrorBoundaryError({error}: {error: Error}): JSX.Element {
+  return <p className={styles.errorBoundaryError}>{error.message}</p>;
 }

--- a/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
@@ -21,12 +21,15 @@ function ErrorDisplay({error, tryAgain}: Props): JSX.Element {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
-        alignItems: 'center',
-        height: '50vh',
+        alignItems: 'flex-start',
+        minHeight: '100vh',
         width: '100%',
+        maxWidth: '60ch',
         fontSize: '20px',
+        margin: '0 auto',
+        padding: '1rem',
       }}>
-      <h1>This page crashed.</h1>
+      <h1 style={{fontSize: '3rem'}}>This page crashed</h1>
       <p>{error.message}</p>
       <button type="button" onClick={tryAgain}>
         Try again

--- a/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
@@ -24,16 +24,25 @@ function ErrorDisplay({error, tryAgain}: Props): JSX.Element {
         alignItems: 'flex-start',
         minHeight: '100vh',
         width: '100%',
-        maxWidth: '60ch',
+        maxWidth: '80ch',
         fontSize: '20px',
         margin: '0 auto',
         padding: '1rem',
       }}>
       <h1 style={{fontSize: '3rem'}}>This page crashed</h1>
-      <p>{error.message}</p>
-      <button type="button" onClick={tryAgain}>
+      <button
+        type="button"
+        onClick={tryAgain}
+        style={{
+          margin: '1rem 0',
+          fontSize: '2rem',
+          cursor: 'pointer',
+          borderRadius: 20,
+          padding: '1rem',
+        }}>
         Try again
       </button>
+      <p style={{whiteSpace: 'pre-wrap'}}>{error.message}</p>
     </div>
   );
 }

--- a/website/src/components/ErrorBoundaryTestButton/index.tsx
+++ b/website/src/components/ErrorBoundaryTestButton/index.tsx
@@ -14,7 +14,7 @@ export default function ErrorBoundaryTestButton({
 }): JSX.Element {
   const [state, setState] = useState(false);
   if (state) {
-    throw new Error('Boom!');
+    throw new Error('Boom!\nSomething bad happened, but you can try again!');
   }
   return (
     <button type="button" onClick={() => setState(true)}>

--- a/website/testCSSOrder.mjs
+++ b/website/testCSSOrder.mjs
@@ -31,7 +31,6 @@ const EXPECTED_CSS_MARKERS = [
   // See https://github.com/facebook/docusaurus/pull/6222
   '.markdown>h2',
   '.button--outline.button--active',
-  '.DocSearch-Hit-content-wrapper',
   '--ifm-color-scheme:light',
   '.col[class*=col--]',
   '.padding-vert--xl',
@@ -49,6 +48,7 @@ const EXPECTED_CSS_MARKERS = [
 
   // Lazy-loaded lib
   '.DocSearch-Modal',
+  '.DocSearch-Hit-content-wrapper',
 ];
 
 const cssDirName = fileURLToPath(new URL('build/assets/css', import.meta.url));


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
The ErrorDisplay in its original state was a bit tough to digest when the text occupied 100% of the viewport width. It also overflowed the viewport at smaller screen heights due to the `height: 50vh` declaration. My proposed changes ensure the ErrorDisplay styling is a bit more responsive and resembles how the Docusaurus [404 pages](https://docusaurus.io/docs/api/themes/configuration/foo) look. Totally an optional change!

### Before
<img width="880" alt="Screen Shot 2023-03-05 at 1 56 30 AM" src="https://user-images.githubusercontent.com/48612525/222953632-cf2d4543-3bf2-47b7-a5f7-c2175bb39f90.png">

### After
<img width="880" alt="Screen Shot 2023-03-05 at 1 42 23 AM" src="https://user-images.githubusercontent.com/48612525/222953412-90cd6533-fd34-43f7-8c33-a652176a6642.png">


## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8736--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
Somewhat related to conversation around improving error messages in https://github.com/facebook/docusaurus/issues/8696
