### PR TITLE
fix(remark-npm2yarn): update npm-to-yarn from 2.0.0 to 2.2.1, fix pnpm extra args syntax

### DIFF
--- a/packages/docusaurus-remark-plugin-npm2yarn/package.json
+++ b/packages/docusaurus-remark-plugin-npm2yarn/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "mdast-util-mdx": "^3.0.0",
-    "npm-to-yarn": "^2.0.0",
+    "npm-to-yarn": "^2.2.1",
     "tslib": "^2.6.0",
     "unified": "^11.0.3",
     "unist-util-visit": "^5.0.0"

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/__snapshots__/index.test.ts.snap
@@ -292,7 +292,7 @@ import TabItem from '@theme/TabItem'
 
   <TabItem value="pnpm" label="pnpm">
     \`\`\`bash
-    pnpm run xxx -- --arg
+    pnpm run xxx --arg
     \`\`\`
   </TabItem>
 </Tabs>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12326,10 +12326,10 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-npm-to-yarn@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-2.0.0.tgz#59c9c615eca3ba8920308a0b418007b73ffc7492"
-  integrity sha512-/IbjiJ7vqbxfxJxAZ+QI9CCRjnIbvGxn5KQcSY9xHh0lMKc/Sgqmm7yp7KPmd6TiTZX5/KiSBKlkGHo59ucZbg==
+npm-to-yarn@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-2.2.1.tgz#048843a6630621daffc6a239dfc89698b8abf7e8"
+  integrity sha512-O/j/ROyX0KGLG7O6Ieut/seQ0oiTpHF2tXAcFbpdTLQFiaNtkyTXXocM1fwpaa60dg1qpWj0nHlbNhx6qwuENQ==
 
 npmlog@6.0.2, npmlog@^6.0.0, npmlog@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

As discussed in #9761 there is an error when converting npm commands with `--` syntax to pnpm, pnpm doesn't support this syntax

Updating to version 2.2.1 fixes this issue by removing `--` in the converted command

## Test Plan

Deploy preview

### Test links

Deploy preview: https://deploy-preview-9861--docusaurus-2.netlify.app/docs/typescript-support#swizzling-typescript-theme-components

## Related issues/PRs

#9761