### PR TITLE
chore: optimize Argos CI setup

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -5,9 +5,25 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types:
+      # Those 3 are the default PR workflow activity types,
+      # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+      - opened
+      - synchronize
+      - reopened
+      # We want trigger workflow on labeled too!
+      - labeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   take-screenshots:
+    # Argos is heavy to run
+    # We only want to trigger Argos on PRs with the 'Argos' label
+    # See https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label
+    if: ${{ github.ref_name == 'main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Argos')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code


### PR DESCRIPTION


## Motivation

Argos visual diffing CI is heavy to run, and in many cases we don't need to run it.

Let's run it more responsibly, only when we add an Argos label to the PRs that need it.

This also permits to dogfood a responsible setup that I plan to recommend to the community, so that they can stay under free quote (Hobby plan) or Fair-use (Open source)

## Test Plan

CI