### PR TITLE
fix(theme-common): fix collapsible component with prefers-reduced-motion

### DIFF
--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -77,7 +77,9 @@ https://github.com/mui-org/material-ui/blob/e724d98eba018e55e1a684236a2037e24bcf
  */
 function getAutoHeightDuration(height: number) {
   if (userPrefersReducedMotion()) {
-    return 0;
+    // Not using 0 because it prevents onTransitionEnd to fire :/
+    // See bug https://github.com/facebook/docusaurus/discussions/8905#discussioncomment-5663928
+    return 1;
   }
   const constant = height / 36;
   return Math.round((4 + 15 * constant ** 0.25 + constant / 5) * 10);

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -77,8 +77,8 @@ https://github.com/mui-org/material-ui/blob/e724d98eba018e55e1a684236a2037e24bcf
  */
 function getAutoHeightDuration(height: number) {
   if (userPrefersReducedMotion()) {
-    // Not using 0 because it prevents onTransitionEnd to fire :/
-    // See bug https://github.com/facebook/docusaurus/discussions/8905#discussioncomment-5663928
+    // Not using 0 because it prevents onTransitionEnd to fire and bubble up :/
+    // See https://github.com/facebook/docusaurus/pull/8906
     return 1;
   }
   const constant = height / 36;


### PR DESCRIPTION
## Motivation

Bug better described here: https://github.com/facebook/docusaurus/discussions/8905#discussioncomment-5663928

When using `prefers-reduced-motion` in OS settings, nested collapsible does not work well because the `onTransitionEnd` callback does not fire. 

We rely on it to notably let the parent know that a child has changed size and recompute its height, because the event bubbles up. We can see it in action with nested details elements where the child was expanded, but the parent collapsible didn't adjust its own size and truncates the child.

![image](https://user-images.githubusercontent.com/749374/233140231-11de7bc6-167e-4388-9655-bab74be3dd02.png)

Workaround: using an animation of 1ms fixes the problem. Not sure how to fix it otherwise but it looks good enough to me 🤷‍♂️.  

We still see the animation a bit which is annoying, but it's better than having the collapsible not uncollapsing and the UI being unusable.

If someone has a cleaner solution using 0 please submit another PR. 


## Test Plan

preview with reduced motion should work for nested collapsibles

### Test links


Deploy preview: https://deploy-preview-8906--docusaurus-2.netlify.app/docs/markdown-features#details

## Related issues/PRs

https://github.com/facebook/docusaurus/discussions/8905
https://github.com/facebook/docusaurus/discussions/8854
https://github.com/facebook/docusaurus/pull/8674
