### PR TITLE
feat(mdx-loader): the table-of-contents should display props passed to headings of imported MDX partials

### DIFF
--- a/packages/docusaurus-mdx-loader/package.json
+++ b/packages/docusaurus-mdx-loader/package.json
@@ -23,6 +23,7 @@
     "@docusaurus/utils-validation": "3.0.0",
     "@mdx-js/mdx": "^3.0.0",
     "@slorber/remark-comment": "^1.0.0",
+    "acorn": "^8.11.3",
     "escape-html": "^1.0.3",
     "estree-util-value-to-estree": "^3.0.1",
     "file-loader": "^6.2.0",

--- a/packages/docusaurus-mdx-loader/src/remark/toc/types.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/types.ts
@@ -23,7 +23,7 @@ export type TOCHeading = {
 // A TOC slice represents a TOCItem[] imported from a partial
 export type TOCSlice = {
   readonly type: 'slice';
-  readonly importName: string;
+  readonly value: string;
 };
 
 export type TOCItems = (TOCHeading | TOCSlice)[];

--- a/packages/docusaurus-mdx-loader/src/remark/toc/types.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/types.ts
@@ -27,3 +27,9 @@ export type TOCSlice = {
 };
 
 export type TOCItems = (TOCHeading | TOCSlice)[];
+
+export type PartialProp = {
+  componentName: string;
+  propName: string;
+  propValue: any;
+};

--- a/packages/docusaurus-mdx-loader/src/remark/toc/utils.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/utils.ts
@@ -175,3 +175,99 @@ export async function createTOCExportNodeAST({
     },
   };
 }
+
+export function createPropsPlacerAST(propsPlacerName: string): MdxjsEsm {
+  return {
+    type: 'mdxjsEsm',
+    value: '',
+    data: {
+      estree: {
+        type: 'Program',
+        body: [
+          {
+            type: 'FunctionDeclaration',
+            id: {
+              type: 'Identifier',
+              name: propsPlacerName,
+            },
+            generator: false,
+            async: false,
+            params: [
+              {
+                type: 'Identifier',
+                name: 'toc',
+              },
+            ],
+            body: {
+              type: 'BlockStatement',
+              body: [
+                {
+                  type: 'ReturnStatement',
+                  argument: {
+                    type: 'CallExpression',
+                    callee: {
+                      type: 'MemberExpression',
+                      object: {
+                        type: 'Identifier',
+                        name: 'toc',
+                      },
+                      property: {
+                        type: 'Identifier',
+                        name: 'map',
+                      },
+                      computed: false,
+                      optional: false,
+                    },
+                    arguments: [
+                      {
+                        type: 'ArrowFunctionExpression',
+                        expression: true,
+                        generator: false,
+                        async: false,
+                        params: [
+                          {
+                            type: 'Identifier',
+                            name: 'tocItem',
+                          },
+                        ],
+                        body: {
+                          type: 'ObjectExpression',
+                          properties: [
+                            {
+                              type: 'SpreadElement',
+                              argument: {
+                                type: 'Identifier',
+                                name: 'tocItem',
+                              },
+                            },
+                            {
+                              type: 'Property',
+                              method: false,
+                              shorthand: false,
+                              computed: false,
+                              key: {
+                                type: 'Identifier',
+                                name: 'value',
+                              },
+                              value: {
+                                type: 'Literal',
+                                value: 'TEST',
+                              },
+                              kind: 'init',
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    optional: false,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        sourceType: 'module',
+      },
+    },
+  };
+}

--- a/packages/docusaurus-mdx-loader/src/remark/toc/utils.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/utils.ts
@@ -12,7 +12,13 @@ import type {
   MdxjsEsm,
   // @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 } from 'mdast-util-mdx';
-import type {TOCHeading, TOCItem, TOCItems, TOCSlice} from './types';
+import type {
+  TOCHeading,
+  TOCItem,
+  TOCItems,
+  TOCSlice,
+  PartialProp,
+} from './types';
 import type {
   Program,
   SpreadElement,
@@ -177,6 +183,48 @@ export async function createTOCExportNodeAST({
   };
 }
 
+export async function createPartialPropsObjAST({
+  partialProps,
+  partialPropsName,
+}: {
+  partialProps: PartialProp[];
+  partialPropsName: string;
+}): Promise<MdxjsEsm> {
+  const {valueToEstree} = await import('estree-util-value-to-estree');
+
+  return {
+    type: 'mdxjsEsm',
+    value: '',
+    data: {
+      estree: {
+        type: 'Program',
+        body: [
+          {
+            type: 'ExportNamedDeclaration',
+            declaration: {
+              type: 'VariableDeclaration',
+              declarations: [
+                {
+                  type: 'VariableDeclarator',
+                  id: {
+                    type: 'Identifier',
+                    name: partialPropsName,
+                  },
+                  init: valueToEstree(partialProps),
+                },
+              ],
+              kind: 'const',
+            },
+            specifiers: [],
+            source: null,
+          },
+        ],
+        sourceType: 'module',
+      },
+    },
+  };
+}
+
 export function createPropsPlacerAST({
   propsPlacerName,
 }: {
@@ -204,7 +252,7 @@ function ${propsPlacerName}(toc, componentName) {
   })
 }
       `,
-        {ecmaVersion: 8},
+        {ecmaVersion: 11},
       ) as Program,
     },
   };

--- a/website/_dogfooding/_docs tests/tests/toc-partials/_partial-with-prop.mdx
+++ b/website/_dogfooding/_docs tests/tests/toc-partials/_partial-with-prop.mdx
@@ -1,0 +1,1 @@
+## This word: {props.word} is from a prop

--- a/website/_dogfooding/_docs tests/tests/toc-partials/basic.mdx
+++ b/website/_dogfooding/_docs tests/tests/toc-partials/basic.mdx
@@ -1,6 +1,6 @@
 import Partial from './_partial.mdx';
 
-# TOC partial test
+# Basic TOC partial test
 
 This page tests that MDX-imported content appears correctly in the table-of-contents
 

--- a/website/_dogfooding/_docs tests/tests/toc-partials/props.mdx
+++ b/website/_dogfooding/_docs tests/tests/toc-partials/props.mdx
@@ -1,11 +1,7 @@
 import PartialWithProp from './_partial-with-prop.mdx';
 
-export const foo = 'bar';
-
 # TOC partial test with props
 
-<PartialWithProp word={foo} />
+<PartialWithProp word="foo" />
 
 The word in the partial above should be visible in the heading itself and in the TOC as well.
-
-## Heading with prop {foo}

--- a/website/_dogfooding/_docs tests/tests/toc-partials/props.mdx
+++ b/website/_dogfooding/_docs tests/tests/toc-partials/props.mdx
@@ -1,0 +1,11 @@
+import PartialWithProp from './_partial-with-prop.mdx';
+
+export const foo = 'bar';
+
+# TOC partial test with props
+
+<PartialWithProp word={foo} />
+
+The word in the partial above should be visible in the heading itself and in the TOC as well.
+
+## Heading with prop {foo}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,10 +4083,10 @@ acorn@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^8.0.0, acorn@^8.0.4, acorn@^8.1.0, acorn@^8.7.1, acorn@^8.8.1, acorn@^8.8.2, acorn@^8.9.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+acorn@^8.0.0, acorn@^8.0.4, acorn@^8.1.0, acorn@^8.11.3, acorn@^8.7.1, acorn@^8.8.1, acorn@^8.8.2, acorn@^8.9.0:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 add-stream@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

This PR allows the usage of props in partial MDX files. 

## Test Plan

This PR will be tested via dogfooding.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/issues/9772
