### PR TITLE
docs: Fix wrong path example

### DIFF
--- a/website/docs/advanced/routing.mdx
+++ b/website/docs/advanced/routing.mdx
@@ -119,7 +119,7 @@ The following directory structure may help you visualize this file → URL mappi
 │   ├── tutorial-basics
 │   │   ├── _category_.json
 │   │   ├── congratulations.md              # -> /docs/tutorial-basics/congratulations
-│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/congratulations
+│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/markdown-features
 │   └── tutorial-extras
 │       ├── _category_.json
 │       ├── manage-docs-versions.md         # -> /docs/tutorial-extras/manage-docs-versions

--- a/website/versioned_docs/version-2.x/advanced/routing.mdx
+++ b/website/versioned_docs/version-2.x/advanced/routing.mdx
@@ -118,7 +118,7 @@ The following directory structure may help you visualize this file → URL mappi
 │   ├── tutorial-basics
 │   │   ├── _category_.json
 │   │   ├── congratulations.md              # -> /docs/tutorial-basics/congratulations
-│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/congratulations
+│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/markdown-features
 │   └── tutorial-extras
 │       ├── _category_.json
 │       ├── manage-docs-versions.md         # -> /docs/tutorial-extras/manage-docs-versions

--- a/website/versioned_docs/version-3.0.1/advanced/routing.mdx
+++ b/website/versioned_docs/version-3.0.1/advanced/routing.mdx
@@ -118,7 +118,7 @@ The following directory structure may help you visualize this file → URL mappi
 │   ├── tutorial-basics
 │   │   ├── _category_.json
 │   │   ├── congratulations.md              # -> /docs/tutorial-basics/congratulations
-│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/congratulations
+│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/markdown-features
 │   └── tutorial-extras
 │       ├── _category_.json
 │       ├── manage-docs-versions.md         # -> /docs/tutorial-extras/manage-docs-versions

--- a/website/versioned_docs/version-3.1.1/advanced/routing.mdx
+++ b/website/versioned_docs/version-3.1.1/advanced/routing.mdx
@@ -118,7 +118,7 @@ The following directory structure may help you visualize this file → URL mappi
 │   ├── tutorial-basics
 │   │   ├── _category_.json
 │   │   ├── congratulations.md              # -> /docs/tutorial-basics/congratulations
-│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/congratulations
+│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/markdown-features
 │   └── tutorial-extras
 │       ├── _category_.json
 │       ├── manage-docs-versions.md         # -> /docs/tutorial-extras/manage-docs-versions

--- a/website/versioned_docs/version-3.2.1/advanced/routing.mdx
+++ b/website/versioned_docs/version-3.2.1/advanced/routing.mdx
@@ -119,7 +119,7 @@ The following directory structure may help you visualize this file → URL mappi
 │   ├── tutorial-basics
 │   │   ├── _category_.json
 │   │   ├── congratulations.md              # -> /docs/tutorial-basics/congratulations
-│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/congratulations
+│   │   └── markdown-features.mdx           # -> /docs/tutorial-basics/markdown-features
 │   └── tutorial-extras
 │       ├── _category_.json
 │       ├── manage-docs-versions.md         # -> /docs/tutorial-extras/manage-docs-versions


### PR DESCRIPTION
The example path in docs is incorrect. This PR fixes it. :)

```
markdown-features.mdx           # -> /docs/tutorial-basics/congratulations
```

should be

```
markdown-features.mdx           # -> /docs/tutorial-basics/markdown-features
```