### PR TITLE
fix(mdx-loader): Ignore contentTitle coming after Markdown thematicBreak

### DIFF
--- a/packages/docusaurus-mdx-loader/src/remark/contentTitle/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/contentTitle/__tests__/index.test.ts
@@ -71,6 +71,21 @@ some **markdown** *content*
       expect(result.data.contentTitle).toBeUndefined();
     });
 
+    it('ignore contentTitle if after thematic break', async () => {
+      const result = await process(`
+
+Hey
+
+---
+
+# contentTitle 1
+
+some **markdown** *content*
+  `);
+
+      expect(result.data.contentTitle).toBeUndefined();
+    });
+
     it('is able to decently serialize Markdown syntax', async () => {
       const result = await process(`
 # some **markdown** \`content\` _italic_

--- a/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
@@ -34,17 +34,24 @@ const plugin: Plugin = function plugin(
     const {toString} = await import('mdast-util-to-string');
     const {visit, EXIT} = await import('unist-util-visit');
 
-    visit(root, 'heading', (headingNode: Heading, index, parent) => {
-      if (headingNode.depth === 1) {
-        vfile.data.contentTitle = toString(headingNode);
-        if (removeContentTitle) {
-          // @ts-expect-error: TODO how to fix?
-          parent!.children.splice(index, 1);
+    visit(root, ['heading', 'thematicBreak'], (node, index, parent) => {
+      if (node.type === 'heading') {
+        const headingNode = node as Heading;
+        if (headingNode.depth === 1) {
+          vfile.data.contentTitle = toString(headingNode);
+          if (removeContentTitle) {
+            // @ts-expect-error: TODO how to fix?
+            parent!.children.splice(index, 1);
+          }
+          return EXIT; // We only handle the very first heading
         }
-        return EXIT; // We only handle the very first heading
+        // We only handle contentTitle if it's the very first heading found
+        if (headingNode.depth >= 1) {
+          return EXIT;
+        }
       }
-      // We only handle contentTitle if it's the very first heading found
-      if (headingNode.depth >= 1) {
+      // We only handle contentTitle when it's above the first thematic break
+      if (node.type === 'thematicBreak') {
         return EXIT;
       }
       return undefined;


### PR DESCRIPTION
## Motivation

This fix shouldn't impact any user, apart some Meta OSS sites like React Native that decided to use `h1` headings in the middle of a doc (which doesn't look good, but it is the current state):

```md
---
title: Title that should be injected as h1
---

Some intro text

--- 

# Reference

## Methods

### `alert()`
```

Without this change, the `frontMatter.title` won't be injected as a `h1` heading at the beginning of the doc (also called "synthetic heading" because it's not a Markdown `# Title`)

I don't really like to introduce such fancy edge case handling just for Meta sites, but the heuristic to ignore h1 after a thematic break still kind of makes sense for other sites, so if we can make it easier to upgrade to V3 Meta sites and it's not annoying for others, let's do it 🤷‍♂️ 

## Test Plan

unit tests, React Native upgrade: https://github.com/facebook/react-native-website/pull/4072

### Test links

https://deploy-preview-9999--docusaurus-2.netlify.app/


