### PR TITLE
docs: link to mermaid config types

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-diagrams.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-diagrams.mdx
@@ -82,4 +82,4 @@ module.exports = {
 };
 ```
 
-See the [Mermaid configuration documentation](https://mermaid-js.github.io/mermaid/#/./Setup?id=configuration) for the available config options.
+See the [Mermaid config documentation](https://mermaid-js.github.io/mermaid/#/./Setup?id=configuration) and the [Mermaid config types](https://github.com/mermaid-js/mermaid/blob/v9.4.3/packages/mermaid/src/config.type.ts) for the available config options.

--- a/website/docs/guides/markdown-features/markdown-features-diagrams.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-diagrams.mdx
@@ -82,4 +82,4 @@ module.exports = {
 };
 ```
 
-See the [Mermaid config documentation](https://mermaid-js.github.io/mermaid/#/./Setup?id=configuration) and the [Mermaid config types](https://github.com/mermaid-js/mermaid/blob/v9.4.3/packages/mermaid/src/config.type.ts) for the available config options.
+See the [Mermaid config documentation](https://mermaid-js.github.io/mermaid/#/./Setup?id=configuration) and the [Mermaid config types](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts) for the available config options.


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

As discussed in https://github.com/facebook/docusaurus/discussions/8806, the current link to the Mermaid docs website offers incomplete information.

This PR adds a link to the Mermaid config types, which makes it super clear what configuration options are available in Mermaid.
