### PR TITLE
fix(theme-transalations): fix Swedish translation of "last updated"

### DIFF
--- a/packages/docusaurus-theme-translations/locales/sv/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/sv/theme-common.json
@@ -60,7 +60,7 @@
   "theme.docs.versions.unreleasedVersionLabel": "Detta är ej utgiven dokumentation för {siteTitle} {versionLabel} version.",
   "theme.lastUpdated.atDate": " den {date}",
   "theme.lastUpdated.byUser": " av {user}",
-  "theme.lastUpdated.lastUpdatedAtBy": "Senast updatera{atDate}{byUser}",
+  "theme.lastUpdated.lastUpdatedAtBy": "Senast uppdaterad{atDate}{byUser}",
   "theme.navbar.mobileLanguageDropdown.label": "Språk",
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": "← Tillbaka till huvudmeny",
   "theme.navbar.mobileVersionsDropdown.label": "Versioner",


### PR DESCRIPTION
## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

I just noticed this spelling error when I enabled the "show last updated" feature and it bugged me! 😃  

Looks like a search and replace miss to me. 

Google Translate proof of translation:
![image](https://github.com/facebook/docusaurus/assets/529614/737e6362-c63a-4462-ae4f-3c2eb83a4e7e)


## Test Plan

If I can switch to Swedish in the PR preview env I'll test it there.

Edit: I could not and can't be bothered to switch language to Swedish. Hope that is ok!

### Test links

Deploy preview: https://deploy-preview-9021--docusaurus-2.netlify.app/

## Related issues/PRs

Didn't find any issue for this.