### PR TITLE
fix(theme-classic): Make unselected tabs tabbable

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -84,7 +84,7 @@ function TabList({
         <li
           // TODO extract TabListItem
           role="tab"
-          tabIndex={selectedValue === value ? 0 : -1}
+          tabIndex={selectedValue === value ? -1 : 0}
           aria-selected={selectedValue === value}
           key={value}
           ref={(tabControl) => tabRefs.push(tabControl)}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Currently, the selected tab in the `Tabs` component of `@docusaurus/theme-classic` has a `tabindex="0"`, while the others have `tabindex="-1"`, making them unreachable via the keyboard. I suspect this is a mistake, and it should be the opposite, so it's possible to select the other tabs, not the current one.

## Test Plan

For instance, one can compare the tab behavior for the `<Tabs>` component on the "Installation" page:
* https://docusaurus.io/docs/installation
* https://deploy-preview-9600--docusaurus-2.netlify.app/docs/installation/

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-9600--docusaurus-2.netlify.app/
