### PR TITLE
feat(i18n): support translating through locale extensions `myDoc.fr.md`

### DIFF
--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/docusaurus.config.js
@@ -11,6 +11,10 @@ module.exports = {
   url: 'https://your-docusaurus-site.example.com',
   baseUrl: '/',
   favicon: 'img/favicon.ico',
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'fr'],
+  },
   markdown: {
     parseFrontMatter: async (params) => {
       const result = await params.defaultParseFrontMatter(params);

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.fr.tsx
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__fixtures__/website/src/pages/typescript.fr.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Head from '@docusaurus/Head';
+
+export default class Home extends React.Component {
+  render() {
+    return (
+      <div>
+        <Head>
+          <title>translated Hello</title>
+        </Head>
+        <div>translated TypeScript...</div>
+      </div>
+    );
+  }
+}

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/__snapshots__/index.test.ts.snap
@@ -69,7 +69,7 @@ exports[`docusaurus-plugin-content-pages loads simple pages with french translat
   },
   {
     "permalink": "/fr/typescript",
-    "source": "@site/src/pages/typescript.tsx",
+    "source": "@site/src/pages/typescript.fr.tsx",
     "type": "jsx",
   },
   {

--- a/website/_dogfooding/_pages tests/i18n/index.fr.md
+++ b/website/_dogfooding/_pages tests/i18n/index.fr.md
@@ -1,0 +1,3 @@
+# Page i18n test
+
+French version

--- a/website/_dogfooding/_pages tests/i18n/index.md
+++ b/website/_dogfooding/_pages tests/i18n/index.md
@@ -1,0 +1,3 @@
+# Page i18n test
+
+English version

--- a/website/_dogfooding/_pages tests/index.mdx
+++ b/website/_dogfooding/_pages tests/index.mdx
@@ -26,6 +26,7 @@ import Readme from "../README.mdx"
 ### Other tests
 
 - [React 18](/tests/pages/react-18)
+- [i18n](/tests/pages/i18n)
 - [Crash test](/tests/pages/crashTest)
 - [Code block tests](/tests/pages/code-block-tests)
 - [Link tests](/tests/pages/link-tests)


### PR DESCRIPTION

## Motivation

Translating through the `i18n` folder is nice for i18n SaaS integrations (Crowdin)

But it is not ideal for simpler needs based on Git, as it requires to explain the i18n folder structure convention.

To make i18n simpler to adopt, let's add support for localized file extensions to all our core content plugins
- `./docs/myDoc.fr.md`
- `./blog/myBlog.fr.md`
- `./src/pages/myPage.fr.tsx`

This kind of convention is already used by other documentation frameworks:
- https://ultrabug.github.io/mkdocs-static-i18n/getting-started/quick-start/
- https://nextra.site/docs/guide/i18n#add-locale-to-filenames


## Test Plan

Unit tests + dogfood

### Test links


Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/


