### PR TITLE
fix(core): `docusaurus serve` redirects should include the site `/baseUrl/` prefix 

### DIFF
--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -87,6 +87,7 @@ export async function serve(
     // Note server-handler is really annoying here:
     // - no easy way to do rewrites such as "/baseUrl/:path" => "/:path"
     // - no easy way to "reapply" the baseUrl to the redirect "Location" header
+    // See also https://github.com/facebook/docusaurus/pull/10090
     req.url = req.url.replace(baseUrl, '/');
 
     serveHandler(req, res, {

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -12,10 +12,18 @@ import logger from '@docusaurus/logger';
 import {DEFAULT_BUILD_DIR_NAME} from '@docusaurus/utils';
 import serveHandler from 'serve-handler';
 import openBrowser from 'react-dev-utils/openBrowser';
+import {applyTrailingSlash} from '@docusaurus/utils-common';
 import {loadSiteConfig} from '../server/config';
 import {build} from './build';
 import {getHostPort, type HostPortOptions} from '../server/getHostPort';
 import type {LoadContextParams} from '../server/site';
+
+function redirect(res: http.ServerResponse, location: string) {
+  res.writeHead(302, {
+    Location: location,
+  });
+  res.end();
+}
 
 export type ServeCLIOptions = HostPortOptions &
   Pick<LoadContextParams, 'config'> & {
@@ -62,15 +70,23 @@ export async function serve(
   const server = http.createServer((req, res) => {
     // Automatically redirect requests to /baseUrl/
     if (!req.url?.startsWith(baseUrl)) {
-      res.writeHead(302, {
-        Location: baseUrl,
-      });
-      res.end();
+      redirect(res, baseUrl);
+      return;
+    }
+
+    // We do the redirect ourselves for a good reason
+    // server-handler is annoying and won't include /baseUrl/ in redirects
+    const normalizedUrl = applyTrailingSlash(req.url, {trailingSlash, baseUrl});
+    if (req.url !== normalizedUrl) {
+      redirect(res, normalizedUrl);
       return;
     }
 
     // Remove baseUrl before calling serveHandler, because /baseUrl/ should
     // serve /build/index.html, not /build/baseUrl/index.html (does not exist)
+    // Note server-handler is really annoying here:
+    // - no easy way to do rewrites such as "/baseUrl/:path" => "/:path"
+    // - no easy way to "reapply" the baseUrl to the redirect "Location" header
     req.url = req.url.replace(baseUrl, '/');
 
     serveHandler(req, res, {


### PR DESCRIPTION


## Motivation

Fix https://github.com/facebook/docusaurus/issues/10078


`docusaurus serve` depends on [vercel/serve-handler](https://github.com/vercel/serve-handler)

This package is not super maintained and quite annoying to work with, particularly when we need to serve a static deployment under a baseUrl.

We can't do a rewrite from `/baseUrl/:path` to `/:path`, all requests end up as 404. I think the destination path must be an existing HTML files, not just a pathname.

Historically we have worked around that limitation thanks to the following hack:

```js
    // Remove baseUrl before calling serveHandler, because /baseUrl/ should
    // serve /build/index.html, not /build/baseUrl/index.html (does not exist)
    req.url = req.url.replace(baseUrl, '/');
```

But the problem is that when the server handler is called with a `trailingSlash: false` setting for example, the responses will redirect `/baseUrl/xyz/` to `/xyz` instead of `/baseUrl/xyz`. And the lib calls `res.end()` so there's no way to properly re-integrate that baseUrl to the redirect Location header.

So, this fix applies another workaround on top of serve-handler, so that we can avoid incorrect "trailing slash redirects" from serve-handler.




## Test Plan

It's hard to test this automatically 😅 but I tested this locally under various scenarios

