### PR TITLE
docs(website): update wrong translate id

### DIFF
--- a/website/src/components/TeamProfileCards/index.tsx
+++ b/website/src/components/TeamProfileCards/index.tsx
@@ -108,7 +108,7 @@ export function ActiveTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Clément Couriol"
         githubUrl="https://github.com/ozakione">
-        <Translate id="team.profile.Yangshun Tay.body">
+        <Translate id="team.profile.Clement Couriol.body">
           Student from CPE Lyon, France. Passionate web developer who tries to
           become an expert web developer.
         </Translate>


### PR DESCRIPTION
## Motivation

Wrong description on the production site

I don't know how translation id works, maybe its related to crowdin and not directly in source code ?

## Test Plan

Deploy doesn't seem to be useful with the translate so I don't know

### Test links

Deploy preview: https://deploy-preview-9946--docusaurus-2.netlify.app/community/team

## Related issues/PRs

#9893 deploy correctly shows the description but once deployed its replaced 
