### PR TITLE
fix(theme): improve a11y of DocSidebarItemCategory expand/collapsed button

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
@@ -101,6 +101,7 @@ function CollapseButton({
               {label: categoryLabel},
             )
       }
+      aria-expanded={!collapsed}
       type="button"
       className="clean-btn menu__caret"
       onClick={onClick}
@@ -193,7 +194,8 @@ export default function DocSidebarItemCategory({
                 }
           }
           aria-current={isCurrentPage ? 'page' : undefined}
-          aria-expanded={collapsible ? !collapsed : undefined}
+          role={collapsible && !href ? 'button' : undefined}
+          aria-expanded={collapsible && !href ? !collapsed : undefined}
           href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}
           {...props}>
           {label}


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

When using [Narrator](https://en.wikipedia.org/wiki/Narrator_(Windows)) on Windows and using <kbd>Tab</kbd> to go over the items in the sidebar, it does not announce the expanded / collapsed state on link elements. This is because link elements should not be expandable, only buttons should be.

For expandable menu items with a preview page I moved the `aria-expanded` state to the actual button. For menu items without, I added `role="button"` to the element.

## Test Plan

1. Use Narrator on Windows in the OS settings
2. Navigate to `http://localhost:3000/docs/category/getting-started`
3. <kbd>Tab</kbd> until you reach the sidebar

Expected: Narrator announces the collapsed / expanded state.
Actual: Does not

### Test links

Deploy preview: https://deploy-preview-9944--docusaurus-2.netlify.app/

## Related issues/PRs

Relates https://github.com/microsoft/playwright.dev/issues/1265

This came out of a discussion with @scottaohara, who is in the W3C WAI-ARIA working group.

