### PR TITLE
fixes docSideBar

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/styles.module.css
@@ -20,8 +20,8 @@
     display: block !important;
     background-color: var(--docusaurus-collapse-button-bg);
     height: 40px;
-    position: sticky;
     bottom: 0;
+    position: sticky;
     border-radius: 0;
     border: 1px solid var(--ifm-toc-border-color);
   }

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -5,41 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState} from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
-import {
-  useAnnouncementBar,
-  useScrollPosition,
-} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import DocSidebarItems from '@theme/DocSidebarItems';
 import type {Props} from '@theme/DocSidebar/Desktop/Content';
 
 import styles from './styles.module.css';
 
-function useShowAnnouncementBar() {
-  const {isActive} = useAnnouncementBar();
-  const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive);
-
-  useScrollPosition(
-    ({scrollY}) => {
-      if (isActive) {
-        setShowAnnouncementBar(scrollY === 0);
-      }
-    },
-    [isActive],
-  );
-  return isActive && showAnnouncementBar;
-}
-
 export default function DocSidebarDesktopContent({
   path,
   sidebar,
   className,
 }: Props): JSX.Element {
-  const showAnnouncementBar = useShowAnnouncementBar();
-
   return (
     <nav
       aria-label={translate({
@@ -47,12 +26,7 @@ export default function DocSidebarDesktopContent({
         message: 'Docs sidebar',
         description: 'The ARIA label for the sidebar navigation',
       })}
-      className={clsx(
-        'menu thin-scrollbar',
-        styles.menu,
-        showAnnouncementBar && styles.menuWithAnnouncementBar,
-        className,
-      )}>
+      className={clsx('menu thin-scrollbar', styles.menu, className)}>
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
         <DocSidebarItems items={sidebar} activePath={path} level={1} />
       </ul>

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -16,8 +16,4 @@
       scrollbar-gutter: stable;
     }
   }
-
-  .menuWithAnnouncementBar {
-    margin-bottom: var(--docusaurus-announcement-bar-height);
-  }
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/index.tsx
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useState, useLayoutEffect} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig} from '@docusaurus/theme-common';
+import {
+  useAnnouncementBar,
+  useScrollPosition,
+} from '@docusaurus/theme-common/internal';
 import Logo from '@theme/Logo';
 import CollapseButton from '@theme/DocSidebar/Desktop/CollapseButton';
 import Content from '@theme/DocSidebar/Desktop/Content';
