### PR TITLE
feat: Docusaurus v3 upgrades and require TypeScript 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
     "stylelint": "^14.16.1",
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-standard": "^29.0.0",
-    "typescript": "~5.0.4"
+    "typescript": "~5.2.2"
   }
 }

--- a/packages/create-docusaurus/templates/classic-typescript/package.json
+++ b/packages/create-docusaurus/templates/classic-typescript/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.0.0-alpha.0",
     "@docusaurus/tsconfig": "3.0.0-alpha.0",
-    "typescript": "~5.0.4"
+    "typescript": "~5.2.2"
   },
   "browserslist": {
     "production": [

--- a/packages/docusaurus-plugin-content-docs/tsconfig.client.json
+++ b/packages/docusaurus-plugin-content-docs/tsconfig.client.json
@@ -5,6 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "rootDir": "src",

--- a/packages/docusaurus-plugin-debug/tsconfig.client.json
+++ b/packages/docusaurus-plugin-debug/tsconfig.client.json
@@ -5,6 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "rootDir": "src",

--- a/packages/docusaurus-plugin-google-analytics/tsconfig.client.json
+++ b/packages/docusaurus-plugin-google-analytics/tsconfig.client.json
@@ -5,6 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "rootDir": "src",

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.client.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.client.json
@@ -5,6 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "rootDir": "src",

--- a/packages/docusaurus-plugin-google-tag-manager/tsconfig.client.json
+++ b/packages/docusaurus-plugin-google-tag-manager/tsconfig.client.json
@@ -5,6 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "rootDir": "src",

--- a/packages/docusaurus-plugin-ideal-image/tsconfig.client.json
+++ b/packages/docusaurus-plugin-ideal-image/tsconfig.client.json
@@ -5,6 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "rootDir": "src",

--- a/packages/docusaurus-plugin-pwa/tsconfig.client.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.client.json
@@ -7,6 +7,7 @@
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
     "rootDir": "src",
     "outDir": "lib",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext"
   },

--- a/packages/docusaurus-plugin-pwa/tsconfig.worker.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.worker.json
@@ -8,6 +8,7 @@
     "tsBuildInfoFile": "./lib/.tsbuildinfo-worker",
     "rootDir": "src",
     "outDir": "lib",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "types": ["node"]

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -891,7 +891,9 @@ declare module '@theme/MDXComponents' {
   import type Mermaid from '@theme/Mermaid';
   import type Head from '@docusaurus/Head';
 
-  export type MDXComponentsObject = {
+  import type {MDXProviderComponentsProp} from '@mdx-js/react';
+
+  export type MDXComponentsObject = MDXProviderComponentsProp & {
     readonly Head: typeof Head;
     readonly details: typeof MDXDetails;
 

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
@@ -7,7 +7,6 @@
 
 import React, {useCallback, useState, useRef, useEffect} from 'react';
 import clsx from 'clsx';
-// @ts-expect-error: TODO, we need to make theme-classic have type: module
 import copy from 'copy-text-to-clipboard';
 import {translate} from '@docusaurus/Translate';
 import type {Props} from '@theme/CodeBlock/CopyButton';

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ComponentProps} from 'react';
 import Head from '@docusaurus/Head';
 import MDXCode from '@theme/MDXComponents/Code';
 import MDXA from '@theme/MDXComponents/A';
@@ -28,12 +28,12 @@ const MDXComponents: MDXComponentsObject = {
   pre: MDXPre,
   ul: MDXUl,
   img: MDXImg,
-  h1: (props) => <MDXHeading as="h1" {...props} />,
-  h2: (props) => <MDXHeading as="h2" {...props} />,
-  h3: (props) => <MDXHeading as="h3" {...props} />,
-  h4: (props) => <MDXHeading as="h4" {...props} />,
-  h5: (props) => <MDXHeading as="h5" {...props} />,
-  h6: (props) => <MDXHeading as="h6" {...props} />,
+  h1: (props: ComponentProps<'h1'>) => <MDXHeading as="h1" {...props} />,
+  h2: (props: ComponentProps<'h2'>) => <MDXHeading as="h2" {...props} />,
+  h3: (props: ComponentProps<'h3'>) => <MDXHeading as="h3" {...props} />,
+  h4: (props: ComponentProps<'h4'>) => <MDXHeading as="h4" {...props} />,
+  h5: (props: ComponentProps<'h5'>) => <MDXHeading as="h5" {...props} />,
+  h6: (props: ComponentProps<'h6'>) => <MDXHeading as="h6" {...props} />,
   admonition: Admonition,
   mermaid: Mermaid,
 };

--- a/packages/docusaurus-theme-classic/src/theme/MDXContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXContent/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import {MDXProvider} from '@mdx-js/react';
 import MDXComponents from '@theme/MDXComponents';
 import type {Props} from '@theme/MDXContent';

--- a/packages/docusaurus-theme-classic/tsconfig.client.json
+++ b/packages/docusaurus-theme-classic/tsconfig.client.json
@@ -7,6 +7,7 @@
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
     "rootDir": "src",
     "outDir": "lib",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext"
   },

--- a/packages/docusaurus-theme-common/tsconfig.json
+++ b/packages/docusaurus-theme-common/tsconfig.json
@@ -4,6 +4,7 @@
     "noEmit": false,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "sourceMap": true,

--- a/packages/docusaurus-theme-live-codeblock/tsconfig.client.json
+++ b/packages/docusaurus-theme-live-codeblock/tsconfig.client.json
@@ -7,6 +7,7 @@
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
     "rootDir": "src",
     "outDir": "lib",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext"
   },

--- a/packages/docusaurus-theme-mermaid/tsconfig.client.json
+++ b/packages/docusaurus-theme-mermaid/tsconfig.client.json
@@ -7,6 +7,7 @@
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
     "rootDir": "src",
     "outDir": "lib",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext"
   },

