### PR TITLE
docs: update link for commonly used languages

### DIFF
--- a/website/versioned_docs/version-2.0.1/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/versioned_docs/version-2.0.1/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -78,7 +78,7 @@ Because a Prism theme is just a JS object, you can also write your own theme if 
 
 ### Supported Languages {#supported-languages}
 
-By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js).
+By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23).
 
 :::caution
 

--- a/website/versioned_docs/version-2.1.0/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/versioned_docs/version-2.1.0/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -78,7 +78,7 @@ Because a Prism theme is just a JS object, you can also write your own theme if 
 
 ### Supported Languages {#supported-languages}
 
-By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js).
+By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23).
 
 :::caution
 

--- a/website/versioned_docs/version-2.2.0/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/versioned_docs/version-2.2.0/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -78,7 +78,7 @@ Because a Prism theme is just a JS object, you can also write your own theme if 
 
 ### Supported Languages {#supported-languages}
 
-By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js).
+By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23).
 
 :::caution
 

--- a/website/versioned_docs/version-2.3.1/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/versioned_docs/version-2.3.1/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -78,7 +78,7 @@ Because a Prism theme is just a JS object, you can also write your own theme if 
 
 ### Supported Languages {#supported-languages}
 
-By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js).
+By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23).
 
 :::caution
 

--- a/website/versioned_docs/version-2.4.1/guides/markdown-features/markdown-features-code-blocks.mdx
+++ b/website/versioned_docs/version-2.4.1/guides/markdown-features/markdown-features-code-blocks.mdx
@@ -78,7 +78,7 @@ Because a Prism theme is just a JS object, you can also write your own theme if 
 
 ### Supported Languages {#supported-languages}
 
-By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js).
+By default, Docusaurus comes with a subset of [commonly used languages](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23).
 
 :::caution
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

The link to  [commonly used languages](https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages) was broken.
Closes #9062
## Test Plan

I found new link for supported languages from here https://github.com/FormidableLabs/prism-react-renderer#installation:~:text=includes%20a%20base%20set%20of%20languages


### Test links

Affected Supported Lang Docs Page https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages

Deploy preview: https://deploy-preview-9065--docusaurus-2.netlify.app/

## Related issues/PRs
#9062 
<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
