### PR TITLE
chore: remove deprecated Google UA tracking id

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -445,7 +445,7 @@ module.exports = async function createConfigAsync() {
           },
           gtag: !(isDeployPreview || isBranchDeploy)
             ? {
-                trackingID: ['G-E5CR2Q1NRE', 'UA-141789564-1'],
+                trackingID: ['G-E5CR2Q1NRE'],
               }
             : undefined,
           sitemap: {


### PR DESCRIPTION

## Motivation

The UA tracking id is now useless.

We can see in practice no data is collected anymore by this tracker:

<img width="1900" alt="CleanShot 2023-10-08 at 19 19 00@2x" src="https://github.com/facebook/docusaurus/assets/749374/f7910229-f299-4f1c-932b-7fea7456bfb9">


See also https://github.com/facebook/docusaurus/issues/7221

[Google Analytics 4 has replaced Universal Analytics](https://support.google.com/analytics/answer/11583528)

> [Google Analytics 4](https://support.google.com/analytics/answer/10089681) is our next-generation measurement solution, and it has replaced Universal Analytics. Starting on July 1, 2023, standard Universal Analytics properties stopped processing new data. To maintain your website measurement, you'll need a Google Analytics 4 property. [Learn how to make the switch to Google Analytics 4](https://support.google.com/analytics/answer/10759417)


## Test Plan

local (analytics are disabled in previews)


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/


