### PR TITLE
chore: disable broken links check for i18n staging

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -184,10 +184,11 @@ module.exports = async function createConfigAsync() {
       },
     },
     onBrokenLinks:
-      // Do not fail the build if a localized site has a broken link
-      process.env.DOCUSAURUS_CURRENT_LOCALE === defaultLocale && !isBuildFast
-        ? 'throw'
-        : 'warn',
+      isBuildFast ||
+      isVersioningDisabled ||
+      process.env.DOCUSAURUS_CURRENT_LOCALE !== defaultLocale
+        ? 'warn'
+        : 'throw',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/docusaurus.ico',
     customFields: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -389,7 +389,11 @@ module.exports = async function createConfigAsync() {
             rehypePlugins: [(await import('rehype-katex')).default],
             disableVersioning: isVersioningDisabled,
             lastVersion:
-              isDev || isDeployPreview || isBranchDeploy || isBuildFast
+              isDev ||
+              isVersioningDisabled ||
+              isDeployPreview ||
+              isBranchDeploy ||
+              isBuildFast
                 ? 'current'
                 : getLastVersion(),
 


### PR DESCRIPTION


## Motivation

Broken link checker report errors due to blog post linking to 3.0 beta paths.

Follow-up of https://github.com/facebook/docusaurus/pull/9363 and https://github.com/facebook/docusaurus/pull/9374

## Test Plan

local
