### PR TITLE
perf(core): optimize broken links checker

### DIFF
--- a/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
+++ b/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
@@ -736,25 +736,25 @@ describe('handleBrokenLinks', () => {
 
     const collectedLinks: Params['collectedLinks'] = Object.fromEntries(
       Array.from<SimpleRoute>({length: scale}).map((_, i) => [
-          `/page${i}`,
-          {
-            links: [
-              ...Array.from<SimpleRoute>({length: scale}).flatMap((_2, j) => [
-                `/page${j}`,
-                `/page${j}?age=42`,
-                `/page${j}#anchor${j}`,
-                `/page${j}?age=42#anchor${j}`,
-                `/pageDynamic/subPath${j}`,
-                `/pageDynamic/subPath${j}?age=42`,
-                // `/pageDynamic/subPath${j}#anchor${j}`,
-                // `/pageDynamic/subPath${j}?age=42#anchor${j}`,
-              ]),
-            ],
-            anchors: Array.from<SimpleRoute>({length: scale}).map(
-              (_2, j) => `anchor${j}`,
-            ),
-          },
-        ]),
+        `/page${i}`,
+        {
+          links: [
+            ...Array.from<SimpleRoute>({length: scale}).flatMap((_2, j) => [
+              `/page${j}`,
+              `/page${j}?age=42`,
+              `/page${j}#anchor${j}`,
+              `/page${j}?age=42#anchor${j}`,
+              `/pageDynamic/subPath${j}`,
+              `/pageDynamic/subPath${j}?age=42`,
+              // `/pageDynamic/subPath${j}#anchor${j}`,
+              // `/pageDynamic/subPath${j}?age=42#anchor${j}`,
+            ]),
+          ],
+          anchors: Array.from<SimpleRoute>({length: scale}).map(
+            (_2, j) => `anchor${j}`,
+          ),
+        },
+      ]),
     );
 
     // console.time('testBrokenLinks');

--- a/packages/docusaurus/src/server/brokenLinks.ts
+++ b/packages/docusaurus/src/server/brokenLinks.ts
@@ -42,19 +42,20 @@ function getBrokenLinksForPage({
 
   function isPathBrokenLink(linkPath: URLPath) {
     const pathnames = [linkPath.pathname, decodeURI(linkPath.pathname)];
-    const matchedRoutes = pathnames
-      // @ts-expect-error: React router types RouteConfig with an actual React
-      // component, but we load route components with string paths.
-      // We don't actually access component here, so it's fine.
-      .map((l) => matchRoutes(routes, l))
-      .flat();
-    // The link path is broken if:
-    // - it doesn't match any route
-    // - it doesn't match any collected path
-    return (
-      matchedRoutes.length === 0 &&
-      !pathnames.some((p) => allCollectedPaths.has(p))
-    );
+
+    // A link that matches an existing collected path is valid
+    if (pathnames.some((p) => allCollectedPaths.has(p))) {
+      return false;
+    }
+
+    // @ts-expect-error: React router types RouteConfig with an actual React
+    // component, but we load route components with string paths.
+    // We don't actually access component here, so it's fine.
+    if (pathnames.some((p) => matchRoutes(routes, p).length > 0)) {
+      return false;
+    }
+
+    return true;
   }
 
   function isAnchorBrokenLink(linkPath: URLPath) {


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/9754

The new logic added for the broken anchor link checker made the algorithm slow for large sites with many routes and links.

This PR optimizes the algo:
- reduces the number of useless `matchRoutes(routes,pathname)` calls
- reduces the number of routes to match against when possible
- uses more scalable Set/Map data structures

## Test Plan

CI + unit tests

---

Considering this site/commit: https://github.com/harness/developer-hub/commit/d5d13117ea51f8f7810a819234d58d411a478d5a

Upgrading to Docusaurus v3.1 leads the broken link checker to take 5 minutes. After this PR it only takes 1 second.


Another site reporting significant build time improvements:
https://github.com/facebook/docusaurus/issues/9754#issuecomment-1905748944