### PR TITLE
SEO: add <meta name="robots" content="noindex" /> to pagination pages after page 1 to tackle duplicate content issues

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -25,13 +25,13 @@ function BlogListPageMetadata(props: Props): JSX.Element {
   const {
     siteConfig: {title: siteTitle},
   } = useDocusaurusContext();
-  const {blogDescription, blogTitle, permalink} = metadata;
+  const {blogDescription, blogTitle, permalink, page} = metadata;
   const isBlogOnlyMode = permalink === '/';
   const title = isBlogOnlyMode ? siteTitle : blogTitle;
   return (
     <>
       <PageMetadata title={title} description={blogDescription}>
-        <meta name="robots" content="noindex" />
+        {page === 1 ? null : <meta name="robots" content="noindex" />}
       </PageMetadata>
       <SearchMetadata tag="blog_posts_list" />
     </>

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -30,7 +30,9 @@ function BlogListPageMetadata(props: Props): JSX.Element {
   const title = isBlogOnlyMode ? siteTitle : blogTitle;
   return (
     <>
-      <PageMetadata title={title} description={blogDescription} />
+      <PageMetadata title={title} description={blogDescription}>
+        <meta name="robots" content="noindex" />
+      </PageMetadata>
       <SearchMetadata tag="blog_posts_list" />
     </>
   );

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
@@ -27,7 +27,9 @@ export default function BlogTagsListPage({tags, sidebar}: Props): JSX.Element {
         ThemeClassNames.wrapper.blogPages,
         ThemeClassNames.page.blogTagsListPage,
       )}>
-      <PageMetadata title={title} />
+      <PageMetadata title={title}>
+        <meta name="robots" content="noindex" />
+      </PageMetadata>
       <SearchMetadata tag="blog_tags_list" />
       <BlogLayout sidebar={sidebar}>
         <Heading as="h1">{title}</Heading>

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
@@ -27,9 +27,7 @@ export default function BlogTagsListPage({tags, sidebar}: Props): JSX.Element {
         ThemeClassNames.wrapper.blogPages,
         ThemeClassNames.page.blogTagsListPage,
       )}>
-      <PageMetadata title={title}>
-        <meta name="robots" content="noindex" />
-      </PageMetadata>
+      <PageMetadata title={title} />
       <SearchMetadata tag="blog_tags_list" />
       <BlogLayout sidebar={sidebar}>
         <Heading as="h1">{title}</Heading>

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -53,12 +53,15 @@ function useBlogTagsPostsPageTitle(tag: Props['tag']): string {
   );
 }
 
-function BlogTagsPostsPageMetadata({tag}: Props): JSX.Element {
+function BlogTagsPostsPageMetadata(props: Props): JSX.Element {
+  const {tag, listMetadata} = props;
   const title = useBlogTagsPostsPageTitle(tag);
   return (
     <>
       <PageMetadata title={title}>
-        <meta name="robots" content="noindex" />
+        {listMetadata.page === 1 ? null : (
+          <meta name="robots" content="noindex" />
+        )}
       </PageMetadata>
       <SearchMetadata tag="blog_tags_posts" />
     </>

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -57,7 +57,9 @@ function BlogTagsPostsPageMetadata({tag}: Props): JSX.Element {
   const title = useBlogTagsPostsPageTitle(tag);
   return (
     <>
-      <PageMetadata title={title} />
+      <PageMetadata title={title}>
+        <meta name="robots" content="noindex" />
+      </PageMetadata>
       <SearchMetadata tag="blog_tags_posts" />
     </>
   );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Improves SEO behaviour of Docusaurus by indicating that pagination pages which duplicate content should not be indexed by search engines. This does not apply to the initial page; but would apply to pages 2, 3, 4, 5 ....

See also the relevant portion of my blog on the topic: https://johnnyreilly.com/how-we-fixed-my-seo#1-remove-or-noindex-unnecessary-pages

## Test Plan

See screenshots from PR preview below demonstrating presence of:

```jsx
<meta name="robots" content="noindex" />
```

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-9658--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Note there is **no `noindex`** on the first page of the blog:

https://deploy-preview-9658--docusaurus-2.netlify.app/blog/

![image](https://github.com/facebook/docusaurus/assets/1010525/0538d71d-4074-4f08-a6e1-12d33d9fd343)

However, consider page 2 where there **is a  `noindex`**: https://deploy-preview-9658--docusaurus-2.netlify.app/blog/page/2/

![image](https://github.com/facebook/docusaurus/assets/1010525/1885aa80-7c6e-4379-a0d3-11209e8bb894)

Note there is **no `noindex`** on the first page of a tags page:

https://deploy-preview-9658--docusaurus-2.netlify.app/blog/tags/release/

![image](https://github.com/facebook/docusaurus/assets/1010525/6ace5caf-4f04-43c1-902c-dad70a26d8bf)

However, consider page 2 where there is: https://deploy-preview-9658--docusaurus-2.netlify.app/blog/tags/release/page/2/

![image](https://github.com/facebook/docusaurus/assets/1010525/51756c00-3178-42c9-b108-2aa6e5f5e98a)

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

https://github.com/facebook/docusaurus/issues/9657