### PR TITLE
docs: fix localhost url without link

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -135,7 +135,7 @@ cd my-website
 npm run start
 ```
 
-By default, a browser window will open at http://localhost:3000.
+By default, a browser window will open at [http://localhost:3000](http://localhost:3000).
 
 Congratulations! You have just created your first Docusaurus site! Browse around the site to see what's available.
 

--- a/website/versioned_docs/version-2.0.1/installation.mdx
+++ b/website/versioned_docs/version-2.0.1/installation.mdx
@@ -163,7 +163,7 @@ cd my-website
 npm run start
 ```
 
-By default, a browser window will open at http://localhost:3000.
+By default, a browser window will open at [http://localhost:3000](http://localhost:3000).
 
 Congratulations! You have just created your first Docusaurus site! Browse around the site to see what's available.
 

--- a/website/versioned_docs/version-2.1.0/installation.mdx
+++ b/website/versioned_docs/version-2.1.0/installation.mdx
@@ -163,7 +163,7 @@ cd my-website
 npm run start
 ```
 
-By default, a browser window will open at http://localhost:3000.
+By default, a browser window will open at [http://localhost:3000](http://localhost:3000).
 
 Congratulations! You have just created your first Docusaurus site! Browse around the site to see what's available.
 

--- a/website/versioned_docs/version-2.2.0/installation.mdx
+++ b/website/versioned_docs/version-2.2.0/installation.mdx
@@ -163,7 +163,7 @@ cd my-website
 npm run start
 ```
 
-By default, a browser window will open at http://localhost:3000.
+By default, a browser window will open at [http://localhost:3000](http://localhost:3000).
 
 Congratulations! You have just created your first Docusaurus site! Browse around the site to see what's available.
 

--- a/website/versioned_docs/version-2.3.1/installation.mdx
+++ b/website/versioned_docs/version-2.3.1/installation.mdx
@@ -163,7 +163,7 @@ cd my-website
 npm run start
 ```
 
-By default, a browser window will open at http://localhost:3000.
+By default, a browser window will open at [http://localhost:3000](http://localhost:3000).
 
 Congratulations! You have just created your first Docusaurus site! Browse around the site to see what's available.
 


### PR DESCRIPTION
Minor docs change because my new visual diff toy reports a diff in the MDX 2 PR (https://github.com/facebook/docusaurus/pull/8288)

This change permits me to avoid excluding the whole `/docs/installation` URL from the visual diff

MDX 2 + GFM will autolink while MDX 1 does not.

![CleanShot 2023-03-16 at 15 31 24@2x](https://user-images.githubusercontent.com/749374/225649976-9d4ec452-5074-4ee7-8c8e-5555bb875ab8.png)

https://app.argos-ci.com/slorber/docusaurus-visual-tests/builds/10/40206528

