### PR TITLE
fix(core): fix `docusaurus serve` broken for assets when using trailingSlash

### DIFF
--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -76,10 +76,21 @@ export async function serve(
 
     // We do the redirect ourselves for a good reason
     // server-handler is annoying and won't include /baseUrl/ in redirects
-    const normalizedUrl = applyTrailingSlash(req.url, {trailingSlash, baseUrl});
-    if (req.url !== normalizedUrl) {
-      redirect(res, normalizedUrl);
-      return;
+    // See https://github.com/facebook/docusaurus/issues/10078#issuecomment-2084932934
+    if (baseUrl !== '/') {
+      // Not super robust, but should be good enough for our use case
+      // See https://github.com/facebook/docusaurus/pull/10090
+      const looksLikeAsset = !!req.url.match(/.[a-z]{1,4}$/);
+      if (!looksLikeAsset) {
+        const normalizedUrl = applyTrailingSlash(req.url, {
+          trailingSlash,
+          baseUrl,
+        });
+        if (req.url !== normalizedUrl) {
+          redirect(res, normalizedUrl);
+          return;
+        }
+      }
     }
 
     // Remove baseUrl before calling serveHandler, because /baseUrl/ should


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/10139

The workaround applied in https://github.com/facebook/docusaurus/pull/10090 lead to a regression for serving assets. I'm now applying this workaround more defensively.

The workaround impl is not 100% robust but should work fine for 99.9% of websites and only applies to sites using `docusauris serve` with a baseurl + trailingSlash.

## Test Plan

no 😅 it works locally
