### PR TITLE
fix(theme-translations): fix missing pluralization for label DocCard.categoryDescription.plurals

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -32,7 +32,7 @@ function useCategoryItemsPlural() {
       count,
       translate(
         {
-          message: '{count} items',
+          message: '1 item|{count} items',
           id: 'theme.docs.DocCard.categoryDescription.plurals',
           description:
             'The default description for a category card in the generated index about how many items this category includes',

--- a/packages/docusaurus-theme-translations/locales/base/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/base/theme-common.json
@@ -81,7 +81,7 @@
   "theme.common.headingLinkTitle___DESCRIPTION": "Title for link to heading",
   "theme.common.skipToMainContent": "Skip to main content",
   "theme.common.skipToMainContent___DESCRIPTION": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.DocCard.categoryDescription.plurals___DESCRIPTION": "The default description for a category card in the generated index about how many items this category includes",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.home___DESCRIPTION": "The ARIA label for the home page in the breadcrumbs",

--- a/packages/docusaurus-theme-translations/locales/bn/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/bn/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "এই পেজটি এডিট করুন",
   "theme.common.headingLinkTitle": "{heading} এর সঙ্গে সরাসরি লিংকড",
   "theme.common.skipToMainContent": "স্কিপ করে মূল কন্টেন্ট এ যান",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "ডক্স পেজ",

--- a/packages/docusaurus-theme-translations/locales/cs/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/cs/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Upravit tuto stránku",
   "theme.common.headingLinkTitle": "Přímý odkaz na {heading}",
   "theme.common.skipToMainContent": "Přeskočit na hlavní obsah",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Stránka dokumentace",

--- a/packages/docusaurus-theme-translations/locales/da/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/da/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Rediger denne side",
   "theme.common.headingLinkTitle": "Direkte link til {heading}",
   "theme.common.skipToMainContent": "Hop til hovedindhold",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Dokumentside",

--- a/packages/docusaurus-theme-translations/locales/de/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/de/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Diese Seite bearbeiten",
   "theme.common.headingLinkTitle": "Direkter Link zur {heading}",
   "theme.common.skipToMainContent": "Zum Hauptinhalt springen",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} Einträge",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 Eintrag|{count} Einträge",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Dokumentation Seiten",

--- a/packages/docusaurus-theme-translations/locales/es/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/es/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Editar esta página",
   "theme.common.headingLinkTitle": "Enlace directo al {heading}",
   "theme.common.skipToMainContent": "Saltar al contenido principal",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} artículos",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 artículo|{count} artículos",
   "theme.docs.breadcrumbs.home": "Página de Inicio",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Página del documento",

--- a/packages/docusaurus-theme-translations/locales/fil/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/fil/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "I-edit ang page",
   "theme.common.headingLinkTitle": "Direktang link patungo sa {heading}",
   "theme.common.skipToMainContent": "Lumaktaw patungo sa pangunahing content",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Docs Pages",

--- a/packages/docusaurus-theme-translations/locales/fr/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/fr/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Éditer cette page",
   "theme.common.headingLinkTitle": "Lien direct vers {heading}",
   "theme.common.skipToMainContent": "Aller au contenu principal",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} éléments",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 élément|{count} éléments",
   "theme.docs.breadcrumbs.home": "Page d'accueil",
   "theme.docs.breadcrumbs.navAriaLabel": "Fil d'Ariane",
   "theme.docs.paginator.navAriaLabel": "Pages de documentation",

--- a/packages/docusaurus-theme-translations/locales/he/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/he/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "ערוך דף זה",
   "theme.common.headingLinkTitle": "קישור ישיר אל {heading}",
   "theme.common.skipToMainContent": "דלג לתוכן הראשי",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "רשימת דוקומנטאציה",

--- a/packages/docusaurus-theme-translations/locales/hi/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/hi/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "इस पेज को बदलें",
   "theme.common.headingLinkTitle": "{heading} का सीधा लिंक",
   "theme.common.skipToMainContent": "मुख्य कंटेंट तक स्किप करें",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "डॉक्स पेज",

--- a/packages/docusaurus-theme-translations/locales/hu/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/hu/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Szerkesztés GitHub-on",
   "theme.common.headingLinkTitle": "Közvetlen hivatkozás erre: {heading}",
   "theme.common.skipToMainContent": "Ugrás a fő tartalomhoz",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} elemek",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 elem|{count} elemek",
   "theme.docs.breadcrumbs.home": "Kezdőlap",
   "theme.docs.breadcrumbs.navAriaLabel": "Navigációs sáv a jelenlegi oldalhoz",
   "theme.docs.paginator.navAriaLabel": "Dokumentációs oldal",

--- a/packages/docusaurus-theme-translations/locales/it/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/it/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Modifica questa pagina",
   "theme.common.headingLinkTitle": "Link diretto a {heading}",
   "theme.common.skipToMainContent": "Passa al contenuto principale",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} elementi",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 elemento|{count} elementi",
   "theme.docs.breadcrumbs.home": "Pagina principale",
   "theme.docs.breadcrumbs.navAriaLabel": "Briciole di pane",
   "theme.docs.paginator.navAriaLabel": "Pagina del documento",

