### PR TITLE
fix(core): fix configurePostCss v3.2 regression

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -325,6 +325,10 @@ async function getBuildClientConfig({
     bundleAnalyzer: cliOptions.bundleAnalyzer ?? false,
   });
   let {config} = result;
+  config = executePluginsConfigurePostCss({
+    plugins,
+    config,
+  });
   config = executePluginsConfigureWebpack({
     plugins,
     config,
@@ -340,10 +344,6 @@ async function getBuildServerConfig({props}: {props: Props}) {
     props,
   });
   let {config} = result;
-  config = executePluginsConfigurePostCss({
-    plugins,
-    config,
-  });
   config = executePluginsConfigureWebpack({
     plugins,
     config,


### PR DESCRIPTION
## Motivation

My v3.2 refactors led to a regression, and `configurePostCss` was wrongly applied to the Webpack server config instead of client config.

Fix https://github.com/facebook/docusaurus/issues/10005

## Test Plan

none 😅 I'll probably have to refactor things more to make this easier to test, for now I'm just fixing the regression asap.

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/


