### PR TITLE
Update v3 beta installation instructions

### DIFF
--- a/website/versioned_docs/version-3.0.0-beta.0/installation.mdx
+++ b/website/versioned_docs/version-3.0.0-beta.0/installation.mdx
@@ -29,7 +29,7 @@ Use **[docusaurus.new](https://docusaurus.new)** to test Docusaurus immediately 
 The easiest way to install Docusaurus is to use the command line tool that helps you scaffold a skeleton Docusaurus website. You can run this command anywhere in a new empty repository or within an existing repository, it will create a new directory containing the scaffolded files.
 
 ```bash
-npx create-docusaurus@latest my-website classic
+npx create-docusaurus@next my-website classic
 ```
 
 We recommend the `classic` template so that you can get started quickly, and it contains features found in Docusaurus 1. The `classic` template contains `@docusaurus/preset-classic` which includes standard documentation, a blog, custom pages, and a CSS framework (with dark mode support). You can get up and running extremely quickly with the classic template and customize things later on when you have gained more familiarity with Docusaurus.
@@ -37,7 +37,7 @@ We recommend the `classic` template so that you can get started quickly, and it 
 You can also use the template's TypeScript variant by passing the `--typescript` flag. See [TypeScript support](./typescript-support.mdx) for more information.
 
 ```bash
-npx create-docusaurus@latest my-website classic --typescript
+npx create-docusaurus@next my-website classic --typescript
 ```
 
 :::info Meta-Only
@@ -61,7 +61,7 @@ npm init docusaurus
 
 </details>
 
-Run `npx create-docusaurus@latest --help`, or check out its [API docs](./api/misc/create-docusaurus.mdx) for more information about all available flags.
+Run `npx create-docusaurus@next --help`, or check out its [API docs](./api/misc/create-docusaurus.mdx) for more information about all available flags.
 
 ## Project structure {#project-structure}
 


### PR DESCRIPTION
v3 beta instructions still use `@latest`, which will install using v2.4.3 at the time of this commit. Changed to `@next` to use v3 beta install