### PR TITLE
docs: remove old github action description

### DIFF
--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -355,11 +355,6 @@ Our goal is that:
 1. When a new pull request is made to `main`, there's an action that ensures the site builds successfully, without actually deploying. This job will be called `test-deploy`.
 2. When a pull request is merged to the `main` branch or someone pushes to the `main` branch directly, it will be built and deployed to GitHub Pages. This job will be called `deploy`.
 
-Here are two approaches to deploying your docs with GitHub Actions. Based on the location of your deployment branch (`gh-pages`), choose the relevant tab below:
-
-- Source repo and deployment repo are the **same** repository.
-- The deployment repo is a **remote** repository, different from the source. Instructions for this scenario assume [publishing source](https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) is the `gh-pages` branch.
-
 ```mdx-code-block
 <Tabs>
 <TabItem value="same" label="Same">

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -355,6 +355,11 @@ Our goal is that:
 1. When a new pull request is made to `main`, there's an action that ensures the site builds successfully, without actually deploying. This job will be called `test-deploy`.
 2. When a pull request is merged to the `main` branch or someone pushes to the `main` branch directly, it will be built and deployed to GitHub Pages. This job will be called `deploy`.
 
+Here are two approaches to deploying your docs with GitHub Actions. Based on the location of your deployment repository, choose the relevant tab below:
+
+- Source repo and deployment repo are the **same** repository.
+- The deployment repo is a **remote** repository, different from the source. Instructions for this scenario assume [publishing source](https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) is the `gh-pages` branch.
+
 ```mdx-code-block
 <Tabs>
 <TabItem value="same" label="Same">


### PR DESCRIPTION
## Motivation

We changed GitHub action in #9937 and now the GitHub action doesn't use `gh_pages` branch anymore

Maybe we can add a new description like this :

> When triggered by a push to the main branch, the workflow builds a Docusaurus site, creates artifacts of that build, and deploys them to GitHub Pages.

## Test Plan

Deploy

### Test links

[Deployment](https://deploy-preview-9980--docusaurus-2.netlify.app/docs/deployment#triggering-deployment-with-github-actions)

## Related issues/PRs

#9937