### PR TITLE
fix(search): search page should react to querystring changes + cleanup/refactor

### DIFF
--- a/packages/docusaurus-theme-common/src/hooks/useSearchPage.ts
+++ b/packages/docusaurus-theme-common/src/hooks/useSearchPage.ts
@@ -5,32 +5,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {useCallback, useEffect, useState} from 'react';
-import {useHistory} from '@docusaurus/router';
+import {useCallback} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useQueryString} from '../utils/historyUtils';
 import type {ThemeConfig as AlgoliaThemeConfig} from '@docusaurus/theme-search-algolia';
 
 const SEARCH_PARAM_QUERY = 'q';
 
-/** Some utility functions around search queries. */
-export function useSearchPage(): {
-  /**
-   * Works hand-in-hand with `setSearchQuery`; whatever the user has inputted
-   * into the search box.
-   */
-  searchQuery: string;
-  /**
-   * Set a new search query. In addition to updating `searchQuery`, this handle
-   * also mutates the location and appends the query.
-   */
-  setSearchQuery: (newSearchQuery: string) => void;
-  /**
-   * Given a query, this handle generates the corresponding search page link,
-   * with base URL prepended.
-   */
-  generateSearchPageLink: (targetSearchQuery: string) => string;
-} {
-  const history = useHistory();
+/**
+ * Permits to read/write the current search query string
+ */
+export function useSearchQueryString(): [string, (newValue: string) => void] {
+  return useQueryString(SEARCH_PARAM_QUERY);
+}
+
+/**
+ * Permits to create links to the search page with the appropriate query string
+ */
+export function useSearchLinkCreator(): (searchValue: string) => string {
   const {
     siteConfig: {baseUrl, themeConfig},
   } = useDocusaurusContext();
@@ -38,47 +30,13 @@ export function useSearchPage(): {
     algolia: {searchPagePath},
   } = themeConfig as AlgoliaThemeConfig;
 
-  const [searchQuery, setSearchQueryState] = useState('');
-
-  // Init search query just after React hydration
-  useEffect(() => {
-    const searchQueryStringValue =
-      new URLSearchParams(window.location.search).get(SEARCH_PARAM_QUERY) ?? '';
-
-    setSearchQueryState(searchQueryStringValue);
-  }, []);
-
-  const setSearchQuery = useCallback(
-    (newSearchQuery: string) => {
-      const searchParams = new URLSearchParams(window.location.search);
-
-      if (newSearchQuery) {
-        searchParams.set(SEARCH_PARAM_QUERY, newSearchQuery);
-      } else {
-        searchParams.delete(SEARCH_PARAM_QUERY);
-      }
-
-      history.replace({
-        search: searchParams.toString(),
-      });
-      setSearchQueryState(newSearchQuery);
-    },
-    [history],
-  );
-
-  const generateSearchPageLink = useCallback(
-    (targetSearchQuery: string) =>
+  return useCallback(
+    (searchValue: string) =>
       // Refer to https://github.com/facebook/docusaurus/pull/2838
       // Note: if searchPagePath is falsy, useSearchPage() will not be called
       `${baseUrl}${
         searchPagePath as string
-      }?${SEARCH_PARAM_QUERY}=${encodeURIComponent(targetSearchQuery)}`,
+      }?${SEARCH_PARAM_QUERY}=${encodeURIComponent(searchValue)}`,
     [baseUrl, searchPagePath],
   );
-
-  return {
-    searchQuery,
-    setSearchQuery,
-    generateSearchPageLink,
-  };
 }

--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -73,6 +73,11 @@ export {
   type TagLetterEntry,
 } from './utils/tagsUtils';
 
+export {
+  useSearchQueryString,
+  useSearchLinkCreator,
+} from './hooks/useSearchPage';
+
 export {isMultiColumnFooterLinks} from './utils/footerUtils';
 
 export {isRegexpStringMatch} from './utils/regexpUtils';

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -121,10 +121,6 @@ export {
   keyboardFocusedClassName,
 } from './hooks/useKeyboardNavigation';
 export {useLockBodyScroll} from './hooks/useLockBodyScroll';
-export {
-  useSearchQueryString,
-  useSearchLinkCreator,
-} from './hooks/useSearchPage';
 export {useCodeWordWrap} from './hooks/useCodeWordWrap';
 export {getPrismCssVariables} from './utils/codeBlockUtils';
 export {useBackToTopButton} from './hooks/useBackToTopButton';

--- a/packages/docusaurus-theme-common/src/internal.ts
+++ b/packages/docusaurus-theme-common/src/internal.ts
@@ -121,7 +121,10 @@ export {
   keyboardFocusedClassName,
 } from './hooks/useKeyboardNavigation';
 export {useLockBodyScroll} from './hooks/useLockBodyScroll';
-export {useSearchPage} from './hooks/useSearchPage';
+export {
+  useSearchQueryString,
+  useSearchLinkCreator,
+} from './hooks/useSearchPage';
 export {useCodeWordWrap} from './hooks/useCodeWordWrap';
 export {getPrismCssVariables} from './utils/codeBlockUtils';
 export {useBackToTopButton} from './hooks/useBackToTopButton';

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -10,8 +10,10 @@ import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import {useHistory} from '@docusaurus/router';
-import {isRegexpStringMatch} from '@docusaurus/theme-common';
-import {useSearchLinkCreator} from '@docusaurus/theme-common/internal';
+import {
+  isRegexpStringMatch,
+  useSearchLinkCreator,
+} from '@docusaurus/theme-common';
 import {
   useAlgoliaContextualFacetFilters,
   useSearchResultUrlProcessor,

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -11,7 +11,7 @@ import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import {useHistory} from '@docusaurus/router';
 import {isRegexpStringMatch} from '@docusaurus/theme-common';
-import {useSearchPage} from '@docusaurus/theme-common/internal';
+import {useSearchLinkCreator} from '@docusaurus/theme-common/internal';
 import {
   useAlgoliaContextualFacetFilters,
   useSearchResultUrlProcessor,
@@ -59,10 +59,10 @@ type ResultsFooterProps = {
 };
 
 function ResultsFooter({state, onClose}: ResultsFooterProps) {
-  const {generateSearchPageLink} = useSearchPage();
+  const createSearchLink = useSearchLinkCreator();
 
   return (
-    <Link to={generateSearchPageLink(state.query)} onClick={onClose}>
+    <Link to={createSearchLink(state.query)} onClick={onClose}>
       <Translate
         id="theme.SearchBar.seeAll"
         values={{count: state.context.nbHits}}>

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
@@ -21,11 +21,9 @@ import {
   HtmlClassNameProvider,
   useEvent,
   usePluralForm,
-} from '@docusaurus/theme-common';
-import {
   useSearchQueryString,
-  useTitleFormatter,
-} from '@docusaurus/theme-common/internal';
+} from '@docusaurus/theme-common';
+import {useTitleFormatter} from '@docusaurus/theme-common/internal';
 import Translate, {translate} from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
@@ -23,7 +23,7 @@ import {
   usePluralForm,
 } from '@docusaurus/theme-common';
 import {
-  useSearchPage,
+  useSearchQueryString,
   useTitleFormatter,
 } from '@docusaurus/theme-common/internal';
 import Translate, {translate} from '@docusaurus/Translate';
@@ -167,7 +167,7 @@ function SearchPageContent(): JSX.Element {
   const documentsFoundPlural = useDocumentsFoundPlural();
 
   const docsSearchVersionsHelpers = useDocsSearchVersionsHelpers();
-  const {searchQuery, setSearchQuery} = useSearchPage();
+  const [searchQuery, setSearchQuery] = useSearchQueryString();
   const initialSearchResultState: ResultDispatcherState = {
     items: [],
     query: null,


### PR DESCRIPTION
## Motivation

The search page results do no React do external querystring changes (ie `history.replaceState`) but only to local setState calls because the state is somehow duplicated and not synchronized properly.

Using the new common hook utils based on `useSyncExternalStore` make it easier to deal with synchronization by avoiding duplicating state in the first place: we should use them more.

I also did some cleanup and split an awkward larger `useSearchPage` hook into 2 more specific hooks.

The SearchPage remains a quite messy page that we'll have to refactor someday, but that will not be in this PR.

## Test Plan

preview

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

https://deploy-preview-8757--docusaurus-2.netlify.app/search?q=docs

## Related issues/PRs

fix https://github.com/facebook/docusaurus/issues/8755
