### PR TITLE
A11Y improvements for DropdownNavbarItemDesktop

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/styles.module.css
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.dropdownButton {
+  font-size: inherit;
+  border: none;
+  background: none;
+  color: var(--ifm-navbar-link-color);
+  font-weight: var(--ifm-font-weight-semibold);
+  cursor: pointer;
+  padding: 0;
+}
+
+.dropdownButton:hover {
+  color: var(--ifm-navbar-link-hover-color);
+}
+
+.dropdownButton::after {
+  display: inline-block;
+  border-color: currentColor transparent;
+  border-style: solid;
+  border-width: 0.4em 0.4em 0;
+  content: '';
+  margin-left: 0.3em;
+  position: relative;
+  top: 2px;
+  transform: translateY(-50%);
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

Draft to improve this issue https://github.com/facebook/docusaurus/issues/8478 

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation


The goal of this PR is to improve the usability of the dropdown buttons, for example, the versions dropdown:
<img width="208" alt="image" src="https://github.com/facebook/docusaurus/assets/85184231/071d8326-346f-4026-8caf-2b6d9215687c">

### Improvements

- I uses a  `button` instead of a `link` with an ARIA Role, a button should be usable with the `SPACE` and `ENTER` key, it was only working with the `ENTER` key 

- I removed `aria-haspopup: true`: When using this ARIA attributes, the dropdown should match the menu role 

> A popup element usually appears as a block of content that is on top of other content. Authors MUST ensure that the role of the element that serves as the container for the popup content is [menu](https://w3c.github.io/aria/#menu), [listbox](https://w3c.github.io/aria/#listbox), [tree](https://w3c.github.io/aria/#tree), [grid](https://w3c.github.io/aria/#grid), or [dialog](https://w3c.github.io/aria/#dialog), and that the value of aria-haspopup matches the role of the popup container.

See also https://adrianroselli.com/2017/10/dont-use-aria-menu-roles-for-site-nav.html 

- I made sure the `onClick` expands and collapses the dropdown (For this issue https://github.com/facebook/docusaurus/issues/8478#issuecomment-1763440131) 

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links


<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
