### PR TITLE
chore: do not error on broken links when doing test build

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -185,7 +185,7 @@ module.exports = async function createConfigAsync() {
     },
     onBrokenLinks:
       // Do not fail the build if a localized site has a broken link
-      process.env.DOCUSAURUS_CURRENT_LOCALE === defaultLocale
+      process.env.DOCUSAURUS_CURRENT_LOCALE === defaultLocale && !isBuildFast
         ? 'throw'
         : 'warn',
     onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

CI tests are failing: https://github.com/facebook/docusaurus/actions/runs/6370480578/job/17295576861?pr=9362

```
Error: Unable to build website for locale en.
    at tryToBuildLocale (/home/runner/work/docusaurus/docusaurus/packages/docusaurus/lib/commands/build.js:55:19) {
  [cause]: Error: Docusaurus found broken links!
  
  Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
  Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
  
  Exhaustive list of all broken links found:
  
  - On source page path = /blog/preparing-your-site-for-docusaurus-v3:
     -> linking to /docs/3.0.0-beta.0/markdown-features/react
     -> linking to /docs/3.0.0-beta.0/markdown-features/react#mdx-component-scope (resolved as: /docs/3.0.0-beta.0/markdown-features/react)
     -> linking to /docs/3.0.0-beta.0/markdown-features/plugins#installing-plugins (resolved as: /docs/3.0.0-beta.0/markdown-features/plugins)
```

The cause is that `BUILD_FAST` does not include these alternate versions. Let's disable throwing for now. Maybe we'll still want some broken links to throw? Presumably not, though...

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
