### PR TITLE
fix(mdx-loader): resolve Markdown/MDX links with Remark instead of RegExp 

### DIFF
--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -17,6 +17,7 @@ import stringifyObject from 'stringify-object';
 import preprocessor from './preprocessor';
 import {validateMDXFrontMatter} from './frontMatter';
 import {createProcessorCached} from './processor';
+import type {ResolveMarkdownLink} from './remark/linkify';
 import type {MDXOptions} from './processor';
 
 import type {MarkdownConfig} from '@docusaurus/types';
@@ -45,6 +46,7 @@ export type Options = Partial<MDXOptions> & {
     frontMatter: {[key: string]: unknown};
     metadata: {[key: string]: unknown};
   }) => {[key: string]: unknown};
+  resolveMarkdownLink?: ResolveMarkdownLink;
 };
 
 /**

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -10,6 +10,7 @@ import contentTitle from './remark/contentTitle';
 import toc from './remark/toc';
 import transformImage from './remark/transformImage';
 import transformLinks from './remark/transformLinks';
+import linkify from './remark/linkify';
 import details from './remark/details';
 import head from './remark/head';
 import mermaid from './remark/mermaid';
@@ -120,6 +121,10 @@ async function createProcessorFactory() {
           siteDir: options.siteDir,
         },
       ],
+      // TODO merge this with transformLinks?
+      options.resolveMarkdownLink
+        ? [linkify, {resolveMarkdownLink: options.resolveMarkdownLink}]
+        : undefined,
       [
         transformLinks,
         {

--- a/packages/docusaurus-mdx-loader/src/remark/linkify/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/linkify/__tests__/index.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import remark2rehype from 'remark-rehype';
+import stringify from 'rehype-stringify';
+import mermaid from '..';
+
+async function process(content: string) {
+  const {remark} = await import('remark');
+
+  // const {default: mdx} = await import('remark-mdx');
+  // const result = await remark().use(mermaid).use(mdx).process(content);
+
+  const result = await remark()
+    .use(mermaid)
+    .use(remark2rehype)
+    .use(stringify)
+    .process(content);
+
+  return result.value;
+}
+
+describe('mermaid remark plugin', () => {
+  it("does nothing if there's no mermaid code block", async () => {
+    const result = await process(
+      `# Heading 1
+
+No Mermaid diagram :(
+
+\`\`\`js
+this is not mermaid
+\`\`\`
+`,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "<h1>Heading 1</h1>
+      <p>No Mermaid diagram :(</p>
+      <pre><code class="language-js">this is not mermaid
+      </code></pre>"
+    `);
+  });
+
+  it('works for basic mermaid code blocks', async () => {
+    const result = await process(`# Heading 1
+
+\`\`\`mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+\`\`\``);
+    expect(result).toMatchInlineSnapshot(`
+      "<h1>Heading 1</h1>
+      <mermaid value="graph TD;
+          A-->B;
+          A-->C;
+          B-->D;
+          C-->D;"></mermaid>"
+    `);
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/remark/linkify/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/linkify/index.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {stringifyContent} from '../utils';
+
+// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
+import type {Transformer} from 'unified';
+import type {Link} from 'mdast';
+
+export type ResolveMarkdownLink = ({
+  link,
+  filePath,
+}: {
+  link: string;
+  filePath: string;
+}) => string | undefined;
+
+// TODO: this plugin shouldn't be in the core MDX loader
+// After we allow plugins to provide Remark/Rehype plugins (see
+// https://github.com/facebook/docusaurus/issues/6370), this should be provided
+// by theme-mermaid itself
+export interface PluginOptions {
+  resolveMarkdownLink: ResolveMarkdownLink;
+}
+
+// TODO as of April 2023, no way to import/re-export this ESM type easily :/
+// TODO upgrade to TS 5.3
+// See https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1517839391
+// import type {Plugin} from 'unified';
+type Plugin = any; // TODO fix this asap
+
+const LINK_PATTERN = /\.mdx?$/g;
+
+function ignoreLink(link: Link) {
+  // Probably not 100% accurate, but this is faster than proper url parsing
+  // Historical code, nobody complained about it so far
+  const hasProtocol =
+    link.url.toLowerCase().startsWith('http://') ||
+    link.url.toLowerCase().startsWith('https://');
+  return hasProtocol || !LINK_PATTERN.test(link.url);
+}
+
+export type BrokenMarkdownLink = {
+  /** Absolute path to the file containing this link. */
+  filePath: string;
+  /**
+   * The content of the link, like `"./brokenFile.md"`
+   */
+  link: Link;
+};
+
+/**
+ * A remark plugin to extract the h1 heading found in Markdown files
+ * This is exposed as "data.contentTitle" to the processed vfile
+ * Also gives the ability to strip that content title (used for the blog plugin)
+ */
+const plugin: Plugin = function plugin(options: PluginOptions): Transformer {
+  const {resolveMarkdownLink} = options;
+  return async (root, file) => {
+    const {toString} = await import('mdast-util-to-string');
+
+    const {visit} = await import('unist-util-visit');
+
+    const brokenMarkdownLinks: BrokenMarkdownLink[] = [];
+
+    visit(root, 'link', (link: Link) => {
+      if (ignoreLink(link)) {
+        return;
+      }
+      const permalink = resolveMarkdownLink({
+        link: link.url,
+        filePath: file.path,
+      });
+
+      /*
+            const sourcesToTry: string[] = [];
+      // ./file.md and ../file.md are always relative to the current file
+      if (!mdLink.startsWith('./') && !mdLink.startsWith('../')) {
+        sourcesToTry.push(...getContentPathList(contentPaths), siteDir);
+      }
+      // /file.md is always relative to the content path
+      if (!mdLink.startsWith('/')) {
+        sourcesToTry.push(path.dirname(filePath));
+      }
+
+      const aliasedSourceMatch = sourcesToTry
+        .map((p) => path.join(p, decodeURIComponent(mdLink)))
+        .map((source) => aliasedSitePath(source, siteDir))
+        .find((source) => sourceToPermalink[source]);
+
+      const permalink: string | undefined = aliasedSourceMatch
+        ? sourceToPermalink[aliasedSourceMatch]
+        : undefined;
+
+       */
+      if (permalink) {
+        console.log(`✅ Markdown link resolved: ${link.url} => ${permalink}`);
+        link.url = permalink;
+      } else {
+        const linkContent = stringifyContent(link, toString);
+        console.log(`❌ Markdown link broken: [${linkContent}](${link.url})`);
+        brokenMarkdownLinks.push({
+          filePath: file.path,
+          link,
+        });
+      }
+    });
+
+    if (brokenMarkdownLinks.length > 0) {
+      console.log(
+        `❌ ${brokenMarkdownLinks.length} broken Markdown links for ${file.path}\n`,
+      );
+    }
+  };
+};
+
+export default plugin;

