### PR TITLE
feat(theme): add ability to inject data attributes from query-string - possibility to create an iframe/embed variant of a page

### DIFF
--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -140,9 +140,9 @@ Examples:
 
 :::
 
-:::tip
+### Data Attributes {#data-attributes}
 
-It is also possible to inject html data attributes with query string parameters following the `docusaurus-data-<key>` pattern. This allows you to style a page differently based on its query string. For example, you could decide to style your page differently when it's embedded in an iframe and accessed with `?docusaurus-data-mode=embedded-iframe`. It is your responsibility to provide the additional styles.
+It is possible to inject `<html>` data attributes with query string parameters following the `docusaurus-data-<key>` pattern. This gives you the flexibility to style a page differently based on the query string.
 
 For example, let's render one of our pages with a red border and no navbar:
 
@@ -157,6 +157,10 @@ html[data-red-border] div#__docusaurus {
 ```
 
 <IframeWindow url="/docs/?docusaurus-data-navbar=false&docusaurus-data-red-border" />
+
+:::tip Iframe Mode
+
+If you plan to embed some Docusaurus pages on another site though an iframe, it can be useful to create an alternative display mode and use iframe urls such as `https://mysite.com/docs/myDoc?docusaurus-data-mode=iframe`. It is your responsibility to provide the additional styles and decide which UI elements you want to keep or hide.
 
 :::
 

--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -3,6 +3,7 @@ description: A Docusaurus site is a pre-rendered single-page React application. 
 ---
 
 import ColorGenerator from '@site/src/components/ColorGenerator';
+import IframeWindow from '@site/src/components/BrowserWindow/IframeWindow';
 
 # Styling and Layout
 
@@ -133,8 +134,29 @@ It is possible to initialize the Docusaurus theme directly from a `docusaurus-th
 
 Examples:
 
-- [`https://docusaurus.io/?docusaurus-theme=dark`](https://docusaurus.io/?docusaurus-theme=dark)
-- [`https://docusaurus.io/docs/configuration?docusaurus-theme=light`](https://docusaurus.io/docs/configuration?docusaurus-theme=light)
+<IframeWindow url="/docs/?docusaurus-theme=dark" />
+
+<IframeWindow url="/docs/configuration?docusaurus-theme=light" />
+
+:::
+
+:::tip
+
+It is also possible to inject html data attributes with query string parameters following the `docusaurus-data-<key>` pattern. This allows you to style a page differently based on its query string. For example, you could decide to style your page differently when it's embedded in an iframe and accessed with `?docusaurus-data-mode=embedded-iframe`. It is your responsibility to provide the additional styles.
+
+For example, let's render one of our pages with a red border and no navbar:
+
+```css title="/src/css/custom.css"
+html[data-navbar='false'] .navbar {
+  display: none;
+}
+
+html[data-red-border] div#__docusaurus {
+  border: red solid thick;
+}
+```
+
+<IframeWindow url="/docs/?docusaurus-data-navbar=false&docusaurus-data-red-border" />
 
 :::
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -230,3 +230,11 @@ div[class^='announcementBar_'] {
 [data-theme='dark'] [data-rmiz-modal-overlay='visible'] {
   background-color: rgba(0 0 0 / 95%);
 }
+
+html[data-navbar='false'] .navbar {
+  display: none;
+}
+
+html[data-red-border] div#__docusaurus {
+  border: red solid thick;
+}


### PR DESCRIPTION
## Motivation

We should be able to use `/docs/someDoc?docusaurus-data-mode=iframe` and then provide alternate styling for iframe/embedded rendering mode

```css
html[data-mode='iframe'] .navbar {
  display: none;
}

html[data-mode='iframe'] .footer {
  display: none;
}
```

The system implemented allows you to inject arbitrary data-attribute values in the HTML, inlined (no FOUC / layout shifts expected), as long as they follow the `?docusaurus-data-<key>=<value>` pattern (value can be omitted)

Note: it was chosen to allow injecting data attributes over classes because classes would solve the same use case and class injection was more complicated to implement (React-Helmet would erase the injected classes after React hydration).

## Test Plan

Preview + CI

The docs dogfood the feature:

![CleanShot 2023-05-31 at 16 04 08](https://github.com/facebook/docusaurus/assets/749374/2e3b4dfa-92ea-4afd-881d-0773c666b0de)


### Test links

https://deploy-preview-9028--docusaurus-2.netlify.app/docs/styling-layout#data-attributes

## Related issues/PRs

https://github.com/facebook/docusaurus/issues/7480#issuecomment-1568964805

