### PR TITLE
docs(website): add theme-environment-variables community plugin

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -227,6 +227,8 @@ palenight
 paletton
 palo
 paraiso
+parameterize
+parameterizes
 pathinfo
 pathnames
 paularmstrong

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -35,7 +35,8 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 
 ### Features {#features}
 
-- [docusaurus-theme-github-codeblock](https://github.com/saucelabs/docusaurus-theme-github-codeblock). A Docusaurus v2 plugin that supports referencing code examples from public GitHub repositories
+- [theme-environment-variables](https://www.docupotamus.io/docs/themes/theme-environment-variables/) - A Docusaurus theme that parameterizes code blocks. Never use `{{ REPLACE_THIS }}` again.
+- [docusaurus-theme-github-codeblock](https://github.com/saucelabs/docusaurus-theme-github-codeblock) - A Docusaurus v2 plugin that supports referencing code examples from public GitHub repositories
 - [mr-pdf](https://github.com/kohheepeace/mr-pdf) - Generate documentation into PDF format, suitable for Docusaurus v1 and v2 (including beta versions)
 - [docusaurus-plugin-sass](https://github.com/rlamana/docusaurus-plugin-sass) - Sass/SCSS stylesheets support
 - [docusaurus-plugin-remote-content](https://github.com/rdilweb/docusaurus-plugin-remote-content) - A Docusaurus v2 plugin that allows you to fetch content from remote sources


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have signed the [Contributor License Agreement](https://docusaurus.io/community/contributing#contributor-license-agreement-cla).

## Motivation

I'd like to add a link to `theme-environment-variables` on the community resources page.

This was originally discussed on Discord [here](https://discord.com/channels/398180168688074762/877243736806019102/1085640344449851392).

You'll note I also modified `theme-github-codeblock`. The convention on this page appears to use hyphens as delimiters but this list item used a period. I can remove this change from the PR if you'd like.

## Test Plan

<img width="1278" alt="Screen Shot 2023-03-20 at 7 53 45 AM" src="https://user-images.githubusercontent.com/18382519/226363165-3c470e59-1bae-41ae-ab9d-d9fbe7f7fdb3.png">

### Test links

Deploy Preview: https://deploy-preview-8793--docusaurus-2.netlify.app/community/resources/