### PR TITLE
docs: add Flightcontrol as a deployment option

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -413,3 +413,6 @@ zhou
 zoomable
 zpao
 hastscript
+Flightcontrol
+Fargate
+Flightcontrol's

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -675,6 +675,12 @@ trigger:
 
 Now, whenever you push a new tag to GitHub, this trigger will start the drone CI job to publish your website.
 
+## Deploying to Flightcontrol {#deploying-to-flightcontrol}
+
+[Flightcontol](https://www.flightcontrol.dev/?ref=docusaurus) is a service that automatically builds and deploys your web apps to AWS Fargate directly from your Git repository. It gives you full access to inspect and make infrastructure changes without the limitations of a traditional PaaS. 
+
+Get started by following [Flightcontrol's step-by-step Docusaurus guide](https://www.flightcontrol.dev/docs/reference/examples/docusaurus/?ref=docusaurus).
+
 ## Deploying to Koyeb {#deploying-to-koyeb}
 
 [Koyeb](https://www.koyeb.com) is a developer-friendly serverless platform to deploy apps globally. The platform lets you seamlessly run Docker containers, web apps, and APIs with git-based deployment, native autoscaling, a global edge network, and built-in service mesh and discovery. Check out the [Koyeb's Docusaurus deployment guide](https://www.koyeb.com/tutorials/deploy-docusaurus-on-koyeb) to get started.
@@ -819,3 +825,5 @@ See [docs](https://docs.quantcdn.io/docs/cli/continuous-integration) and [blog](
 ## Deploying to Kinsta Application Hosting {#deploying-to-kinsta}
 
 [Kinsta Application Hosting](https://kinsta.com/application-hosting) is a service that lets you build and deploy your web apps directly from your Git repository. Get started in just a minutes by following our [Docusaurus on Kinsta](https://kinsta.com/help/docusaurus-example/) article.
+
+

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -677,7 +677,7 @@ Now, whenever you push a new tag to GitHub, this trigger will start the drone CI
 
 ## Deploying to Flightcontrol {#deploying-to-flightcontrol}
 
-[Flightcontol](https://www.flightcontrol.dev/?ref=docusaurus) is a service that automatically builds and deploys your web apps to AWS Fargate directly from your Git repository. It gives you full access to inspect and make infrastructure changes without the limitations of a traditional PaaS. 
+[flightcontrol](https://www.flightcontrol.dev/?ref=docusaurus) is a service that automatically builds and deploys your web apps to AWS Fargate directly from your Git repository. It gives you full access to inspect and make infrastructure changes without the limitations of a traditional PaaS. 
 
 Get started by following [Flightcontrol's step-by-step Docusaurus guide](https://www.flightcontrol.dev/docs/reference/examples/docusaurus/?ref=docusaurus).
 

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -677,7 +677,7 @@ Now, whenever you push a new tag to GitHub, this trigger will start the drone CI
 
 ## Deploying to Flightcontrol {#deploying-to-flightcontrol}
 
-[flightcontrol](https://www.flightcontrol.dev/?ref=docusaurus) is a service that automatically builds and deploys your web apps to AWS Fargate directly from your Git repository. It gives you full access to inspect and make infrastructure changes without the limitations of a traditional PaaS.
+[Flightcontrol](https://www.flightcontrol.dev/?ref=docusaurus) is a service that automatically builds and deploys your web apps to AWS Fargate directly from your Git repository. It gives you full access to inspect and make infrastructure changes without the limitations of a traditional PaaS.
 
 Get started by following [Flightcontrol's step-by-step Docusaurus guide](https://www.flightcontrol.dev/docs/reference/examples/docusaurus/?ref=docusaurus).
 

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -825,5 +825,3 @@ See [docs](https://docs.quantcdn.io/docs/cli/continuous-integration) and [blog](
 ## Deploying to Kinsta Application Hosting {#deploying-to-kinsta}
 
 [Kinsta Application Hosting](https://kinsta.com/application-hosting) is a service that lets you build and deploy your web apps directly from your Git repository. Get started in just a minutes by following our [Docusaurus on Kinsta](https://kinsta.com/help/docusaurus-example/) article.
-
-

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -677,7 +677,7 @@ Now, whenever you push a new tag to GitHub, this trigger will start the drone CI
 
 ## Deploying to Flightcontrol {#deploying-to-flightcontrol}
 
-[flightcontrol](https://www.flightcontrol.dev/?ref=docusaurus) is a service that automatically builds and deploys your web apps to AWS Fargate directly from your Git repository. It gives you full access to inspect and make infrastructure changes without the limitations of a traditional PaaS. 
+[flightcontrol](https://www.flightcontrol.dev/?ref=docusaurus) is a service that automatically builds and deploys your web apps to AWS Fargate directly from your Git repository. It gives you full access to inspect and make infrastructure changes without the limitations of a traditional PaaS.
 
 Get started by following [Flightcontrol's step-by-step Docusaurus guide](https://www.flightcontrol.dev/docs/reference/examples/docusaurus/?ref=docusaurus).
 


### PR DESCRIPTION
Added Flightcontrol as a docusaurus deployment option 

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Flightcontrol allows users to deploy their Docusaurus project on AWS Fargate directly from their GitHub account.


