### PR TITLE
test(e2e): TypeCheck website/starter in min/max range of TS versions

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -125,15 +125,15 @@ jobs:
         if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'
         working-directory: ../test-website
         run: |
-          yarn workspace website add typescript@5.1.6 --exact
-          yarn workspace website typecheck
+          yarn add typescript@5.1.6 --exact
+          yarn typecheck
       - name: TypeCheck website - max version - Latest
         # TODO: there're some lingering issues with PnP + tsc. Enable tsc in PnP later.
         if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'
         working-directory: ../test-website
         run: |
-          yarn workspace website add typescript@latest --exact
-          yarn workspace website typecheck
+          yarn add typescript@latest --exact
+          yarn typecheck
 
       - name: Build test-website project
         run: yarn build

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -114,11 +114,27 @@ jobs:
         working-directory: ../test-website
         env:
           E2E_TEST: true
-      - name: Type check
+
+      - name: TypeCheck website
         # TODO: there're some lingering issues with PnP + tsc. Enable tsc in PnP later.
         if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'
-        run: yarn typecheck
         working-directory: ../test-website
+        run: yarn typecheck
+      - name: TypeCheck website - min version - v5.1
+        # TODO: there're some lingering issues with PnP + tsc. Enable tsc in PnP later.
+        if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'
+        working-directory: ../test-website
+        run: |
+          yarn workspace website add typescript@5.1.6 --exact
+          yarn workspace website typecheck
+      - name: TypeCheck website - max version - Latest
+        # TODO: there're some lingering issues with PnP + tsc. Enable tsc in PnP later.
+        if: matrix.variant == '-st' && matrix.nodeLinker != 'pnp'
+        working-directory: ../test-website
+        run: |
+          yarn workspace website add typescript@latest --exact
+          yarn workspace website typecheck
+
       - name: Build test-website project
         run: yarn build
         working-directory: ../test-website

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -52,5 +52,14 @@ jobs:
         run: yarn workspace website test:swizzle:wrap:ts
       - name: Docusaurus Build
         run: yarn build:website:fast
+
       - name: TypeCheck website
         run: yarn workspace website typecheck
+      - name: TypeCheck website - min version - v5.1
+        run: |
+          yarn workspace website add typescript@5.1.6 --exact
+          yarn workspace website typecheck
+      - name: TypeCheck website - max version - Latest
+        run: |
+          yarn workspace website add typescript@latest --exact
+          yarn workspace website typecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,18 @@ jobs:
         run: yarn
       - name: Test
         run: yarn test
-      - name: TypeCheck website
-        run: yarn workspace website typecheck
       - name: Remove Theme Internal Re-export
         run: yarn workspace @docusaurus/theme-common removeThemeInternalReexport
       - name: Docusaurus Build
         run: yarn build:website:fast
+
+      - name: TypeCheck website
+        run: yarn workspace website typecheck
+      - name: TypeCheck website - min version - v5.1
+        run: |
+          yarn workspace website add typescript@5.1.6 --exact
+          yarn workspace website typecheck
+      - name: TypeCheck website - max version - Latest
+        run: |
+          yarn workspace website add typescript@latest --exact
+          yarn workspace website typecheck

--- a/website/docs/migration/v3.mdx
+++ b/website/docs/migration/v3.mdx
@@ -36,7 +36,7 @@ Docusaurus v3 now uses the following dependencies:
 - Node.js v18.0+
 - React v18.0+
 - MDX v3.0+
-- TypeScript v5.0+
+- TypeScript v5.1+
 - prism-react-renderer v2.0+
 - react-live v4.0+
 - remark-emoji v4.0+
@@ -98,7 +98,7 @@ For TypeScript users:
      // upgrade React types to v18.0+
 -    "@types/react": "^17.0.69",
 +    "@types/react": "^18.2.29",
-     // upgrade TypeScript to v5.0+
+     // upgrade TypeScript to v5.1+
 -    "typescript": "~4.7.4"
 +    "typescript": "~5.2.2"
    }
@@ -689,9 +689,9 @@ However, this is a new major library version containing breaking changes, and we
 
 :::
 
-### TypeScript v5.0+
+### TypeScript v5.1+
 
-Docusaurus v3 now requires **TypeScript >= 5.0**.
+Docusaurus v3 now requires **TypeScript >= 5.1**.
 
 :::info How to upgrade
 

--- a/website/docs/typescript-support.mdx
+++ b/website/docs/typescript-support.mdx
@@ -6,7 +6,7 @@ description: Docusaurus is written in TypeScript and provides first-class TypeSc
 
 Docusaurus is written in TypeScript and provides first-class TypeScript support.
 
-The minimum required version is **TypeScript 5.0**.
+The minimum required version is **TypeScript 5.1**.
 
 ## Initialization {#initialization}
 

--- a/website/versioned_docs/version-3.0.1/migration/v3.mdx
+++ b/website/versioned_docs/version-3.0.1/migration/v3.mdx
@@ -36,7 +36,7 @@ Docusaurus v3 now uses the following dependencies:
 - Node.js v18.0+
 - React v18.0+
 - MDX v3.0+
-- TypeScript v5.0+
+- TypeScript v5.1+
 - prism-react-renderer v2.0+
 - react-live v4.0+
 - remark-emoji v4.0+
@@ -98,7 +98,7 @@ For TypeScript users:
      // upgrade React types to v18.0+
 -    "@types/react": "^17.0.69",
 +    "@types/react": "^18.2.29",
-     // upgrade TypeScript to v5.0+
+     // upgrade TypeScript to v5.1+
 -    "typescript": "~4.7.4"
 +    "typescript": "~5.2.2"
    }
