### PR TITLE
chore: attempt fo fix Lint Autofix workflow

### DIFF
--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
       - name: Installation


### PR DESCRIPTION
Follow-up of https://github.com/facebook/docusaurus/pull/9604 which doesn't work yet


I'm not super confident this fix will work either unfortunately 😅 
See https://github.com/stefanzweifel/git-auto-commit-action/issues/211

This probably requires the usage unsafe of `pull_request_target`
See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/