### PR TITLE
chore: fix production site deployment due to Crowdin 

### DIFF
--- a/website/versioned_docs/version-2.4.0/api/misc/eslint-plugin/README.mdx
+++ b/website/versioned_docs/version-2.4.0/api/misc/eslint-plugin/README.mdx
@@ -48,9 +48,9 @@ For more fine-grained control, you can also enable the plugin manually and confi
 
 ## Supported rules
 
-| Name | Description |  |
+| Name | Description | `` |
 | --- | --- | --- |
-| [`@docusaurus/no-untranslated-text`](./no-untranslated-text.mdx) | Enforce text labels in JSX to be wrapped by translate calls |  |
+| [`@docusaurus/no-untranslated-text`](./no-untranslated-text.mdx) | Enforce text labels in JSX to be wrapped by translate calls | `` |
 | [`@docusaurus/string-literal-i18n-messages`](./string-literal-i18n-messages.mdx) | Enforce translate APIs to be called on plain text labels | ✅ |
 
 ✅ = recommended

--- a/website/versioned_docs/version-2.4.0/api/plugins/plugin-ideal-image.mdx
+++ b/website/versioned_docs/version-2.4.0/api/plugins/plugin-ideal-image.mdx
@@ -49,8 +49,8 @@ Accepted fields:
 | `name` | `string` | `ideal-img/[name].[hash:hex:7].[width].[ext]` | Filename template for output files. |
 | `sizes` | `number[]` | _original size_ | Specify all widths you want to use. If a specified size exceeds the original image's width, the latter will be used (i.e. images won't be scaled up). |
 | `size` | `number` | _original size_ | Specify one width you want to use; if the specified size exceeds the original image's width, the latter will be used (i.e. images won't be scaled up) |
-| `min` | `number` |  | As an alternative to manually specifying `sizes`, you can specify `min`, `max` and `steps`, and the sizes will be generated for you. |
-| `max` | `number` |  | See `min` above |
+| `min` | `number` | `undefined` | As an alternative to manually specifying `sizes`, you can specify `min`, `max` and `steps`, and the sizes will be generated for you. |
+| `max` | `number` | `undefined` | See `min` above |
 | `steps` | `number` | `4` | Configure the number of images generated between `min` and `max` (inclusive) |
 | `quality` | `number` | `85` | JPEG compression quality |
 | `disableInDev` | `boolean` | `true` | You can test ideal image behavior in dev mode by setting this to `false`. **Tip**: use [network throttling](https://www.browserstack.com/guide/how-to-perform-network-throttling-in-chrome) in your browser to simulate slow networks. |


### PR DESCRIPTION
Crowdin now "supports" MDX (not really 😅 ) and  this makes the site deployment to fail on newly uploaded mdx files.

2 files in particular now refuse to upload despite being valid MDX (v1+v2):

❌ File 'website/versioned_docs/version-2.4.0/api/plugins/plugin-ideal-image.mdx'
❌ Error from server: <Code: 500, Message: Internal Server Error>

❌ File 'website/versioned_docs/version-2.4.0/api/misc/eslint-plugin/README.mdx'
❌ Error from server: <Code: 500, Message: Internal Server Error>


I'm in touch with Crowdin to troubleshoot this but in the meantime here's a quickfix



