### PR TITLE
fix(debug-plugin): upgrade react-json-view to maintained React-18 compatible fork

### DIFF
--- a/packages/docusaurus-plugin-debug/package.json
+++ b/packages/docusaurus-plugin-debug/package.json
@@ -23,8 +23,8 @@
     "@docusaurus/core": "3.0.0-alpha.0",
     "@docusaurus/types": "3.0.0-alpha.0",
     "@docusaurus/utils": "3.0.0-alpha.0",
+    "@microlink/react-json-view": "^1.22.2",
     "fs-extra": "^11.1.0",
-    "react-json-view": "^1.21.3",
     "tslib": "^2.5.0"
   },
   "peerDependencies": {

--- a/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import type {Props} from '@theme/DebugJsonView';
-import type {ReactJsonViewProps} from 'react-json-view';
+import type {ReactJsonViewProps} from '@microlink/react-json-view';
 
 // Avoids "react-json-view" displaying "root"
 const RootName = null;
@@ -21,7 +21,7 @@ function BrowserOnlyReactJson(props: ReactJsonViewProps) {
       {() => {
         const {default: ReactJson} =
           // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-          require('react-json-view') as typeof import('react-json-view');
+          require('@microlink/react-json-view') as typeof import('@microlink/react-json-view');
         return <ReactJson {...props} />;
       }}
     </BrowserOnly>

--- a/project-words.txt
+++ b/project-words.txt
@@ -189,6 +189,7 @@ metastring
 metrica
 metrika
 microdata
+microlink
 middlewares
 minifier
 mkcert

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -526,14 +526,7 @@ module.exports = async function createConfigAsync() {
               label: 'Tests',
               docsPluginId: 'docs-tests',
             },
-            // This item links to an unlisted doc: only displayed
-            // in dev or when directly access
-            {
-              type: 'doc',
-              docId: 'tests/visibility/some-unlisteds/unlisted1',
-              label: 'Unlisted',
-              docsPluginId: 'docs-tests',
-            },
+            isDev && {to: '/__docusaurus/debug', label: 'Debug'},
             // Custom item for dogfooding: only displayed in /tests/ routes
             {
               type: 'custom-dogfood-navbar-item',
@@ -594,7 +587,7 @@ module.exports = async function createConfigAsync() {
               className: 'header-github-link',
               'aria-label': 'GitHub repository',
             },
-          ],
+          ].filter(Boolean),
         },
         footer: {
           style: 'dark',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,6 +2027,16 @@
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
 
+"@microlink/react-json-view@^1.22.2":
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/@microlink/react-json-view/-/react-json-view-1.22.2.tgz#dc8262d40912655d5c4a4cf8c7e0549e683808f6"
+  integrity sha512-liJzdlbspT5GbEuPffw4jzZfXOypKLK1Er9br03T31bAaIi/WptZqpcJaXPi7OmwC7v/YYczCkmAS7WaEfItPQ==
+  dependencies:
+    flux "~4.0.1"
+    react-base16-styling "~0.6.0"
+    react-lifecycles-compat "~3.0.4"
+    react-textarea-autosize "~8.3.2"
+
 "@netlify/functions@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@netlify/functions/-/functions-1.4.0.tgz#027a2e5d54df5519ccbd14cf450231e97bbbf93a"
@@ -7612,10 +7622,10 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.201.0.tgz#d2005d4dae6fddf60d30f9ae0fb49a13c9c51cfe"
   integrity sha512-G4oeDNpNGyIrweF9EnoHatncAihMT0tQgV6NMdyM5I7fhrz9Pr13PJ2KLQ673O4wj9KooTdBpeeYHdDNAQoyyw==
 
-flux@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/flux/-/flux-4.0.3.tgz#573b504a24982c4768fdfb59d8d2ea5637d72ee7"
-  integrity sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==
+flux@~4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/flux/-/flux-4.0.4.tgz#9661182ea81d161ee1a6a6af10d20485ef2ac572"
+  integrity sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==
   dependencies:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
@@ -13306,7 +13316,7 @@ react-attr-converter@^0.3.1:
   resolved "https://registry.yarnpkg.com/react-attr-converter/-/react-attr-converter-0.3.1.tgz#4a2abf6d907b7ddae4d862dfec80e489ce41ad6e"
   integrity sha512-dSxo2Mn6Zx4HajeCeQNLefwEO4kNtV/0E682R1+ZTyFRPqxDa5zYb5qM/ocqw9Bxr/kFQO0IUiqdV7wdHw+Cdg==
 
-react-base16-styling@^0.6.0:
+react-base16-styling@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/react-base16-styling/-/react-base16-styling-0.6.0.tgz#ef2156d66cf4139695c8a167886cb69ea660792c"
   integrity sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==
@@ -13392,17 +13402,7 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-json-view@^1.21.3:
-  version "1.21.3"
-  resolved "https://registry.yarnpkg.com/react-json-view/-/react-json-view-1.21.3.tgz#f184209ee8f1bf374fb0c41b0813cff54549c475"
-  integrity sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==
-  dependencies:
-    flux "^4.0.1"
-    react-base16-styling "^0.6.0"
-    react-lifecycles-compat "^3.0.4"
-    react-textarea-autosize "^8.3.2"
-
-react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
@@ -13502,10 +13502,10 @@ react-test-renderer@^18.0.0:
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
 
-react-textarea-autosize@^8.3.2:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz#4d0244d6a50caa897806b8c44abc0540a69bfc8c"
-  integrity sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==
+react-textarea-autosize@~8.3.2:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz#270a343de7ad350534141b02c9cb78903e553524"
+  integrity sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==
   dependencies:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.3.0"


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/9105

Need to replace the unmaintained JSON viewer lib in our debug plugin.

Also added a navbar button to easily navigate to the debug view in dev.

For reference, I choose to use the [fork from `@microlink`](https://www.npmjs.com/package/@microlink/react-json-view) because other projects were not immediate project forks and more alternative libs. Also, we already depend on other projects from the same author, such as [unavatar](https://github.com/microlinkhq/unavatar). It does not feel necessary to create/maintain our own fork for now, but time will tell.

I'm open to replacing it with another different lib later. But for now this fix is good enough.


## Test Plan

ci

### Test links



Deploy preview: https://deploy-preview-9116--docusaurus-2.netlify.app/


