### PR TITLE
chore: fix workbox precaching page link + weird mdx structure breaking Crowdin

### DIFF
--- a/website/docs/api/plugins/plugin-pwa.mdx
+++ b/website/docs/api/plugins/plugin-pwa.mdx
@@ -78,12 +78,8 @@ App installation requires the HTTPS protocol and a valid manifest.
 
 We enable users to browse a Docusaurus site offline, by using service-worker precaching.
 
-> <h3>
->   <a href="https://developers.google.com/web/tools/workbox/modules/workbox-precaching">
->     {'What is Precaching?'}
->   </a>
-> </h3>
->
+The [workbox-precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching) page explains the idea:
+
 > One feature of service workers is the ability to save a set of files to the cache when the service worker is installing. This is often referred to as "precaching", since you are caching content ahead of the service worker being used.
 >
 > The main reason for doing this is that it gives developers control over the cache, meaning they can determine when and how long a file is cached as well as serve it to the browser without going to the network, meaning it can be used to create web apps that work offline.

--- a/website/versioned_docs/version-2.0.1/api/plugins/plugin-pwa.mdx
+++ b/website/versioned_docs/version-2.0.1/api/plugins/plugin-pwa.mdx
@@ -78,12 +78,8 @@ App installation requires the HTTPS protocol and a valid manifest.
 
 We enable users to browse a Docusaurus site offline, by using service-worker precaching.
 
-> <h3>
->   <a href="https://developers.google.com/web/tools/workbox/modules/workbox-precaching">
->     {'What is Precaching?'}
->   </a>
-> </h3>
->
+The [workbox-precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching) page explains the idea:
+
 > One feature of service workers is the ability to save a set of files to the cache when the service worker is installing. This is often referred to as "precaching", since you are caching content ahead of the service worker being used.
 >
 > The main reason for doing this is that it gives developers control over the cache, meaning they can determine when and how long a file is cached as well as serve it to the browser without going to the network, meaning it can be used to create web apps that work offline.

--- a/website/versioned_docs/version-2.1.0/api/plugins/plugin-pwa.mdx
+++ b/website/versioned_docs/version-2.1.0/api/plugins/plugin-pwa.mdx
@@ -78,12 +78,8 @@ App installation requires the HTTPS protocol and a valid manifest.
 
 We enable users to browse a Docusaurus site offline, by using service-worker precaching.
 
-> <h3>
->   <a href="https://developers.google.com/web/tools/workbox/modules/workbox-precaching">
->     {'What is Precaching?'}
->   </a>
-> </h3>
->
+The [workbox-precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching) page explains the idea:
+
 > One feature of service workers is the ability to save a set of files to the cache when the service worker is installing. This is often referred to as "precaching", since you are caching content ahead of the service worker being used.
 >
 > The main reason for doing this is that it gives developers control over the cache, meaning they can determine when and how long a file is cached as well as serve it to the browser without going to the network, meaning it can be used to create web apps that work offline.

--- a/website/versioned_docs/version-2.2.0/api/plugins/plugin-pwa.mdx
+++ b/website/versioned_docs/version-2.2.0/api/plugins/plugin-pwa.mdx
@@ -78,12 +78,8 @@ App installation requires the HTTPS protocol and a valid manifest.
 
 We enable users to browse a Docusaurus site offline, by using service-worker precaching.
 
-> <h3>
->   <a href="https://developers.google.com/web/tools/workbox/modules/workbox-precaching">
->     {'What is Precaching?'}
->   </a>
-> </h3>
->
+The [workbox-precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching) page explains the idea:
+
 > One feature of service workers is the ability to save a set of files to the cache when the service worker is installing. This is often referred to as "precaching", since you are caching content ahead of the service worker being used.
 >
 > The main reason for doing this is that it gives developers control over the cache, meaning they can determine when and how long a file is cached as well as serve it to the browser without going to the network, meaning it can be used to create web apps that work offline.

--- a/website/versioned_docs/version-2.3.1/api/plugins/plugin-pwa.mdx
+++ b/website/versioned_docs/version-2.3.1/api/plugins/plugin-pwa.mdx
@@ -78,12 +78,8 @@ App installation requires the HTTPS protocol and a valid manifest.
 
 We enable users to browse a Docusaurus site offline, by using service-worker precaching.
 
-> <h3>
->   <a href="https://developers.google.com/web/tools/workbox/modules/workbox-precaching">
->     {'What is Precaching?'}
->   </a>
-> </h3>
->
+The [workbox-precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching) page explains the idea:
+
 > One feature of service workers is the ability to save a set of files to the cache when the service worker is installing. This is often referred to as "precaching", since you are caching content ahead of the service worker being used.
 >
 > The main reason for doing this is that it gives developers control over the cache, meaning they can determine when and how long a file is cached as well as serve it to the browser without going to the network, meaning it can be used to create web apps that work offline.


### PR DESCRIPTION
Goal is to fix our website prod deployment due to Crowdin unability to understand MDX well + previous page link was broken/redirected

![CleanShot 2023-03-23 at 15 56 16](https://user-images.githubusercontent.com/749374/227243556-c9963f00-9d05-4dd6-b14b-8222b0ca166f.png)

https://app.netlify.com/sites/docusaurus-2/deploys/641b45d5d6f0f10008edad8d

![CleanShot 2023-03-23 at 15 57 10@2x](https://user-images.githubusercontent.com/749374/227243732-3d2f3ae1-2569-452c-9651-a0a45213a762.png)

https://crowdin.com/translate/docusaurus-v2/16353/en-fr?filter=basic&value=0
