### PR TITLE
fix: remove old useless mdx typedefs

### DIFF
--- a/packages/docusaurus-theme-classic/package.json
+++ b/packages/docusaurus-theme-classic/package.json
@@ -47,7 +47,6 @@
     "utility-types": "^3.10.0"
   },
   "devDependencies": {
-    "@types/mdx-js__react": "^1.5.5",
     "@types/nprogress": "^0.2.0",
     "@types/prismjs": "^1.26.0",
     "@types/rtlcss": "^3.5.1",

--- a/packages/docusaurus-theme-mermaid/package.json
+++ b/packages/docusaurus-theme-mermaid/package.json
@@ -42,7 +42,6 @@
     "tslib": "^2.6.0"
   },
   "devDependencies": {
-    "@types/mdx-js__react": "^1.5.5",
     "react-test-renderer": "^18.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,13 +3378,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/mdx-js__react@^1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@types/mdx-js__react/-/mdx-js__react-1.5.5.tgz#fa6daa1a28336d77b6cf071aacc7e497600de9ee"
-  integrity sha512-k8pnaP6JXVlQh18HgL5X6sYFNC/qZnzO7R2+HsmwrwUd+JnnsU0d9lyyT0RQrHg1anxDU36S98TI/fsGtmYqqg==
-  dependencies:
-    "@types/react" "*"
-
 "@types/mdx@^2.0.0":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.5.tgz#9a85a8f70c7c4d9e695a21d5ae5c93645eda64b1"


### PR DESCRIPTION

## Motivation

We shouldn't use `@types/mdx-js__react` anymore

## Test Plan

ci
