### PR TITLE
feat: support bun package manager in `create-docusaurus`

### DIFF
--- a/packages/create-docusaurus/bin/index.js
+++ b/packages/create-docusaurus/bin/index.js
@@ -31,7 +31,7 @@ program
   .arguments('[siteName] [template] [rootDir]')
   .option(
     '-p, --package-manager <manager>',
-    'The package manager used to install dependencies. One of yarn, npm, and pnpm.',
+    'The package manager used to install dependencies. One of yarn, npm, pnpm, and bun.',
   )
   .option(
     '-s, --skip-install',

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -565,7 +565,7 @@ export default async function init(
   code=${`${pkgManager} ${useRunCommand ? 'run ' : ''}serve`}
     Serves the built website locally.
 
-  code=${`${pkgManager} ${useRunCommand ? 'run' : ''}deploy`}
+  code=${`${pkgManager} ${useRunCommand ? 'run ' : ''}deploy`}
     Publishes the website to GitHub pages.
 
 We recommend that you begin by typing:

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -30,6 +30,7 @@ const lockfileNames = {
   npm: 'package-lock.json',
   yarn: 'yarn.lock',
   pnpm: 'pnpm-lock.yaml',
+  bun: 'bun.lockb',
 };
 
 type PackageManager = keyof typeof lockfileNames;
@@ -57,11 +58,12 @@ function findPackageManagerFromUserAgent(): PackageManager | undefined {
 async function askForPackageManagerChoice(): Promise<PackageManager> {
   const hasYarn = shell.exec('yarn --version', {silent: true}).code === 0;
   const hasPnpm = shell.exec('pnpm --version', {silent: true}).code === 0;
+  const hasBun = shell.exec('bun --version', {silent: true}).code === 0;
 
-  if (!hasYarn && !hasPnpm) {
+  if (!hasYarn && !hasPnpm && !hasBun) {
     return 'npm';
   }
-  const choices = ['npm', hasYarn && 'yarn', hasPnpm && 'pnpm']
+  const choices = ['npm', hasYarn && 'yarn', hasPnpm && 'pnpm', hasBun && 'bun']
     .filter((p): p is string => Boolean(p))
     .map((p) => ({title: p, value: p}));
 

--- a/packages/create-docusaurus/src/index.ts
+++ b/packages/create-docusaurus/src/index.ts
@@ -526,7 +526,11 @@ export default async function init(
     logger.info`Installing dependencies with name=${pkgManager}...`;
     if (
       shell.exec(
-        pkgManager === 'yarn' ? 'yarn' : `${pkgManager} install --color always`,
+        pkgManager === 'yarn'
+          ? 'yarn'
+          : pkgManager === 'bun'
+          ? 'bun install'
+          : `${pkgManager} install --color always`,
         {
           env: {
             ...process.env,
@@ -547,19 +551,21 @@ export default async function init(
   }
 
   const useNpm = pkgManager === 'npm';
+  const useBun = pkgManager === 'bun';
+  const useRunCommand = useNpm || useBun;
   logger.success`Created name=${cdpath}.`;
   logger.info`Inside that directory, you can run several commands:
 
   code=${`${pkgManager} start`}
     Starts the development server.
 
-  code=${`${pkgManager} ${useNpm ? 'run ' : ''}build`}
+  code=${`${pkgManager} ${useRunCommand ? 'run ' : ''}build`}
     Bundles your website into static files for production.
 
-  code=${`${pkgManager} ${useNpm ? 'run ' : ''}serve`}
+  code=${`${pkgManager} ${useRunCommand ? 'run ' : ''}serve`}
     Serves the built website locally.
 
-  code=${`${pkgManager} deploy`}
+  code=${`${pkgManager} ${useRunCommand ? 'run' : ''}deploy`}
     Publishes the website to GitHub pages.
 
 We recommend that you begin by typing:

--- a/project-words.txt
+++ b/project-words.txt
@@ -31,6 +31,7 @@ browserslist
 browserstack
 buble
 builtins
+bunx
 caabernathy
 cacheable
 callouts
@@ -167,6 +168,7 @@ lifecycles
 lighthouserc
 linkify
 localizable
+lockb
 longpaths
 lorber
 lowercased

--- a/website/docs/api/misc/create-docusaurus.mdx
+++ b/website/docs/api/misc/create-docusaurus.mdx
@@ -47,10 +47,10 @@ Used when the template argument is a git repo. It needs to be one of:
 
 ### `-p, --package-manager` {#package-manager}
 
-Value should be one of `npm`, `yarn`, or `pnpm`. If it's not explicitly provided, Docusaurus will infer one based on:
+Value should be one of `npm`, `yarn`, `pnpm`, or `bun`. If it's not explicitly provided, Docusaurus will infer one based on:
 
 - The lockfile already present in the CWD (e.g. if you are setting up website in an existing project)
-- The command used to invoke `create-docusaurus` (e.g. `npm init`, `npx`, `yarn create`, etc.)
+- The command used to invoke `create-docusaurus` (e.g. `npm init`, `npx`, `yarn create`, `bunx`, etc.)
 - Interactive prompting, in case all heuristics are not present
 
 ### `-s, --skip-install` {#skip-install}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

Detect usage of the `bun` package manager when executing the `create-docusaurus` CLI.

## Test Plan

I couldn't find tests for the other package manager detection logic. Below are some successful run on my local machine.

With `npm_config_user_agent` set appropriately:

```sh
$ npm_config_user_agent=bun/1.0 node bin/index.js
✔ What should we name this site? … mysite
✔ Select a template below... › classic (recommended)
✔ This template is available in TypeScript. Do you want to use the TS variant? … yes
[INFO] Creating new Docusaurus project...
[INFO] Installing dependencies with bun...
bun install v0.7.4 (f74585ff)
 Saved lockfile
 + @docusaurus/module-type-aliases@3.0.0-alpha.0
 + @docusaurus/tsconfig@3.0.0-alpha.0
 + @docusaurus/core@3.0.0-alpha.0
 + @docusaurus/preset-classic@3.0.0-alpha.0
 + @mdx-js/react@2.3.0
 + clsx@1.2.1
 + prism-react-renderer@1.3.5
 + react@18.2.0
 + react-dom@18.2.0

 1099 packages installed [736.00ms]
[SUCCESS] Created mysite.
[INFO] Inside that directory, you can run several commands:

  `bun start`
    Starts the development server.

  `bun run build`
    Bundles your website into static files for production.

  `bun run serve`
    Serves the built website locally.

  `bun run deploy`
    Publishes the website to GitHub pages.

We recommend that you begin by typing:

  `cd mysite`
  `bun start`

Happy building awesome websites!
```

With the `--package-manager` flag.

```sh
$ node bin/index.js --package-manager bun
✔ What should we name this site? … mysite2
✔ Select a template below... › classic (recommended)
✔ This template is available in TypeScript. Do you want to use the TS variant? … yes
[INFO] Creating new Docusaurus project...
[INFO] Installing dependencies with bun...
bun install v0.7.4 (f74585ff)
 Resolving dependencies
 Resolved, downloaded and extracted [900]
 Saved lockfile
 + @docusaurus/module-type-aliases@3.0.0-alpha.0
 + @docusaurus/tsconfig@3.0.0-alpha.0
 + @docusaurus/core@3.0.0-alpha.0
 + @docusaurus/preset-classic@3.0.0-alpha.0
 + @mdx-js/react@2.3.0
 + clsx@1.2.1
 + prism-react-renderer@1.3.5
 + react@18.2.0
 + react-dom@18.2.0

 1099 packages installed [2.42s]
[SUCCESS] Created mysite2.
```

Detecting `bun.lockb` in the current repo:

```sh
$ touch bun.lockb
$ node bin/index.js --package-manager bun
✔ What should we name this site? … mysite3
✔ Select a template below... › classic (recommended)
✔ This template is available in TypeScript. Do you want to use the TS variant? … yes
[INFO] Creating new Docusaurus project...
[INFO] Installing dependencies with bun...
bun install v0.7.4 (f74585ff)
 Saved lockfile
 + @docusaurus/module-type-aliases@3.0.0-alpha.0
 + @docusaurus/tsconfig@3.0.0-alpha.0
 + @docusaurus/core@3.0.0-alpha.0
 + @docusaurus/preset-classic@3.0.0-alpha.0
 + @mdx-js/react@2.3.0
 + clsx@1.2.1
 + prism-react-renderer@1.3.5
 + react@18.2.0
 + react-dom@18.2.0

 1099 packages installed [736.00ms]
[SUCCESS] Created mysite3.
```

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: 

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
