### PR TITLE
fix(theme-common): ThemedComponent should display something when JS is disabled

### DIFF
--- a/packages/docusaurus-theme-common/src/components/ThemedComponent/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/ThemedComponent/styles.module.css
@@ -21,7 +21,6 @@
 JS disabled??? Show light version by default => better than showing nothing
 TODO bad, but we currently always show light mode when there's no data-theme
  */
-
-:not[data-theme] .themedComponent--light {
+:not([data-theme]) .themedComponent--light {
   display: initial;
 }

--- a/packages/docusaurus-theme-common/src/components/ThemedComponent/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/ThemedComponent/styles.module.css
@@ -21,6 +21,6 @@
 JS disabled??? Show light version by default => better than showing nothing
 TODO bad, but we currently always show light mode when there's no data-theme
  */
-:not([data-theme]) .themedComponent--light {
+html:not([data-theme]) .themedComponent--light {
   display: initial;
 }

--- a/packages/docusaurus-theme-common/src/components/ThemedComponent/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/ThemedComponent/styles.module.css
@@ -16,3 +16,12 @@
 [data-theme='dark'] .themedComponent--dark {
   display: initial;
 }
+
+/*
+JS disabled??? Show light version by default => better than showing nothing
+TODO bad, but we currently always show light mode when there's no data-theme
+ */
+
+:not[data-theme] .themedComponent--light {
+  display: initial;
+}


### PR DESCRIPTION

## Motivation

`<ThemedComponent/>` and `<ThemedIImage/>` should always display something for progressive enhancement reasons, even if `data-theme` is not set (JS disabled)

Currently it displays nothing:

<img width="1010" alt="CleanShot 2023-08-18 at 16 40 53@2x" src="https://github.com/facebook/docusaurus/assets/749374/f921fd4c-e428-4036-96d1-3f248cb65d54">

Note: this is not an ideal solution but good enough for now.

In the future we should let the theme-classic "register" to core a default value for `data-theme` so that a fallback can be set without using any JS.

Currently with JS disabled the theme is always "light" even if the default colormode is dark.

Not a big deal for most users because people are more likely to have network issues than disabling JS, but this little issue led to flakiness in Argos/Playwright visual tests due to screenshots being taken before `data-theme` is set.

## Test Plan

preview

### Test links

Deploy preview: https://deploy-preview-9243--docusaurus-2.netlify.app/
