### PR TITLE
feat(core): site storage config options (experimental)

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -26,6 +26,13 @@ declare module '@generated/site-metadata' {
   export = siteMetadata;
 }
 
+declare module '@generated/site-storage' {
+  import type {SiteStorage} from '@docusaurus/types';
+
+  const siteStorage: SiteStorage;
+  export = siteStorage;
+}
+
 declare module '@generated/registry' {
   import type {Registry} from '@docusaurus/types';
 

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -58,7 +58,7 @@ const noFlashColorMode = ({
 
     function getStoredTheme() {
       try {
-        return window[${siteStorage.type}].getItem('${themeStorageKey}');
+        return window['${siteStorage.type}'].getItem('${themeStorageKey}');
       } catch (err) {
       }
     }

--- a/packages/docusaurus-theme-classic/src/index.ts
+++ b/packages/docusaurus-theme-classic/src/index.ts
@@ -10,7 +10,7 @@ import {createRequire} from 'module';
 import rtlcss from 'rtlcss';
 import {readDefaultCodeTranslationMessages} from '@docusaurus/theme-translations';
 import {getTranslationFiles, translateThemeConfig} from './translations';
-import type {LoadContext, Plugin} from '@docusaurus/types';
+import type {LoadContext, Plugin, SiteStorage} from '@docusaurus/types';
 import type {ThemeConfig} from '@docusaurus/theme-common';
 import type {Plugin as PostCssPlugin} from 'postcss';
 import type {PluginOptions} from '@docusaurus/theme-classic';
@@ -23,58 +23,66 @@ const ContextReplacementPlugin = requireFromDocusaurusCore(
   'webpack/lib/ContextReplacementPlugin',
 ) as typeof webpack.ContextReplacementPlugin;
 
-// Need to be inlined to prevent dark mode FOUC
-// Make sure the key is the same as the one in `/theme/hooks/useTheme.js`
-const ThemeStorageKey = 'theme';
 // Support for ?docusaurus-theme=dark
 const ThemeQueryStringKey = 'docusaurus-theme';
 // Support for ?docusaurus-data-mode=embed&docusaurus-data-myAttr=42
 const DataQueryStringPrefixKey = 'docusaurus-data-';
 
 const noFlashColorMode = ({
-  defaultMode,
-  respectPrefersColorScheme,
-}: ThemeConfig['colorMode']) =>
+  colorMode: {defaultMode, respectPrefersColorScheme},
+  siteStorage,
+}: {
+  colorMode: ThemeConfig['colorMode'];
+  siteStorage: SiteStorage;
+}) => {
+  // Need to be inlined to prevent dark mode FOUC
+  // Make sure the key is the same as the one in the color mode React context
+  // Currently defined in: `docusaurus-theme-common/src/contexts/colorMode.tsx`
+  const themeStorageKey = `theme${siteStorage.namespace}`;
+
   /* language=js */
-  `(function() {
-  var defaultMode = '${defaultMode}';
-  var respectPrefersColorScheme = ${respectPrefersColorScheme};
+  return `(function() {
+    var defaultMode = '${defaultMode}';
+    var respectPrefersColorScheme = ${respectPrefersColorScheme};
 
-  function setDataThemeAttribute(theme) {
-    document.documentElement.setAttribute('data-theme', theme);
-  }
-
-  function getQueryStringTheme() {
-    try {
-      return new URLSearchParams(window.location.search).get('${ThemeQueryStringKey}')
-    } catch(e) {}
-  }
-
-  function getStoredTheme() {
-    try {
-      return localStorage.getItem('${ThemeStorageKey}');
-    } catch (err) {}
-  }
-
-  var initialTheme = getQueryStringTheme() || getStoredTheme();
-  if (initialTheme !== null) {
-    setDataThemeAttribute(initialTheme);
-  } else {
-    if (
-      respectPrefersColorScheme &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches
-    ) {
-      setDataThemeAttribute('dark');
-    } else if (
-      respectPrefersColorScheme &&
-      window.matchMedia('(prefers-color-scheme: light)').matches
-    ) {
-      setDataThemeAttribute('light');
-    } else {
-      setDataThemeAttribute(defaultMode === 'dark' ? 'dark' : 'light');
+    function setDataThemeAttribute(theme) {
+      document.documentElement.setAttribute('data-theme', theme);
     }
-  }
-})();`;
+
+    function getQueryStringTheme() {
+      try {
+        return new URLSearchParams(window.location.search).get('${ThemeQueryStringKey}')
+      } catch (e) {
+      }
+    }
+
+    function getStoredTheme() {
+      try {
+        return window[${siteStorage.type}].getItem('${themeStorageKey}');
+      } catch (err) {
+      }
+    }
+
+    var initialTheme = getQueryStringTheme() || getStoredTheme();
+    if (initialTheme !== null) {
+      setDataThemeAttribute(initialTheme);
+    } else {
+      if (
+        respectPrefersColorScheme &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches
+      ) {
+        setDataThemeAttribute('dark');
+      } else if (
+        respectPrefersColorScheme &&
+        window.matchMedia('(prefers-color-scheme: light)').matches
+      ) {
+        setDataThemeAttribute('light');
+      } else {
+        setDataThemeAttribute(defaultMode === 'dark' ? 'dark' : 'light');
+      }
+    }
+  })();`;
+};
 
 /* language=js */
 const DataAttributeQueryStringInlineJavaScript = `
@@ -126,6 +134,7 @@ export default function themeClassic(
 ): Plugin<undefined> {
   const {
     i18n: {currentLocale, localeConfigs},
+    siteStorage,
   } = context;
   const themeConfig = context.siteConfig.themeConfig as ThemeConfig;
   const {
@@ -218,7 +227,7 @@ export default function themeClassic(
           {
             tagName: 'script',
             innerHTML: `
-${noFlashColorMode(colorMode)}
+${noFlashColorMode({colorMode, siteStorage})}
 ${DataAttributeQueryStringInlineJavaScript}
 ${announcementBar ? AnnouncementBarInlineJavaScript : ''}
             `,

--- a/packages/docusaurus-theme-common/src/utils/storageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/storageUtils.ts
@@ -6,12 +6,15 @@
  */
 
 import {useCallback, useRef, useSyncExternalStore} from 'react';
+import SiteStorage from '@generated/site-storage';
 
-const StorageTypes = ['localStorage', 'sessionStorage', 'none'] as const;
+export type StorageType = (typeof SiteStorage)['type'] | 'none';
 
-export type StorageType = (typeof StorageTypes)[number];
+const DefaultStorageType: StorageType = SiteStorage.type;
 
-const DefaultStorageType: StorageType = 'localStorage';
+function applyNamespace(storageKey: string): string {
+  return `${storageKey}${SiteStorage.namespace}`;
+}
 
 // window.addEventListener('storage') only works for different windows...
 // so for current window we have to dispatch the event manually
@@ -134,9 +137,10 @@ Please only call storage APIs in effects and event handlers.`);
  * this API can be a no-op. See also https://github.com/facebook/docusaurus/issues/6036
  */
 export function createStorageSlot(
-  key: string,
+  keyInput: string,
   options?: {persistence?: StorageType},
 ): StorageSlot {
+  const key = applyNamespace(keyInput);
   if (typeof window === 'undefined') {
     return createServerStorageSlot(key);
   }

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {SiteStorage} from './context';
 import type {RuleSetRule} from 'webpack';
 import type {Required as RequireKeys, DeepPartial} from 'utility-types';
 import type {I18nConfig} from './i18n';
@@ -115,6 +116,15 @@ export type MarkdownConfig = {
   anchors: MarkdownAnchorsConfig;
 };
 
+export type StorageOption = {
+  type: SiteStorage['type'];
+  namespace: boolean | string;
+};
+
+export type DocusaurusFuture = {
+  experimental_storage: StorageOption;
+};
+
 /**
  * Docusaurus config, after validation/normalization.
  */
@@ -171,6 +181,11 @@ export type DocusaurusConfig = {
    * @see https://docusaurus.io/docs/api/docusaurus-config#i18n
    */
   i18n: I18nConfig;
+  /**
+   * Docusaurus future flags and experimental features.
+   * Similar to Remix future flags, see https://remix.run/blog/future-flags
+   */
+  future: DocusaurusFuture;
   /**
    * This option adds `<meta name="robots" content="noindex, nofollow">` to
    * every page to tell search engines to avoid indexing your site.

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -116,13 +116,13 @@ export type MarkdownConfig = {
   anchors: MarkdownAnchorsConfig;
 };
 
-export type StorageOption = {
+export type StorageConfig = {
   type: SiteStorage['type'];
   namespace: boolean | string;
 };
 
-export type DocusaurusFuture = {
-  experimental_storage: StorageOption;
+export type FutureConfig = {
+  experimental_storage: StorageConfig;
 };
 
 /**
@@ -185,7 +185,7 @@ export type DocusaurusConfig = {
    * Docusaurus future flags and experimental features.
    * Similar to Remix future flags, see https://remix.run/blog/future-flags
    */
-  future: DocusaurusFuture;
+  future: FutureConfig;
   /**
    * This option adds `<meta name="robots" content="noindex, nofollow">` to
    * every page to tell search engines to avoid indexing your site.

--- a/packages/docusaurus-types/src/context.d.ts
+++ b/packages/docusaurus-types/src/context.d.ts
@@ -27,6 +27,28 @@ export type SiteMetadata = {
   readonly pluginVersions: {[pluginName: string]: PluginVersionInformation};
 };
 
+// Should we have a value to disable storage?
+export type SiteStorageType = 'localStorage' | 'sessionStorage';
+
+export type SiteStorage = {
+  /**
+   * Which browser storage do you want to use?
+   * Between "localStorage" and "sessionStorage".
+   * The default is "localStorage".
+   */
+  type: SiteStorageType;
+
+  /**
+   * Applies a namespace to the theme storage key
+   * For readability, the namespace is applied at the end of the key
+   * The final storage key will be = `${key}${namespace}`
+   *
+   * The default namespace is "" for retro-compatibility reasons
+   * If you want a separator, the namespace should contain it ("-myNamespace")
+   */
+  namespace: string;
+};
+
 export type GlobalData = {[pluginName: string]: {[pluginId: string]: unknown}};
 
 export type LoadContext = {
@@ -50,6 +72,11 @@ export type LoadContext = {
   baseUrl: string;
   i18n: I18n;
   codeTranslations: CodeTranslations;
+
+  /**
+   * Defines the default browser storage behavior for a site
+   */
+  siteStorage: SiteStorage;
 };
 
 export type Props = LoadContext & {

--- a/packages/docusaurus-types/src/context.d.ts
+++ b/packages/docusaurus-types/src/context.d.ts
@@ -27,16 +27,13 @@ export type SiteMetadata = {
   readonly pluginVersions: {[pluginName: string]: PluginVersionInformation};
 };
 
-// Should we have a value to disable storage?
-export type SiteStorageType = 'localStorage' | 'sessionStorage';
-
 export type SiteStorage = {
   /**
    * Which browser storage do you want to use?
    * Between "localStorage" and "sessionStorage".
    * The default is "localStorage".
    */
-  type: SiteStorageType;
+  type: 'localStorage' | 'sessionStorage';
 
   /**
    * Applies a namespace to the theme storage key

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -20,6 +20,7 @@ export {
   DocusaurusContext,
   GlobalData,
   LoadContext,
+  SiteStorage,
   Props,
 } from './context';
 

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -12,6 +12,8 @@ export {
   DefaultParseFrontMatter,
   ParseFrontMatter,
   DocusaurusConfig,
+  FutureConfig,
+  StorageConfig,
   Config,
 } from './config';
 

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -7,6 +7,12 @@ exports[`loadSiteConfig website with .cjs siteConfig 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -61,6 +67,12 @@ exports[`loadSiteConfig website with ts + js config 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -115,6 +127,12 @@ exports[`loadSiteConfig website with valid JS CJS config 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -169,6 +187,12 @@ exports[`loadSiteConfig website with valid JS ESM config 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -223,6 +247,12 @@ exports[`loadSiteConfig website with valid TypeScript CJS config 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -277,6 +307,12 @@ exports[`loadSiteConfig website with valid TypeScript ESM config 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -331,6 +367,12 @@ exports[`loadSiteConfig website with valid async config 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -387,6 +429,12 @@ exports[`loadSiteConfig website with valid async config creator function 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -443,6 +491,12 @@ exports[`loadSiteConfig website with valid config creator function 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -502,6 +556,12 @@ exports[`loadSiteConfig website with valid siteConfig 1`] = `
     ],
     "customFields": {},
     "favicon": "img/docusaurus.ico",
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -77,6 +77,12 @@ exports[`load loads props for site with custom i18n path 1`] = `
     "baseUrlIssueBanner": true,
     "clientModules": [],
     "customFields": {},
+    "future": {
+      "experimental_storage": {
+        "namespace": false,
+        "type": "localStorage",
+      },
+    },
     "headTags": [],
     "i18n": {
       "defaultLocale": "en",
@@ -138,7 +144,7 @@ exports[`load loads props for site with custom i18n path 1`] = `
     "siteVersion": undefined,
   },
   "siteStorage": {
-    "namespace": "-182",
+    "namespace": "",
     "type": "localStorage",
   },
   "siteVersion": undefined,

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -137,6 +137,10 @@ exports[`load loads props for site with custom i18n path 1`] = `
     "pluginVersions": {},
     "siteVersion": undefined,
   },
+  "siteStorage": {
+    "namespace": "-182",
+    "type": "localStorage",
+  },
   "siteVersion": undefined,
 }
 `;

--- a/packages/docusaurus/src/server/__tests__/site.test.ts
+++ b/packages/docusaurus/src/server/__tests__/site.test.ts
@@ -39,7 +39,7 @@ describe('load', () => {
           baseUrl: '/zh-Hans/',
         },
         siteStorage: {
-          namespace: '-3c3',
+          namespace: '',
           type: 'localStorage',
         },
         plugins: site2.props.plugins,

--- a/packages/docusaurus/src/server/__tests__/site.test.ts
+++ b/packages/docusaurus/src/server/__tests__/site.test.ts
@@ -38,6 +38,10 @@ describe('load', () => {
         siteConfig: {
           baseUrl: '/zh-Hans/',
         },
+        siteStorage: {
+          namespace: '-3c3',
+          type: 'localStorage',
+        },
         plugins: site2.props.plugins,
       }),
     );

--- a/packages/docusaurus/src/server/__tests__/storage.test.ts
+++ b/packages/docusaurus/src/server/__tests__/storage.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {createSiteStorage} from '../storage';
+import {
+  DEFAULT_FUTURE_CONFIG,
+  DEFAULT_STORAGE_CONFIG,
+} from '../configValidation';
+import type {FutureConfig, StorageConfig, SiteStorage} from '@docusaurus/types';
+
+function test({
+  url = 'https://docusaurus.io',
+  baseUrl = '/',
+  storage = {},
+}: {
+  url?: string;
+  baseUrl?: string;
+  storage?: Partial<StorageConfig>;
+}): SiteStorage {
+  const future: FutureConfig = {
+    ...DEFAULT_FUTURE_CONFIG,
+    experimental_storage: {
+      ...DEFAULT_STORAGE_CONFIG,
+      ...storage,
+    },
+  };
+
+  return createSiteStorage({url, baseUrl, future});
+}
+
+const DefaultSiteStorage: SiteStorage = {
+  type: 'localStorage',
+  namespace: '',
+};
+
+describe('storage', () => {
+  it('default', () => {
+    expect(test({})).toEqual(DefaultSiteStorage);
+  });
+
+  describe('type', () => {
+    it('localStorage', () => {
+      expect(test({storage: {type: 'localStorage'}})).toEqual({
+        ...DefaultSiteStorage,
+        type: 'localStorage',
+      });
+    });
+
+    it('sessionStorage', () => {
+      expect(test({storage: {type: 'sessionStorage'}})).toEqual({
+        ...DefaultSiteStorage,
+        type: 'sessionStorage',
+      });
+    });
+  });
+
+  describe('namespace', () => {
+    describe('true', () => {
+      function testAutomaticNamespace(
+        {
+          url,
+          baseUrl,
+        }: {
+          url: string;
+          baseUrl: string;
+        },
+        expectedNamespace: string,
+      ) {
+        return expect(test({url, baseUrl, storage: {namespace: true}})).toEqual(
+          expect.objectContaining({namespace: expectedNamespace}),
+        );
+      }
+
+      it('automatic namespace - https://docusaurus.io/', () => {
+        testAutomaticNamespace(
+          {
+            url: 'https://docusaurus.io',
+            baseUrl: '/',
+          },
+          '-189',
+        );
+      });
+
+      it('automatic namespace - https://docusaurus.io/baseUrl/', () => {
+        testAutomaticNamespace(
+          {
+            url: 'https://docusaurus.io',
+            baseUrl: '/baseUrl/',
+          },
+          '-b21',
+        );
+      });
+
+      it('automatic namespace - https://example.com/', () => {
+        testAutomaticNamespace(
+          {
+            url: 'https://example.com',
+            baseUrl: '/',
+          },
+          '-182',
+        );
+      });
+
+      it('automatic namespace - https://example.com/baseUrl/', () => {
+        testAutomaticNamespace(
+          {
+            url: 'https://example.com',
+            baseUrl: '/baseUrl/',
+          },
+          '-ad6',
+        );
+      });
+
+      it('automatic namespace - is not slash sensitive', () => {
+        const expectedNamespace = '-b21';
+        testAutomaticNamespace(
+          {
+            url: 'https://docusaurus.io',
+            baseUrl: '/baseUrl/',
+          },
+          expectedNamespace,
+        );
+        testAutomaticNamespace(
+          {
+            url: 'https://docusaurus.io/',
+            baseUrl: '/baseUrl/',
+          },
+          expectedNamespace,
+        );
+        testAutomaticNamespace(
+          {
+            url: 'https://docusaurus.io/',
+            baseUrl: '/baseUrl',
+          },
+          expectedNamespace,
+        );
+        testAutomaticNamespace(
+          {
+            url: 'https://docusaurus.io',
+            baseUrl: 'baseUrl',
+          },
+          expectedNamespace,
+        );
+      });
+    });
+
+    it('false', () => {
+      expect(test({storage: {namespace: false}})).toEqual({
+        ...DefaultSiteStorage,
+        namespace: '',
+      });
+    });
+
+    it('string', () => {
+      expect(test({storage: {namespace: 'my-namespace'}})).toEqual({
+        ...DefaultSiteStorage,
+        namespace: '-my-namespace',
+      });
+    });
+  });
+});

--- a/packages/docusaurus/src/server/codegen/codegen.ts
+++ b/packages/docusaurus/src/server/codegen/codegen.ts
@@ -18,6 +18,7 @@ import type {
   I18n,
   PluginRouteConfig,
   SiteMetadata,
+  SiteStorage,
 } from '@docusaurus/types';
 
 function genWarning({generatedFilesDir}: {generatedFilesDir: string}) {
@@ -131,6 +132,20 @@ function genSiteMetadata({
   );
 }
 
+function genSiteStorage({
+  generatedFilesDir,
+  siteStorage,
+}: {
+  generatedFilesDir: string;
+  siteStorage: SiteStorage;
+}) {
+  return generate(
+    generatedFilesDir,
+    'site-storage.json',
+    JSON.stringify(siteStorage, null, 2),
+  );
+}
+
 type CodegenParams = {
   generatedFilesDir: string;
   siteConfig: DocusaurusConfig;
@@ -140,6 +155,7 @@ type CodegenParams = {
   i18n: I18n;
   codeTranslations: CodeTranslations;
   siteMetadata: SiteMetadata;
+  siteStorage: SiteStorage;
   routes: PluginRouteConfig[];
 };
 
@@ -151,6 +167,7 @@ export async function generateSiteFiles(params: CodegenParams): Promise<void> {
     generateRouteFiles(params),
     genGlobalData(params),
     genSiteMetadata(params),
+    genSiteStorage(params),
     genI18n(params),
     genCodeTranslations(params),
   ]);

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -16,6 +16,7 @@ import {
   addLeadingSlash,
   removeTrailingSlash,
 } from '@docusaurus/utils-common';
+import type {FutureConfig, StorageConfig} from '@docusaurus/types/src/config';
 import type {
   DocusaurusConfig,
   I18nConfig,
@@ -29,6 +30,15 @@ export const DEFAULT_I18N_CONFIG: I18nConfig = {
   path: DEFAULT_I18N_DIR_NAME,
   locales: [DEFAULT_I18N_LOCALE],
   localeConfigs: {},
+};
+
+export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
+  type: 'localStorage',
+  namespace: false,
+};
+
+export const DEFAULT_FUTURE_CONFIG: FutureConfig = {
+  experimental_storage: DEFAULT_STORAGE_CONFIG,
 };
 
 export const DEFAULT_MARKDOWN_CONFIG: MarkdownConfig = {
@@ -50,6 +60,7 @@ export const DEFAULT_MARKDOWN_CONFIG: MarkdownConfig = {
 export const DEFAULT_CONFIG: Pick<
   DocusaurusConfig,
   | 'i18n'
+  | 'future'
   | 'onBrokenLinks'
   | 'onBrokenAnchors'
   | 'onBrokenMarkdownLinks'
@@ -71,6 +82,7 @@ export const DEFAULT_CONFIG: Pick<
   | 'markdown'
 > = {
   i18n: DEFAULT_I18N_CONFIG,
+  future: DEFAULT_FUTURE_CONFIG,
   onBrokenLinks: 'throw',
   onBrokenAnchors: 'warn', // TODO Docusaurus v4: change to throw
   onBrokenMarkdownLinks: 'warn',
@@ -181,6 +193,23 @@ const I18N_CONFIG_SCHEMA = Joi.object<I18nConfig>({
   .optional()
   .default(DEFAULT_I18N_CONFIG);
 
+const STORAGE_CONFIG_SCHEMA = Joi.object({
+  type: Joi.string()
+    .equal('localStorage', 'sessionStorage')
+    .default(DEFAULT_STORAGE_CONFIG.type),
+  namespace: Joi.alternatives()
+    .try(Joi.string(), Joi.boolean())
+    .default(DEFAULT_STORAGE_CONFIG.namespace),
+})
+  .optional()
+  .default(DEFAULT_STORAGE_CONFIG);
+
+const FUTURE_CONFIG_SCHEMA = Joi.object<FutureConfig>({
+  experimental_storage: STORAGE_CONFIG_SCHEMA,
+})
+  .optional()
+  .default(DEFAULT_FUTURE_CONFIG);
+
 const SiteUrlSchema = Joi.string()
   .required()
   .custom((value: string, helpers) => {
@@ -215,6 +244,7 @@ export const ConfigSchema = Joi.object<DocusaurusConfig>({
   url: SiteUrlSchema,
   trailingSlash: Joi.boolean(), // No default value! undefined = retrocompatible legacy behavior!
   i18n: I18N_CONFIG_SCHEMA,
+  future: FUTURE_CONFIG_SCHEMA,
   onBrokenLinks: Joi.string()
     .equal('ignore', 'log', 'warn', 'throw')
     .default(DEFAULT_CONFIG.onBrokenLinks),

--- a/packages/docusaurus/src/server/site.ts
+++ b/packages/docusaurus/src/server/site.ts
@@ -62,9 +62,15 @@ export type Site = {
   params: LoadSiteParams;
 };
 
+function defaultNamespace(config: DocusaurusConfig): string {
+  return simpleHash(normalizeUrl([config.url, config.baseUrl]), 3);
+}
+
 function createSiteStorage(config: DocusaurusConfig): SiteStorage {
   // TODO make it configurable, default to ""
-  const namespace = simpleHash(normalizeUrl([config.url, config.baseUrl]), 3);
+  const namespaceSuffix = defaultNamespace(config);
+
+  const namespace = `-${namespaceSuffix}`;
   return {
     type: 'localStorage',
     namespace,

--- a/packages/docusaurus/src/server/site.ts
+++ b/packages/docusaurus/src/server/site.ts
@@ -10,8 +10,6 @@ import {
   localizePath,
   DEFAULT_BUILD_DIR_NAME,
   GENERATED_FILES_DIR_NAME,
-  normalizeUrl,
-  simpleHash,
 } from '@docusaurus/utils';
 import combinePromises from 'combine-promises';
 import {loadSiteConfig} from './config';
@@ -27,6 +25,7 @@ import {
 import {PerfLogger} from '../utils';
 import {generateSiteFiles} from './codegen/codegen';
 import {getRoutesPaths, handleDuplicateRoutes} from './routes';
+import {createSiteStorage} from './storage';
 import type {LoadPluginsResult} from './plugins/plugins';
 import type {
   DocusaurusConfig,
@@ -34,7 +33,6 @@ import type {
   LoadContext,
   Props,
   PluginIdentifier,
-  SiteStorage,
 } from '@docusaurus/types';
 
 export type LoadContextParams = {
@@ -61,21 +59,6 @@ export type Site = {
   props: Props;
   params: LoadSiteParams;
 };
-
-function defaultNamespace(config: DocusaurusConfig): string {
-  return simpleHash(normalizeUrl([config.url, config.baseUrl]), 3);
-}
-
-function createSiteStorage(config: DocusaurusConfig): SiteStorage {
-  // TODO make it configurable, default to ""
-  const namespaceSuffix = defaultNamespace(config);
-
-  const namespace = `-${namespaceSuffix}`;
-  return {
-    type: 'localStorage',
-    namespace,
-  };
-}
 
 /**
  * Loading context is the very first step in site building. Its params are

--- a/packages/docusaurus/src/server/storage.ts
+++ b/packages/docusaurus/src/server/storage.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {normalizeUrl, simpleHash} from '@docusaurus/utils';
+import type {DocusaurusConfig, SiteStorage} from '@docusaurus/types';
+
+type Params = Pick<DocusaurusConfig, 'url' | 'baseUrl' | 'future'>;
+
+function automaticNamespace(params: Params): string {
+  return simpleHash(normalizeUrl([params.url, params.baseUrl]), 3);
+}
+
+function getNamespaceString(params: Params): string | null {
+  if (params.future.experimental_storage.namespace === true) {
+    return automaticNamespace(params);
+  } else if (params.future.experimental_storage.namespace === false) {
+    return null;
+  } else {
+    return params.future.experimental_storage.namespace;
+  }
+}
+
+export function createSiteStorage(config: DocusaurusConfig): SiteStorage {
+  const {type} = config.future.experimental_storage;
+  const namespaceString = getNamespaceString(config);
+
+  const namespace = namespaceString ? `-${namespaceString}` : '';
+  return {
+    type,
+    namespace,
+  };
+}

--- a/packages/docusaurus/src/server/storage.ts
+++ b/packages/docusaurus/src/server/storage.ts
@@ -6,25 +6,33 @@
  */
 
 import {normalizeUrl, simpleHash} from '@docusaurus/utils';
+import {addTrailingSlash} from '@docusaurus/utils-common';
 import type {DocusaurusConfig, SiteStorage} from '@docusaurus/types';
 
-type Params = Pick<DocusaurusConfig, 'url' | 'baseUrl' | 'future'>;
+type PartialFuture = Pick<DocusaurusConfig['future'], 'experimental_storage'>;
 
-function automaticNamespace(params: Params): string {
-  return simpleHash(normalizeUrl([params.url, params.baseUrl]), 3);
+type PartialConfig = Pick<DocusaurusConfig, 'url' | 'baseUrl'> & {
+  future: PartialFuture;
+};
+
+function automaticNamespace(config: PartialConfig): string {
+  const normalizedUrl = addTrailingSlash(
+    normalizeUrl([config.url, config.baseUrl]),
+  );
+  return simpleHash(normalizedUrl, 3);
 }
 
-function getNamespaceString(params: Params): string | null {
-  if (params.future.experimental_storage.namespace === true) {
-    return automaticNamespace(params);
-  } else if (params.future.experimental_storage.namespace === false) {
+function getNamespaceString(config: PartialConfig): string | null {
+  if (config.future.experimental_storage.namespace === true) {
+    return automaticNamespace(config);
+  } else if (config.future.experimental_storage.namespace === false) {
     return null;
   } else {
-    return params.future.experimental_storage.namespace;
+    return config.future.experimental_storage.namespace;
   }
 }
 
-export function createSiteStorage(config: DocusaurusConfig): SiteStorage {
+export function createSiteStorage(config: PartialConfig): SiteStorage {
   const {type} = config.future.experimental_storage;
   const namespaceString = getNamespaceString(config);
 

--- a/website/_dogfooding/dogfooding.config.ts
+++ b/website/_dogfooding/dogfooding.config.ts
@@ -104,6 +104,7 @@ export const dogfoodingPluginInstances: PluginConfig[] = [
         return [
           require.resolve('./clientModuleExample.ts'),
           require.resolve('./clientModuleCSS.css'),
+          require.resolve('./migrateStorageNamespace.ts'),
         ];
       },
     };

--- a/website/_dogfooding/migrateStorageNamespace.ts
+++ b/website/_dogfooding/migrateStorageNamespace.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import SiteStorage from '@generated/site-storage';
+
+// The purpose is to test a migration script for storage namespacing
+// See also: https://github.com/facebook/docusaurus/pull/10121
+
+if (ExecutionEnvironment.canUseDOM) {
+  const migrateStorageKey = (key: string) => {
+    const value = localStorage.getItem(key);
+    if (value !== null && SiteStorage.namespace) {
+      const newKey = `${key}${SiteStorage.namespace}`;
+      console.log(`Updating storage key [${key} => ${newKey}], value=${value}`);
+      localStorage.setItem(newKey, value);
+      localStorage.removeItem(key);
+    }
+  };
+
+  const storageKeys = [
+    'theme',
+    'docusaurus.announcement.id',
+    'docusaurus.announcement.dismiss',
+    'docs-preferred-version-default',
+  ];
+  storageKeys.forEach(migrateStorageKey);
+}

--- a/website/community/5-release-process.mdx
+++ b/website/community/5-release-process.mdx
@@ -158,7 +158,7 @@ We will outline what accounts as the public API surface.
 
 ❌ Our public API **excludes**:
 
-- Docusaurus config [`future`](/docs/api/docusaurus-config#future) features
+- Docusaurus config `future`
 - All features prefixed by `experimental_` or `unstable_`
 - All features prefixed by `v<MajorVersion>_` (`v6_` `v7_`, etc.)
 

--- a/website/community/5-release-process.mdx
+++ b/website/community/5-release-process.mdx
@@ -156,6 +156,12 @@ We will outline what accounts as the public API surface.
 - `@docusaurus/types` TypeScript types
   - We still retain the freedom to make types stricter (which may break type-checking).
 
+❌ Our public API **excludes**:
+
+- Docusaurus config [`future`](/docs/api/docusaurus-config#future) features
+- All features prefixed by `experimental_` or `unstable_`
+- All features prefixed by `v<MajorVersion>_` (`v6_` `v7_`, etc.)
+
 :::tip
 
 For non-theme APIs, any documented API is considered public (and will be stable); any undocumented API is considered internal.

--- a/website/docs/api/docusaurus.config.js.mdx
+++ b/website/docs/api/docusaurus.config.js.mdx
@@ -174,6 +174,41 @@ export default {
   - `calendar`: the [calendar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar) used to calculate the date era. Note that it doesn't control the actual string displayed: `MM/DD/YYYY` and `DD/MM/YYYY` are both `gregory`. To choose the format (`DD/MM/YYYY` or `MM/DD/YYYY`), set your locale name to `en-GB` or `en-US` (`en` means `en-US`).
   - `path`: Root folder that all plugin localization folders of this locale are relative to. Will be resolved against `i18n.path`. Defaults to the locale's name. Note: this has no effect on the locale's `baseUrl`—customization of base URL is a work-in-progress.
 
+### `future` {#future}
+
+- Type: `Object`
+
+The `future` configuration object permits to opt-in for upcoming/unstable/experimental Docusaurus features that are not ready for prime time.
+
+It is also a way to opt-in for upcoming breaking changes coming in the next major versions, enabling you to prepare your site for the next version while staying on the previous one. The [Remix Future Flags blog post](https://remix.run/blog/future-flags) greatly explains this idea.
+
+:::danger Breaking changes in minor versions
+
+Features prefixed by `experimental_` or `unstable_` are subject to changes in **minor versions**, and not considered as [Semantic Versioning breaking changes](/community/release-process).
+
+Features prefixed by `v<MajorVersion>_` (`v6_` `v7_`, etc.) are future flags that are expected to be turned on by default in the next major versions. These are less likely to change, but we keep the possibility to do so.
+
+`future` API breaking changes should be easy to handle, and will be documented in minor/major version blog posts.
+
+:::
+
+Example:
+
+```js title="docusaurus.config.js"
+export default {
+  future: {
+    experimental_storage: {
+      type: 'localStorage',
+      namespace: true,
+    },
+  },
+};
+```
+
+- `experimental_storage`: Site-wide browser storage options that theme authors should strive to respect.
+  - `type`: The browser storage theme authors should use. Possible values are `localStorage` and `sessionStorage`. Defaults to `localStorage`.
+  - `namespace`: Whether to namespace the browser storage keys to avoid storage key conflicts when Docusaurus sites are hosted under the same domain, or on localhost. Possible values are `string | boolean`. The namespace is appended at the end of the storage keys `key-namespace`. Use `true` to automatically generate a random namespace from your site `url + baseUrl`. Defaults to `false` (no namespace, historical behavior).
+
 ### `noIndex` {#noIndex}
 
 - Type: `boolean`

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -147,6 +147,11 @@ export default async function createConfigAsync() {
     baseUrl,
     baseUrlIssueBanner: true,
     url: 'https://docusaurus.io',
+    future: {
+      experimental_storage: {
+        namespace: true,
+      },
+    },
     // Dogfood both settings:
     // - force trailing slashes for deploy previews
     // - avoid trailing slashes in prod


### PR DESCRIPTION
## Motivation

This introduces new site config options to let users control the default browser storage behavior of a Docusaurus site. 

Note: our themes respect that config, but third-party themes are not forced to, and it's only a default that can be ignored on a case-by-case basis.

It is useful to apply a namespace to browser storage keys, to avoid storage key conflicts on the same domain:
- Docusaurus devs might work on multiple sites locally (all under `http://localhost:3000`)
- Docusaurus sites might be hosted on the same domain using `/baseUrl/` (`https://example.com/site1/` + `https://example.com/site2/`). This is notably the case at Meta.

While we work on this, it's also a good opportunity to let users decide between `localStorage` or `sessionStorage` for browser persistence.


For retro-compatibility reasons, we can't apply a namespace by default in v3, so it has to be turned on through options.

This is a good opportunity for Docusaurus to introduce [Future Flags](https://remix.run/blog/future-flags) similar to what the Remix framework does. We can ship opt-in breaking changes that we might turn on by default on upcoming major versions.

The config for this new feature:

```js
export default {
  future: {
    experimental_storage: {
      type: "localStorage",
      namespace: "my-namespace-key-suffix",
    }
  }
}
```

For convenience, it's possible to use `config.future.experimental_storage.namespace = true`.
In this case, we'll compute a 3-char hash based on your `https://siteUrl.com/baseUrl/siteUrl/` (ie your `theme` storage key become `theme-x7j`)
We may turn this on by default in Docusaurus v4 (breaking change), with an option to revert.


For now, this API is experimental until we get feedback from internal usage at Meta. We might refactor it in minor versions according to feedback.

## Test Plan

CI + preview + internal rollout at Meta 

When namespacing is on, storage keys should have a suffix:

![CleanShot 2024-05-09 at 19 47 00](https://github.com/facebook/docusaurus/assets/749374/dc19ba14-2199-416f-93df-00ed4ebf7f8c)


### Test links

https://deploy-preview-10121--docusaurus-2.netlify.app/


### Migration strategy

The default/classic Docusaurus theme stores the following keys in localStorage:
- Theme
- Announcement bar state
- Docs preferred version (last version selected, displayed in the dropdown on home/blog pages)

It shouldn't be a big deal to have these stored values being reset, but if you want to turn on storage namspacing without disrupting the user experience, you can migrate storage keys with a [client module script](https://docusaurus.io/docs/api/docusaurus-config#clientModules) like this one:

```ts
import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
import SiteStorage from '@generated/site-storage';

if (ExecutionEnvironment.canUseDOM) {
  const migrateStorageKey = (key: string) => {
    const value = localStorage.getItem(key);
    if (value !== null && SiteStorage.namespace) {
      const newKey = `${key}${SiteStorage.namespace}`;
      console.log(`Migrating storage key [ ${key} => ${newKey} ], value=${value}`);
      localStorage.setItem(newKey, value);
      localStorage.removeItem(key);
    }
  };

  const storageKeys = [
    'theme',
    'docusaurus.announcement.id',
    'docusaurus.announcement.dismiss',
    // You might need more if you have multiple versioned docs
    'docs-preferred-version-default', 
  ];
  storageKeys.forEach(migrateStorageKey);
}
```

Note that:
- If you had storage key conflicts, it's probably not really useful to migrate keys considering your keys were already shared and produced issues. It might be better to reset them? 🤷‍♂️ 
- Third-party plugins might also use localStorage. They probably don't respect (yet) your namespace since it's a new feature and they'd need to add support for it.

