### PR TITLE
chore: fix codesandbox default privacy

### DIFF
--- a/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
+++ b/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
@@ -11,9 +11,9 @@ const CookieName = 'DocusaurusPlaygroundName';
 
 const PlaygroundConfigs = {
   codesandbox:
-    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic?file=%2FREADME.md',
+    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic?file=%2FREADME.md&fork=true&privacy=public',
   'codesandbox-ts':
-    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic-typescript?file=%2FREADME.md',
+    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic-typescript?file=%2FREADME.md&fork=true&privacy=public',
 
   // Slow to load
   // stackblitz: 'https://stackblitz.com/github/facebook/docusaurus/tree/main/examples/classic',

--- a/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
+++ b/admin/new.docusaurus.io/functionUtils/playgroundUtils.ts
@@ -11,9 +11,9 @@ const CookieName = 'DocusaurusPlaygroundName';
 
 const PlaygroundConfigs = {
   codesandbox:
-    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic?file=%2FREADME.md&fork=true&privacy=public',
+    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic?file=%2FREADME.md&privacy=public',
   'codesandbox-ts':
-    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic-typescript?file=%2FREADME.md&fork=true&privacy=public',
+    'https://codesandbox.io/p/sandbox/github/facebook/docusaurus/tree/main/examples/classic-typescript?file=%2FREADME.md&privacy=public',
 
   // Slow to load
   // stackblitz: 'https://stackblitz.com/github/facebook/docusaurus/tree/main/examples/classic',


### PR DESCRIPTION

## Motivation

CodeSandbox repros we receive lately are private by default, which is annoying:

![image](https://github.com/facebook/docusaurus/assets/749374/9104e407-fccd-4413-8a28-55f7ee6c53fa)


Apparently, new query string options have been implemented to prevent this, so let's figure what is the best for our use case.

https://twitter.com/CompuIves/status/1773028692752539825

![CleanShot 2024-03-28 at 10 41 25](https://github.com/facebook/docusaurus/assets/749374/688723da-aa16-4fbc-b0bf-95072fae9aa5)

