### PR TITLE
fix(utils): getFileCommitDate should support `log.showSignature=true`

### DIFF
--- a/packages/docusaurus-utils/src/gitUtils.ts
+++ b/packages/docusaurus-utils/src/gitUtils.ts
@@ -107,9 +107,12 @@ export async function getFileCommitDate(
     );
   }
 
-  const format = includeAuthor ? 'RESULT:%ct,%an' : 'RESULT:%ct';
+  // We add a "RESULT:" prefix to make parsing easier
+  // See why: https://github.com/facebook/docusaurus/pull/10022
+  const resultFormat = includeAuthor ? 'RESULT:%ct,%an' : 'RESULT:%ct';
+
   const args = [
-    `--format=${format}`,
+    `--format=${resultFormat}`,
     '--max-count=1',
     age === 'oldest' ? '--follow --diff-filter=A' : undefined,
   ]
@@ -144,6 +147,8 @@ export async function getFileCommitDate(
     );
   }
 
+  // We only parse the output line starting with our "RESULT:" prefix
+  // See why https://github.com/facebook/docusaurus/pull/10022
   const regex = includeAuthor
     ? /(?:^|\n)RESULT:(?<timestamp>\d+),(?<author>.+)(?:$|\n)/
     : /(?:^|\n)RESULT:(?<timestamp>\d+)(?:$|\n)/;

--- a/packages/docusaurus-utils/src/gitUtils.ts
+++ b/packages/docusaurus-utils/src/gitUtils.ts
@@ -145,8 +145,8 @@ export async function getFileCommitDate(
   }
 
   const regex = includeAuthor
-    ? /^RESULT:(?<timestamp>\d+),(?<author>.+)$/
-    : /^RESULT:(?<timestamp>\d+)$/;
+    ? /(?:^|\n)RESULT:(?<timestamp>\d+),(?<author>.+)(?:$|\n)/
+    : /(?:^|\n)RESULT:(?<timestamp>\d+)(?:$|\n)/;
 
   const output = result.stdout.trim();
 


### PR DESCRIPTION

## Motivation

When the user shows signatures by default in his config (`git config log.showSignature true`), `getFileCommitDate` fails to parse the result because of the extra lines being printed, and the regexp to extract it not being able to process the command output due to the signature lines.

Problem reported here: https://github.com/facebook/docusaurus/pull/9954#issuecomment-2033742153

![CleanShot 2024-04-05 at 12 28 57@2x](https://github.com/facebook/docusaurus/assets/749374/1f1bb521-e562-4bd7-85ae-944e78f3509f)

I'm now adding a `RESULT:` prefix so that we only attempt to parse the correct lines, ignore all the others.

Also, we don't need signatures to get the result, so I'm also passing `git -c log.showSignature=false log` as an option so that the command can execute faster. If users have signatures turned on, we don't want this function to be 3x slower.


```bash
hyperfine --runs 50 'git -c log.showSignature=true log --format=RESULT:%ct,%an --max-count=1 -- CHANGELOG.md'
Benchmark 1: git -c log.showSignature=true log --format=RESULT:%ct,%an --max-count=1 -- CHANGELOG.md
  Time (mean ± σ):       9.7 ms ±   1.1 ms    [User: 4.3 ms, System: 3.7 ms]
  Range (min … max):     8.0 ms …  12.5 ms    50 runs

hyperfine --runs 50 'git -c log.showSignature=false log --format=RESULT:%ct,%an --max-count=1 -- CHANGELOG.md'
Benchmark 1: git -c log.showSignature=false log --format=RESULT:%ct,%an --max-count=1 -- CHANGELOG.md
  Time (mean ± σ):       3.5 ms ±   0.2 ms    [User: 1.8 ms, System: 1.4 ms]
  Range (min … max):     3.0 ms …   4.2 ms    50 runs
```


Note: I also considered the following command but it's not faster and won't work well with the "age: 'oldest'` option:

```bash
git rev-list --no-commit-header --max-count=1 --format=%ct,%an HEAD -- CHANGELOG.md
```


## Test Plan

Unit tests

