### PR TITLE
perf: optimize getFileCommitDate, make it async

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -437,7 +437,7 @@ describe('blog plugin', () => {
     const noDateSource = path.posix.join('@site', PluginPath, 'no date.md');
     const noDateSourceFile = path.posix.join(siteDir, PluginPath, 'no date.md');
     // We know the file exists and we know we have git
-    const result = getFileCommitDate(noDateSourceFile, {age: 'oldest'});
+    const result = await getFileCommitDate(noDateSourceFile, {age: 'oldest'});
     const noDateSourceTime = result.date;
 
     expect({

--- a/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
+++ b/packages/docusaurus-plugin-content-blog/src/blogUtils.ts
@@ -258,10 +258,11 @@ async function processBlogSourceFile(
     }
 
     try {
-      const result = getFileCommitDate(blogSourceAbsolute, {
+      const result = await getFileCommitDate(blogSourceAbsolute, {
         age: 'oldest',
         includeAuthor: false,
       });
+
       return result.date;
     } catch (err) {
       logger.warn(err);

--- a/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
+++ b/packages/docusaurus-plugin-content-docs/src/lastUpdate.ts
@@ -25,10 +25,11 @@ export async function getFileLastUpdate(
   // Wrap in try/catch in case the shell commands fail
   // (e.g. project doesn't use Git, etc).
   try {
-    const result = getFileCommitDate(filePath, {
+    const result = await getFileCommitDate(filePath, {
       age: 'newest',
       includeAuthor: true,
     });
+
     return {timestamp: result.timestamp, author: result.author};
   } catch (err) {
     if (err instanceof GitNotFoundError) {

--- a/packages/docusaurus-utils/src/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/gitUtils.test.ts
@@ -47,88 +47,92 @@ function initializeTempRepo() {
 describe('getFileCommitDate', () => {
   const repoDir = initializeTempRepo();
   it('returns earliest commit date', async () => {
-    expect(getFileCommitDate(path.join(repoDir, 'test.txt'), {})).toEqual({
+    await expect(
+      getFileCommitDate(path.join(repoDir, 'test.txt'), {}),
+    ).resolves.toEqual({
       date: new Date('2020-06-19'),
       timestamp: new Date('2020-06-19').getTime() / 1000,
     });
-    expect(getFileCommitDate(path.join(repoDir, 'dest.txt'), {})).toEqual({
+    await expect(
+      getFileCommitDate(path.join(repoDir, 'dest.txt'), {}),
+    ).resolves.toEqual({
       date: new Date('2020-09-13'),
       timestamp: new Date('2020-09-13').getTime() / 1000,
     });
   });
   it('returns latest commit date', async () => {
-    expect(
+    await expect(
       getFileCommitDate(path.join(repoDir, 'test.txt'), {age: 'newest'}),
-    ).toEqual({
+    ).resolves.toEqual({
       date: new Date('2020-09-13'),
       timestamp: new Date('2020-09-13').getTime() / 1000,
     });
-    expect(
+    await expect(
       getFileCommitDate(path.join(repoDir, 'dest.txt'), {age: 'newest'}),
-    ).toEqual({
+    ).resolves.toEqual({
       date: new Date('2020-11-13'),
       timestamp: new Date('2020-11-13').getTime() / 1000,
     });
   });
   it('returns latest commit date with author', async () => {
-    expect(
+    await expect(
       getFileCommitDate(path.join(repoDir, 'test.txt'), {
         age: 'oldest',
         includeAuthor: true,
       }),
-    ).toEqual({
+    ).resolves.toEqual({
       date: new Date('2020-06-19'),
       timestamp: new Date('2020-06-19').getTime() / 1000,
       author: 'Caroline',
     });
-    expect(
+    await expect(
       getFileCommitDate(path.join(repoDir, 'dest.txt'), {
         age: 'oldest',
         includeAuthor: true,
       }),
-    ).toEqual({
+    ).resolves.toEqual({
       date: new Date('2020-09-13'),
       timestamp: new Date('2020-09-13').getTime() / 1000,
       author: 'Caroline',
     });
   });
   it('returns earliest commit date with author', async () => {
-    expect(
+    await expect(
       getFileCommitDate(path.join(repoDir, 'test.txt'), {
         age: 'newest',
         includeAuthor: true,
       }),
-    ).toEqual({
+    ).resolves.toEqual({
       date: new Date('2020-09-13'),
       timestamp: new Date('2020-09-13').getTime() / 1000,
       author: 'Caroline',
     });
-    expect(
+    await expect(
       getFileCommitDate(path.join(repoDir, 'dest.txt'), {
         age: 'newest',
         includeAuthor: true,
       }),
-    ).toEqual({
+    ).resolves.toEqual({
       date: new Date('2020-11-13'),
       timestamp: new Date('2020-11-13').getTime() / 1000,
       author: 'Josh-Cena',
     });
   });
   it('throws custom error when file is not tracked', async () => {
-    expect(() =>
+    await expect(() =>
       getFileCommitDate(path.join(repoDir, 'untracked.txt'), {
         age: 'newest',
         includeAuthor: true,
       }),
-    ).toThrow(FileNotTrackedError);
+    ).rejects.toThrow(FileNotTrackedError);
   });
   it('throws when file not found', async () => {
-    expect(() =>
+    await expect(() =>
       getFileCommitDate(path.join(repoDir, 'nonexistent.txt'), {
         age: 'newest',
         includeAuthor: true,
       }),
-    ).toThrow(
+    ).rejects.toThrow(
       /Failed to retrieve git history for ".*nonexistent.txt" because the file does not exist./,
     );
   });


### PR DESCRIPTION

## Motivation

`getFileCommitDate()` has been identified as a strong sync IO bottleneck of the `loadContent` blog and docs lifecycle hooks. 

Making it async greatly optimizes the time it takes to call `loadContent` on all plugins. This only affects the production build because `getFileCommitDate()` was already bypassed in dev mode.

## Local benchmark

`yarn clear:website && yarn build:website --locale en`

**Before:**

- `loadContent`: 17s
- Total build time: 84s

**After:** 🔥

- `loadContent`: 1.2s
- Total build time: 68s

## Test Plan

unit tests + CI

### Test links

https://deploy-preview-9890--docusaurus-2.netlify.app/
