### PR TITLE
refactor(core): improve dev perf, fine-grained site reloads - part 3

### DIFF
--- a/packages/docusaurus-types/src/context.d.ts
+++ b/packages/docusaurus-types/src/context.d.ts
@@ -31,6 +31,7 @@ export type GlobalData = {[pluginName: string]: {[pluginId: string]: unknown}};
 
 export type LoadContext = {
   siteDir: string;
+  siteVersion: string | undefined;
   generatedFilesDir: string;
   siteConfig: DocusaurusConfig;
   siteConfigPath: string;

--- a/packages/docusaurus-types/src/plugin.d.ts
+++ b/packages/docusaurus-types/src/plugin.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {TranslationFile} from './i18n';
+import type {CodeTranslations, TranslationFile} from './i18n';
 import type {RuleSetRule, Configuration as WebpackConfiguration} from 'webpack';
 import type {CustomizeRuleString} from 'webpack-merge/dist/types';
 import type {CommanderStatic} from 'commander';
@@ -185,6 +185,7 @@ export type LoadedPlugin = InitializedPlugin & {
   readonly content: unknown;
   readonly globalData: unknown;
   readonly routes: RouteConfig[];
+  readonly defaultCodeTranslations: CodeTranslations;
 };
 
 export type PluginModule<Content = unknown> = {

--- a/packages/docusaurus-utils/src/emitUtils.ts
+++ b/packages/docusaurus-utils/src/emitUtils.ts
@@ -12,6 +12,10 @@ import {findAsyncSequential} from './jsUtils';
 
 const fileHash = new Map<string, string>();
 
+const hashContent = (content: string): string => {
+  return createHash('md5').update(content).digest('hex');
+};
+
 /**
  * Outputs a file to the generated files directory. Only writes files if content
  * differs from cache (for hot reload performance).
@@ -38,7 +42,7 @@ export async function generate(
     // first "A" remains in cache. But if the file never existed in cache, no
     // need to register it.
     if (fileHash.get(filepath)) {
-      fileHash.set(filepath, createHash('md5').update(content).digest('hex'));
+      fileHash.set(filepath, hashContent(content));
     }
     return;
   }
@@ -50,11 +54,11 @@ export async function generate(
   // overwriting and we can reuse old file.
   if (!lastHash && (await fs.pathExists(filepath))) {
     const lastContent = await fs.readFile(filepath, 'utf8');
-    lastHash = createHash('md5').update(lastContent).digest('hex');
+    lastHash = hashContent(lastContent);
     fileHash.set(filepath, lastHash);
   }
 
-  const currentHash = createHash('md5').update(content).digest('hex');
+  const currentHash = hashContent(content);
 
   if (lastHash !== currentHash) {
     await fs.outputFile(filepath, content);

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -64,23 +64,15 @@ export async function build(
     process.on(sig, () => process.exit());
   });
 
-  async function tryToBuildLocale({
-    locale,
-    isLastLocale,
-  }: {
-    locale: string;
-    isLastLocale: boolean;
-  }) {
+  async function tryToBuildLocale({locale}: {locale: string}) {
     try {
-      PerfLogger.start(`Building site for locale ${locale}`);
-      await buildLocale({
-        siteDir,
-        locale,
-        cliOptions,
-        forceTerminate,
-        isLastLocale,
-      });
-      PerfLogger.end(`Building site for locale ${locale}`);
+      await PerfLogger.async(`${logger.name(locale)}`, () =>
+        buildLocale({
+          siteDir,
+          locale,
+          cliOptions,
+        }),
+      );
     } catch (err) {
       throw new Error(
         logger.interpolate`Unable to build website for locale name=${locale}.`,
@@ -91,20 +83,28 @@ export async function build(
     }
   }
 
-  PerfLogger.start(`Get locales to build`);
-  const locales = await getLocalesToBuild({siteDir, cliOptions});
-  PerfLogger.end(`Get locales to build`);
+  const locales = await PerfLogger.async('Get locales to build', () =>
+    getLocalesToBuild({siteDir, cliOptions}),
+  );
 
   if (locales.length > 1) {
     logger.info`Website will be built for all these locales: ${locales}`;
   }
 
-  PerfLogger.start(`Building ${locales.length} locales`);
-  await mapAsyncSequential(locales, (locale) => {
-    const isLastLocale = locales.indexOf(locale) === locales.length - 1;
-    return tryToBuildLocale({locale, isLastLocale});
-  });
-  PerfLogger.end(`Building ${locales.length} locales`);
+  await PerfLogger.async(`Build`, () =>
+    mapAsyncSequential(locales, async (locale) => {
+      const isLastLocale = locales.indexOf(locale) === locales.length - 1;
+      await tryToBuildLocale({locale});
+      if (isLastLocale) {
+        logger.info`Use code=${'npm run serve'} command to test your build locally.`;
+      }
+
+      // TODO do we really need this historical forceTerminate exit???
+      if (forceTerminate && isLastLocale && !cliOptions.bundleAnalyzer) {
+        process.exit(0);
+      }
+    }),
+  );
 }
 
 async function getLocalesToBuild({
@@ -144,14 +144,10 @@ async function buildLocale({
   siteDir,
   locale,
   cliOptions,
-  forceTerminate,
-  isLastLocale,
 }: {
   siteDir: string;
   locale: string;
   cliOptions: Partial<BuildCLIOptions>;
-  forceTerminate: boolean;
-  isLastLocale: boolean;
 }): Promise<string> {
   // Temporary workaround to unlock the ability to translate the site config
   // We'll remove it if a better official API can be designed
@@ -160,80 +156,65 @@ async function buildLocale({
 
   logger.info`name=${`[${locale}]`} Creating an optimized production build...`;
 
-  PerfLogger.start('Loading site');
-  const site = await loadSite({
-    siteDir,
-    outDir: cliOptions.outDir,
-    config: cliOptions.config,
-    locale,
-    localizePath: cliOptions.locale ? false : undefined,
-  });
-  PerfLogger.end('Loading site');
+  const site = await PerfLogger.async('Load site', () =>
+    loadSite({
+      siteDir,
+      outDir: cliOptions.outDir,
+      config: cliOptions.config,
+      locale,
+      localizePath: cliOptions.locale ? false : undefined,
+    }),
+  );
 
   const {props} = site;
   const {outDir, plugins} = props;
 
   // We can build the 2 configs in parallel
-  PerfLogger.start('Creating webpack configs');
   const [{clientConfig, clientManifestPath}, {serverConfig, serverBundlePath}] =
-    await Promise.all([
-      getBuildClientConfig({
-        props,
-        cliOptions,
-      }),
-      getBuildServerConfig({
-        props,
-      }),
-    ]);
-  PerfLogger.end('Creating webpack configs');
-
-  // Make sure generated client-manifest is cleaned first, so we don't reuse
-  // the one from previous builds.
-  // TODO do we really need this? .docusaurus folder is cleaned between builds
-  PerfLogger.start('Deleting previous client manifest');
-  await ensureUnlink(clientManifestPath);
-  PerfLogger.end('Deleting previous client manifest');
+    await PerfLogger.async('Creating webpack configs', () =>
+      Promise.all([
+        getBuildClientConfig({
+          props,
+          cliOptions,
+        }),
+        getBuildServerConfig({
+          props,
+        }),
+      ]),
+    );
 
   // Run webpack to build JS bundle (client) and static html files (server).
-  PerfLogger.start('Bundling');
-  await compile([clientConfig, serverConfig]);
-  PerfLogger.end('Bundling');
+  await PerfLogger.async('Bundling with Webpack', () =>
+    compile([clientConfig, serverConfig]),
+  );
 
-  PerfLogger.start('Executing static site generation');
-  const {collectedData} = await executeSSG({
-    props,
-    serverBundlePath,
-    clientManifestPath,
-  });
-  PerfLogger.end('Executing static site generation');
+  const {collectedData} = await PerfLogger.async('SSG', () =>
+    executeSSG({
+      props,
+      serverBundlePath,
+      clientManifestPath,
+    }),
+  );
 
   // Remove server.bundle.js because it is not needed.
-  PerfLogger.start('Deleting server bundle');
-  await ensureUnlink(serverBundlePath);
-  PerfLogger.end('Deleting server bundle');
+  await PerfLogger.async('Deleting server bundle', () =>
+    ensureUnlink(serverBundlePath),
+  );
 
   // Plugin Lifecycle - postBuild.
-  PerfLogger.start('Executing postBuild()');
-  await executePluginsPostBuild({plugins, props, collectedData});
-  PerfLogger.end('Executing postBuild()');
+  await PerfLogger.async('postBuild()', () =>
+    executePluginsPostBuild({plugins, props, collectedData}),
+  );
 
   // TODO execute this in parallel to postBuild?
-  PerfLogger.start('Executing broken links checker');
-  await executeBrokenLinksCheck({props, collectedData});
-  PerfLogger.end('Executing broken links checker');
+  await PerfLogger.async('Broken links checker', () =>
+    executeBrokenLinksCheck({props, collectedData}),
+  );
 
   logger.success`Generated static files in path=${path.relative(
     process.cwd(),
     outDir,
   )}.`;
-
-  if (isLastLocale) {
-    logger.info`Use code=${'npm run serve'} command to test your build locally.`;
-  }
-
-  if (forceTerminate && isLastLocale && !cliOptions.bundleAnalyzer) {
-    process.exit(0);
-  }
 
   return outDir;
 }
@@ -247,40 +228,39 @@ async function executeSSG({
   serverBundlePath: string;
   clientManifestPath: string;
 }) {
-  PerfLogger.start('Reading client manifest');
-  const manifest: Manifest = await fs.readJSON(clientManifestPath, 'utf-8');
-  PerfLogger.end('Reading client manifest');
-
-  PerfLogger.start('Compiling SSR template');
-  const ssrTemplate = await compileSSRTemplate(
-    props.siteConfig.ssrTemplate ?? defaultSSRTemplate,
+  const manifest: Manifest = await PerfLogger.async(
+    'Read client manifest',
+    () => fs.readJSON(clientManifestPath, 'utf-8'),
   );
-  PerfLogger.end('Compiling SSR template');
 
-  PerfLogger.start('Loading App renderer');
-  const renderer = await loadAppRenderer({
-    serverBundlePath,
-  });
-  PerfLogger.end('Loading App renderer');
+  const ssrTemplate = await PerfLogger.async('Compile SSR template', () =>
+    compileSSRTemplate(props.siteConfig.ssrTemplate ?? defaultSSRTemplate),
+  );
 
-  PerfLogger.start('Generate static files');
-  const ssgResult = await generateStaticFiles({
-    pathnames: props.routesPaths,
-    renderer,
-    params: {
-      trailingSlash: props.siteConfig.trailingSlash,
-      outDir: props.outDir,
-      baseUrl: props.baseUrl,
-      manifest,
-      headTags: props.headTags,
-      preBodyTags: props.preBodyTags,
-      postBodyTags: props.postBodyTags,
-      ssrTemplate,
-      noIndex: props.siteConfig.noIndex,
-      DOCUSAURUS_VERSION,
-    },
-  });
-  PerfLogger.end('Generate static files');
+  const renderer = await PerfLogger.async('Load App renderer', () =>
+    loadAppRenderer({
+      serverBundlePath,
+    }),
+  );
+
+  const ssgResult = await PerfLogger.async('Generate static files', () =>
+    generateStaticFiles({
+      pathnames: props.routesPaths,
+      renderer,
+      params: {
+        trailingSlash: props.siteConfig.trailingSlash,
+        outDir: props.outDir,
+        baseUrl: props.baseUrl,
+        manifest,
+        headTags: props.headTags,
+        preBodyTags: props.preBodyTags,
+        postBodyTags: props.postBodyTags,
+        ssrTemplate,
+        noIndex: props.siteConfig.noIndex,
+        DOCUSAURUS_VERSION,
+      },
+    }),
+  );
 
   return ssgResult;
 }

--- a/packages/docusaurus/src/commands/writeTranslations.ts
+++ b/packages/docusaurus/src/commands/writeTranslations.ts
@@ -13,7 +13,7 @@ import {
   writePluginTranslations,
   writeCodeTranslations,
   type WriteTranslationsOptions,
-  getPluginsDefaultCodeTranslationMessages,
+  loadPluginsDefaultCodeTranslationMessages,
   applyDefaultCodeTranslations,
 } from '../server/translations/translations';
 import {
@@ -114,7 +114,7 @@ Available locales are: ${context.i18n.locales.join(',')}.`,
     await getExtraSourceCodeFilePaths(),
   );
 
-  const defaultCodeMessages = await getPluginsDefaultCodeTranslationMessages(
+  const defaultCodeMessages = await loadPluginsDefaultCodeTranslationMessages(
     plugins,
   );
 

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -132,5 +132,6 @@ exports[`load loads props for site with custom i18n path 1`] = `
     "pluginVersions": {},
     "siteVersion": undefined,
   },
+  "siteVersion": undefined,
 }
 `;

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -36,6 +36,7 @@ exports[`load loads props for site with custom i18n path 1`] = `
   "plugins": [
     {
       "content": undefined,
+      "defaultCodeTranslations": {},
       "getClientModules": [Function],
       "globalData": undefined,
       "injectHtmlTags": [Function],
@@ -52,6 +53,7 @@ exports[`load loads props for site with custom i18n path 1`] = `
     {
       "configureWebpack": [Function],
       "content": undefined,
+      "defaultCodeTranslations": {},
       "globalData": undefined,
       "name": "docusaurus-mdx-fallback-plugin",
       "options": {

--- a/packages/docusaurus/src/server/__tests__/clientModules.test.ts
+++ b/packages/docusaurus/src/server/__tests__/clientModules.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {loadClientModules} from '../clientModules';
+import {getAllClientModules} from '../clientModules';
 import type {LoadedPlugin} from '@docusaurus/types';
 
 const pluginEmpty = {
@@ -33,14 +33,14 @@ const pluginHelloWorld = {
   },
 } as unknown as LoadedPlugin;
 
-describe('loadClientModules', () => {
+describe('getAllClientModules', () => {
   it('loads an empty plugin', () => {
-    const clientModules = loadClientModules([pluginEmpty]);
+    const clientModules = getAllClientModules([pluginEmpty]);
     expect(clientModules).toMatchInlineSnapshot(`[]`);
   });
 
   it('loads a non-empty plugin', () => {
-    const clientModules = loadClientModules([pluginFooBar]);
+    const clientModules = getAllClientModules([pluginFooBar]);
     expect(clientModules).toMatchInlineSnapshot(`
       [
         "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/foo",
@@ -50,7 +50,7 @@ describe('loadClientModules', () => {
   });
 
   it('loads multiple non-empty plugins', () => {
-    const clientModules = loadClientModules([pluginFooBar, pluginHelloWorld]);
+    const clientModules = getAllClientModules([pluginFooBar, pluginHelloWorld]);
     expect(clientModules).toMatchInlineSnapshot(`
       [
         "<PROJECT_ROOT>/packages/docusaurus/src/server/__tests__/foo",
@@ -62,7 +62,7 @@ describe('loadClientModules', () => {
   });
 
   it('loads multiple non-empty plugins in different order', () => {
-    const clientModules = loadClientModules([pluginHelloWorld, pluginFooBar]);
+    const clientModules = getAllClientModules([pluginHelloWorld, pluginFooBar]);
     expect(clientModules).toMatchInlineSnapshot(`
       [
         "/hello",
@@ -74,7 +74,7 @@ describe('loadClientModules', () => {
   });
 
   it('loads both empty and non-empty plugins', () => {
-    const clientModules = loadClientModules([
+    const clientModules = getAllClientModules([
       pluginHelloWorld,
       pluginEmpty,
       pluginFooBar,
@@ -90,7 +90,7 @@ describe('loadClientModules', () => {
   });
 
   it('loads empty and non-empty in a different order', () => {
-    const clientModules = loadClientModules([
+    const clientModules = getAllClientModules([
       pluginHelloWorld,
       pluginFooBar,
       pluginEmpty,

--- a/packages/docusaurus/src/server/__tests__/siteMetadata.test.ts
+++ b/packages/docusaurus/src/server/__tests__/siteMetadata.test.ts
@@ -7,13 +7,13 @@
 
 import path from 'path';
 import {DOCUSAURUS_VERSION} from '@docusaurus/utils';
-import {getPluginVersion, loadSiteMetadata} from '../siteMetadata';
+import {loadPluginVersion, createSiteMetadata} from '../siteMetadata';
 import type {LoadedPlugin} from '@docusaurus/types';
 
-describe('getPluginVersion', () => {
+describe('loadPluginVersion', () => {
   it('detects external packages plugins versions', async () => {
     await expect(
-      getPluginVersion(
+      loadPluginVersion(
         path.join(__dirname, '__fixtures__/siteMetadata/dummy-plugin.js'),
         // Make the plugin appear external.
         path.join(__dirname, '..', '..', '..', '..', '..', '..', 'website'),
@@ -23,7 +23,7 @@ describe('getPluginVersion', () => {
 
   it('detects project plugins versions', async () => {
     await expect(
-      getPluginVersion(
+      loadPluginVersion(
         path.join(__dirname, '__fixtures__/siteMetadata/dummy-plugin.js'),
         // Make the plugin appear project local.
         path.join(__dirname, '__fixtures__/siteMetadata'),
@@ -32,14 +32,14 @@ describe('getPluginVersion', () => {
   });
 
   it('detects local packages versions', async () => {
-    await expect(getPluginVersion('/', '/')).resolves.toEqual({type: 'local'});
+    await expect(loadPluginVersion('/', '/')).resolves.toEqual({type: 'local'});
   });
 });
 
-describe('loadSiteMetadata', () => {
-  it('throws if plugin versions mismatch', async () => {
-    await expect(
-      loadSiteMetadata({
+describe('createSiteMetadata', () => {
+  it('throws if plugin versions mismatch', () => {
+    expect(() =>
+      createSiteMetadata({
         plugins: [
           {
             name: 'docusaurus-plugin-content-docs',
@@ -50,10 +50,9 @@ describe('loadSiteMetadata', () => {
             },
           },
         ] as LoadedPlugin[],
-        siteDir: path.join(__dirname, '__fixtures__/siteMetadata'),
+        siteVersion: 'some-random-version',
       }),
-    ).rejects
-      .toThrow(`Invalid name=docusaurus-plugin-content-docs version number=1.0.0.
+    ).toThrow(`Invalid name=docusaurus-plugin-content-docs version number=1.0.0.
 All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=${DOCUSAURUS_VERSION}).
 Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?`);
   });

--- a/packages/docusaurus/src/server/clientModules.ts
+++ b/packages/docusaurus/src/server/clientModules.ts
@@ -12,7 +12,7 @@ import type {LoadedPlugin} from '@docusaurus/types';
  * Runs the `getClientModules` lifecycle. The returned file paths are all
  * absolute.
  */
-export function loadClientModules(plugins: LoadedPlugin[]): string[] {
+export function getAllClientModules(plugins: LoadedPlugin[]): string[] {
   return plugins.flatMap(
     (plugin) =>
       plugin.getClientModules?.().map((p) => path.resolve(plugin.path, p)) ??

--- a/packages/docusaurus/src/server/plugins/actions.ts
+++ b/packages/docusaurus/src/server/plugins/actions.ts
@@ -48,6 +48,7 @@ export async function createPluginActionsUtils({
     dataDir,
     `${docuHash('pluginRouteContextModule')}.json`,
   );
+  // TODO not ideal place to generate that file
   await generate(
     '/',
     pluginRouteContextModulePath,

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -12,7 +12,7 @@ import {
   normalizePluginOptions,
   normalizeThemeConfig,
 } from '@docusaurus/utils-validation';
-import {getPluginVersion} from '../siteMetadata';
+import {loadPluginVersion} from '../siteMetadata';
 import {ensureUniquePluginInstanceIds} from './pluginIds';
 import {loadPluginConfigs, type NormalizedPluginConfig} from './configs';
 import type {
@@ -61,14 +61,14 @@ export async function initPlugins(
   const pluginRequire = createRequire(context.siteConfigPath);
   const pluginConfigs = await loadPluginConfigs(context);
 
-  async function doGetPluginVersion(
+  async function doLoadPluginVersion(
     normalizedPluginConfig: NormalizedPluginConfig,
   ): Promise<PluginVersionInformation> {
     if (normalizedPluginConfig.pluginModule?.path) {
       const pluginPath = pluginRequire.resolve(
         normalizedPluginConfig.pluginModule.path,
       );
-      return getPluginVersion(pluginPath, context.siteDir);
+      return loadPluginVersion(pluginPath, context.siteDir);
     }
     return {type: 'local'};
   }
@@ -109,7 +109,7 @@ export async function initPlugins(
   async function initializePlugin(
     normalizedPluginConfig: NormalizedPluginConfig,
   ): Promise<InitializedPlugin> {
-    const pluginVersion: PluginVersionInformation = await doGetPluginVersion(
+    const pluginVersion: PluginVersionInformation = await doLoadPluginVersion(
       normalizedPluginConfig,
     );
     const pluginOptions = doValidatePluginOptions(normalizedPluginConfig);

--- a/packages/docusaurus/src/server/plugins/plugins.ts
+++ b/packages/docusaurus/src/server/plugins/plugins.ts
@@ -87,10 +87,16 @@ async function executePluginContentLoading({
       }),
     );
 
+    const defaultCodeTranslations =
+      (await PerfLogger.async('getDefaultCodeTranslationMessages()', () =>
+        plugin.getDefaultCodeTranslationMessages?.(),
+      )) ?? {};
+
     if (!plugin.contentLoaded) {
       return {
         ...plugin,
         content,
+        defaultCodeTranslations,
         routes: [],
         globalData: undefined,
       };
@@ -114,6 +120,7 @@ async function executePluginContentLoading({
     return {
       ...plugin,
       content,
+      defaultCodeTranslations,
       routes: pluginActionsUtils.getRoutes(),
       globalData: pluginActionsUtils.getGlobalData(),
     };

--- a/packages/docusaurus/src/server/plugins/plugins.ts
+++ b/packages/docusaurus/src/server/plugins/plugins.ts
@@ -15,6 +15,7 @@ import {
   aggregateAllContent,
   aggregateGlobalData,
   aggregateRoutes,
+  formatPluginName,
   getPluginByIdentifier,
   mergeGlobalData,
 } from './pluginsUtils';
@@ -73,46 +74,50 @@ async function executePluginContentLoading({
   plugin: InitializedPlugin;
   context: LoadContext;
 }): Promise<LoadedPlugin> {
-  return PerfLogger.async(
-    `Plugins - single plugin content loading - ${plugin.name}@${plugin.options.id}`,
-    async () => {
-      let content = await plugin.loadContent?.();
+  return PerfLogger.async(`Load ${formatPluginName(plugin)}`, async () => {
+    let content = await PerfLogger.async('loadContent()', () =>
+      plugin.loadContent?.(),
+    );
 
-      content = await translatePluginContent({
+    content = await PerfLogger.async('translatePluginContent()', () =>
+      translatePluginContent({
         plugin,
         content,
         context,
-      });
+      }),
+    );
 
-      if (!plugin.contentLoaded) {
-        return {
-          ...plugin,
-          content,
-          routes: [],
-          globalData: undefined,
-        };
-      }
-
-      const pluginActionsUtils = await createPluginActionsUtils({
-        plugin,
-        generatedFilesDir: context.generatedFilesDir,
-        baseUrl: context.siteConfig.baseUrl,
-        trailingSlash: context.siteConfig.trailingSlash,
-      });
-
-      await plugin.contentLoaded({
-        content,
-        actions: pluginActionsUtils.getActions(),
-      });
-
+    if (!plugin.contentLoaded) {
       return {
         ...plugin,
         content,
-        routes: pluginActionsUtils.getRoutes(),
-        globalData: pluginActionsUtils.getGlobalData(),
+        routes: [],
+        globalData: undefined,
       };
-    },
-  );
+    }
+
+    const pluginActionsUtils = await createPluginActionsUtils({
+      plugin,
+      generatedFilesDir: context.generatedFilesDir,
+      baseUrl: context.siteConfig.baseUrl,
+      trailingSlash: context.siteConfig.trailingSlash,
+    });
+
+    await PerfLogger.async('contentLoaded()', () =>
+      // @ts-expect-error: should autofix with TS 5.4
+      plugin.contentLoaded({
+        content,
+        actions: pluginActionsUtils.getActions(),
+      }),
+    );
+
+    return {
+      ...plugin,
+      content,
+      routes: pluginActionsUtils.getRoutes(),
+      globalData: pluginActionsUtils.getGlobalData(),
+    };
+  });
 }
 
 async function executeAllPluginsContentLoading({
@@ -122,7 +127,7 @@ async function executeAllPluginsContentLoading({
   plugins: InitializedPlugin[];
   context: LoadContext;
 }): Promise<LoadedPlugin[]> {
-  return PerfLogger.async(`Plugins - all plugins content loading`, () => {
+  return PerfLogger.async(`Load plugins content`, () => {
     return Promise.all(
       plugins.map((plugin) => executePluginContentLoading({plugin, context})),
     );
@@ -139,7 +144,7 @@ async function executePluginAllContentLoaded({
   allContent: AllContent;
 }): Promise<{routes: RouteConfig[]; globalData: unknown}> {
   return PerfLogger.async(
-    `Plugins - allContentLoaded - ${plugin.name}@${plugin.options.id}`,
+    `allContentLoaded() - ${formatPluginName(plugin)}`,
     async () => {
       if (!plugin.allContentLoaded) {
         return {routes: [], globalData: undefined};
@@ -171,7 +176,7 @@ async function executeAllPluginsAllContentLoaded({
   plugins: LoadedPlugin[];
   context: LoadContext;
 }): Promise<AllContentLoadedResult> {
-  return PerfLogger.async(`Plugins - allContentLoaded`, async () => {
+  return PerfLogger.async(`allContentLoaded()`, async () => {
     const allContent = aggregateAllContent(plugins);
 
     const routes: RouteConfig[] = [];
@@ -199,6 +204,9 @@ async function executeAllPluginsAllContentLoaded({
   });
 }
 
+// This merges plugins routes and global data created from both lifecycles:
+// - contentLoaded()
+// - allContentLoaded()
 function mergeResults({
   plugins,
   allContentLoadedResult,
@@ -232,9 +240,9 @@ export type LoadPluginsResult = {
 export async function loadPlugins(
   context: LoadContext,
 ): Promise<LoadPluginsResult> {
-  return PerfLogger.async('Plugins - loadPlugins', async () => {
+  return PerfLogger.async('Load plugins', async () => {
     const initializedPlugins: InitializedPlugin[] = await PerfLogger.async(
-      'Plugins - initPlugins',
+      'Init plugins',
       () => initPlugins(context),
     );
 
@@ -272,36 +280,39 @@ export async function reloadPlugin({
   plugins: LoadedPlugin[];
   context: LoadContext;
 }): Promise<LoadPluginsResult> {
-  return PerfLogger.async('Plugins - reloadPlugin', async () => {
-    const previousPlugin = getPluginByIdentifier({
-      plugins: previousPlugins,
-      pluginIdentifier,
-    });
-    const plugin = await executePluginContentLoading({
-      plugin: previousPlugin,
-      context,
-    });
+  return PerfLogger.async(
+    `Reload plugin ${formatPluginName(pluginIdentifier)}`,
+    async () => {
+      const previousPlugin = getPluginByIdentifier({
+        plugins: previousPlugins,
+        pluginIdentifier,
+      });
+      const plugin = await executePluginContentLoading({
+        plugin: previousPlugin,
+        context,
+      });
 
-    /*
+      /*
     // TODO Docusaurus v4 - upgrade to Node 20, use array.with()
     const plugins = previousPlugins.with(
       previousPlugins.indexOf(previousPlugin),
       plugin,
     );
      */
-    const plugins = [...previousPlugins];
-    plugins[previousPlugins.indexOf(previousPlugin)] = plugin;
+      const plugins = [...previousPlugins];
+      plugins[previousPlugins.indexOf(previousPlugin)] = plugin;
 
-    const allContentLoadedResult = await executeAllPluginsAllContentLoaded({
-      plugins,
-      context,
-    });
+      const allContentLoadedResult = await executeAllPluginsAllContentLoaded({
+        plugins,
+        context,
+      });
 
-    const {routes, globalData} = mergeResults({
-      plugins,
-      allContentLoadedResult,
-    });
+      const {routes, globalData} = mergeResults({
+        plugins,
+        allContentLoadedResult,
+      });
 
-    return {plugins, routes, globalData};
-  });
+      return {plugins, routes, globalData};
+    },
+  );
 }

--- a/packages/docusaurus/src/server/plugins/pluginsUtils.ts
+++ b/packages/docusaurus/src/server/plugins/pluginsUtils.ts
@@ -29,7 +29,9 @@ export function getPluginByIdentifier<P extends InitializedPlugin>({
   );
   if (!plugin) {
     throw new Error(
-      logger.interpolate`Plugin not found for identifier ${pluginIdentifier.name}@${pluginIdentifier.id}`,
+      logger.interpolate`Plugin not found for identifier ${formatPluginName(
+        pluginIdentifier,
+      )}`,
     );
   }
   return plugin;
@@ -84,4 +86,21 @@ export function mergeGlobalData(...globalDataList: GlobalData[]): GlobalData {
   });
 
   return result;
+}
+
+export function formatPluginName(
+  plugin: InitializedPlugin | PluginIdentifier,
+): string {
+  let formattedName = plugin.name;
+  // Hacky way to reduce string size for logging purpose
+  formattedName = formattedName.replace('docusaurus-plugin-content-', '');
+  formattedName = formattedName.replace('docusaurus-plugin-', '');
+  formattedName = formattedName.replace('docusaurus-theme-', '');
+  formattedName = formattedName.replace('-plugin', '');
+  formattedName = logger.name(formattedName);
+
+  const id = 'id' in plugin ? plugin.id : plugin.options.id;
+  const formattedId = logger.subdue(id);
+
+  return `${formattedName}@${formattedId}`;
 }

--- a/packages/docusaurus/src/server/plugins/pluginsUtils.ts
+++ b/packages/docusaurus/src/server/plugins/pluginsUtils.ts
@@ -88,6 +88,8 @@ export function mergeGlobalData(...globalDataList: GlobalData[]): GlobalData {
   return result;
 }
 
+// This is primarily useful for colored logging purpose
+// Do not rely on this for logic
 export function formatPluginName(
   plugin: InitializedPlugin | PluginIdentifier,
 ): string {

--- a/packages/docusaurus/src/server/site.ts
+++ b/packages/docusaurus/src/server/site.ts
@@ -20,7 +20,7 @@ import {createSiteMetadata, loadSiteVersion} from './siteMetadata';
 import {loadI18n} from './i18n';
 import {
   loadSiteCodeTranslations,
-  getPluginsDefaultCodeTranslationMessages,
+  getPluginsDefaultCodeTranslations,
 } from './translations/translations';
 import {PerfLogger} from '../utils';
 import {generateSiteFiles} from './codegen/codegen';
@@ -125,9 +125,9 @@ export async function loadContext(
   };
 }
 
-async function createSiteProps(
+function createSiteProps(
   params: LoadPluginsResult & {context: LoadContext},
-): Promise<Props> {
+): Props {
   const {plugins, routes, context} = params;
   const {
     generatedFilesDir,
@@ -146,13 +146,10 @@ async function createSiteProps(
 
   const siteMetadata = createSiteMetadata({plugins, siteVersion});
 
-  const codeTranslations = await PerfLogger.async(
-    'Load code translations',
-    async () => ({
-      ...(await getPluginsDefaultCodeTranslationMessages(plugins)),
-      ...siteCodeTranslations,
-    }),
-  );
+  const codeTranslations = {
+    ...getPluginsDefaultCodeTranslations({plugins}),
+    ...siteCodeTranslations,
+  };
 
   handleDuplicateRoutes(routes, siteConfig.onDuplicateRoutes);
   const routesPaths = getRoutesPaths(routes, baseUrl);
@@ -226,6 +223,7 @@ export async function loadSite(params: LoadContextParams): Promise<Site> {
   );
 
   const {plugins, routes, globalData} = await loadPlugins(context);
+
   const props = await createSiteProps({plugins, routes, globalData, context});
 
   const site: Site = {props, params};

--- a/packages/docusaurus/src/server/siteMetadata.ts
+++ b/packages/docusaurus/src/server/siteMetadata.ts
@@ -14,7 +14,7 @@ import type {
   SiteMetadata,
 } from '@docusaurus/types';
 
-async function getPackageJsonVersion(
+async function loadPackageJsonVersion(
   packageJsonPath: string,
 ): Promise<string | undefined> {
   if (await fs.pathExists(packageJsonPath)) {
@@ -24,14 +24,20 @@ async function getPackageJsonVersion(
   return undefined;
 }
 
-async function getPackageJsonName(
+async function loadPackageJsonName(
   packageJsonPath: string,
 ): Promise<string | undefined> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
   return (require(packageJsonPath) as {name?: string}).name;
 }
 
-export async function getPluginVersion(
+export async function loadSiteVersion(
+  siteDir: string,
+): Promise<string | undefined> {
+  return loadPackageJsonVersion(path.join(siteDir, 'package.json'));
+}
+
+export async function loadPluginVersion(
   pluginPath: string,
   siteDir: string,
 ): Promise<PluginVersionInformation> {
@@ -52,8 +58,8 @@ export async function getPluginVersion(
       }
       return {
         type: 'package',
-        name: await getPackageJsonName(packageJsonPath),
-        version: await getPackageJsonVersion(packageJsonPath),
+        name: await loadPackageJsonName(packageJsonPath),
+        version: await loadPackageJsonVersion(packageJsonPath),
       };
     }
     potentialPluginPackageJsonDirectory = path.dirname(
@@ -89,18 +95,16 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
   );
 }
 
-export async function loadSiteMetadata({
+export function createSiteMetadata({
+  siteVersion,
   plugins,
-  siteDir,
 }: {
+  siteVersion: string | undefined;
   plugins: LoadedPlugin[];
-  siteDir: string;
-}): Promise<SiteMetadata> {
+}): SiteMetadata {
   const siteMetadata: SiteMetadata = {
     docusaurusVersion: DOCUSAURUS_VERSION,
-    siteVersion: await getPackageJsonVersion(
-      path.join(siteDir, 'package.json'),
-    ),
+    siteVersion,
     pluginVersions: Object.fromEntries(
       plugins
         .filter(({version: {type}}) => type !== 'synthetic')

--- a/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
+++ b/packages/docusaurus/src/server/translations/__tests__/translations.test.ts
@@ -15,7 +15,7 @@ import {
   readCodeTranslationFileContent,
   type WriteTranslationsOptions,
   localizePluginTranslationFile,
-  getPluginsDefaultCodeTranslationMessages,
+  loadPluginsDefaultCodeTranslationMessages,
   applyDefaultCodeTranslations,
 } from '../translations';
 import type {
@@ -537,7 +537,7 @@ describe('readCodeTranslationFileContent', () => {
   });
 });
 
-describe('getPluginsDefaultCodeTranslationMessages', () => {
+describe('loadPluginsDefaultCodeTranslationMessages', () => {
   function createTestPlugin(
     fn: InitializedPlugin['getDefaultCodeTranslationMessages'],
   ): InitializedPlugin {
@@ -547,14 +547,14 @@ describe('getPluginsDefaultCodeTranslationMessages', () => {
   it('works for empty plugins', async () => {
     const plugins: InitializedPlugin[] = [];
     await expect(
-      getPluginsDefaultCodeTranslationMessages(plugins),
+      loadPluginsDefaultCodeTranslationMessages(plugins),
     ).resolves.toEqual({});
   });
 
   it('works for 1 plugin without lifecycle', async () => {
     const plugins: InitializedPlugin[] = [createTestPlugin(undefined)];
     await expect(
-      getPluginsDefaultCodeTranslationMessages(plugins),
+      loadPluginsDefaultCodeTranslationMessages(plugins),
     ).resolves.toEqual({});
   });
 
@@ -566,7 +566,7 @@ describe('getPluginsDefaultCodeTranslationMessages', () => {
       })),
     ];
     await expect(
-      getPluginsDefaultCodeTranslationMessages(plugins),
+      loadPluginsDefaultCodeTranslationMessages(plugins),
     ).resolves.toEqual({
       a: '1',
       b: '2',
@@ -585,7 +585,7 @@ describe('getPluginsDefaultCodeTranslationMessages', () => {
       })),
     ];
     await expect(
-      getPluginsDefaultCodeTranslationMessages(plugins),
+      loadPluginsDefaultCodeTranslationMessages(plugins),
     ).resolves.toEqual({
       a: '1',
       b: '2',
@@ -613,7 +613,7 @@ describe('getPluginsDefaultCodeTranslationMessages', () => {
       createTestPlugin(undefined),
     ];
     await expect(
-      getPluginsDefaultCodeTranslationMessages(plugins),
+      loadPluginsDefaultCodeTranslationMessages(plugins),
     ).resolves.toEqual({
       // merge, last plugin wins
       b: '2',

--- a/packages/docusaurus/src/server/translations/translations.ts
+++ b/packages/docusaurus/src/server/translations/translations.ts
@@ -20,6 +20,7 @@ import type {
   TranslationFile,
   CodeTranslations,
   InitializedPlugin,
+  LoadedPlugin,
 } from '@docusaurus/types';
 
 export type WriteTranslationsOptions = {
@@ -242,17 +243,33 @@ export async function localizePluginTranslationFile({
   return translationFile;
 }
 
-export async function getPluginsDefaultCodeTranslationMessages(
+export function mergeCodeTranslations(
+  codeTranslations: CodeTranslations[],
+): CodeTranslations {
+  return codeTranslations.reduce(
+    (allCodeTranslations, current) => ({
+      ...allCodeTranslations,
+      ...current,
+    }),
+    {},
+  );
+}
+
+export async function loadPluginsDefaultCodeTranslationMessages(
   plugins: InitializedPlugin[],
 ): Promise<CodeTranslations> {
   const pluginsMessages = await Promise.all(
     plugins.map((plugin) => plugin.getDefaultCodeTranslationMessages?.() ?? {}),
   );
+  return mergeCodeTranslations(pluginsMessages);
+}
 
-  return pluginsMessages.reduce(
-    (allMessages, pluginMessages) => ({...allMessages, ...pluginMessages}),
-    {},
-  );
+export function getPluginsDefaultCodeTranslations({
+  plugins,
+}: {
+  plugins: LoadedPlugin[];
+}): CodeTranslations {
+  return mergeCodeTranslations(plugins.map((p) => p.defaultCodeTranslations));
 }
 
 export function applyDefaultCodeTranslations({

--- a/project-words.txt
+++ b/project-words.txt
@@ -16,6 +16,7 @@ architecting
 Astro
 atrule
 Autoconverted
+autofix
 Autogen
 autogen
 autogenerating


### PR DESCRIPTION
## Motivation

This is a follow-up of the DX improvements from:
- https://github.com/facebook/docusaurus/pull/9903
- https://github.com/facebook/docusaurus/pull/9968

The goal of this is to improve the dev experience performance.

This notably improves the little perf logging infrastructure to trace nested async calls so that we easily notice what is slow in our codebase.

![CleanShot 2024-03-21 at 19 31 27@2x](https://github.com/facebook/docusaurus/assets/749374/f4058a4f-a62d-44f7-8639-cbac8bfaa69c)


It also moves some async/IO calls around to make plugin hot reloading a bit faster.

## Test Plan

Unit tests + dogfood

### Test links

https://deploy-preview-9975--docusaurus-2.netlify.app/
