### PR TITLE
fix(utils): handle Markdown links with spaces to route correctly

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/__snapshots__/markdownLinks.test.ts.snap
+++ b/packages/docusaurus-utils/src/__tests__/__snapshots__/markdownLinks.test.ts.snap
@@ -110,6 +110,20 @@ exports[`replaceMarkdownLinks ignores links in inline code 1`] = `
 }
 `;
 
+exports[`replaceMarkdownLinks replaces Markdown links with spaces 1`] = `
+{
+  "brokenMarkdownLinks": [],
+  "newContent": "
+[doc a](/docs/doc%20a)
+[doc a](</docs/doc%20a>)
+[doc a](/docs/doc%20a)
+[doc b](/docs/my%20docs/doc%20b)
+[doc b](</docs/my%20docs/doc%20b>)
+[doc b](/docs/my%20docs/doc%20b)
+",
+}
+`;
+
 exports[`replaceMarkdownLinks replaces links with same title as URL 1`] = `
 {
   "brokenMarkdownLinks": [],

--- a/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
@@ -260,4 +260,29 @@ The following operations are defined for [URI]s:
       }),
     ).toMatchSnapshot();
   });
+
+  it('replaces Markdown links with spaces', () => {
+    expect(
+      replaceMarkdownLinks({
+        siteDir: '.',
+        filePath: 'docs/intro.md',
+        contentPaths: {
+          contentPath: 'docs',
+          contentPathLocalized: 'i18n/docs-localized',
+        },
+        sourceToPermalink: {
+          '@site/docs/doc a.md': '/docs/doc%20a',
+          '@site/docs/my docs/doc b.md': '/docs/my%20docs/doc%20b',
+        },
+        fileString: `
+[doc a](./doc%20a.md)
+[doc a](<./doc a.md>)
+[doc a](./doc a.md)
+[doc b](./my%20docs/doc%20b.md)
+[doc b](<./my docs/doc b.md>)
+[doc b](./my docs/doc b.md)
+`,
+      }),
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -103,7 +103,7 @@ export function replaceMarkdownLinks<T extends ContentPaths>({
     // This is [Document 1](doc1.md)
     // [doc1]: doc1.md
     const mdRegex =
-      /(?:\]\(|\]:\s*)(?!https?:\/\/|@site\/)(?<filename>[^'")\]\s>]+\.mdx?)/g;
+      /(?:\]\(|\]:\s*)(?!https?:\/\/|@site\/)<?(?<filename>[^'"\]\s>]+(?:\s[^'"\]\s>]+)*\.mdx?)>?/g;
     let mdMatch = mdRegex.exec(modifiedLine);
     while (mdMatch !== null) {
       // Replace it to correct html link.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
Fixes #8867

Links to Markdown files with spaces are routed to the original filename (i.e. they also keep the original file extension).
The problem is that existing regex for Markdown links doesn't match filenames that contain whitespaces and wrapped with `<>` .

Thus, here are changes I applied to the regex:
- match links wrapped with `<>`
- match spaces in filename

`replaceMarkdownLinks` method already replaces spaces with `%20` in a link, therefore we are good to go here. 

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
This issue can be tested using examples provided in #8867.
I have also added unit tests.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
#8867
