### PR TITLE
feat(core): support an offline mode build - SSG solution

### DIFF
--- a/packages/docusaurus/src/server/htmlTags.ts
+++ b/packages/docusaurus/src/server/htmlTags.ts
@@ -36,16 +36,24 @@ function assertIsHtmlTagObject(val: unknown): asserts val is HtmlTagObject {
   }
 }
 
+function absoluteToRelativeTagAttribute(name: string, value: string): string {
+  if ((name === 'src' || name === 'href') && value.startsWith('/')) {
+    return `.${value}`; // TODO would only work for homepage
+  }
+  return value;
+}
+
 function htmlTagObjectToString(tag: unknown): string {
   assertIsHtmlTagObject(tag);
   const isVoidTag = (voidHtmlTags as string[]).includes(tag.tagName);
   const tagAttributes = tag.attributes ?? {};
   const attributes = Object.keys(tagAttributes)
     .map((attr) => {
-      const value = tagAttributes[attr]!;
+      let value = tagAttributes[attr]!;
       if (typeof value === 'boolean') {
         return value ? attr : undefined;
       }
+      value = absoluteToRelativeTagAttribute(attr, value);
       return `${attr}="${escapeHTML(value)}"`;
     })
     .filter((str): str is string => Boolean(str));

--- a/packages/docusaurus/src/ssg.ts
+++ b/packages/docusaurus/src/ssg.ts
@@ -182,6 +182,7 @@ async function generateStaticFile({
     });
     // This renders the full page HTML, including head tags...
     const fullPageHtml = renderSSRTemplate({
+      pathname,
       params,
       result,
     });

--- a/packages/docusaurus/src/templates/templates.ts
+++ b/packages/docusaurus/src/templates/templates.ts
@@ -63,9 +63,11 @@ function getScriptsAndStylesheets({
 }
 
 export function renderSSRTemplate({
+  pathname,
   params,
   result,
 }: {
+  pathname: string;
   params: SSGParams;
   result: AppRenderResult;
 }): string {
@@ -96,9 +98,18 @@ export function renderSSRTemplate({
   ];
   const metaAttributes = metaStrings.filter(Boolean);
 
+  const numberOfSlashes = pathname.match(/\//g)?.length ?? 0;
+
+  const local = true;
+
+  const localBaseUrl =
+    numberOfSlashes === 1 ? `./` : '../'.repeat(numberOfSlashes - 1);
+
+  // console.log({pathname, numberOfSlashes, baseUrl, finalBaseUrl, headTags});
+
   const data: SSRTemplateData = {
     appHtml,
-    baseUrl,
+    baseUrl: local ? localBaseUrl : baseUrl,
     htmlAttributes,
     bodyAttributes,
     headTags,

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -112,7 +112,7 @@ export async function createBaseConfig({
       chunkFilename: isProd
         ? 'assets/js/[name].[contenthash:8].js'
         : '[name].js',
-      publicPath: baseUrl,
+      publicPath: isServer ? baseUrl : 'auto',
       hashFunction: 'xxhash64',
     },
     // Don't throw warning when asset created is over 250kb


### PR DESCRIPTION
## Motivation

WIP/POC attempt to solve https://github.com/facebook/docusaurus/issues/3825 and make a Docusaurus build usable without a server, distributed as a `docs.zip` file for example.

This attempt assumes we want to generate a static file for each page. 
See possible solutions/alternatives here:
https://github.com/facebook/docusaurus/issues/3825#issuecomment-1948240586

Note, in practice it's going to be complicated to use that approach, because:
- all links should be relative and end with `.html`?
- all assets paths should be relative
- it's not clear if React Router history browser even supports matching routes with a `file://` (see also https://github.com/remix-run/react-router/issues/3943 + https://twitter.com/sebastienlorber/status/1758461561037877282)
- we have to teach the bundler how to resolve chunks for each page. (webpack [`publicPath: "auto"`](https://webpack.js.org/guides/public-path/) seems to do that, but we should make sure it's supported by other solutions otherwise we'll have to stay on webpack forever 😅 )
- we probably have hooks that use the history API
- there are many hydration mismatches in this POC  

## Test Plan

???

### Test links


https://deploy-preview-9857--docusaurus-2.netlify.app/

