### PR TITLE
fix(theme): avoid rendering empty search container if site has no search plugin

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -15,5 +15,5 @@ export default function NavbarSearch({
   children,
   className,
 }: Props): JSX.Element {
-  return <div className={clsx(className, styles.searchBox)}>{children}</div>;
+  return <div className={clsx(className, styles.navbarSearch)}>{children}</div>;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -15,5 +15,9 @@ export default function NavbarSearch({
   children,
   className,
 }: Props): JSX.Element {
-  return <div className={clsx(className, styles.navbarSearch)}>{children}</div>;
+  return (
+    <div className={clsx(className, styles.navbarSearchContainer)}>
+      {children}
+    </div>
+  );
 }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/styles.module.css
@@ -7,21 +7,21 @@
 
 /*
 Workaround to avoid rendering empty search container
-See https://github.com/facebook/docusaurus/pull/7990
+See https://github.com/facebook/docusaurus/pull/9385
 */
-.navbarSearch:not(:has(> *)) {
+.navbarSearchContainer:not(:has(> *)) {
   display: none;
 }
 
 @media (max-width: 996px) {
-  .navbarSearch {
+  .navbarSearchContainer {
     position: absolute;
     right: var(--ifm-navbar-padding-horizontal);
   }
 }
 
 @media (min-width: 997px) {
-  .navbarSearch {
+  .navbarSearchContainer {
     padding: var(--ifm-navbar-item-padding-vertical)
       var(--ifm-navbar-item-padding-horizontal);
   }

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/styles.module.css
@@ -5,15 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/*
+Workaround to avoid rendering empty search container
+See https://github.com/facebook/docusaurus/pull/7990
+*/
+.navbarSearch:not(:has(> *)) {
+  display: none;
+}
+
 @media (max-width: 996px) {
-  .searchBox {
+  .navbarSearch {
     position: absolute;
     right: var(--ifm-navbar-padding-horizontal);
   }
 }
 
 @media (min-width: 997px) {
-  .searchBox {
+  .navbarSearch {
     padding: var(--ifm-navbar-item-padding-vertical)
       var(--ifm-navbar-item-padding-horizontal);
   }


### PR DESCRIPTION


## Motivation

If a site has no search plugin, we shouldn't display the navbar search container container. 

It adds useless paddings and shifts the other navbar items.

![image](https://github.com/facebook/docusaurus/assets/749374/10915f1b-80dc-472c-a327-0dc04880bd34)


Not an ideal solution but at least it works. CSS `:has` is going to be cross-browser supported very soon.

fix https://github.com/facebook/docusaurus/pull/7990
fix https://github.com/facebook/docusaurus/issues/8889

## Test Plan

local only

