### PR TITLE
changed the documentation link from v1.docusaurus.io(deprecated) to docusaurus.io(latest)

### DIFF
--- a/website/blog/2017-12-14-introducing-docusaurus.mdx
+++ b/website/blog/2017-12-14-introducing-docusaurus.mdx
@@ -150,7 +150,7 @@ Without their dedication to creating or migrating their websites over to the pla
 
 ## Resources
 
-- [Read our documentation](https://v1.docusaurus.io)
+- [Read our documentation](https://docusaurus.io)
 - [Follow our Twitter feed](https://twitter.com/docusaurus)
 - [Follow us on GitHub](https://github.com/facebook/docusaurus)
 - [About Slash, the Docusaurus mascot](https://v1.docusaurus.io/about-slash.html)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

In introduction to docusaurus blog the hyperlink is directed to v1.docusaurus.io documentation which is deprecated so I changed it to docusaurus.io (v2 which is latest documentation on latest verion).

Link-
https://docusaurus.io/blog/2017/12/14/introducing-docusaurus#resources (-read our documentation)


