### PR TITLE
fix(core): ensure core error boundary is able to render theme layout

### DIFF
--- a/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
@@ -55,6 +55,10 @@ function ErrorBoundaryError({error}: {error: Error}): JSX.Element {
   return <p style={{whiteSpace: 'pre-wrap'}}>{fullMessage}</p>;
 }
 
+// A bit hacky: we need to add an artificial RouteContextProvider here
+// The goal is to be able to render the error inside the theme layout
+// Without this, our theme classic would crash due to lack of route context
+// See also https://github.com/facebook/docusaurus/pull/9852
 function ErrorRouteContextProvider({children}: {children: ReactNode}) {
   return (
     <RouteContextProvider

--- a/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
@@ -8,12 +8,13 @@
 // Should we translate theme-fallback?
 /* eslint-disable @docusaurus/no-untranslated-text */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Head from '@docusaurus/Head';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import {getErrorCausalChain} from '@docusaurus/utils-common';
 import Layout from '@theme/Layout';
 import type {Props} from '@theme/Error';
+import {RouteContextProvider} from '../../routeContext';
 
 function ErrorDisplay({error, tryAgain}: Props): JSX.Element {
   return (
@@ -54,21 +55,34 @@ function ErrorBoundaryError({error}: {error: Error}): JSX.Element {
   return <p style={{whiteSpace: 'pre-wrap'}}>{fullMessage}</p>;
 }
 
+function ErrorRouteContextProvider({children}: {children: ReactNode}) {
+  return (
+    <RouteContextProvider
+      value={{
+        plugin: {name: 'docusaurus-core-error-boundary', id: 'default'},
+      }}>
+      {children}
+    </RouteContextProvider>
+  );
+}
+
 export default function Error({error, tryAgain}: Props): JSX.Element {
   // We wrap the error in its own error boundary because the layout can actually
   // throw too... Only the ErrorDisplay component is simple enough to be
   // considered safe to never throw
   return (
-    <ErrorBoundary
-      // Note: we display the original error here, not the error that we
-      // captured in this extra error boundary
-      fallback={() => <ErrorDisplay error={error} tryAgain={tryAgain} />}>
-      <Head>
-        <title>Page Error</title>
-      </Head>
-      <Layout>
-        <ErrorDisplay error={error} tryAgain={tryAgain} />
-      </Layout>
-    </ErrorBoundary>
+    <ErrorRouteContextProvider>
+      <ErrorBoundary
+        // Note: we display the original error here, not the error that we
+        // captured in this extra error boundary
+        fallback={() => <ErrorDisplay error={error} tryAgain={tryAgain} />}>
+        <Head>
+          <title>Page Error</title>
+        </Head>
+        <Layout>
+          <ErrorDisplay error={error} tryAgain={tryAgain} />
+        </Layout>
+      </ErrorBoundary>
+    </ErrorRouteContextProvider>
   );
 }


### PR DESCRIPTION
## Motivation

There are cases where the core React error boundary will catch a React rendering error, and display a fallback UI, trying to eventually display that error in the current theme layout.

But due to a missing `routeContext`, the classic theme layout will always error, trigger the re-rendering of the error without the theme layout, and produce unexpected error messages unrelated to the user's mistake.

Notably, the classic theme layout uses `useRouteContext()` to retrieve the current plugin name and add it to `<html>` classes, for CSS targeting purposes. But the core error boundary will try to render the theme layout without and route context provider, so it crashes:



We should prevent that from happening and make it possible to render caught errors inside the theme layout whenever possible.

For that reason I'm adding a kind-of artificial route context for rendering caught errors. It's not super elegant but it solves the problem.


### Before:

![CleanShot 2024-02-15 at 16 59 45@2x](https://github.com/facebook/docusaurus/assets/749374/95e525ee-1b88-46fc-b0fd-dc6087fb3c39)

console:

```
// This is the user's mistake
Uncaught Invariant Violation: You may be attempting to nest <Helmet> components within each other, which is not allowed. Refer to our API for more information.
    at invariant (webpack-internal:///../node_modules/invariant/browser.js:38:15)

// This is a totally unrelated, unhelpful error:
Unexpected: no Docusaurus route context found
    at useRouteContext (webpack-internal:///../packages/docusaurus/lib/client/exports/useRouteContext.js:18:15)
    at PluginHtmlClassNameProvider (webpack-internal:///../packages/docusaurus-theme-common/lib/utils/metadataUtils.js:142:97)
    at renderWithHooks (webpack-internal:///../no
```

### After:

![CleanShot 2024-02-15 at 17 01 02@2x](https://github.com/facebook/docusaurus/assets/749374/825e34d9-a333-4fad-81b2-e464de21e992)

console:

```
// This is the user's mistake
Uncaught Invariant Violation: You may be attempting to nest <Helmet> components within each other, which is not allowed. Refer to our API for more information.
    at invariant (webpack-internal:///../node_modules/invariant/browser.js:38:15)
```


## Test Plan

none, local test 😅 

### Test links

https://deploy-preview-9852--docusaurus-2.netlify.app/