--- a/packages/docusaurus-theme-translations/locales/nb/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/nb/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Rediger denne siden",
   "theme.common.headingLinkTitle": "Direkte lenke til {heading}",
   "theme.common.skipToMainContent": "Gå til hovedinnhold",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} artikler",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 artikkel|{count} artikler",
   "theme.docs.breadcrumbs.home": "Hjemmeside",
   "theme.docs.breadcrumbs.navAriaLabel": "Søkvei",
   "theme.docs.paginator.navAriaLabel": "Dokumenter side",

--- a/packages/docusaurus-theme-translations/locales/nl/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/nl/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Bewerk deze pagina",
   "theme.common.headingLinkTitle": "Direct link naar {heading}",
   "theme.common.skipToMainContent": "Ga naar hoofdinhoud",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} artikelen",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 artikel|{count} artikelen",
   "theme.docs.breadcrumbs.home": "Homepagina",
   "theme.docs.breadcrumbs.navAriaLabel": "Broodkruimels",
   "theme.docs.paginator.navAriaLabel": "Documentatie pagina",

--- a/packages/docusaurus-theme-translations/locales/pl/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/pl/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Edytuj tę stronę",
   "theme.common.headingLinkTitle": "Bezpośredni link do {heading}",
   "theme.common.skipToMainContent": "Przejdź do głównej zawartości",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} elementów",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 element|{count} elementy|{count} elementów",
   "theme.docs.breadcrumbs.home": "Strona główna",
   "theme.docs.breadcrumbs.navAriaLabel": "Pasek nawigacji",
   "theme.docs.paginator.navAriaLabel": "Strona dokumentacji",

--- a/packages/docusaurus-theme-translations/locales/pt-BR/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/pt-BR/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Editar essa página",
   "theme.common.headingLinkTitle": "Link direto para {heading}",
   "theme.common.skipToMainContent": "Pular para o conteúdo principal",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Página Inicial",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Páginas de documentação",

--- a/packages/docusaurus-theme-translations/locales/pt-PT/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/pt-PT/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Editar esta página",
   "theme.common.headingLinkTitle": "Link direto para {heading}",
   "theme.common.skipToMainContent": "Saltar para o conteúdo principal",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Páginas de documento",

--- a/packages/docusaurus-theme-translations/locales/sl/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/sl/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Uredi to stran",
   "theme.common.headingLinkTitle": "Direktna povezava na {heading}",
   "theme.common.skipToMainContent": "Preskoči na vsebino",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} vnosov",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 vnos|2 vnosy|{count} vnosy|{count} vnosov",
   "theme.docs.breadcrumbs.home": "Domača stran",
   "theme.docs.breadcrumbs.navAriaLabel": "Drobtine",
   "theme.docs.paginator.navAriaLabel": "Strani z dokumenti",

--- a/packages/docusaurus-theme-translations/locales/sr/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/sr/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Уреди ову страницу",
   "theme.common.headingLinkTitle": "Веза до {heading}",
   "theme.common.skipToMainContent": "Пређи на главни садржај",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} items",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 item|{count} items",
   "theme.docs.breadcrumbs.home": "Home page",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "странице докумената",

--- a/packages/docusaurus-theme-translations/locales/sv/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/sv/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Redigera denna sida",
   "theme.common.headingLinkTitle": "Direktlänk till {heading}",
   "theme.common.skipToMainContent": "Hoppa till huvudinnehåll",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} artiklar",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 artikel|{count} artiklar",
   "theme.docs.breadcrumbs.home": "Hemsida",
   "theme.docs.breadcrumbs.navAriaLabel": "Sökväg",
   "theme.docs.paginator.navAriaLabel": "Dokumentsidor",

--- a/packages/docusaurus-theme-translations/locales/tr/theme-common.json
+++ b/packages/docusaurus-theme-translations/locales/tr/theme-common.json
@@ -40,7 +40,7 @@
   "theme.common.editThisPage": "Bu sayfayı düzenle",
   "theme.common.headingLinkTitle": "{heading} doğrudan bağlantı",
   "theme.common.skipToMainContent": "Ana içeriğe geç",
-  "theme.docs.DocCard.categoryDescription.plurals": "{count} öğe",
+  "theme.docs.DocCard.categoryDescription.plurals": "1 öğe|{count} öğe",
   "theme.docs.breadcrumbs.home": "Ana sayfa",
   "theme.docs.breadcrumbs.navAriaLabel": "Breadcrumbs",
   "theme.docs.paginator.navAriaLabel": "Dokümanlar sayfası",


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/10098

Category card description label should display "1 item" and not "1 items"

I tried to fix many languages as well using google translate, but there could be mistakes.

I have no idea how to translate ar/fa so left them untouched.

Note I choose to not use "One item" because it does not seem better for the UX, and I'm not sure how capitalization works for each locale.


## Test Plan

preview

### Test links

https://deploy-preview-10118--docusaurus-2.netlify.app/tests/docs/category/tests


