### PR TITLE
docs: v2 docs should discourage the usage of a lower-case MDX component (will not work in v3)

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -152,16 +152,16 @@ For example, given this MDX file:
 - a
 - list!
 
-And some <highlight>custom markup</highlight>...
+And some <Highlight>custom markup</Highlight>...
 ```
 
-It will be compiled to a React component containing `ul`, `li`, `p`, and `highlight` tags. Now, you can optionally provide your own implementation for any of these tags in the form of React components. (`highlight` isn't even an intrinsic element: it needs an implementation!)
+It will be compiled to a React component containing `ul`, `li`, `p`, and `Highlight` elements. `Highlight` is not a native html element: you need to provide your own React component implementation for it.
 
-In Docusaurus, this MDX component scope is provided by the `@theme/MDXComponents` component. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `ul` and `img` to their custom implementations.
+In Docusaurus, the MDX component scope is provided by the `@theme/MDXComponents` file. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `Highlight` to their React component implementations.
 
-If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been re-implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Head` (which is used to implement the [`<head>`](./markdown-features-head-metadata.mdx) feature).
+If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Code` (which is used to render [Markdown code blocks](./markdown-features-code-blocks.mdx)).
 
-If you want to register extra tag names (like the `<highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
+If you want to register extra tag names (like the `<Highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
 
 ```js title="src/theme/MDXComponents.js"
 import React from 'react';
@@ -173,30 +173,32 @@ import Highlight from '@site/src/components/Highlight';
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  // Map the "highlight" tag to our <Highlight /> component!
-  // `Highlight` will receive all props that were passed to `highlight` in MDX
+  // Map the "<Highlight>" tag to our Highlight component
+  // `Highlight` will receive all props that were passed to `<Highlight>` in MDX
   // highlight-next-line
-  highlight: Highlight,
+  Highlight,
 };
 ```
 
-And now, you can freely use `<highlight>` in every page, without writing the import statement:
+And now, you can freely use `<Highlight>` in every page, without writing the import statement:
 
 ```md
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 ```
 
 ```mdx-code-block
 <BrowserWindow>
 
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 
 </BrowserWindow>
 ```
 
-:::info
+:::warning
 
-We use lower-case tag names like `highlight` to "pretend" that they are intrinsic elements, but you can use capitalized ones like `Highlight` as well.
+We use **upper-case** tag names like `Highlight` on purpose.
+
+From MDX v2+ onward (Docusaurus v3+), lower-case tag names are always rendered as native html elements, and will not use any component mapping you provide.
 
 :::
 

--- a/website/src/theme/MDXComponents.tsx
+++ b/website/src/theme/MDXComponents.tsx
@@ -11,6 +11,6 @@ import TweetQuote from '@site/src/components/TweetQuote';
 
 export default {
   ...MDXComponents,
-  highlight: Highlight,
+  Highlight,
   TweetQuote,
 };

--- a/website/versioned_docs/version-2.0.1/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-2.0.1/guides/markdown-features/markdown-features-react.mdx
@@ -152,16 +152,16 @@ For example, given this MDX file:
 - a
 - list!
 
-And some <highlight>custom markup</highlight>...
+And some <Highlight>custom markup</Highlight>...
 ```
 
