### PR TITLE
fix(theme): canonical url should be not change after hydration if url accessed with/without trailing slash

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
@@ -62,8 +62,7 @@ function useDefaultCanonicalUrl() {
   } = useDocusaurusContext();
   const {pathname} = useLocation();
   return (
-    siteUrl +
-    useBaseUrl(pathname).replace(/\/+$/, trailingSlash ? '/' : '')
+    siteUrl + useBaseUrl(pathname).replace(/\/+$/, trailingSlash ? '/' : '')
   );
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
@@ -16,6 +16,7 @@ import {
   keyboardFocusedClassName,
 } from '@docusaurus/theme-common/internal';
 import {useLocation} from '@docusaurus/router';
+import {applyTrailingSlash} from '@docusaurus/utils-common';
 import SearchMetadata from '@theme/SearchMetadata';
 
 // TODO move to SiteMetadataDefaults or theme-common ?
@@ -58,12 +59,19 @@ function AlternateLangHeaders(): JSX.Element {
 // Default canonical url inferred from current page location pathname
 function useDefaultCanonicalUrl() {
   const {
-    siteConfig: {url: siteUrl, trailingSlash = false},
+    siteConfig: {url: siteUrl, baseUrl, trailingSlash},
   } = useDocusaurusContext();
+
+  // TODO using useLocation().pathname is not reliable to create a canonical url
+  // Ex: use CDN features so that 2 paths serve the same html file (/a and /b)
+  // Then we would obtain 2 distinct canonical urls after React hydration: bad
   const {pathname} = useLocation();
-  return (
-    siteUrl + useBaseUrl(pathname).replace(/\/+$/, trailingSlash ? '/' : '')
-  );
+
+  const canonicalPathname = applyTrailingSlash(useBaseUrl(pathname), {
+    trailingSlash,
+    baseUrl,
+  });
+  return siteUrl + canonicalPathname;
 }
 
 // TODO move to SiteMetadataDefaults or theme-common ?

--- a/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
@@ -58,10 +58,10 @@ function AlternateLangHeaders(): JSX.Element {
 // Default canonical url inferred from current page location pathname
 function useDefaultCanonicalUrl() {
   const {
-    siteConfig: {url: siteUrl},
+    siteConfig: {url: siteUrl, trailingSlash = false},
   } = useDocusaurusContext();
   const {pathname} = useLocation();
-  return siteUrl + useBaseUrl(pathname);
+  return siteUrl + useBaseUrl(pathname).replace(/\/+$/, '') + (trailingSlash ? '/' : '');
 }
 
 // TODO move to SiteMetadataDefaults or theme-common ?

--- a/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
@@ -61,7 +61,11 @@ function useDefaultCanonicalUrl() {
     siteConfig: {url: siteUrl, trailingSlash = false},
   } = useDocusaurusContext();
   const {pathname} = useLocation();
-  return siteUrl + useBaseUrl(pathname).replace(/\/+$/, '') + (trailingSlash ? '/' : '');
+  return (
+    siteUrl +
+    useBaseUrl(pathname).replace(/\/+$/, '') +
+    (trailingSlash ? '/' : '')
+  );
 }
 
 // TODO move to SiteMetadataDefaults or theme-common ?

--- a/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
@@ -63,8 +63,7 @@ function useDefaultCanonicalUrl() {
   const {pathname} = useLocation();
   return (
     siteUrl +
-    useBaseUrl(pathname).replace(/\/+$/, '') +
-    (trailingSlash ? '/' : '')
+    useBaseUrl(pathname).replace(/\/+$/, trailingSlash ? '/' : '')
   );
 }
 

--- a/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
@@ -62,15 +62,15 @@ function useDefaultCanonicalUrl() {
     siteConfig: {url: siteUrl, baseUrl, trailingSlash},
   } = useDocusaurusContext();
 
-  // TODO using useLocation().pathname is not reliable to create a canonical url
-  // Ex: use CDN features so that 2 paths serve the same html file (/a and /b)
-  // Then we would obtain 2 distinct canonical urls after React hydration: bad
+  // TODO using useLocation().pathname is not a super idea
+  // See https://github.com/facebook/docusaurus/issues/9170
   const {pathname} = useLocation();
 
   const canonicalPathname = applyTrailingSlash(useBaseUrl(pathname), {
     trailingSlash,
     baseUrl,
   });
+
   return siteUrl + canonicalPathname;
 }
 

--- a/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/useAlternatePageUtils.ts
@@ -7,6 +7,7 @@
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useLocation} from '@docusaurus/router';
+import {applyTrailingSlash} from '@docusaurus/utils-common';
 
 /**
  * Permits to obtain the url of the current page in another locale, useful to
@@ -35,17 +36,25 @@ export function useAlternatePageUtils(): {
   }) => string;
 } {
   const {
-    siteConfig: {baseUrl, url},
+    siteConfig: {baseUrl, url, trailingSlash},
     i18n: {defaultLocale, currentLocale},
   } = useDocusaurusContext();
+
+  // TODO using useLocation().pathname is not a super idea
+  // See https://github.com/facebook/docusaurus/issues/9170
   const {pathname} = useLocation();
+
+  const canonicalPathname = applyTrailingSlash(pathname, {
+    trailingSlash,
+    baseUrl,
+  });
 
   const baseUrlUnlocalized =
     currentLocale === defaultLocale
       ? baseUrl
       : baseUrl.replace(`/${currentLocale}/`, '/');
 
-  const pathnameSuffix = pathname.replace(baseUrl, '');
+  const pathnameSuffix = canonicalPathname.replace(baseUrl, '');
 
   function getLocalizedBaseUrl(locale: string) {
     return locale === defaultLocale


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
  **I'm not really sure how to test it but we have it on every page of the site so I guess we can say there is a dogfooding...**
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
See #9128

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Visit a page on the website with a trailing slash in the URL and inspect the canonical link using dev tools.
Then navigate to the same page without a trailing slash and inspect the canonical link using dev tools again.

If both versions of the page have the same URL then the bug is fixed.

https://github.com/facebook/docusaurus/assets/12466863/9e5dcd95-7c7f-4be9-87d4-4b6c8f566a1a

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-9130--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

Closes #9128