### PR TITLE
feat(theme-common): Get desktopThresholdWidth from docusaurus config

### DIFF
--- a/examples/classic/docusaurus.config.js
+++ b/examples/classic/docusaurus.config.js
@@ -133,9 +133,6 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
-      breakpoints: {
-        desktop: 744,
-      }
     }),
 };
 

--- a/examples/classic/docusaurus.config.js
+++ b/examples/classic/docusaurus.config.js
@@ -133,6 +133,9 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      breakpoints: {
+        desktop: 744,
+      }
     }),
 };
 

--- a/packages/docusaurus-theme-common/src/hooks/useWindowSize.ts
+++ b/packages/docusaurus-theme-common/src/hooks/useWindowSize.ts
@@ -8,6 +8,7 @@
 import {useEffect, useState} from 'react';
 
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 const windowSizes = {
   desktop: 'desktop',
@@ -17,13 +18,12 @@ const windowSizes = {
 
 type WindowSize = keyof typeof windowSizes;
 
-const DesktopThresholdWidth = 996;
-
-function getWindowSize() {
+function getWindowSize(desktopThresholdWidth = 996): WindowSize {
   if (!ExecutionEnvironment.canUseDOM) {
     return windowSizes.ssr;
   }
-  return window.innerWidth > DesktopThresholdWidth
+
+  return window.innerWidth > desktopThresholdWidth
     ? windowSizes.desktop
     : windowSizes.mobile;
 }
@@ -44,16 +44,18 @@ const DevSimulateSSR = process.env.NODE_ENV === 'development' && true;
  * catch potential layout shifts, similar to strict mode calling effects twice.
  */
 export function useWindowSize(): WindowSize {
+  const {siteConfig} = useDocusaurusContext();
+  const desktopThresholdWidth = siteConfig?.themeConfig?.breakpoints?.desktop;
   const [windowSize, setWindowSize] = useState<WindowSize>(() => {
     if (DevSimulateSSR) {
       return 'ssr';
     }
-    return getWindowSize();
+    return getWindowSize(desktopThresholdWidth);
   });
 
   useEffect(() => {
     function updateWindowSize() {
-      setWindowSize(getWindowSize());
+      setWindowSize(getWindowSize(desktopThresholdWidth));
     }
 
     const timeout = DevSimulateSSR

--- a/packages/docusaurus-theme-common/src/hooks/useWindowSize.ts
+++ b/packages/docusaurus-theme-common/src/hooks/useWindowSize.ts
@@ -45,7 +45,7 @@ const DevSimulateSSR = process.env.NODE_ENV === 'development' && true;
  */
 export function useWindowSize(): WindowSize {
   const {siteConfig} = useDocusaurusContext();
-  const desktopThresholdWidth = siteConfig?.themeConfig?.breakpoints?.desktop;
+  const desktopThresholdWidth = siteConfig?.themeConfig?.breakpoints?.desktop ?? 996;
   const [windowSize, setWindowSize] = useState<WindowSize>(() => {
     if (DevSimulateSSR) {
       return 'ssr';

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -14,6 +14,10 @@ export type ReportingSeverity = 'ignore' | 'log' | 'warn' | 'throw';
 
 export type ThemeConfig = {
   [key: string]: unknown;
+  breakpoints?: {
+    desktop?: number;
+    [key: string]: unknown;
+  }
 };
 
 export type MarkdownPreprocessor = (args: {

--- a/website/_dogfooding/dogfooding.config.js
+++ b/website/_dogfooding/dogfooding.config.js
@@ -5,6 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/** @type {import('@docusaurus/types').ThemeConfig} */
+const dogFoodingThemeConfig = {
+  breakpoints: {
+    desktop: 744,
+  }
+}
+exports.dogFoodingThemeConfig = dogFoodingThemeConfig;
+
 /** @type {import('@docusaurus/types').PluginConfig[]} */
 const dogfoodingThemeInstances = [
   /** @type {import('@docusaurus/types').PluginModule} */

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,6 +14,7 @@ const versions = require('./versions.json');
 const VersionsArchived = require('./versionsArchived.json');
 const {
   dogfoodingPluginInstances,
+  dogFoodingThemeConfig,
   dogfoodingThemeInstances,
   dogfoodingRedirects,
 } = require('./_dogfooding/dogfooding.config');
@@ -450,6 +451,7 @@ module.exports = async function createConfigAsync() {
     themeConfig:
       /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
       ({
+        ...dogFoodingThemeConfig,
         liveCodeBlock: {
           playgroundPosition: 'bottom',
         },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

The `desktopThresholdWidth` in the `useWindowSize` hook is currently hardcoded at 996px. This makes it impossible to customize the breakpoint for the navbar, which creates inconsistencies when other CSS media query breakpoints are customized for the rest of the site.

This change allows for customization of that value by looking for a `breakpoints.desktop` value in the `themeConfig` in the `docusaurus.config.js` file. If none is present, it will default to the original 996 value.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

An additional theme config has been added to `website/_dogfooding/dogfooding.config.js`:

```js
/** @type {import('@docusaurus/types').ThemeConfig} */
const dogFoodingThemeConfig = {
  breakpoints: {
    desktop: 744,
  }
}
exports.dogFoodingThemeConfig = dogFoodingThemeConfig;
```

The `website/docusaurus.config.js` config has been updated to add this new `dogfoodingThemeConfig` to its existing `themeConfig`. Spin up that site and change the viewport width to observe that the navbar hamburger menu icon is visible below and hidden above 744px.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
