### PR TITLE
fix(utils): Markdown link replacement with <> but no spaces

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/__snapshots__/markdownLinks.test.ts.snap
+++ b/packages/docusaurus-utils/src/__tests__/__snapshots__/markdownLinks.test.ts.snap
@@ -176,6 +176,7 @@ exports[`replaceMarkdownLinks replaces links with same title as URL 1`] = `
   "brokenMarkdownLinks": [],
   "newContent": "
 [foo.md](/docs/foo)
+[./foo.md](</docs/foo>)
 [./foo.md](/docs/foo)
 [foo.md](/docs/foo)
 [./foo.md](/docs/foo)

--- a/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownLinks.test.ts
@@ -231,6 +231,7 @@ The following operations are defined for [URI]s:
         },
         fileString: `
 [foo.md](foo.md)
+[./foo.md](<./foo.md>)
 [./foo.md](./foo.md)
 [foo.md](./foo.md)
 [./foo.md](foo.md)

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -128,7 +128,7 @@ export function replaceMarkdownLinks<T extends ContentPaths>({
     const linkSuffixPattern = '(?:\\?[^#>\\s]+)?(?:#[^>\\s]+)?';
     const linkCapture = (forbidden: string) =>
       `((?!https?://|@site/)[^${forbidden}#?]+)`;
-    const linkURLPattern = `(?:${linkCapture(
+    const linkURLPattern = `(?:(?!<)${linkCapture(
       '()\\s',
     )}${linkSuffixPattern}|<${linkCapture('>')}${linkSuffixPattern}>)`;
     const linkPattern = new RegExp(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes https://github.com/facebook/docusaurus/issues/9614) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

We are once again complicating this algorithm 😅 It's because we cannot make `<>` get matched by the non-spaced link syntax.

@slorber Do you know if the write access is renewed automatically or if you have to poke someone again?