### PR TITLE
fix(core): conditionally include `hostname` parameter when using…

### DIFF
--- a/packages/docusaurus/src/server/getHostPort.ts
+++ b/packages/docusaurus/src/server/getHostPort.ts
@@ -54,7 +54,10 @@ async function choosePort(
   defaultPort: number,
 ): Promise<number | null> {
   try {
-    const port = await detect({port: defaultPort, hostname: host});
+    const port = await detect({
+      port: defaultPort,
+      ...(host !== 'localhost' && {hostname: host}),
+    });
     if (port === defaultPort) {
       return port;
     }


### PR DESCRIPTION
… detect port

- Skip adding the `hostname` parameter if the host is "localhost".

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Fixing bugs for Hacktoberfest.

This closes #8202  

Don't think it warrants a unit test for this, but LMK if you disagree.


<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

**How do you know this change has worked?**

Previously, if user starts a node server using 

```
const http = require("http");

const port = 3000;

const requestListener = function (req, res) {
  res.writeHead(200);
  res.end("My first server!");
};

const server = http.createServer(requestListener);

server.listen(port, () => {
  console.log(`Server is running on http://localhost:${port}`);
});
```

And they were to start a docusaurus project, it would not detect the above script running on 3000, and therefore start docusaurus on 3000 too.

The workaround before this PR was to specifically add the "localhost" host property into the other apps code:

`server.listen(port, "localhost", () => {`

But this PR avoids the user having todo that, and still supports and `server.listen(port, "localhost", () => {` use cases.

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-9407--docusaurus-2.netlify.app/

## Related issues/PRs

#8202 

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
