### PR TITLE
docs: visit is a named export of unist-util-visit

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-plugins.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-plugins.mdx
@@ -160,7 +160,7 @@ The writeup below is **not** meant to be a comprehensive guide to creating a plu
 For example, let's make a plugin that visits every `h2` heading and adds a `Section X. ` prefix. First, create your plugin source file anywhere—you can even publish it as a separate npm package and install it like explained above. We would put ours at `src/remark/section-prefix.js`. A remark/rehype plugin is just a function that receives the `options` and returns a `transformer` that operates on the AST.
 
 ```js "src/remark/section-prefix.js"
-import { visit } from 'unist-util-visit';
+import {visit} from 'unist-util-visit';
 
 const plugin = (options) => {
   const transformer = async (ast) => {

--- a/website/docs/guides/markdown-features/markdown-features-plugins.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-plugins.mdx
@@ -160,7 +160,7 @@ The writeup below is **not** meant to be a comprehensive guide to creating a plu
 For example, let's make a plugin that visits every `h2` heading and adds a `Section X. ` prefix. First, create your plugin source file anywhere—you can even publish it as a separate npm package and install it like explained above. We would put ours at `src/remark/section-prefix.js`. A remark/rehype plugin is just a function that receives the `options` and returns a `transformer` that operates on the AST.
 
 ```js "src/remark/section-prefix.js"
-import visit from 'unist-util-visit';
+import { visit } from 'unist-util-visit';
 
 const plugin = (options) => {
   const transformer = async (ast) => {


### PR DESCRIPTION

<img width="1115" alt="image" src="https://github.com/facebook/docusaurus/assets/49330279/ab5f7536-b485-42ff-8963-31eeaf9cb684">

[source](https://github.com/syntax-tree/unist-util-visit/blob/main/index.js)
