### PR TITLE
chore: do not fail the build if a localized site has a broken link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -183,7 +183,11 @@ module.exports = async function createConfigAsync() {
         return result;
       },
     },
-    onBrokenLinks: 'throw',
+    onBrokenLinks:
+      // Do not fail the build if a localized site has a broken link
+      process.env.DOCUSAURUS_CURRENT_LOCALE === defaultLocale
+        ? 'throw'
+        : 'warn',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/docusaurus.ico',
     customFields: {


### PR DESCRIPTION


## Motivation

i18n / Crowdin is often a reason why the production website build fails.

And Markdown broken links is a good subset of those i18n errors.
Example: https://app.netlify.com/sites/docusaurus-2/deploys/650db064f9a39f1221ed9487

Failing the prod build due to community translations is annoying, so let's only warn for localized broken links. 

Those broken links in i18n sites are less important and can be fixed in batch.