### PR TITLE
fix(core): links with target "_blank" should no be checked by the broken link checker

### DIFF
--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -143,8 +143,13 @@ function Link(
   // It is simple local anchor link targeting current page?
   const isAnchorLink = targetLink?.startsWith('#') ?? false;
 
+  // See also RR logic:
+  // https://github.com/remix-run/react-router/blob/v5/packages/react-router-dom/modules/Link.js#L47
+  const hasInternalTarget = !props.target || props.target === '_self';
+
   // Should we use a regular <a> tag instead of React-Router Link component?
-  const isRegularHtmlLink = !targetLink || !isInternal || isAnchorLink;
+  const isRegularHtmlLink =
+    !targetLink || !isInternal || !hasInternalTarget || isAnchorLink;
 
   if (!noBrokenLinkCheck && (isAnchorLink || !isRegularHtmlLink)) {
     brokenLinks.collectLink(targetLink!);

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -361,6 +361,37 @@ See [#3309](https://github.com/facebook/docusaurus/issues/3309)
 
 - [pathname://../dogfooding/javadoc/index.html](pathname://../dogfooding/javadoc/index.html)
 
+### Linking to non-SPA page with Link component
+
+See [#9758](https://github.com/facebook/docusaurus/issues/9758), these external urls should not be reported by the broken links checker:
+
+```mdx-code-block
+import Link from '@docusaurus/Link';
+
+export function TestLink({noCheck, ...props}) {
+  return (
+    <Link {...props} data-noBrokenLinkCheck={noCheck}>
+      {(noCheck ? '❌' : '✅') +
+        ' ' +
+        (props.to ?? props.href) +
+        (props.target ? ` (target=${props.target})` : '')}
+    </Link>
+  );
+}
+```
+
+- <TestLink to="pathname:///dogfooding/javadoc#goodlink1" />
+- <TestLink href="pathname:///dogfooding/javadoc#goodlink2" />
+- <TestLink to="/dogfooding/javadoc#goodlink3" target="_blank" />
+- <TestLink href="/dogfooding/javadoc#goodlink4" target="_blank" />
+
+These links are broken (try to single click on them) and should be reported. We need to explicitly disable the broken link checker for them:
+
+- <TestLink to="/dogfooding/javadoc#badlink1" noCheck />
+- <TestLink href="/dogfooding/javadoc#badlink2" noCheck />
+- <TestLink to="/dogfooding/javadoc#badlink3" target="_self" noCheck />
+- <TestLink href="/dogfooding/javadoc#badlink4" target="_self" noCheck />
+
 ### Linking to JSON
 
 - [./script.js](./_script.js)


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/9758

If a link has `target="_blank"` (or any other external target !== "_self"), that link shouldn't be checked by the broken link checker because it can't trigger a SPA soft navigation, and can only navigate to an external url.

## Test Plan

dogfood

### Test links


https://deploy-preview-9788--docusaurus-2.netlify.app/tests/pages/markdown-tests-mdx#linking-to-non-spa-page-with-link-component

