### PR TITLE
chore(plugin-docs): remove legacy versioned prefix on doc ids and sidebar names in versioned sidebars

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/community_versioned_sidebars/version-1.0.0-sidebars.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/community_versioned_sidebars/version-1.0.0-sidebars.json
@@ -1,3 +1,3 @@
 {
-  "version-1.0.0/community": ["version-1.0.0/team"]
+  "version-1.0.0/community": ["team"]
 }

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/community_versioned_sidebars/version-1.0.0-sidebars.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/community_versioned_sidebars/version-1.0.0-sidebars.json
@@ -1,3 +1,3 @@
 {
-  "version-1.0.0/community": ["team"]
+  "community": ["team"]
 }

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-1.0.0-sidebars.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-1.0.0-sidebars.json
@@ -1,11 +1,11 @@
 {
   "version-1.0.0/docs": {
     "Test": [
-      "version-1.0.0/foo/bar",
-      "version-1.0.0/foo/baz"
+      "foo/bar",
+      "foo/baz"
     ],
     "Guides": [
-      "version-1.0.0/hello"
+      "hello"
     ]
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-1.0.0-sidebars.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-1.0.0-sidebars.json
@@ -1,5 +1,5 @@
 {
-  "version-1.0.0/docs": {
+  "docs": {
     "Test": [
       "foo/bar",
       "foo/baz"

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-1.0.1-sidebars.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-1.0.1-sidebars.json
@@ -4,7 +4,7 @@
       "foo/bar"
     ],
     "Guides": [
-      "version-1.0.1/hello"
+      "hello"
     ]
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-withSlugs-sidebars.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-withSlugs-sidebars.json
@@ -1,5 +1,5 @@
 {
-  "version-1.0.1/docs": {
+  "docs": {
     "Test": ["rootAbsoluteSlug"]
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-withSlugs-sidebars.json
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__fixtures__/versioned-site/versioned_sidebars/version-withSlugs-sidebars.json
@@ -1,5 +1,5 @@
 {
   "version-1.0.1/docs": {
-    "Test": ["version-withSlugs/rootAbsoluteSlug"]
+    "Test": ["rootAbsoluteSlug"]
   }
 }

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -95,7 +95,6 @@ exports[`simple website content 1`] = `
   ],
   "title": "baz",
   "unlisted": false,
-  "unversionedId": "foo/baz",
   "version": "current",
 }
 `;
@@ -142,7 +141,6 @@ exports[`simple website content 2`] = `
   ],
   "title": "Hello, World !",
   "unlisted": false,
-  "unversionedId": "hello",
   "version": "current",
 }
 `;
@@ -174,7 +172,6 @@ exports[`simple website content 3`] = `
   "tags": [],
   "title": "Bar",
   "unlisted": false,
-  "unversionedId": "foo/bar",
   "version": "current",
 }
 `;
@@ -451,7 +448,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-custom-last-update-md-b8d.json": "{
-  "unversionedId": "customLastUpdate",
   "id": "customLastUpdate",
   "title": "Custom Last Update",
   "description": "Custom last update",
@@ -472,7 +468,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-doc-draft-md-584.json": "{
-  "unversionedId": "doc-draft",
   "id": "doc-draft",
   "title": "doc-draft",
   "description": "This is a draft document",
@@ -489,7 +484,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-doc-unlisted-md-80b.json": "{
-  "unversionedId": "doc-unlisted",
   "id": "doc-unlisted",
   "title": "doc-unlisted",
   "description": "This is an unlisted document",
@@ -515,7 +509,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-doc-with-space-md-e90.json": "{
-  "unversionedId": "doc with space",
   "id": "doc with space",
   "title": "Hoo hoo, if this path tricks you...",
   "description": "",
@@ -530,7 +523,6 @@ exports[`simple website content: data 1`] = `
   "frontMatter": {}
 }",
   "site-docs-foo-bar-md-8c2.json": "{
-  "unversionedId": "foo/bar",
   "id": "foo/bar",
   "title": "Bar",
   "description": "This is custom description",
@@ -552,7 +544,6 @@ exports[`simple website content: data 1`] = `
   "sidebar": "docs"
 }",
   "site-docs-foo-baz-md-a69.json": "{
-  "unversionedId": "foo/baz",
   "id": "foo/baz",
   "title": "baz",
   "description": "Images",
@@ -598,7 +589,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-heading-as-title-md-c6d.json": "{
-  "unversionedId": "headingAsTitle",
   "id": "headingAsTitle",
   "title": "My heading as title",
   "description": "",
@@ -622,7 +612,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-hello-md-9df.json": "{
-  "unversionedId": "hello",
   "id": "hello",
   "title": "Hello, World !",
   "description": "Hi, Endilie here :)",
@@ -660,7 +649,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-ipsum-md-c61.json": "{
-  "unversionedId": "ipsum",
   "id": "ipsum",
   "title": "ipsum",
   "description": "Lorem ipsum.",
@@ -683,7 +671,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-last-update-author-only-md-352.json": "{
-  "unversionedId": "lastUpdateAuthorOnly",
   "id": "lastUpdateAuthorOnly",
   "title": "Last Update Author Only",
   "description": "Only custom author, so it will still use the date from Git",
@@ -703,7 +690,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-last-update-date-only-md-987.json": "{
-  "unversionedId": "lastUpdateDateOnly",
   "id": "lastUpdateDateOnly",
   "title": "Last Update Date Only",
   "description": "Only custom date, so it will still use the author from Git",
@@ -723,7 +709,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-lorem-md-b27.json": "{
-  "unversionedId": "lorem",
   "id": "lorem",
   "title": "lorem",
   "description": "Lorem ipsum.",
@@ -742,7 +727,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-root-absolute-slug-md-db5.json": "{
-  "unversionedId": "rootAbsoluteSlug",
   "id": "rootAbsoluteSlug",
   "title": "rootAbsoluteSlug",
   "description": "Lorem",
@@ -770,7 +754,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-root-relative-slug-md-3dd.json": "{
-  "unversionedId": "rootRelativeSlug",
   "id": "rootRelativeSlug",
   "title": "rootRelativeSlug",
   "description": "Lorem",
@@ -798,7 +781,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-root-resolved-slug-md-4d1.json": "{
-  "unversionedId": "rootResolvedSlug",
   "id": "rootResolvedSlug",
   "title": "rootResolvedSlug",
   "description": "Lorem",
@@ -826,7 +808,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-root-try-to-escape-slug-md-9ee.json": "{
-  "unversionedId": "rootTryToEscapeSlug",
   "id": "rootTryToEscapeSlug",
   "title": "rootTryToEscapeSlug",
   "description": "Lorem",
@@ -854,7 +835,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-slugs-absolute-slug-md-4e8.json": "{
-  "unversionedId": "slugs/absoluteSlug",
   "id": "slugs/absoluteSlug",
   "title": "absoluteSlug",
   "description": "Lorem",
@@ -871,7 +851,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-slugs-relative-slug-md-d1c.json": "{
-  "unversionedId": "slugs/relativeSlug",
   "id": "slugs/relativeSlug",
   "title": "relativeSlug",
   "description": "Lorem",
@@ -888,7 +867,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-slugs-resolved-slug-md-02b.json": "{
-  "unversionedId": "slugs/resolvedSlug",
   "id": "slugs/resolvedSlug",
   "title": "resolvedSlug",
   "description": "Lorem",
@@ -905,7 +883,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-slugs-try-to-escape-slug-md-70d.json": "{
-  "unversionedId": "slugs/tryToEscapeSlug",
   "id": "slugs/tryToEscapeSlug",
   "title": "tryToEscapeSlug",
   "description": "Lorem",
@@ -922,7 +899,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-unlisted-category-index-md-efa.json": "{
-  "unversionedId": "unlisted-category/unlisted-category-index",
   "id": "unlisted-category/unlisted-category-index",
   "title": "unlisted-category-index",
   "description": "This is an unlisted category index",
@@ -949,7 +925,6 @@ exports[`simple website content: data 1`] = `
   }
 }",
   "site-docs-unlisted-category-unlisted-category-doc-md-bd6.json": "{
-  "unversionedId": "unlisted-category/unlisted-category-doc",
   "id": "unlisted-category/unlisted-category-doc",
   "title": "unlisted-category-doc",
   "description": "This is an unlisted category doc",
@@ -1856,7 +1831,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/3-API/01_Core APIs/0 --- Client API.md",
       "sourceDirName": "3-API/01_Core APIs",
       "title": "Client API",
-      "unversionedId": "API/Core APIs/Client API",
     },
     {
       "frontMatter": {},
@@ -1865,7 +1839,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/3-API/01_Core APIs/1 --- Server API.md",
       "sourceDirName": "3-API/01_Core APIs",
       "title": "Server API",
-      "unversionedId": "API/Core APIs/Server API",
     },
     {
       "frontMatter": {},
@@ -1874,7 +1847,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/3-API/02_Extension APIs/0. Plugin API.md",
       "sourceDirName": "3-API/02_Extension APIs",
       "title": "Plugin API",
-      "unversionedId": "API/Extension APIs/Plugin API",
     },
     {
       "frontMatter": {},
@@ -1883,7 +1855,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/3-API/02_Extension APIs/1. Theme API.md",
       "sourceDirName": "3-API/02_Extension APIs",
       "title": "Theme API",
-      "unversionedId": "API/Extension APIs/Theme API",
     },
     {
       "frontMatter": {},
@@ -1892,7 +1863,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/3-API/03_api-end.md",
       "sourceDirName": "3-API",
       "title": "API End",
-      "unversionedId": "API/api-end",
     },
     {
       "frontMatter": {},
@@ -1901,7 +1871,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/3-API/00_api-overview.md",
       "sourceDirName": "3-API",
       "title": "API Overview",
-      "unversionedId": "API/api-overview",
     },
     {
       "frontMatter": {
@@ -1913,7 +1882,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/Guides/z-guide1.md",
       "sourceDirName": "Guides",
       "title": "Guide 1",
-      "unversionedId": "Guides/guide1",
     },
     {
       "frontMatter": {
@@ -1924,7 +1892,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/Guides/02-guide2.md",
       "sourceDirName": "Guides",
       "title": "Guide 2",
-      "unversionedId": "Guides/guide2",
     },
     {
       "frontMatter": {
@@ -1936,7 +1903,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/Guides/0-guide2.5.md",
       "sourceDirName": "Guides",
       "title": "Guide 2.5",
-      "unversionedId": "Guides/guide2.5",
     },
     {
       "frontMatter": {
@@ -1948,7 +1914,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/Guides/guide3.md",
       "sourceDirName": "Guides",
       "title": "Guide 3",
-      "unversionedId": "Guides/guide3",
     },
     {
       "frontMatter": {
@@ -1959,7 +1924,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/Guides/a-guide4.md",
       "sourceDirName": "Guides",
       "title": "Guide 4",
-      "unversionedId": "Guides/guide4",
     },
     {
       "frontMatter": {
@@ -1970,7 +1934,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/Guides/b-guide5.md",
       "sourceDirName": "Guides",
       "title": "Guide 5",
-      "unversionedId": "Guides/guide5",
     },
     {
       "frontMatter": {},
@@ -1979,7 +1942,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/0-getting-started.md",
       "sourceDirName": ".",
       "title": "Getting Started",
-      "unversionedId": "getting-started",
     },
     {
       "frontMatter": {},
@@ -1988,7 +1950,6 @@ exports[`site with custom sidebar items generator sidebarItemsGenerator is calle
       "source": "@site/docs/1-installation.md",
       "sourceDirName": ".",
       "title": "Installation",
-      "unversionedId": "installation",
     },
   ],
   "isCategoryIndex": [Function],
@@ -2028,7 +1989,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Getting Started",
   "unlisted": false,
-  "unversionedId": "getting-started",
   "version": "current",
 }
 `;
@@ -2060,7 +2020,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Installation",
   "unlisted": false,
-  "unversionedId": "installation",
   "version": "current",
 }
 `;
@@ -2095,7 +2054,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Guide 1",
   "unlisted": false,
-  "unversionedId": "Guides/guide1",
   "version": "current",
 }
 `;
@@ -2129,7 +2087,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Guide 2",
   "unlisted": false,
-  "unversionedId": "Guides/guide2",
   "version": "current",
 }
 `;
@@ -2164,7 +2121,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Guide 2.5",
   "unlisted": false,
-  "unversionedId": "Guides/guide2.5",
   "version": "current",
 }
 `;
@@ -2199,7 +2155,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Guide 3",
   "unlisted": false,
-  "unversionedId": "Guides/guide3",
   "version": "current",
 }
 `;
@@ -2233,7 +2188,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Guide 4",
   "unlisted": false,
-  "unversionedId": "Guides/guide4",
   "version": "current",
 }
 `;
@@ -2267,7 +2221,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Guide 5",
   "unlisted": false,
-  "unversionedId": "Guides/guide5",
   "version": "current",
 }
 `;
@@ -2299,7 +2252,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "API Overview",
   "unlisted": false,
-  "unversionedId": "API/api-overview",
   "version": "current",
 }
 `;
@@ -2331,7 +2283,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Client API",
   "unlisted": false,
-  "unversionedId": "API/Core APIs/Client API",
   "version": "current",
 }
 `;
@@ -2363,7 +2314,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Server API",
   "unlisted": false,
-  "unversionedId": "API/Core APIs/Server API",
   "version": "current",
 }
 `;
@@ -2395,7 +2345,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Plugin API",
   "unlisted": false,
-  "unversionedId": "API/Extension APIs/Plugin API",
   "version": "current",
 }
 `;
@@ -2427,7 +2376,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "Theme API",
   "unlisted": false,
-  "unversionedId": "API/Extension APIs/Theme API",
   "version": "current",
 }
 `;
@@ -2456,7 +2404,6 @@ exports[`site with full autogenerated sidebar docs in fully generated sidebar ha
   "tags": [],
   "title": "API End",
   "unlisted": false,
-  "unversionedId": "API/api-end",
   "version": "current",
 }
 `;
@@ -2637,7 +2584,6 @@ exports[`site with partial autogenerated sidebars docs in partially generated si
   "tags": [],
   "title": "API End",
   "unlisted": false,
-  "unversionedId": "API/api-end",
   "version": "current",
 }
 `;
@@ -2669,7 +2615,6 @@ exports[`site with partial autogenerated sidebars docs in partially generated si
   "tags": [],
   "title": "API Overview",
   "unlisted": false,
-  "unversionedId": "API/api-overview",
   "version": "current",
 }
 `;
@@ -2701,7 +2646,6 @@ exports[`site with partial autogenerated sidebars docs in partially generated si
   "tags": [],
   "title": "Plugin API",
   "unlisted": false,
-  "unversionedId": "API/Extension APIs/Plugin API",
   "version": "current",
 }
 `;
@@ -2730,7 +2674,6 @@ exports[`site with partial autogenerated sidebars docs in partially generated si
   "tags": [],
   "title": "Theme API",
   "unlisted": false,
-  "unversionedId": "API/Extension APIs/Theme API",
   "version": "current",
 }
 `;
@@ -2819,250 +2762,6 @@ exports[`versioned website (community) content 2`] = `
   "unversionedId": "team",
   "version": "1.0.0",
 }
-`;
-
-exports[`versioned website (community) content: 100 version sidebars 1`] = `
-{
-  "version-1.0.0/community": [
-    {
-      "id": "version-1.0.0/team",
-      "type": "doc",
-    },
-  ],
-}
-`;
-
-exports[`versioned website (community) content: current version sidebars 1`] = `
-{
-  "community": [
-    {
-      "id": "team",
-      "type": "doc",
-    },
-  ],
-}
-`;
-
-exports[`versioned website (community) content: data 1`] = `
-{
-  "site-community-versioned-docs-version-1-0-0-team-md-359.json": "{
-  "unversionedId": "team",
-  "id": "version-1.0.0/team",
-  "title": "team",
-  "description": "Team 1.0.0",
-  "source": "@site/community_versioned_docs/version-1.0.0/team.md",
-  "sourceDirName": ".",
-  "slug": "/team",
-  "permalink": "/community/team",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "1.0.0",
-  "frontMatter": {},
-  "sidebar": "version-1.0.0/community"
-}",
-  "site-i-18-n-en-docusaurus-plugin-content-docs-community-current-team-md-7e5.json": "{
-  "unversionedId": "team",
-  "id": "team",
-  "title": "Team title translated",
-  "description": "Team current version (translated)",
-  "source": "@site/i18n/en/docusaurus-plugin-content-docs-community/current/team.md",
-  "sourceDirName": ".",
-  "slug": "/team",
-  "permalink": "/community/next/team",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "current",
-  "frontMatter": {
-    "title": "Team title translated"
-  },
-  "sidebar": "community"
-}",
-  "version-1-0-0-metadata-prop-608.json": "{
-  "pluginId": "community",
-  "version": "1.0.0",
-  "label": "1.0.0",
-  "banner": null,
-  "badge": true,
-  "noIndex": false,
-  "className": "docs-version-1.0.0",
-  "isLast": true,
-  "docsSidebars": {
-    "version-1.0.0/community": [
-      {
-        "type": "link",
-        "label": "team",
-        "href": "/community/team",
-        "docId": "team",
-        "unlisted": false
-      }
-    ]
-  },
-  "docs": {
-    "team": {
-      "id": "team",
-      "title": "team",
-      "description": "Team 1.0.0",
-      "sidebar": "version-1.0.0/community"
-    }
-  }
-}",
-  "version-current-metadata-prop-751.json": "{
-  "pluginId": "community",
-  "version": "current",
-  "label": "Next",
-  "banner": "unreleased",
-  "badge": true,
-  "noIndex": false,
-  "className": "docs-version-current",
-  "isLast": false,
-  "docsSidebars": {
-    "community": [
-      {
-        "type": "link",
-        "label": "Team title translated",
-        "href": "/community/next/team",
-        "docId": "team",
-        "unlisted": false
-      }
-    ]
-  },
-  "docs": {
-    "team": {
-      "id": "team",
-      "title": "Team title translated",
-      "description": "Team current version (translated)",
-      "sidebar": "community"
-    }
-  }
-}",
-}
-`;
-
-exports[`versioned website (community) content: global data 1`] = `
-{
-  "pluginName": {
-    "pluginId": {
-      "breadcrumbs": true,
-      "path": "/community",
-      "versions": [
-        {
-          "docs": [
-            {
-              "id": "team",
-              "path": "/community/next/team",
-              "sidebar": "community",
-            },
-          ],
-          "draftIds": [],
-          "isLast": false,
-          "label": "Next",
-          "mainDocId": "team",
-          "name": "current",
-          "path": "/community/next",
-          "sidebars": {
-            "community": {
-              "link": {
-                "label": "team",
-                "path": "/community/next/team",
-              },
-            },
-          },
-        },
-        {
-          "docs": [
-            {
-              "id": "team",
-              "path": "/community/team",
-              "sidebar": "version-1.0.0/community",
-            },
-          ],
-          "draftIds": [],
-          "isLast": true,
-          "label": "1.0.0",
-          "mainDocId": "team",
-          "name": "1.0.0",
-          "path": "/community",
-          "sidebars": {
-            "version-1.0.0/community": {
-              "link": {
-                "label": "version-1.0.0/team",
-                "path": "/community/team",
-              },
-            },
-          },
-        },
-      ],
-    },
-  },
-}
-`;
-
-exports[`versioned website (community) content: route config 1`] = `
-[
-  {
-    "component": "@theme/DocsRoot",
-    "exact": false,
-    "path": "/community",
-    "routes": [
-      {
-        "component": "@theme/DocVersionRoot",
-        "exact": false,
-        "modules": {
-          "version": "~docs/version-current-metadata-prop-751.json",
-        },
-        "path": "/community/next",
-        "priority": undefined,
-        "routes": [
-          {
-            "component": "@theme/DocRoot",
-            "exact": false,
-            "path": "/community/next",
-            "routes": [
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/i18n/en/docusaurus-plugin-content-docs-community/current/team.md",
-                },
-                "path": "/community/next/team",
-                "sidebar": "community",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        "component": "@theme/DocVersionRoot",
-        "exact": false,
-        "modules": {
-          "version": "~docs/version-1-0-0-metadata-prop-608.json",
-        },
-        "path": "/community",
-        "priority": -1,
-        "routes": [
-          {
-            "component": "@theme/DocRoot",
-            "exact": false,
-            "path": "/community",
-            "routes": [
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/community_versioned_docs/version-1.0.0/team.md",
-                },
-                "path": "/community/team",
-                "sidebar": "version-1.0.0/community",
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-]
 `;
 
 exports[`versioned website (community) getPathToWatch 1`] = `
@@ -3250,1311 +2949,6 @@ exports[`versioned website content 5`] = `
   "unlisted": false,
   "unversionedId": "foo/baz",
   "version": "1.0.0",
-}
-`;
-
-exports[`versioned website content: 100 version sidebars 1`] = `
-{
-  "version-1.0.0/docs": [
-    {
-      "collapsed": true,
-      "collapsible": true,
-      "items": [
-        {
-          "id": "version-1.0.0/foo/bar",
-          "type": "doc",
-        },
-        {
-          "id": "version-1.0.0/foo/baz",
-          "type": "doc",
-        },
-      ],
-      "label": "Test",
-      "link": undefined,
-      "type": "category",
-    },
-    {
-      "collapsed": true,
-      "collapsible": true,
-      "items": [
-        {
-          "id": "version-1.0.0/hello",
-          "type": "doc",
-        },
-      ],
-      "label": "Guides",
-      "link": undefined,
-      "type": "category",
-    },
-  ],
-}
-`;
-
-exports[`versioned website content: 101 version sidebars 1`] = `
-{
-  "VersionedSideBarNameDoesNotMatter/docs": [
-    {
-      "collapsed": true,
-      "collapsible": true,
-      "items": [
-        {
-          "id": "foo/bar",
-          "type": "doc",
-        },
-      ],
-      "label": "Test",
-      "link": undefined,
-      "type": "category",
-    },
-    {
-      "collapsed": true,
-      "collapsible": true,
-      "items": [
-        {
-          "id": "version-1.0.1/hello",
-          "type": "doc",
-        },
-      ],
-      "label": "Guides",
-      "link": undefined,
-      "type": "category",
-    },
-  ],
-}
-`;
-
-exports[`versioned website content: current version sidebars 1`] = `
-{
-  "docs": [
-    {
-      "collapsed": true,
-      "collapsible": true,
-      "items": [
-        {
-          "id": "foo/bar",
-          "type": "doc",
-        },
-      ],
-      "label": "Test",
-      "link": undefined,
-      "type": "category",
-    },
-    {
-      "collapsed": true,
-      "collapsible": true,
-      "items": [
-        {
-          "id": "hello",
-          "type": "doc",
-        },
-      ],
-      "label": "Guides",
-      "link": undefined,
-      "type": "category",
-    },
-  ],
-}
-`;
-
-exports[`versioned website content: data 1`] = `
-{
-  "site-docs-foo-bar-md-8c2.json": "{
-  "unversionedId": "foo/bar",
-  "id": "foo/bar",
-  "title": "bar",
-  "description": "This is next version of bar.",
-  "source": "@site/docs/foo/bar.md",
-  "sourceDirName": "foo",
-  "slug": "/foo/barSlug",
-  "permalink": "/docs/next/foo/barSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [
-    {
-      "label": "barTag 1",
-      "permalink": "/docs/next/tags/bar-tag-1"
-    },
-    {
-      "label": "barTag-2",
-      "permalink": "/docs/next/tags/bar-tag-2"
-    },
-    {
-      "label": "barTag 3",
-      "permalink": "/docs/next/tags/barTag-3-permalink"
-    }
-  ],
-  "version": "current",
-  "frontMatter": {
-    "slug": "barSlug",
-    "tags": [
-      "barTag 1",
-      "barTag-2",
-      {
-        "label": "barTag 3",
-        "permalink": "barTag-3-permalink"
-      }
-    ]
-  },
-  "sidebar": "docs",
-  "next": {
-    "title": "hello",
-    "permalink": "/docs/next/"
-  }
-}",
-  "site-docs-hello-md-9df.json": "{
-  "unversionedId": "hello",
-  "id": "hello",
-  "title": "hello",
-  "description": "Hello next !",
-  "source": "@site/docs/hello.md",
-  "sourceDirName": ".",
-  "slug": "/",
-  "permalink": "/docs/next/",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "current",
-  "frontMatter": {
-    "slug": "/"
-  },
-  "sidebar": "docs",
-  "previous": {
-    "title": "bar",
-    "permalink": "/docs/next/foo/barSlug"
-  }
-}",
-  "site-docs-slugs-absolute-slug-md-4e8.json": "{
-  "unversionedId": "slugs/absoluteSlug",
-  "id": "slugs/absoluteSlug",
-  "title": "absoluteSlug",
-  "description": "Lorem",
-  "source": "@site/docs/slugs/absoluteSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/absoluteSlug",
-  "permalink": "/docs/next/absoluteSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "current",
-  "frontMatter": {
-    "slug": "/absoluteSlug"
-  }
-}",
-  "site-docs-slugs-relative-slug-md-d1c.json": "{
-  "unversionedId": "slugs/relativeSlug",
-  "id": "slugs/relativeSlug",
-  "title": "relativeSlug",
-  "description": "Lorem",
-  "source": "@site/docs/slugs/relativeSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/slugs/relativeSlug",
-  "permalink": "/docs/next/slugs/relativeSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "current",
-  "frontMatter": {
-    "slug": "relativeSlug"
-  }
-}",
-  "site-docs-slugs-resolved-slug-md-02b.json": "{
-  "unversionedId": "slugs/resolvedSlug",
-  "id": "slugs/resolvedSlug",
-  "title": "resolvedSlug",
-  "description": "Lorem",
-  "source": "@site/docs/slugs/resolvedSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/slugs/hey/resolvedSlug",
-  "permalink": "/docs/next/slugs/hey/resolvedSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "current",
-  "frontMatter": {
-    "slug": "./hey/ho/../resolvedSlug"
-  }
-}",
-  "site-docs-slugs-try-to-escape-slug-md-70d.json": "{
-  "unversionedId": "slugs/tryToEscapeSlug",
-  "id": "slugs/tryToEscapeSlug",
-  "title": "tryToEscapeSlug",
-  "description": "Lorem",
-  "source": "@site/docs/slugs/tryToEscapeSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/tryToEscapeSlug",
-  "permalink": "/docs/next/tryToEscapeSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "current",
-  "frontMatter": {
-    "slug": "../../../../../../../../tryToEscapeSlug"
-  }
-}",
-  "site-i-18-n-en-docusaurus-plugin-content-docs-version-1-0-0-hello-md-fe5.json": "{
-  "unversionedId": "hello",
-  "id": "version-1.0.0/hello",
-  "title": "hello",
-  "description": "Hello 1.0.0 ! (translated en)",
-  "source": "@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md",
-  "sourceDirName": ".",
-  "slug": "/",
-  "permalink": "/docs/1.0.0/",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "1.0.0",
-  "frontMatter": {
-    "slug": "/"
-  },
-  "sidebar": "version-1.0.0/docs",
-  "previous": {
-    "title": "baz",
-    "permalink": "/docs/1.0.0/foo/baz"
-  }
-}",
-  "site-versioned-docs-version-1-0-0-foo-bar-md-7a6.json": "{
-  "unversionedId": "foo/bar",
-  "id": "version-1.0.0/foo/bar",
-  "title": "bar",
-  "description": "Bar 1.0.0 !",
-  "source": "@site/versioned_docs/version-1.0.0/foo/bar.md",
-  "sourceDirName": "foo",
-  "slug": "/foo/barSlug",
-  "permalink": "/docs/1.0.0/foo/barSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "1.0.0",
-  "frontMatter": {
-    "slug": "barSlug"
-  },
-  "sidebar": "version-1.0.0/docs",
-  "next": {
-    "title": "baz",
-    "permalink": "/docs/1.0.0/foo/baz"
-  }
-}",
-  "site-versioned-docs-version-1-0-0-foo-baz-md-883.json": "{
-  "unversionedId": "foo/baz",
-  "id": "version-1.0.0/foo/baz",
-  "title": "baz",
-  "description": "Baz 1.0.0 ! This will be deleted in next subsequent versions.",
-  "source": "@site/versioned_docs/version-1.0.0/foo/baz.md",
-  "sourceDirName": "foo",
-  "slug": "/foo/baz",
-  "permalink": "/docs/1.0.0/foo/baz",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "1.0.0",
-  "frontMatter": {},
-  "sidebar": "version-1.0.0/docs",
-  "previous": {
-    "title": "bar",
-    "permalink": "/docs/1.0.0/foo/barSlug"
-  },
-  "next": {
-    "title": "hello",
-    "permalink": "/docs/1.0.0/"
-  }
-}",
-  "site-versioned-docs-version-1-0-1-foo-bar-md-7a3.json": "{
-  "unversionedId": "foo/bar",
-  "id": "version-1.0.1/foo/bar",
-  "title": "bar",
-  "description": "Bar 1.0.1 !",
-  "source": "@site/versioned_docs/version-1.0.1/foo/bar.md",
-  "sourceDirName": "foo",
-  "slug": "/foo/bar",
-  "permalink": "/docs/foo/bar",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "1.0.1",
-  "frontMatter": {},
-  "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
-  "next": {
-    "title": "hello",
-    "permalink": "/docs/"
-  }
-}",
-  "site-versioned-docs-version-1-0-1-hello-md-0c7.json": "{
-  "unversionedId": "hello",
-  "id": "version-1.0.1/hello",
-  "title": "hello",
-  "description": "Hello 1.0.1 !",
-  "source": "@site/versioned_docs/version-1.0.1/hello.md",
-  "sourceDirName": ".",
-  "slug": "/",
-  "permalink": "/docs/",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "1.0.1",
-  "frontMatter": {
-    "slug": "/"
-  },
-  "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
-  "previous": {
-    "title": "bar",
-    "permalink": "/docs/foo/bar"
-  }
-}",
-  "site-versioned-docs-version-with-slugs-root-absolute-slug-md-4d2.json": "{
-  "unversionedId": "rootAbsoluteSlug",
-  "id": "version-withSlugs/rootAbsoluteSlug",
-  "title": "rootAbsoluteSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/rootAbsoluteSlug.md",
-  "sourceDirName": ".",
-  "slug": "/rootAbsoluteSlug",
-  "permalink": "/docs/withSlugs/rootAbsoluteSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "/rootAbsoluteSlug"
-  },
-  "sidebar": "version-1.0.1/docs"
-}",
-  "site-versioned-docs-version-with-slugs-root-relative-slug-md-32a.json": "{
-  "unversionedId": "rootRelativeSlug",
-  "id": "version-withSlugs/rootRelativeSlug",
-  "title": "rootRelativeSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/rootRelativeSlug.md",
-  "sourceDirName": ".",
-  "slug": "/rootRelativeSlug",
-  "permalink": "/docs/withSlugs/rootRelativeSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "rootRelativeSlug"
-  }
-}",
-  "site-versioned-docs-version-with-slugs-root-resolved-slug-md-aee.json": "{
-  "unversionedId": "rootResolvedSlug",
-  "id": "version-withSlugs/rootResolvedSlug",
-  "title": "rootResolvedSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/rootResolvedSlug.md",
-  "sourceDirName": ".",
-  "slug": "/hey/rootResolvedSlug",
-  "permalink": "/docs/withSlugs/hey/rootResolvedSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "./hey/ho/../rootResolvedSlug"
-  }
-}",
-  "site-versioned-docs-version-with-slugs-root-try-to-escape-slug-md-b5d.json": "{
-  "unversionedId": "rootTryToEscapeSlug",
-  "id": "version-withSlugs/rootTryToEscapeSlug",
-  "title": "rootTryToEscapeSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/rootTryToEscapeSlug.md",
-  "sourceDirName": ".",
-  "slug": "/rootTryToEscapeSlug",
-  "permalink": "/docs/withSlugs/rootTryToEscapeSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "../../../../../../../../rootTryToEscapeSlug"
-  }
-}",
-  "site-versioned-docs-version-with-slugs-slugs-absolute-slug-md-47a.json": "{
-  "unversionedId": "slugs/absoluteSlug",
-  "id": "version-withSlugs/slugs/absoluteSlug",
-  "title": "absoluteSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/slugs/absoluteSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/absoluteSlug",
-  "permalink": "/docs/withSlugs/absoluteSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "/absoluteSlug"
-  }
-}",
-  "site-versioned-docs-version-with-slugs-slugs-relative-slug-md-a95.json": "{
-  "unversionedId": "slugs/relativeSlug",
-  "id": "version-withSlugs/slugs/relativeSlug",
-  "title": "relativeSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/slugs/relativeSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/slugs/relativeSlug",
-  "permalink": "/docs/withSlugs/slugs/relativeSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "relativeSlug"
-  }
-}",
-  "site-versioned-docs-version-with-slugs-slugs-resolved-slug-md-5a1.json": "{
-  "unversionedId": "slugs/resolvedSlug",
-  "id": "version-withSlugs/slugs/resolvedSlug",
-  "title": "resolvedSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/slugs/resolvedSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/slugs/hey/resolvedSlug",
-  "permalink": "/docs/withSlugs/slugs/hey/resolvedSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "./hey/ho/../resolvedSlug"
-  }
-}",
-  "site-versioned-docs-version-with-slugs-slugs-try-to-escape-slug-md-4e1.json": "{
-  "unversionedId": "slugs/tryToEscapeSlug",
-  "id": "version-withSlugs/slugs/tryToEscapeSlug",
-  "title": "tryToEscapeSlug",
-  "description": "Lorem",
-  "source": "@site/versioned_docs/version-withSlugs/slugs/tryToEscapeSlug.md",
-  "sourceDirName": "slugs",
-  "slug": "/tryToEscapeSlug",
-  "permalink": "/docs/withSlugs/tryToEscapeSlug",
-  "draft": false,
-  "unlisted": false,
-  "tags": [],
-  "version": "withSlugs",
-  "frontMatter": {
-    "slug": "../../../../../../../../tryToEscapeSlug"
-  }
-}",
-  "tag-docs-next-tags-bar-tag-1-a8f.json": "{
-  "label": "barTag 1",
-  "permalink": "/docs/next/tags/bar-tag-1",
-  "allTagsPath": "/docs/next/tags",
-  "count": 1,
-  "items": [
-    {
-      "id": "foo/bar",
-      "title": "bar",
-      "description": "This is next version of bar.",
-      "permalink": "/docs/next/foo/barSlug"
-    }
-  ],
-  "unlisted": false
-}",
-  "tag-docs-next-tags-bar-tag-2-216.json": "{
-  "label": "barTag-2",
-  "permalink": "/docs/next/tags/bar-tag-2",
-  "allTagsPath": "/docs/next/tags",
-  "count": 1,
-  "items": [
-    {
-      "id": "foo/bar",
-      "title": "bar",
-      "description": "This is next version of bar.",
-      "permalink": "/docs/next/foo/barSlug"
-    }
-  ],
-  "unlisted": false
-}",
-  "tag-docs-next-tags-bar-tag-3-permalink-94a.json": "{
-  "label": "barTag 3",
-  "permalink": "/docs/next/tags/barTag-3-permalink",
-  "allTagsPath": "/docs/next/tags",
-  "count": 1,
-  "items": [
-    {
-      "id": "foo/bar",
-      "title": "bar",
-      "description": "This is next version of bar.",
-      "permalink": "/docs/next/foo/barSlug"
-    }
-  ],
-  "unlisted": false
-}",
-  "tags-list-current-prop-15a.json": "[
-  {
-    "label": "barTag 1",
-    "permalink": "/docs/next/tags/bar-tag-1",
-    "count": 1
-  },
-  {
-    "label": "barTag-2",
-    "permalink": "/docs/next/tags/bar-tag-2",
-    "count": 1
-  },
-  {
-    "label": "barTag 3",
-    "permalink": "/docs/next/tags/barTag-3-permalink",
-    "count": 1
-  }
-]",
-  "version-1-0-0-metadata-prop-608.json": "{
-  "pluginId": "default",
-  "version": "1.0.0",
-  "label": "1.0.0",
-  "banner": "unmaintained",
-  "badge": true,
-  "noIndex": false,
-  "className": "docs-version-1.0.0",
-  "isLast": false,
-  "docsSidebars": {
-    "version-1.0.0/docs": [
-      {
-        "type": "category",
-        "label": "Test",
-        "items": [
-          {
-            "type": "link",
-            "label": "bar",
-            "href": "/docs/1.0.0/foo/barSlug",
-            "docId": "foo/bar",
-            "unlisted": false
-          },
-          {
-            "type": "link",
-            "label": "baz",
-            "href": "/docs/1.0.0/foo/baz",
-            "docId": "foo/baz",
-            "unlisted": false
-          }
-        ],
-        "collapsed": true,
-        "collapsible": true
-      },
-      {
-        "type": "category",
-        "label": "Guides",
-        "items": [
-          {
-            "type": "link",
-            "label": "hello",
-            "href": "/docs/1.0.0/",
-            "docId": "hello",
-            "unlisted": false
-          }
-        ],
-        "collapsed": true,
-        "collapsible": true
-      }
-    ]
-  },
-  "docs": {
-    "foo/bar": {
-      "id": "foo/bar",
-      "title": "bar",
-      "description": "Bar 1.0.0 !",
-      "sidebar": "version-1.0.0/docs"
-    },
-    "foo/baz": {
-      "id": "foo/baz",
-      "title": "baz",
-      "description": "Baz 1.0.0 ! This will be deleted in next subsequent versions.",
-      "sidebar": "version-1.0.0/docs"
-    },
-    "hello": {
-      "id": "hello",
-      "title": "hello",
-      "description": "Hello 1.0.0 ! (translated en)",
-      "sidebar": "version-1.0.0/docs"
-    }
-  }
-}",
-  "version-1-0-1-metadata-prop-e87.json": "{
-  "pluginId": "default",
-  "version": "1.0.1",
-  "label": "1.0.1",
-  "banner": null,
-  "badge": true,
-  "noIndex": true,
-  "className": "docs-version-1.0.1",
-  "isLast": true,
-  "docsSidebars": {
-    "VersionedSideBarNameDoesNotMatter/docs": [
-      {
-        "type": "category",
-        "label": "Test",
-        "items": [
-          {
-            "type": "link",
-            "label": "bar",
-            "href": "/docs/foo/bar",
-            "docId": "foo/bar",
-            "unlisted": false
-          }
-        ],
-        "collapsed": true,
-        "collapsible": true
-      },
-      {
-        "type": "category",
-        "label": "Guides",
-        "items": [
-          {
-            "type": "link",
-            "label": "hello",
-            "href": "/docs/",
-            "docId": "hello",
-            "unlisted": false
-          }
-        ],
-        "collapsed": true,
-        "collapsible": true
-      }
-    ]
-  },
-  "docs": {
-    "foo/bar": {
-      "id": "foo/bar",
-      "title": "bar",
-      "description": "Bar 1.0.1 !",
-      "sidebar": "VersionedSideBarNameDoesNotMatter/docs"
-    },
-    "hello": {
-      "id": "hello",
-      "title": "hello",
-      "description": "Hello 1.0.1 !",
-      "sidebar": "VersionedSideBarNameDoesNotMatter/docs"
-    }
-  }
-}",
-  "version-current-metadata-prop-751.json": "{
-  "pluginId": "default",
-  "version": "current",
-  "label": "Next",
-  "banner": "unreleased",
-  "badge": true,
-  "noIndex": false,
-  "className": "docs-version-current",
-  "isLast": false,
-  "docsSidebars": {
-    "docs": [
-      {
-        "type": "category",
-        "label": "Test",
-        "items": [
-          {
-            "type": "link",
-            "label": "bar",
-            "href": "/docs/next/foo/barSlug",
-            "docId": "foo/bar",
-            "unlisted": false
-          }
-        ],
-        "collapsed": true,
-        "collapsible": true
-      },
-      {
-        "type": "category",
-        "label": "Guides",
-        "items": [
-          {
-            "type": "link",
-            "label": "hello",
-            "href": "/docs/next/",
-            "docId": "hello",
-            "unlisted": false
-          }
-        ],
-        "collapsed": true,
-        "collapsible": true
-      }
-    ]
-  },
-  "docs": {
-    "foo/bar": {
-      "id": "foo/bar",
-      "title": "bar",
-      "description": "This is next version of bar.",
-      "sidebar": "docs"
-    },
-    "hello": {
-      "id": "hello",
-      "title": "hello",
-      "description": "Hello next !",
-      "sidebar": "docs"
-    },
-    "slugs/absoluteSlug": {
-      "id": "slugs/absoluteSlug",
-      "title": "absoluteSlug",
-      "description": "Lorem"
-    },
-    "slugs/relativeSlug": {
-      "id": "slugs/relativeSlug",
-      "title": "relativeSlug",
-      "description": "Lorem"
-    },
-    "slugs/resolvedSlug": {
-      "id": "slugs/resolvedSlug",
-      "title": "resolvedSlug",
-      "description": "Lorem"
-    },
-    "slugs/tryToEscapeSlug": {
-      "id": "slugs/tryToEscapeSlug",
-      "title": "tryToEscapeSlug",
-      "description": "Lorem"
-    }
-  }
-}",
-  "version-with-slugs-metadata-prop-2bf.json": "{
-  "pluginId": "default",
-  "version": "withSlugs",
-  "label": "withSlugs",
-  "banner": "unmaintained",
-  "badge": true,
-  "noIndex": false,
-  "className": "docs-version-withSlugs",
-  "isLast": false,
-  "docsSidebars": {
-    "version-1.0.1/docs": [
-      {
-        "type": "category",
-        "label": "Test",
-        "items": [
-          {
-            "type": "link",
-            "label": "rootAbsoluteSlug",
-            "href": "/docs/withSlugs/rootAbsoluteSlug",
-            "docId": "rootAbsoluteSlug",
-            "unlisted": false
-          }
-        ],
-        "collapsed": true,
-        "collapsible": true
-      }
-    ]
-  },
-  "docs": {
-    "rootAbsoluteSlug": {
-      "id": "rootAbsoluteSlug",
-      "title": "rootAbsoluteSlug",
-      "description": "Lorem",
-      "sidebar": "version-1.0.1/docs"
-    },
-    "rootRelativeSlug": {
-      "id": "rootRelativeSlug",
-      "title": "rootRelativeSlug",
-      "description": "Lorem"
-    },
-    "rootResolvedSlug": {
-      "id": "rootResolvedSlug",
-      "title": "rootResolvedSlug",
-      "description": "Lorem"
-    },
-    "rootTryToEscapeSlug": {
-      "id": "rootTryToEscapeSlug",
-      "title": "rootTryToEscapeSlug",
-      "description": "Lorem"
-    },
-    "slugs/absoluteSlug": {
-      "id": "slugs/absoluteSlug",
-      "title": "absoluteSlug",
-      "description": "Lorem"
-    },
-    "slugs/relativeSlug": {
-      "id": "slugs/relativeSlug",
-      "title": "relativeSlug",
-      "description": "Lorem"
-    },
-    "slugs/resolvedSlug": {
-      "id": "slugs/resolvedSlug",
-      "title": "resolvedSlug",
-      "description": "Lorem"
-    },
-    "slugs/tryToEscapeSlug": {
-      "id": "slugs/tryToEscapeSlug",
-      "title": "tryToEscapeSlug",
-      "description": "Lorem"
-    }
-  }
-}",
-}
-`;
-
-exports[`versioned website content: global data 1`] = `
-{
-  "pluginName": {
-    "pluginId": {
-      "breadcrumbs": true,
-      "path": "/docs",
-      "versions": [
-        {
-          "docs": [
-            {
-              "id": "foo/bar",
-              "path": "/docs/next/foo/barSlug",
-              "sidebar": "docs",
-            },
-            {
-              "id": "hello",
-              "path": "/docs/next/",
-              "sidebar": "docs",
-            },
-            {
-              "id": "slugs/absoluteSlug",
-              "path": "/docs/next/absoluteSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "slugs/relativeSlug",
-              "path": "/docs/next/slugs/relativeSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "slugs/resolvedSlug",
-              "path": "/docs/next/slugs/hey/resolvedSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "slugs/tryToEscapeSlug",
-              "path": "/docs/next/tryToEscapeSlug",
-              "sidebar": undefined,
-            },
-          ],
-          "draftIds": [],
-          "isLast": false,
-          "label": "Next",
-          "mainDocId": "hello",
-          "name": "current",
-          "path": "/docs/next",
-          "sidebars": {
-            "docs": {
-              "link": {
-                "label": "foo/bar",
-                "path": "/docs/next/foo/barSlug",
-              },
-            },
-          },
-        },
-        {
-          "docs": [
-            {
-              "id": "foo/bar",
-              "path": "/docs/foo/bar",
-              "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
-            },
-            {
-              "id": "hello",
-              "path": "/docs/",
-              "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
-            },
-          ],
-          "draftIds": [],
-          "isLast": true,
-          "label": "1.0.1",
-          "mainDocId": "hello",
-          "name": "1.0.1",
-          "path": "/docs",
-          "sidebars": {
-            "VersionedSideBarNameDoesNotMatter/docs": {
-              "link": {
-                "label": "foo/bar",
-                "path": "/docs/foo/bar",
-              },
-            },
-          },
-        },
-        {
-          "docs": [
-            {
-              "id": "foo/bar",
-              "path": "/docs/1.0.0/foo/barSlug",
-              "sidebar": "version-1.0.0/docs",
-            },
-            {
-              "id": "foo/baz",
-              "path": "/docs/1.0.0/foo/baz",
-              "sidebar": "version-1.0.0/docs",
-            },
-            {
-              "id": "hello",
-              "path": "/docs/1.0.0/",
-              "sidebar": "version-1.0.0/docs",
-            },
-          ],
-          "draftIds": [],
-          "isLast": false,
-          "label": "1.0.0",
-          "mainDocId": "hello",
-          "name": "1.0.0",
-          "path": "/docs/1.0.0",
-          "sidebars": {
-            "version-1.0.0/docs": {
-              "link": {
-                "label": "version-1.0.0/foo/bar",
-                "path": "/docs/1.0.0/foo/barSlug",
-              },
-            },
-          },
-        },
-        {
-          "docs": [
-            {
-              "id": "rootAbsoluteSlug",
-              "path": "/docs/withSlugs/rootAbsoluteSlug",
-              "sidebar": "version-1.0.1/docs",
-            },
-            {
-              "id": "rootRelativeSlug",
-              "path": "/docs/withSlugs/rootRelativeSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "rootResolvedSlug",
-              "path": "/docs/withSlugs/hey/rootResolvedSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "rootTryToEscapeSlug",
-              "path": "/docs/withSlugs/rootTryToEscapeSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "slugs/absoluteSlug",
-              "path": "/docs/withSlugs/absoluteSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "slugs/relativeSlug",
-              "path": "/docs/withSlugs/slugs/relativeSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "slugs/resolvedSlug",
-              "path": "/docs/withSlugs/slugs/hey/resolvedSlug",
-              "sidebar": undefined,
-            },
-            {
-              "id": "slugs/tryToEscapeSlug",
-              "path": "/docs/withSlugs/tryToEscapeSlug",
-              "sidebar": undefined,
-            },
-          ],
-          "draftIds": [],
-          "isLast": false,
-          "label": "withSlugs",
-          "mainDocId": "rootAbsoluteSlug",
-          "name": "withSlugs",
-          "path": "/docs/withSlugs",
-          "sidebars": {
-            "version-1.0.1/docs": {
-              "link": {
-                "label": "version-withSlugs/rootAbsoluteSlug",
-                "path": "/docs/withSlugs/rootAbsoluteSlug",
-              },
-            },
-          },
-        },
-      ],
-    },
-  },
-}
-`;
-
-exports[`versioned website content: route config 1`] = `
-[
-  {
-    "component": "@theme/DocsRoot",
-    "exact": false,
-    "path": "/docs",
-    "routes": [
-      {
-        "component": "@theme/DocVersionRoot",
-        "exact": false,
-        "modules": {
-          "version": "~docs/version-1-0-0-metadata-prop-608.json",
-        },
-        "path": "/docs/1.0.0",
-        "priority": undefined,
-        "routes": [
-          {
-            "component": "@theme/DocRoot",
-            "exact": false,
-            "path": "/docs/1.0.0",
-            "routes": [
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md",
-                },
-                "path": "/docs/1.0.0/",
-                "sidebar": "version-1.0.0/docs",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-1.0.0/foo/bar.md",
-                },
-                "path": "/docs/1.0.0/foo/barSlug",
-                "sidebar": "version-1.0.0/docs",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-1.0.0/foo/baz.md",
-                },
-                "path": "/docs/1.0.0/foo/baz",
-                "sidebar": "version-1.0.0/docs",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        "component": "@theme/DocVersionRoot",
-        "exact": false,
-        "modules": {
-          "version": "~docs/version-current-metadata-prop-751.json",
-        },
-        "path": "/docs/next",
-        "priority": undefined,
-        "routes": [
-          {
-            "component": "@theme/DocTagsListPage",
-            "exact": true,
-            "modules": {
-              "tags": "~docs/tags-list-current-prop-15a.json",
-            },
-            "path": "/docs/next/tags",
-          },
-          {
-            "component": "@theme/DocTagDocListPage",
-            "exact": true,
-            "modules": {
-              "tag": "~docs/tag-docs-next-tags-bar-tag-1-a8f.json",
-            },
-            "path": "/docs/next/tags/bar-tag-1",
-          },
-          {
-            "component": "@theme/DocTagDocListPage",
-            "exact": true,
-            "modules": {
-              "tag": "~docs/tag-docs-next-tags-bar-tag-2-216.json",
-            },
-            "path": "/docs/next/tags/bar-tag-2",
-          },
-          {
-            "component": "@theme/DocTagDocListPage",
-            "exact": true,
-            "modules": {
-              "tag": "~docs/tag-docs-next-tags-bar-tag-3-permalink-94a.json",
-            },
-            "path": "/docs/next/tags/barTag-3-permalink",
-          },
-          {
-            "component": "@theme/DocRoot",
-            "exact": false,
-            "path": "/docs/next",
-            "routes": [
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/docs/hello.md",
-                },
-                "path": "/docs/next/",
-                "sidebar": "docs",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/docs/slugs/absoluteSlug.md",
-                },
-                "path": "/docs/next/absoluteSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/docs/foo/bar.md",
-                },
-                "path": "/docs/next/foo/barSlug",
-                "sidebar": "docs",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/docs/slugs/resolvedSlug.md",
-                },
-                "path": "/docs/next/slugs/hey/resolvedSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/docs/slugs/relativeSlug.md",
-                },
-                "path": "/docs/next/slugs/relativeSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/docs/slugs/tryToEscapeSlug.md",
-                },
-                "path": "/docs/next/tryToEscapeSlug",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        "component": "@theme/DocVersionRoot",
-        "exact": false,
-        "modules": {
-          "version": "~docs/version-with-slugs-metadata-prop-2bf.json",
-        },
-        "path": "/docs/withSlugs",
-        "priority": undefined,
-        "routes": [
-          {
-            "component": "@theme/DocRoot",
-            "exact": false,
-            "path": "/docs/withSlugs",
-            "routes": [
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/slugs/absoluteSlug.md",
-                },
-                "path": "/docs/withSlugs/absoluteSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/rootResolvedSlug.md",
-                },
-                "path": "/docs/withSlugs/hey/rootResolvedSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/rootAbsoluteSlug.md",
-                },
-                "path": "/docs/withSlugs/rootAbsoluteSlug",
-                "sidebar": "version-1.0.1/docs",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/rootRelativeSlug.md",
-                },
-                "path": "/docs/withSlugs/rootRelativeSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/rootTryToEscapeSlug.md",
-                },
-                "path": "/docs/withSlugs/rootTryToEscapeSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/slugs/resolvedSlug.md",
-                },
-                "path": "/docs/withSlugs/slugs/hey/resolvedSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/slugs/relativeSlug.md",
-                },
-                "path": "/docs/withSlugs/slugs/relativeSlug",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-withSlugs/slugs/tryToEscapeSlug.md",
-                },
-                "path": "/docs/withSlugs/tryToEscapeSlug",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        "component": "@theme/DocVersionRoot",
-        "exact": false,
-        "modules": {
-          "version": "~docs/version-1-0-1-metadata-prop-e87.json",
-        },
-        "path": "/docs",
-        "priority": -1,
-        "routes": [
-          {
-            "component": "@theme/DocRoot",
-            "exact": false,
-            "path": "/docs",
-            "routes": [
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-1.0.1/hello.md",
-                },
-                "path": "/docs/",
-                "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
-              },
-              {
-                "component": "@theme/DocItem",
-                "exact": true,
-                "modules": {
-                  "content": "@site/versioned_docs/version-1.0.1/foo/bar.md",
-                },
-                "path": "/docs/foo/bar",
-                "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-]
-`;
-
-exports[`versioned website content: withSlugs version sidebars 1`] = `
-{
-  "version-1.0.1/docs": [
-    {
-      "collapsed": true,
-      "collapsible": true,
-      "items": [
-        {
-          "id": "version-withSlugs/rootAbsoluteSlug",
-          "type": "doc",
-        },
-      ],
-      "label": "Test",
-      "link": undefined,
-      "type": "category",
-    },
-  ],
 }
 `;
 

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -2733,7 +2733,6 @@ exports[`versioned website (community) content 1`] = `
   "tags": [],
   "title": "Team title translated",
   "unlisted": false,
-  "unversionedId": "team",
   "version": "current",
 }
 `;
@@ -2745,7 +2744,7 @@ exports[`versioned website (community) content 2`] = `
   "editUrl": undefined,
   "formattedLastUpdatedAt": undefined,
   "frontMatter": {},
-  "id": "version-1.0.0/team",
+  "id": "team",
   "lastUpdatedAt": undefined,
   "lastUpdatedBy": undefined,
   "next": undefined,
@@ -2759,9 +2758,250 @@ exports[`versioned website (community) content 2`] = `
   "tags": [],
   "title": "team",
   "unlisted": false,
-  "unversionedId": "team",
   "version": "1.0.0",
 }
+`;
+
+exports[`versioned website (community) content: 100 version sidebars 1`] = `
+{
+  "version-1.0.0/community": [
+    {
+      "id": "team",
+      "type": "doc",
+    },
+  ],
+}
+`;
+
+exports[`versioned website (community) content: current version sidebars 1`] = `
+{
+  "community": [
+    {
+      "id": "team",
+      "type": "doc",
+    },
+  ],
+}
+`;
+
+exports[`versioned website (community) content: data 1`] = `
+{
+  "site-community-versioned-docs-version-1-0-0-team-md-359.json": "{
+  "id": "team",
+  "title": "team",
+  "description": "Team 1.0.0",
+  "source": "@site/community_versioned_docs/version-1.0.0/team.md",
+  "sourceDirName": ".",
+  "slug": "/team",
+  "permalink": "/community/team",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "1.0.0",
+  "frontMatter": {},
+  "sidebar": "version-1.0.0/community"
+}",
+  "site-i-18-n-en-docusaurus-plugin-content-docs-community-current-team-md-7e5.json": "{
+  "id": "team",
+  "title": "Team title translated",
+  "description": "Team current version (translated)",
+  "source": "@site/i18n/en/docusaurus-plugin-content-docs-community/current/team.md",
+  "sourceDirName": ".",
+  "slug": "/team",
+  "permalink": "/community/next/team",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "current",
+  "frontMatter": {
+    "title": "Team title translated"
+  },
+  "sidebar": "community"
+}",
+  "version-1-0-0-metadata-prop-608.json": "{
+  "pluginId": "community",
+  "version": "1.0.0",
+  "label": "1.0.0",
+  "banner": null,
+  "badge": true,
+  "noIndex": false,
+  "className": "docs-version-1.0.0",
+  "isLast": true,
+  "docsSidebars": {
+    "version-1.0.0/community": [
+      {
+        "type": "link",
+        "label": "team",
+        "href": "/community/team",
+        "docId": "team",
+        "unlisted": false
+      }
+    ]
+  },
+  "docs": {
+    "team": {
+      "id": "team",
+      "title": "team",
+      "description": "Team 1.0.0",
+      "sidebar": "version-1.0.0/community"
+    }
+  }
+}",
+  "version-current-metadata-prop-751.json": "{
+  "pluginId": "community",
+  "version": "current",
+  "label": "Next",
+  "banner": "unreleased",
+  "badge": true,
+  "noIndex": false,
+  "className": "docs-version-current",
+  "isLast": false,
+  "docsSidebars": {
+    "community": [
+      {
+        "type": "link",
+        "label": "Team title translated",
+        "href": "/community/next/team",
+        "docId": "team",
+        "unlisted": false
+      }
+    ]
+  },
+  "docs": {
+    "team": {
+      "id": "team",
+      "title": "Team title translated",
+      "description": "Team current version (translated)",
+      "sidebar": "community"
+    }
+  }
+}",
+}
+`;
+
+exports[`versioned website (community) content: global data 1`] = `
+{
+  "pluginName": {
+    "pluginId": {
+      "breadcrumbs": true,
+      "path": "/community",
+      "versions": [
+        {
+          "docs": [
+            {
+              "id": "team",
+              "path": "/community/next/team",
+              "sidebar": "community",
+            },
+          ],
+          "draftIds": [],
+          "isLast": false,
+          "label": "Next",
+          "mainDocId": "team",
+          "name": "current",
+          "path": "/community/next",
+          "sidebars": {
+            "community": {
+              "link": {
+                "label": "team",
+                "path": "/community/next/team",
+              },
+            },
+          },
+        },
+        {
+          "docs": [
+            {
+              "id": "team",
+              "path": "/community/team",
+              "sidebar": "version-1.0.0/community",
+            },
+          ],
+          "draftIds": [],
+          "isLast": true,
+          "label": "1.0.0",
+          "mainDocId": "team",
+          "name": "1.0.0",
+          "path": "/community",
+          "sidebars": {
+            "version-1.0.0/community": {
+              "link": {
+                "label": "team",
+                "path": "/community/team",
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`versioned website (community) content: route config 1`] = `
+[
+  {
+    "component": "@theme/DocsRoot",
+    "exact": false,
+    "path": "/community",
+    "routes": [
+      {
+        "component": "@theme/DocVersionRoot",
+        "exact": false,
+        "modules": {
+          "version": "~docs/version-current-metadata-prop-751.json",
+        },
+        "path": "/community/next",
+        "priority": undefined,
+        "routes": [
+          {
+            "component": "@theme/DocRoot",
+            "exact": false,
+            "path": "/community/next",
+            "routes": [
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/i18n/en/docusaurus-plugin-content-docs-community/current/team.md",
+                },
+                "path": "/community/next/team",
+                "sidebar": "community",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "component": "@theme/DocVersionRoot",
+        "exact": false,
+        "modules": {
+          "version": "~docs/version-1-0-0-metadata-prop-608.json",
+        },
+        "path": "/community",
+        "priority": -1,
+        "routes": [
+          {
+            "component": "@theme/DocRoot",
+            "exact": false,
+            "path": "/community",
+            "routes": [
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/community_versioned_docs/version-1.0.0/team.md",
+                },
+                "path": "/community/team",
+                "sidebar": "version-1.0.0/community",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
 `;
 
 exports[`versioned website (community) getPathToWatch 1`] = `
@@ -2824,7 +3064,6 @@ exports[`versioned website content 1`] = `
   ],
   "title": "bar",
   "unlisted": false,
-  "unversionedId": "foo/bar",
   "version": "current",
 }
 `;
@@ -2836,7 +3075,7 @@ exports[`versioned website content 2`] = `
   "editUrl": undefined,
   "formattedLastUpdatedAt": undefined,
   "frontMatter": {},
-  "id": "version-1.0.1/foo/bar",
+  "id": "foo/bar",
   "lastUpdatedAt": undefined,
   "lastUpdatedBy": undefined,
   "next": {
@@ -2853,7 +3092,6 @@ exports[`versioned website content 2`] = `
   "tags": [],
   "title": "bar",
   "unlisted": false,
-  "unversionedId": "foo/bar",
   "version": "1.0.1",
 }
 `;
@@ -2884,7 +3122,6 @@ exports[`versioned website content 3`] = `
   "tags": [],
   "title": "hello",
   "unlisted": false,
-  "unversionedId": "hello",
   "version": "current",
 }
 `;
@@ -2898,7 +3135,7 @@ exports[`versioned website content 4`] = `
   "frontMatter": {
     "slug": "/",
   },
-  "id": "version-1.0.1/hello",
+  "id": "hello",
   "lastUpdatedAt": undefined,
   "lastUpdatedBy": undefined,
   "next": undefined,
@@ -2915,7 +3152,6 @@ exports[`versioned website content 4`] = `
   "tags": [],
   "title": "hello",
   "unlisted": false,
-  "unversionedId": "hello",
   "version": "1.0.1",
 }
 `;
@@ -2927,7 +3163,7 @@ exports[`versioned website content 5`] = `
   "editUrl": undefined,
   "formattedLastUpdatedAt": undefined,
   "frontMatter": {},
-  "id": "version-1.0.0/foo/baz",
+  "id": "foo/baz",
   "lastUpdatedAt": undefined,
   "lastUpdatedBy": undefined,
   "next": {
@@ -2947,8 +3183,1293 @@ exports[`versioned website content 5`] = `
   "tags": [],
   "title": "baz",
   "unlisted": false,
-  "unversionedId": "foo/baz",
   "version": "1.0.0",
+}
+`;
+
+exports[`versioned website content: 100 version sidebars 1`] = `
+{
+  "version-1.0.0/docs": [
+    {
+      "collapsed": true,
+      "collapsible": true,
+      "items": [
+        {
+          "id": "foo/bar",
+          "type": "doc",
+        },
+        {
+          "id": "foo/baz",
+          "type": "doc",
+        },
+      ],
+      "label": "Test",
+      "link": undefined,
+      "type": "category",
+    },
+    {
+      "collapsed": true,
+      "collapsible": true,
+      "items": [
+        {
+          "id": "hello",
+          "type": "doc",
+        },
+      ],
+      "label": "Guides",
+      "link": undefined,
+      "type": "category",
+    },
+  ],
+}
+`;
+
+exports[`versioned website content: 101 version sidebars 1`] = `
+{
+  "VersionedSideBarNameDoesNotMatter/docs": [
+    {
+      "collapsed": true,
+      "collapsible": true,
+      "items": [
+        {
+          "id": "foo/bar",
+          "type": "doc",
+        },
+      ],
+      "label": "Test",
+      "link": undefined,
+      "type": "category",
+    },
+    {
+      "collapsed": true,
+      "collapsible": true,
+      "items": [
+        {
+          "id": "hello",
+          "type": "doc",
+        },
+      ],
+      "label": "Guides",
+      "link": undefined,
+      "type": "category",
+    },
+  ],
+}
+`;
+
+exports[`versioned website content: current version sidebars 1`] = `
+{
+  "docs": [
+    {
+      "collapsed": true,
+      "collapsible": true,
+      "items": [
+        {
+          "id": "foo/bar",
+          "type": "doc",
+        },
+      ],
+      "label": "Test",
+      "link": undefined,
+      "type": "category",
+    },
+    {
+      "collapsed": true,
+      "collapsible": true,
+      "items": [
+        {
+          "id": "hello",
+          "type": "doc",
+        },
+      ],
+      "label": "Guides",
+      "link": undefined,
+      "type": "category",
+    },
+  ],
+}
+`;
+
+exports[`versioned website content: data 1`] = `
+{
+  "site-docs-foo-bar-md-8c2.json": "{
+  "id": "foo/bar",
+  "title": "bar",
+  "description": "This is next version of bar.",
+  "source": "@site/docs/foo/bar.md",
+  "sourceDirName": "foo",
+  "slug": "/foo/barSlug",
+  "permalink": "/docs/next/foo/barSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [
+    {
+      "label": "barTag 1",
+      "permalink": "/docs/next/tags/bar-tag-1"
+    },
+    {
+      "label": "barTag-2",
+      "permalink": "/docs/next/tags/bar-tag-2"
+    },
+    {
+      "label": "barTag 3",
+      "permalink": "/docs/next/tags/barTag-3-permalink"
+    }
+  ],
+  "version": "current",
+  "frontMatter": {
+    "slug": "barSlug",
+    "tags": [
+      "barTag 1",
+      "barTag-2",
+      {
+        "label": "barTag 3",
+        "permalink": "barTag-3-permalink"
+      }
+    ]
+  },
+  "sidebar": "docs",
+  "next": {
+    "title": "hello",
+    "permalink": "/docs/next/"
+  }
+}",
+  "site-docs-hello-md-9df.json": "{
+  "id": "hello",
+  "title": "hello",
+  "description": "Hello next !",
+  "source": "@site/docs/hello.md",
+  "sourceDirName": ".",
+  "slug": "/",
+  "permalink": "/docs/next/",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "current",
+  "frontMatter": {
+    "slug": "/"
+  },
+  "sidebar": "docs",
+  "previous": {
+    "title": "bar",
+    "permalink": "/docs/next/foo/barSlug"
+  }
+}",
+  "site-docs-slugs-absolute-slug-md-4e8.json": "{
+  "id": "slugs/absoluteSlug",
+  "title": "absoluteSlug",
+  "description": "Lorem",
+  "source": "@site/docs/slugs/absoluteSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/absoluteSlug",
+  "permalink": "/docs/next/absoluteSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "current",
+  "frontMatter": {
+    "slug": "/absoluteSlug"
+  }
+}",
+  "site-docs-slugs-relative-slug-md-d1c.json": "{
+  "id": "slugs/relativeSlug",
+  "title": "relativeSlug",
+  "description": "Lorem",
+  "source": "@site/docs/slugs/relativeSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/slugs/relativeSlug",
+  "permalink": "/docs/next/slugs/relativeSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "current",
+  "frontMatter": {
+    "slug": "relativeSlug"
+  }
+}",
+  "site-docs-slugs-resolved-slug-md-02b.json": "{
+  "id": "slugs/resolvedSlug",
+  "title": "resolvedSlug",
+  "description": "Lorem",
+  "source": "@site/docs/slugs/resolvedSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/slugs/hey/resolvedSlug",
+  "permalink": "/docs/next/slugs/hey/resolvedSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "current",
+  "frontMatter": {
+    "slug": "./hey/ho/../resolvedSlug"
+  }
+}",
+  "site-docs-slugs-try-to-escape-slug-md-70d.json": "{
+  "id": "slugs/tryToEscapeSlug",
+  "title": "tryToEscapeSlug",
+  "description": "Lorem",
+  "source": "@site/docs/slugs/tryToEscapeSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/tryToEscapeSlug",
+  "permalink": "/docs/next/tryToEscapeSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "current",
+  "frontMatter": {
+    "slug": "../../../../../../../../tryToEscapeSlug"
+  }
+}",
+  "site-i-18-n-en-docusaurus-plugin-content-docs-version-1-0-0-hello-md-fe5.json": "{
+  "id": "hello",
+  "title": "hello",
+  "description": "Hello 1.0.0 ! (translated en)",
+  "source": "@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md",
+  "sourceDirName": ".",
+  "slug": "/",
+  "permalink": "/docs/1.0.0/",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "1.0.0",
+  "frontMatter": {
+    "slug": "/"
+  },
+  "sidebar": "version-1.0.0/docs",
+  "previous": {
+    "title": "baz",
+    "permalink": "/docs/1.0.0/foo/baz"
+  }
+}",
+  "site-versioned-docs-version-1-0-0-foo-bar-md-7a6.json": "{
+  "id": "foo/bar",
+  "title": "bar",
+  "description": "Bar 1.0.0 !",
+  "source": "@site/versioned_docs/version-1.0.0/foo/bar.md",
+  "sourceDirName": "foo",
+  "slug": "/foo/barSlug",
+  "permalink": "/docs/1.0.0/foo/barSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "1.0.0",
+  "frontMatter": {
+    "slug": "barSlug"
+  },
+  "sidebar": "version-1.0.0/docs",
+  "next": {
+    "title": "baz",
+    "permalink": "/docs/1.0.0/foo/baz"
+  }
+}",
+  "site-versioned-docs-version-1-0-0-foo-baz-md-883.json": "{
+  "id": "foo/baz",
+  "title": "baz",
+  "description": "Baz 1.0.0 ! This will be deleted in next subsequent versions.",
+  "source": "@site/versioned_docs/version-1.0.0/foo/baz.md",
+  "sourceDirName": "foo",
+  "slug": "/foo/baz",
+  "permalink": "/docs/1.0.0/foo/baz",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "1.0.0",
+  "frontMatter": {},
+  "sidebar": "version-1.0.0/docs",
+  "previous": {
+    "title": "bar",
+    "permalink": "/docs/1.0.0/foo/barSlug"
+  },
+  "next": {
+    "title": "hello",
+    "permalink": "/docs/1.0.0/"
+  }
+}",
+  "site-versioned-docs-version-1-0-1-foo-bar-md-7a3.json": "{
+  "id": "foo/bar",
+  "title": "bar",
+  "description": "Bar 1.0.1 !",
+  "source": "@site/versioned_docs/version-1.0.1/foo/bar.md",
+  "sourceDirName": "foo",
+  "slug": "/foo/bar",
+  "permalink": "/docs/foo/bar",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "1.0.1",
+  "frontMatter": {},
+  "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
+  "next": {
+    "title": "hello",
+    "permalink": "/docs/"
+  }
+}",
+  "site-versioned-docs-version-1-0-1-hello-md-0c7.json": "{
+  "id": "hello",
+  "title": "hello",
+  "description": "Hello 1.0.1 !",
+  "source": "@site/versioned_docs/version-1.0.1/hello.md",
+  "sourceDirName": ".",
+  "slug": "/",
+  "permalink": "/docs/",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "1.0.1",
+  "frontMatter": {
+    "slug": "/"
+  },
+  "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
+  "previous": {
+    "title": "bar",
+    "permalink": "/docs/foo/bar"
+  }
+}",
+  "site-versioned-docs-version-with-slugs-root-absolute-slug-md-4d2.json": "{
+  "id": "rootAbsoluteSlug",
+  "title": "rootAbsoluteSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/rootAbsoluteSlug.md",
+  "sourceDirName": ".",
+  "slug": "/rootAbsoluteSlug",
+  "permalink": "/docs/withSlugs/rootAbsoluteSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "/rootAbsoluteSlug"
+  },
+  "sidebar": "version-1.0.1/docs"
+}",
+  "site-versioned-docs-version-with-slugs-root-relative-slug-md-32a.json": "{
+  "id": "rootRelativeSlug",
+  "title": "rootRelativeSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/rootRelativeSlug.md",
+  "sourceDirName": ".",
+  "slug": "/rootRelativeSlug",
+  "permalink": "/docs/withSlugs/rootRelativeSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "rootRelativeSlug"
+  }
+}",
+  "site-versioned-docs-version-with-slugs-root-resolved-slug-md-aee.json": "{
+  "id": "rootResolvedSlug",
+  "title": "rootResolvedSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/rootResolvedSlug.md",
+  "sourceDirName": ".",
+  "slug": "/hey/rootResolvedSlug",
+  "permalink": "/docs/withSlugs/hey/rootResolvedSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "./hey/ho/../rootResolvedSlug"
+  }
+}",
+  "site-versioned-docs-version-with-slugs-root-try-to-escape-slug-md-b5d.json": "{
+  "id": "rootTryToEscapeSlug",
+  "title": "rootTryToEscapeSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/rootTryToEscapeSlug.md",
+  "sourceDirName": ".",
+  "slug": "/rootTryToEscapeSlug",
+  "permalink": "/docs/withSlugs/rootTryToEscapeSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "../../../../../../../../rootTryToEscapeSlug"
+  }
+}",
+  "site-versioned-docs-version-with-slugs-slugs-absolute-slug-md-47a.json": "{
+  "id": "slugs/absoluteSlug",
+  "title": "absoluteSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/slugs/absoluteSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/absoluteSlug",
+  "permalink": "/docs/withSlugs/absoluteSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "/absoluteSlug"
+  }
+}",
+  "site-versioned-docs-version-with-slugs-slugs-relative-slug-md-a95.json": "{
+  "id": "slugs/relativeSlug",
+  "title": "relativeSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/slugs/relativeSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/slugs/relativeSlug",
+  "permalink": "/docs/withSlugs/slugs/relativeSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "relativeSlug"
+  }
+}",
+  "site-versioned-docs-version-with-slugs-slugs-resolved-slug-md-5a1.json": "{
+  "id": "slugs/resolvedSlug",
+  "title": "resolvedSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/slugs/resolvedSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/slugs/hey/resolvedSlug",
+  "permalink": "/docs/withSlugs/slugs/hey/resolvedSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "./hey/ho/../resolvedSlug"
+  }
+}",
+  "site-versioned-docs-version-with-slugs-slugs-try-to-escape-slug-md-4e1.json": "{
+  "id": "slugs/tryToEscapeSlug",
+  "title": "tryToEscapeSlug",
+  "description": "Lorem",
+  "source": "@site/versioned_docs/version-withSlugs/slugs/tryToEscapeSlug.md",
+  "sourceDirName": "slugs",
+  "slug": "/tryToEscapeSlug",
+  "permalink": "/docs/withSlugs/tryToEscapeSlug",
+  "draft": false,
+  "unlisted": false,
+  "tags": [],
+  "version": "withSlugs",
+  "frontMatter": {
+    "slug": "../../../../../../../../tryToEscapeSlug"
+  }
+}",
+  "tag-docs-next-tags-bar-tag-1-a8f.json": "{
+  "label": "barTag 1",
+  "permalink": "/docs/next/tags/bar-tag-1",
+  "allTagsPath": "/docs/next/tags",
+  "count": 1,
+  "items": [
+    {
+      "id": "foo/bar",
+      "title": "bar",
+      "description": "This is next version of bar.",
+      "permalink": "/docs/next/foo/barSlug"
+    }
+  ],
+  "unlisted": false
+}",
+  "tag-docs-next-tags-bar-tag-2-216.json": "{
+  "label": "barTag-2",
+  "permalink": "/docs/next/tags/bar-tag-2",
+  "allTagsPath": "/docs/next/tags",
+  "count": 1,
+  "items": [
+    {
+      "id": "foo/bar",
+      "title": "bar",
+      "description": "This is next version of bar.",
+      "permalink": "/docs/next/foo/barSlug"
+    }
+  ],
+  "unlisted": false
+}",
+  "tag-docs-next-tags-bar-tag-3-permalink-94a.json": "{
+  "label": "barTag 3",
+  "permalink": "/docs/next/tags/barTag-3-permalink",
+  "allTagsPath": "/docs/next/tags",
+  "count": 1,
+  "items": [
+    {
+      "id": "foo/bar",
+      "title": "bar",
+      "description": "This is next version of bar.",
+      "permalink": "/docs/next/foo/barSlug"
+    }
+  ],
+  "unlisted": false
+}",
+  "tags-list-current-prop-15a.json": "[
+  {
+    "label": "barTag 1",
+    "permalink": "/docs/next/tags/bar-tag-1",
+    "count": 1
+  },
+  {
+    "label": "barTag-2",
+    "permalink": "/docs/next/tags/bar-tag-2",
+    "count": 1
+  },
+  {
+    "label": "barTag 3",
+    "permalink": "/docs/next/tags/barTag-3-permalink",
+    "count": 1
+  }
+]",
+  "version-1-0-0-metadata-prop-608.json": "{
+  "pluginId": "default",
+  "version": "1.0.0",
+  "label": "1.0.0",
+  "banner": "unmaintained",
+  "badge": true,
+  "noIndex": false,
+  "className": "docs-version-1.0.0",
+  "isLast": false,
+  "docsSidebars": {
+    "version-1.0.0/docs": [
+      {
+        "type": "category",
+        "label": "Test",
+        "items": [
+          {
+            "type": "link",
+            "label": "bar",
+            "href": "/docs/1.0.0/foo/barSlug",
+            "docId": "foo/bar",
+            "unlisted": false
+          },
+          {
+            "type": "link",
+            "label": "baz",
+            "href": "/docs/1.0.0/foo/baz",
+            "docId": "foo/baz",
+            "unlisted": false
+          }
+        ],
+        "collapsed": true,
+        "collapsible": true
+      },
+      {
+        "type": "category",
+        "label": "Guides",
+        "items": [
+          {
+            "type": "link",
+            "label": "hello",
+            "href": "/docs/1.0.0/",
+            "docId": "hello",
+            "unlisted": false
+          }
+        ],
+        "collapsed": true,
+        "collapsible": true
+      }
+    ]
+  },
+  "docs": {
+    "foo/bar": {
+      "id": "foo/bar",
+      "title": "bar",
+      "description": "Bar 1.0.0 !",
+      "sidebar": "version-1.0.0/docs"
+    },
+    "foo/baz": {
+      "id": "foo/baz",
+      "title": "baz",
+      "description": "Baz 1.0.0 ! This will be deleted in next subsequent versions.",
+      "sidebar": "version-1.0.0/docs"
+    },
+    "hello": {
+      "id": "hello",
+      "title": "hello",
+      "description": "Hello 1.0.0 ! (translated en)",
+      "sidebar": "version-1.0.0/docs"
+    }
+  }
+}",
+  "version-1-0-1-metadata-prop-e87.json": "{
+  "pluginId": "default",
+  "version": "1.0.1",
+  "label": "1.0.1",
+  "banner": null,
+  "badge": true,
+  "noIndex": true,
+  "className": "docs-version-1.0.1",
+  "isLast": true,
+  "docsSidebars": {
+    "VersionedSideBarNameDoesNotMatter/docs": [
+      {
+        "type": "category",
+        "label": "Test",
+        "items": [
+          {
+            "type": "link",
+            "label": "bar",
+            "href": "/docs/foo/bar",
+            "docId": "foo/bar",
+            "unlisted": false
+          }
+        ],
+        "collapsed": true,
+        "collapsible": true
+      },
+      {
+        "type": "category",
+        "label": "Guides",
+        "items": [
+          {
+            "type": "link",
+            "label": "hello",
+            "href": "/docs/",
+            "docId": "hello",
+            "unlisted": false
+          }
+        ],
+        "collapsed": true,
+        "collapsible": true
+      }
+    ]
+  },
+  "docs": {
+    "foo/bar": {
+      "id": "foo/bar",
+      "title": "bar",
+      "description": "Bar 1.0.1 !",
+      "sidebar": "VersionedSideBarNameDoesNotMatter/docs"
+    },
+    "hello": {
+      "id": "hello",
+      "title": "hello",
+      "description": "Hello 1.0.1 !",
+      "sidebar": "VersionedSideBarNameDoesNotMatter/docs"
+    }
+  }
+}",
+  "version-current-metadata-prop-751.json": "{
+  "pluginId": "default",
+  "version": "current",
+  "label": "Next",
+  "banner": "unreleased",
+  "badge": true,
+  "noIndex": false,
+  "className": "docs-version-current",
+  "isLast": false,
+  "docsSidebars": {
+    "docs": [
+      {
+        "type": "category",
+        "label": "Test",
+        "items": [
+          {
+            "type": "link",
+            "label": "bar",
+            "href": "/docs/next/foo/barSlug",
+            "docId": "foo/bar",
+            "unlisted": false
+          }
+        ],
+        "collapsed": true,
+        "collapsible": true
+      },
+      {
+        "type": "category",
+        "label": "Guides",
+        "items": [
+          {
+            "type": "link",
+            "label": "hello",
+            "href": "/docs/next/",
+            "docId": "hello",
+            "unlisted": false
+          }
+        ],
+        "collapsed": true,
+        "collapsible": true
+      }
+    ]
+  },
+  "docs": {
+    "foo/bar": {
+      "id": "foo/bar",
+      "title": "bar",
+      "description": "This is next version of bar.",
+      "sidebar": "docs"
+    },
+    "hello": {
+      "id": "hello",
+      "title": "hello",
+      "description": "Hello next !",
+      "sidebar": "docs"
+    },
+    "slugs/absoluteSlug": {
+      "id": "slugs/absoluteSlug",
+      "title": "absoluteSlug",
+      "description": "Lorem"
+    },
+    "slugs/relativeSlug": {
+      "id": "slugs/relativeSlug",
+      "title": "relativeSlug",
+      "description": "Lorem"
+    },
+    "slugs/resolvedSlug": {
+      "id": "slugs/resolvedSlug",
+      "title": "resolvedSlug",
+      "description": "Lorem"
+    },
+    "slugs/tryToEscapeSlug": {
+      "id": "slugs/tryToEscapeSlug",
+      "title": "tryToEscapeSlug",
+      "description": "Lorem"
+    }
+  }
+}",
+  "version-with-slugs-metadata-prop-2bf.json": "{
+  "pluginId": "default",
+  "version": "withSlugs",
+  "label": "withSlugs",
+  "banner": "unmaintained",
+  "badge": true,
+  "noIndex": false,
+  "className": "docs-version-withSlugs",
+  "isLast": false,
+  "docsSidebars": {
+    "version-1.0.1/docs": [
+      {
+        "type": "category",
+        "label": "Test",
+        "items": [
+          {
+            "type": "link",
+            "label": "rootAbsoluteSlug",
+            "href": "/docs/withSlugs/rootAbsoluteSlug",
+            "docId": "rootAbsoluteSlug",
+            "unlisted": false
+          }
+        ],
+        "collapsed": true,
+        "collapsible": true
+      }
+    ]
+  },
+  "docs": {
+    "rootAbsoluteSlug": {
+      "id": "rootAbsoluteSlug",
+      "title": "rootAbsoluteSlug",
+      "description": "Lorem",
+      "sidebar": "version-1.0.1/docs"
+    },
+    "rootRelativeSlug": {
+      "id": "rootRelativeSlug",
+      "title": "rootRelativeSlug",
+      "description": "Lorem"
+    },
+    "rootResolvedSlug": {
+      "id": "rootResolvedSlug",
+      "title": "rootResolvedSlug",
+      "description": "Lorem"
+    },
+    "rootTryToEscapeSlug": {
+      "id": "rootTryToEscapeSlug",
+      "title": "rootTryToEscapeSlug",
+      "description": "Lorem"
+    },
+    "slugs/absoluteSlug": {
+      "id": "slugs/absoluteSlug",
+      "title": "absoluteSlug",
+      "description": "Lorem"
+    },
+    "slugs/relativeSlug": {
+      "id": "slugs/relativeSlug",
+      "title": "relativeSlug",
+      "description": "Lorem"
+    },
+    "slugs/resolvedSlug": {
+      "id": "slugs/resolvedSlug",
+      "title": "resolvedSlug",
+      "description": "Lorem"
+    },
+    "slugs/tryToEscapeSlug": {
+      "id": "slugs/tryToEscapeSlug",
+      "title": "tryToEscapeSlug",
+      "description": "Lorem"
+    }
+  }
+}",
+}
+`;
+
+exports[`versioned website content: global data 1`] = `
+{
+  "pluginName": {
+    "pluginId": {
+      "breadcrumbs": true,
+      "path": "/docs",
+      "versions": [
+        {
+          "docs": [
+            {
+              "id": "foo/bar",
+              "path": "/docs/next/foo/barSlug",
+              "sidebar": "docs",
+            },
+            {
+              "id": "hello",
+              "path": "/docs/next/",
+              "sidebar": "docs",
+            },
+            {
+              "id": "slugs/absoluteSlug",
+              "path": "/docs/next/absoluteSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "slugs/relativeSlug",
+              "path": "/docs/next/slugs/relativeSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "slugs/resolvedSlug",
+              "path": "/docs/next/slugs/hey/resolvedSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "slugs/tryToEscapeSlug",
+              "path": "/docs/next/tryToEscapeSlug",
+              "sidebar": undefined,
+            },
+          ],
+          "draftIds": [],
+          "isLast": false,
+          "label": "Next",
+          "mainDocId": "hello",
+          "name": "current",
+          "path": "/docs/next",
+          "sidebars": {
+            "docs": {
+              "link": {
+                "label": "foo/bar",
+                "path": "/docs/next/foo/barSlug",
+              },
+            },
+          },
+        },
+        {
+          "docs": [
+            {
+              "id": "foo/bar",
+              "path": "/docs/foo/bar",
+              "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
+            },
+            {
+              "id": "hello",
+              "path": "/docs/",
+              "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
+            },
+          ],
+          "draftIds": [],
+          "isLast": true,
+          "label": "1.0.1",
+          "mainDocId": "hello",
+          "name": "1.0.1",
+          "path": "/docs",
+          "sidebars": {
+            "VersionedSideBarNameDoesNotMatter/docs": {
+              "link": {
+                "label": "foo/bar",
+                "path": "/docs/foo/bar",
+              },
+            },
+          },
+        },
+        {
+          "docs": [
+            {
+              "id": "foo/bar",
+              "path": "/docs/1.0.0/foo/barSlug",
+              "sidebar": "version-1.0.0/docs",
+            },
+            {
+              "id": "foo/baz",
+              "path": "/docs/1.0.0/foo/baz",
+              "sidebar": "version-1.0.0/docs",
+            },
+            {
+              "id": "hello",
+              "path": "/docs/1.0.0/",
+              "sidebar": "version-1.0.0/docs",
+            },
+          ],
+          "draftIds": [],
+          "isLast": false,
+          "label": "1.0.0",
+          "mainDocId": "hello",
+          "name": "1.0.0",
+          "path": "/docs/1.0.0",
+          "sidebars": {
+            "version-1.0.0/docs": {
+              "link": {
+                "label": "foo/bar",
+                "path": "/docs/1.0.0/foo/barSlug",
+              },
+            },
+          },
+        },
+        {
+          "docs": [
+            {
+              "id": "rootAbsoluteSlug",
+              "path": "/docs/withSlugs/rootAbsoluteSlug",
+              "sidebar": "version-1.0.1/docs",
+            },
+            {
+              "id": "rootRelativeSlug",
+              "path": "/docs/withSlugs/rootRelativeSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "rootResolvedSlug",
+              "path": "/docs/withSlugs/hey/rootResolvedSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "rootTryToEscapeSlug",
+              "path": "/docs/withSlugs/rootTryToEscapeSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "slugs/absoluteSlug",
+              "path": "/docs/withSlugs/absoluteSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "slugs/relativeSlug",
+              "path": "/docs/withSlugs/slugs/relativeSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "slugs/resolvedSlug",
+              "path": "/docs/withSlugs/slugs/hey/resolvedSlug",
+              "sidebar": undefined,
+            },
+            {
+              "id": "slugs/tryToEscapeSlug",
+              "path": "/docs/withSlugs/tryToEscapeSlug",
+              "sidebar": undefined,
+            },
+          ],
+          "draftIds": [],
+          "isLast": false,
+          "label": "withSlugs",
+          "mainDocId": "rootAbsoluteSlug",
+          "name": "withSlugs",
+          "path": "/docs/withSlugs",
+          "sidebars": {
+            "version-1.0.1/docs": {
+              "link": {
+                "label": "rootAbsoluteSlug",
+                "path": "/docs/withSlugs/rootAbsoluteSlug",
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`versioned website content: route config 1`] = `
+[
+  {
+    "component": "@theme/DocsRoot",
+    "exact": false,
+    "path": "/docs",
+    "routes": [
+      {
+        "component": "@theme/DocVersionRoot",
+        "exact": false,
+        "modules": {
+          "version": "~docs/version-1-0-0-metadata-prop-608.json",
+        },
+        "path": "/docs/1.0.0",
+        "priority": undefined,
+        "routes": [
+          {
+            "component": "@theme/DocRoot",
+            "exact": false,
+            "path": "/docs/1.0.0",
+            "routes": [
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md",
+                },
+                "path": "/docs/1.0.0/",
+                "sidebar": "version-1.0.0/docs",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-1.0.0/foo/bar.md",
+                },
+                "path": "/docs/1.0.0/foo/barSlug",
+                "sidebar": "version-1.0.0/docs",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-1.0.0/foo/baz.md",
+                },
+                "path": "/docs/1.0.0/foo/baz",
+                "sidebar": "version-1.0.0/docs",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "component": "@theme/DocVersionRoot",
+        "exact": false,
+        "modules": {
+          "version": "~docs/version-current-metadata-prop-751.json",
+        },
+        "path": "/docs/next",
+        "priority": undefined,
+        "routes": [
+          {
+            "component": "@theme/DocTagsListPage",
+            "exact": true,
+            "modules": {
+              "tags": "~docs/tags-list-current-prop-15a.json",
+            },
+            "path": "/docs/next/tags",
+          },
+          {
+            "component": "@theme/DocTagDocListPage",
+            "exact": true,
+            "modules": {
+              "tag": "~docs/tag-docs-next-tags-bar-tag-1-a8f.json",
+            },
+            "path": "/docs/next/tags/bar-tag-1",
+          },
+          {
+            "component": "@theme/DocTagDocListPage",
+            "exact": true,
+            "modules": {
+              "tag": "~docs/tag-docs-next-tags-bar-tag-2-216.json",
+            },
+            "path": "/docs/next/tags/bar-tag-2",
+          },
+          {
+            "component": "@theme/DocTagDocListPage",
+            "exact": true,
+            "modules": {
+              "tag": "~docs/tag-docs-next-tags-bar-tag-3-permalink-94a.json",
+            },
+            "path": "/docs/next/tags/barTag-3-permalink",
+          },
+          {
+            "component": "@theme/DocRoot",
+            "exact": false,
+            "path": "/docs/next",
+            "routes": [
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/docs/hello.md",
+                },
+                "path": "/docs/next/",
+                "sidebar": "docs",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/docs/slugs/absoluteSlug.md",
+                },
+                "path": "/docs/next/absoluteSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/docs/foo/bar.md",
+                },
+                "path": "/docs/next/foo/barSlug",
+                "sidebar": "docs",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/docs/slugs/resolvedSlug.md",
+                },
+                "path": "/docs/next/slugs/hey/resolvedSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/docs/slugs/relativeSlug.md",
+                },
+                "path": "/docs/next/slugs/relativeSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/docs/slugs/tryToEscapeSlug.md",
+                },
+                "path": "/docs/next/tryToEscapeSlug",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "component": "@theme/DocVersionRoot",
+        "exact": false,
+        "modules": {
+          "version": "~docs/version-with-slugs-metadata-prop-2bf.json",
+        },
+        "path": "/docs/withSlugs",
+        "priority": undefined,
+        "routes": [
+          {
+            "component": "@theme/DocRoot",
+            "exact": false,
+            "path": "/docs/withSlugs",
+            "routes": [
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/slugs/absoluteSlug.md",
+                },
+                "path": "/docs/withSlugs/absoluteSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/rootResolvedSlug.md",
+                },
+                "path": "/docs/withSlugs/hey/rootResolvedSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/rootAbsoluteSlug.md",
+                },
+                "path": "/docs/withSlugs/rootAbsoluteSlug",
+                "sidebar": "version-1.0.1/docs",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/rootRelativeSlug.md",
+                },
+                "path": "/docs/withSlugs/rootRelativeSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/rootTryToEscapeSlug.md",
+                },
+                "path": "/docs/withSlugs/rootTryToEscapeSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/slugs/resolvedSlug.md",
+                },
+                "path": "/docs/withSlugs/slugs/hey/resolvedSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/slugs/relativeSlug.md",
+                },
+                "path": "/docs/withSlugs/slugs/relativeSlug",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-withSlugs/slugs/tryToEscapeSlug.md",
+                },
+                "path": "/docs/withSlugs/tryToEscapeSlug",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        "component": "@theme/DocVersionRoot",
+        "exact": false,
+        "modules": {
+          "version": "~docs/version-1-0-1-metadata-prop-e87.json",
+        },
+        "path": "/docs",
+        "priority": -1,
+        "routes": [
+          {
+            "component": "@theme/DocRoot",
+            "exact": false,
+            "path": "/docs",
+            "routes": [
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-1.0.1/hello.md",
+                },
+                "path": "/docs/",
+                "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
+              },
+              {
+                "component": "@theme/DocItem",
+                "exact": true,
+                "modules": {
+                  "content": "@site/versioned_docs/version-1.0.1/foo/bar.md",
+                },
+                "path": "/docs/foo/bar",
+                "sidebar": "VersionedSideBarNameDoesNotMatter/docs",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
+exports[`versioned website content: withSlugs version sidebars 1`] = `
+{
+  "version-1.0.1/docs": [
+    {
+      "collapsed": true,
+      "collapsible": true,
+      "items": [
+        {
+          "id": "rootAbsoluteSlug",
+          "type": "doc",
+        },
+      ],
+      "label": "Test",
+      "link": undefined,
+      "type": "category",
+    },
+  ],
 }
 `;
 

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -2750,7 +2750,7 @@ exports[`versioned website (community) content 2`] = `
   "next": undefined,
   "permalink": "/community/team",
   "previous": undefined,
-  "sidebar": "version-1.0.0/community",
+  "sidebar": "community",
   "sidebarPosition": undefined,
   "slug": "/team",
   "source": "@site/community_versioned_docs/version-1.0.0/team.md",
@@ -2764,7 +2764,7 @@ exports[`versioned website (community) content 2`] = `
 
 exports[`versioned website (community) content: 100 version sidebars 1`] = `
 {
-  "version-1.0.0/community": [
+  "community": [
     {
       "id": "team",
       "type": "doc",
@@ -2799,7 +2799,7 @@ exports[`versioned website (community) content: data 1`] = `
   "tags": [],
   "version": "1.0.0",
   "frontMatter": {},
-  "sidebar": "version-1.0.0/community"
+  "sidebar": "community"
 }",
   "site-i-18-n-en-docusaurus-plugin-content-docs-community-current-team-md-7e5.json": "{
   "id": "team",
@@ -2828,7 +2828,7 @@ exports[`versioned website (community) content: data 1`] = `
   "className": "docs-version-1.0.0",
   "isLast": true,
   "docsSidebars": {
-    "version-1.0.0/community": [
+    "community": [
       {
         "type": "link",
         "label": "team",
@@ -2843,7 +2843,7 @@ exports[`versioned website (community) content: data 1`] = `
       "id": "team",
       "title": "team",
       "description": "Team 1.0.0",
-      "sidebar": "version-1.0.0/community"
+      "sidebar": "community"
     }
   }
 }",
@@ -2914,7 +2914,7 @@ exports[`versioned website (community) content: global data 1`] = `
             {
               "id": "team",
               "path": "/community/team",
-              "sidebar": "version-1.0.0/community",
+              "sidebar": "community",
             },
           ],
           "draftIds": [],
@@ -2924,7 +2924,7 @@ exports[`versioned website (community) content: global data 1`] = `
           "name": "1.0.0",
           "path": "/community",
           "sidebars": {
-            "version-1.0.0/community": {
+            "community": {
               "link": {
                 "label": "team",
                 "path": "/community/team",
@@ -2993,7 +2993,7 @@ exports[`versioned website (community) content: route config 1`] = `
                   "content": "@site/community_versioned_docs/version-1.0.0/team.md",
                 },
                 "path": "/community/team",
-                "sidebar": "version-1.0.0/community",
+                "sidebar": "community",
               },
             ],
           },
@@ -3175,7 +3175,7 @@ exports[`versioned website content 5`] = `
     "permalink": "/docs/1.0.0/foo/barSlug",
     "title": "bar",
   },
-  "sidebar": "version-1.0.0/docs",
+  "sidebar": "docs",
   "sidebarPosition": undefined,
   "slug": "/foo/baz",
   "source": "@site/versioned_docs/version-1.0.0/foo/baz.md",
@@ -3189,7 +3189,7 @@ exports[`versioned website content 5`] = `
 
 exports[`versioned website content: 100 version sidebars 1`] = `
 {
-  "version-1.0.0/docs": [
+  "docs": [
     {
       "collapsed": true,
       "collapsible": true,
@@ -3434,7 +3434,7 @@ exports[`versioned website content: data 1`] = `
   "frontMatter": {
     "slug": "/"
   },
-  "sidebar": "version-1.0.0/docs",
+  "sidebar": "docs",
   "previous": {
     "title": "baz",
     "permalink": "/docs/1.0.0/foo/baz"
@@ -3455,7 +3455,7 @@ exports[`versioned website content: data 1`] = `
   "frontMatter": {
     "slug": "barSlug"
   },
-  "sidebar": "version-1.0.0/docs",
+  "sidebar": "docs",
   "next": {
     "title": "baz",
     "permalink": "/docs/1.0.0/foo/baz"
@@ -3474,7 +3474,7 @@ exports[`versioned website content: data 1`] = `
   "tags": [],
   "version": "1.0.0",
   "frontMatter": {},
-  "sidebar": "version-1.0.0/docs",
+  "sidebar": "docs",
   "previous": {
     "title": "bar",
     "permalink": "/docs/1.0.0/foo/barSlug"
@@ -3539,7 +3539,7 @@ exports[`versioned website content: data 1`] = `
   "frontMatter": {
     "slug": "/rootAbsoluteSlug"
   },
-  "sidebar": "version-1.0.1/docs"
+  "sidebar": "docs"
 }",
   "site-versioned-docs-version-with-slugs-root-relative-slug-md-32a.json": "{
   "id": "rootRelativeSlug",
@@ -3725,7 +3725,7 @@ exports[`versioned website content: data 1`] = `
   "className": "docs-version-1.0.0",
   "isLast": false,
   "docsSidebars": {
-    "version-1.0.0/docs": [
+    "docs": [
       {
         "type": "category",
         "label": "Test",
@@ -3770,19 +3770,19 @@ exports[`versioned website content: data 1`] = `
       "id": "foo/bar",
       "title": "bar",
       "description": "Bar 1.0.0 !",
-      "sidebar": "version-1.0.0/docs"
+      "sidebar": "docs"
     },
     "foo/baz": {
       "id": "foo/baz",
       "title": "baz",
       "description": "Baz 1.0.0 ! This will be deleted in next subsequent versions.",
-      "sidebar": "version-1.0.0/docs"
+      "sidebar": "docs"
     },
     "hello": {
       "id": "hello",
       "title": "hello",
       "description": "Hello 1.0.0 ! (translated en)",
-      "sidebar": "version-1.0.0/docs"
+      "sidebar": "docs"
     }
   }
 }",
@@ -3932,7 +3932,7 @@ exports[`versioned website content: data 1`] = `
   "className": "docs-version-withSlugs",
   "isLast": false,
   "docsSidebars": {
-    "version-1.0.1/docs": [
+    "docs": [
       {
         "type": "category",
         "label": "Test",
@@ -3955,7 +3955,7 @@ exports[`versioned website content: data 1`] = `
       "id": "rootAbsoluteSlug",
       "title": "rootAbsoluteSlug",
       "description": "Lorem",
-      "sidebar": "version-1.0.1/docs"
+      "sidebar": "docs"
     },
     "rootRelativeSlug": {
       "id": "rootRelativeSlug",
@@ -4085,17 +4085,17 @@ exports[`versioned website content: global data 1`] = `
             {
               "id": "foo/bar",
               "path": "/docs/1.0.0/foo/barSlug",
-              "sidebar": "version-1.0.0/docs",
+              "sidebar": "docs",
             },
             {
               "id": "foo/baz",
               "path": "/docs/1.0.0/foo/baz",
-              "sidebar": "version-1.0.0/docs",
+              "sidebar": "docs",
             },
             {
               "id": "hello",
               "path": "/docs/1.0.0/",
-              "sidebar": "version-1.0.0/docs",
+              "sidebar": "docs",
             },
           ],
           "draftIds": [],
@@ -4105,7 +4105,7 @@ exports[`versioned website content: global data 1`] = `
           "name": "1.0.0",
           "path": "/docs/1.0.0",
           "sidebars": {
-            "version-1.0.0/docs": {
+            "docs": {
               "link": {
                 "label": "foo/bar",
                 "path": "/docs/1.0.0/foo/barSlug",
@@ -4118,7 +4118,7 @@ exports[`versioned website content: global data 1`] = `
             {
               "id": "rootAbsoluteSlug",
               "path": "/docs/withSlugs/rootAbsoluteSlug",
-              "sidebar": "version-1.0.1/docs",
+              "sidebar": "docs",
             },
             {
               "id": "rootRelativeSlug",
@@ -4163,7 +4163,7 @@ exports[`versioned website content: global data 1`] = `
           "name": "withSlugs",
           "path": "/docs/withSlugs",
           "sidebars": {
-            "version-1.0.1/docs": {
+            "docs": {
               "link": {
                 "label": "rootAbsoluteSlug",
                 "path": "/docs/withSlugs/rootAbsoluteSlug",
@@ -4205,7 +4205,7 @@ exports[`versioned website content: route config 1`] = `
                   "content": "@site/i18n/en/docusaurus-plugin-content-docs/version-1.0.0/hello.md",
                 },
                 "path": "/docs/1.0.0/",
-                "sidebar": "version-1.0.0/docs",
+                "sidebar": "docs",
               },
               {
                 "component": "@theme/DocItem",
@@ -4214,7 +4214,7 @@ exports[`versioned website content: route config 1`] = `
                   "content": "@site/versioned_docs/version-1.0.0/foo/bar.md",
                 },
                 "path": "/docs/1.0.0/foo/barSlug",
-                "sidebar": "version-1.0.0/docs",
+                "sidebar": "docs",
               },
               {
                 "component": "@theme/DocItem",
@@ -4223,7 +4223,7 @@ exports[`versioned website content: route config 1`] = `
                   "content": "@site/versioned_docs/version-1.0.0/foo/baz.md",
                 },
                 "path": "/docs/1.0.0/foo/baz",
-                "sidebar": "version-1.0.0/docs",
+                "sidebar": "docs",
               },
             ],
           },
@@ -4366,7 +4366,7 @@ exports[`versioned website content: route config 1`] = `
                   "content": "@site/versioned_docs/version-withSlugs/rootAbsoluteSlug.md",
                 },
                 "path": "/docs/withSlugs/rootAbsoluteSlug",
-                "sidebar": "version-1.0.1/docs",
+                "sidebar": "docs",
               },
               {
                 "component": "@theme/DocItem",
@@ -4455,7 +4455,7 @@ exports[`versioned website content: route config 1`] = `
 
 exports[`versioned website content: withSlugs version sidebars 1`] = `
 {
-  "version-1.0.1/docs": [
+  "docs": [
     {
       "collapsed": true,
       "collapsible": true,

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/index.test.ts.snap
@@ -43,7 +43,8 @@ Available document ids are:
 - slugs/resolvedSlug
 - slugs/tryToEscapeSlug
 - unlisted-category/unlisted-category-doc
-- unlisted-category/unlisted-category-index"
+- unlisted-category/unlisted-category-index
+"
 `;
 
 exports[`simple website content 1`] = `

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/translations.test.ts.snap
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/__snapshots__/translations.test.ts.snap
@@ -132,7 +132,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc1 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -153,7 +152,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc2 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -174,7 +172,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc3 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -195,7 +192,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc4 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -216,7 +212,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc5 title",
-          "unversionedId": "any",
           "version": "any",
         },
       ],
@@ -308,7 +303,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc1 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -329,7 +323,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc2 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -350,7 +343,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc3 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -371,7 +363,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc4 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -392,7 +383,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc5 title",
-          "unversionedId": "any",
           "version": "any",
         },
       ],
@@ -484,7 +474,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc1 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -505,7 +494,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc2 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -526,7 +514,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc3 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -547,7 +534,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc4 title",
-          "unversionedId": "any",
           "version": "any",
         },
         {
@@ -568,7 +554,6 @@ exports[`translateLoadedContent returns translated loaded content 1`] = `
           "sourceDirName": "",
           "tags": [],
           "title": "doc5 title",
-          "unversionedId": "any",
           "version": "any",
         },
       ],

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -916,7 +916,7 @@ describe('versioned site', () => {
     const {version101TestUtils, version100TestUtils} = await loadSite();
 
     await version100TestUtils.testMeta(path.join('foo', 'bar.md'), {
-      id: 'version-1.0.0/foo/bar',
+      id: 'foo/bar',
       sourceDirName: 'foo',
       permalink: '/docs/1.0.0/foo/barSlug',
       slug: '/foo/barSlug',
@@ -928,7 +928,7 @@ describe('versioned site', () => {
       unlisted: false,
     });
     await version100TestUtils.testMeta(path.join('hello.md'), {
-      id: 'version-1.0.0/hello',
+      id: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -944,7 +944,7 @@ describe('versioned site', () => {
       unlisted: false,
     });
     await version101TestUtils.testMeta(path.join('foo', 'bar.md'), {
-      id: 'version-1.0.1/foo/bar',
+      id: 'foo/bar',
       sourceDirName: 'foo',
       permalink: '/docs/foo/bar',
       slug: '/foo/bar',
@@ -956,7 +956,7 @@ describe('versioned site', () => {
       unlisted: false,
     });
     await version101TestUtils.testMeta(path.join('hello.md'), {
-      id: 'version-1.0.1/hello',
+      id: 'hello',
       sourceDirName: '.',
       permalink: '/docs/',
       slug: '/',
@@ -1049,7 +1049,7 @@ describe('versioned site', () => {
     });
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
-      id: 'version-1.0.0/hello',
+      id: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -1091,7 +1091,7 @@ describe('versioned site', () => {
     });
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
-      id: 'version-1.0.0/hello',
+      id: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -1126,7 +1126,7 @@ describe('versioned site', () => {
     });
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
-      id: 'version-1.0.0/hello',
+      id: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -1162,7 +1162,7 @@ describe('versioned site', () => {
     });
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
-      id: 'version-1.0.0/hello',
+      id: 'hello',
       sourceDirName: '.',
       permalink: '/fr/docs/1.0.0/',
       slug: '/',
@@ -1199,7 +1199,7 @@ describe('versioned site', () => {
     });
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
-      id: 'version-1.0.0/hello',
+      id: 'hello',
       sourceDirName: '.',
       permalink: '/fr/docs/1.0.0/',
       slug: '/',

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -268,7 +268,6 @@ describe('simple site', () => {
     await defaultTestUtils.testMeta(path.join('foo', 'bar.md'), {
       version: 'current',
       id: 'foo/bar',
-      unversionedId: 'foo/bar',
       sourceDirName: 'foo',
       permalink: '/docs/foo/bar',
       slug: '/foo/bar',
@@ -287,7 +286,6 @@ describe('simple site', () => {
     await defaultTestUtils.testMeta(path.join('hello.md'), {
       version: 'current',
       id: 'hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/docs/',
       slug: '/',
@@ -332,7 +330,6 @@ describe('simple site', () => {
     await testUtilsLocal.testMeta(path.join('foo', 'baz.md'), {
       version: 'current',
       id: 'foo/baz',
-      unversionedId: 'foo/baz',
       sourceDirName: 'foo',
       permalink: '/docs/foo/bazSlug.html',
       slug: '/foo/bazSlug.html',
@@ -371,7 +368,6 @@ describe('simple site', () => {
     await defaultTestUtils.testMeta('lorem.md', {
       version: 'current',
       id: 'lorem',
-      unversionedId: 'lorem',
       sourceDirName: '.',
       permalink: '/docs/lorem',
       slug: '/lorem',
@@ -409,7 +405,6 @@ describe('simple site', () => {
     await testUtilsLocal.testMeta(path.join('foo', 'baz.md'), {
       version: 'current',
       id: 'foo/baz',
-      unversionedId: 'foo/baz',
       sourceDirName: 'foo',
       permalink: '/docs/foo/bazSlug.html',
       slug: '/foo/bazSlug.html',
@@ -469,7 +464,6 @@ describe('simple site', () => {
     await testUtilsLocal.testMeta('lorem.md', {
       version: 'current',
       id: 'lorem',
-      unversionedId: 'lorem',
       sourceDirName: '.',
       permalink: '/docs/lorem',
       slug: '/lorem',
@@ -516,7 +510,6 @@ describe('simple site', () => {
     const baseMeta = {
       version: 'current',
       id: 'doc-unlisted',
-      unversionedId: 'doc-unlisted',
       sourceDirName: '.',
       permalink: '/docs/doc-unlisted',
       slug: '/doc-unlisted',
@@ -567,7 +560,6 @@ describe('simple site', () => {
     await testUtilsLocal.testMeta('customLastUpdate.md', {
       version: 'current',
       id: 'customLastUpdate',
-      unversionedId: 'customLastUpdate',
       sourceDirName: '.',
       permalink: '/docs/customLastUpdate',
       slug: '/customLastUpdate',
@@ -608,7 +600,6 @@ describe('simple site', () => {
     await testUtilsLocal.testMeta('lastUpdateAuthorOnly.md', {
       version: 'current',
       id: 'lastUpdateAuthorOnly',
-      unversionedId: 'lastUpdateAuthorOnly',
       sourceDirName: '.',
       permalink: '/docs/lastUpdateAuthorOnly',
       slug: '/lastUpdateAuthorOnly',
@@ -648,7 +639,6 @@ describe('simple site', () => {
     await testUtilsLocal.testMeta('lastUpdateDateOnly.md', {
       version: 'current',
       id: 'lastUpdateDateOnly',
-      unversionedId: 'lastUpdateDateOnly',
       sourceDirName: '.',
       permalink: '/docs/lastUpdateDateOnly',
       slug: '/lastUpdateDateOnly',
@@ -688,7 +678,6 @@ describe('simple site', () => {
     await testUtilsLocal.testMeta('customLastUpdate.md', {
       version: 'current',
       id: 'customLastUpdate',
-      unversionedId: 'customLastUpdate',
       sourceDirName: '.',
       permalink: '/docs/customLastUpdate',
       slug: '/customLastUpdate',
@@ -875,7 +864,6 @@ describe('versioned site', () => {
     await currentVersionTestUtils.testMeta(path.join('foo', 'bar.md'), {
       id: 'foo/bar',
       version: 'current',
-      unversionedId: 'foo/bar',
       sourceDirName: 'foo',
       permalink: '/docs/next/foo/barSlug',
       slug: '/foo/barSlug',
@@ -911,7 +899,6 @@ describe('versioned site', () => {
     await currentVersionTestUtils.testMeta(path.join('hello.md'), {
       id: 'hello',
       version: 'current',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/docs/next/',
       slug: '/',
@@ -930,7 +917,6 @@ describe('versioned site', () => {
 
     await version100TestUtils.testMeta(path.join('foo', 'bar.md'), {
       id: 'version-1.0.0/foo/bar',
-      unversionedId: 'foo/bar',
       sourceDirName: 'foo',
       permalink: '/docs/1.0.0/foo/barSlug',
       slug: '/foo/barSlug',
@@ -943,7 +929,6 @@ describe('versioned site', () => {
     });
     await version100TestUtils.testMeta(path.join('hello.md'), {
       id: 'version-1.0.0/hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -960,7 +945,6 @@ describe('versioned site', () => {
     });
     await version101TestUtils.testMeta(path.join('foo', 'bar.md'), {
       id: 'version-1.0.1/foo/bar',
-      unversionedId: 'foo/bar',
       sourceDirName: 'foo',
       permalink: '/docs/foo/bar',
       slug: '/foo/bar',
@@ -973,7 +957,6 @@ describe('versioned site', () => {
     });
     await version101TestUtils.testMeta(path.join('hello.md'), {
       id: 'version-1.0.1/hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/docs/',
       slug: '/',
@@ -1067,7 +1050,6 @@ describe('versioned site', () => {
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
       id: 'version-1.0.0/hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -1110,7 +1092,6 @@ describe('versioned site', () => {
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
       id: 'version-1.0.0/hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -1146,7 +1127,6 @@ describe('versioned site', () => {
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
       id: 'version-1.0.0/hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/docs/1.0.0/',
       slug: '/',
@@ -1183,7 +1163,6 @@ describe('versioned site', () => {
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
       id: 'version-1.0.0/hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/fr/docs/1.0.0/',
       slug: '/',
@@ -1221,7 +1200,6 @@ describe('versioned site', () => {
 
     await testUtilsLocal.testMeta(path.join('hello.md'), {
       id: 'version-1.0.0/hello',
-      unversionedId: 'hello',
       sourceDirName: '.',
       permalink: '/fr/docs/1.0.0/',
       slug: '/',

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/globalData.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/globalData.test.ts
@@ -15,21 +15,21 @@ describe('toGlobalDataVersion', () => {
   it('generates the right docs, sidebars, and metadata', () => {
     const docs = [
       {
-        unversionedId: 'main',
+        id: 'main',
         permalink: '/current/main',
         sidebar: 'tutorial',
         frontMatter: {},
         unlisted: false,
       },
       {
-        unversionedId: 'doc',
+        id: 'doc',
         permalink: '/current/doc',
         sidebar: 'tutorial',
         frontMatter: {},
         unlisted: undefined,
       },
       {
-        unversionedId: 'docNoSidebarUnlisted',
+        id: 'docNoSidebarUnlisted',
         permalink: '/current/docNoSidebarUnlisted',
         sidebar: undefined,
         frontMatter: {},
@@ -102,7 +102,7 @@ describe('toGlobalDataVersion', () => {
         docs,
         drafts: [
           {
-            unversionedId: 'some-draft-id',
+            id: 'some-draft-id',
             permalink: '/current/draft',
             sidebar: undefined,
           },

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/index.test.ts
@@ -38,26 +38,21 @@ import type {
   NormalizedSidebar,
 } from '../sidebars/types';
 
-function findDocById(
-  version: LoadedVersion | undefined,
-  unversionedId: string,
-) {
+function findDocById(version: LoadedVersion | undefined, id: string) {
   if (!version) {
     throw new Error('Version not found');
   }
-  return version.docs.find((item) => item.unversionedId === unversionedId);
+  return version.docs.find((item) => item.id === id);
 }
-function getDocById(version: LoadedVersion | undefined, unversionedId: string) {
+function getDocById(version: LoadedVersion | undefined, id: string) {
   if (!version) {
     throw new Error('Version not found');
   }
-  const doc = findDocById(version, unversionedId);
+  const doc = findDocById(version, id);
   if (!doc) {
     throw new Error(
-      `No doc found with id "${unversionedId}" in version ${
-        version.versionName
-      }.
-Available ids are:\n- ${version.docs.map((d) => d.unversionedId).join('\n- ')}`,
+      `No doc found with id "${id}" in version ${version.versionName}.
+Available ids are:\n- ${version.docs.map((d) => d.id).join('\n- ')}`,
     );
   }
   return doc;

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
@@ -19,6 +19,7 @@ describe('toTagDocListProp', () => {
       label: 'tag1',
       permalink: '/tag1',
       docIds: ['id1', 'id3'],
+      unlisted: false,
     };
 
     const doc1 = {
@@ -69,7 +70,6 @@ describe('toSidebarDocItemLinkProp', () => {
   type Doc = Params['doc'];
 
   const id = 'some-doc-id';
-  const unversionedId = 'some-unversioned-doc-id';
 
   const item: DocSidebarItem = {
     type: 'doc',
@@ -79,7 +79,6 @@ describe('toSidebarDocItemLinkProp', () => {
 
   const doc: Doc = {
     id,
-    unversionedId,
     title: 'doc title',
     permalink: '/docPermalink',
     frontMatter: {},
@@ -94,7 +93,7 @@ describe('toSidebarDocItemLinkProp', () => {
 
     expect(result).toEqual({
       type: 'link',
-      docId: unversionedId,
+      docId: id,
       unlisted: false,
       label: item.label,
       autoAddBaseUrl: undefined,

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/props.test.ts
@@ -58,6 +58,7 @@ describe('toTagDocListProp', () => {
       count: 2,
       label: tag.label,
       permalink: tag.permalink,
+      unlisted: false,
       items: [doc3, doc1], // Docs sorted by title, ignore "id5" absence
     });
   });

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/translations.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/translations.test.ts
@@ -30,7 +30,6 @@ function createSampleDoc(doc: Pick<DocMetadata, 'id'>): DocMetadata {
     permalink: 'any',
     slug: 'any',
     source: 'any',
-    unversionedId: 'any',
     version: 'any',
     title: `${doc.id} title`,
     frontMatter: {

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -317,17 +317,12 @@ function getUnlistedIds(docs: DocMetadataBase[]): Set<string> {
 export function addDocNavigation({
   docs,
   sidebarsUtils,
-  sidebarFilePath,
 }: {
   docs: DocMetadataBase[];
   sidebarsUtils: SidebarsUtils;
-  sidebarFilePath: string;
 }): LoadedVersion['docs'] {
   const docsById = createDocsByIdIndex(docs);
-  const allDocIds = Object.keys(docsById);
   const unlistedIds = getUnlistedIds(docs);
-
-  sidebarsUtils.checkSidebarsDocIds(allDocIds, sidebarFilePath);
 
   // Add sidebar/next/previous to the docs
   function addNavData(doc: DocMetadataBase): DocMetadata {

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -7,6 +7,7 @@
 
 import path from 'path';
 import fs from 'fs-extra';
+import _ from 'lodash';
 import logger from '@docusaurus/logger';
 import {
   aliasedSitePath,
@@ -24,7 +25,6 @@ import {
 
 import {getFileLastUpdate} from './lastUpdate';
 import getSlug from './slug';
-import {CURRENT_VERSION_NAME} from './constants';
 import {stripPathNumberPrefixes} from './numberPrefix';
 import {validateDocFrontMatter} from './frontMatter';
 import {toDocNavigationLink, toNavigationLink} from './sidebars/utils';
@@ -189,14 +189,6 @@ async function doProcessDocMetadata({
     frontMatter.sidebar_position ?? numberPrefix;
 
   // TODO legacy retrocompatibility
-  // The same doc in 2 distinct version could keep the same id,
-  // we just need to namespace the data by version
-  const versionIdPrefix =
-    versionMetadata.versionName === CURRENT_VERSION_NAME
-      ? undefined
-      : `version-${versionMetadata.versionName}`;
-
-  // TODO legacy retrocompatibility
   // I think it's bad to affect the front matter id with the dirname?
   function computeDirNameIdPrefix() {
     if (sourceDirName === '.') {
@@ -208,13 +200,7 @@ async function doProcessDocMetadata({
       : sourceDirName;
   }
 
-  const unversionedId = [computeDirNameIdPrefix(), baseID]
-    .filter(Boolean)
-    .join('/');
-
-  // TODO is versioning the id very useful in practice?
-  // legacy versioned id, requires a breaking change to modify this
-  const id = [versionIdPrefix, unversionedId].filter(Boolean).join('/');
+  const id = [computeDirNameIdPrefix(), baseID].filter(Boolean).join('/');
 
   const docSlug = getSlug({
     baseID,
@@ -281,7 +267,6 @@ async function doProcessDocMetadata({
   // Adding properties to object after instantiation will cause hidden
   // class transitions.
   return {
-    unversionedId,
     id,
     title,
     description,
@@ -339,15 +324,15 @@ export function addDocNavigation({
   sidebarFilePath: string;
 }): LoadedVersion['docs'] {
   const docsById = createDocsByIdIndex(docs);
+  const allDocIds = Object.keys(docsById);
   const unlistedIds = getUnlistedIds(docs);
 
-  sidebarsUtils.checkSidebarsDocIds(docs.flatMap(getDocIds), sidebarFilePath);
+  sidebarsUtils.checkSidebarsDocIds(allDocIds, sidebarFilePath);
 
   // Add sidebar/next/previous to the docs
   function addNavData(doc: DocMetadataBase): DocMetadata {
     const navigation = sidebarsUtils.getDocNavigation({
-      unversionedId: doc.unversionedId,
-      versionedId: doc.id,
+      docId: doc.id,
       displayedSidebar: doc.frontMatter.displayed_sidebar,
       unlistedIds,
     });
@@ -412,16 +397,12 @@ export function getMainDocId({
     if (versionHomeDoc) {
       return versionHomeDoc;
     } else if (firstDocIdOfFirstSidebar) {
-      return docs.find(
-        (doc) =>
-          doc.id === firstDocIdOfFirstSidebar ||
-          doc.unversionedId === firstDocIdOfFirstSidebar,
-      )!;
+      return docs.find((doc) => doc.id === firstDocIdOfFirstSidebar)!;
     }
     return docs[0]!;
   }
 
-  return getMainDoc().unversionedId;
+  return getMainDoc().id;
 }
 
 // By convention, Docusaurus considers some docs are "indexes":
@@ -465,25 +446,9 @@ export function toCategoryIndexMatcherParam({
   };
 }
 
-// Return both doc ids
-// TODO legacy retro-compatibility due to old versioned sidebars using
-// versioned doc ids ("id" should be removed & "versionedId" should be renamed
-// to "id")
-export function getDocIds(doc: DocMetadataBase): [string, string] {
-  return [doc.unversionedId, doc.id];
-}
-
-// Docs are indexed by both versioned and unversioned ids at the same time
-// TODO legacy retro-compatibility due to old versioned sidebars using
-// versioned doc ids ("id" should be removed & "versionedId" should be renamed
-// to "id")
-export function createDocsByIdIndex<
-  Doc extends {id: string; unversionedId: string},
->(docs: Doc[]): {[docId: string]: Doc} {
-  return Object.fromEntries(
-    docs.flatMap((doc) => [
-      [doc.unversionedId, doc],
-      [doc.id, doc],
-    ]),
-  );
+// Docs are indexed by their id
+export function createDocsByIdIndex<Doc extends {id: string}>(
+  docs: Doc[],
+): {[docId: string]: Doc} {
+  return _.keyBy(docs, (d) => d.id);
 }

--- a/packages/docusaurus-plugin-content-docs/src/globalData.ts
+++ b/packages/docusaurus-plugin-content-docs/src/globalData.ts
@@ -21,7 +21,7 @@ import type {Sidebars} from './sidebars/types';
 
 function toGlobalDataDoc(doc: DocMetadata): GlobalDoc {
   return {
-    id: doc.unversionedId,
+    id: doc.id,
     path: doc.permalink,
 
     // optimize global data size: do not add unlisted: false/undefined
@@ -56,10 +56,7 @@ function toGlobalSidebars(
         path:
           firstLink.type === 'generated-index'
             ? firstLink.permalink
-            : version.docs.find(
-                (doc) =>
-                  doc.id === firstLink.id || doc.unversionedId === firstLink.id,
-              )!.permalink,
+            : version.docs.find((doc) => doc.id === firstLink.id)!.permalink,
         label: firstLink.label,
       },
     };
@@ -76,7 +73,7 @@ export function toGlobalDataVersion(version: FullVersion): GlobalVersion {
     docs: version.docs
       .map(toGlobalDataDoc)
       .concat(version.categoryGeneratedIndices.map(toGlobalDataGeneratedIndex)),
-    draftIds: version.drafts.map((doc) => doc.unversionedId),
+    draftIds: version.drafts.map((doc) => doc.id),
     sidebars: toGlobalSidebars(version.sidebars, version),
   };
 }

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -183,8 +183,15 @@ export default async function pluginContentDocs(
         const docsById = createDocsByIdIndex(docs);
         const allDocIds = Object.keys(docsById);
 
-        const sidebarFilePath = versionMetadata.sidebarFilePath as string;
-        sidebarsUtils.checkSidebarsDocIds({allDocIds, sidebarFilePath});
+        sidebarsUtils.checkLegacyVersionedSidebarNames({
+          sidebarFilePath: versionMetadata.sidebarFilePath as string,
+          versionMetadata,
+        });
+        sidebarsUtils.checkSidebarsDocIds({
+          allDocIds,
+          sidebarFilePath: versionMetadata.sidebarFilePath as string,
+          versionMetadata,
+        });
 
         return {
           ...versionMetadata,

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -26,6 +26,7 @@ import {
   processDocMetadata,
   addDocNavigation,
   type DocEnv,
+  createDocsByIdIndex,
 } from './docs';
 import {readVersionsMetadata, toFullVersion} from './versions';
 import {cliDocsVersionCommand} from './cli';
@@ -179,12 +180,17 @@ export default async function pluginContentDocs(
 
         const sidebarsUtils = createSidebarsUtils(sidebars);
 
+        const docsById = createDocsByIdIndex(docs);
+        const allDocIds = Object.keys(docsById);
+
+        const sidebarFilePath = versionMetadata.sidebarFilePath as string;
+        sidebarsUtils.checkSidebarsDocIds({allDocIds, sidebarFilePath});
+
         return {
           ...versionMetadata,
           docs: addDocNavigation({
             docs,
             sidebarsUtils,
-            sidebarFilePath: versionMetadata.sidebarFilePath as string,
           }),
           drafts,
           sidebars,

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -414,17 +414,11 @@ declare module '@docusaurus/plugin-content-docs' {
   };
 
   export type DocMetadataBase = LastUpdateData & {
-    // TODO
     /**
-     * Legacy versioned ID. Will be refactored in the future to be unversioned.
+     * The document id.
+     * Multiple documents can have the same id, when in different versions.
      */
     id: string;
-    // TODO
-    /**
-     * Unversioned ID. Should be preferred everywhere over `id` until the latter
-     * is refactored.
-     */
-    unversionedId: string;
     /** The name of the version this doc belongs to. */
     version: string;
     /**

--- a/packages/docusaurus-plugin-content-docs/src/props.ts
+++ b/packages/docusaurus-plugin-content-docs/src/props.ts
@@ -35,10 +35,11 @@ export function toSidebarDocItemLinkProp({
   item: SidebarItemDoc;
   doc: Pick<
     DocMetadata,
-    'id' | 'title' | 'permalink' | 'unlisted' | 'frontMatter' | 'unversionedId'
+    'id' | 'title' | 'permalink' | 'unlisted' | 'frontMatter'
   >;
 }): PropSidebarItemLink {
   const {
+    id,
     title,
     permalink,
     frontMatter: {
@@ -46,7 +47,6 @@ export function toSidebarDocItemLinkProp({
       sidebar_custom_props: customProps,
     },
     unlisted,
-    unversionedId,
   } = doc;
   return {
     type: 'link',
@@ -54,7 +54,7 @@ export function toSidebarDocItemLinkProp({
     href: permalink,
     className: item.className,
     customProps: item.customProps ?? customProps,
-    docId: unversionedId,
+    docId: id,
     unlisted,
   };
 }
@@ -151,9 +151,9 @@ Available document ids are:
 function toVersionDocsProp(loadedVersion: LoadedVersion): PropVersionDocs {
   return Object.fromEntries(
     loadedVersion.docs.map((doc) => [
-      doc.unversionedId,
+      doc.id,
       {
-        id: doc.unversionedId,
+        id: doc.id,
         title: doc.title,
         description: doc.description,
         sidebar: doc.sidebar,

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/generator.test.ts
@@ -67,7 +67,6 @@ describe('DefaultSidebarItemsGenerator', () => {
             sidebar_custom_props: {custom: 'prop'},
           },
           title: '',
-          unversionedId: 'doc1',
         },
         {
           id: 'doc2',
@@ -76,7 +75,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 3,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc2',
         },
         {
           id: 'doc3',
@@ -85,7 +83,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 1,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc3',
         },
         {
           id: 'doc4',
@@ -94,7 +91,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 1.5,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc4',
         },
         {
           id: 'doc5',
@@ -103,7 +99,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: undefined,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc5',
         },
       ],
       isCategoryIndex: () => false,
@@ -150,7 +145,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 0,
           frontMatter: {},
           title: '',
-          unversionedId: 'intro',
         },
         {
           id: 'tutorials-index',
@@ -159,7 +153,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 2,
           frontMatter: {},
           title: 'Tutorials',
-          unversionedId: 'tutorials-index',
         },
         {
           id: 'tutorial2',
@@ -168,7 +161,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 2,
           frontMatter: {},
           title: '',
-          unversionedId: 'tutorial2',
         },
         {
           id: 'tutorial1',
@@ -177,7 +169,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 1,
           frontMatter: {},
           title: '',
-          unversionedId: 'tutorial1',
         },
         {
           id: 'guides-index',
@@ -185,7 +176,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: '02-Guides',
           frontMatter: {},
           title: 'Guides',
-          unversionedId: 'guides-index',
         },
         {
           id: 'guide2',
@@ -194,7 +184,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 2,
           frontMatter: {},
           title: '',
-          unversionedId: 'guide2',
         },
         {
           id: 'guide1',
@@ -205,7 +194,6 @@ describe('DefaultSidebarItemsGenerator', () => {
             sidebar_class_name: 'foo',
           },
           title: '',
-          unversionedId: 'guide1',
         },
         {
           id: 'nested-guide',
@@ -214,7 +202,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: undefined,
           frontMatter: {},
           title: '',
-          unversionedId: 'nested-guide',
         },
         {
           id: 'end',
@@ -223,7 +210,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 3,
           frontMatter: {},
           title: '',
-          unversionedId: 'end',
         },
       ],
     });
@@ -268,7 +254,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           title: 'Subsubsubfolder category label',
           sidebarPosition: undefined,
           frontMatter: {},
-          unversionedId: 'doc1',
         },
         {
           id: 'doc2',
@@ -277,7 +262,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: undefined,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc2',
         },
         {
           id: 'doc3',
@@ -286,7 +270,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: undefined,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc2',
         },
         {
           id: 'doc4',
@@ -295,7 +278,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: undefined,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc4',
         },
         {
           id: 'doc5',
@@ -304,7 +286,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: undefined,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc5',
         },
         {
           id: 'doc6',
@@ -313,7 +294,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: undefined,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc6',
         },
         {
           id: 'doc7',
@@ -322,7 +302,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 2,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc7',
         },
         {
           id: 'doc8',
@@ -331,7 +310,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 1,
           frontMatter: {},
           title: '',
-          unversionedId: 'doc8',
         },
       ],
     });
@@ -370,7 +348,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: 'Category',
           frontMatter: {},
           title: '',
-          unversionedId: 'parent/doc1',
         },
         {
           id: 'parent/doc2',
@@ -378,7 +355,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: 'Category',
           frontMatter: {},
           title: '',
-          unversionedId: 'parent/doc2',
         },
         {
           id: 'parent/doc3',
@@ -386,7 +362,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: 'Category',
           frontMatter: {},
           title: '',
-          unversionedId: 'parent/doc3',
         },
         {
           id: 'parent/doc4',
@@ -394,7 +369,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: 'Category2',
           frontMatter: {},
           title: '',
-          unversionedId: 'parent/doc4',
         },
         {
           id: 'parent/doc5',
@@ -402,7 +376,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: 'Category2',
           frontMatter: {},
           title: '',
-          unversionedId: 'parent/doc5',
         },
         {
           id: 'parent/doc6',
@@ -410,7 +383,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: 'Category2',
           frontMatter: {},
           title: '',
-          unversionedId: 'parent/doc6',
         },
       ],
       isCategoryIndex: () => false,
@@ -449,7 +421,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 0,
           frontMatter: {},
           title: '',
-          unversionedId: 'intro',
         },
         {
           id: 'tutorials-index',
@@ -458,7 +429,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 2,
           frontMatter: {},
           title: 'Tutorials',
-          unversionedId: 'tutorials-index',
         },
         {
           id: 'tutorial2',
@@ -467,7 +437,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 2,
           frontMatter: {},
           title: '',
-          unversionedId: 'tutorial2',
         },
         {
           id: 'tutorial1',
@@ -476,7 +445,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 1,
           frontMatter: {},
           title: '',
-          unversionedId: 'tutorial1',
         },
         {
           id: 'not-guides-index',
@@ -484,7 +452,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sourceDirName: '02-Guides',
           frontMatter: {},
           title: 'Guides',
-          unversionedId: 'not-guides-index',
         },
         {
           id: 'guide2',
@@ -493,7 +460,6 @@ describe('DefaultSidebarItemsGenerator', () => {
           sidebarPosition: 2,
           frontMatter: {},
           title: 'guide2',
-          unversionedId: 'guide2',
         },
         {
           id: 'guide1',
@@ -504,7 +470,6 @@ describe('DefaultSidebarItemsGenerator', () => {
             sidebar_class_name: 'foo',
           },
           title: '',
-          unversionedId: 'guide1',
         },
       ],
     });
@@ -536,7 +501,6 @@ describe('DefaultSidebarItemsGenerator', () => {
         docs: [
           {
             id: 'intro',
-            unversionedId: 'intro',
             source: '@site/docs/category/intro.md',
             sourceDirName: 'category',
             frontMatter: {},

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/postProcessor.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/postProcessor.test.ts
@@ -155,7 +155,7 @@ describe('postProcess', () => {
         {
           sidebarOptions: {sidebarCollapsed: true, sidebarCollapsible: true},
           version: {path: 'version'},
-          drafts: [{id: 'foo', unversionedId: 'foo'}],
+          drafts: [{id: 'foo'}],
         } as unknown as SidebarPostProcessorParams,
       ),
     ).toMatchSnapshot();

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
@@ -155,8 +155,7 @@ describe('createSidebarsUtils', () => {
   it('getDocNavigation', () => {
     expect(
       getDocNavigation({
-        unversionedId: 'doc1',
-        versionedId: 'doc1',
+        docId: 'doc1',
         displayedSidebar: undefined,
         unlistedIds: new Set(),
       }),
@@ -170,8 +169,7 @@ describe('createSidebarsUtils', () => {
     });
     expect(
       getDocNavigation({
-        unversionedId: 'doc2',
-        versionedId: 'doc2',
+        docId: 'doc2',
         displayedSidebar: undefined,
         unlistedIds: new Set(),
       }),
@@ -186,8 +184,7 @@ describe('createSidebarsUtils', () => {
 
     expect(
       getDocNavigation({
-        unversionedId: 'doc3',
-        versionedId: 'doc3',
+        docId: 'doc3',
         displayedSidebar: undefined,
         unlistedIds: new Set(),
       }),
@@ -201,8 +198,7 @@ describe('createSidebarsUtils', () => {
     });
     expect(
       getDocNavigation({
-        unversionedId: 'doc4',
-        versionedId: 'doc4',
+        docId: 'doc4',
         displayedSidebar: undefined,
         unlistedIds: new Set(),
       }),
@@ -218,8 +214,7 @@ describe('createSidebarsUtils', () => {
 
     expect(
       getDocNavigation({
-        unversionedId: 'doc5',
-        versionedId: 'doc5',
+        docId: 'doc5',
         displayedSidebar: undefined,
         unlistedIds: new Set(),
       }),
@@ -233,8 +228,7 @@ describe('createSidebarsUtils', () => {
     });
     expect(
       getDocNavigation({
-        unversionedId: 'doc6',
-        versionedId: 'doc6',
+        docId: 'doc6',
         displayedSidebar: undefined,
         unlistedIds: new Set(),
       }),
@@ -251,8 +245,7 @@ describe('createSidebarsUtils', () => {
     });
     expect(
       getDocNavigation({
-        unversionedId: 'doc7',
-        versionedId: 'doc7',
+        docId: 'doc7',
         displayedSidebar: undefined,
         unlistedIds: new Set(),
       }),
@@ -266,8 +259,7 @@ describe('createSidebarsUtils', () => {
     });
     expect(
       getDocNavigation({
-        unversionedId: 'doc3',
-        versionedId: 'doc3',
+        docId: 'doc3',
         displayedSidebar: null,
         unlistedIds: new Set(),
       }),
@@ -278,8 +270,7 @@ describe('createSidebarsUtils', () => {
     });
     expect(() =>
       getDocNavigation({
-        unversionedId: 'doc3',
-        versionedId: 'doc3',
+        docId: 'doc3',
         displayedSidebar: 'foo',
         unlistedIds: new Set(),
       }),
@@ -288,8 +279,7 @@ describe('createSidebarsUtils', () => {
     );
     expect(
       getDocNavigation({
-        unversionedId: 'doc3',
-        versionedId: 'doc3',
+        docId: 'doc3',
         displayedSidebar: 'sidebar1',
         unlistedIds: new Set(),
       }),

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/postProcessor.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/postProcessor.ts
@@ -7,7 +7,6 @@
 
 import _ from 'lodash';
 import {normalizeUrl} from '@docusaurus/utils';
-import {getDocIds} from '../docs';
 import type {
   SidebarItem,
   Sidebars,
@@ -102,7 +101,7 @@ export function postProcessSidebars(
   sidebars: ProcessedSidebars,
   params: SidebarProcessorParams,
 ): Sidebars {
-  const draftIds = new Set(params.drafts.flatMap(getDocIds));
+  const draftIds = new Set(params.drafts.map((d) => d.id));
 
   return _.mapValues(sidebars, (sidebar) =>
     sidebar

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/processor.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/processor.ts
@@ -33,7 +33,6 @@ function toSidebarItemsGeneratorDoc(
 ): SidebarItemsGeneratorDoc {
   return _.pick(doc, [
     'id',
-    'unversionedId',
     'title',
     'frontMatter',
     'source',

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/types.ts
@@ -235,7 +235,6 @@ export type CategoryMetadataFile = {
 export type SidebarItemsGeneratorDoc = Pick<
   DocMetadataBase,
   | 'id'
-  | 'unversionedId'
   | 'title'
   | 'frontMatter'
   | 'source'

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -375,7 +375,7 @@ This breaking change is documented on Docusaurus v3 release notes: https://docus
         `Invalid sidebar file at "${toMessageRelativeFilePath(
           sidebarFilePath,
         )}".
-These legacy versioned sidebar document ids are not supported anymore in Docusaurus v3:
+These legacy versioned document ids are not supported anymore in Docusaurus v3:
 - ${legacyVersionedDocIds.sort().join('\n- ')}
 
 The document ids you should now use are:

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -136,8 +136,7 @@ export type SidebarsUtils = {
   getFirstDocIdOfFirstSidebar: () => string | undefined;
   getSidebarNameByDocId: (docId: string) => string | undefined;
   getDocNavigation: (params: {
-    unversionedId: string;
-    versionedId: string;
+    docId: string;
     displayedSidebar: string | null | undefined;
     unlistedIds: Set<string>;
   }) => SidebarNavigation;
@@ -194,26 +193,18 @@ export function createSidebarsUtils(sidebars: Sidebars): SidebarsUtils {
   }
 
   function getDocNavigation({
-    unversionedId,
-    versionedId,
+    docId,
     displayedSidebar,
     unlistedIds,
   }: {
-    unversionedId: string;
-    versionedId: string;
+    docId: string;
     displayedSidebar: string | null | undefined;
     unlistedIds: Set<string>;
   }): SidebarNavigation {
-    // TODO legacy id retro-compatibility!
-    let docId = unversionedId;
-    let sidebarName =
+    const sidebarName =
       displayedSidebar === undefined
         ? getSidebarNameByDocId(docId)
         : displayedSidebar;
-    if (sidebarName === undefined) {
-      docId = versionedId;
-      sidebarName = getSidebarNameByDocId(docId);
-    }
 
     if (!sidebarName) {
       return emptySidebarNavigation();

--- a/packages/docusaurus-plugin-content-docs/src/translations.ts
+++ b/packages/docusaurus-plugin-content-docs/src/translations.ts
@@ -40,23 +40,6 @@ function getVersionFileName(versionName: string): string {
   return `version-${versionName}`;
 }
 
-// TODO legacy, the sidebar name is like "version-2.0.0-alpha.66/docs"
-// input: "version-2.0.0-alpha.66/docs"
-// output: "docs"
-function getNormalizedSidebarName({
-  versionName,
-  sidebarName,
-}: {
-  versionName: string;
-  sidebarName: string;
-}): string {
-  if (versionName === CURRENT_VERSION_NAME || !sidebarName.includes('/')) {
-    return sidebarName;
-  }
-  const [, ...rest] = sidebarName.split('/');
-  return rest.join('/');
-}
-
 function getSidebarTranslationFileContent(
   sidebar: Sidebar,
   sidebarName: string,
@@ -199,13 +182,7 @@ function getSidebarsTranslations(
   version: LoadedVersion,
 ): TranslationFileContent {
   return mergeTranslations(
-    Object.entries(version.sidebars).map(([sidebarName, sidebar]) => {
-      const normalizedSidebarName = getNormalizedSidebarName({
-        sidebarName,
-        versionName: version.versionName,
-      });
-      return getSidebarTranslationFileContent(sidebar, normalizedSidebarName);
-    }),
+    Object.entries(version.sidebars).map(([sidebarName, sidebar]) => getSidebarTranslationFileContent(sidebar, sidebarName)),
   );
 }
 function translateSidebars(
@@ -215,10 +192,7 @@ function translateSidebars(
   return _.mapValues(version.sidebars, (sidebar, sidebarName) =>
     translateSidebar({
       sidebar,
-      sidebarName: getNormalizedSidebarName({
-        sidebarName,
-        versionName: version.versionName,
-      }),
+      sidebarName,
       sidebarsTranslations,
     }),
   );

--- a/packages/docusaurus-plugin-content-docs/src/translations.ts
+++ b/packages/docusaurus-plugin-content-docs/src/translations.ts
@@ -182,7 +182,9 @@ function getSidebarsTranslations(
   version: LoadedVersion,
 ): TranslationFileContent {
   return mergeTranslations(
-    Object.entries(version.sidebars).map(([sidebarName, sidebar]) => getSidebarTranslationFileContent(sidebar, sidebarName)),
+    Object.entries(version.sidebars).map(([sidebarName, sidebar]) =>
+      getSidebarTranslationFileContent(sidebar, sidebarName),
+    ),
   );
 }
 function translateSidebars(

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -13,7 +13,7 @@ import DocItemLayout from '@theme/DocItem/Layout';
 import type {Props} from '@theme/DocItem';
 
 export default function DocItem(props: Props): JSX.Element {
-  const docHtmlClassName = `docs-doc-id-${props.content.metadata.unversionedId}`;
+  const docHtmlClassName = `docs-doc-id-${props.content.metadata.id}`;
   const MDXComponent = props.content;
   return (
     <DocProvider content={props.content}>


### PR DESCRIPTION
## Breaking change

Docusaurus v3 does not support anymore the legacy versioned sidebar files that add a versioned prefix to all doc ids and sidebar names.

For example, this versioned sidebar file is now invalid. 

```json
{
   "version-v2.0.0/docs":[
     "version-v2.0.0/introduction-to-relay",
     "version-v2.0.0/prerequisites",
   ]
}
``` 

The fix is simple: remove the `version-v2.0.0/` prefix everywhere

## Motivation

Fix https://github.com/facebook/docusaurus/issues/6018

Very early Docusaurus v2 versions used to create versioned sidebar files with useless "versioned prefixes.

Example from an older version of the Relay website: https://github.com/facebook/relay/blob/main/website/versioned_sidebars/version-v2.0.0-sidebars.json

```json
{
   "version-v2.0.0/docs":[
      {
         "type":"category",
         "label":"Introduction",
         "items":[
            {
               "type":"doc",
               "id":"version-v2.0.0/introduction-to-relay"
            },
            {
               "type":"doc",
               "id":"version-v2.0.0/prerequisites"
            },
            {
               "type":"doc",
               "id":"version-v2.0.0/installation-and-setup"
            },
            {
               "type":"doc",
               "id":"version-v2.0.0/quick-start-guide"
            }
         ]
      }
   ]
}
```

We stopped adding that prefix a long time ago in Docusaurus v2, but still kept supporting these version prefixes, at the cost of increased complexity.

In Docusaurus v3, we remove this historical retrocompatible support and clean the Docusaurus codebase from that extra complexity.

If your oldest sidebar files still use these version prefixes, please remove them. The example above should be refactored to:

```json
{
   "docs":[
      {
         "type":"category",
         "label":"Introduction",
         "items":[
            {
               "type":"doc",
               "id":"introduction-to-relay"
            },
            {
               "type":"doc",
               "id":"prerequisites"
            },
            {
               "type":"doc",
               "id":"installation-and-setup"
            },
            {
               "type":"doc",
               "id":"quick-start-guide"
            }
         ]
      }
   ]
}
```

## Test Plan

CI

### Test links


Deploy preview: https://deploy-preview-9310--docusaurus-2.netlify.app/

