### PR TITLE
chore: fix build-hash-router.yml workflow to trigger on main

### DIFF
--- a/.github/workflows/build-hash-router.yml
+++ b/.github/workflows/build-hash-router.yml
@@ -1,6 +1,8 @@
 name: Build Hash Router
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches:
       - main


### PR DESCRIPTION
typo prevents workflow to run on main