### PR TITLE
Render `NotFoundContent` via route if `routeBasePath` is `/`

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/routes.ts
+++ b/packages/docusaurus-plugin-content-docs/src/routes.ts
@@ -226,6 +226,13 @@ export async function buildAllRoutes(
       }),
     ),
   );
+  if (param.options.routeBasePath === '/') {
+    subRoutes.push({
+      path: '/*',
+      component: '@docusaurus/ComponentCreator',
+      exact: true,
+    });
+  }
 
   // all docs routes are wrapped under a single parent route, this ensures
   // the theme layout never unmounts/remounts when navigating between versions

--- a/packages/docusaurus/src/client/exports/ComponentCreator.tsx
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.tsx
@@ -43,6 +43,24 @@ export default function ComponentCreator(
       },
     });
   }
+  if (path === '/*') {
+    return Loadable({
+        loading: Loading,
+        loader: () => import('@theme/NotFound/Content'),
+        modules: ['@theme/NotFound/Content'],
+        webpack: () => [require.resolveWeak('@theme/NotFound/Content')],
+        render(loaded, props) {
+            const NotFoundContent = loaded.default;
+            return (
+              <RouteContextProvider
+                // Do we want a better name than native-default?
+                value={{plugin: {name: 'native', id: 'default'}}}>
+                <NotFoundContent {...(props as JSX.IntrinsicAttributes)} />
+              </RouteContextProvider>
+            );
+        },
+    });
+}
 
   const chunkNames = routesChunkNames[`${path}-${hash}`]!;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/docusaurus/src/server/plugins/routeConfig.ts
+++ b/packages/docusaurus/src/server/plugins/routeConfig.ts
@@ -42,6 +42,14 @@ export function sortConfig(
       return -1;
     }
 
+    // Wildcard also should get placed last
+    if (a.path.endsWith('/*')) {
+      return 1;
+    }
+    if (b.path.endsWith('/*')) {
+      return -1;
+    }
+
     if (a.routes && !b.routes) {
       return 1;
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Fixes https://github.com/facebook/docusaurus/issues/9688

The behavior was semi-inspired by option 1 to https://github.com/facebook/docusaurus/issues/9688#issuecomment-1878522911

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

(Let me know what else needs to happen)

On the repo which reproduces https://github.com/facebook/docusaurus/issues/9688, I made this change (e.g. leveraged my fork) and was successfully able to get a 404 on any `/<whatever>` page, while still getting the content on the correct docs subroutes.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