-It will be compiled to a React component containing `ul`, `li`, `p`, and `highlight` tags. Now, you can optionally provide your own implementation for any of these tags in the form of React components. (`highlight` isn't even an intrinsic element: it needs an implementation!)
+It will be compiled to a React component containing `ul`, `li`, `p`, and `Highlight` elements. `Highlight` is not a native html element: you need to provide your own React component implementation for it.
 
-In Docusaurus, this MDX component scope is provided by the `@theme/MDXComponents` component. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `ul` and `img` to their custom implementations.
+In Docusaurus, the MDX component scope is provided by the `@theme/MDXComponents` file. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `Highlight` to their React component implementations.
 
-If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been re-implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Head` (which is used to implement the [`<head>`](./markdown-features-head-metadata.mdx) feature).
+If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Code` (which is used to render [Markdown code blocks](./markdown-features-code-blocks.mdx)).
 
-If you want to register extra tag names (like the `<highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
+If you want to register extra tag names (like the `<Highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
 
 ```js title="src/theme/MDXComponents.js"
 import React from 'react';
@@ -173,30 +173,32 @@ import Highlight from '@site/src/components/Highlight';
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  // Map the "highlight" tag to our <Highlight /> component!
-  // `Highlight` will receive all props that were passed to `highlight` in MDX
+  // Map the "<Highlight>" tag to our Highlight component
+  // `Highlight` will receive all props that were passed to `<Highlight>` in MDX
   // highlight-next-line
-  highlight: Highlight,
+  Highlight,
 };
 ```
 
-And now, you can freely use `<highlight>` in every page, without writing the import statement:
+And now, you can freely use `<Highlight>` in every page, without writing the import statement:
 
 ```md
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 ```
 
 ```mdx-code-block
 <BrowserWindow>
 
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 
 </BrowserWindow>
 ```
 
-:::info
+:::warning
 
-We use lower-case tag names like `highlight` to "pretend" that they are intrinsic elements, but you can use capitalized ones like `Highlight` as well.
+We use **upper-case** tag names like `Highlight` on purpose.
+
+From MDX v2+ onward (Docusaurus v3+), lower-case tag names are always rendered as native html elements, and will not use any component mapping you provide.
 
 :::
 

--- a/website/versioned_docs/version-2.1.0/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-2.1.0/guides/markdown-features/markdown-features-react.mdx
@@ -152,16 +152,16 @@ For example, given this MDX file:
 - a
 - list!
 
-And some <highlight>custom markup</highlight>...
+And some <Highlight>custom markup</Highlight>...
 ```
 
-It will be compiled to a React component containing `ul`, `li`, `p`, and `highlight` tags. Now, you can optionally provide your own implementation for any of these tags in the form of React components. (`highlight` isn't even an intrinsic element: it needs an implementation!)
+It will be compiled to a React component containing `ul`, `li`, `p`, and `Highlight` elements. `Highlight` is not a native html element: you need to provide your own React component implementation for it.
 
-In Docusaurus, this MDX component scope is provided by the `@theme/MDXComponents` component. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `ul` and `img` to their custom implementations.
+In Docusaurus, the MDX component scope is provided by the `@theme/MDXComponents` file. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `Highlight` to their React component implementations.
 
-If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been re-implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Head` (which is used to implement the [`<head>`](./markdown-features-head-metadata.mdx) feature).
+If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Code` (which is used to render [Markdown code blocks](./markdown-features-code-blocks.mdx)).
 
-If you want to register extra tag names (like the `<highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
+If you want to register extra tag names (like the `<Highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
 
 ```js title="src/theme/MDXComponents.js"
 import React from 'react';
@@ -173,30 +173,32 @@ import Highlight from '@site/src/components/Highlight';
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  // Map the "highlight" tag to our <Highlight /> component!
-  // `Highlight` will receive all props that were passed to `highlight` in MDX
+  // Map the "<Highlight>" tag to our Highlight component
+  // `Highlight` will receive all props that were passed to `<Highlight>` in MDX
   // highlight-next-line
-  highlight: Highlight,
+  Highlight,
 };
 ```
 
-And now, you can freely use `<highlight>` in every page, without writing the import statement:
+And now, you can freely use `<Highlight>` in every page, without writing the import statement:
 
 ```md
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 ```
 
 ```mdx-code-block
 <BrowserWindow>
 
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 
 </BrowserWindow>
 ```
 
-:::info
+:::warning
 
-We use lower-case tag names like `highlight` to "pretend" that they are intrinsic elements, but you can use capitalized ones like `Highlight` as well.
+We use **upper-case** tag names like `Highlight` on purpose.
+
+From MDX v2+ onward (Docusaurus v3+), lower-case tag names are always rendered as native html elements, and will not use any component mapping you provide.
 
 :::
 

--- a/website/versioned_docs/version-2.2.0/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-2.2.0/guides/markdown-features/markdown-features-react.mdx
@@ -152,16 +152,16 @@ For example, given this MDX file:
 - a
 - list!
 
-And some <highlight>custom markup</highlight>...
+And some <Highlight>custom markup</Highlight>...
 ```
 
-It will be compiled to a React component containing `ul`, `li`, `p`, and `highlight` tags. Now, you can optionally provide your own implementation for any of these tags in the form of React components. (`highlight` isn't even an intrinsic element: it needs an implementation!)
+It will be compiled to a React component containing `ul`, `li`, `p`, and `Highlight` elements. `Highlight` is not a native html element: you need to provide your own React component implementation for it.
 
-In Docusaurus, this MDX component scope is provided by the `@theme/MDXComponents` component. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `ul` and `img` to their custom implementations.
+In Docusaurus, the MDX component scope is provided by the `@theme/MDXComponents` file. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `Highlight` to their React component implementations.
 
-If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been re-implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Head` (which is used to implement the [`<head>`](./markdown-features-head-metadata.mdx) feature).
+If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Code` (which is used to render [Markdown code blocks](./markdown-features-code-blocks.mdx)).
 
-If you want to register extra tag names (like the `<highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
+If you want to register extra tag names (like the `<Highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
 
 ```js title="src/theme/MDXComponents.js"
 import React from 'react';
@@ -173,30 +173,32 @@ import Highlight from '@site/src/components/Highlight';
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  // Map the "highlight" tag to our <Highlight /> component!
-  // `Highlight` will receive all props that were passed to `highlight` in MDX
+  // Map the "<Highlight>" tag to our Highlight component
+  // `Highlight` will receive all props that were passed to `<Highlight>` in MDX
   // highlight-next-line
-  highlight: Highlight,
+  Highlight,
 };
 ```
 
-And now, you can freely use `<highlight>` in every page, without writing the import statement:
+And now, you can freely use `<Highlight>` in every page, without writing the import statement:
 
 ```md
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 ```
 
 ```mdx-code-block
 <BrowserWindow>
 
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 
 </BrowserWindow>
 ```
 
-:::info
+:::warning
 
-We use lower-case tag names like `highlight` to "pretend" that they are intrinsic elements, but you can use capitalized ones like `Highlight` as well.
+We use **upper-case** tag names like `Highlight` on purpose.
+
+From MDX v2+ onward (Docusaurus v3+), lower-case tag names are always rendered as native html elements, and will not use any component mapping you provide.
 
 :::
 

--- a/website/versioned_docs/version-2.3.1/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-2.3.1/guides/markdown-features/markdown-features-react.mdx
@@ -152,16 +152,16 @@ For example, given this MDX file:
 - a
 - list!
 
-And some <highlight>custom markup</highlight>...
+And some <Highlight>custom markup</Highlight>...
 ```
 
-It will be compiled to a React component containing `ul`, `li`, `p`, and `highlight` tags. Now, you can optionally provide your own implementation for any of these tags in the form of React components. (`highlight` isn't even an intrinsic element: it needs an implementation!)
+It will be compiled to a React component containing `ul`, `li`, `p`, and `Highlight` elements. `Highlight` is not a native html element: you need to provide your own React component implementation for it.
 
-In Docusaurus, this MDX component scope is provided by the `@theme/MDXComponents` component. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `ul` and `img` to their custom implementations.
+In Docusaurus, the MDX component scope is provided by the `@theme/MDXComponents` file. It's not a React component, _per se_, unlike most other exports under the `@theme/` alias: it is a record from tag names like `Highlight` to their React component implementations.
 
-If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been re-implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Head` (which is used to implement the [`<head>`](./markdown-features-head-metadata.mdx) feature).
+If you [swizzle](../../swizzling.mdx) this component, you will find all tags that have been implemented, and you can further customize our implementation by swizzling the respective sub-component, like `@theme/MDXComponents/Code` (which is used to render [Markdown code blocks](./markdown-features-code-blocks.mdx)).
 
-If you want to register extra tag names (like the `<highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
+If you want to register extra tag names (like the `<Highlight>` tag above), you should consider [wrapping `@theme/MDXComponents`](../../swizzling.mdx#wrapping), so you don't have to maintain all the existing mappings. Since the swizzle CLI doesn't allow wrapping non-component files yet, you should manually create the wrapper:
 
 ```js title="src/theme/MDXComponents.js"
 import React from 'react';
@@ -173,30 +173,32 @@ import Highlight from '@site/src/components/Highlight';
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  // Map the "highlight" tag to our <Highlight /> component!
-  // `Highlight` will receive all props that were passed to `highlight` in MDX
+  // Map the "<Highlight>" tag to our Highlight component
+  // `Highlight` will receive all props that were passed to `<Highlight>` in MDX
   // highlight-next-line
-  highlight: Highlight,
+  Highlight,
 };
 ```
 
-And now, you can freely use `<highlight>` in every page, without writing the import statement:
+And now, you can freely use `<Highlight>` in every page, without writing the import statement:
 
 ```md
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 ```
 
 ```mdx-code-block
 <BrowserWindow>
 
-I can conveniently use <highlight color="#25c2a0">Docusaurus green</highlight> everywhere!
+I can conveniently use <Highlight color="#25c2a0">Docusaurus green</Highlight> everywhere!
 
 </BrowserWindow>
 ```
 
-:::info
+:::warning
 
-We use lower-case tag names like `highlight` to "pretend" that they are intrinsic elements, but you can use capitalized ones like `Highlight` as well.
+We use **upper-case** tag names like `Highlight` on purpose.
+
+From MDX v2+ onward (Docusaurus v3+), lower-case tag names are always rendered as native html elements, and will not use any component mapping you provide.
 
 :::
 


### PR DESCRIPTION

## Motivation

In MDX v2, lower-case elements can't be replaced by custom components anymore. Only the upper-case components can.

The following will stop working in Docusaurus v3, so we should start encouraging users to not use lower-case tag names for custom MDX components, even if it still temporarily works

<img width="1009" alt="CleanShot 2023-03-16 at 15 10 28@2x" src="https://user-images.githubusercontent.com/749374/225643998-b4b1195f-44a1-4b50-998e-01fa4d1c09b5.png">


Also did some cleanup that was related to prepare for MDX 2 (for example there's no more `MDXComponents/Head` component)


## Test Plan

preview

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

https://deploy-preview-8779--docusaurus-2.netlify.app/docs/markdown-features/react#mdx-component-scope

## Related issues/PRs

MDX 2 PR: https://github.com/facebook/docusaurus/pull/8288
