### PR TITLE
chore: fix argos workflow

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -23,7 +23,7 @@ jobs:
     # Argos is heavy to run
     # We only want to trigger Argos on PRs with the 'Argos' label
     # See https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label
-    if: ${{ github.ref_name == 'main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Argos')) }}
+    if: ${{ (github.event_name != 'pull_request' && github.ref_name == 'main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Argos')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code


### PR DESCRIPTION
attempt to fix Argos workflow being triggered when label is added to an already merged PR

See for example: https://github.com/facebook/docusaurus/pull/9487#issuecomment-1834377610