### PR TITLE
fix(mdx-loader): loader error message should display stacktrace if no extra MDX details

### DIFF
--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -162,11 +162,21 @@ export async function mdxLoader(
     result = await processor.process({content, filePath});
   } catch (errorUnknown) {
     const error = errorUnknown as Error;
+
+    // MDX can emit errors that have useful extra attributes
+    const errorJSON = JSON.stringify(error, null, 2);
+    const errorDetails =
+      errorJSON === '{}'
+        ? // regular JS error case: print stacktrace
+          error.stack ?? 'N/A'
+        : // MDX error: print extra attributes + stacktrace
+          `${errorJSON}\n${error.stack}`;
+
     return callback(
       new Error(
         `MDX compilation failed for file ${logger.path(filePath)}\nCause: ${
           error.message
-        }\nDetails:\n${JSON.stringify(error, null, 2)}`,
+        }\nDetails:\n${errorDetails}`,
         // TODO error cause doesn't seem to be used by Webpack stats.errors :s
         {cause: error},
       ),


### PR DESCRIPTION

## Motivation

When MDX throws a regular JS error without extra useful attributes, the error message is not really helpful because the stacktrace is not included.

In these cases we want the stacktrace to be printed as well to troubleshoot the problem.


Note, for now this only works in the Webpack dev server:

<img width="1630" alt="CleanShot 2023-06-22 at 11 48 17@2x" src="https://github.com/facebook/docusaurus/assets/749374/945ccd7a-4e43-467b-87a4-e9c3291fad4b">

The console (start+build) will print an unhelpful stacktrace:

<img width="1036" alt="CleanShot 2023-06-22 at 11 49 38@2x" src="https://github.com/facebook/docusaurus/assets/749374/88d5eef8-37cb-484e-9084-f45c1dbe349b">

This is very likely related to this issue: https://github.com/facebook/docusaurus/issues/9023

## Test Plan

local only 😓 
