### PR TITLE
fix(core): fix duplicate app render when url accessed through .html extension

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/styles.module.css
@@ -26,3 +26,9 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+:global(#__docusaurus-app) {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -29,20 +29,22 @@ export default function App(): JSX.Element {
   const routeElement = renderRoutes(routes);
   const location = useLocation();
   return (
-    <ErrorBoundary>
-      <DocusaurusContextProvider>
-        <BrowserContextProvider>
-          <Root>
-            <SiteMetadataDefaults />
-            <SiteMetadata />
-            <BaseUrlIssueBanner />
-            <PendingNavigation location={normalizeLocation(location)}>
-              {routeElement}
-            </PendingNavigation>
-          </Root>
-          <HasHydratedDataAttribute />
-        </BrowserContextProvider>
-      </DocusaurusContextProvider>
-    </ErrorBoundary>
+    <div id="__docusaurus-app">
+      <ErrorBoundary>
+        <DocusaurusContextProvider>
+          <BrowserContextProvider>
+            <Root>
+              <SiteMetadataDefaults />
+              <SiteMetadata />
+              <BaseUrlIssueBanner />
+              <PendingNavigation location={normalizeLocation(location)}>
+                {routeElement}
+              </PendingNavigation>
+            </Root>
+            <HasHydratedDataAttribute />
+          </BrowserContextProvider>
+        </DocusaurusContextProvider>
+      </ErrorBoundary>
+    </div>
   );
 }


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/10053

When a Docusaurus page is accessed through its non-canonical variant ending with `.html`, we get a weird duplicate render

It looks like React is not able to hydrate and fully recreate an app alongside the existing static markup, leading to duplicated HTML markup

This can be seen in production: https://docusaurus.io/tests.html

![CleanShot 2024-04-19 at 10 10 10](https://github.com/facebook/docusaurus/assets/749374/4b6327c0-0c15-4627-a4ff-c938e23bf927)



Note: technically it's not really a bug because URLs should be accessed through their canonical URLs, that work fine. Users should configure their host properly so that this is always the URL used: https://docusaurus.io/tests

However, not all hosts have access to a "pretty URL" setting that do the redirect to the canonical URL (and apparently Netlify's pretty URL setting does not even work for us...)

I tried investigating the problem and it's very unclear what's causing this issue. It might be React Router v5, or our integration of it through the `<PendingNavigation/>` component. It looks like a core problem, not a theme-classic nor layout issue because I can reproduce with an empty theme layout too.

It looks like just adding a wrapper div around the `<App>` fixes the problem (cf this PR). I suspect this is a bug in React that fails to hydrate when the `<App>` renders a fragment of multiple elements. I don't mind adding this extra wapper div, it probably wouldn't harm, but let's delay this to v4 considering it might break some user selectors (breaking change? 🤔 ). Also, it's possible that simply upgrading to React Router v6 and React 19 fixes the problem 🤷‍♂️ . But that does not look like a bad idea to add this wrapper for v4 anyway.

Note: to reproduce locally with `docusaurus serve`, it requires explicitly disabling clean URLs in `serve.ts`:

```ts
    serveHandler(req, res, {
      cleanUrls: false,
      // ... rest
    });
```
 

## Test Plan

Netlify preview should work for 

https://deploy-preview-_____--docusaurus-2.netlify.app/


