### PR TITLE
refactor(docs,blog): last update timestamp should be in milliseconds instead of seconds

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -539,7 +539,7 @@ describe('last update', () => {
     'website-blog-with-last-update',
   );
 
-  const lastUpdateFor = (date: string) => new Date(date).getTime() / 1000;
+  const lastUpdateFor = (date: string) => new Date(date).getTime();
 
   it('author and time', async () => {
     const plugin = await getPlugin(

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/docs.test.ts
@@ -8,7 +8,12 @@
 import {jest} from '@jest/globals';
 import path from 'path';
 import {loadContext} from '@docusaurus/core/src/server/site';
-import {createSlugger, posixPath, DEFAULT_PLUGIN_ID} from '@docusaurus/utils';
+import {
+  createSlugger,
+  posixPath,
+  DEFAULT_PLUGIN_ID,
+  GIT_FALLBACK_LAST_UPDATE_DATE,
+} from '@docusaurus/utils';
 import {createSidebarsUtils} from '../sidebars/utils';
 import {
   processDocMetadata,
@@ -474,7 +479,7 @@ describe('simple site', () => {
         custom_edit_url: 'https://github.com/customUrl/docs/lorem.md',
         unrelated_front_matter: "won't be part of metadata",
       },
-      lastUpdatedAt: 1539502055,
+      lastUpdatedAt: GIT_FALLBACK_LAST_UPDATE_DATE,
       lastUpdatedBy: 'Author',
       tags: [],
       unlisted: false,
@@ -571,7 +576,7 @@ describe('simple site', () => {
         },
         title: 'Custom Last Update',
       },
-      lastUpdatedAt: new Date('1/1/2000').getTime() / 1000,
+      lastUpdatedAt: new Date('1/1/2000').getTime(),
       lastUpdatedBy: 'Custom Author (processed by parseFrontMatter)',
       sidebarPosition: undefined,
       tags: [],
@@ -609,7 +614,7 @@ describe('simple site', () => {
         },
         title: 'Last Update Author Only',
       },
-      lastUpdatedAt: 1539502055,
+      lastUpdatedAt: GIT_FALLBACK_LAST_UPDATE_DATE,
       lastUpdatedBy: 'Custom Author (processed by parseFrontMatter)',
       sidebarPosition: undefined,
       tags: [],
@@ -647,7 +652,7 @@ describe('simple site', () => {
         },
         title: 'Last Update Date Only',
       },
-      lastUpdatedAt: new Date('1/1/2000').getTime() / 1000,
+      lastUpdatedAt: new Date('1/1/2000').getTime(),
       lastUpdatedBy: 'Author',
       sidebarPosition: undefined,
       tags: [],

--- a/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
@@ -16,7 +16,7 @@ function LastUpdatedAtDate({
 }: {
   lastUpdatedAt: number;
 }): JSX.Element {
-  const atDate = new Date(lastUpdatedAt * 1000);
+  const atDate = new Date(lastUpdatedAt);
 
   const dateTimeFormat = useDateTimeFormat({
     day: 'numeric',

--- a/packages/docusaurus-theme-common/src/utils/structuredDataUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/structuredDataUtils.ts
@@ -23,7 +23,7 @@ import type {
 } from '@docusaurus/plugin-content-blog';
 import type {DocusaurusConfig} from '@docusaurus/types';
 
-const convertDate = (dateMs: number) => new Date(dateMs * 1000).toISOString();
+const convertDate = (dateMs: number) => new Date(dateMs).toISOString();
 
 function getBlogPost(
   blogPostContent: PropBlogPostContent,

--- a/packages/docusaurus-utils/src/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/gitUtils.test.ts
@@ -52,13 +52,13 @@ describe('getFileCommitDate', () => {
       getFileCommitDate(path.join(repoDir, 'test.txt'), {}),
     ).resolves.toEqual({
       date: new Date('2020-06-19'),
-      timestamp: new Date('2020-06-19').getTime() / 1000,
+      timestamp: new Date('2020-06-19').getTime(),
     });
     await expect(
       getFileCommitDate(path.join(repoDir, 'dest.txt'), {}),
     ).resolves.toEqual({
       date: new Date('2020-09-13'),
-      timestamp: new Date('2020-09-13').getTime() / 1000,
+      timestamp: new Date('2020-09-13').getTime(),
     });
   });
   it('returns latest commit date', async () => {
@@ -66,13 +66,13 @@ describe('getFileCommitDate', () => {
       getFileCommitDate(path.join(repoDir, 'test.txt'), {age: 'newest'}),
     ).resolves.toEqual({
       date: new Date('2020-09-13'),
-      timestamp: new Date('2020-09-13').getTime() / 1000,
+      timestamp: new Date('2020-09-13').getTime(),
     });
     await expect(
       getFileCommitDate(path.join(repoDir, 'dest.txt'), {age: 'newest'}),
     ).resolves.toEqual({
       date: new Date('2020-11-13'),
-      timestamp: new Date('2020-11-13').getTime() / 1000,
+      timestamp: new Date('2020-11-13').getTime(),
     });
   });
   it('returns latest commit date with author', async () => {
@@ -83,7 +83,7 @@ describe('getFileCommitDate', () => {
       }),
     ).resolves.toEqual({
       date: new Date('2020-06-19'),
-      timestamp: new Date('2020-06-19').getTime() / 1000,
+      timestamp: new Date('2020-06-19').getTime(),
       author: 'Caroline',
     });
     await expect(
@@ -93,7 +93,7 @@ describe('getFileCommitDate', () => {
       }),
     ).resolves.toEqual({
       date: new Date('2020-09-13'),
-      timestamp: new Date('2020-09-13').getTime() / 1000,
+      timestamp: new Date('2020-09-13').getTime(),
       author: 'Caroline',
     });
   });
@@ -105,7 +105,7 @@ describe('getFileCommitDate', () => {
       }),
     ).resolves.toEqual({
       date: new Date('2020-09-13'),
-      timestamp: new Date('2020-09-13').getTime() / 1000,
+      timestamp: new Date('2020-09-13').getTime(),
       author: 'Caroline',
     });
     await expect(
@@ -115,7 +115,7 @@ describe('getFileCommitDate', () => {
       }),
     ).resolves.toEqual({
       date: new Date('2020-11-13'),
-      timestamp: new Date('2020-11-13').getTime() / 1000,
+      timestamp: new Date('2020-11-13').getTime(),
       author: 'Josh-Cena',
     });
   });

--- a/packages/docusaurus-utils/src/__tests__/lastUpdateUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/lastUpdateUtils.test.ts
@@ -103,7 +103,7 @@ describe('getFileLastUpdate', () => {
 
 describe('readLastUpdateData', () => {
   const testDate = '2021-01-01';
-  const testDateTime = new Date(testDate).getTime() / 1000;
+  const testTimestamp = new Date(testDate).getTime();
   const testAuthor = 'ozaki';
 
   it('read last time show author time', async () => {
@@ -112,7 +112,7 @@ describe('readLastUpdateData', () => {
       {showLastUpdateAuthor: true, showLastUpdateTime: true},
       {date: testDate},
     );
-    expect(lastUpdatedAt).toEqual(testDateTime);
+    expect(lastUpdatedAt).toEqual(testTimestamp);
     expect(lastUpdatedBy).toBe(GIT_FALLBACK_LAST_UPDATE_AUTHOR);
   });
 
@@ -133,7 +133,7 @@ describe('readLastUpdateData', () => {
       {author: testAuthor, date: testDate},
     );
     expect(lastUpdatedBy).toEqual(testAuthor);
-    expect(lastUpdatedAt).toEqual(testDateTime);
+    expect(lastUpdatedAt).toEqual(testTimestamp);
   });
 
   it('read last default show none', async () => {
@@ -191,7 +191,7 @@ describe('readLastUpdateData', () => {
       {date: testDate},
     );
     expect(lastUpdatedBy).toBeUndefined();
-    expect(lastUpdatedAt).toEqual(testDateTime);
+    expect(lastUpdatedAt).toEqual(testTimestamp);
   });
 
   it('read last author show time', async () => {
@@ -211,7 +211,7 @@ describe('readLastUpdateData', () => {
       {author: testAuthor, date: testDate},
     );
     expect(lastUpdatedBy).toBeUndefined();
-    expect(lastUpdatedAt).toEqual(testDateTime);
+    expect(lastUpdatedAt).toEqual(testTimestamp);
   });
 
   it('read last author show author only - both front matter', async () => {

--- a/packages/docusaurus-utils/src/gitUtils.ts
+++ b/packages/docusaurus-utils/src/gitUtils.ts
@@ -39,7 +39,7 @@ export async function getFileCommitDate(
 ): Promise<{
   /** Relevant commit date. */
   date: Date;
-  /** Timestamp in **seconds**, as returned from git. */
+  /** Timestamp returned from git, converted to **milliseconds**. */
   timestamp: number;
 }>;
 /**
@@ -66,7 +66,7 @@ export async function getFileCommitDate(
 ): Promise<{
   /** Relevant commit date. */
   date: Date;
-  /** Timestamp in **seconds**, as returned from git. */
+  /** Timestamp returned from git, converted to **milliseconds**. */
   timestamp: number;
   /** The author's name, as returned from git. */
   author: string;
@@ -150,8 +150,9 @@ export async function getFileCommitDate(
     );
   }
 
-  const timestamp = Number(match.groups!.timestamp);
-  const date = new Date(timestamp * 1000);
+  const timestampInSeconds = Number(match.groups!.timestamp);
+  const timestamp = timestampInSeconds * 1_000;
+  const date = new Date(timestamp);
 
   if (includeAuthor) {
     return {date, timestamp, author: match.groups!.author!};

--- a/packages/docusaurus-utils/src/lastUpdateUtils.ts
+++ b/packages/docusaurus-utils/src/lastUpdateUtils.ts
@@ -14,7 +14,7 @@ import {
 } from './gitUtils';
 import type {PluginOptions} from '@docusaurus/types';
 
-export const GIT_FALLBACK_LAST_UPDATE_DATE = 1539502055;
+export const GIT_FALLBACK_LAST_UPDATE_DATE = 1539502055000;
 
 export const GIT_FALLBACK_LAST_UPDATE_AUTHOR = 'Author';
 
@@ -31,9 +31,9 @@ async function getGitLastUpdate(filePath: string): Promise<LastUpdateData> {
 }
 
 export type LastUpdateData = {
-  /** A timestamp in **seconds**, directly acquired from `git log`. */
+  /** A timestamp in **milliseconds**, usually read from `git log` */
   lastUpdatedAt?: number;
-  /** The author's name directly acquired from `git log`. */
+  /** The author's name, usually coming from `git log` */
   lastUpdatedBy?: string;
 };
 
@@ -105,7 +105,7 @@ export async function readLastUpdateData(
 
   const frontMatterAuthor = lastUpdateFrontMatter?.author;
   const frontMatterTimestamp = lastUpdateFrontMatter?.date
-    ? new Date(lastUpdateFrontMatter.date).getTime() / 1000
+    ? new Date(lastUpdateFrontMatter.date).getTime()
     : undefined;
 
   // We try to minimize git last update calls


### PR DESCRIPTION


## Motivation

The last updated at timestamp read should be in milliseconds instead of seconds

Dealing with milliseconds is more convenient in JavaScript, and we shouldn't need to constantly convert it.

The only reason it was in second is because historically reading from git gives us a value in seconds, so let's convert it to ms at the root just after reading it from Git. This simplifies all the code down the line.

## Test Plan

Unit tests + preview

