### PR TITLE
Add aria-expanded for mobile navigation dropdown

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem.tsx
@@ -146,6 +146,8 @@ function DropdownNavbarItemMobile({
           'menu__link menu__link--sublist menu__link--sublist-caret',
           className,
         )}
+        href="#"
+        aria-expanded={!collapsed}
         {...props}
         onClick={(e) => {
           e.preventDefault();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

The mobile dropdown on the navigation is not conveying the **expanded** state to assistive technologies, it's also not focusable

<img width="1194" alt="image" src="https://github.com/facebook/docusaurus/assets/85184231/8d799e86-aaa4-4258-83be-79ddd4f9e917">


https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element

> If the element has an [href](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href) attribute: [Interactive content](https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2). 

It would be preferable to use an HTML button (a button should work with `SPACE` `onKeyUp` and `ENTER` `onKeyDown`) I think it could be done in another PR (styling changes would be needed)

## Test Plan

Can be tested on Docusaurus website homepage with a zoom to trigger the mobile version:
- buttons should be keyboard focusable
<img width="535" alt="" src="https://github.com/facebook/docusaurus/assets/85184231/bd0dab13-195d-4176-bec3-d65bc8a5692b">

- buttons should convey their expanded state

<img width="677" alt="" src="https://github.com/facebook/docusaurus/assets/85184231/36943782-2742-43d6-a4d5-f3486b2d2cbd">

On the [chrome accessibility tree view](https://developer.chrome.com/blog/full-accessibility-tree/), we can see that:
- _Versions_ has `expanded: false`
- _Languages_ has `expanded: true`



<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
