### PR TITLE
fix(core): broken links optimization behaves differently than non-optimized logic

### DIFF
--- a/packages/docusaurus-types/src/routing.d.ts
+++ b/packages/docusaurus-types/src/routing.d.ts
@@ -60,6 +60,11 @@ export type RouteConfig = {
   routes?: RouteConfig[];
   /** React router config option: `exact` routes would not match subroutes. */
   exact?: boolean;
+  /**
+   * React router config option: `strict` routes are sensitive to the presence
+   * of a trailing slash.
+   */
+  strict?: boolean;
   /** Used to sort routes. Higher-priority routes will be placed first. */
   priority?: number;
   /** Extra props; will be copied to routes.js. */

--- a/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
+++ b/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
@@ -48,6 +48,36 @@ describe('handleBrokenLinks', () => {
     });
   });
 
+  it('accepts valid non-exact link', async () => {
+    await testBrokenLinks({
+      routes: [{path: '/page1', exact: false}, {path: '/page2/'}],
+      collectedLinks: {
+        '/page1': {
+          links: [
+            '/page1',
+            '/page1/',
+            '/page2',
+            '/page2/',
+            '/page1/subPath',
+            '/page2/subPath',
+          ],
+          anchors: [],
+        },
+        '/page2/': {
+          links: [
+            '/page1',
+            '/page1/',
+            '/page2',
+            '/page2/',
+            '/page1/subPath',
+            '/page2/subPath',
+          ],
+          anchors: [],
+        },
+      },
+    });
+  });
+
   it('accepts valid non-strict link', async () => {
     await testBrokenLinks({
       routes: [{path: '/page1', strict: false}, {path: '/page2/'}],

--- a/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
+++ b/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
@@ -13,7 +13,12 @@ import type {RouteConfig} from '@docusaurus/types';
 type Params = Parameters<typeof handleBrokenLinks>[0];
 
 // We don't need all the routes attributes for our tests
-type SimpleRoute = {path: string; routes?: SimpleRoute[]};
+type SimpleRoute = {
+  path: string;
+  routes?: SimpleRoute[];
+  exact?: boolean;
+  strict?: boolean;
+};
 
 // Conveniently apply defaults to function under test
 async function testBrokenLinks(params: {
@@ -39,6 +44,22 @@ describe('handleBrokenLinks', () => {
       collectedLinks: {
         '/page1': {links: ['/page2'], anchors: []},
         '/page2': {links: [], anchors: []},
+      },
+    });
+  });
+
+  it('accepts valid non-strict link', async () => {
+    await testBrokenLinks({
+      routes: [{path: '/page1', strict: false}, {path: '/page2/'}],
+      collectedLinks: {
+        '/page1': {
+          links: ['/page1', '/page1/', '/page2', '/page2/'],
+          anchors: [],
+        },
+        '/page2/': {
+          links: ['/page1', '/page1/', '/page2', '/page2/'],
+          anchors: [],
+        },
       },
     });
   });
@@ -288,6 +309,76 @@ describe('handleBrokenLinks', () => {
       Exhaustive list of all broken links found:
       - Broken link on source page path = /page1:
          -> linking to /brokenLink
+      "
+    `);
+  });
+
+  it('rejects broken link due to strict matching', async () => {
+    await expect(() =>
+      testBrokenLinks({
+        routes: [
+          {path: '/page1', strict: true},
+          {path: '/page2/', strict: true},
+        ],
+
+        collectedLinks: {
+          '/page1': {
+            links: ['/page1', '/page1/', '/page2', '/page2/'],
+            anchors: [],
+          },
+          '/page2/': {
+            links: ['/page1', '/page1/', '/page2', '/page2/'],
+            anchors: [],
+          },
+        },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "Docusaurus found broken links!
+
+      Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
+      Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
+
+      Exhaustive list of all broken links found:
+      - Broken link on source page path = /page1:
+         -> linking to /page2
+      - Broken link on source page path = /page2/:
+         -> linking to /page2
+      "
+    `);
+  });
+
+  it('rejects broken link due to strict exact matching', async () => {
+    await expect(() =>
+      testBrokenLinks({
+        routes: [
+          {path: '/page1', exact: true, strict: true},
+          {path: '/page2/', exact: true, strict: true},
+        ],
+
+        collectedLinks: {
+          '/page1': {
+            links: ['/page1', '/page1/', '/page2', '/page2/'],
+            anchors: [],
+          },
+          '/page2/': {
+            links: ['/page1', '/page1/', '/page2', '/page2/'],
+            anchors: [],
+          },
+        },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "Docusaurus found broken links!
+
+      Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
+      Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
+
+      Exhaustive list of all broken links found:
+      - Broken link on source page path = /page1:
+         -> linking to /page1/
+         -> linking to /page2
+      - Broken link on source page path = /page2/:
+         -> linking to /page1/
+         -> linking to /page2
       "
     `);
   });
@@ -728,6 +819,10 @@ describe('handleBrokenLinks', () => {
     const routes: SimpleRoute[] = [
       ...Array.from<SimpleRoute>({length: scale}).map((_, i) => ({
         path: `/page${i}`,
+        exact: true,
+      })),
+      ...Array.from<SimpleRoute>({length: scale}).map((_, i) => ({
+        path: `/page/nonExact/${i}`,
       })),
       ...Array.from<SimpleRoute>({length: scale}).fill({
         path: '/pageDynamic/:subpath1',
@@ -741,6 +836,7 @@ describe('handleBrokenLinks', () => {
           links: [
             ...Array.from<SimpleRoute>({length: scale}).flatMap((_2, j) => [
               `/page${j}`,
+              `/page/nonExact/${j}`,
               `/page${j}?age=42`,
               `/page${j}#anchor${j}`,
               `/page${j}?age=42#anchor${j}`,
@@ -770,9 +866,9 @@ describe('handleBrokenLinks', () => {
     // See https://github.com/facebook/docusaurus/issues/9754
     // See https://twitter.com/sebastienlorber/status/1749392773415858587
     // We expect no more matchRoutes calls than number of dynamic route links
-    expect(matchRoutesMock).toHaveBeenCalledTimes(scale);
+    expect(matchRoutesMock).toHaveBeenCalledTimes(scale * 2);
     // We expect matchRoutes to be called with a reduced number of routes
-    expect(routes).toHaveLength(scale * 2);
-    expect(matchRoutesMock.mock.calls[0]![0]).toHaveLength(scale);
+    expect(routes).toHaveLength(scale * 3);
+    expect(matchRoutesMock.mock.calls[0]![0]).toHaveLength(scale * 2);
   });
 });


### PR DESCRIPTION


## Motivation

My broken link checker optimization in https://github.com/facebook/docusaurus/pull/9778 applied a wrong heuristic to optimize the algorithm, assuming a route always matches exactly and strictly, which is not the case in practice (we don't use strict matching on our core plugins).

As a result, users reported bug related to urls with trailing slashes being reported:

- https://github.com/facebook/docusaurus/discussions/9787
- https://github.com/facebook/docusaurus/issues/9758#issuecomment-1910258622

The goal of this PR is to keep the existing optimization, and fix it so that the behavior is the same, and correct, with/without optimization.



## Test Plan

unit tests

