### PR TITLE
Allowing custom icons in the DocCards

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -85,7 +85,7 @@ function CardCategory({
   return (
     <CardLayout
       href={href}
-      icon="🗃️"
+      icon={item.customIcon || '🗃️'}
       title={item.label}
       description={
         item.description ??
@@ -104,7 +104,7 @@ function CardCategory({
 }
 
 function CardLink({item}: {item: PropSidebarItemLink}): JSX.Element {
-  const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
+  const icon = item.customIcon || isInternalUrl(item.href) ? '📄️' : '🔗';
   const doc = useDocById(item.docId ?? undefined);
   return (
     <CardLayout

--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -85,7 +85,7 @@ function CardCategory({
   return (
     <CardLayout
       href={href}
-      icon={item.customIcon || '🗃️'}
+      icon={(item.customProps?.customIcon as ReactNode) || '🗃️'}
       title={item.label}
       description={
         item.description ??
@@ -104,7 +104,10 @@ function CardCategory({
 }
 
 function CardLink({item}: {item: PropSidebarItemLink}): JSX.Element {
-  const icon = item.customIcon || isInternalUrl(item.href) ? '📄️' : '🔗';
+  const icon =
+    (item.customProps?.customIcon as ReactNode) || isInternalUrl(item.href)
+      ? '📄️'
+      : '🔗';
   const doc = useDocById(item.docId ?? undefined);
   return (
     <CardLayout


### PR DESCRIPTION
## Pre-flight checklist

- [x] First time contributor
- [x] I have read the [Contributing Guidelines on pull requests] (https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

When creating a separated blog I wanted to have custom icons of instead the 3 available.
This way a page can determine by just adding in the heading
`sidebar_custom_props:
    customIcon: 🚀`

## Test Plan

No bonus points for me, I haven't been able to make the repo run for me.
I'll be making help requests in the discord server.

### Test links

Deploy preview: https://deploy-preview-9268--docusaurus-2.netlify.app/

## Related issues/PRs

I just started to code, should I make an issue for this?
