### PR TITLE
fix(plugin-blog): blog archive should hide unlisted blog posts

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -191,6 +191,8 @@ export default async function pluginContentBlog(
         blogTagsListPath,
       } = blogContents;
 
+      const listedBlogPosts = blogPosts.filter(shouldBeListed);
+
       const blogItemsToMetadata: {[postId: string]: BlogPostMetadata} = {};
 
       const sidebarBlogPosts =
@@ -213,7 +215,7 @@ export default async function pluginContentBlog(
         });
       }
 
-      if (archiveBasePath && blogPosts.length) {
+      if (archiveBasePath && listedBlogPosts.length) {
         const archiveUrl = normalizeUrl([
           baseUrl,
           routeBasePath,
@@ -222,7 +224,7 @@ export default async function pluginContentBlog(
         // Create a blog archive route
         const archiveProp = await createData(
           `${docuHash(archiveUrl)}.json`,
-          JSON.stringify({blogPosts}, null, 2),
+          JSON.stringify({blogPosts: listedBlogPosts}, null, 2),
         );
         addRoute({
           path: archiveUrl,


### PR DESCRIPTION


## Motivation

Fix https://github.com/facebook/docusaurus/issues/9432

blog posts with `unlisted: true` shouldn't appear on `/blog/archive`

## Test Plan

deploy preview

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

