### PR TITLE
Fix nested routes dispaly in sitemap plugin.

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -17,7 +17,7 @@ describe('createSitemap', () => {
       {
         url: 'https://example.com',
       } as DocusaurusConfig,
-      ['/', '/test'],
+      [{ path: '/' }, { path: '/test' }],
       {},
       {
         changefreq: EnumChangefreq.DAILY,
@@ -44,7 +44,7 @@ describe('createSitemap', () => {
       {
         url: 'https://example.com',
       } as DocusaurusConfig,
-      ['/', '/404.html', '/my-page'],
+      [{ path: '/' }, { path: '/404.html' }, { path: '/my-page' }],
       {},
       {
         changefreq: EnumChangefreq.DAILY,
@@ -61,7 +61,7 @@ describe('createSitemap', () => {
       {
         url: 'https://example.com',
       } as DocusaurusConfig,
-      ['/', '/search/', '/tags/', '/search/foo', '/tags/foo/bar'],
+      [{ path: '/' }, { path: '/search/' }, { path: '/tags/' }, { path: '/search/foo' }, { path: '/tags/foo/bar' }],
       {},
       {
         changefreq: EnumChangefreq.DAILY,
@@ -86,7 +86,7 @@ describe('createSitemap', () => {
         url: 'https://example.com',
         trailingSlash: undefined,
       } as DocusaurusConfig,
-      ['/', '/test', '/nested/test', '/nested/test2/'],
+      [{ path: '/' }, { path: '/test' }, { path: '/nested/test' }, { path: '/nested/test2/' }],
       {},
       {
         changefreq: EnumChangefreq.DAILY,
@@ -108,7 +108,7 @@ describe('createSitemap', () => {
         url: 'https://example.com',
         trailingSlash: true,
       } as DocusaurusConfig,
-      ['/', '/test', '/nested/test', '/nested/test2/'],
+      [{ path: '/' }, { path: '/test' }, { path: '/nested/test' }, { path: '/nested/test2/' }],
       {},
       {
         changefreq: EnumChangefreq.DAILY,
@@ -130,7 +130,7 @@ describe('createSitemap', () => {
         url: 'https://example.com',
         trailingSlash: false,
       } as DocusaurusConfig,
-      ['/', '/test', '/nested/test', '/nested/test2/'],
+      [{ path: '/' }, { path: '/test' }, { path: '/nested/test' }, { path: '/nested/test2/' }],
       {},
       {
         changefreq: EnumChangefreq.DAILY,
@@ -146,13 +146,32 @@ describe('createSitemap', () => {
     expect(sitemap).toContain('<loc>https://example.com/nested/test2</loc>');
   });
 
+  it('site with nested pages in routes', async () => {
+    const sitemap = await createSitemap(
+      {
+        url: 'https://example.com',
+      } as DocusaurusConfig,
+      [{ path: '/', routes: [{ path: '/test', routes: [{ path: '/test/nested' }] }] }],
+      {},
+      {
+        changefreq: EnumChangefreq.DAILY,
+        priority: 0.7,
+        ignorePatterns: [],
+        filename: 'sitemap.xml',
+      },
+    );
+    expect(sitemap).toContain('<loc>https://example.com/</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/test</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/test/nested</loc>');
+  });
+
   it('filters pages with noindex', async () => {
     const sitemap = await createSitemap(
       {
         url: 'https://example.com',
         trailingSlash: false,
       } as DocusaurusConfig,
-      ['/', '/noindex', '/nested/test', '/nested/test2/'],
+      [{ path: '/' }, { path: '/noindex' }, { path: '/nested/test' }, { path: '/nested/test2/' }],
       {
         '/noindex': {
           meta: {
@@ -182,7 +201,7 @@ describe('createSitemap', () => {
         url: 'https://example.com',
         trailingSlash: false,
       } as DocusaurusConfig,
-      ['/', '/noindex'],
+      [{ path: '/' }, { path: '/noindex' }],
       {
         '/': {
           meta: {

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -9,7 +9,7 @@ import type {ReactElement} from 'react';
 import {SitemapStream, streamToPromise} from 'sitemap';
 import {applyTrailingSlash} from '@docusaurus/utils-common';
 import {createMatcher} from '@docusaurus/utils';
-import type {DocusaurusConfig} from '@docusaurus/types';
+import type {DocusaurusConfig, RouteConfig} from '@docusaurus/types';
 import type {HelmetServerState} from 'react-helmet-async';
 import type {PluginOptions} from './options';
 
@@ -47,9 +47,17 @@ function isNoIndexMetaRoute({
   );
 }
 
+function collectAllPaths({ routes, path }: {
+  routes?: RouteConfig[];
+  path?: string;
+}): string[] {
+  const subRoutes: string[][] = routes ? routes.map(subRoute => collectAllPaths(subRoute)) : [];
+  return subRoutes.flat(1).concat(path || []);
+}
+
 export default async function createSitemap(
   siteConfig: DocusaurusConfig,
-  routesPaths: string[],
+  routes: RouteConfig[],
   head: {[location: string]: HelmetServerState},
   options: PluginOptions,
 ): Promise<string | null> {
@@ -69,7 +77,7 @@ export default async function createSitemap(
     );
   }
 
-  const includedRoutes = routesPaths.filter((route) => !isRouteExcluded(route));
+  const includedRoutes = collectAllPaths({ routes }).filter((route) => !isRouteExcluded(route));
 
   if (includedRoutes.length === 0) {
     return null;

--- a/packages/docusaurus-plugin-sitemap/src/index.ts
+++ b/packages/docusaurus-plugin-sitemap/src/index.ts
@@ -19,14 +19,14 @@ export default function pluginSitemap(
   return {
     name: 'docusaurus-plugin-sitemap',
 
-    async postBuild({siteConfig, routesPaths, outDir, head}) {
+    async postBuild({siteConfig, routes, outDir, head}) {
       if (siteConfig.noIndex) {
         return;
       }
       // Generate sitemap.
       const generatedSitemap = await createSitemap(
         siteConfig,
-        routesPaths,
+        routes,
         head,
         options,
       );


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

The docs nested route pages are missing form the sitemap.xml

## Test Plan

See the added unit test