### PR TITLE
docs: Add PostHog plugin

### DIFF
--- a/website/docs/api/plugins/overview.mdx
+++ b/website/docs/api/plugins/overview.mdx
@@ -28,3 +28,4 @@ These plugins will add a useful behavior to your Docusaurus site.
 - [@docusaurus/plugin-ideal-image](./plugin-ideal-image.mdx)
 - [@docusaurus/plugin-google-analytics](./plugin-google-analytics.mdx)
 - [@docusaurus/plugin-google-gtag](./plugin-google-gtag.mdx)
+- [@posthog/posthog-docusaurus](https://posthog.com/docs/libraries/docusaurus)


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).

## Motivation

PostHog has a plugin that makes it easy to add analytics, session replays, surveys, and more to Docusaurus. I just updated it and the docs for it.

The [Google Analytics plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics) is also being deprecated, meaning there will be fewer options for analytics.

## Test Plan

Tested plugin locally and it is already in use.

### Test links

https://docusaurus.io/docs/api/plugins

Deploy preview: https://deploy-preview-10163--docusaurus-2.netlify.app/docs/api/plugins/

## Related issues/PRs

https://github.com/PostHog/posthog.com/pull/8512
https://github.com/PostHog/posthog-docusaurus/pull/15
