### PR TITLE
fix(theme): docs html sidebar items should always be visible

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/docsUtils.tsx
@@ -177,7 +177,7 @@ export function isVisibleSidebarItem(
       // An unlisted item remains visible if it is active
       return !item.unlisted || isActiveSidebarItem(item, activePath);
     default:
-      return false;
+      return true;
   }
 }
 


### PR DESCRIPTION
## Motivation

Bug introduced with the `frontMatter.unlisted` feature.

Docs sidebar items of types !== "link" or "category" shouldn't not be filtered out and hidden by default

Fix https://github.com/facebook/docusaurus/issues/9483

## Test Plan

preview

### Test links


Deploy preview: https://deploy-preview-9531--docusaurus-2.netlify.app/tests/docs

![CleanShot 2023-11-10 at 18 06 50@2x](https://github.com/facebook/docusaurus/assets/749374/55440941-68d7-46bd-968e-d881bcb2c36b)

(we'll enable Argos visual regression tests on `/tests/` pages to catch this kind of bugs in the future)
