### PR TITLE
fix(theme): fix details element accessibility/search

### DIFF
--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -48,7 +48,7 @@ export function useCollapsible({
 }
 
 const CollapsedStyles = {
-  display: 'none',
+  display: 'block',
   overflow: 'hidden',
   height: '0px',
 } as const;

--- a/packages/docusaurus-theme-common/src/components/Details/styles.module.css
+++ b/packages/docusaurus-theme-common/src/components/Details/styles.module.css
@@ -47,7 +47,7 @@ CSS variables, meant to be overridden by final theme
 /* When JS disabled/failed to load: we use the open property for arrow animation: */
 .details[open]:not(.isBrowser) > summary::before,
 /* When JS works: we use the data-attribute for arrow animation */
-.details[data-collapsed='false'].isBrowser > summary::before {
+.details[open].isBrowser > summary::before {
   transform: rotate(90deg);
 }
 


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/10055

Details are natively searcheable so our animated progressively enhanced version should rather keep this behavior

## Test Plan

???

### Test links

https://deploy-preview-10057--docusaurus-2.netlify.app/docs/markdown-features

https://deploy-preview-10057--docusaurus-2.netlify.app/tests/pages/markdown-tests-mdx#details
