### PR TITLE
feat: add createSitemapItems hook

### DIFF
--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -84,6 +84,37 @@ describe('createSitemap', () => {
     expect(sitemap).not.toContain('/tags');
   });
 
+  it('excludes items that createSitemapItems configures to be ignored', async () => {
+    const sitemap = await createSitemap({
+      siteConfig,
+      routes: routes([
+        '/',
+        '/search/',
+        '/tags/',
+        '/search/foo',
+        '/tags/foo/bar',
+      ]),
+      head: {},
+      options: {
+        ...options,
+        createSitemapItems: async (params) => {
+          const {defaultCreateSitemapItems, ...rest} = params;
+          const sitemapItems = await defaultCreateSitemapItems(rest);
+          const sitemapsWithoutPageAndTags = sitemapItems.filter(
+            (sitemapItem) =>
+              !sitemapItem.url.includes('/tags/') &&
+              !sitemapItem.url.endsWith('/search/'),
+          );
+          return sitemapsWithoutPageAndTags;
+        },
+      },
+    });
+
+    expect(sitemap).not.toContain('/search/</loc>');
+    expect(sitemap).toContain('/search/foo');
+    expect(sitemap).not.toContain('/tags');
+  });
+
   it('keep trailing slash unchanged', async () => {
     const sitemap = await createSitemap({
       siteConfig,

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/createSitemap.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import {createElement} from 'react';
 import {fromPartial} from '@total-typescript/shoehorn';
 import createSitemap from '../createSitemap';
 import type {PluginOptions} from '../options';
@@ -115,6 +115,22 @@ describe('createSitemap', () => {
     expect(sitemap).not.toContain('/tags');
   });
 
+  it('returns null when createSitemapItems returns no items', async () => {
+    const sitemap = await createSitemap({
+      siteConfig,
+      routes: routes(['/', '/docs/myDoc/', '/blog/post']),
+      head: {},
+      options: {
+        ...options,
+        createSitemapItems: async () => {
+          return [];
+        },
+      },
+    });
+
+    expect(sitemap).toBeNull();
+  });
+
   it('keep trailing slash unchanged', async () => {
     const sitemap = await createSitemap({
       siteConfig,
@@ -171,7 +187,7 @@ describe('createSitemap', () => {
           meta: {
             // @ts-expect-error: bad lib def
             toComponent: () => [
-              React.createElement('meta', {
+              createElement('meta', {
                 name: 'robots',
                 content: 'NoFolloW, NoiNDeX',
               }),
@@ -195,7 +211,7 @@ describe('createSitemap', () => {
           meta: {
             // @ts-expect-error: bad lib def
             toComponent: () => [
-              React.createElement('meta', {name: 'robots', content: 'noindex'}),
+              createElement('meta', {name: 'robots', content: 'noindex'}),
             ],
           },
         },
@@ -203,7 +219,7 @@ describe('createSitemap', () => {
           meta: {
             // @ts-expect-error: bad lib def
             toComponent: () => [
-              React.createElement('meta', {name: 'robots', content: 'noindex'}),
+              createElement('meta', {name: 'robots', content: 'noindex'}),
             ],
           },
         },

--- a/packages/docusaurus-plugin-sitemap/src/__tests__/options.test.ts
+++ b/packages/docusaurus-plugin-sitemap/src/__tests__/options.test.ts
@@ -249,4 +249,44 @@ describe('validateOptions', () => {
       );
     });
   });
+
+  describe('createSitemapItems', () => {
+    it('accept createSitemapItems undefined', () => {
+      const userOptions: Options = {
+        createSitemapItems: undefined,
+      };
+      expect(testValidate(userOptions)).toEqual(defaultOptions);
+    });
+
+    it('accept createSitemapItems valid', () => {
+      const userOptions: Options = {
+        createSitemapItems: async (params) => {
+          const {defaultCreateSitemapItems, ...rest} = params;
+          const sitemapItems = await defaultCreateSitemapItems(rest);
+          const sitemapsWithoutPageAndTags = sitemapItems.filter(
+            (sitemapItem) =>
+              !sitemapItem.url.includes('/tags/') &&
+              !sitemapItem.url.includes('/page/'),
+          );
+          return sitemapsWithoutPageAndTags;
+        },
+      };
+      expect(testValidate(userOptions)).toEqual({
+        ...defaultOptions,
+        ...userOptions,
+      });
+    });
+
+    it('rejects createSitemapItems bad input type', () => {
+      const userOptions: Options = {
+        // @ts-expect-error: test
+        createSitemapItems: 'not a function',
+      };
+      expect(() =>
+        testValidate(userOptions),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `""createSitemapItems" must be of type function"`,
+      );
+    });
+  });
 });

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -10,7 +10,7 @@ import {createMatcher, flattenRoutes} from '@docusaurus/utils';
 import {sitemapItemsToXmlString} from './xml';
 import {createSitemapItem} from './createSitemapItem';
 import type {SitemapItem, DefaultCreateSitemapParams} from './types';
-import type {RouteConfig} from '@docusaurus/types';
+import type {DocusaurusConfig, RouteConfig} from '@docusaurus/types';
 import type {HelmetServerState} from 'react-helmet-async';
 
 // Maybe we want to add a routeConfig.metadata.noIndex instead?
@@ -89,16 +89,28 @@ export default async function createSitemap(
   params: DefaultCreateSitemapParams,
 ): Promise<string | null> {
   const {head, options, routes, siteConfig} = params;
-  const createSitemapItems =
-    params.options.createSitemapItems ?? defaultCreateSitemapItems;
 
-  const sitemapItems = await createSitemapItems({
-    head,
-    options,
-    routes,
-    siteConfig,
-    defaultCreateSitemapItems,
-  });
+  const sitemapItems = params.options.createSitemapItems
+    ? await params.options.createSitemapItems({
+        routes,
+        siteConfig,
+        defaultCreateSitemapItems: (userParams: {
+          routes: RouteConfig[];
+          siteConfig: DocusaurusConfig;
+        }) =>
+          defaultCreateSitemapItems({
+            head,
+            options,
+            ...userParams,
+          }),
+      })
+    : await defaultCreateSitemapItems({
+        head,
+        options,
+        routes,
+        siteConfig,
+      });
+
   if (sitemapItems.length === 0) {
     return null;
   }

--- a/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
+++ b/packages/docusaurus-plugin-sitemap/src/createSitemap.ts
@@ -5,55 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {ReactElement} from 'react';
 import {createMatcher, flattenRoutes} from '@docusaurus/utils';
 import {sitemapItemsToXmlString} from './xml';
 import {createSitemapItem} from './createSitemapItem';
-import type {SitemapItem, DefaultCreateSitemapParams} from './types';
-import type {DocusaurusConfig, RouteConfig} from '@docusaurus/types';
+import {isNoIndexMetaRoute} from './head';
+import type {CreateSitemapItemsFn, CreateSitemapItemsParams} from './types';
+import type {RouteConfig} from '@docusaurus/types';
+import type {PluginOptions} from './options';
 import type {HelmetServerState} from 'react-helmet-async';
-
-// Maybe we want to add a routeConfig.metadata.noIndex instead?
-// But using Helmet is more reliable for third-party plugins...
-function isNoIndexMetaRoute({
-  head,
-  route,
-}: {
-  head: {[location: string]: HelmetServerState};
-  route: string;
-}) {
-  const isNoIndexMetaTag = ({
-    name,
-    content,
-  }: {
-    name?: string;
-    content?: string;
-  }): boolean => {
-    if (!name || !content) {
-      return false;
-    }
-    return (
-      // meta name is not case-sensitive
-      name.toLowerCase() === 'robots' &&
-      // Robots directives are not case-sensitive
-      content.toLowerCase().includes('noindex')
-    );
-  };
-
-  // https://github.com/staylor/react-helmet-async/pull/167
-  const meta = head[route]?.meta.toComponent() as unknown as
-    | ReactElement<{name?: string; content?: string}>[]
-    | undefined;
-  return meta?.some((tag) =>
-    isNoIndexMetaTag({name: tag.props.name, content: tag.props.content}),
-  );
-}
 
 // Not all routes should appear in the sitemap, and we should filter:
 // - parent routes, used for layouts
 // - routes matching options.ignorePatterns
 // - routes with no index metadata
-function getSitemapRoutes({routes, head, options}: DefaultCreateSitemapParams) {
+function getSitemapRoutes({routes, head, options}: CreateSitemapParams) {
   const {ignorePatterns} = options;
 
   const ignoreMatcher = createMatcher(ignorePatterns);
@@ -67,46 +32,48 @@ function getSitemapRoutes({routes, head, options}: DefaultCreateSitemapParams) {
   return flattenRoutes(routes).filter((route) => !isRouteExcluded(route));
 }
 
-async function defaultCreateSitemapItems(
-  params: DefaultCreateSitemapParams,
-): Promise<SitemapItem[]> {
-  const sitemapRoutes = getSitemapRoutes(params);
-  if (sitemapRoutes.length === 0) {
-    return [];
-  }
-  return Promise.all(
-    sitemapRoutes.map((route) =>
-      createSitemapItem({
-        route,
-        siteConfig: params.siteConfig,
-        options: params.options,
-      }),
-    ),
-  );
+// Our default implementation receives some additional parameters on purpose
+// Params such as "head" are "messy" and not directly exposed to the user
+function createDefaultCreateSitemapItems(
+  internalParams: Pick<CreateSitemapParams, 'head' | 'options'>,
+): CreateSitemapItemsFn {
+  return async (params) => {
+    const sitemapRoutes = getSitemapRoutes({...params, ...internalParams});
+    if (sitemapRoutes.length === 0) {
+      return [];
+    }
+    return Promise.all(
+      sitemapRoutes.map((route) =>
+        createSitemapItem({
+          route,
+          siteConfig: params.siteConfig,
+          options: internalParams.options,
+        }),
+      ),
+    );
+  };
 }
 
+type CreateSitemapParams = CreateSitemapItemsParams & {
+  head: {[location: string]: HelmetServerState};
+  options: PluginOptions;
+};
+
 export default async function createSitemap(
-  params: DefaultCreateSitemapParams,
+  params: CreateSitemapParams,
 ): Promise<string | null> {
   const {head, options, routes, siteConfig} = params;
+
+  const defaultCreateSitemapItems: CreateSitemapItemsFn =
+    createDefaultCreateSitemapItems({head, options});
 
   const sitemapItems = params.options.createSitemapItems
     ? await params.options.createSitemapItems({
         routes,
         siteConfig,
-        defaultCreateSitemapItems: (userParams: {
-          routes: RouteConfig[];
-          siteConfig: DocusaurusConfig;
-        }) =>
-          defaultCreateSitemapItems({
-            head,
-            options,
-            ...userParams,
-          }),
+        defaultCreateSitemapItems,
       })
     : await defaultCreateSitemapItems({
-        head,
-        options,
         routes,
         siteConfig,
       });

--- a/packages/docusaurus-plugin-sitemap/src/head.ts
+++ b/packages/docusaurus-plugin-sitemap/src/head.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {ReactElement} from 'react';
+import type {HelmetServerState} from 'react-helmet-async';
+
+// Maybe we want to add a routeConfig.metadata.noIndex instead?
+// But using Helmet is more reliable for third-party plugins...
+export function isNoIndexMetaRoute({
+  head,
+  route,
+}: {
+  head: {[location: string]: HelmetServerState};
+  route: string;
+}): boolean {
+  const isNoIndexMetaTag = ({
+    name,
+    content,
+  }: {
+    name?: string;
+    content?: string;
+  }): boolean => {
+    if (!name || !content) {
+      return false;
+    }
+    return (
+      // meta name is not case-sensitive
+      name.toLowerCase() === 'robots' &&
+      // Robots directives are not case-sensitive
+      content.toLowerCase().includes('noindex')
+    );
+  };
+
+  // https://github.com/staylor/react-helmet-async/pull/167
+  const meta = head[route]?.meta.toComponent() as unknown as
+    | ReactElement<{name?: string; content?: string}>[]
+    | undefined;
+  return (
+    meta?.some((tag) =>
+      isNoIndexMetaTag({name: tag.props.name, content: tag.props.content}),
+    ) ?? false
+  );
+}

--- a/packages/docusaurus-plugin-sitemap/src/options.ts
+++ b/packages/docusaurus-plugin-sitemap/src/options.ts
@@ -8,7 +8,12 @@
 import {Joi} from '@docusaurus/utils-validation';
 import {ChangeFreqList, LastModOptionList} from './types';
 import type {OptionValidationContext} from '@docusaurus/types';
-import type {ChangeFreq, LastModOption} from './types';
+import type {
+  ChangeFreq,
+  DefaultCreateSitemapParams,
+  LastModOption,
+  SitemapItem,
+} from './types';
 
 export type PluginOptions = {
   /**
@@ -44,6 +49,19 @@ export type PluginOptions = {
    * @see https://www.sitemaps.org/protocol.html#xmlTagDefinitions
    */
   priority: number | null;
+
+  /** Allow control over the construction of SitemapItems */
+  createSitemapItems?: CreateSitemapItemsFn;
+};
+
+type CreateSitemapItemsFn = (
+  params: CreateSitemapItemsParams,
+) => Promise<SitemapItem[]>;
+
+type CreateSitemapItemsParams = DefaultCreateSitemapParams & {
+  defaultCreateSitemapItems: (
+    params: DefaultCreateSitemapParams,
+  ) => Promise<SitemapItem[]>;
 };
 
 export type Options = Partial<PluginOptions>;
@@ -89,6 +107,8 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
   lastmod: Joi.string()
     .valid(null, ...LastModOptionList)
     .default(DEFAULT_OPTIONS.lastmod),
+
+  createSitemapItems: Joi.function(),
 
   ignorePatterns: Joi.array()
     .items(Joi.string())

--- a/packages/docusaurus-plugin-sitemap/src/options.ts
+++ b/packages/docusaurus-plugin-sitemap/src/options.ts
@@ -58,9 +58,12 @@ type CreateSitemapItemsFn = (
   params: CreateSitemapItemsParams,
 ) => Promise<SitemapItem[]>;
 
-type CreateSitemapItemsParams = DefaultCreateSitemapParams & {
+type CreateSitemapItemsParams = Omit<
+  DefaultCreateSitemapParams,
+  'head' | 'options'
+> & {
   defaultCreateSitemapItems: (
-    params: DefaultCreateSitemapParams,
+    params: Omit<DefaultCreateSitemapParams, 'head' | 'options'>,
   ) => Promise<SitemapItem[]>;
 };
 

--- a/packages/docusaurus-plugin-sitemap/src/options.ts
+++ b/packages/docusaurus-plugin-sitemap/src/options.ts
@@ -10,9 +10,10 @@ import {ChangeFreqList, LastModOptionList} from './types';
 import type {OptionValidationContext} from '@docusaurus/types';
 import type {
   ChangeFreq,
-  DefaultCreateSitemapParams,
   LastModOption,
   SitemapItem,
+  CreateSitemapItemsFn,
+  CreateSitemapItemsParams,
 } from './types';
 
 export type PluginOptions = {
@@ -51,21 +52,14 @@ export type PluginOptions = {
   priority: number | null;
 
   /** Allow control over the construction of SitemapItems */
-  createSitemapItems?: CreateSitemapItemsFn;
+  createSitemapItems?: CreateSitemapItemsOption;
 };
 
-type CreateSitemapItemsFn = (
-  params: CreateSitemapItemsParams,
+type CreateSitemapItemsOption = (
+  params: CreateSitemapItemsParams & {
+    defaultCreateSitemapItems: CreateSitemapItemsFn;
+  },
 ) => Promise<SitemapItem[]>;
-
-type CreateSitemapItemsParams = Omit<
-  DefaultCreateSitemapParams,
-  'head' | 'options'
-> & {
-  defaultCreateSitemapItems: (
-    params: Omit<DefaultCreateSitemapParams, 'head' | 'options'>,
-  ) => Promise<SitemapItem[]>;
-};
 
 export type Options = Partial<PluginOptions>;
 

--- a/packages/docusaurus-plugin-sitemap/src/types.ts
+++ b/packages/docusaurus-plugin-sitemap/src/types.ts
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {DocusaurusConfig, RouteConfig} from '@docusaurus/types';
+import type {HelmetServerState} from 'react-helmet-async';
+import type {PluginOptions} from './options';
+
 export const LastModOptionList = ['date', 'datetime'] as const;
 
 export type LastModOption = (typeof LastModOptionList)[number];
@@ -64,4 +68,11 @@ export type SitemapItem = {
    * See also https://github.com/facebook/docusaurus/issues/2604
    */
   priority?: number | null;
+};
+
+export type DefaultCreateSitemapParams = {
+  siteConfig: DocusaurusConfig;
+  routes: RouteConfig[];
+  head: {[location: string]: HelmetServerState};
+  options: PluginOptions;
 };

--- a/packages/docusaurus-plugin-sitemap/src/types.ts
+++ b/packages/docusaurus-plugin-sitemap/src/types.ts
@@ -6,8 +6,6 @@
  */
 
 import type {DocusaurusConfig, RouteConfig} from '@docusaurus/types';
-import type {HelmetServerState} from 'react-helmet-async';
-import type {PluginOptions} from './options';
 
 export const LastModOptionList = ['date', 'datetime'] as const;
 
@@ -70,9 +68,11 @@ export type SitemapItem = {
   priority?: number | null;
 };
 
-export type DefaultCreateSitemapParams = {
+export type CreateSitemapItemsParams = {
   siteConfig: DocusaurusConfig;
   routes: RouteConfig[];
-  head: {[location: string]: HelmetServerState};
-  options: PluginOptions;
 };
+
+export type CreateSitemapItemsFn = (
+  params: CreateSitemapItemsParams,
+) => Promise<SitemapItem[]>;

--- a/website/docs/api/plugins/plugin-sitemap.mdx
+++ b/website/docs/api/plugins/plugin-sitemap.mdx
@@ -44,9 +44,23 @@ Accepted fields:
 | `priority` | `number \| null` | `0.5` | See [sitemap docs](https://www.sitemaps.org/protocol.html#xmlTagDefinitions) |
 | `ignorePatterns` | `string[]` | `[]` | A list of glob patterns; matching route paths will be filtered from the sitemap. Note that you may need to include the base URL in here. |
 | `filename` | `string` | `sitemap.xml` | The path to the created sitemap file, relative to the output directory. Useful if you have two plugin instances outputting two files. |
+| `createSitemapItems` | <code>[CreateSitemapItemsFn](#CreateSitemapItemsFn) \| undefined</code> | `undefined` | An optional function which can be used to transform and / or filter the items in the sitemap. |
 
 ```mdx-code-block
 </APITable>
+```
+
+### Types {#types}
+
+#### `CreateSitemapItemsFn` {#CreateSitemapItemsFn}
+
+```ts
+type CreateSitemapItemsFn = (params: {
+  siteConfig: DocusaurusConfig;
+  routes: RouteConfig[];
+  head: {[location: string]: HelmetServerState};
+  options: PluginOptions;
+}) => Promise<SitemapItem[]>;
 ```
 
 :::info
@@ -86,6 +100,14 @@ const config = {
   priority: 0.5,
   ignorePatterns: ['/tags/**'],
   filename: 'sitemap.xml',
+  createSitemapItems: async (params) => {
+    const {defaultCreateSitemapItems, ...rest} = params;
+    const sitemapItems = await defaultCreateSitemapItems(rest);
+    const sitemapsWithoutPage = sitemapItems.filter(
+      (sitemapItem) => !sitemapItem.url.includes('/page/'),
+    );
+    return sitemapsWithoutPage;
+  },
 };
 ```
 

--- a/website/docs/api/plugins/plugin-sitemap.mdx
+++ b/website/docs/api/plugins/plugin-sitemap.mdx
@@ -101,11 +101,8 @@ const config = {
   filename: 'sitemap.xml',
   createSitemapItems: async (params) => {
     const {defaultCreateSitemapItems, ...rest} = params;
-    const sitemapItems = await defaultCreateSitemapItems(rest);
-    const sitemapsWithoutPage = sitemapItems.filter(
-      (sitemapItem) => !sitemapItem.url.includes('/page/'),
-    );
-    return sitemapsWithoutPage;
+    const items = await defaultCreateSitemapItems(rest);
+    return items.filter((item) => !item.url.includes('/page/'));
   },
 };
 ```

--- a/website/docs/api/plugins/plugin-sitemap.mdx
+++ b/website/docs/api/plugins/plugin-sitemap.mdx
@@ -58,6 +58,7 @@ Accepted fields:
 type CreateSitemapItemsFn = (params: {
   siteConfig: DocusaurusConfig;
   routes: RouteConfig[];
+  defaultCreateSitemapItems: CreateSitemapItemsFn;
 }) => Promise<SitemapItem[]>;
 ```
 

--- a/website/docs/api/plugins/plugin-sitemap.mdx
+++ b/website/docs/api/plugins/plugin-sitemap.mdx
@@ -58,8 +58,6 @@ Accepted fields:
 type CreateSitemapItemsFn = (params: {
   siteConfig: DocusaurusConfig;
   routes: RouteConfig[];
-  head: {[location: string]: HelmetServerState};
-  options: PluginOptions;
 }) => Promise<SitemapItem[]>;
 ```
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -490,16 +490,6 @@ export default async function createConfigAsync() {
             lastmod: 'date',
             priority: null,
             changefreq: null,
-            createSitemapItems: async (params) => {
-              const {defaultCreateSitemapItems, ...rest} = params;
-              const sitemapItems = await defaultCreateSitemapItems(rest);
-              const sitemapsWithoutPageAndTags = sitemapItems.filter(
-                (sitemapItem) =>
-                  !sitemapItem.url.includes('/tags/') &&
-                  !sitemapItem.url.includes('/page/'),
-              );
-              return sitemapsWithoutPageAndTags;
-            },
           },
         } satisfies Preset.Options,
       ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -490,6 +490,16 @@ export default async function createConfigAsync() {
             lastmod: 'date',
             priority: null,
             changefreq: null,
+            createSitemapItems: async (params) => {
+              const {defaultCreateSitemapItems, ...rest} = params;
+              const sitemapItems = await defaultCreateSitemapItems(rest);
+              const sitemapsWithoutPageAndTags = sitemapItems.filter(
+                (sitemapItem) =>
+                  !sitemapItem.url.includes('/tags/') &&
+                  !sitemapItem.url.includes('/page/'),
+              );
+              return sitemapsWithoutPageAndTags;
+            },
           },
         } satisfies Preset.Options,
       ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #10081) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

I presently mutate my sitemap manually on each build as a post processing step.  I've written about it [here](https://johnnyreilly.com/xml-read-and-write-with-node-js) and I have historically done this for two reasons:
1. To add `lastmod` to sitemap entries (something that is [no longer necessary as of 3.2](https://docusaurus.io/blog/releases/3.2#sitemap-lastmod))
2. To trim pagination, tags pages and programmatically determined canonicals from the sitemap - this is still necessary

If there was a hook that allowed control of the sitemap, I would no longer need to do 2 as a separate post processing step

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Automated tests, plus look at the generated sitemap for the preview site: https://deploy-preview-10083--docusaurus-2.netlify.app/sitemap.xml

The screenshot below was taken from the current live Docusaurus sitemap: https://docusaurus.io/sitemap.xml

![image](https://github.com/facebook/docusaurus/assets/1010525/1ba000b3-2f70-42aa-ac01-a24feab56ac9)

Please note the URLs above which feature `page`.  Now look at the sitemap generated using this PR which filters those sitemap items out out using the new hook: https://deploy-preview-10083--docusaurus-2.netlify.app/sitemap.xml
![image](https://github.com/facebook/docusaurus/assets/1010525/05346119-b508-4422-8b99-012304be8c21)

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview sitemap: https://deploy-preview-10083--docusaurus-2.netlify.app/sitemap.xml
Updated docs: https://deploy-preview-10083--docusaurus-2.netlify.app/docs/api/plugins/@docusaurus/plugin-sitemap

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

#10081 