### PR TITLE
chore: remove useless Argos screenshot css

### DIFF
--- a/argos/tests/screenshot.css
+++ b/argos/tests/screenshot.css
@@ -52,8 +52,3 @@ Mermaid diagrams are rendered client-side and produce layout shifts
 article.yt-lite {
   visibility: hidden;
 }
-
-/* Can't remember why we need this one :/ */
-h2#using-jsx-markup ~ div > div[class*='browserWindowBody']:has(b) {
-  visibility: hidden;
-}


### PR DESCRIPTION
This CSS is not useful anymore, as since the MDX v2 upgrade it doesn't generate any Argos visual diff between main/PR