### PR TITLE
docs(deployment): add GITHUB_TOKEN permission info...

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -545,6 +545,24 @@ jobs:
 
 <details>
 
+<summary>GITHUB_TOKEN permissions</summary>
+
+The `GITHUB_TOKEN` is a GitHub secret that is automatically generated when you enable GitHub Actions in your repository. It is used to authenticate the workflow run. You can read more about it [here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret).
+
+In the default setting, the token has read only access, so the job will fail once it tries to push to the deployment branch.
+
+Configure the permissions:
+
+1. Go to your repository's Settings > Actions > General
+2. Scroll to the "Workflow permissions" section
+3. Enable "Read and write permissions"
+
+You can specify more granular permissions in the workflow using YAML. [Learn more about managing permissions](https://docs.github.com/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token).
+
+</details>
+
+<details>
+
 <summary>Site not deployed properly?</summary>
 
 After pushing to main, if you don't see your site published at the desired location (for example, it says "There isn't a GitHub Pages site here", or it's showing your repo's README.md file), try the following:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

When I set up a new docusaurus repo and following the GitHub Pages deployment guide with GitHub Actions, I ran into the issue, that the automatic token has read only access per default.

In order to help new users I added information to the guide, so other users don't have to figure it out on their own

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

no code change, only mdx

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

https://deploy-preview-9373--docusaurus-2.netlify.app/docs/deployment#triggering-deployment-with-github-actions

http://localhost:3000/docs/deployment#triggering-deployment-with-github-actions

New details box "GITHUB_TOKEN permissions"


## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
