### PR TITLE
docs: update troubleshooting details for v3 migration

### DIFF
--- a/website/docs/migration/v3.mdx
+++ b/website/docs/migration/v3.mdx
@@ -980,12 +980,12 @@ This syntax is now invalid MDX, and would require to escape the `{` character: `
 
 We recommend to keep this compatibility option on for now, until we provide a new syntax compatible with newer versions of MDX.
 
-## Ask For Help
+## Troubleshooting
 
 In case of any upgrade problem, the first things to try are:
 
 - make sure all your docs compile in the [MDX playground](https://mdxjs.com/playground/), or using [`npx docusaurus-mdx-checker`](https://github.com/slorber/docusaurus-mdx-checker)
-- delete `node_modules` and run `npm install` again
+- delete `node_modules` and `package-lock.json`, and then run `npm install` again
 - run `docusaurus clear` to clear the caches
 - remove third-party plugins that might not support Docusaurus v3
 - delete all your swizzled components


### PR DESCRIPTION
When I was migrating from Docusaurus v2 to v3 today, I ran into a React "invalid hook call" error, which was caused by two different versions of React being pulled in as dependencies. Even after deleting my `node_modules` directory and re-running `npm install`, I was still getting the issue. It turns out my `package-lock.json` file still had a reference to React 17 somewhere, because the issue got resolved after I tried deleting **both** `node_modules` and `package-lock.json`, and then re-running `npm install`.

I wanted to make a documentation update to the troubleshooting steps to help prevent others who run into this from getting stuck.

I also thought it would be good to rename the "Ask For Help" section here to "Troubleshooting", as I feel that name more accurately reflects the content of the section. I didn't initially read that section when I ran into trouble, because I assumed it was only about how to ask someone else for help, and I wasn't ready to do that yet.