### PR TITLE
fix(theme): allow empty code blocks and live playgrounds

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -363,6 +363,14 @@ declare module '@theme/CodeBlock' {
   export default function CodeBlock(props: Props): JSX.Element;
 }
 
+declare module '@theme/CodeInline' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'code'> {}
+
+  export default function CodeInline(props: Props): JSX.Element;
+}
+
 declare module '@theme/CodeBlock/CopyButton' {
   export interface Props {
     readonly code: string;

--- a/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type {Props} from '@theme/CodeInline';
+
+// Simple component used to render inline code blocks
+// its purpose is to be swizzled and customized
+// MDX 1 used to have a inlineCode comp, see https://mdxjs.com/migrating/v2/
+export default function CodeInline(props: Props): JSX.Element {
+  return <code {...props} />;
+}

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
@@ -10,12 +10,18 @@ import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import type {Props} from '@theme/MDXComponents/Code';
 
-export default function MDXCode(props: Props): JSX.Element {
-  const shouldBeInline = React.Children.toArray(props.children).every(
-    (el) => typeof el === 'string' && !el.includes('\n'),
+function shouldBeInline(props: Props) {
+  return (
+    typeof props.children !== 'undefined' &&
+    React.Children.toArray(props.children).every(
+      (el) => typeof el === 'string' && !el.includes('\n'),
+    )
   );
+}
 
-  return shouldBeInline ? (
+export default function MDXCode(props: Props): JSX.Element {
+  const inline = shouldBeInline(props);
+  return inline ? (
     <code {...props} />
   ) : (
     <CodeBlock {...(props as ComponentProps<typeof CodeBlock>)} />

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
@@ -8,10 +8,13 @@
 import type {ComponentProps} from 'react';
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
+import CodeInline from '@theme/CodeInline';
 import type {Props} from '@theme/MDXComponents/Code';
 
 function shouldBeInline(props: Props) {
   return (
+    // empty code blocks have no props.children,
+    // see https://github.com/facebook/docusaurus/pull/9704
     typeof props.children !== 'undefined' &&
     React.Children.toArray(props.children).every(
       (el) => typeof el === 'string' && !el.includes('\n'),
@@ -20,9 +23,8 @@ function shouldBeInline(props: Props) {
 }
 
 export default function MDXCode(props: Props): JSX.Element {
-  const inline = shouldBeInline(props);
-  return inline ? (
-    <code {...props} />
+  return shouldBeInline(props) ? (
+    <CodeInline {...props} />
   ) : (
     <CodeBlock {...(props as ComponentProps<typeof CodeBlock>)} />
   );

--- a/packages/docusaurus-theme-live-codeblock/src/theme-live-codeblock.d.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/theme-live-codeblock.d.ts
@@ -24,7 +24,8 @@ declare module '@theme/Playground' {
   type LiveProviderProps = React.ComponentProps<typeof LiveProvider>;
 
   export interface Props extends CodeBlockProps, LiveProviderProps {
-    children: string;
+    // Allow empty live playgrounds
+    children?: string;
   }
   export default function Playground(props: LiveProviderProps): JSX.Element;
 }

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
@@ -120,7 +120,7 @@ export default function Playground({
   return (
     <div className={styles.playgroundContainer}>
       <LiveProvider
-        code={children.replace(/\n$/, '')}
+        code={children?.replace(/\n$/, '')}
         noInline={noInline}
         transformCode={transformCode ?? DEFAULT_TRANSFORM_CODE}
         theme={prismTheme}

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -458,3 +458,33 @@ See https://github.com/facebook/docusaurus/issues/9517
   </head>
 </html>
 ```
+
+## Empty code blocks edge cases
+
+Empty inline code block: ``
+
+Single space inline code block: ` `
+
+Empty code block
+
+{/* prettier-ignore */}
+```
+```
+
+Empty 1 line code block
+
+```
+
+```
+
+Empty 2 line code block
+
+```
+
+```
+
+Empty live code block
+
+```js live
+
+```


### PR DESCRIPTION
## Motivation

An empty code block should render as a code block, not an inline code block

An empty code block can be a live playground



Fix https://github.com/facebook/docusaurus/issues/9699

Note: MDX will emit no children prop if the code block is empty or has a single line, which is kind-of surprising but we'll handle it.

![CleanShot 2024-01-05 at 13 07 30@2x](https://github.com/facebook/docusaurus/assets/749374/c85fe384-fdf2-41e4-b67f-eee4948ab7fa)

Also extracts `CodeInline` to make it easier to swizzle and customize without ejecting `<MDXCode/>` (the RN website does that)
(MDX v1 used to have a spacial `inlineCode` component but it was removed in v2: https://mdxjs.com/migrating/v2/)


## Test Plan

dogfood + deploy preview

### Test links


https://deploy-preview-9704--docusaurus-2.netlify.app/tests/pages/code-block-tests#empty-code-blocks-edge-cases

