### PR TITLE
docs: broken link in release 3.0 page

### DIFF
--- a/website/blog/releases/3.0/index.mdx
+++ b/website/blog/releases/3.0/index.mdx
@@ -291,7 +291,7 @@ function Hello() {
 }
 ```
 
-In [#8982](https://github.com/facebook/docusaurus/pull/8982) and [#8870](https://github.com/facebook/docusaurus/pull/8870), we also added [magic comments](docs/markdown-features/code-blocks#custom-magic-comments) support for TeX-like, Haskell-like, and WebAssembly comment syntax.
+In [#8982](https://github.com/facebook/docusaurus/pull/8982) and [#8870](https://github.com/facebook/docusaurus/pull/8870), we also added [magic comments](/docs/markdown-features/code-blocks#custom-magic-comments) support for TeX-like, Haskell-like, and WebAssembly comment syntax.
 
 ```haskell title="haskell.hs"
 stringLength :: String -> Int


### PR DESCRIPTION
## Motivation

Link is missing `/` at the beginning resulting in a broken link

## Test Plan

Local build fixed the error

[Deploy preview page](https://deploy-preview-9573--docusaurus-2.netlify.app/blog/releases/3.0/#code-blocks)

### Test links

Deploy preview: https://deploy-preview-9573--docusaurus-2.netlify.app/