### PR TITLE
fix(live-codeblock): stabilize react-live transformCode callback, fix editor/preview desync

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
@@ -98,6 +98,10 @@ function EditorWithHeader() {
   );
 }
 
+// this should rather be a stable function
+// see https://github.com/facebook/docusaurus/issues/9630#issuecomment-1855682643
+const DEFAULT_TRANSFORM_CODE = (code: string) => `${code};`;
+
 export default function Playground({
   children,
   transformCode,
@@ -118,7 +122,7 @@ export default function Playground({
       <LiveProvider
         code={children.replace(/\n$/, '')}
         noInline={noInline}
-        transformCode={transformCode ?? ((code) => `${code};`)}
+        transformCode={transformCode ?? DEFAULT_TRANSFORM_CODE}
         theme={prismTheme}
         {...props}>
         {playgroundPosition === 'top' ? (


### PR DESCRIPTION

## Motivation

Passing an inline unstable callback leads to a weird edge case of react-live out of sync editor/preview on theme change

![image](https://github.com/facebook/docusaurus/assets/749374/2f04122f-8e1b-4049-982c-47c17c136198)


It's likely a bug in react-live, but let's stabilize as a workaround anyway, it can also optimize a bit.

Fix https://github.com/facebook/docusaurus/issues/9630


## Test Plan

preview

https://deploy-preview-9631--docusaurus-2.netlify.app/docs/markdown-features/code-blocks#interactive-code-editor
