### PR TITLE
fix(mdx-loader): mdx-code-block should support CRLF

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -1166,6 +1166,37 @@ describe('unwrapMdxCodeBlocks', () => {
     `);
   });
 
+  it('can unwrap a simple mdx code block with CRLF', () => {
+    // Note: looks like string dedent mess up with \r
+    expect(
+      unwrapMdxCodeBlocks(`
+# Title\r
+\`\`\`mdx-code-block\r
+import Comp, {User} from "@site/components/comp"\r
+\r
+<Comp prop="test">\r
+  <User user={{firstName: "Sébastien"}} />\r
+</Comp>\r
+\r
+export const age = 36\r
+\`\`\`\r
+\r
+text\r
+`),
+    ).toBe(`
+# Title\r
+import Comp, {User} from "@site/components/comp"\r
+\r
+<Comp prop="test">\r
+  <User user={{firstName: "Sébastien"}} />\r
+</Comp>\r
+\r
+export const age = 36\r
+\r
+text\r
+`);
+  });
+
   it('can unwrap a nested mdx code block', () => {
     expect(
       unwrapMdxCodeBlocks(dedent`

--- a/packages/docusaurus-utils/src/markdownUtils.ts
+++ b/packages/docusaurus-utils/src/markdownUtils.ts
@@ -70,9 +70,9 @@ export function escapeMarkdownHeadingIds(content: string): string {
 export function unwrapMdxCodeBlocks(content: string): string {
   // We only support 3/4 backticks on purpose, should be good enough
   const regexp3 =
-    /(?<begin>^|\n)```(?<spaces>\x20*)mdx-code-block\n(?<children>.*?)\n```(?<end>\n|$)/gs;
+    /(?<begin>^|\r?\n)```(?<spaces>\x20*)mdx-code-block\r?\n(?<children>.*?)\r?\n```(?<end>\r?\n|$)/gs;
   const regexp4 =
-    /(?<begin>^|\n)````(?<spaces>\x20*)mdx-code-block\n(?<children>.*?)\n````(?<end>\n|$)/gs;
+    /(?<begin>^|\r?\n)````(?<spaces>\x20*)mdx-code-block\r?\n(?<children>.*?)\r?\n````(?<end>\r?\n|$)/gs;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const replacer = (substring: string, ...args: any[]) => {


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/9896

## Test Plan

Unit test

Also local testing. A page with CLRF was failing before the change was applied locally, and now it works:

![CleanShot 2024-02-29 at 13 04 50](https://github.com/facebook/docusaurus/assets/749374/caf08850-d847-4236-8e4b-b68682862a24)