--- a/packages/docusaurus-theme-mermaid/tsconfig.json
+++ b/packages/docusaurus-theme-mermaid/tsconfig.json
@@ -5,7 +5,6 @@
     "noEmit": false,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo",
-    "module": "commonjs",
     "rootDir": "src",
     "outDir": "lib"
   },

--- a/packages/docusaurus-theme-search-algolia/tsconfig.client.json
+++ b/packages/docusaurus-theme-search-algolia/tsconfig.client.json
@@ -7,6 +7,7 @@
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
     "rootDir": "src",
     "outDir": "lib",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext"
   },

--- a/packages/docusaurus-tsconfig/tsconfig.json
+++ b/packages/docusaurus-tsconfig/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "lib": ["DOM"],
-    "moduleResolution": "Node16",
+    "moduleResolution": "bundler",
+    "module": "esnext",
     "noEmit": true,
     "types": [
       "node",

--- a/packages/docusaurus/tsconfig.client.json
+++ b/packages/docusaurus/tsconfig.client.json
@@ -5,6 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "./lib/.tsbuildinfo-client",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",
     "rootDir": "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16320,10 +16320,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@~5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@~5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 ua-parser-js@^1.0.35:
   version "1.0.35"


### PR DESCRIPTION


## Breaking change

TypeScript 5 is now required for Docusaurus v3

## Motivation

Handle https://github.com/facebook/docusaurus/pull/9050#pullrequestreview-1489257714, use these settings for client code packaging:

```js
    "moduleResolution": "bundler",
    "module": "esnext",
```

"bundler" is a new TS 5.0 option: https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler

This also fix our setup for TypeScript 5.2 because this version introduces new errors that makes it impossible to:
- typecheck our starter template (see E2E CI failing after 5.2 GA release https://github.com/facebook/docusaurus/actions/runs/5966898905/job/16187482764?pr=9256)
- build our monorepo

## Test Plan

CI

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

