### PR TITLE
fix(docs): sidebar item label impact the pagination label of docs

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/__tests__/utils.test.ts
@@ -719,6 +719,22 @@ describe('toDocNavigationLink', () => {
     } as PropNavigationLink);
   });
 
+  it('with sidebar item label', () => {
+    expect(
+      toDocNavigationLink(
+        testDoc({
+          title: 'Doc Title',
+          permalink: '/docPermalink',
+          frontMatter: {},
+        }),
+        {sidebarItemLabel: 'Doc sidebar item label'},
+      ),
+    ).toEqual({
+      title: 'Doc sidebar item label',
+      permalink: '/docPermalink',
+    } as PropNavigationLink);
+  });
+
   it('with pagination_label + sidebar_label front matter', () => {
     expect(
       toDocNavigationLink(
@@ -733,6 +749,24 @@ describe('toDocNavigationLink', () => {
       ),
     ).toEqual({
       title: 'pagination_label',
+      permalink: '/docPermalink',
+    } as PropNavigationLink);
+  });
+
+  it('with sidebar_label + sidebar item label', () => {
+    expect(
+      toDocNavigationLink(
+        testDoc({
+          title: 'Doc Title',
+          permalink: '/docPermalink',
+          frontMatter: {
+            sidebar_label: 'sidebar_label',
+          },
+        }),
+        {sidebarItemLabel: 'Doc sidebar item label'},
+      ),
+    ).toEqual({
+      title: 'sidebar_label',
       permalink: '/docPermalink',
     } as PropNavigationLink);
   });

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -480,7 +480,7 @@ Available document ids are:
 
 export function toDocNavigationLink(
   doc: DocMetadataBase,
-  sidebarItemLabel?: string | undefined,
+  options?: {sidebarItemLabel?: string | undefined},
 ): PropNavigationLink {
   const {
     title,
@@ -491,7 +491,8 @@ export function toDocNavigationLink(
     },
   } = doc;
   return {
-    title: paginationLabel ?? sidebarLabel ?? sidebarItemLabel ?? title,
+    title:
+      paginationLabel ?? sidebarLabel ?? options?.sidebarItemLabel ?? title,
     permalink,
   };
 }
@@ -522,8 +523,7 @@ export function toNavigationLink(
           permalink: navigationItem.link.permalink,
         };
   }
-  return toDocNavigationLink(
-    getDocById(navigationItem.id),
-    navigationItem?.label,
-  );
+  return toDocNavigationLink(getDocById(navigationItem.id), {
+    sidebarItemLabel: navigationItem?.label,
+  });
 }

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -478,7 +478,10 @@ Available document ids are:
   };
 }
 
-export function toDocNavigationLink(doc: DocMetadataBase, sidebarItemLabel?:string | undefined): PropNavigationLink {
+export function toDocNavigationLink(
+  doc: DocMetadataBase,
+  sidebarItemLabel?: string | undefined,
+): PropNavigationLink {
   const {
     title,
     permalink,
@@ -487,7 +490,10 @@ export function toDocNavigationLink(doc: DocMetadataBase, sidebarItemLabel?:stri
       sidebar_label: sidebarLabel,
     },
   } = doc;
-  return {title: paginationLabel ?? sidebarLabel ?? sidebarItemLabel ?? title, permalink};
+  return {
+    title: paginationLabel ?? sidebarLabel ?? sidebarItemLabel ?? title,
+    permalink,
+  };
 }
 
 export function toNavigationLink(
@@ -510,11 +516,14 @@ export function toNavigationLink(
 
   if (navigationItem.type === 'category') {
     return navigationItem.link.type === 'doc'
-      ? toDocNavigationLink(getDocById(navigationItem.link.id), navigationItem?.label)
+      ? toDocNavigationLink(getDocById(navigationItem.link.id))
       : {
           title: navigationItem.label,
           permalink: navigationItem.link.permalink,
         };
   }
-  return toDocNavigationLink(getDocById(navigationItem.id), navigationItem?.label);
+  return toDocNavigationLink(
+    getDocById(navigationItem.id),
+    navigationItem?.label,
+  );
 }

--- a/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
+++ b/packages/docusaurus-plugin-content-docs/src/sidebars/utils.ts
@@ -478,7 +478,7 @@ Available document ids are:
   };
 }
 
-export function toDocNavigationLink(doc: DocMetadataBase): PropNavigationLink {
+export function toDocNavigationLink(doc: DocMetadataBase, sidebarItemLabel?:string | undefined): PropNavigationLink {
   const {
     title,
     permalink,
@@ -487,7 +487,7 @@ export function toDocNavigationLink(doc: DocMetadataBase): PropNavigationLink {
       sidebar_label: sidebarLabel,
     },
   } = doc;
-  return {title: paginationLabel ?? sidebarLabel ?? title, permalink};
+  return {title: paginationLabel ?? sidebarLabel ?? sidebarItemLabel ?? title, permalink};
 }
 
 export function toNavigationLink(
@@ -510,11 +510,11 @@ export function toNavigationLink(
 
   if (navigationItem.type === 'category') {
     return navigationItem.link.type === 'doc'
-      ? toDocNavigationLink(getDocById(navigationItem.link.id))
+      ? toDocNavigationLink(getDocById(navigationItem.link.id), navigationItem?.label)
       : {
           title: navigationItem.label,
           permalink: navigationItem.link.permalink,
         };
   }
-  return toDocNavigationLink(getDocById(navigationItem.id));
+  return toDocNavigationLink(getDocById(navigationItem.id), navigationItem?.label);
 }


### PR DESCRIPTION
…file name as pagination label rather than the sidebar 'label' defined through item definition

Fixes #9781

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Bug fix

## Test Plan

Ran local tests which passed and compiled the demo website to ensure that it runs and the bug is fixed. 

Sample Doc file used without H1 or Title:
```md
test
```
Properties set in sidebar:
```js
{
      type: 'doc',
      label: 'Quick Start test',
      id: 'test',
}
```

Results (2nd screenshot is of page before test, so see the next button to view updated pagination label):
![Screenshot 2024-04-05 234439](https://github.com/facebook/docusaurus/assets/43924652/12f35c51-17d5-4921-8b41-618441131625)
![Screenshot 2024-04-05 234425](https://github.com/facebook/docusaurus/assets/43924652/0326d600-9249-44c4-b846-7e9a0639f866)


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-10025--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
#9781 
