### PR TITLE
feat: create official TypeScript base config @docusaurus/tsconfig

### DIFF
--- a/packages/create-docusaurus/README.md
+++ b/packages/create-docusaurus/README.md
@@ -35,5 +35,18 @@ cd `git rev-parse --show-toplevel` # Back to repo root
 rm -rf test-website-in-workspace
 yarn create-docusaurus test-website-in-workspace classic
 cd test-website-in-workspace
+yarn build
+yarn start
+```
+
+For the TypeScript template:
+
+```bash
+cd `git rev-parse --show-toplevel` # Back to repo root
+rm -rf test-website-in-workspace
+yarn create-docusaurus test-website-in-workspace classic --typescript
+cd test-website-in-workspace
+yarn typecheck
+yarn build
 yarn start
 ```

--- a/packages/create-docusaurus/templates/classic-typescript/package.json
+++ b/packages/create-docusaurus/templates/classic-typescript/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.0-alpha.0",
-    "@tsconfig/docusaurus": "^1.0.5",
+    "@docusaurus/tsconfig": "^3.0.0-alpha.0",
     "typescript": "^5.0.4"
   },
   "browserslist": {

--- a/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures/index.tsx
+++ b/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';

--- a/packages/create-docusaurus/templates/classic-typescript/src/pages/index.tsx
+++ b/packages/create-docusaurus/templates/classic-typescript/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';

--- a/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
+++ b/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": "."
   }

--- a/packages/create-docusaurus/templates/classic/src/components/HomepageFeatures/index.js
+++ b/packages/create-docusaurus/templates/classic/src/components/HomepageFeatures/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';

--- a/packages/create-docusaurus/templates/classic/src/pages/index.js
+++ b/packages/create-docusaurus/templates/classic/src/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';

--- a/packages/docusaurus-tsconfig/package.json
+++ b/packages/docusaurus-tsconfig/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@docusaurus/tsconfig",
+  "version": "3.0.0-alpha.0",
+  "description": "Docusaurus base TypeScript configuration.",
+  "main": "tsconfig.json",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "tsconfig",
+    "typescript",
+    "docusaurus"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/docusaurus.git",
+    "directory": "packages/docusaurus-tsconfig"
+  },
+  "license": "MIT"
+}

--- a/packages/docusaurus-tsconfig/tsconfig.json
+++ b/packages/docusaurus-tsconfig/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Docusaurus",
+  "docs": "https://docusaurus.io/docs/typescript-support",
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "lib": ["DOM"],
+    "moduleResolution": "Node16",
+    "noEmit": true,
+    "types": [
+      "node",
+      "@docusaurus/module-type-aliases",
+      "@docusaurus/theme-classic"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@site/*": ["./*"]
+    },
+    "skipLibCheck": true
+  }
+}

--- a/website/docs/typescript-support.mdx
+++ b/website/docs/typescript-support.mdx
@@ -21,14 +21,14 @@ Below are some guides on how to migrate an existing project to TypeScript.
 To start using TypeScript, add `@docusaurus/module-type-aliases` and the base TS config to your project:
 
 ```bash npm2yarn
-npm install --save-dev typescript @docusaurus/module-type-aliases @tsconfig/docusaurus
+npm install --save-dev typescript @docusaurus/module-type-aliases @docusaurus/tsconfig
 ```
 
 Then add `tsconfig.json` to your project root with the following content:
 
 ```json title="tsconfig.json"
 {
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": "."
   }

--- a/website/package.json
+++ b/website/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "@docusaurus/eslint-plugin": "^3.0.0-alpha.0",
-    "@tsconfig/docusaurus": "^1.0.7",
+    "@docusaurus/tsconfig": "^3.0.0-alpha.0",
     "@types/jest": "^29.4.0",
     "cross-env": "^7.0.3",
     "rimraf": "^3.0.2"

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,9 +1,7 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "jsx": "preserve", // TODO add to preset config
-
     "lib": ["DOM", "ESNext"],
     "baseUrl": ".",
     "resolveJsonModule": true,

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -7,7 +7,7 @@
     "resolveJsonModule": true,
 
     // Duplicated from the root config, because TS does not support extending
-    // multiple configs and we want to dogfood the @tsconfig/docusaurus one
+    // multiple configs and we want to dogfood the @docusaurus/tsconfig one
     "allowUnreachableCode": false,
     "exactOptionalPropertyTypes": false,
     "noFallthroughCasesInSwitch": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,11 +2818,6 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@tsconfig/docusaurus@^1.0.5", "@tsconfig/docusaurus@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-1.0.7.tgz#a3ee3c8109b3fec091e3d61a61834e563aeee3c3"
-  integrity sha512-ffTXxGIP/IRMCjuzHd6M4/HdIrw1bMfC7Bv8hMkTadnePkpe0lG0oDSdbRpSDZb2rQMAgpbWiR10BvxvNYwYrg==
-
 "@types/acorn@^4.0.0":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"


### PR DESCRIPTION
## Breaking change

The old external [`@tsconfig/docusaurus`](https://www.npmjs.com/package/@tsconfig/docusaurus) package is now deprecated and you should use our new official versioned package `@docusaurus/tsconfig`.

## Motivation

Follow-up of the React 18 upgrade (https://github.com/facebook/docusaurus/pull/8961) including the usage of the automatic JSX runtime: we should now use `jsx: "preserve"` in our base default TS config

As discussed in the past: our base TS config should evolve alongside the codebase and be versioned (cf https://github.com/tsconfig/bases/pull/122)


## Test Plan

website + dogfood + CI

### Test links



Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Automatic JSX runtime needs use to change the config to `jsx: "preserve"` instead of `jsx: "react"`.
See also:
- https://github.com/facebook/docusaurus/pull/8961
- https://www.totaltypescript.com/react-refers-to-a-umd-global
