### PR TITLE
feat: JSON-LD structured data implementation for blog

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -217,6 +217,7 @@ async function processBlogSourceFile(
     truncateMarker,
     showReadingTime,
     editUrl,
+    blogTitle: baseBlogTitle,
   } = options;
 
   // Lookup in localized folder in priority
@@ -314,6 +315,8 @@ async function processBlogSourceFile(
     return undefined;
   }
 
+  const baseBlogPermalink = normalizeUrl([baseUrl, routeBasePath]);
+
   const tagsBasePath = normalizeUrl([
     baseUrl,
     routeBasePath,
@@ -325,6 +328,8 @@ async function processBlogSourceFile(
     id: slug,
     metadata: {
       permalink,
+      baseBlogPermalink,
+      baseBlogTitle,
       editUrl: getBlogEditUrl(),
       source: aliasedSource,
       title,

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -197,6 +197,10 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
     readonly formattedDate: string;
     /** Full link including base URL. */
     readonly permalink: string;
+    /** the path to the base of the blog */
+    readonly baseBlogPermalink: string;
+    /** title of the overall blog */
+    readonly baseBlogTitle: string;
     /**
      * Description used in the meta. Could be an empty string (empty content)
      */
@@ -552,6 +556,27 @@ declare module '@theme/BlogPostPage/Metadata' {
   export default function BlogPostPageMetadata(): JSX.Element;
 }
 
+declare module '@theme/BlogPostPage/StructuredData' {
+  import type {
+    BlogPostFrontMatter,
+    PropBlogPostContent,
+  } from '@docusaurus/plugin-content-blog';
+
+  export type FrontMatter = BlogPostFrontMatter;
+
+  export type Assets = PropBlogPostContent['assets'];
+
+  export type Metadata = PropBlogPostContent['metadata'];
+
+  export interface Props {
+    readonly assets: Assets;
+    readonly frontMatter: FrontMatter;
+    readonly metadata: Metadata;
+  }
+
+  export default function BlogPostStructuredData(props: Props): JSX.Element;
+}
+
 declare module '@theme/BlogListPage' {
   import type {Content} from '@theme/BlogPostPage';
   import type {
@@ -572,6 +597,28 @@ declare module '@theme/BlogListPage' {
   }
 
   export default function BlogListPage(props: Props): JSX.Element;
+}
+
+declare module '@theme/BlogListPage/StructuredData' {
+  import type {Content} from '@theme/BlogPostPage';
+  import type {
+    BlogSidebar,
+    BlogPaginatedMetadata,
+  } from '@docusaurus/plugin-content-blog';
+
+  export interface Props {
+    /** Blog sidebar. */
+    readonly sidebar: BlogSidebar;
+    /** Metadata of the current listing page. */
+    readonly metadata: BlogPaginatedMetadata;
+    /**
+     * Array of blog posts included on this page. Every post's metadata is also
+     * available.
+     */
+    readonly items: readonly {readonly content: Content}[];
+  }
+
+  export default function BlogListPageStructuredData(props: Props): JSX.Element;
 }
 
 declare module '@theme/BlogTagsListPage' {

--- a/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
@@ -25,9 +25,7 @@ export default function BlogLayout(props: Props): JSX.Element {
             className={clsx('col', {
               'col--7': hasSidebar,
               'col--9 col--offset-1': !hasSidebar,
-            })}
-            itemScope
-            itemType="https://schema.org/Blog">
+            })}>
             {children}
           </main>
           {toc && <div className="col col--2">{toc}</div>}

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/StructuredData/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/StructuredData/index.tsx
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import type {Props} from '@theme/BlogListPage/StructuredData';
+
+export default function BlogListPageStructuredData(props: Props): JSX.Element {
+  const {siteConfig} = useDocusaurusContext();
+  const {withBaseUrl} = useBaseUrlUtils();
+
+  const {
+    metadata: {blogDescription, blogTitle, permalink},
+  } = props;
+
+  const url = `${siteConfig.url}${permalink}`;
+
+  // details on structured data support: https://schema.org/Blog
+  const blogStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    '@id': url,
+    mainEntityOfPage: url,
+    headline: blogTitle,
+    description: blogDescription,
+    blogPost: props.items.map((blogItem) => {
+      const {
+        content: {assets, frontMatter, metadata},
+      } = blogItem;
+      const {date, title, description} = metadata;
+
+      const image = assets.image ?? frontMatter.image;
+      const keywords = frontMatter.keywords ?? [];
+
+      // an array of https://schema.org/Person
+      const authorsStructuredData = metadata.authors.map((author) => ({
+        '@type': 'Person',
+        ...(author.name ? {name: author.name} : {}),
+        ...(author.title ? {description: author.title} : {}),
+        ...(author.url ? {url: author.url} : {}),
+        ...(author.email ? {email: author.email} : {}),
+        ...(author.imageURL ? {image: author.imageURL} : {}),
+      }));
+
+      const blogUrl = `${siteConfig.url}${metadata.permalink}`;
+      const imageUrl = image ? withBaseUrl(image, {absolute: true}) : undefined;
+
+      return {
+        '@type': 'BlogPosting',
+        '@id': blogUrl,
+        mainEntityOfPage: blogUrl,
+        url: blogUrl,
+        headline: title,
+        name: title,
+        description,
+        datePublished: date,
+        author:
+          authorsStructuredData.length === 1
+            ? authorsStructuredData[0]
+            : authorsStructuredData,
+        ...(image
+          ? {
+              // details on structured data support: https://schema.org/ImageObject
+              image: {
+                '@type': 'ImageObject',
+                '@id': imageUrl,
+                url: imageUrl,
+                contentUrl: imageUrl,
+                caption: `title image for the blog post: ${title}`,
+              },
+            }
+          : {}),
+        ...(keywords ? {keywords} : {}),
+      };
+    }),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      // We're using dangerouslySetInnerHTML because we want to avoid React
+      // transforming transforming quotes into &quot; which upsets parsers.
+      // The entire contents is a stringified JSON object so it is safe
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(blogStructuredData),
+      }}
+    />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -19,6 +19,7 @@ import BlogListPaginator from '@theme/BlogListPaginator';
 import SearchMetadata from '@theme/SearchMetadata';
 import type {Props} from '@theme/BlogListPage';
 import BlogPostItems from '@theme/BlogPostItems';
+import BlogListPageStructuredData from '@theme/BlogListPage/StructuredData';
 
 function BlogListPageMetadata(props: Props): JSX.Element {
   const {metadata} = props;
@@ -54,6 +55,7 @@ export default function BlogListPage(props: Props): JSX.Element {
         ThemeClassNames.page.blogListPage,
       )}>
       <BlogListPageMetadata {...props} />
+      <BlogListPageStructuredData {...props} />
       <BlogListPageContent {...props} />
     </HtmlClassNameProvider>
   );

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
@@ -6,36 +6,11 @@
  */
 
 import React from 'react';
-import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
-import {useBlogPost} from '@docusaurus/theme-common/internal';
 import type {Props} from '@theme/BlogPostItem/Container';
 
 export default function BlogPostItemContainer({
   children,
   className,
 }: Props): JSX.Element {
-  const {
-    frontMatter,
-    assets,
-    metadata: {description},
-  } = useBlogPost();
-  const {withBaseUrl} = useBaseUrlUtils();
-  const image = assets.image ?? frontMatter.image;
-  const keywords = frontMatter.keywords ?? [];
-  return (
-    <article
-      className={className}
-      itemProp="blogPost"
-      itemScope
-      itemType="https://schema.org/BlogPosting">
-      {description && <meta itemProp="description" content={description} />}
-      {image && (
-        <link itemProp="image" href={withBaseUrl(image, {absolute: true})} />
-      )}
-      {keywords.length > 0 && (
-        <meta itemProp="keywords" content={keywords.join(',')} />
-      )}
-      {children}
-    </article>
-  );
+  return <article className={className}>{children}</article>;
 }

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Content/index.tsx
@@ -21,8 +21,7 @@ export default function BlogPostItemContent({
     <div
       // This ID is used for the feed generation to locate the main content
       id={isBlogPostPage ? blogPostContainerID : undefined}
-      className={clsx('markdown', className)}
-      itemProp="articleBody">
+      className={clsx('markdown', className)}>
       <MDXContent>{children}</MDXContent>
     </div>
   );

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Author/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Author/index.tsx
@@ -28,31 +28,18 @@ export default function BlogPostItemHeaderAuthor({
     <div className={clsx('avatar margin-bottom--sm', className)}>
       {imageURL && (
         <MaybeLink href={link} className="avatar__photo-link">
-          <img
-            className="avatar__photo"
-            src={imageURL}
-            alt={name}
-            itemProp="image"
-          />
+          <img className="avatar__photo" src={imageURL} alt={name} />
         </MaybeLink>
       )}
 
       {name && (
-        <div
-          className="avatar__intro"
-          itemProp="author"
-          itemScope
-          itemType="https://schema.org/Person">
+        <div className="avatar__intro">
           <div className="avatar__name">
-            <MaybeLink href={link} itemProp="url">
-              <span itemProp="name">{name}</span>
+            <MaybeLink href={link}>
+              <span>{name}</span>
             </MaybeLink>
           </div>
-          {title && (
-            <small className="avatar__subtitle" itemProp="description">
-              {title}
-            </small>
-          )}
+          {title && <small className="avatar__subtitle">{title}</small>}
         </div>
       )}
     </div>

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -40,11 +40,7 @@ function ReadingTime({readingTime}: {readingTime: number}) {
 }
 
 function Date({date, formattedDate}: {date: string; formattedDate: string}) {
-  return (
-    <time dateTime={date} itemProp="datePublished">
-      {formattedDate}
-    </time>
-  );
+  return <time dateTime={date}>{formattedDate}</time>;
 }
 
 function Spacer() {

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -20,14 +20,8 @@ export default function BlogPostItemHeaderTitle({
   const {permalink, title} = metadata;
   const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
   return (
-    <TitleHeading className={clsx(styles.title, className)} itemProp="headline">
-      {isBlogPostPage ? (
-        title
-      ) : (
-        <Link itemProp="url" to={permalink}>
-          {title}
-        </Link>
-      )}
+    <TitleHeading className={clsx(styles.title, className)}>
+      {isBlogPostPage ? title : <Link to={permalink}>{title}</Link>}
     </TitleHeading>
   );
 }

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/StructuredData/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/StructuredData/index.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import type {Props} from '@theme/BlogPostPage/StructuredData';
+
+export default function BlogPostStructuredData(props: Props): JSX.Element {
+  const {siteConfig} = useDocusaurusContext();
+  const {withBaseUrl} = useBaseUrlUtils();
+  const {assets, frontMatter, metadata} = props;
+  const {date, title, description} = metadata;
+
+  const image = assets.image ?? frontMatter.image;
+  const keywords = frontMatter.keywords ?? [];
+
+  // an array of https://schema.org/Person
+  const authorsStructuredData = metadata.authors.map((author) => ({
+    '@type': 'Person',
+    ...(author.name ? {name: author.name} : {}),
+    ...(author.title ? {description: author.title} : {}),
+    ...(author.url ? {url: author.url} : {}),
+    ...(author.email ? {email: author.email} : {}),
+    ...(author.imageURL ? {image: author.imageURL} : {}),
+  }));
+
+  const url = `${siteConfig.url}${metadata.permalink}`;
+  const imageUrl = image ? withBaseUrl(image, {absolute: true}) : undefined;
+
+  // details on structured data support: https://schema.org/BlogPosting
+  // BlogPosting is one of the structured data types that Google explicitly
+  // supports: https://developers.google.com/search/docs/appearance/structured-data/article#structured-data-type-definitions
+  const blogPostStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    '@id': url,
+    mainEntityOfPage: url,
+    url,
+    headline: title,
+    name: title,
+    description,
+    datePublished: date,
+    author:
+      authorsStructuredData.length === 1
+        ? authorsStructuredData[0]
+        : authorsStructuredData,
+    ...(image
+      ? {
+          // details on structured data support: https://schema.org/ImageObject
+          image: {
+            '@type': 'ImageObject',
+            '@id': imageUrl,
+            url: imageUrl,
+            contentUrl: imageUrl,
+            caption: `title image for the blog post: ${title}`,
+          },
+        }
+      : {}),
+    ...(keywords ? {keywords} : {}),
+    isPartOf: {
+      '@type': 'Blog',
+      '@id': `${siteConfig.url}${metadata.baseBlogPermalink}`,
+      name: metadata.baseBlogTitle,
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      // We're using dangerouslySetInnerHTML because we want to avoid React
+      // transforming transforming quotes into &quot; which upsets parsers.
+      // The entire contents is a stringified JSON object so it is safe
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(blogPostStructuredData),
+      }}
+    />
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
@@ -13,6 +13,7 @@ import BlogLayout from '@theme/BlogLayout';
 import BlogPostItem from '@theme/BlogPostItem';
 import BlogPostPaginator from '@theme/BlogPostPaginator';
 import BlogPostPageMetadata from '@theme/BlogPostPage/Metadata';
+import BlogPostPageStructuredData from '@theme/BlogPostPage/StructuredData';
 import TOC from '@theme/TOC';
 import type {Props} from '@theme/BlogPostPage';
 import Unlisted from '@theme/Unlisted';
@@ -25,7 +26,7 @@ function BlogPostPageContent({
   sidebar: BlogSidebar;
   children: ReactNode;
 }): JSX.Element {
-  const {metadata, toc} = useBlogPost();
+  const {metadata, toc, assets} = useBlogPost();
   const {nextItem, prevItem, frontMatter, unlisted} = metadata;
   const {
     hide_table_of_contents: hideTableOfContents,
@@ -45,6 +46,13 @@ function BlogPostPageContent({
         ) : undefined
       }>
       {unlisted && <Unlisted />}
+
+      <BlogPostPageStructuredData
+        frontMatter={frontMatter}
+        assets={assets}
+        metadata={metadata}
+      />
+
       <BlogPostItem>{children}</BlogPostItem>
 
       {(nextItem || prevItem) && (

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -430,6 +430,8 @@ module.exports = async function createConfigAsync() {
               type: 'all',
               copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
             },
+            blogTitle: 'Docusaurus blog',
+            blogDescription: 'Read blog posts about Docusaurus from the team',
             blogSidebarCount: 'ALL',
             blogSidebarTitle: 'All our posts',
           },


### PR DESCRIPTION
<!--https://validator.schema.org/
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #9274) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

I originally contributed Structured Data support for blog posts back in 2021: https://github.com/facebook/docusaurus/pull/5322

@lex111 subsequently submitted a PR to migrate the approach to use microdata instead: https://github.com/facebook/docusaurus/pull/5355

I had reservations which I voiced at the time, but left it at that. Since then time I've had [something of a baptism of fire around the world of SEO]https://johnnyreilly.com/how-we-fixed-my-seo). And consequently I've been working with some excellent folk in the SEO industry to improve my own ranking. A thing that comes up repeatedly is a suggestion to use JSON-LD instead of microdata as that is what Google prefers: https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data#supported-formats

> In general, Google recommends using JSON-LD for structured data if your site's setup allows it, as it's the easiest solution for website owners to implement and maintain at scale (in other words, less prone to user errors).

I raised #9274 to discuss this and received some good feedback.

I've now implemented JSON-LD support for blog posts and I'm submitting this PR for review. With this change in place, it's now possible to separately configure the Structured Data through swizzling the two new components:

- `BlogListPage/StructuredData`
- `BlogPostPage/StructuredData`

From @Josh-Cena: 
> Swizzability does seem desirable. I also wonder if there are cases in the wild where people swizzle blog component and inadvertently broke microdata. This sounds reasonable to me.

The default behaviour for these components is to produce JSON-LD structured data that aligns with the Schema.org and Google's Rich Results guidelines. 

Let's talk for a moment about each of these components.

### BlogListPage/StructuredData

This component is responsible for generating the Structured Data for the blog list page. It renders JSON-LD structured data that aligns with the https://schema.org/Blog schema. 

### BlogPostPage/StructuredData

This component is responsible for generating the Structured Data for the blog post page. It renders JSON-LD structured data that aligns with the https://schema.org/BlogPosting schema. The `BlogPosting` schema is one of the structured data types that Google explicitly supports for Rich Results: https://developers.google.com/search/docs/appearance/structured-data/article#structured-data-type-definitions

All the Google-supported properties are included in the Structured Data generated by this component apart from `dateModified` which is optional. A number of other properties documented in the `BlogPosting` schema are included as well.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I will use the pull request preview on this PR to demonstrate that the Structured Data is generated as expected. I will also use the Structured Data Testing Tools to verify that the Structured Data is valid: 
- https://search.google.com/test/rich-results - this tool is used to test for Rich Results; only applicable to the blog post page
- https://validator.schema.org/ - this tool is used to validate the Structured Data; applicable to both the blog list page and the blog post page

Expect screenshots to be added to this PR.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

#9274