### PR TITLE
test: fix flaky screenshots, add html data-has-hydrated attribute

### DIFF
--- a/argos/tests/screenshot.css
+++ b/argos/tests/screenshot.css
@@ -13,6 +13,7 @@ article.yt-lite,
 .avatar__photo,
 img[src$='.gif'],
 h2#using-jsx-markup ~ div > div[class*='browserWindowBody']:has(b),
+.DocSearch-Button-Keys > kbd,
 [class*='playgroundPreview'] {
   visibility: hidden;
 }
@@ -22,5 +23,12 @@ Different docs last-update dates can alter layout
 "visibility: hidden" is not enough
  */
 .theme-last-updated {
+  display: none;
+}
+
+/*
+Mermaid diagrams are rendered client-side and produce layout shifts
+ */
+.docusaurus-mermaid-container {
   display: none;
 }

--- a/argos/tests/screenshot.spec.ts
+++ b/argos/tests/screenshot.spec.ts
@@ -13,6 +13,9 @@ const siteUrl = 'http://localhost:3000';
 const sitemapPath = '../website/build/sitemap.xml';
 const stylesheetPath = './tests/screenshot.css';
 
+// Use ONLY_PATH="/docs/installation" to debug a specific page
+const onlyPath: string | undefined = process.env.ONLY_PATH;
+
 // eslint-disable-next-line no-restricted-properties
 const sitemap = fs.readFileSync(sitemapPath).toString();
 // eslint-disable-next-line no-restricted-properties
@@ -28,6 +31,9 @@ function extractSitemapUrls() {
 }
 
 function isBlacklisted(pathname: string) {
+  if (onlyPath && onlyPath !== pathname) {
+    return true;
+  }
   // Some paths explicitly blacklisted
   const BlacklistedPathnames: string[] = [
     '/feature-requests', // Flaky because of Canny widget

--- a/argos/tests/screenshot.spec.ts
+++ b/argos/tests/screenshot.spec.ts
@@ -81,10 +81,17 @@ function pathnameToArgosName(pathname: string): string {
   return pathname;
 }
 
+// See https://github.com/facebook/docusaurus/pull/9256
+// Docusaurus adds a <html data-has-hydrated="true">
+function waitForDocusaurusHydration() {
+  return document.documentElement.dataset.hasHydrated === 'true';
+}
+
 function createPathnameTest(pathname: string) {
   test(`pathname ${pathname}`, async ({page}) => {
     const url = siteUrl + pathname;
     await page.goto(url);
+    await page.waitForFunction(waitForDocusaurusHydration);
     await page.addStyleTag({content: stylesheet});
     // await expect(page).toHaveScreenshot({ fullPage: true, ...options });
     await argosScreenshot(page, pathnameToArgosName(pathname));

--- a/packages/create-docusaurus/templates/classic-typescript/package.json
+++ b/packages/create-docusaurus/templates/classic-typescript/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.0.0-alpha.0",
     "@docusaurus/tsconfig": "3.0.0-alpha.0",
-    "typescript": "^5.0.4"
+    "typescript": "~5.0.4"
   },
   "browserslist": {
     "production": [

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -23,7 +23,7 @@ import SiteMetadataDefaults from './SiteMetadataDefaults';
 // TODO, quick fix for CSS insertion order
 // eslint-disable-next-line import/order
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
-import {HasHydratedDataAttribute} from './hasHydratedDataAttribute';
+import HasHydratedDataAttribute from './hasHydratedDataAttribute';
 
 export default function App(): JSX.Element {
   const routeElement = renderRoutes(routes);

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -23,6 +23,7 @@ import SiteMetadataDefaults from './SiteMetadataDefaults';
 // TODO, quick fix for CSS insertion order
 // eslint-disable-next-line import/order
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
+import {HasHydratedDataAttribute} from './hasHydratedDataAttribute';
 
 export default function App(): JSX.Element {
   const routeElement = renderRoutes(routes);
@@ -39,6 +40,7 @@ export default function App(): JSX.Element {
               {routeElement}
             </PendingNavigation>
           </Root>
+          <HasHydratedDataAttribute />
         </BrowserContextProvider>
       </DocusaurusContextProvider>
     </ErrorBoundary>

--- a/packages/docusaurus/src/client/hasHydratedDataAttribute.tsx
+++ b/packages/docusaurus/src/client/hasHydratedDataAttribute.tsx
@@ -11,7 +11,7 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 
 // See https://github.com/facebook/docusaurus/pull/9256
 // Docusaurus adds a <html data-has-hydrated="true"> after hydration
-export function HasHydratedDataAttribute(): JSX.Element {
+export default function HasHydratedDataAttribute(): JSX.Element {
   const isBrowser = useIsBrowser();
   return (
     <Head>

--- a/packages/docusaurus/src/client/hasHydratedDataAttribute.tsx
+++ b/packages/docusaurus/src/client/hasHydratedDataAttribute.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Head from '@docusaurus/Head';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
+// See https://github.com/facebook/docusaurus/pull/9256
+// Docusaurus adds a <html data-has-hydrated="true"> after hydration
+export function HasHydratedDataAttribute(): JSX.Element {
+  const isBrowser = useIsBrowser();
+  return (
+    <Head>
+      <html data-has-hydrated={isBrowser} />
+    </Head>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16320,11 +16320,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@^5.0.4:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
 typescript@~5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"


### PR DESCRIPTION
## Motivation

Fix Argos visual test flakiness found in https://app.argos-ci.com/meta-open-source/docusaurus/builds/186/56059354

I think it's related to anything that runs in `useEffect` instead of `useLayoutEffect`.

Let's introduce a `<html data-has-hydrated="true">` to be able to wait for `BrowserOnly` and other useEffect components to run.

Unfortunately it kind of requires merging to test and see if it works.

---

The Algolia keyboard shortcuts do not appear immediately and can create some flakiness:

![CleanShot 2023-08-24 at 17 40 23](https://github.com/facebook/docusaurus/assets/749374/b48e8110-5ca7-4e83-9636-7d444285a0ec)


---

Mermaid diagrams can lead to layout shifts leading to the end of the page being cropped

![CleanShot 2023-08-24 at 17 38 55](https://github.com/facebook/docusaurus/assets/749374/ae1ffdcd-9586-419f-837d-7a1b1849baec)

(related to https://github.com/microsoft/playwright/issues/620#issuecomment-1691403070)

---


There's also one related to the TOC highlighting:

![CleanShot 2023-08-24 at 18 08 26](https://github.com/facebook/docusaurus/assets/749374/4dd7f436-c283-4e26-b1a4-3713de4ffd21)

We'll see if the data-attribute fixes it