### PR TITLE
fix(core): docusaurus CLI should detect the correct yarn version when suggesting upgrades

### DIFF
--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -107,21 +107,21 @@ export default async function beforeCli() {
       .join(' ');
 
     const getYarnVersion = async () => {
-      const fallbackYarnVersion = 1;
+      if (!(await fs.pathExists(path.resolve('yarn.lock')))) {
+        return undefined;
+      }
+
       const yarnVersionResult = shell.exec('yarn --version', {silent: true});
       if (yarnVersionResult?.code === 0) {
-        const yarnVersionOutput = yarnVersionResult.stdout?.trim();
         const majorVersion = parseInt(
-          yarnVersionOutput?.split('.')[0] ?? '',
+          yarnVersionResult.stdout?.trim()?.split('.')[0] ?? '',
           10,
         );
-        if (typeof majorVersion === 'number' && !Number.isNaN(majorVersion)) {
+        if (!Number.isNaN(majorVersion)) {
           return majorVersion;
         }
       }
-      if (await fs.pathExists(path.resolve('yarn.lock'))) {
-        return fallbackYarnVersion;
-      }
+
       return undefined;
     };
 
@@ -130,9 +130,9 @@ export default async function beforeCli() {
       if (!yarnVersion) {
         return `npm i ${siteDocusaurusPackagesForUpdate}`;
       }
-      return yarnVersion === 1
-        ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
-        : `yarn up ${siteDocusaurusPackagesForUpdate}`;
+      return yarnVersion >= 2
+        ? `yarn up ${siteDocusaurusPackagesForUpdate}`
+        : `yarn upgrade ${siteDocusaurusPackagesForUpdate}`;
     };
 
     /** @type {import('boxen').Options} */

--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -114,7 +114,7 @@ export default async function beforeCli() {
       const yarnVersionResult = shell.exec('yarn --version', {silent: true});
       if (yarnVersionResult?.code === 0) {
         const majorVersion = parseInt(
-          yarnVersionResult.stdout?.trim()?.split('.')[0] ?? '',
+          yarnVersionResult.stdout?.trim().split('.')[0] ?? '',
           10,
         );
         if (!Number.isNaN(majorVersion)) {

--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -9,6 +9,7 @@
 
 import fs from 'fs-extra';
 import path from 'path';
+import Yaml from 'js-yaml';
 import {createRequire} from 'module';
 import logger from '@docusaurus/logger';
 import semver from 'semver';
@@ -111,12 +112,21 @@ export default async function beforeCli() {
         return `npm i ${siteDocusaurusPackagesForUpdate}`;
       }
 
-      const isYarnClassicUsed = !(await fs.pathExists(
-        path.resolve('.yarnrc.yml'),
-      ));
-      return isYarnClassicUsed
-        ? `yarn upgrade ${siteDocusaurusPackagesForUpdate}`
-        : `yarn up ${siteDocusaurusPackagesForUpdate}`;
+      const isYarnrcExists = await fs.pathExists(path.resolve('.yarnrc.yml'));
+      if (!isYarnrcExists) {
+        return `yarn upgrade ${siteDocusaurusPackagesForUpdate}`;
+      }
+
+      try {
+        const yamlData = Yaml.load(await fs.readFile(path.resolve('.yarnrc.yml'), 'utf8')); 
+        // @ts-expect-error: yamlData is not typed
+        const isYarn2PlusUsed = 'yarnPath' in yamlData && !yamlData.yarnPath.includes('yarn-1.');
+        return isYarn2PlusUsed
+          ? `yarn up ${siteDocusaurusPackagesForUpdate}`
+          : `yarn upgrade ${siteDocusaurusPackagesForUpdate}`;
+      } catch {
+        return `yarn upgrade ${siteDocusaurusPackagesForUpdate}`;
+      }
     };
 
     /** @type {import('boxen').Options} */

--- a/packages/docusaurus/bin/beforeCli.mjs
+++ b/packages/docusaurus/bin/beforeCli.mjs
@@ -108,7 +108,7 @@ export default async function beforeCli() {
 
     const getYarnVersion = async () => {
       const fallbackYarnVersion = 1;
-      const yarnVersionResult = shell.exec('yarn --version');
+      const yarnVersionResult = shell.exec('yarn --version', {silent: true});
       if (yarnVersionResult?.code === 0) {
         const yarnVersionOutput = yarnVersionResult.stdout?.trim();
         const majorVersion = parseInt(

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -77,6 +77,7 @@
     "html-tags": "^3.2.0",
     "html-webpack-plugin": "^5.5.0",
     "import-fresh": "^3.3.0",
+    "js-yaml": "^4.1.0",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^2.7.3",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -77,7 +77,6 @@
     "html-tags": "^3.2.0",
     "html-webpack-plugin": "^5.5.0",
     "import-fresh": "^3.3.0",
-    "js-yaml": "^4.1.0",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^2.7.3",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I've checked PR #8908.
Great idea to check which Yarn verison is being used.

However, the presence of a `.yarnrc.yml` file alone is not a definitive indicator of Yarn 2+ being used, as this file can be used by Yarn 1.x as well.

Check out the capture image below

![screenshot1](https://github.com/facebook/docusaurus/assets/22449484/245854c7-9af5-4a74-93cb-7b86ab17d6f0)

This can be happened when you change Yarn 2+ -> Yarn 1

```bash
yarn set version 1
```

So, I think we should check `yarnPath` value (by using `js-yaml`),
to make sure what Yarn version is being used.

## Test Plan

- Check out an older docusaurus project and copy the file in place.
- Install the project with `npm`
- Run a `npm run start`
- Close and run it again
  - Confirm the notice had an appropriate `npm i` command
- `rm -rf node_modules`
- Install with yarn classic
- Run` yarn start`
- Close and run it again
  - Confirm the notice had an appropriate `npm i` command
- `rm -rf node_modules`
- Repeat with yarn 2

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-9006--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

Related PR : #8908
