### PR TITLE
refactor(blog): improve doc global data hook error message + add doc warning to blogOnly mode

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/client/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/index.ts
@@ -86,10 +86,20 @@ export const useAllDocsData = (): {[pluginId: string]: GlobalPluginData} =>
       }
     | undefined) ?? StableEmptyObject;
 
-export const useDocsData = (pluginId: string | undefined): GlobalPluginData =>
-  usePluginData('docusaurus-plugin-content-docs', pluginId, {
-    failfast: true,
-  }) as GlobalPluginData;
+export const useDocsData = (pluginId: string | undefined): GlobalPluginData => {
+  try {
+    return usePluginData('docusaurus-plugin-content-docs', pluginId, {
+      failfast: true,
+    }) as GlobalPluginData;
+  } catch (error) {
+    throw new Error(
+      `You are using a feature of the Docusaurus docs plugin, but this plugin does not seem to be enabled${
+        pluginId === 'Default' ? '' : ` (pluginId=${pluginId}`
+      }`,
+      {cause: error as Error},
+    );
+  }
+};
 
 // TODO this feature should be provided by docusaurus core
 export function useActivePlugin(
@@ -143,16 +153,9 @@ export function useActiveVersion(
 export function useActiveDocContext(
   pluginId: string | undefined,
 ): ActiveDocContext {
-  try {
-    const data = useDocsData(pluginId);
-    const {pathname} = useLocation();
-    return getActiveDocContext(data, pathname);
-  } catch (error) {
-    throw new Error(
-      'It seems that you are using a doc plugin feature while the doc plugin seems to be disabled in `docusaurus.config.js`.',
-      error as Error,
-    );
-  }
+  const data = useDocsData(pluginId);
+  const {pathname} = useLocation();
+  return getActiveDocContext(data, pathname);
 }
 /**
  * Useful to say "hey, you are not on the latest docs version, please switch"

--- a/packages/docusaurus-plugin-content-docs/src/client/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/client/index.ts
@@ -143,9 +143,16 @@ export function useActiveVersion(
 export function useActiveDocContext(
   pluginId: string | undefined,
 ): ActiveDocContext {
-  const data = useDocsData(pluginId);
-  const {pathname} = useLocation();
-  return getActiveDocContext(data, pathname);
+  try {
+    const data = useDocsData(pluginId);
+    const {pathname} = useLocation();
+    return getActiveDocContext(data, pathname);
+  } catch (error) {
+    throw new Error(
+      'It seems that you are using a doc plugin feature while the doc plugin seems to be disabled in `docusaurus.config.js`.',
+      error as Error,
+    );
+  }
 }
 /**
  * Useful to say "hey, you are not on the latest docs version, please switch"

--- a/website/docs/blog.mdx
+++ b/website/docs/blog.mdx
@@ -625,6 +625,12 @@ Don't forget to delete the existing homepage at `./src/pages/index.js` or else t
 
 :::
 
+:::warning
+
+Don't forget to delete element of type doc in `docusaurus.config.js` in the navbar for example or else Docusaurus will crash.
+
+:::
+
 :::tip
 
 There's also a "Docs-only mode" for those who only want to use the docs. Read [Docs-only mode](./guides/docs/docs-introduction.mdx) for detailed instructions or a more elaborate explanation of `routeBasePath`.

--- a/website/docs/blog.mdx
+++ b/website/docs/blog.mdx
@@ -627,7 +627,7 @@ Don't forget to delete the existing homepage at `./src/pages/index.js` or else t
 
 :::warning
 
-Don't forget to delete element of type doc in `docusaurus.config.js` in the navbar for example or else Docusaurus will crash.
+If you disable the docs plugin, don't forget to delete references to the docs plugin elsewhere in your configuration file. Notably, make sure to remove the docs-related navbar items.
 
 :::
 


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Error log when disabling doc to have docusaurus in blog only mode and using doc feature in docusaurus.config.js isn't clear to the user

## Test Plan

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

