### PR TITLE
fix: v3 admonitions should support v2 title syntax for nested admonitions

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -1288,17 +1288,23 @@ describe('admonitionTitleToDirectiveLabel', () => {
     `);
   });
 
-  it('does not transform left-padded directives', () => {
+  it('transforms space indented directives', () => {
     expect(
       admonitionTitleToDirectiveLabel(
         dedent`
         before
 
-         :::note Title
+         :::note 1 space
 
-        content
+         content
 
-        :::
+         :::
+
+          :::note 2 spaces
+
+          content
+
+          :::
 
         after
     `,
@@ -1307,13 +1313,60 @@ describe('admonitionTitleToDirectiveLabel', () => {
     ).toEqual(dedent`
         before
 
-         :::note Title
+         :::note[1 space]
 
-        content
+         content
 
-        :::
+         :::
+
+          :::note[2 spaces]
+
+          content
+
+          :::
 
         after
+    `);
+  });
+
+  it('transforms tab indented directives', () => {
+    expect(
+      admonitionTitleToDirectiveLabel(
+        `
+before
+
+\t:::note 1 tab
+
+\tcontent
+
+\t:::
+
+\t\t:::note 2 tabs
+
+\t\tcontent
+
+\t\t:::
+
+after
+    `,
+        directives,
+      ),
+    ).toBe(`
+before
+
+\t:::note[1 tab]
+
+\tcontent
+
+\t:::
+
+\t\t:::note[2 tabs]
+
+\t\tcontent
+
+\t\t:::
+
+after
     `);
   });
 

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -97,14 +97,14 @@ export function admonitionTitleToDirectiveLabel(
 
   const directiveNameGroup = `(${admonitionContainerDirectives.join('|')})`;
   const regexp = new RegExp(
-    `^(?<directive>:{3,}${directiveNameGroup}) +(?<title>.*)$`,
+    `^(?<indentation>( +|\t+))?(?<directive>:{3,}${directiveNameGroup}) +(?<title>.*)$`,
     'gm',
   );
 
   return content.replaceAll(regexp, (substring, ...args: any[]) => {
     const groups = args.at(-1);
 
-    return `${groups.directive}[${groups.title}]`;
+    return `${groups.indentation ?? ''}${groups.directive}[${groups.title}]`;
   });
 }
 

--- a/website/_dogfooding/_docs tests/tests/admonitions.mdx
+++ b/website/_dogfooding/_docs tests/tests/admonitions.mdx
@@ -54,6 +54,26 @@ import InfoIcon from "@theme/Admonition/Icon/Info"
 </Admonition>
 ```
 
+## Indented admonitions
+
+See admonition title v2 compat syntax bug: https://github.com/facebook/docusaurus/issues/9507
+
+1. Item 1
+
+   :::info Important Considerations
+
+   For better experience, try to keep the upgrade experience smooth.
+
+   :::
+
+- **Scale-up cluster**
+
+  :::caution Warning
+
+  Scaling up a cluster may cause several minutes of downtime. Please exercise caution.
+
+  :::
+
 ## Official admonitions
 
 Admonitions that are [officially documented](/docs/markdown-features/admonitions)


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/9507


## Test Plan

unit tests + preview

### Test links



https://deploy-preview-9535--docusaurus-2.netlify.app/tests/docs/tests/admonitions#indented-admonitions

<img width="894" alt="CleanShot 2023-11-11 at 19 33 30@2x" src="https://github.com/facebook/docusaurus/assets/749374/7904fe4d-083f-403a-81ac-41378948e706">

