### PR TITLE
chore: bump devcontainer to Ubuntu 22.04 to resolve arm64 incompatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
   "settings": {
     "[typescript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Cloning Docusaurus into a dev container volume ([explained in greater detail here](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume)) failed on arm64 devices like my Apple Silicon Mac:

```log
Error fetching image details: No manifest found for mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04.
Start: Run: docker pull mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04
Looking up Docker credential helper for 'mcr.microsoft.com'.
ubuntu-20.04: Pulling from vscode/devcontainers/base
no matching manifest for linux/arm64/v8 in the manifest list entries
```

This chore updates the dev container config to 22.04 for arm64 support and switches to the new [devcontainers images](https://github.com/devcontainers/images) from the soon-to-be-archived vscode-dev-containers (https://github.com/microsoft/vscode-dev-containers/issues/1762).

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Test Plan is a bit tough to provide here since it's essentially an "it didn't work on my machine" situation. It _does_ work on my machine now though ✨

If the maintainers have access to an Apple Silicon Mac or other arm64 machine, you can also verify for yourselves that the new dev container environment works by [following Microsoft's guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) and cloning my AFRUITPIE/docusaurus fork into a dev container volume.

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

This issue only took a less time to debug and resolve than it would to create an issue, so I haven't created one. If the maintainers *require* one, I'm happy to create it.
