### PR TITLE
fix(core): do not recreate ReactDOM Root, fix React warning on hot reload

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -387,4 +387,5 @@ interface Window {
     prefetch: (url: string) => false | Promise<void[]>;
     preload: (url: string) => false | Promise<void[]>;
   };
+  docusaurusRoot?: import('react-dom/client').Root;
 }

--- a/packages/docusaurus/src/client/clientEntry.tsx
+++ b/packages/docusaurus/src/client/clientEntry.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {startTransition} from 'react';
 import ReactDOM, {type ErrorInfo} from 'react-dom/client';
 import {BrowserRouter} from 'react-router-dom';
 import {HelmetProvider} from 'react-helmet-async';
@@ -46,21 +46,24 @@ if (ExecutionEnvironment.canUseDOM) {
   };
 
   const renderApp = () => {
+    if (window.docusaurusRoot) {
+      window.docusaurusRoot.render(app);
+      return;
+    }
     if (hydrate) {
-      React.startTransition(() => {
-        ReactDOM.hydrateRoot(container, app, {
-          onRecoverableError,
-        });
+      window.docusaurusRoot = ReactDOM.hydrateRoot(container, app, {
+        onRecoverableError,
       });
     } else {
       const root = ReactDOM.createRoot(container, {onRecoverableError});
-      React.startTransition(() => {
-        root.render(app);
-      });
+      root.render(app);
+      window.docusaurusRoot = root;
     }
   };
 
-  preload(window.location.pathname).then(renderApp);
+  preload(window.location.pathname).then(() => {
+    startTransition(renderApp);
+  });
 
   // Webpack Hot Module Replacement API
   if (module.hot) {

--- a/project-words.txt
+++ b/project-words.txt
@@ -67,7 +67,6 @@ datagit
 Datagit
 Datagit's
 dedup
-Déja
 devto
 dingers
 Dmitry


### PR DESCRIPTION
## Motivation

Fix React 18 hot reloading warning:

Initially reported here: https://github.com/facebook/docusaurus/issues/10099#issuecomment-2092738192

> Warning: You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before. Instead, call root.render() on the existing root instead if you want to update it.

![image](https://github.com/facebook/docusaurus/assets/749374/f1a7186e-78cd-4d53-b94b-393f42d7be46)

Note: this is not a React v18.3 warning, we can also have it in v18.2.

Note: Docusaurus does not have React Fast Refresh support, but we probably should have that. It [doesn't look super easy to support](https://github.com/facebook/react/issues/16604#issuecomment-528663101) 😅


## Test Plan

CI + Tests

Local dev, hot reload works for both MD and JS files

### Test links

https://deploy-preview-10103--docusaurus-2.netlify.app/

