### PR TITLE
fix: allow html syntax in MDX v2 with format md

### DIFF
--- a/jest/deps.d.ts
+++ b/jest/deps.d.ts
@@ -13,10 +13,6 @@ declare module 'to-vfile' {
   export function read(path: string, encoding?: string): Promise<VFile>;
 }
 
-declare module 'remark-rehype';
-
-declare module 'rehype-stringify';
-
 declare module '@testing-utils/git' {
   const createTempRepo: typeof import('./utils/git').createTempRepo;
   export {createTempRepo};

--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -32,6 +32,7 @@
     "image-size": "^1.0.2",
     "mdast-util-to-string": "^3.0.0",
     "mdast-util-mdx": "^2.0.0",
+    "rehype-raw": "^6.1.1",
     "remark-comment": "^1.0.0",
     "remark-gfm": "^3.0.1",
     "remark-directive": "^2.0.1",

--- a/packages/docusaurus-mdx-loader/src/__tests__/format.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/format.test.ts
@@ -9,9 +9,7 @@ import {getFormat} from '../format';
 
 describe('getFormat', () => {
   it('uses frontMatter format over anything else', () => {
-    expect(getFormat({frontMatterFormat: 'md', filePath: 'xyz.md'})).toBe(
-      'md',
-    );
+    expect(getFormat({frontMatterFormat: 'md', filePath: 'xyz.md'})).toBe('md');
     expect(getFormat({frontMatterFormat: 'md', filePath: 'xyz.mdx'})).toBe(
       'md',
     );
@@ -24,9 +22,9 @@ describe('getFormat', () => {
   });
 
   it('detects appropriate format from file extension', () => {
-    expect(
-      getFormat({frontMatterFormat: 'detect', filePath: 'xyz.md'}),
-    ).toBe('md');
+    expect(getFormat({frontMatterFormat: 'detect', filePath: 'xyz.md'})).toBe(
+      'md',
+    );
     expect(
       getFormat({frontMatterFormat: 'detect', filePath: 'xyz.markdown'}),
     ).toBe('md');
@@ -37,9 +35,9 @@ describe('getFormat', () => {
     expect(
       getFormat({frontMatterFormat: 'detect', filePath: 'folder/xyz.markdown'}),
     ).toBe('md');
-    expect(
-      getFormat({frontMatterFormat: 'detect', filePath: 'xyz.mdx'}),
-    ).toBe('mdx');
+    expect(getFormat({frontMatterFormat: 'detect', filePath: 'xyz.mdx'})).toBe(
+      'mdx',
+    );
     expect(
       getFormat({frontMatterFormat: 'detect', filePath: 'folder/xyz.mdx'}),
     ).toBe('mdx');

--- a/packages/docusaurus-mdx-loader/src/__tests__/format.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/format.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {getFormat} from '../format';
+
+describe('getFormat', () => {
+  it('uses frontMatter format over anything else', () => {
+    expect(getFormat({frontMatterFormat: 'md', filePath: 'xyz.md'})).toBe(
+      'md',
+    );
+    expect(getFormat({frontMatterFormat: 'md', filePath: 'xyz.mdx'})).toBe(
+      'md',
+    );
+    expect(getFormat({frontMatterFormat: 'mdx', filePath: 'xyz.md'})).toBe(
+      'mdx',
+    );
+    expect(getFormat({frontMatterFormat: 'mdx', filePath: 'xyz.mdx'})).toBe(
+      'mdx',
+    );
+  });
+
+  it('detects appropriate format from file extension', () => {
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'xyz.md'}),
+    ).toBe('md');
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'xyz.markdown'}),
+    ).toBe('md');
+
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'folder/xyz.md'}),
+    ).toBe('md');
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'folder/xyz.markdown'}),
+    ).toBe('md');
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'xyz.mdx'}),
+    ).toBe('mdx');
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'folder/xyz.mdx'}),
+    ).toBe('mdx');
+
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'xyz.unknown'}),
+    ).toBe('mdx');
+    expect(
+      getFormat({frontMatterFormat: 'detect', filePath: 'folder/xyz.unknown'}),
+    ).toBe('mdx');
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/__tests__/processor.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/processor.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// import {createProcessor} from '../processor';
+// import type {Options} from '../loader';
+
+/*
+async function testProcess({
+  format,
+  options,
+}: {
+  format: 'md' | 'mdx';
+  options: Options;
+}) {
+  return async (content: string) => {
+    const processor = await createProcessor({format, options});
+    return processor.process(content);
+  };
+}
+ */
+
+describe('md processor', () => {
+  it('parses simple commonmark', async () => {
+    // TODO no tests for now, wait until ESM support
+    // Jest does not support well ESM modules
+    // It would require to vendor too much Unified modules as CJS
+    // See https://mdxjs.com/docs/troubleshooting-mdx/#esm
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/format.ts
+++ b/packages/docusaurus-mdx-loader/src/format.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import type {MDXFrontMatter} from './frontMatter';
+
+// Copied from https://mdxjs.com/packages/mdx/#optionsmdextensions
+// Although we are likely to only use .md / .mdx anyway...
+const mdFormatExtensions = [
+  '.md',
+  '.markdown',
+  '.mdown',
+  '.mkdn',
+  '.mkd',
+  '.mdwn',
+  '.mkdown',
+  '.ron',
+];
+
+function isMDFormat(filepath: string) {
+  return mdFormatExtensions.includes(path.extname(filepath));
+}
+
+export function getFormat({
+  filePath,
+  frontMatterFormat,
+}: {
+  filePath: string;
+  frontMatterFormat: MDXFrontMatter['format'];
+}): 'md' | 'mdx' {
+  if (frontMatterFormat !== 'detect') {
+    return frontMatterFormat;
+  }
+  // Bias toward mdx if unknown extension
+  return isMDFormat(filePath) ? 'md' : 'mdx';
+}

--- a/packages/docusaurus-mdx-loader/src/index.ts
+++ b/packages/docusaurus-mdx-loader/src/index.ts
@@ -30,4 +30,6 @@ export type LoadedMDXContent<FrontMatter, Metadata, Assets = undefined> = {
   readonly assets: Assets;
   (): JSX.Element;
 };
-export type {Options, MDXPlugin, MDXOptions} from './loader';
+
+export type {Options, MDXPlugin} from './loader';
+export type {MDXOptions} from './processor';

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -16,7 +16,7 @@ import {
 import stringifyObject from 'stringify-object';
 import preprocessor from './preprocessor';
 import {validateMDXFrontMatter} from './frontMatter';
-import {getProcessorCached} from './processor';
+import {createProcessorCached} from './processor';
 import type {MDXOptions} from './processor';
 
 import type {MarkdownConfig} from '@docusaurus/types';
@@ -150,7 +150,7 @@ export async function mdxLoader(
 
   const hasFrontMatter = Object.keys(frontMatter).length > 0;
 
-  const processor = await getProcessorCached({
+  const processor = await createProcessorCached({
     filePath,
     reqOptions,
     query,
@@ -159,12 +159,7 @@ export async function mdxLoader(
 
   let result: string;
   try {
-    result = await processor
-      .process({
-        value: content,
-        path: filePath,
-      })
-      .then((res) => res.toString());
+    result = await processor.process({content, filePath});
   } catch (errorUnknown) {
     const error = errorUnknown as Error;
     return callback(

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -280,6 +280,10 @@ export async function mdxLoader(
       mdCompiler: createProcessor({
         ...options,
         format: 'md',
+        remarkRehypeOptions: {
+          allowDangerousHtml: true,
+          passThrough: ['div', 'button', 'img', 'iframe', 'html'],
+        },
       }),
       mdxCompiler: createProcessor({
         ...options,

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -16,7 +16,7 @@ import {
 import stringifyObject from 'stringify-object';
 import preprocessor from './preprocessor';
 import {validateMDXFrontMatter} from './frontMatter';
-import {getProcessor} from './processor';
+import {getProcessorCached} from './processor';
 import type {MDXOptions} from './processor';
 
 import type {MarkdownConfig} from '@docusaurus/types';
@@ -150,7 +150,7 @@ export async function mdxLoader(
 
   const hasFrontMatter = Object.keys(frontMatter).length > 0;
 
-  const processor = await getProcessor({
+  const processor = await getProcessorCached({
     filePath,
     reqOptions,
     query,

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
 import emoji from 'remark-emoji';
 import headings from './remark/headings';
 import toc from './remark/toc';
@@ -16,6 +15,7 @@ import head from './remark/head';
 import mermaid from './remark/mermaid';
 import transformAdmonitions from './remark/admonitions';
 import codeCompatPlugin from './remark/mdx1Compat/codeCompatPlugin';
+import {getFormat} from './format';
 import type {MDXFrontMatter} from './frontMatter';
 import type {Options} from './loader';
 
@@ -30,37 +30,6 @@ import type {ProcessorOptions} from '@mdx-js/mdx';
 // This might change soon, likely after TS 5.2
 // See https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1517839391
 type Pluggable = any; // TODO fix this asap
-
-// Copied from https://mdxjs.com/packages/mdx/#optionsmdextensions
-// Although we are likely to only use .md / .mdx anyway...
-const mdFormatExtensions = [
-  '.md',
-  '.markdown',
-  '.mdown',
-  '.mkdn',
-  '.mkd',
-  '.mdwn',
-  '.mkdown',
-  '.ron',
-];
-
-function isMDFormat(filepath: string) {
-  return mdFormatExtensions.includes(path.extname(filepath));
-}
-
-function getFormat({
-  filePath,
-  frontMatterFormat,
-}: {
-  filePath: string;
-  frontMatterFormat: MDXFrontMatter['format'];
-}): 'md' | 'mdx' {
-  return frontMatterFormat === 'detect'
-    ? isMDFormat(filePath)
-      ? 'md'
-      : 'mdx'
-    : frontMatterFormat;
-}
 
 const DEFAULT_OPTIONS: MDXOptions = {
   admonitions: true,

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -119,27 +119,30 @@ async function createProcessorFactory() {
     // (after npm2yarn for example)
     remarkPlugins.push(codeCompatPlugin);
 
-    // This is what permits to embed HTML elements with format 'md'
-    // See https://github.com/mdx-js/mdx/pull/2295#issuecomment-1540085960
-    const rehypeRawPlugin: MDXPlugin = [
-      rehypeRaw,
-      {
-        passThrough: [
-          'mdxFlowExpression',
-          'mdxJsxFlowElement',
-          'mdxJsxTextElement',
-          'mdxTextExpression',
-          'mdxjsEsm',
-        ],
-      },
-    ];
-
     const rehypePlugins: MDXPlugin[] = [
-      rehypeRawPlugin,
       ...(options.beforeDefaultRehypePlugins ?? []),
       ...DEFAULT_OPTIONS.rehypePlugins,
       ...(options.rehypePlugins ?? []),
     ];
+
+    if (format === 'md') {
+      // This is what permits to embed HTML elements with format 'md'
+      // See https://github.com/facebook/docusaurus/pull/8960
+      // See https://github.com/mdx-js/mdx/pull/2295#issuecomment-1540085960
+      const rehypeRawPlugin: MDXPlugin = [
+        rehypeRaw,
+        {
+          passThrough: [
+            'mdxFlowExpression',
+            'mdxJsxFlowElement',
+            'mdxJsxTextElement',
+            'mdxTextExpression',
+            'mdxjsEsm',
+          ],
+        },
+      ];
+      rehypePlugins.unshift(rehypeRawPlugin);
+    }
 
     const processorOptions: ProcessorOptions & Options = {
       ...options,

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import emoji from 'remark-emoji';
+import headings from './remark/headings';
+import toc from './remark/toc';
+import transformImage from './remark/transformImage';
+import transformLinks from './remark/transformLinks';
+import details from './remark/details';
+import head from './remark/head';
+import mermaid from './remark/mermaid';
+import transformAdmonitions from './remark/admonitions';
+import codeCompatPlugin from './remark/mdx1Compat/codeCompatPlugin';
+import type {MDXFrontMatter} from './frontMatter';
+import type {Options} from './loader';
+
+// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
+import type {Processor} from 'unified';
+import type {AdmonitionOptions} from './remark/admonitions';
+
+// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
+import type {ProcessorOptions} from '@mdx-js/mdx';
+
+// TODO as of April 2023, no way to import/re-export this ESM type easily :/
+// This might change soon, likely after TS 5.2
+// See https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1517839391
+type Pluggable = any; // TODO fix this asap
+
+// Copied from https://mdxjs.com/packages/mdx/#optionsmdextensions
+// Although we are likely to only use .md / .mdx anyway...
+const mdFormatExtensions = [
+  '.md',
+  '.markdown',
+  '.mdown',
+  '.mkdn',
+  '.mkd',
+  '.mdwn',
+  '.mkdown',
+  '.ron',
+];
+
+function isMDFormat(filepath: string) {
+  return mdFormatExtensions.includes(path.extname(filepath));
+}
+
+function getFormat({
+  filePath,
+  frontMatterFormat,
+}: {
+  filePath: string;
+  frontMatterFormat: MDXFrontMatter['format'];
+}): 'md' | 'mdx' {
+  return frontMatterFormat === 'detect'
+    ? isMDFormat(filePath)
+      ? 'md'
+      : 'mdx'
+    : frontMatterFormat;
+}
+
+const DEFAULT_OPTIONS: MDXOptions = {
+  admonitions: true,
+  rehypePlugins: [],
+  remarkPlugins: [emoji, headings, toc],
+  beforeDefaultRemarkPlugins: [],
+  beforeDefaultRehypePlugins: [],
+};
+
+// We use different compilers depending on the file type (md vs mdx)
+type Processors = {
+  mdCompiler: Processor;
+  mdxCompiler: Processor;
+};
+
+// Compilers are cached so that Remark/Rehype plugins can run
+// expensive code during initialization
+const compilersCache = new Map<string | Options, Processors>();
+
+export type MDXPlugin = Pluggable;
+
+export type MDXOptions = {
+  admonitions: boolean | Partial<AdmonitionOptions>;
+  remarkPlugins: MDXPlugin[];
+  rehypePlugins: MDXPlugin[];
+  beforeDefaultRemarkPlugins: MDXPlugin[];
+  beforeDefaultRehypePlugins: MDXPlugin[];
+};
+
+function getAdmonitionsPlugins(
+  admonitionsOption: MDXOptions['admonitions'],
+): MDXPlugin[] {
+  if (admonitionsOption) {
+    const plugin: MDXPlugin =
+      admonitionsOption === true
+        ? transformAdmonitions
+        : [transformAdmonitions, admonitionsOption];
+    return [plugin];
+  }
+
+  return [];
+}
+
+export async function getProcessors({
+  query,
+  reqOptions,
+}: {
+  query: string | Options;
+  reqOptions: Options;
+}): Promise<Processors> {
+  const {createProcessor} = await import('@mdx-js/mdx');
+  const {default: rehypeRaw} = await import('rehype-raw');
+  const {default: gfm} = await import('remark-gfm');
+  const {default: comment} = await import('remark-comment');
+  const {default: directives} = await import('remark-directive');
+
+  const compilers = compilersCache.get(query);
+  if (compilers) {
+    return compilers;
+  }
+
+  // /!\ this method is synchronous on purpose
+  // Using async code here can create cache entry race conditions!
+  function createCompilersSynchronous(): Processors {
+    const remarkPlugins: MDXPlugin[] = [
+      ...(reqOptions.beforeDefaultRemarkPlugins ?? []),
+      directives,
+      ...getAdmonitionsPlugins(reqOptions.admonitions ?? false),
+      ...DEFAULT_OPTIONS.remarkPlugins,
+      details,
+      head,
+      ...(reqOptions.markdownConfig.mermaid ? [mermaid] : []),
+      [
+        transformImage,
+        {
+          staticDirs: reqOptions.staticDirs,
+          siteDir: reqOptions.siteDir,
+        },
+      ],
+      [
+        transformLinks,
+        {
+          staticDirs: reqOptions.staticDirs,
+          siteDir: reqOptions.siteDir,
+        },
+      ],
+      gfm,
+      reqOptions.markdownConfig.mdx1Compat.comments ? comment : null,
+      ...(reqOptions.remarkPlugins ?? []),
+    ].filter((plugin): plugin is MDXPlugin => Boolean(plugin));
+
+    // codeCompatPlugin needs to be applied last after user-provided plugins
+    // (after npm2yarn for example)
+    remarkPlugins.push(codeCompatPlugin);
+
+    // This is what permits to embed HTML elements with format 'md'
+    // See https://github.com/mdx-js/mdx/pull/2295#issuecomment-1540085960
+    const rehypeRawPlugin: MDXPlugin = [
+      rehypeRaw,
+      {
+        passThrough: [
+          'mdxFlowExpression',
+          'mdxJsxFlowElement',
+          'mdxJsxTextElement',
+          'mdxTextExpression',
+          'mdxjsEsm',
+        ],
+      },
+    ];
+
+    const rehypePlugins: MDXPlugin[] = [
+      rehypeRawPlugin,
+      ...(reqOptions.beforeDefaultRehypePlugins ?? []),
+      ...DEFAULT_OPTIONS.rehypePlugins,
+      ...(reqOptions.rehypePlugins ?? []),
+    ];
+
+    const options: ProcessorOptions & Options = {
+      ...reqOptions,
+      remarkPlugins,
+      rehypePlugins,
+      providerImportSource: '@mdx-js/react',
+    };
+
+    return {
+      mdCompiler: createProcessor({
+        ...options,
+        rehypePlugins: [rehypeRawPlugin, ...(options.rehypePlugins ?? [])],
+        format: 'md',
+      }),
+      mdxCompiler: createProcessor({
+        ...options,
+        format: 'mdx',
+      }),
+    };
+  }
+
+  const compilerCacheEntry = createCompilersSynchronous();
+  compilersCache.set(query, compilerCacheEntry);
+  return compilerCacheEntry;
+}
+
+export async function getProcessor({
+  filePath,
+  mdxFrontMatter,
+  query,
+  reqOptions,
+}: {
+  filePath: string;
+  mdxFrontMatter: MDXFrontMatter;
+  query: string | Options;
+  reqOptions: Options;
+}): Promise<Processor> {
+  const compilers = await getProcessors({query, reqOptions});
+  const format = getFormat({
+    filePath,
+    frontMatterFormat: mdxFrontMatter.format,
+  });
+  return format === 'md' ? compilers.mdCompiler : compilers.mdxCompiler;
+}

--- a/website/_dogfooding/_pages tests/markdown-tests-md.md
+++ b/website/_dogfooding/_pages tests/markdown-tests-md.md
@@ -23,7 +23,7 @@ import BrowserWindow from '@site/src/components/BrowserWindow';
 
 BrowserWindow content
 
-<BrowserWindow/>
+</BrowserWindow>
 
 export const answer = 42;
 
@@ -42,3 +42,47 @@ note
 ## Heading Id {#custom-heading-id}
 
 Custom heading syntax `{#custom-heading-id}` still works
+
+## HTML
+
+### Styling
+
+<span style="color: blue;">blue span</span>
+
+<p style="color: green;">green p</p>
+
+<button style="color: red;">red button</button>
+
+<div style="border: solid; background-color: lime; padding: 10px">
+  lime <span style="color: red; margin: 10px;">red</span>
+</div>
+
+### Embeds
+
+### Images
+
+#### Closed image tag:
+
+<img src="/img/docusaurus.png"/>
+
+#### Unclosed image tag:
+
+<img src="/img/docusaurus.png">
+
+### Iframe
+
+<iframe src="/"/>
+
+### Security
+
+```md
+<p>
+  When pressing this button, no alert should be printed
+  <button onClick="alert('unsafe');">Click me</button>
+</p>
+```
+
+<p>
+  When pressing this button, no alert should be printed
+  <button onClick="alert('unsafe');">Click me</button>
+</p>

--- a/website/_dogfooding/_pages tests/markdown-tests-md.md
+++ b/website/_dogfooding/_pages tests/markdown-tests-md.md
@@ -43,6 +43,8 @@ note
 
 Custom heading syntax `{#custom-heading-id}` still works
 
+---
+
 ## HTML
 
 ### Styling
@@ -53,25 +55,31 @@ Custom heading syntax `{#custom-heading-id}` still works
 
 <button style="color: red;">red button</button>
 
-<div style="border: solid; background-color: lime; padding: 10px">
+<div style="border: solid; background-color: grey; color: lime; padding: 10px">
   lime <span style="color: red; margin: 10px;">red</span>
 </div>
 
-### Embeds
+<br/>
 
-### Images
+### Embeds
 
 #### Closed image tag:
 
 <img src="/img/docusaurus.png"/>
 
+<br/>
+
 #### Unclosed image tag:
 
 <img src="/img/docusaurus.png">
 
+<br/>
+
 ### Iframe
 
-<iframe src="/"/>
+<iframe src="/" style="width: 100%; height: 300px; border: solid red thick;"></iframe>
+
+<br/>
 
 ### Security
 

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -4,6 +4,8 @@ description: Markdown Page tests description
 wrapperClassName: docusaurus-markdown-example
 ---
 
+<button onClick={() => alert('unsafe :s')}>Should not alert</button>
+
 # Markdown .mdx tests
 
 This is a page generated from Markdown to illustrate the Markdown page feature and test some edge cases.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3268,6 +3268,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
+"@types/parse5@^6.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
+  integrity sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==
+
 "@types/picomatch@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/picomatch/-/picomatch-2.3.0.tgz#75db5e75a713c5a83d5b76780c3da84a82806003"
@@ -8235,6 +8240,23 @@ hast-util-parse-selector@^3.0.0:
   dependencies:
     "@types/hast" "^2.0.0"
 
+hast-util-raw@^7.2.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-7.2.3.tgz#dcb5b22a22073436dbdc4aa09660a644f4991d99"
+  integrity sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/parse5" "^6.0.0"
+    hast-util-from-parse5 "^7.0.0"
+    hast-util-to-parse5 "^7.0.0"
+    html-void-elements "^2.0.0"
+    parse5 "^6.0.0"
+    unist-util-position "^4.0.0"
+    unist-util-visit "^4.0.0"
+    vfile "^5.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-to-estree@^2.0.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/hast-util-to-estree/-/hast-util-to-estree-2.3.2.tgz#11ab0cd2e70ecf0305151af56e636b1cdfbba0bf"
@@ -8271,6 +8293,18 @@ hast-util-to-html@^7.1.1:
     stringify-entities "^3.0.1"
     unist-util-is "^4.0.0"
     xtend "^4.0.0"
+
+hast-util-to-parse5@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz#c49391bf8f151973e0c9adcd116b561e8daf29f3"
+  integrity sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
 
 hast-util-to-string@^1.0.4:
   version "1.0.4"
@@ -8441,6 +8475,11 @@ html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
+
+html-void-elements@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-2.0.1.tgz#29459b8b05c200b6c5ee98743c41b979d577549f"
+  integrity sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==
 
 html-webpack-plugin@^5.5.0:
   version "5.5.0"
@@ -13831,6 +13870,15 @@ rehype-parse@^8.0.0:
     "@types/hast" "^2.0.0"
     hast-util-from-parse5 "^7.0.0"
     parse5 "^6.0.0"
+    unified "^10.0.0"
+
+rehype-raw@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-6.1.1.tgz#81bbef3793bd7abacc6bf8335879d1b6c868c9d4"
+  integrity sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    hast-util-raw "^7.2.0"
     unified "^10.0.0"
 
 rehype-stringify@^8.0.0:


### PR DESCRIPTION
## Motivation

Current MDX 2 setup does not allow arbitrary HTML elements when using format `md` (ie when using `.md` file extension)

Related: I am contributing new useful options to the MDX playground because otherwise this is not simple to debug how this new md format works: https://github.com/mdx-js/mdx/pull/2295


Note: this PR refactors many things to cleanup our MDX setup, but overall the solution to this specific html embed problem was:

```js
[
      rehypeRaw,
      {
        passThrough: [
          'mdxFlowExpression',
          'mdxJsxFlowElement',
          'mdxJsxTextElement',
          'mdxTextExpression',
          'mdxjsEsm',
        ],
      },
    ];
```

## Test Plan

preview should render fine

### Test links

https://deploy-preview-8960--docusaurus-2.netlify.app/tests/pages/markdown-tests-md

![CleanShot 2023-05-11 at 19 50 13](https://github.com/facebook/docusaurus/assets/749374/8830d168-499e-4f6a-a7cc-1ae870f282fb)


## Related issues/PRs

https://github.com/facebook/docusaurus/discussions/8469#discussioncomment-5804253