### PR TITLE
polish(theme): MDX images should use async decoding

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img/index.tsx
@@ -19,6 +19,7 @@ export default function MDXImg(props: Props): JSX.Element {
   return (
     // eslint-disable-next-line jsx-a11y/alt-text
     <img
+      decoding="async"
       loading="lazy"
       {...props}
       className={transformImgClassName(props.className)}


### PR DESCRIPTION
This pull request adds the `decoding="async"` attribute to the `<img />` HTML tag, enhancing image loading performance. This implementation is inspired by the default implementation of the Next.js image component, which prioritizes efficient and fast image loading.