### PR TITLE
test(argos): fix Argos visual tests flakiness, hide docs last-update element

### DIFF
--- a/argos/tests/screenshot.css
+++ b/argos/tests/screenshot.css
@@ -6,14 +6,21 @@
  */
 
 /*
-Things to hide in Argos screenshots because it's source of flakiness
+Hide some things in Argos screenshots because they are a source of flakiness
  */
 iframe,
 article.yt-lite,
-.theme-last-updated,
 .avatar__photo,
 img[src$='.gif'],
 h2#using-jsx-markup ~ div > div[class*='browserWindowBody']:has(b),
 [class*='playgroundPreview'] {
   visibility: hidden;
+}
+
+/*
+Different docs last-update dates can alter layout
+"visibility: hidden" is not enough
+ */
+.theme-last-updated {
+  display: none;
 }


### PR DESCRIPTION
Argos tests report false positives because last-update dates between prod / pr produce a different layout (1 line vs 2 lines) depending on that update date.

<img width="1462" alt="CleanShot 2023-08-11 at 15 19 27@2x" src="https://github.com/facebook/docusaurus/assets/749374/50e4b02d-4e83-409f-bfdc-3269da4f12cf">
