### PR TITLE
fix(theme): fix firefox CSS :has() support bug

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/styles.module.css
@@ -9,8 +9,15 @@
 Workaround to avoid rendering empty search container
 See https://github.com/facebook/docusaurus/pull/9385
 */
-.navbarSearchContainer:not(:has(> *)) {
-  display: none;
+/*
+TODO temporary @supports check, remove before 2025
+only needed for Firefox < 121
+see https://github.com/facebook/docusaurus/issues/9527#issuecomment-1805272379
+ */
+@supports selector(:has(*)) {
+  .navbarSearchContainer:not(:has(> *)) {
+    display: none;
+  }
 }
 
 @media (max-width: 996px) {


### PR DESCRIPTION
## Motivation

Bug introduced in https://github.com/facebook/docusaurus/pull/9385 by using CSS `:has()`

Prod build minifies/merge CSS rules, but lack of `:has` support in Firefox (coming soon in v121) prevents other CSS rules from being applied, leading to various bugs.

Using `@supports` prevent this from happening (see also https://www.bram.us/2023/01/04/css-has-feature-detection-with-supportsselector-you-want-has-not-has/#:~:text=To%20feature%20detect%20browser%20support,used%20in%20a%20feature%20query%20.)

![CleanShot 2023-11-10 at 17 30 46](https://github.com/facebook/docusaurus/assets/749374/9d6e38c2-1923-4d70-9165-c180fcf597d5)

More details in https://github.com/facebook/docusaurus/issues/9493

Fix https://github.com/facebook/docusaurus/issues/9493

Fix https://github.com/facebook/docusaurus/issues/9527

Fix https://github.com/facebook/docusaurus/issues/9525


## Test Plan

Preview

### Test links

https://deploy-preview-9530--docusaurus-2.netlify.app/
