### PR TITLE
docs: Updates the Algolia DocSearch eligibility description to match DocSearch page

### DIFF
--- a/website/docs/search.mdx
+++ b/website/docs/search.mdx
@@ -25,7 +25,7 @@ There are a few options you can use to add search to your website:
 
 Docusaurus has **official support** for [Algolia DocSearch](https://docsearch.algolia.com).
 
-The service is **free** for any open-source project: just make sure to read the [checklist](https://docsearch.algolia.com/docs/who-can-apply/) and [apply to the DocSearch program](https://docsearch.algolia.com/apply).
+The service is **free** for any developer documentation or technical blog: just make sure to read the [checklist](https://docsearch.algolia.com/docs/who-can-apply/) and [apply to the DocSearch program](https://docsearch.algolia.com/apply).
 
 DocSearch crawls your website once a week (the schedule is configurable from the web interface) and aggregates all the content in an Algolia index. This content is then queried directly from your front-end using the Algolia API.
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

The previous documentation of the free Algolia DocSearch program only mentions open-source projects. At first this led me to believe I couldn't use it for our developer docs at Prefab (https://docs.prefab.cloud).

However, my understanding from reading https://docsearch.algolia.com/docs/who-can-apply/ is that DocSearch is free for **all** developer documentation, including commercial projects.

My change uses the same language as the above linked Algolia page for clarity and consistency.

## Test Plan

N/A, this is only a documentation change.

### Test links

Link to the changed page:
https://docusaurus.io/docs/search#using-algolia-docsearch

## Related issues/PRs

N/A