### PR TITLE
fix(create-docusaurus): fix init template code blocks, and little improvements

### DIFF
--- a/packages/create-docusaurus/README.md
+++ b/packages/create-docusaurus/README.md
@@ -10,6 +10,10 @@ npm init docusaurus
 yarn create docusaurus
 ```
 
+```bash
+npx create-docusaurus@latest
+```
+
 ## Usage
 
 Please see the [installation documentation](https://docusaurus.io/docs/installation).

--- a/packages/create-docusaurus/templates/shared/docs/tutorial-basics/markdown-features.mdx
+++ b/packages/create-docusaurus/templates/shared/docs/tutorial-basics/markdown-features.mdx
@@ -60,15 +60,15 @@ You can reference images relative to the current file as well. This is particula
 ## Code Blocks
 
 Markdown code blocks are supported with Syntax highlighting.
+
+````md
+```jsx title="src/components/HelloDocusaurus.js"
+function HelloDocusaurus() {
+  return <h1>Hello, Docusaurus!</h1>;
+}
 ```
-    ```jsx title="src/components/HelloDocusaurus.js"
-    function HelloDocusaurus() {
-        return (
-            <h1>Hello, Docusaurus!</h1>
-        )
-    }
-    ```
-```
+````
+
 ```jsx title="src/components/HelloDocusaurus.js"
 function HelloDocusaurus() {
   return <h1>Hello, Docusaurus!</h1>;
@@ -78,19 +78,21 @@ function HelloDocusaurus() {
 ## Admonitions
 
 Docusaurus has a special syntax to create admonitions and callouts:
+
+```md
+:::tip My tip
+
+Use this awesome feature option
+
+:::
+
+:::danger Take care
+
+This action is dangerous
+
+:::
 ```
-    :::tip My tip
 
-    Use this awesome feature option
-
-    :::
-
-    :::danger Take care
-
-    This action is dangerous
-
-    :::
-```
 :::tip My tip
 
 Use this awesome feature option

--- a/packages/create-docusaurus/templates/shared/docs/tutorial-basics/markdown-features.mdx
+++ b/packages/create-docusaurus/templates/shared/docs/tutorial-basics/markdown-features.mdx
@@ -60,7 +60,7 @@ You can reference images relative to the current file as well. This is particula
 ## Code Blocks
 
 Markdown code blocks are supported with Syntax highlighting.
-
+```
     ```jsx title="src/components/HelloDocusaurus.js"
     function HelloDocusaurus() {
         return (
@@ -68,7 +68,7 @@ Markdown code blocks are supported with Syntax highlighting.
         )
     }
     ```
-
+```
 ```jsx title="src/components/HelloDocusaurus.js"
 function HelloDocusaurus() {
   return <h1>Hello, Docusaurus!</h1>;
@@ -78,7 +78,7 @@ function HelloDocusaurus() {
 ## Admonitions
 
 Docusaurus has a special syntax to create admonitions and callouts:
-
+```
     :::tip My tip
 
     Use this awesome feature option
@@ -90,7 +90,7 @@ Docusaurus has a special syntax to create admonitions and callouts:
     This action is dangerous
 
     :::
-
+```
 :::tip My tip
 
 Use this awesome feature option


### PR DESCRIPTION

## Motivation

The init template has problems we didn't notice when upgrading MDX, since MDX v2+ does not support indented code blocks anymore:

![image](https://github.com/facebook/docusaurus/assets/749374/1542c158-284a-4a3d-8c2e-12591ac01cbe)

Fix problem reported in https://github.com/facebook/docusaurus/pull/9694 (+ other little improvements)

## Test Plan

local

### Test links


https://deploy-preview-9696--docusaurus-2.netlify.app/

