### PR TITLE
docs: added docusaurus scheduler to awesome resources

### DIFF
--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -66,6 +66,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [docusaurus-plugin-typedoc](https://github.com/tgreyuk/typedoc-plugin-markdown/tree/master/packages/docusaurus-plugin-typedoc) - A Docusaurus plugin to build documentation with [TypeDoc](https://typedoc.org/)
 - [docusaurus-openapi-docs](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs) - A Docusaurus plugin and theme for generating interactive OpenAPI docs
 - [docusaurus-post-generator](https://github.com/moojing/docusaurus-post-generator) - A command line tool for user to add a blog/doc file quickly by command like `yarn gen-post new [template] [post_name]`.
+- [docusaurus-scheduler](https://github.com/alvarolorentedev/docusaurus-scheduler) - A docusarus compatible github action to schedule blog article releases based on a defined date in front-mater of md & mdx files.
 
 ## Enterprise usage {#enterprise-usage}
 


### PR DESCRIPTION
## Motivation

Docusarus does not allow post scheduling, so this needs to be achieved through a file moving process that can be run in the integration pipelienes. I am adding that capability/extension made externally to the documentation of awesome external resources.