### PR TITLE
Fix missing triple``` characters in markdown-features.mdx

### DIFF
--- a/packages/create-docusaurus/templates/shared/docs/tutorial-basics/markdown-features.mdx
+++ b/packages/create-docusaurus/templates/shared/docs/tutorial-basics/markdown-features.mdx
@@ -60,7 +60,7 @@ You can reference images relative to the current file as well. This is particula
 ## Code Blocks
 
 Markdown code blocks are supported with Syntax highlighting.
-
+```
     ```jsx title="src/components/HelloDocusaurus.js"
     function HelloDocusaurus() {
         return (
@@ -68,7 +68,7 @@ Markdown code blocks are supported with Syntax highlighting.
         )
     }
     ```
-
+```
 ```jsx title="src/components/HelloDocusaurus.js"
 function HelloDocusaurus() {
   return <h1>Hello, Docusaurus!</h1>;
@@ -78,7 +78,7 @@ function HelloDocusaurus() {
 ## Admonitions
 
 Docusaurus has a special syntax to create admonitions and callouts:
-
+```
     :::tip My tip
 
     Use this awesome feature option
@@ -90,7 +90,7 @@ Docusaurus has a special syntax to create admonitions and callouts:
     This action is dangerous
 
     :::
-
+```
 :::tip My tip
 
 Use this awesome feature option


### PR DESCRIPTION
Sorry to be blunt, but I'm not gonna spend +1-2h reading the PR rules just to send such a simple fix.
I'm just fixing missing ``` characters.
Take it or leave it. I don't care either way.