### PR TITLE
fix(a11y): move focus algolia-search focus back to search input on Escape

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -150,6 +150,7 @@ function DocSearch({
   const onClose = useCallback(() => {
     setIsOpen(false);
     searchContainer.current?.remove();
+    searchButtonRef.current?.focus();
   }, [setIsOpen]);
 
   const onInput = useCallback(


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

When using <kbd>Tab</kbd>  to navigate through the website and enter the Algolia search, type something but decide to go back (<kbd>Esc</kbd>) the focus gets lost. It should go back where it came from (search input).

## Test Plan

1. Tab through the page until you reach the Search input
2. Press <kbd>Enter</kbd> to open the Popup
3. Enter something and press <kbd>Esc</kbd>

Expected: Focus is back in the search input
Actual: Focus is lost

### Test links

Deploy preview: https://deploy-preview-9945--docusaurus-2.netlify.app/

## Related issues/PRs

Fixes https://github.com/facebook/docusaurus/issues/9917