### PR TITLE
feat: Add siteDir to external command

### DIFF
--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -234,7 +234,7 @@ function isInternalCommand(command) {
 }
 
 if (!isInternalCommand(process.argv.slice(2)[0])) {
-  await externalCommand(cli);
+  await externalCommand(cli, process.argv.slice(-1)[0]);
 }
 
 if (!process.argv.slice(2).length) {

--- a/packages/docusaurus/src/commands/external.ts
+++ b/packages/docusaurus/src/commands/external.ts
@@ -10,8 +10,11 @@ import {loadContext} from '../server';
 import {initPlugins} from '../server/plugins/init';
 import type {CommanderStatic} from 'commander';
 
-export async function externalCommand(cli: CommanderStatic): Promise<void> {
-  const siteDir = await fs.realpath('.');
+export async function externalCommand(
+  cli: CommanderStatic,
+  siteDirParam: string = '.',
+): Promise<void> {
+  const siteDir = await fs.realpath(siteDirParam);
   const context = await loadContext({siteDir});
   const plugins = await initPlugins(context);
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

Add `siteDir` parameter to external commands to be able to execute external commands from another directory. For example, considering the following project organization:

my-app/
|-- package.json
|-- docs/
│  |-- docusaurus.config.js

This PR adds the possibility to execute external command (docs:version) directly from `my-app`: `yarn docusaurus  docs:version 1 docs`

## Related issues

Fixes #9029