### PR TITLE
fix(theme): `<Admonition>` should render properly without heading/icon

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Layout/index.tsx
@@ -50,7 +50,7 @@ export default function AdmonitionLayout(props: Props): JSX.Element {
   const {type, icon, title, children, className} = props;
   return (
     <AdmonitionContainer type={type} className={className}>
-      <AdmonitionHeading title={title} icon={icon} />
+      {title || icon ? <AdmonitionHeading title={title} icon={icon} /> : null}
       <AdmonitionContent>{children}</AdmonitionContent>
     </AdmonitionContainer>
   );

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -333,6 +333,12 @@ test
 
 ::::
 
+:::
+
+Admonition content without heading
+
+:::
+
 ## Linking
 
 This is a test page to see if Docusaurus Markdown features are working properly

--- a/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
+++ b/website/_dogfooding/_pages tests/markdown-tests-mdx.mdx
@@ -333,11 +333,19 @@ test
 
 ::::
 
-:::
+```mdx-code-block
+import Admonition from '@theme/Admonition';
 
-Admonition content without heading
+export function AdmonitionWithoutHeading(props) {
+  return (
+    <Admonition {...props} type="info" icon={null} title={null}>
+      Admonition content without heading
+    </Admonition>
+  );
+}
+```
 
-:::
+<AdmonitionWithoutHeading />
 
 ## Linking
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

closes #8568 

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

![Admonition example](https://github.com/facebook/docusaurus/assets/60042277/878bcf84-c985-4feb-b14b-16bbe69cd582)

### Test links

https://deploy-preview-10080--docusaurus-2.netlify.app/tests/pages/markdown-tests-mdx/#admonitions

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
