### PR TITLE
fix(theme-common): fix missing code block MagicComments style in Visual Basic (.NET) 16

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -28,6 +28,7 @@ const commentPatterns = {
   wasm: {start: '\\;\\;', end: ''},
   tex: {start: '%', end: ''},
   vb: {start: "['‘’]", end: ''},
+  vbnet: {start: "_\s*['‘’]", end: ''}, // Visual Studio 2019 or later
   rem: {start: '[Rr][Ee][Mm]\\b', end: ''},
   f90: {start: '!', end: ''}, // Free format only
   ml: {start: '\\(\\*', end: '\\*\\)'},
@@ -113,10 +114,11 @@ function getAllMagicCommentDirectiveStyles(
       return getCommentPattern(['wasm'], magicCommentDirectives);
 
     case 'vb':
-    case 'vbnet':
     case 'vba':
     case 'visual-basic':
       return getCommentPattern(['vb', 'rem'], magicCommentDirectives);
+    case 'vbnet':
+      return getCommentPattern(['vbnet', 'rem'], magicCommentDirectives);
 
     case 'batch':
       return getCommentPattern(['rem'], magicCommentDirectives);

--- a/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/codeBlockUtils.ts
@@ -28,7 +28,7 @@ const commentPatterns = {
   wasm: {start: '\\;\\;', end: ''},
   tex: {start: '%', end: ''},
   vb: {start: "['‘’]", end: ''},
-  vbnet: {start: "_\s*['‘’]", end: ''}, // Visual Studio 2019 or later
+  vbnet: {start: "(?:_\\s*)?['‘’]", end: ''}, // Visual Studio 2019 or later
   rem: {start: '[Rr][Ee][Mm]\\b', end: ''},
   f90: {start: '!', end: ''}, // Free format only
   ml: {start: '\\(\\*', end: '\\*\\)'},

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -384,6 +384,25 @@ y = times2(x);
 \end{document}
 ```
 
+```vba title="vba.vb"
+Function Factorial(ByVal n As Long) As Long
+    If n < 0 Then
+        Err.Raise 5 ' Invalid argument
+    End If
+    'highlight-next-line
+    Factorial = 1 ' return value
+    If n < 2 Then
+        Exit Function
+    End If
+    Dim i As Long
+    ' highlight-start
+    For i = 2 To n
+        Factorial = Factorial * i
+    Next
+    ' highlight-end
+End Function
+```
+
 ```vbnet title="vbnet.vb"
 ' highlight-next-line
 Dim languages As New Set(Of String) From {

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -385,15 +385,15 @@ y = times2(x);
 ```
 
 ```vbnet title="vbnet.vb"
+' highlight-next-line
 Dim languages As New Set(Of String) From {
-    ' highlight-start
     "C#",
     "Visual Basic",
+    _ ' highlight-start
     "F#",
-    ' highlight-end
     "PowerShell",
-    ' highlight-next-line
     "TypeScript"
+    _' highlight-end
 }
 ```
 

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -391,9 +391,6 @@ Function Factorial(ByVal n As Long) As Long
     End If
     'highlight-next-line
     Factorial = 1 ' return value
-    If n < 2 Then
-        Exit Function
-    End If
     Dim i As Long
     ' highlight-start
     For i = 2 To n

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -402,7 +402,7 @@ End Function
 
 ```vbnet title="vbnet.vb"
 ' highlight-next-line
-Dim languages As New Set(Of String) From {
+Dim languages As New HashSet(Of String) From {
     "C#",
     "Visual Basic",
     _ ' highlight-start


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

The following code in VB.NET and VB.NET code in Dogfooding test cases is not valid due to the magick comment:

```vbnet
Dim array = {
  1,
  2,
  ' highlight-next-line
  3 ' Don't add the trailing comma here!
}
```

We have to use `_ '` there instead but it has not been supported in Docusaurus yet.

```vbnet
Dim array = {
  1,
  2,
  _ ' highlight-next-line
  3 ' Don't add the trailing comma here!
}
```

This `_ '` is supported [only in Visual Studio 2019 or later (VB 16.x)](https://learn.microsoft.com/en-us/dotnet/visual-basic/whats-new/#visual-basic-160). There is no way to add comments in the middle of statements in older VB including Excel VBA.

I believe that this can be safely merged in v3.1.1. (minor language & does not break existing code blocks)

Also, VB.NET code in Dogfooding test has the wrong name for set. `Set` is wrong and must be `HashSet` instead.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Dogfooding



### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-9727--docusaurus-2.netlify.app/tests/pages/code-block-tests#magic-comments-tests

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

#9671 
