### PR TITLE
feat(theme-classic): add description & keywords microdata to blog posts

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
@@ -30,7 +30,7 @@ export default function BlogPostItemContainer({
       itemType="http://schema.org/BlogPosting">
       {description && <meta itemProp="description" content={description} />}
       {image && (
-        <meta itemProp="image" content={withBaseUrl(image, {absolute: true})} />
+        <link itemProp="image" href={withBaseUrl(image, {absolute: true})} />
       )}
       {keywords.length > 0 && (
         <meta itemProp="keywords" content={keywords.join(',')} />

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
@@ -14,17 +14,26 @@ export default function BlogPostItemContainer({
   children,
   className,
 }: Props): JSX.Element {
-  const {frontMatter, assets} = useBlogPost();
+  const {
+    frontMatter,
+    assets,
+    metadata: {description},
+  } = useBlogPost();
   const {withBaseUrl} = useBaseUrlUtils();
   const image = assets.image ?? frontMatter.image;
+  const keywords = frontMatter.keywords ?? [];
   return (
     <article
       className={className}
       itemProp="blogPost"
       itemScope
       itemType="http://schema.org/BlogPosting">
+      {description && <meta itemProp="description" content={description} />}
       {image && (
         <meta itemProp="image" content={withBaseUrl(image, {absolute: true})} />
+      )}
+      {keywords.length > 0 && (
+        <meta itemProp="keywords" content={keywords.join(',')} />
       )}
       {children}
     </article>

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Author/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Author/index.tsx
@@ -28,7 +28,12 @@ export default function BlogPostItemHeaderAuthor({
     <div className={clsx('avatar margin-bottom--sm', className)}>
       {imageURL && (
         <MaybeLink href={link} className="avatar__photo-link">
-          <img className="avatar__photo" src={imageURL} alt={name} />
+          <img
+            className="avatar__photo"
+            src={imageURL}
+            alt={name}
+            itemProp="image"
+          />
         </MaybeLink>
       )}
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

We're trying to improve SEO on our site and have implemented a similar change by swizzling the `BlogPostItem/Container` component.

Just thought it would be nice to get this minor change added to the official theme component for the benefit of all :)

## Test Plan

Implemented on another Docusaurus site and verified with [Google's schema markup testing tools](https://developers.google.com/search/docs/appearance/structured-data).

### Test links

Deploy preview: https://deploy-preview-9108--docusaurus-2.netlify.app/blog