@@ -16,6 +20,9 @@ import type {Props} from '@theme/DocSidebar/Desktop';
 import styles from './styles.module.css';
 
 function DocSidebarDesktop({path, sidebar, onCollapse, isHidden}: Props) {
+  const {isActive} = useAnnouncementBar();
+  const [dynamicHeight, setDynamicHeight] = useState(0);
+
   const {
     navbar: {hideOnScroll},
     docs: {
@@ -23,13 +30,37 @@ function DocSidebarDesktop({path, sidebar, onCollapse, isHidden}: Props) {
     },
   } = useThemeConfig();
 
+  useLayoutEffect(() => {
+    if (isActive) {
+      setDynamicHeight(30);
+    } else {
+      setDynamicHeight(0);
+    }
+  }, [isActive]);
+
+  useScrollPosition(
+    ({scrollY}) => {
+      if (isActive) {
+        setDynamicHeight(30 - scrollY);
+      }
+    },
+
+    [isActive],
+  );
+
   return (
     <div
       className={clsx(
         styles.sidebar,
         hideOnScroll && styles.sidebarWithHideableNavbar,
         isHidden && styles.sidebarHidden,
-      )}>
+      )}
+      style={{
+        height:
+          isActive && dynamicHeight >= 0 && dynamicHeight <= 30
+            ? `calc(100% - ${dynamicHeight}px)`
+            : '100%',
+      }}>
       {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
       <Content path={path} sidebar={sidebar} />
       {hideable && <CollapseButton onClick={onCollapse} />}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

I originally tried to fix this issue a few months back.  My original attempts just looked at the CSS strictly.  Since then, I have learned a substantial amount about React Hooks, so I decided to take another look at it and was able to come up with a solution.

## **The Problem:**

When the announcement bar is present it takes up `30px` of space at the top of the page.  This causes all the elements below it to adjust their position.  Previously it appears we attempted to set up a useState, useEffect, and useContext hooks to handle this issue.  This hook functionality essentially added a `margin-bottom` of `30px` when `useAnnouncementBar` context returned true.  This functionality was added to the nav element located at `packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx`.  This attempt was close to fixing this issue, but instead we needed to:

  - change the height of the entire container instead of margin.
  - also the height needed to be changed dynamically as the scroll was happening.  `30px` would work when the `scrollY` 
    value was `0`, but as the user scrolled, it needs to adjust dynamically based on current `scrollY` position.

## The Fix:
In order to fix the issue I:

  - moved the useContext, useState, and useEffect functionality from `packages/docusaurus-theme- classic/src/theme/DocSidebar/Desktop/Content/index.tsx` to `packages/docusaurus-theme- classic/src/theme/DocSidebar/Desktop/index.tsx.`
  -  Added functionality to adjust the entire sideBar height dynamically.  Because this style needed to be set dynamically, it was set within the react component itself using the `style` attribute.
  - removed the margin css that was previously added because it was no longer of use.

**Note:**
When adding the height functionality, some unwanted side effects starting occurring when reducing window size to less than `277px` height.  When less than `277px`, the sidebar `close button` would start overlapping the other elements in the sidebar.  To fix this issue I:
- changed the sidebar `close button` to no longer have a position of fixed.
- added a `min-height` property to ensure that the sidebar would not reduce its size to anything less then 277px.  This matches what we currently see in production with one caveat: 
  - at a window height size of less than `277px`, the side bar close button becomes less visible and can only being seen by scrolling down on the entire page.  This didn't seem ideal, but because the side bar now correctly displays with or without the announcement bar at `277px` window height or greater, I figured it was a better solution then whats currently seen in production.  _If anyone has any suggestions on how we can match how it looks previously from window heights `177px - 277px`, that would be awesome._

# below there is a video and screenshots.
 - the video shows the solution working on my local computer.  This solution can also be viewed on the deployment preview link listed below.  I'm not sure how long these links are active, so if it expires, you may have to test it on your local machine.
 
 - there are 4 screenshots.  Two of them show what the sidebar looks like after this fix, at minimum window height with and without the announcement bar active.  The other two show what it looks like currently.
 
 **video demonstrating fix:**
https://github.com/facebook/docusaurus/assets/62929526/a75e8dcd-c6f0-4608-a401-a20654ca8010

 **screenshots with fix**
![fix_without_bar](https://github.com/facebook/docusaurus/assets/62929526/0203ca64-ad67-4b2e-a5b1-e225480f2f9b)
![fix_with_bar](https://github.com/facebook/docusaurus/assets/62929526/e1d9ef45-4959-4ead-8901-822da4b8397d)

 **screenshots without fix**
![without_bar](https://github.com/facebook/docusaurus/assets/62929526/3f408b5f-92fc-4495-9f15-a7c15ee167f5)
![with_bar](https://github.com/facebook/docusaurus/assets/62929526/79585312-3734-4bf0-a677-21358e93c6ef)

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

**from your local machine:**
1. download this branch to your local
2. start the server using `yarn start`
3. verify at the below URL's there is no longer overlapping issues in the docSidebar when resizing screen.  An example of what this bug looked like can be found [here](https://github.com/facebook/docusaurus/issues/8370).
- navigate to http://localhost:3000/tests/docs
- navigate to http://localhost:3000/tests/docs/toc/toc-_-5/
- navigate to http://localhost:3000/docs/sidebar/items

**from the deployment preview:**
1. verify at the below URL's there is no longer overlapping issues in the docSidebar when resizing screen. 
- navigate to https://deploy-preview-8966--docusaurus-2.netlify.app/tests/docs
- navigate to https://deploy-preview-8966--docusaurus-2.netlify.app/tests/docs/toc/toc-_-5/
- navigate to https://deploy-preview-8966--docusaurus-2.netlify.app/docs/sidebar/items

**Note:**
When testing if you close the announcement, you can re-enable it by clearing your local browser storage.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-8966--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

Issue #8370 