@@ -601,9 +601,9 @@ However, this is a new major library version containing breaking changes, and we
 
 :::
 
-### TypeScript v5.0+
+### TypeScript v5.1+
 
-Docusaurus v3 now requires **TypeScript >= 5.0**.
+Docusaurus v3 now requires **TypeScript >= 5.1**.
 
 :::info How to upgrade
 

--- a/website/versioned_docs/version-3.0.1/typescript-support.mdx
+++ b/website/versioned_docs/version-3.0.1/typescript-support.mdx
@@ -6,7 +6,7 @@ description: Docusaurus is written in TypeScript and provides first-class TypeSc
 
 Docusaurus is written in TypeScript and provides first-class TypeScript support.
 
-The minimum required version is **TypeScript 5.0**.
+The minimum required version is **TypeScript 5.1**.
 
 ## Initialization {#initialization}
 

--- a/website/versioned_docs/version-3.1.1/migration/v3.mdx
+++ b/website/versioned_docs/version-3.1.1/migration/v3.mdx
@@ -36,7 +36,7 @@ Docusaurus v3 now uses the following dependencies:
 - Node.js v18.0+
 - React v18.0+
 - MDX v3.0+
-- TypeScript v5.0+
+- TypeScript v5.1+
 - prism-react-renderer v2.0+
 - react-live v4.0+
 - remark-emoji v4.0+
@@ -98,7 +98,7 @@ For TypeScript users:
      // upgrade React types to v18.0+
 -    "@types/react": "^17.0.69",
 +    "@types/react": "^18.2.29",
-     // upgrade TypeScript to v5.0+
+     // upgrade TypeScript to v5.1+
 -    "typescript": "~4.7.4"
 +    "typescript": "~5.2.2"
    }
@@ -689,9 +689,9 @@ However, this is a new major library version containing breaking changes, and we
 
 :::
 
-### TypeScript v5.0+
+### TypeScript v5.1+
 
-Docusaurus v3 now requires **TypeScript >= 5.0**.
+Docusaurus v3 now requires **TypeScript >= 5.1**.
 
 :::info How to upgrade
 

--- a/website/versioned_docs/version-3.1.1/typescript-support.mdx
+++ b/website/versioned_docs/version-3.1.1/typescript-support.mdx
@@ -6,7 +6,7 @@ description: Docusaurus is written in TypeScript and provides first-class TypeSc
 
 Docusaurus is written in TypeScript and provides first-class TypeScript support.
 
-The minimum required version is **TypeScript 5.0**.
+The minimum required version is **TypeScript 5.1**.
 
 ## Initialization {#initialization}
 

--- a/website/versioned_docs/version-3.2.1/migration/v3.mdx
+++ b/website/versioned_docs/version-3.2.1/migration/v3.mdx
@@ -36,7 +36,7 @@ Docusaurus v3 now uses the following dependencies:
 - Node.js v18.0+
 - React v18.0+
 - MDX v3.0+
-- TypeScript v5.0+
+- TypeScript v5.1+
 - prism-react-renderer v2.0+
 - react-live v4.0+
 - remark-emoji v4.0+
@@ -98,7 +98,7 @@ For TypeScript users:
      // upgrade React types to v18.0+
 -    "@types/react": "^17.0.69",
 +    "@types/react": "^18.2.29",
-     // upgrade TypeScript to v5.0+
+     // upgrade TypeScript to v5.1+
 -    "typescript": "~4.7.4"
 +    "typescript": "~5.2.2"
    }
@@ -689,9 +689,9 @@ However, this is a new major library version containing breaking changes, and we
 
 :::
 
-### TypeScript v5.0+
+### TypeScript v5.1+
 
-Docusaurus v3 now requires **TypeScript >= 5.0**.
+Docusaurus v3 now requires **TypeScript >= 5.1**.
 
 :::info How to upgrade
 

--- a/website/versioned_docs/version-3.2.1/typescript-support.mdx
+++ b/website/versioned_docs/version-3.2.1/typescript-support.mdx
@@ -6,7 +6,7 @@ description: Docusaurus is written in TypeScript and provides first-class TypeSc
 
 Docusaurus is written in TypeScript and provides first-class TypeScript support.
 
-The minimum required version is **TypeScript 5.0**.
+The minimum required version is **TypeScript 5.1**.
 
 ## Initialization {#initialization}
 


### PR DESCRIPTION
## Motivation

We have no tests covering that we keep supporting older versions of TypeScript.

As we upgrade TypeScript on our monorepo, it's easy to be misled and release some libs that are incompatible with former TS versions.

Now we ensure that our website + starter remains compatible with TS 5.1

Note, although v3.0 is supposed to support TS 5.0, I think it never actually worked in practice. I can't get it working and get errors such as:

![CleanShot 2024-04-19 at 18 46 08@2x](https://github.com/facebook/docusaurus/assets/749374/0cc69f99-ad2e-41d1-b20d-c48b37ab2c09)

I suspect this is a bug related to the newly released v5.0 moduleResolution "bundler", but can't be sure. Starting v5.1 it works fine.

Also I think it's not a bad idea to require TS 5.1 in Docusaurus v3, because it permits to use ReactNode instead of `JSX.Element`: 
https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#decoupled-type-checking-between-jsx-elements-and-jsx-tag-types

Considering Docusaurus v3 was released after TS 5.1, I suspect it never worked under v5.0 and nobody noticed. So I'll bump the docs to mention v5.1 instead of v5.0 as the minimum version, and will not consider it as a breaking change.

## Test Plan

CI
