### PR TITLE
fix(create): add missing await

### DIFF
--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -241,7 +241,7 @@ async function getSiteName(
     return true;
   }
   if (reqName) {
-    const res = validateSiteName(reqName);
+    const res = await validateSiteName(reqName);
     if (typeof res === 'string') {
       throw new Error(res);
     }


### PR DESCRIPTION

The error in this function is that validateSiteName is an asynchronous function, so it returns a promise. However, in the getSiteName function, the returned value of validateSiteName is not being awaited, and instead, it's being treated as a synchronous value. This can cause unexpected behavior and errors.

To fix this error, you need to await the result of validateSiteName using the await keyword, like this: