### PR TITLE
chore: Crowdin download languages pt-BR + ja

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "serve:website:ssl:serve": "serve website/build --ssl-cert ./website/.docusaurus/selfsigned.crt --ssl-key ./website/.docusaurus/selfsigned.key",
     "crowdin:upload:website": "crowdin upload sources --config ./crowdin-v2.yaml",
     "crowdin:download": "crowdin download --config ./crowdin-v2.yaml",
-    "crowdin:download:website": "yarn crowdin:download --language fr --language ko --language pt-BR --language zh-CN",
+    "crowdin:download:website": "yarn crowdin:download --language fr --language ko --language pt-BR --language zh-CN --language ja",
     "canary": "yarn canary:bumpVersion && yarn canary:publish",
     "canary:version": "echo 0.0.0-`git rev-list --count HEAD`+`git rev-parse --short HEAD`",
     "canary:bumpVersion": "yarn lerna version `yarn --silent canary:version` --exact --no-push --yes",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "serve:website:ssl:serve": "serve website/build --ssl-cert ./website/.docusaurus/selfsigned.crt --ssl-key ./website/.docusaurus/selfsigned.key",
     "crowdin:upload:website": "crowdin upload sources --config ./crowdin-v2.yaml",
     "crowdin:download": "crowdin download --config ./crowdin-v2.yaml",
-    "crowdin:download:website": "yarn crowdin:download --language fr --language ko --language pt-PT --language zh-CN",
+    "crowdin:download:website": "yarn crowdin:download --language fr --language ko --language pt-BR --language zh-CN",
     "canary": "yarn canary:bumpVersion && yarn canary:publish",
     "canary:version": "echo 0.0.0-`git rev-list --count HEAD`+`git rev-parse --short HEAD`",
     "canary:bumpVersion": "yarn lerna version `yarn --silent canary:version` --exact --no-push --yes",


### PR DESCRIPTION
Crowdin should download:
- pt-BR instead of pt-PT
- ja for our i18n staging env: https://docusaurus-i18n-staging.netlify.app/
