### PR TITLE
fix(theme): support details/summary in CommonMark + add md dogfood test cases

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -893,6 +893,8 @@ declare module '@theme/MDXComponents' {
 
   export type MDXComponentsObject = {
     readonly Head: typeof Head;
+    readonly details: typeof MDXDetails;
+
     readonly Details: typeof MDXDetails;
     readonly code: typeof MDXCode;
     readonly a: typeof MDXA;

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -21,6 +21,7 @@ import type {MDXComponentsObject} from '@theme/MDXComponents';
 
 const MDXComponents: MDXComponentsObject = {
   Head,
+  details: MDXDetails, // For MD mode support, see https://github.com/facebook/docusaurus/issues/9092#issuecomment-1602902274
   Details: MDXDetails,
   code: MDXCode,
   a: MDXA,

--- a/website/_dogfooding/_pages tests/markdown-tests-md.md
+++ b/website/_dogfooding/_pages tests/markdown-tests-md.md
@@ -12,8 +12,21 @@ This file should be interpreted in a more CommonMark compliant way
 
 Html comment: <!-- comment -->
 
+Html comment multi-line:
+
+<!--
+comment
+-->
+
 <!-- prettier-ignore -->
 MDX comment: {/* comment */}
+
+MDX comment multi-line:
+
+<!-- prettier-ignore -->
+{/*
+comment 
+*/}
 
 ## JSX syntax
 

--- a/website/_dogfooding/_pages tests/markdown-tests-md.md
+++ b/website/_dogfooding/_pages tests/markdown-tests-md.md
@@ -8,6 +8,26 @@ wrapperClassName: docusaurus-markdown-example
 
 This file should be interpreted in a more CommonMark compliant way
 
+## SEO
+
+```md
+<head>
+  <title>HEAD Markdown Page tests title</title>
+  <meta name="keywords" content="cooking, blog">
+</head>
+```
+
+<head>
+  <title>HEAD Markdown Page tests title</title>
+  <meta name="keywords" content="cooking, blog">
+</head>
+
+:::danger
+
+TODO unsupported (yet), see [issue](https://github.com/facebook/docusaurus/issues/9092)
+
+:::
+
 ## Comment
 
 Html comment: <!-- comment -->

--- a/website/_dogfooding/_pages tests/markdown-tests-md.md
+++ b/website/_dogfooding/_pages tests/markdown-tests-md.md
@@ -52,6 +52,100 @@ note
 
 :::
 
+## Details
+
+<details>
+  <summary>MD Summary</summary>
+
+Our custom Details/Summary does not work (yet) in CommonMark mode
+
+</details>
+
+:::danger
+
+TODO unsupported (yet), see [issue](https://github.com/facebook/docusaurus/issues/9092)
+
+:::
+
+## Tab
+
+<tabs>
+  <tabItem value="apple" label="Apple" default>
+    This is an apple 🍎
+  </tabItem>
+  <tabItem value="orange" label="Orange">
+    This is an orange 🍊
+  </tabItem>
+  <tabItem value="banana" label="Banana">
+    This is a banana 🍌
+  </tabItem>
+</tabs>
+
+:::danger
+
+TODO unsupported (yet), see [issue](https://github.com/facebook/docusaurus/issues/9092)
+
+:::
+
+## Code block test
+
+```js title="Title"
+function Clock(props) {
+  const [date, setDate] = useState(new Date());
+  useEffect(() => {
+    var timerID = setInterval(() => tick(), 1000);
+
+    return function cleanup() {
+      clearInterval(timerID);
+    };
+  });
+
+  function tick() {
+    setDate(new Date());
+  }
+
+  return (
+    <div>
+      <h2>It is {date.toLocaleTimeString()}.</h2>
+      // highlight-start
+      {/* prettier-ignore */}
+      long long long long long long long long long long long long line
+      {/* prettier-ignore */}
+      // highlight-end
+    </div>
+  );
+}
+```
+
+```jsx live
+function Clock(props) {
+  const [date, setDate] = useState(new Date());
+  useEffect(() => {
+    var timerID = setInterval(() => tick(), 1000);
+
+    return function cleanup() {
+      clearInterval(timerID);
+    };
+  });
+
+  function tick() {
+    setDate(new Date());
+  }
+
+  return (
+    <div>
+      <h2>It is {date.toLocaleTimeString()}.</h2>
+    </div>
+  );
+}
+```
+
+:::danger
+
+TODO unsupported (yet), see [issue](https://github.com/facebook/docusaurus/issues/9092)
+
+:::
+
 ## Heading Id {#custom-heading-id}
 
 Custom heading syntax `{#custom-heading-id}` still works

--- a/website/_dogfooding/_pages tests/markdown-tests-md.md
+++ b/website/_dogfooding/_pages tests/markdown-tests-md.md
@@ -77,15 +77,9 @@ note
 <details>
   <summary>MD Summary</summary>
 
-Our custom Details/Summary does not work (yet) in CommonMark mode
+Our custom Details/Summary also works in CommonMark mode
 
 </details>
-
-:::danger
-
-TODO unsupported (yet), see [issue](https://github.com/facebook/docusaurus/issues/9092)
-
-:::
 
 ## Tab
 
@@ -165,6 +159,22 @@ function Clock(props) {
 TODO unsupported (yet), see [issue](https://github.com/facebook/docusaurus/issues/9092)
 
 :::
+
+## Mermaid
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Health check
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```
 
 ## Heading Id {#custom-heading-id}
 

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -36,16 +36,16 @@ import Tabs from '@theme/Tabs';
 
 import TabItem from '@theme/TabItem';
 
-<Tabs
-  defaultValue="apple"
-  values={[
-    {label: 'Apple', value: 'apple'},
-    {label: 'Orange', value: 'orange'},
-    {label: 'Banana', value: 'banana'},
-  ]}>
-  <TabItem value="apple">This is an apple 🍎</TabItem>
-  <TabItem value="orange">This is an orange 🍊</TabItem>
-  <TabItem value="banana">This is a banana 🍌</TabItem>
+<Tabs>
+  <TabItem value="apple" label="Apple" default>
+    This is an apple 🍎
+  </TabItem>
+  <TabItem value="orange" label="Orange">
+    This is an orange 🍊
+  </TabItem>
+  <TabItem value="banana" label="Banana">
+    This is a banana 🍌
+  </TabItem>
 </Tabs>
 
 ## Comments

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -172,6 +172,22 @@ function Clock(props) {
 }
 ```
 
+## Mermaid
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Health check
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```
+
 ## Custom heading ID {#custom}
 
 ### Weird heading {#你好}

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -50,15 +50,23 @@ import TabItem from '@theme/TabItem';
 
 ## Comments
 
-MDX comments can be used with
+Html comment: <!-- comment -->
 
-```mdx
-{/* My comment */}
-```
+Html comment multi-line:
 
-See, nothing is displayed:
+<!--
+comment
+-->
 
-{/* My comment */}
+<!-- prettier-ignore -->
+MDX comment: {/* comment */}
+
+MDX comment multi-line:
+
+<!-- prettier-ignore -->
+{/*
+comment
+*/}
 
 ## Import code block from source code file
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -162,6 +162,9 @@ module.exports = async function createConfigAsync() {
         // comments: false,
       },
       preprocessor: ({filePath, fileContent}) => {
+        // TODO temporary quick fix for https://github.com/facebook/docusaurus/issues/9084
+        fileContent = fileContent.replaceAll('<!--\n', '<!-- \n');
+
         if (isDev) {
           // "vscode://file/${projectPath}${filePath}:${line}:${column}",
           // "webstorm://open?file=${projectPath}${filePath}&line=${line}&column=${column}",


### PR DESCRIPTION
## Motivation

Having similar tests for md/mdx modes ensure we offer a consistent experience to our users.

Currently, those tests show it's not the case, see problems reported here: https://github.com/facebook/docusaurus/issues/9092

Also add better tests for html comments support, cf edge case bug reported here: https://github.com/facebook/docusaurus/issues/9084

This PR is also a mini fix adding support for summary/details in CommonMark mode, see https://github.com/facebook/docusaurus/issues/9092#issuecomment-1602902274

## Test Plan

preview

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

https://deploy-preview-9093--docusaurus-2.netlify.app/tests/pages/markdown-tests-md

https://deploy-preview-9093--docusaurus-2.netlify.app/tests/pages/markdown-tests-mdx

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
