### PR TITLE
docs: add admonition for incompatibility with `*` and `**` in Chinese and Japanese in MDX v2+

### DIFF
--- a/website/docs/migration/v3.mdx
+++ b/website/docs/migration/v3.mdx
@@ -426,6 +426,79 @@ console.log('hello');
 
 :::
 
+### Other Markdown incompatibilities
+
+#### Emphasis starting or ending with a space or a punctuation
+
+New MDX parser now strictly complies with the CommonMark spec. CommonMark spec has introduced rules for emphasis around spaces and punctuation, which are incompatible especially with languages that do not use a space to split words, since v0.14.
+
+Japanese and Chinese are most affected by this, but there are some other languages that can be affected (e.g. Thai and Khmer), for example when you try to emphasize an inline code or a link. Languages that use a space to split words are much less affected.
+
+`**` (other than `` `**` ``) in the following example were parsed as intended in Docusaurus 2, but are not now in Docusaurus 3.
+
+{/* For Chinese translators: you can translate the following Japanese into Chinese. */}
+
+{/* prettier-ignore */}
+```md title="example.md"
+**Do not end a range of emphasis with a space. **Or `**` will not work as intended.
+
+<!-- Japanese -->
+**「。」の後に文を続けると`**`が意図した動作をしません。**また、**[リンク](https://docusaurus.io/)**や**`コード`**のすぐ外側に`**`、そのさらに外側に句読点以外がある場合も同様です。
+```
+
+<details>
+<summary>See the detailed conditions and how to upgrade</summary>
+
+If `*` or `**` matches either of the following conditions, it will not work as the beginning of an emphasis mark anymore:
+
+- The next character is a space (e.g. `word* word`)
+- The previous character is a punctuation character and the next character is a letter (not a space or punctuation character) (e.g. `文**（文）`)
+
+On the contrary, if `*` or `**` matches either of the following conditions, it will not work as the end of an emphasis mark anymore:
+
+- The previous character is a space (e.g. `word *word`)
+- The next character is a punctuation character and the previous character is a letter (e.g. `文。**文`)
+
+“A punctuation character” includes non-ASCII ones, brackets, quotation marks and some symbols including `%` and `@`. More strictly speaking, a character whose 2-letters Unicode category starts with `P` is treated as a punctuation character here.
+
+:::tip How to upgrade
+
+If the offending emphasis mark is next to a space, move the space out of the range of emphasis:
+
+```md title="english.md"
+**Do not end a range of emphasis with a space.** Or `**` will not work.
+```
+
+If the offending emphasis mark is surrounded by both a punctuation character and a letter, you can fix it without modifying the content by:
+
+1. Convert the document to MDX if it is a vanilla Markdown.
+2. replace the offending emphasis mark with a raw HTML tag (`<em>` or `<strong>`) instead:
+
+{/* prettier-ignore */}
+```mdx title="japanese.mdx"
+<strong>「。」の後に文を続けると`**`が意図した動作をしません。</strong>また、<strong>[リンク](https://docusaurus.io/)</strong>や<strong>`コード`</strong>のすぐ外側に`**`、そのさらに外側に句読点以外がある場合も同様です。
+```
+
+While not an ideal solution, you can also either of the following without converting the document to MDX:
+
+- Move the most outside punctuation character out of the emphasis mark.
+
+  {/* prettier-ignore */}
+  ```md title="japanese.md"
+  **「。」の後に文を続けると`**`が意図した動作をしません**。また、[**リンク**](https://docusaurus.io/)や・・・
+  ```
+
+- Put a space just outside of the offending `*` or `**`. This solution does not force you to convert the document to MDX.
+
+  {/* prettier-ignore */}
+  ```md title="japanese.md"
+  **「。」の後に文を続けると`**`が意図した動作をしません。** また、**[リンク](https://docusaurus.io/)** や **`コード`** のすぐ外側に`**`、そのさらに外側に句読点以外がある場合も同様です。
+  ```
+
+:::
+
+</details>
+
 ### MDX plugins
 
 All the official packages (Unified, Remark, Rehype...) in the MDX ecosystem are now [**ES Modules only**](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) and do not support [CommonJS](https://nodejs.org/api/modules.html#modules-commonjs-modules) anymore.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

`**` in `**重要的中文。**其他的中文。` and `**重要な日本語の文。**別の日本語の文。` will not treated as `<strong>` due to a regression in CommonMark spec 0.14+.
MDX v2+ strictly follow CM and have this regression.

https://github.com/commonmark/commonmark-spec/issues/650

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

https://deploy-preview-9692--docusaurus-2.netlify.app/docs/migration/v3/#other-markdown-incompatibilities

## Related issues/PRs

https://github.com/commonmark/commonmark-spec/issues/650