--- a/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {linkify} from './linkify';
+// import {linkify} from './linkify';
 import type {DocsMarkdownOption} from '../types';
 import type {LoaderContext} from 'webpack';
 
@@ -15,6 +15,7 @@ export default function markdownLoader(
 ): void {
   const fileString = source;
   const callback = this.async();
-  const options = this.getOptions();
-  return callback(null, linkify(fileString, this.resourcePath, options));
+  // const options = this.getOptions();
+  // return callback(null, linkify(fileString, this.resourcePath, options));
+  return callback(null, fileString);
 }

--- a/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
+++ b/packages/docusaurus-plugin-content-docs/src/markdown/linkify.ts
@@ -7,8 +7,12 @@
 
 import {replaceMarkdownLinks, getContentPathList} from '@docusaurus/utils';
 import type {DocsMarkdownOption} from '../types';
+import type {VersionMetadata} from '@docusaurus/plugin-content-docs';
 
-function getVersion(filePath: string, options: DocsMarkdownOption) {
+export function getVersion(
+  filePath: string,
+  options: DocsMarkdownOption,
+): VersionMetadata {
   const versionFound = options.versionsMetadata.find((version) =>
     getContentPathList(version).some((docsDirPath) =>
       filePath.startsWith(docsDirPath),

--- a/packages/docusaurus-utils/src/markdownLinks.ts
+++ b/packages/docusaurus-utils/src/markdownLinks.ts
@@ -69,6 +69,7 @@ function parseCodeFence(line: string): CodeFence | null {
  * `<siteDir>/docs/tutorials/intro.md`). Links that contain the `http(s):` or
  * `@site/` prefix will always be ignored.
  */
+// TODO remove this
 export function replaceMarkdownLinks<T extends ContentPaths>({
   siteDir,
   fileString,


### PR DESCRIPTION

## Motivation

Implement proper resolution of Markdown links (`[title](./file.md)`) 

We process the AST with Remark instead of a raw string with hacky RegExp that don't understand well comments, code blocks, etc...

Fix https://github.com/facebook/docusaurus/issues/9048

## Test Plan

Unit tests + dogfooding (all links on our own website should keep resolving)

### Test links



Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

