### PR TITLE
fix(core): Correct yarn upgrade command for yarn 2.x

### DIFF
--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -104,10 +104,20 @@ export default async function beforeCli() {
       .filter((p) => p.startsWith('@docusaurus'))
       .map((p) => p.concat('@latest'))
       .join(' ');
-    const isYarnUsed = await fs.pathExists(path.resolve('yarn.lock'));
-    const upgradeCommand = isYarnUsed
-      ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
-      : `npm i ${siteDocusaurusPackagesForUpdate}`;
+
+    const getUpgradeCommand = async () => {
+      const isYarnUsed = await fs.pathExists(path.resolve('yarn.lock'));
+      const isYarnClassicUsed = !(await fs.pathExists(
+        path.resolve('.yarnrc.yml'),
+      ));
+      if (!isYarnUsed) {
+        return `npm i ${siteDocusaurusPackagesForUpdate}`;
+      }
+
+      return isYarnClassicUsed
+        ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
+        : `yarn up ${siteDocusaurusPackagesForUpdate}`;
+    };
 
     /** @type {import('boxen').Options} */
     const boxenOptions = {
@@ -124,7 +134,7 @@ export default async function beforeCli() {
       )} → ${logger.green(`${notifier.update.latest}`)}
 
   To upgrade Docusaurus packages with the latest version, run the following command:
-  ${logger.code(upgradeCommand)}`,
+  ${logger.code(await getUpgradeCommand())}`,
       boxenOptions,
     );
 

--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -107,13 +107,13 @@ export default async function beforeCli() {
 
     const getUpgradeCommand = async () => {
       const isYarnUsed = await fs.pathExists(path.resolve('yarn.lock'));
-      const isYarnClassicUsed = !(await fs.pathExists(
-        path.resolve('.yarnrc.yml'),
-      ));
       if (!isYarnUsed) {
         return `npm i ${siteDocusaurusPackagesForUpdate}`;
       }
 
+      const isYarnClassicUsed = !(await fs.pathExists(
+        path.resolve('.yarnrc.yml'),
+      ));
       return isYarnClassicUsed
         ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
         : `yarn up ${siteDocusaurusPackagesForUpdate}`;


### PR DESCRIPTION
## Pre-flight checklist

- [Y] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [N] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [N/A] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Incorrect notice on upgrade with unclear error message in yarn 2+.

Note: There are also incorrect messges in the installation.mdx files, and likely from. npmToYarn (which doesn't support yarn2+ yet) so I haven't done anything about these yet without a clear indication of direction.

## Test Plan

- Check out an older docusaurus project and copy the file in place.
- Install the project with `npm`
- Run a `npm run start`
- Close and run it again
  - **Confirm the notice had an appropriate `npm i` command**
- `rm -rf node_modules`
- Install with yarn classic
- Run `yarn start`
- Close and run it again
  - **Confirm the notice had an appropriate `npm i` command**
- `rm -rf node_modules`
- Repeat with yarn 2

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
