### PR TITLE
fix: add auto theme switch to the Canny widget

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -19,7 +19,7 @@
   --site-color-tooltip-background: #353738;
   --site-color-svg-icon-favorite: #e9669e;
   --site-color-checkbox-checked-bg: hsl(167deg 56% 73% / 25%);
-  --site-color-feedback-background: #fff;
+  --site-color-feedback-background: #f0f8ff;
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 10%);
   /* Use a darker color to ensure contrast, ideally we don't need important */
   --ifm-breadcrumb-color-active: var(--ifm-color-primary-darker) !important;
@@ -27,7 +27,7 @@
 }
 
 html[data-theme='dark'] {
-  --site-color-feedback-background: #f0f8ff;
+  --site-color-feedback-background: #2a2929;
   --site-color-favorite-background: #1d1e1e;
   --site-color-checkbox-checked-bg: hsl(167deg 56% 73% / 10%);
   --docusaurus-highlighted-code-line-bg: rgb(66 66 66 / 35%);

--- a/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
@@ -26,6 +26,7 @@ export default function FeatureRequests({
     Canny('render', {
       boardToken: BOARD_TOKEN,
       basePath,
+      theme: 'auto'
     });
   }, [basePath]);
 

--- a/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
@@ -7,6 +7,7 @@
 
 import React, {useEffect} from 'react';
 import clsx from 'clsx';
+import {useColorMode} from '@docusaurus/theme-common';
 import Layout from '@theme/Layout';
 
 import cannyScript from './cannyScript';
@@ -14,28 +15,43 @@ import styles from './styles.module.css';
 
 const BOARD_TOKEN = '054e0e53-d951-b14c-7e74-9eb8f9ed2f91';
 
-export default function FeatureRequests({
-  basePath,
-}: {
-  basePath: string;
-}): JSX.Element {
+function useCannyTheme() {
+  const {colorMode} = useColorMode();
+  return colorMode === 'light' ? 'light' : 'dark';
+}
+
+function CannyWidget({basePath}: {basePath: string}) {
   useEffect(() => {
     cannyScript();
+  }, []);
+
+  const theme = useCannyTheme();
+  useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const {Canny} = window as any;
     Canny('render', {
       boardToken: BOARD_TOKEN,
       basePath,
-      theme: 'auto'
+      theme,
     });
-  }, [basePath]);
+  }, [basePath, theme]);
+  return (
+    <main
+      key={theme} // widget needs a full reset: unable to update the theme
+      className={clsx('container', 'margin-vert--lg', styles.main)}
+      data-canny
+    />
+  );
+}
 
+export default function FeatureRequests({
+  basePath,
+}: {
+  basePath: string;
+}): JSX.Element {
   return (
     <Layout title="Feedback" description="Docusaurus 2 Feature Requests page">
-      <main
-        className={clsx('container', 'margin-vert--lg', styles.main)}
-        data-canny
-      />
+      <CannyWidget basePath={basePath} />
     </Layout>
   );
 }


### PR DESCRIPTION
https://developers.canny.io/install/widget/web / https://feedback.canny.io/feature-requests/p/widget-dark-theme

Canny just added dark mode support to their widget. I figure setting it from "light" to "auto" is a good default for now - we could set it to switch explicitly using `useColorMode` if we wanted - valid values are `light` / `dark` and `auto`

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

https://deploy-preview-8846--docusaurus-2.netlify.app/feature-requests/


## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
