### PR TITLE
feat(blog): allow sorting blog posts through a `options.sortPosts` function hook

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
@@ -18,7 +18,29 @@ import {
   sortBlogPosts,
 } from '../blogUtils';
 import type {BlogBrokenMarkdownLink, BlogContentPaths} from '../types';
-import type {BlogPost} from '@docusaurus/plugin-content-blog';
+import type {BlogPost, BlogPostMetadata} from '@docusaurus/plugin-content-blog';
+
+const defaultValuesForOtherKeys: Omit<BlogPostMetadata, 'date'> = {
+  source: '',
+  title: '',
+  formattedDate: '',
+  permalink: '',
+  description: '',
+  hasTruncateMarker: false,
+  authors: [],
+  frontMatter: {},
+  tags: [],
+  unlisted: false,
+};
+const createBlogPost = (args: Partial<BlogPost>): BlogPost => ({
+  id: '',
+  metadata: {
+    date: new Date(),
+    ...defaultValuesForOtherKeys,
+    ...args.metadata,
+  },
+  content: args.content || '',
+});
 
 describe('truncate', () => {
   it('truncates texts', () => {
@@ -215,6 +237,7 @@ describe('linkify', () => {
         frontMatter: {},
         authors: [],
         formattedDate: '',
+        unlisted: false,
       },
       content: '',
     },
@@ -275,218 +298,68 @@ describe('linkify', () => {
 });
 
 describe('blog sort', () => {
-  const pluginDir = 'blog-with-ref';
+  const blogPost2022 = createBlogPost({
+    metadata: {date: new Date('2022-12-14'), ...defaultValuesForOtherKeys},
+  });
 
-  const descendingBlogPost: BlogPost[] = [
-    {
-      id: 'newest',
-      metadata: {
-        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
-        source: path.posix.join(
-          '@site',
-          pluginDir,
-          '2018-12-14-Happy-First-Birthday-Slash.md',
-        ),
-        title: 'Happy 1st Birthday Slash!',
-        description: `pattern name`,
-        date: new Date('2018-12-14'),
-        tags: [],
-        prevItem: {
-          permalink: '/blog/2019/01/01/date-matter',
-          title: 'date-matter',
-        },
-        hasTruncateMarker: false,
-        frontMatter: {},
-        authors: [],
-        unlisted: false,
-        formattedDate: '',
-      },
-      content: '',
-    },
-    {
-      id: 'oldest',
-      metadata: {
-        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
-        source: path.posix.join(
-          '@site',
-          pluginDir,
-          '2018-12-14-Happy-First-Birthday-Slash.md',
-        ),
-        title: 'draft',
-        description: `pattern name`,
-        date: new Date('2017-12-14'),
-        tags: [],
-        prevItem: {
-          permalink: '/blog/2019/01/01/date-matter',
-          title: 'date-matter',
-        },
-        hasTruncateMarker: false,
-        frontMatter: {},
-        authors: [],
-        unlisted: false,
-        formattedDate: '',
-      },
-      content: '',
-    },
-  ];
-
-  const ascendingBlogPost: BlogPost[] = [
-    {
-      id: 'oldest',
-      metadata: {
-        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
-        source: path.posix.join(
-          '@site',
-          pluginDir,
-          '2018-12-14-Happy-First-Birthday-Slash.md',
-        ),
-        title: 'draft',
-        description: `pattern name`,
-        date: new Date('2017-12-14'),
-        tags: [],
-        prevItem: {
-          permalink: '/blog/2019/01/01/date-matter',
-          title: 'date-matter',
-        },
-        hasTruncateMarker: false,
-        frontMatter: {},
-        authors: [],
-        unlisted: false,
-        formattedDate: '',
-      },
-      content: '',
-    },
-    {
-      id: 'newest',
-      metadata: {
-        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
-        source: path.posix.join(
-          '@site',
-          pluginDir,
-          '2018-12-14-Happy-First-Birthday-Slash.md',
-        ),
-        title: 'Happy 1st Birthday Slash!',
-        description: `pattern name`,
-        date: new Date('2018-12-14'),
-        tags: [],
-        prevItem: {
-          permalink: '/blog/2019/01/01/date-matter',
-          title: 'date-matter',
-        },
-        hasTruncateMarker: false,
-        frontMatter: {},
-        authors: [],
-        unlisted: false,
-        formattedDate: '',
-      },
-      content: '',
-    },
-  ];
-
-  const BlogPostList: BlogPost[] = [
-    {
-      id: 'newest',
-      metadata: {
-        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
-        source: path.posix.join(
-          '@site',
-          pluginDir,
-          '2018-12-14-Happy-First-Birthday-Slash.md',
-        ),
-        title: 'Happy 1st Birthday Slash!',
-        description: `pattern name`,
-        date: new Date('2018-12-14'),
-        tags: [],
-        prevItem: {
-          permalink: '/blog/2019/01/01/date-matter',
-          title: 'date-matter',
-        },
-        hasTruncateMarker: false,
-        frontMatter: {},
-        authors: [],
-        unlisted: false,
-        formattedDate: '',
-      },
-      content: '',
-    },
-    {
-      id: 'oldest',
-      metadata: {
-        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
-        source: path.posix.join(
-          '@site',
-          pluginDir,
-          '2018-12-14-Happy-First-Birthday-Slash.md',
-        ),
-        title: 'draft',
-        description: `pattern name`,
-        date: new Date('2017-12-14'),
-        tags: [],
-        prevItem: {
-          permalink: '/blog/2019/01/01/date-matter',
-          title: 'date-matter',
-        },
-        hasTruncateMarker: false,
-        frontMatter: {},
-        authors: [],
-        unlisted: false,
-        formattedDate: '',
-      },
-      content: '',
-    },
-  ];
+  const blogPost2023 = createBlogPost({
+    metadata: {date: new Date('2023-12-14'), ...defaultValuesForOtherKeys},
+  });
+  const blogPost2024 = createBlogPost({
+    metadata: {date: new Date('2024-12-14'), ...defaultValuesForOtherKeys},
+  });
 
   it('sort blog posts by descending date no return', () => {
     const sortedBlogPosts = sortBlogPosts({
-      blogPosts: BlogPostList,
+      blogPosts: [blogPost2023, blogPost2022, blogPost2024],
       sortPosts: 'descending',
     });
-    expect(sortedBlogPosts).toEqual(BlogPostList);
+    expect(sortedBlogPosts).toEqual([blogPost2024, blogPost2023, blogPost2022]);
   });
 
   it('sort blog posts by ascending date no return', () => {
     const sortedBlogPosts = sortBlogPosts({
-      blogPosts: BlogPostList,
+      blogPosts: [blogPost2023, blogPost2022, blogPost2024],
       sortPosts: 'ascending',
     });
-    expect(sortedBlogPosts).toEqual(BlogPostList);
+    expect(sortedBlogPosts).toEqual([blogPost2022, blogPost2023, blogPost2024]);
   });
 
-  it('sort blog posts by descending date with function return', () => {
-    const sortedBlogPosts = sortBlogPosts({
-      blogPosts: BlogPostList,
-      sortPosts: ({blogPosts}) =>
-        [...blogPosts].sort(
-          (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
-        ),
-    });
-    expect(sortedBlogPosts).toEqual(descendingBlogPost);
-  });
+  // it('sort blog posts by descending date with function return', () => {
+  //   const sortedBlogPosts = sortBlogPosts({
+  //     blogPosts: [blogPost2023, blogPost2022, blogPost2024],
+  //     sortPosts: ({blogPosts}) =>
+  //       [...blogPosts].sort(
+  //         (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
+  //       ),
+  //   });
+  //   expect(sortedBlogPosts).toEqual([blogPost2024, blogPost2023, blogPost2022]);
+  // });
 
-  it('sort blog posts by ascending date with function return', () => {
-    const sortedBlogPosts = sortBlogPosts({
-      blogPosts: BlogPostList,
-      sortPosts: ({blogPosts}) =>
-        [...blogPosts].sort(
-          (b, a) => b.metadata.date.getTime() - a.metadata.date.getTime(),
-        ),
-    });
-    expect(sortedBlogPosts).toEqual(ascendingBlogPost);
-  });
+  // it('sort blog posts by ascending date with function return', () => {
+  //   const sortedBlogPosts = sortBlogPosts({
+  //     blogPosts: [blogPost2023, blogPost2022, blogPost2024],
+  //     sortPosts: ({blogPosts}) =>
+  //       [...blogPosts].sort(
+  //         (b, a) => b.metadata.date.getTime() - a.metadata.date.getTime(),
+  //       ),
+  //   });
+  //   expect(sortedBlogPosts).toEqual([blogPost2022, blogPost2023, blogPost2024]);
+  // });
 
-  it('sort blog posts with empty function', () => {
-    const sortedBlogPosts = sortBlogPosts({
-      blogPosts: BlogPostList,
-      sortPosts: () => {},
-    });
-    expect(sortedBlogPosts).toEqual(ascendingBlogPost);
-  });
+  // it('sort blog posts with empty function', () => {
+  //   const sortedBlogPosts = sortBlogPosts({
+  //     blogPosts: [blogPost2023, blogPost2022, blogPost2024],
+  //     sortPosts: () => {},
+  //   });
+  //   expect(sortedBlogPosts).toEqual([blogPost2023, blogPost2022, blogPost2024]);
+  // });
 
-  it('sort blog posts with function return empty array', () => {
-    const sortedBlogPosts = sortBlogPosts({
-      blogPosts: BlogPostList,
-      sortPosts: () => [],
-    });
-    expect(sortedBlogPosts).toEqual(ascendingBlogPost);
-  });
+  // it('sort blog posts with function return empty array', () => {
+  //   const sortedBlogPosts = sortBlogPosts({
+  //     blogPosts: [blogPost2023, blogPost2022, blogPost2024],
+  //     sortPosts: () => [],
+  //   });
+  //   expect(sortedBlogPosts).toEqual([blogPost2023, blogPost2022, blogPost2024]);
+  // });
 });

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
@@ -473,4 +473,20 @@ describe('blog sort', () => {
     });
     expect(sortedBlogPosts).toEqual(ascendingBlogPost);
   });
+
+  it('sort blog posts with empty function', () => {
+    const sortedBlogPosts = sortBlogPosts({
+      blogPosts: BlogPostList,
+      sortPosts: () => {},
+    });
+    expect(sortedBlogPosts).toEqual(ascendingBlogPost);
+  });
+
+  it('sort blog posts with function return empty array', () => {
+    const sortedBlogPosts = sortBlogPosts({
+      blogPosts: BlogPostList,
+      sortPosts: () => [],
+    });
+    expect(sortedBlogPosts).toEqual(ascendingBlogPost);
+  });
 });

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/blogUtils.test.ts
@@ -15,6 +15,7 @@ import {
   getSourceToPermalink,
   paginateBlogPosts,
   type LinkifyParams,
+  sortBlogPosts,
 } from '../blogUtils';
 import type {BlogBrokenMarkdownLink, BlogContentPaths} from '../types';
 import type {BlogPost} from '@docusaurus/plugin-content-blog';
@@ -270,5 +271,206 @@ describe('linkify', () => {
       contentPaths,
       link: './postNotExist2.mdx',
     } as BlogBrokenMarkdownLink);
+  });
+});
+
+describe('blog sort', () => {
+  const pluginDir = 'blog-with-ref';
+
+  const descendingBlogPost: BlogPost[] = [
+    {
+      id: 'newest',
+      metadata: {
+        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
+        source: path.posix.join(
+          '@site',
+          pluginDir,
+          '2018-12-14-Happy-First-Birthday-Slash.md',
+        ),
+        title: 'Happy 1st Birthday Slash!',
+        description: `pattern name`,
+        date: new Date('2018-12-14'),
+        tags: [],
+        prevItem: {
+          permalink: '/blog/2019/01/01/date-matter',
+          title: 'date-matter',
+        },
+        hasTruncateMarker: false,
+        frontMatter: {},
+        authors: [],
+        unlisted: false,
+        formattedDate: '',
+      },
+      content: '',
+    },
+    {
+      id: 'oldest',
+      metadata: {
+        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
+        source: path.posix.join(
+          '@site',
+          pluginDir,
+          '2018-12-14-Happy-First-Birthday-Slash.md',
+        ),
+        title: 'draft',
+        description: `pattern name`,
+        date: new Date('2017-12-14'),
+        tags: [],
+        prevItem: {
+          permalink: '/blog/2019/01/01/date-matter',
+          title: 'date-matter',
+        },
+        hasTruncateMarker: false,
+        frontMatter: {},
+        authors: [],
+        unlisted: false,
+        formattedDate: '',
+      },
+      content: '',
+    },
+  ];
+
+  const ascendingBlogPost: BlogPost[] = [
+    {
+      id: 'oldest',
+      metadata: {
+        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
+        source: path.posix.join(
+          '@site',
+          pluginDir,
+          '2018-12-14-Happy-First-Birthday-Slash.md',
+        ),
+        title: 'draft',
+        description: `pattern name`,
+        date: new Date('2017-12-14'),
+        tags: [],
+        prevItem: {
+          permalink: '/blog/2019/01/01/date-matter',
+          title: 'date-matter',
+        },
+        hasTruncateMarker: false,
+        frontMatter: {},
+        authors: [],
+        unlisted: false,
+        formattedDate: '',
+      },
+      content: '',
+    },
+    {
+      id: 'newest',
+      metadata: {
+        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
+        source: path.posix.join(
+          '@site',
+          pluginDir,
+          '2018-12-14-Happy-First-Birthday-Slash.md',
+        ),
+        title: 'Happy 1st Birthday Slash!',
+        description: `pattern name`,
+        date: new Date('2018-12-14'),
+        tags: [],
+        prevItem: {
+          permalink: '/blog/2019/01/01/date-matter',
+          title: 'date-matter',
+        },
+        hasTruncateMarker: false,
+        frontMatter: {},
+        authors: [],
+        unlisted: false,
+        formattedDate: '',
+      },
+      content: '',
+    },
+  ];
+
+  const BlogPostList: BlogPost[] = [
+    {
+      id: 'newest',
+      metadata: {
+        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
+        source: path.posix.join(
+          '@site',
+          pluginDir,
+          '2018-12-14-Happy-First-Birthday-Slash.md',
+        ),
+        title: 'Happy 1st Birthday Slash!',
+        description: `pattern name`,
+        date: new Date('2018-12-14'),
+        tags: [],
+        prevItem: {
+          permalink: '/blog/2019/01/01/date-matter',
+          title: 'date-matter',
+        },
+        hasTruncateMarker: false,
+        frontMatter: {},
+        authors: [],
+        unlisted: false,
+        formattedDate: '',
+      },
+      content: '',
+    },
+    {
+      id: 'oldest',
+      metadata: {
+        permalink: '/blog/2018/12/14/Happy-First-Birthday-Slash',
+        source: path.posix.join(
+          '@site',
+          pluginDir,
+          '2018-12-14-Happy-First-Birthday-Slash.md',
+        ),
+        title: 'draft',
+        description: `pattern name`,
+        date: new Date('2017-12-14'),
+        tags: [],
+        prevItem: {
+          permalink: '/blog/2019/01/01/date-matter',
+          title: 'date-matter',
+        },
+        hasTruncateMarker: false,
+        frontMatter: {},
+        authors: [],
+        unlisted: false,
+        formattedDate: '',
+      },
+      content: '',
+    },
+  ];
+
+  it('sort blog posts by descending date no return', () => {
+    const sortedBlogPosts = sortBlogPosts({
+      blogPosts: BlogPostList,
+      sortPosts: 'descending',
+    });
+    expect(sortedBlogPosts).toEqual(BlogPostList);
+  });
+
+  it('sort blog posts by ascending date no return', () => {
+    const sortedBlogPosts = sortBlogPosts({
+      blogPosts: BlogPostList,
+      sortPosts: 'ascending',
+    });
+    expect(sortedBlogPosts).toEqual(BlogPostList);
+  });
+
+  it('sort blog posts by descending date with function return', () => {
+    const sortedBlogPosts = sortBlogPosts({
+      blogPosts: BlogPostList,
+      sortPosts: ({blogPosts}) =>
+        [...blogPosts].sort(
+          (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
+        ),
+    });
+    expect(sortedBlogPosts).toEqual(descendingBlogPost);
+  });
+
+  it('sort blog posts by ascending date with function return', () => {
+    const sortedBlogPosts = sortBlogPosts({
+      blogPosts: BlogPostList,
+      sortPosts: ({blogPosts}) =>
+        [...blogPosts].sort(
+          (b, a) => b.metadata.date.getTime() - a.metadata.date.getTime(),
+        ),
+    });
+    expect(sortedBlogPosts).toEqual(ascendingBlogPost);
   });
 });

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/feed.test.ts
@@ -88,6 +88,7 @@ describe.each(['atom', 'rss', 'json'])('%s', (feedType) => {
       } as LoadContext,
       {
         path: 'invalid-blog-path',
+        sortPosts: 'descending',
         routeBasePath: 'blog',
         tagsBasePath: 'tags',
         authorsMapPath: 'authors.yml',
@@ -128,6 +129,7 @@ describe.each(['atom', 'rss', 'json'])('%s', (feedType) => {
       } as LoadContext,
       {
         path: 'blog',
+        sortPosts: 'descending',
         routeBasePath: 'blog',
         tagsBasePath: 'tags',
         authorsMapPath: 'authors.yml',
@@ -171,6 +173,7 @@ describe.each(['atom', 'rss', 'json'])('%s', (feedType) => {
       } as LoadContext,
       {
         path: 'blog',
+        sortPosts: 'descending',
         routeBasePath: 'blog',
         tagsBasePath: 'tags',
         authorsMapPath: 'authors.yml',
@@ -224,6 +227,7 @@ describe.each(['atom', 'rss', 'json'])('%s', (feedType) => {
       } as LoadContext,
       {
         path: 'blog',
+        sortPosts: 'descending',
         routeBasePath: 'blog',
         tagsBasePath: 'tags',
         authorsMapPath: 'authors.yml',

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -37,7 +37,6 @@ import type {
   BlogTags,
   BlogPaginated,
   Options,
-  SortBlogPostsFn,
   SortPresets,
   SortBlogPostsPreset,
 } from '@docusaurus/plugin-content-blog';
@@ -380,45 +379,29 @@ const sortPresets: SortPresets = {
 
 interface SortBlogPostsOptions {
   blogPosts: BlogPost[];
-  sortPosts: SortBlogPostsPreset | SortBlogPostsFn;
+  sortPosts: SortBlogPostsPreset;
 }
 
-function getSortFunction(sortPosts: Options['sortPosts']): SortBlogPostsFn {
-  if (typeof sortPosts === 'function') {
-    return sortPosts;
+function getSortFunction(sortPosts: Options['sortPosts']) {
+  if (sortPosts === undefined) {
+    return sortPresets.descending;
   }
-
-  if (typeof sortPosts === 'string') {
-    const presetFn = sortPresets[sortPosts];
-    if (!presetFn) {
-      throw new Error(
-        `sortPosts preset ${sortPosts} does not exist, valid presets are: ${Object.keys(
-          sortPresets,
-        ).join(', ')}`,
-      );
-    }
-    return presetFn;
+  const presetFn = sortPresets[sortPosts];
+  if (!presetFn) {
+    throw new Error(
+      `sortPosts preset ${sortPosts} does not exist, valid presets are: ${Object.keys(
+        sortPresets,
+      ).join(', ')}`,
+    );
   }
-
-  return () => {};
+  return presetFn;
 }
 
 export function sortBlogPosts({
   blogPosts,
   sortPosts,
 }: SortBlogPostsOptions): BlogPost[] {
-  const sortFunction = getSortFunction(sortPosts);
-  const sortedBlogPosts = sortFunction({blogPosts});
-
-  if (sortedBlogPosts !== undefined) {
-    if (sortedBlogPosts.length === 0) {
-      logger.warn(
-        `Sorting function returned an empty array. Reverting to the original list to prevent issues.`,
-      );
-      return blogPosts;
-    }
-    return sortedBlogPosts;
-  }
+  getSortFunction(sortPosts);
 
   return blogPosts;
 }

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -405,9 +405,14 @@ export async function generateBlogPosts(
     await Promise.all(blogSourceFiles.map(doProcessBlogSourceFile))
   ).filter(Boolean) as BlogPost[];
 
-  blogPosts.sort(
-    (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
-  );
+  if (typeof options.sortPosts === 'function') {
+    console.log('options:', options);
+    blogPosts.sort(options.sortPosts);
+  } else {
+    blogPosts.sort(
+      (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
+    );
+  }
 
   if (options.sortPosts === 'ascending') {
     return blogPosts.reverse();

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -386,7 +386,10 @@ function sortBlogPosts({
   };
 
   if (typeof sortPosts === 'function') {
-    sortPosts({blogPosts});
+    const customSort = sortPosts({blogPosts});
+    if (customSort !== undefined) {
+      return customSort;
+    }
   } else if (sortPresets[sortPosts]) {
     sortPresets[sortPosts]();
   }

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -403,7 +403,7 @@ function getSortFunction(sortPosts: Options['sortPosts']): SortBlogPostsFn {
   return () => {};
 }
 
-function sortBlogPosts({
+export function sortBlogPosts({
   blogPosts,
   sortPosts,
 }: SortBlogPostsOptions): BlogPost[] {

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -386,12 +386,18 @@ function sortBlogPosts({
   sortPosts,
 }: SortBlogPostsOptions): BlogPost[] {
   if (typeof sortPosts === 'function') {
-    const customSort = sortPosts({blogPosts});
-    if (customSort !== undefined) {
-      return customSort;
+    const sortedBlogPosts = sortPosts({blogPosts});
+    if (sortedBlogPosts !== undefined) {
+      return sortedBlogPosts;
     }
   } else if (sortPresets[sortPosts]) {
     return sortPresets[sortPosts](blogPosts);
+  } else {
+    throw new Error(
+      `Invalid blog config sortPost value: ${sortPosts}, must be one of: ${Object.keys(
+        sortPresets,
+      ).join(', ')}`,
+    );
   }
 
   return blogPosts;

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -406,7 +406,6 @@ export async function generateBlogPosts(
   ).filter(Boolean) as BlogPost[];
 
   if (typeof options.sortPosts === 'function') {
-    console.log('options:', options);
     blogPosts.sort(options.sortPosts);
   } else {
     blogPosts.sort(

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -368,7 +368,8 @@ type SortBlogPostsFn = (args: {blogPosts: BlogPost[]}) => void | BlogPost[];
 
 type SortBlogPostsPreset = 'ascending' | 'descending';
 
-const sortPresets: { [key: SortBlogPostsPreset]: SortBlogPostsFn } = {
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+const sortPresets: Record<SortBlogPostsPreset, SortBlogPostsFn> = {
   descending: ({blogPosts}) =>
     blogPosts.sort(
       (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -367,31 +367,31 @@ interface SortBlogPostsOptions {
   sortPosts:
     | 'ascending'
     | 'descending'
-    | ((args: {blogPosts: BlogPost[]}) => undefined | BlogPost[]);
+    | ((args: {blogPosts: BlogPost[]}) => void | BlogPost[]);
 }
+
+const sortPresets = {
+  descending: (blogPosts: BlogPost[]) =>
+    blogPosts.sort(
+      (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
+    ),
+  ascending: (blogPosts: BlogPost[]) =>
+    blogPosts.sort(
+      (a, b) => a.metadata.date.getTime() - b.metadata.date.getTime(),
+    ),
+};
 
 function sortBlogPosts({
   blogPosts,
   sortPosts,
 }: SortBlogPostsOptions): BlogPost[] {
-  const sortPresets = {
-    descending: () =>
-      blogPosts.sort(
-        (a, b) => b.metadata.date.getTime() - a.metadata.date.getTime(),
-      ),
-    ascending: () =>
-      blogPosts.sort(
-        (a, b) => a.metadata.date.getTime() - b.metadata.date.getTime(),
-      ),
-  };
-
   if (typeof sortPosts === 'function') {
     const customSort = sortPosts({blogPosts});
     if (customSort !== undefined) {
       return customSort;
     }
   } else if (sortPresets[sortPosts]) {
-    sortPresets[sortPosts]();
+    return sortPresets[sortPosts](blogPosts);
   }
 
   return blogPosts;

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -107,12 +107,20 @@ export default async function pluginContentBlog(
         blogDescription,
         blogTitle,
         blogSidebarTitle,
+        processPosts,
       } = options;
 
       const baseBlogUrl = normalizeUrl([baseUrl, routeBasePath]);
       const blogTagsListPath = normalizeUrl([baseBlogUrl, tagsBasePath]);
-      const blogPosts = await generateBlogPosts(contentPaths, context, options);
+      let blogPosts = await generateBlogPosts(contentPaths, context, options);
       const listedBlogPosts = blogPosts.filter(shouldBeListed);
+      const processedBlogPosts = processPosts({
+        blogPosts,
+      });
+
+      if (processedBlogPosts !== undefined) {
+        blogPosts = processedBlogPosts;
+      }
 
       if (!blogPosts.length) {
         return {

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -113,7 +113,6 @@ export default async function pluginContentBlog(
       const baseBlogUrl = normalizeUrl([baseUrl, routeBasePath]);
       const blogTagsListPath = normalizeUrl([baseBlogUrl, tagsBasePath]);
       let blogPosts = await generateBlogPosts(contentPaths, context, options);
-      const listedBlogPosts = blogPosts.filter(shouldBeListed);
       const processedBlogPosts = processPosts({
         blogPosts,
       });
@@ -121,6 +120,8 @@ export default async function pluginContentBlog(
       if (processedBlogPosts !== undefined) {
         blogPosts = processedBlogPosts;
       }
+
+      const listedBlogPosts = blogPosts.filter(shouldBeListed);
 
       if (!blogPosts.length) {
         return {

--- a/packages/docusaurus-plugin-content-blog/src/options.ts
+++ b/packages/docusaurus-plugin-content-blog/src/options.ts
@@ -133,7 +133,9 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
   sortPosts: Joi.alternatives()
     .try(Joi.string().valid('descending', 'ascending'))
     .default(DEFAULT_OPTIONS.sortPosts),
-  processPosts: Joi.function().optional().default(DEFAULT_OPTIONS.processPosts),
+  processPosts: Joi.function()
+    .optional()
+    .default(() => DEFAULT_OPTIONS.processPosts),
 }).default(DEFAULT_OPTIONS);
 
 export function validateOptions({

--- a/packages/docusaurus-plugin-content-blog/src/options.ts
+++ b/packages/docusaurus-plugin-content-blog/src/options.ts
@@ -50,6 +50,7 @@ export const DEFAULT_OPTIONS: PluginOptions = {
   authorsMapPath: 'authors.yml',
   readingTime: ({content, defaultReadingTime}) => defaultReadingTime({content}),
   sortPosts: 'descending',
+  processPosts: () => undefined,
 };
 
 const PluginOptionSchema = Joi.object<PluginOptions>({
@@ -130,8 +131,9 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
   authorsMapPath: Joi.string().default(DEFAULT_OPTIONS.authorsMapPath),
   readingTime: Joi.function().default(() => DEFAULT_OPTIONS.readingTime),
   sortPosts: Joi.alternatives()
-    .try(Joi.string().valid('descending', 'ascending'), Joi.function())
+    .try(Joi.string().valid('descending', 'ascending'))
     .default(DEFAULT_OPTIONS.sortPosts),
+  processPosts: Joi.function().optional().default(DEFAULT_OPTIONS.processPosts),
 }).default(DEFAULT_OPTIONS);
 
 export function validateOptions({

--- a/packages/docusaurus-plugin-content-blog/src/options.ts
+++ b/packages/docusaurus-plugin-content-blog/src/options.ts
@@ -129,8 +129,8 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
   }).default(DEFAULT_OPTIONS.feedOptions),
   authorsMapPath: Joi.string().default(DEFAULT_OPTIONS.authorsMapPath),
   readingTime: Joi.function().default(() => DEFAULT_OPTIONS.readingTime),
-  sortPosts: Joi.string()
-    .valid('descending', 'ascending', Joi.function())
+  sortPosts: Joi.alternatives()
+    .try(Joi.string().valid('descending', 'ascending'), Joi.function())
     .default(DEFAULT_OPTIONS.sortPosts),
 }).default(DEFAULT_OPTIONS);
 

--- a/packages/docusaurus-plugin-content-blog/src/options.ts
+++ b/packages/docusaurus-plugin-content-blog/src/options.ts
@@ -130,7 +130,7 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
   authorsMapPath: Joi.string().default(DEFAULT_OPTIONS.authorsMapPath),
   readingTime: Joi.function().default(() => DEFAULT_OPTIONS.readingTime),
   sortPosts: Joi.string()
-    .valid('descending', 'ascending')
+    .valid('descending', 'ascending', Joi.function())
     .default(DEFAULT_OPTIONS.sortPosts),
 }).default(DEFAULT_OPTIONS);
 

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -421,7 +421,7 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
     sortPosts:
       | 'ascending'
       | 'descending'
-      | ((a: BlogPost, b: BlogPost) => number);
+      | (({blogPosts}: {blogPosts: BlogPost[]}) => undefined | BlogPost[]);
   };
 
   /**

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -421,7 +421,7 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
     sortPosts:
       | 'ascending'
       | 'descending'
-      | (({blogPosts}: {blogPosts: BlogPost[]}) => undefined | BlogPost[]);
+      | (({blogPosts}: {blogPosts: BlogPost[]}) => void | BlogPost[]);
   };
 
   /**

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -418,7 +418,10 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
     /** A callback to customize the reading time number displayed. */
     readingTime: ReadingTimeFunctionOption;
     /** Governs the direction of blog post sorting. */
-    sortPosts: 'ascending' | 'descending';
+    sortPosts:
+      | 'ascending'
+      | 'descending'
+      | ((a: BlogPost, b: BlogPost) => number);
   };
 
   /**

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -334,14 +334,14 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
     },
   ) => number | undefined;
 
-  export type SortBlogPostsFn = (params: {
+  export type ProcessBlogPostsFn = (params: {
     blogPosts: BlogPost[];
   }) => void | BlogPost[];
 
   export type SortBlogPostsPreset = 'ascending' | 'descending';
 
   // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  export type SortPresets = Record<SortBlogPostsPreset, SortBlogPostsFn>;
+  export type SortPresets = Record<SortBlogPostsPreset, ProcessBlogPostsFn>;
 
   /**
    * Plugin options after normalization.
@@ -428,7 +428,9 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
     /** A callback to customize the reading time number displayed. */
     readingTime: ReadingTimeFunctionOption;
     /** Governs the direction of blog post sorting. */
-    sortPosts: SortBlogPostsPreset | SortBlogPostsFn;
+    sortPosts: SortBlogPostsPreset;
+    /** TODO process blog posts. */
+    processPosts: ProcessBlogPostsFn;
   };
 
   /**

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -333,6 +333,16 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
       defaultReadingTime: ReadingTimeFunction;
     },
   ) => number | undefined;
+
+  export type SortBlogPostsFn = (params: {
+    blogPosts: BlogPost[];
+  }) => void | BlogPost[];
+
+  export type SortBlogPostsPreset = 'ascending' | 'descending';
+
+  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+  export type SortPresets = Record<SortBlogPostsPreset, SortBlogPostsFn>;
+
   /**
    * Plugin options after normalization.
    */
@@ -418,10 +428,7 @@ yarn workspace v1.22.19image` is a collocated image path, this entry will be the
     /** A callback to customize the reading time number displayed. */
     readingTime: ReadingTimeFunctionOption;
     /** Governs the direction of blog post sorting. */
-    sortPosts:
-      | 'ascending'
-      | 'descending'
-      | (({blogPosts}: {blogPosts: BlogPost[]}) => void | BlogPost[]);
+    sortPosts: SortBlogPostsPreset | SortBlogPostsFn;
   };
 
   /**

--- a/website/docs/api/plugins/plugin-content-blog.mdx
+++ b/website/docs/api/plugins/plugin-content-blog.mdx
@@ -38,7 +38,7 @@ Accepted fields:
 ```
 
 | Name | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | `path` | `string` | `'blog'` | Path to the blog content directory on the file system, relative to site dir. |
 | `editUrl` | <code>string \| <a href="#EditUrlFn">EditUrlFn</a></code> | `undefined` | Base URL to edit your site. The final URL is computed by `editUrl + relativePostPath`. Using a function allows more nuanced control for each file. Omitting this variable entirely will disable edit links. |
 | `editLocalizedFiles` | `boolean` | `false` | The edit URL will target the localized file, instead of the original unlocalized file. Ignored when `editUrl` is a function. |
@@ -73,7 +73,7 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`$\{siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
-| `sortPosts` | <code>'descending' \| 'ascending' | function()</code> | `'descending'` | Governs the direction of blog post sorting. |
+| `sortPosts` | <code>'descending' \| 'ascending' \| function()</code> | `'descending'` | Governs the direction of blog post sorting. |
 
 ```mdx-code-block
 </APITable>

--- a/website/docs/api/plugins/plugin-content-blog.mdx
+++ b/website/docs/api/plugins/plugin-content-blog.mdx
@@ -134,7 +134,7 @@ type CreateFeedItemsFn = (params: {
 
 ```ts
 // TODO document this type
-((args: {blogPosts: BlogPost[]}) => void | BlogPost[])
+type SortBlogPostsFn = (params: {blogPosts: BlogPost[]}) => void | BlogPost[];
 ```
 
 ### Example configuration {#ex-config}

--- a/website/docs/api/plugins/plugin-content-blog.mdx
+++ b/website/docs/api/plugins/plugin-content-blog.mdx
@@ -73,7 +73,7 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`$\{siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
-| `sortPosts` | <code>'descending' \| 'ascending' \| function()</code> | `'descending'` | Governs the direction of blog post sorting. |
+| `sortPosts` | <code>'descending' \| 'ascending' \| <a href="#SortBlogPostsFn">SortBlogPostsFn</a> </code> | `'descending'` | Governs the direction of blog post sorting. |
 
 ```mdx-code-block
 </APITable>
@@ -128,6 +128,13 @@ type CreateFeedItemsFn = (params: {
   outDir: string;
   defaultCreateFeedItemsFn: CreateFeedItemsFn;
 }) => Promise<BlogFeedItem[]>;
+```
+
+#### `SortBlogPostsFn` {#SortBlogPostsFn}
+
+```ts
+// TODO document this type
+((args: {blogPosts: BlogPost[]}) => void | BlogPost[])
 ```
 
 ### Example configuration {#ex-config}

--- a/website/docs/api/plugins/plugin-content-blog.mdx
+++ b/website/docs/api/plugins/plugin-content-blog.mdx
@@ -73,7 +73,8 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`$\{siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
-| `sortPosts` | <code>'descending' \| 'ascending' \| <a href="#SortBlogPostsFn">SortBlogPostsFn</a> </code> | `'descending'` | Governs the direction of blog post sorting. |
+| `sortPosts` | <code>'descending' \| 'ascending' \| </code> | `'descending'` | Governs the direction of blog post sorting. |
+| `processPosts` | <code><a href="#ProcessBlogPostsFn">ProcessBlogPostsFn</a> </code> | `undefined` | Function which process blog posts (filter, modify, delete, etc...). |
 
 ```mdx-code-block
 </APITable>
@@ -130,11 +131,12 @@ type CreateFeedItemsFn = (params: {
 }) => Promise<BlogFeedItem[]>;
 ```
 
-#### `SortBlogPostsFn` {#SortBlogPostsFn}
+#### `ProcessBlogPostsFn` {#ProcessBlogPostsFn}
 
 ```ts
-// TODO document this type
-type SortBlogPostsFn = (params: {blogPosts: BlogPost[]}) => void | BlogPost[];
+type ProcessBlogPostsFn = (params: {
+  blogPosts: BlogPost[];
+}) => void | BlogPost[];
 ```
 
 ### Example configuration {#ex-config}

--- a/website/docs/api/plugins/plugin-content-blog.mdx
+++ b/website/docs/api/plugins/plugin-content-blog.mdx
@@ -38,7 +38,7 @@ Accepted fields:
 ```
 
 | Name | Type | Default | Description |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | `path` | `string` | `'blog'` | Path to the blog content directory on the file system, relative to site dir. |
 | `editUrl` | <code>string \| <a href="#EditUrlFn">EditUrlFn</a></code> | `undefined` | Base URL to edit your site. The final URL is computed by `editUrl + relativePostPath`. Using a function allows more nuanced control for each file. Omitting this variable entirely will disable edit links. |
 | `editLocalizedFiles` | `boolean` | `false` | The edit URL will target the localized file, instead of the original unlocalized file. Ignored when `editUrl` is a function. |
@@ -73,7 +73,7 @@ Accepted fields:
 | `feedOptions.description` | `string` | <code>\`$\{siteConfig.title} Blog\`</code> | Description of the feed. |
 | `feedOptions.copyright` | `string` | `undefined` | Copyright message. |
 | `feedOptions.language` | `string` (See [documentation](http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes) for possible values) | `undefined` | Language metadata of the feed. |
-| `sortPosts` | <code>'descending' \| 'ascending' </code> | `'descending'` | Governs the direction of blog post sorting. |
+| `sortPosts` | <code>'descending' \| 'ascending' | function()</code> | `'descending'` | Governs the direction of blog post sorting. |
 
 ```mdx-code-block
 </APITable>

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -28,10 +28,7 @@ import PrismDark from './src/utils/prismDark';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import type {Options as DocsOptions} from '@docusaurus/plugin-content-docs';
-import type {
-  Options as BlogOptions,
-  BlogPost,
-} from '@docusaurus/plugin-content-blog';
+import type {Options as BlogOptions} from '@docusaurus/plugin-content-blog';
 import type {Options as PageOptions} from '@docusaurus/plugin-content-pages';
 import type {Options as IdealImageOptions} from '@docusaurus/plugin-ideal-image';
 import type {Options as ClientRedirectsOptions} from '@docusaurus/plugin-client-redirects';
@@ -444,8 +441,6 @@ export default async function createConfigAsync() {
           blog: {
             // routeBasePath: '/',
             path: 'blog',
-            sortPosts: (a: BlogPost, b: BlogPost): number =>
-              b.metadata.date.getTime() - a.metadata.date.getTime(),
             editUrl: ({locale, blogDirPath, blogPath}) => {
               if (locale !== defaultLocale) {
                 return `https://crowdin.com/project/docusaurus-v2/${locale}`;

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -28,7 +28,10 @@ import PrismDark from './src/utils/prismDark';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import type {Options as DocsOptions} from '@docusaurus/plugin-content-docs';
-import type {Options as BlogOptions} from '@docusaurus/plugin-content-blog';
+import type {
+  Options as BlogOptions,
+  BlogPost,
+} from '@docusaurus/plugin-content-blog';
 import type {Options as PageOptions} from '@docusaurus/plugin-content-pages';
 import type {Options as IdealImageOptions} from '@docusaurus/plugin-ideal-image';
 import type {Options as ClientRedirectsOptions} from '@docusaurus/plugin-client-redirects';
@@ -441,6 +444,8 @@ export default async function createConfigAsync() {
           blog: {
             // routeBasePath: '/',
             path: 'blog',
+            sortPosts: (a: BlogPost, b: BlogPost): number =>
+              b.metadata.date.getTime() - a.metadata.date.getTime(),
             editUrl: ({locale, blogDirPath, blogPath}) => {
               if (locale !== defaultLocale) {
                 return `https://crowdin.com/project/docusaurus-v2/${locale}`;


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Allow the user to pass a function to sort blog posts, until now, users only had the choice between ascending and descending sorting options, we want to provide to the user the possibility to pass a function which enable other sorting order

Todo:

- [x] check for invalid preset ? check if typescript already protects for this, otherwise create a `getPreset` function
- [x] move presets outside of function
- [ ] put a type for the map input enum output sort function
- [ ] put blogpost as params for preset, presets should have the same signature of the sort function, 
record ascending descending to blogpost sort preset, call sort function like preset function
- [ ] dogfooding test

## Test Plan

### Test links

Deploy preview: https://deploy-preview-9840--docusaurus-2.netlify.app/

## Related issues/PRs

#9831

https://github.com/facebook/docusaurus/pull/5787

https://github.com/facebook/docusaurus/issues/5692