### PR TITLE
docs: fix 3.2 blog post headings

### DIFF
--- a/website/blog/releases/3.2/index.mdx
+++ b/website/blog/releases/3.2/index.mdx
@@ -44,7 +44,7 @@ An incremental build happens when you run another time the `docusaurus build` co
 
 </details>
 
-## Faster Dev Server
+### Faster Dev Server
 
 We also worked on improving the performance of the dev server, so that you can get a faster feedback when editing Markdown/MDX files.
 
@@ -52,7 +52,7 @@ The way we initially implemented content reloading wasn't great. For example, ed
 
 We plan to keep improving the speed of our dev server, with even more granular hot reloads, ensuring we don't run useless computations that would always keep giving the same result.
 
-## MDX partials table-of-contents
+### MDX partials table-of-contents
 
 With [#9684](https://github.com/facebook/docusaurus/pull/9684), Docusaurus is now able to render headings coming from an imported partial into the table-of-contents.
 
@@ -78,7 +78,7 @@ Some paragraph
 
 Previously, the heading `Partial heading` did not appear in the table-of-contents, but now it will!
 
-## Blog improvements
+### Blog improvements
 
 We improved the blog plugin with several new options to make it even more powerful and flexible:
 
@@ -86,7 +86,7 @@ We improved the blog plugin with several new options to make it even more powerf
 - [#9886](https://github.com/facebook/docusaurus/pull/9886): a new `processBlogPosts` option allow you to filter/transform/sort blog posts.
 - [#9838](https://github.com/facebook/docusaurus/pull/9838): a new `pageBasePath` option allows you to customize the blog pagination URL segment (`/blog/page/2`)
 
-## Sitemap lastmod
+### Sitemap lastmod
 
 With [#9954](https://github.com/facebook/docusaurus/pull/9954), the sitemap plugin has a new `lastmod` option that can now emit a `<lastmod>` tag on the XML. The value is read from the Git history by default, but can be overridden with docs and blog `last_update` front matter.
 


### PR DESCRIPTION
Headings in https://github.com/facebook/docusaurus/pull/10000 are not good