### PR TITLE
fix(theme-common): fix confusing theme error message: bad sidebar id suggestions

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
@@ -311,7 +311,7 @@ export function useLayoutDocsSidebar(
           versions.length > 1 ? 's' : ''
         } ${versions.map((version) => version.name).join(', ')}".
 Available sidebar ids are:
-- ${Object.keys(allSidebars).join('\n- ')}`,
+- ${allSidebars.map((entry) => entry[0]).join('\n- ')}`,
       );
     }
     return sidebarEntry[1];


### PR DESCRIPTION


## Motivation

The error message when user provides a bad navbar sidebar id is wrong, it displays indices (0, 1...) instead of actual sidebar names.

Now it will print the sidebar names:

![CleanShot 2023-04-07 at 19 18 30@2x](https://user-images.githubusercontent.com/749374/230650399-1b43e6af-ea5b-409b-b09c-21c5bc2166ec.png)


## Test Plan

local
