### PR TITLE
fix: remove useless js-loader in front of mdx-loader

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -359,7 +359,7 @@ export default async function pluginContentBlog(
       return translateContent(content, translationFiles);
     },
 
-    configureWebpack(_config, isServer, {getJSLoader}, content) {
+    configureWebpack(_config, isServer, utils, content) {
       const {
         admonitions,
         rehypePlugins,
@@ -399,7 +399,6 @@ export default async function pluginContentBlog(
                 // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
                 .map(addTrailingPathSeparator),
               use: [
-                getJSLoader({isServer}),
                 {
                   loader: require.resolve('@docusaurus/mdx-loader'),
                   options: {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -228,7 +228,6 @@ export default async function pluginContentDocs(
     },
 
     configureWebpack(_config, isServer, utils, content) {
-      const {getJSLoader} = utils;
       const {
         rehypePlugins,
         remarkPlugins,
@@ -263,7 +262,6 @@ export default async function pluginContentDocs(
           test: /\.mdx?$/i,
           include: contentDirs,
           use: [
-            getJSLoader({isServer}),
             {
               loader: require.resolve('@docusaurus/mdx-loader'),
               options: {

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -186,7 +186,7 @@ export default function pluginContentPages(
       );
     },
 
-    configureWebpack(config, isServer, {getJSLoader}) {
+    configureWebpack() {
       const {
         admonitions,
         rehypePlugins,
@@ -209,7 +209,6 @@ export default function pluginContentPages(
                 // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
                 .map(addTrailingPathSeparator),
               use: [
-                getJSLoader({isServer}),
                 {
                   loader: require.resolve('@docusaurus/mdx-loader'),
                   options: {

--- a/packages/docusaurus/src/server/plugins/synthetic.ts
+++ b/packages/docusaurus/src/server/plugins/synthetic.ts
@@ -85,7 +85,7 @@ export function createMDXFallbackPlugin({
     version: {type: 'synthetic'},
     // Synthetic, the path doesn't matter much
     path: '.',
-    configureWebpack(config, isServer, {getJSLoader}) {
+    configureWebpack(config) {
       // We need the mdx fallback loader to exclude files that were already
       // processed by content plugins mdx loaders. This works, but a bit
       // hacky... Not sure there's a way to handle that differently in webpack
@@ -117,7 +117,6 @@ export function createMDXFallbackPlugin({
               test: /\.mdx?$/i,
               exclude: getMDXFallbackExcludedPaths(),
               use: [
-                getJSLoader({isServer}),
                 {
                   loader: require.resolve('@docusaurus/mdx-loader'),
                   options: mdxLoaderOptions,

--- a/website/src/plugins/changelog/index.js
+++ b/website/src/plugins/changelog/index.js
@@ -138,7 +138,8 @@ async function ChangelogPlugin(context, options) {
         'default',
       );
       // Redirect the metadata path to our folder
-      config.module.rules[0].use[1].options.metadataPath = (mdxPath) => {
+      const mdxLoader = config.module.rules[0].use[0];
+      mdxLoader.options.metadataPath = (mdxPath) => {
         // Note that metadataPath must be the same/in-sync as
         // the path from createData for each MDX.
         const aliasedPath = aliasedSitePath(mdxPath, context.siteDir);


### PR DESCRIPTION
## Motivation

It is not needed to put a js-loader (Babel/SWC) on top of the mdx compiler.

The output of MDX is already good to be run directly since MDX v2 and does not need any extra transpilation step (the JSX is now transpiled, unlike in MDX v1 output)

## Site benchmark

I run some basic local tests by building our website locally. 
Unfortunately, the impact of this perf improvement is not as significant as I hoped it to be.

Still, we see some improvement for the Docusaurus site when running on the default Babel JS Loader. 
For SWC users, the impact is even smaller.

Before + Babel
- 92s
- 96s
- 95s
- 97s

Before + SWC
- 87s
- 85s
- 81s
- 86s

After + Babel
- 90s
- 90s
- 91s
- 91s

After + SWC
- 84s
- 85s
- 84s
- 83s

## Test Plan

Preview builds and run as before + unit tests

### Test links


Deploy preview: https://deploy-preview-8972--docusaurus-2.netlify.app/
