### PR TITLE
docs: enhance og image tag description in documentation

### DIFF
--- a/website/docs/api/plugins/plugin-content-blog.mdx
+++ b/website/docs/api/plugins/plugin-content-blog.mdx
@@ -220,7 +220,7 @@ Accepted fields:
 | `toc_max_heading_level` | `number` | `3` | The max heading level shown in the table of contents. Must be between 2 and 6. |
 | `keywords` | `string[]` | `undefined` | Keywords meta tag, which will become the `<meta name="keywords" content="keyword1,keyword2,..."/>` in `<head>`, used by search engines. |
 | `description` | `string` | The first line of Markdown content | The description of your document, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. |
-| `image` | `string` | `undefined` | Cover or thumbnail image that will be used when displaying the link to your post. |
+| `image` | `string` | `undefined` | Cover or thumbnail image that will be used as the `<meta property="og:image" content="..."/>` in the `<head>`, enhancing link previews on social media and messaging platforms. |
 | `slug` | `string` | File path | Allows to customize the blog post URL (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-blog-post`, `slug: /my/path/to/blog/post`, slug: `/`. |
 
 ```mdx-code-block

--- a/website/docs/api/plugins/plugin-content-docs.mdx
+++ b/website/docs/api/plugins/plugin-content-docs.mdx
@@ -289,7 +289,7 @@ Accepted fields:
 | `custom_edit_url` | <code>string \| null</code> | Computed using the `editUrl` plugin option | The URL for editing this document. Use `null` to disable showing "Edit this page" for this page. |
 | `keywords` | `string[]` | `undefined` | Keywords meta tag for the document page, for search engines. |
 | `description` | `string` | The first line of Markdown content | The description of your document, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. |
-| `image` | `string` | `undefined` | Cover or thumbnail image that will be used when displaying the link to your post. |
+| `image` | `string` | `undefined` | Cover or thumbnail image that will be used as the `<meta property="og:image" content="..."/>` in the `<head>`, enhancing link previews on social media and messaging platforms. |
 | `slug` | `string` | File path | Allows to customize the document URL (`/<routeBasePath>/<slug>`). Support multiple patterns: `slug: my-doc`, `slug: /my/path/myDoc`, `slug: /`. |
 | `tags` | `Tag[]` | `undefined` | A list of strings or objects of two string fields `label` and `permalink` to tag to your docs. |
 | `draft` | `boolean` | `false` | Draft documents will only be available during development. |

--- a/website/docs/api/plugins/plugin-content-pages.mdx
+++ b/website/docs/api/plugins/plugin-content-pages.mdx
@@ -94,7 +94,7 @@ Accepted fields:
 | `title` | `string` | Markdown title | The blog post title. |
 | `description` | `string` | The first line of Markdown content | The description of your page, which will become the `<meta name="description" content="..."/>` and `<meta property="og:description" content="..."/>` in `<head>`, used by search engines. |
 | `keywords` | `string[]` | `undefined` | Keywords meta tag, which will become the `<meta name="keywords" content="keyword1,keyword2,..."/>` in `<head>`, used by search engines. |
-| `image` | `string` | `undefined` | Cover or thumbnail image that will be used when displaying the link to your post. |
+| `image` | `string` | `undefined` | Cover or thumbnail image that will be used as the `<meta property="og:image" content="..."/>` in the `<head>`, enhancing link previews on social media and messaging platforms. |
 | `wrapperClassName` | `string` |  | Class name to be added to the wrapper element to allow targeting specific page content. |
 | `hide_table_of_contents` | `boolean` | `false` | Whether to hide the table of contents to the right. |
 | `draft` | `boolean` | `false` | Draft pages will only be available during development. |


### PR DESCRIPTION


## Motivation

The motivation for this update is to address a common confusion regarding the use of the image in the documentation. Currently, the image specified is not displayed on the page itself but is crucial for the image meta tag, prominently used in link previews on social sharing platforms. This distinction is not explicitly clear in the existing documentation, leading to misunderstandings about the image's purpose and usage. The proposed changes aim to clarify this functionality, akin to how the description front matter is presently described.

## Related issues/PRs

This update is related to the issue raised in [facebook/docusaurus#9515](https://github.com/facebook/docusaurus/issues/9515), which discusses the need for clearer documentation regarding the role of the image in the Open Graph (OG) meta tag and its absence from the page display, highlighting its use in social media link previews.
