### PR TITLE
fix(core): fix default i18n calendar used, infer it from locale if possible

### DIFF
--- a/packages/docusaurus/src/server/__tests__/i18n.test.ts
+++ b/packages/docusaurus/src/server/__tests__/i18n.test.ts
@@ -81,7 +81,7 @@ describe('defaultLocaleConfig', () => {
       label: 'فارسی',
       direction: 'rtl',
       htmlLang: 'fa',
-      calendar: 'gregory',
+      calendar: 'persian',
       path: 'fa',
     });
     expect(getDefaultLocaleConfig('fa-IR')).toEqual({

--- a/packages/docusaurus/src/server/__tests__/i18n.test.ts
+++ b/packages/docusaurus/src/server/__tests__/i18n.test.ts
@@ -89,7 +89,7 @@ describe('defaultLocaleConfig', () => {
       label: 'فارسی (ایران)',
       direction: 'rtl',
       htmlLang: 'fa-IR',
-      calendar: 'gregory',
+      calendar: 'persian',
       path: 'fa-IR',
     });
     expect(getDefaultLocaleConfig('en-US-u-ca-buddhist')).toEqual({

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -19,13 +19,36 @@ function getDefaultLocaleLabel(locale: string) {
   );
 }
 
+function getDefaultCalendar(localeStr: string) {
+  const locale = new Intl.Locale(localeStr);
+
+  // If the locale name includes -u-ca-xxx the calendar will be defined
+  if (locale.calendar) {
+    return locale.calendar;
+  }
+
+  // Not well-supported but server code can infer a calendar from the locale
+  // See https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars
+  // See https://caniuse.com/mdn-javascript_builtins_intl_locale_getcalendars
+  const calendars =
+    // @ts-expect-error: new std method (Bun/JSC/WebKit)
+    locale.getCalendars?.() ??
+    // @ts-expect-error: non-std attribute (V8/Chromium/Node)
+    locale.calendars;
+
+  if (calendars instanceof Array && calendars[0]) {
+    return calendars[0];
+  }
+
+  return 'gregory';
+}
+
 export function getDefaultLocaleConfig(locale: string): I18nLocaleConfig {
   return {
     label: getDefaultLocaleLabel(locale),
     direction: getLangDir(locale),
     htmlLang: locale,
-    // If the locale name includes -u-ca-xxx the calendar will be defined
-    calendar: new Intl.Locale(locale).calendar ?? 'gregory',
+    calendar: getDefaultCalendar(locale),
     path: locale,
   };
 }


### PR DESCRIPTION

## Motivation

Fix bad default for the i18n calendar we use to format dates. 

The previous default was most often always `gregory` even for locales not supporting gregory calendars (unless the user uses a locale that contains the calendar, which is unlikely)

## Test Plan

Fix existing unit test: `locale: "fa"` locale should have `calendar: "persian"` by default instead of `calendar: "gregory"`
