### PR TITLE
refactor(theme): expose copy, success and word-wrap icons as standalone components

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -1431,6 +1431,14 @@ declare module '@theme/Icon/Close' {
   export default function IconClose(props: Props): JSX.Element;
 }
 
+declare module '@theme/Icon/Copy' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'svg'> {}
+
+  export default function IconCopy(props: Props): JSX.Element;
+}
+
 declare module '@theme/Icon/Language' {
   import type {ComponentProps} from 'react';
 
@@ -1439,12 +1447,28 @@ declare module '@theme/Icon/Language' {
   export default function IconLanguage(props: Props): JSX.Element;
 }
 
+declare module '@theme/Icon/Success' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'svg'> {}
+
+  export default function IconSuccess(props: Props): JSX.Element;
+}
+
 declare module '@theme/Icon/ExternalLink' {
   import type {ComponentProps} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
   export default function IconExternalLink(props: Props): JSX.Element;
+}
+
+declare module '@theme/Icon/WordWrap' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'svg'> {}
+
+  export default function IconWordWrap(props: Props): JSX.Element;
 }
 
 declare module '@theme/TagsListByLetter' {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
@@ -11,6 +11,8 @@ import clsx from 'clsx';
 import copy from 'copy-text-to-clipboard';
 import {translate} from '@docusaurus/Translate';
 import type {Props} from '@theme/CodeBlock/CopyButton';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
 
 import styles from './styles.module.css';
 
@@ -56,12 +58,8 @@ export default function CopyButton({code, className}: Props): JSX.Element {
       )}
       onClick={handleCopyCode}>
       <span className={styles.copyButtonIcons} aria-hidden="true">
-        <svg className={styles.copyButtonIcon} viewBox="0 0 24 24">
-          <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
-        </svg>
-        <svg className={styles.copyButtonSuccessIcon} viewBox="0 0 24 24">
-          <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
-        </svg>
+        <IconCopy className={styles.copyButtonIcon} />
+        <IconSuccess className={styles.copyButtonSuccessIcon} />
       </span>
     </button>
   );

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/WordWrapButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/WordWrapButton/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import type {Props} from '@theme/CodeBlock/WordWrapButton';
+import IconWordWrap from '@theme/Icon/WordWrap';
 
 import styles from './styles.module.css';
 
@@ -35,15 +36,7 @@ export default function WordWrapButton({
       )}
       aria-label={title}
       title={title}>
-      <svg
-        className={styles.wordWrapButtonIcon}
-        viewBox="0 0 24 24"
-        aria-hidden="true">
-        <path
-          fill="currentColor"
-          d="M4 19h6v-2H4v2zM20 5H4v2h16V5zm-3 6H4v2h13.25c1.1 0 2 .9 2 2s-.9 2-2 2H15v-2l-3 3l3 3v-2h2c2.21 0 4-1.79 4-4s-1.79-4-4-4z"
-        />
-      </svg>
+      <IconWordWrap className={styles.wordWrapButtonIcon} aria-hidden="true" />
     </button>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Copy/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Copy/index.tsx
@@ -13,7 +13,7 @@ export default function IconCopy(props: Props): JSX.Element {
     <svg viewBox="0 0 24 24" {...props}>
       <path
         fill="currentColor"
-        d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+        d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
       />
     </svg>
   );

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Copy/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Copy/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/Icon/Copy';
+
+export default function IconCopy(props: Props): JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" {...props}>
+      <path
+        fill="currentColor"
+        d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+      />
+    </svg>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Success/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Success/index.tsx
@@ -13,7 +13,7 @@ export default function IconSuccess(props: Props): JSX.Element {
     <svg viewBox="0 0 24 24" {...props}>
       <path
         fill="currentColor"
-        d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+        d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
       />
     </svg>
   );

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Success/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Success/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/Icon/Success';
+
+export default function IconSuccess(props: Props): JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" {...props}>
+      <path
+        fill="currentColor"
+        d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+      />
+    </svg>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/Icon/WordWrap/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/WordWrap/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/Icon/WordWrap';
+
+export default function IconWordWrap(props: Props): JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" {...props}>
+      <path
+        fill="currentColor"
+        d="M4 19h6v-2H4v2zM20 5H4v2h16V5zm-3 6H4v2h13.25c1.1 0 2 .9 2 2s-.9 2-2 2H15v-2l-3 3l3 3v-2h2c2.21 0 4-1.79 4-4s-1.79-4-4-4z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

I'd like to reuse thos eicons without in playground of typescript-eslint, as for now i had to make a copy

![image](https://user-images.githubusercontent.com/625469/229349247-94f74611-c37b-4877-8767-35886c374119.png)
https://typescript-eslint.io/play/

![image](https://user-images.githubusercontent.com/625469/225652426-7e5c0a49-c119-44f3-bbdf-a6856577c389.png)
https://deploy-preview-6728--typescript-eslint.netlify.app/play/#showAST=es

### Test links

https://docusaurus.io/docs/cli/
https://deploy-preview-8862--docusaurus-2.netlify.app/docs/cli/

## Related issues/PRs

https://github.com/typescript-eslint/typescript-eslint/pull/6728
