### PR TITLE
fix: add v2 retrocompatible support for quoted admonitions

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -1370,6 +1370,57 @@ after
     `);
   });
 
+  it('transforms directives in quotes', () => {
+    expect(
+      admonitionTitleToDirectiveLabel(
+        `
+before
+
+> :::caution There be dragons
+>
+> This is the admonition content
+>
+> :::
+>
+>> :::caution There be dragons
+>>
+>> This is the admonition content
+>>
+>> :::
+> > :::caution There be dragons
+> >
+> > This is the admonition content
+> >
+> > :::
+
+after
+    `,
+        directives,
+      ),
+    ).toBe(`
+before
+
+> :::caution[There be dragons]
+>
+> This is the admonition content
+>
+> :::
+>
+>> :::caution[There be dragons]
+>>
+>> This is the admonition content
+>>
+>> :::
+> > :::caution[There be dragons]
+> >
+> > This is the admonition content
+> >
+> > :::
+
+after
+    `);
+  });
+
   it('does not transform admonition without title', () => {
     expect(
       admonitionTitleToDirectiveLabel(

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -97,14 +97,16 @@ export function admonitionTitleToDirectiveLabel(
 
   const directiveNameGroup = `(${admonitionContainerDirectives.join('|')})`;
   const regexp = new RegExp(
-    `^(?<indentation>( +|\t+))?(?<directive>:{3,}${directiveNameGroup}) +(?<title>.*)$`,
+    `^(?<quote>(> ?)*)(?<indentation>( +|\t+))?(?<directive>:{3,}${directiveNameGroup}) +(?<title>.*)$`,
     'gm',
   );
 
   return content.replaceAll(regexp, (substring, ...args: any[]) => {
     const groups = args.at(-1);
 
-    return `${groups.indentation ?? ''}${groups.directive}[${groups.title}]`;
+    return `${groups.quote ?? ''}${groups.indentation ?? ''}${
+      groups.directive
+    }[${groups.title}]`;
   });
 }
 

--- a/website/_dogfooding/_docs tests/tests/admonitions.mdx
+++ b/website/_dogfooding/_docs tests/tests/admonitions.mdx
@@ -74,6 +74,20 @@ See admonition title v2 compat syntax bug: https://github.com/facebook/docusauru
 
   :::
 
+## Quoted admonitions
+
+> :::caution There be dragons
+>
+> This is the admonition content
+>
+> :::
+>
+> > :::caution There be dragons
+> >
+> > This is the admonition content
+> >
+> > :::
+
 ## Official admonitions
 
 Admonitions that are [officially documented](/docs/markdown-features/admonitions)


### PR DESCRIPTION
## Motivation

Docusaurus v3 regression reported in https://github.com/facebook/docusaurus/discussions/9336#discussioncomment-7630794

Follow-up of https://github.com/facebook/docusaurus/pull/9535


## Test Plan

unit tests + preview

### Test links


https://deploy-preview-9570--docusaurus-2.netlify.app/tests/docs/tests/admonitions#quoted-admonitions

<img width="872" alt="CleanShot 2023-11-21 at 19 34 40@2x" src="https://github.com/facebook/docusaurus/assets/749374/2716902b-f4d8-4638-8704-5f16943b5b2c">
