### PR TITLE
docs: remove problematic mdx2 anchor id docs for MDX 2 migration

### DIFF
--- a/website/docs/guides/docs/docs-create-doc.mdx
+++ b/website/docs/guides/docs/docs-create-doc.mdx
@@ -44,10 +44,6 @@ The headers are well-spaced so that the hierarchy is clear.
 - that you want your users to remember
   - and you may nest them
     - multiple times
-
-## Custom ID headers {#custom-id}
-
-With `{#custom-id}` syntax you can set your own header ID.
 ```
 
 :::note

--- a/website/versioned_docs/version-2.0.1/guides/docs/docs-create-doc.mdx
+++ b/website/versioned_docs/version-2.0.1/guides/docs/docs-create-doc.mdx
@@ -44,10 +44,6 @@ The headers are well-spaced so that the hierarchy is clear.
 - that you want your users to remember
   - and you may nest them
     - multiple times
-
-## Custom ID headers {#custom-id}
-
-With `{#custom-id}` syntax you can set your own header ID.
 ```
 
 :::note

--- a/website/versioned_docs/version-2.1.0/guides/docs/docs-create-doc.mdx
+++ b/website/versioned_docs/version-2.1.0/guides/docs/docs-create-doc.mdx
@@ -44,10 +44,6 @@ The headers are well-spaced so that the hierarchy is clear.
 - that you want your users to remember
   - and you may nest them
     - multiple times
-
-## Custom ID headers {#custom-id}
-
-With `{#custom-id}` syntax you can set your own header ID.
 ```
 
 :::note

--- a/website/versioned_docs/version-2.2.0/guides/docs/docs-create-doc.mdx
+++ b/website/versioned_docs/version-2.2.0/guides/docs/docs-create-doc.mdx
@@ -44,10 +44,6 @@ The headers are well-spaced so that the hierarchy is clear.
 - that you want your users to remember
   - and you may nest them
     - multiple times
-
-## Custom ID headers {#custom-id}
-
-With `{#custom-id}` syntax you can set your own header ID.
 ```
 
 :::note

--- a/website/versioned_docs/version-2.3.1/guides/docs/docs-create-doc.mdx
+++ b/website/versioned_docs/version-2.3.1/guides/docs/docs-create-doc.mdx
@@ -44,10 +44,6 @@ The headers are well-spaced so that the hierarchy is clear.
 - that you want your users to remember
   - and you may nest them
     - multiple times
-
-## Custom ID headers {#custom-id}
-
-With `{#custom-id}` syntax you can set your own header ID.
 ```
 
 :::note


### PR DESCRIPTION
For MDX 2 (https://github.com/facebook/docusaurus/pull/8288) we have to apply a pre-processing step to escape heading ids so that it is valid MDX 2:

```diff
-## Custom ID headers {#custom-id}
+## Custom ID headers \{#custom-id}
```

This usually works fine but when this is found inside a Markdown code block then it should probably be escaped. 

It's possible to hack around this pre-processing by using JSX (or to fix the pre-processing but it would become less efficient). 

Instead I choose to simply remove this special anchor id doc from the example here, considering it's already documented here: https://docusaurus.io/docs/markdown-features/toc#heading-ids

We can reintroduce this later if needed but for now it's simpler to remove it.

Removed in main so that my visual diff tool does not report a false positive. 
CF https://app.argos-ci.com/slorber/docusaurus-visual-tests/builds/21/41550827