### PR TITLE
fix(docs/api): Remove extraneous "hey"

### DIFF
--- a/website/docs/api/docusaurus.config.js.mdx
+++ b/website/docs/api/docusaurus.config.js.mdx
@@ -26,8 +26,6 @@ The `docusaurus.config.js` file supports:
 - [**CommonJS**](https://flaviocopes.com/commonjs/)
 - [**TypeScript**](../typescript-support.mdx#typing-config)
 
-hey
-
 Examples:
 
 ```js title="docusaurus.config.js"


### PR DESCRIPTION
Has no reason to exist, seems to have been added by accident.