### PR TITLE
chore: unlock site deploy for i18n with onInlineTags warn

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -492,7 +492,7 @@ export default async function createConfigAsync() {
             blogDescription: 'Read blog posts about Docusaurus from the team',
             blogSidebarCount: 'ALL',
             blogSidebarTitle: 'All our posts',
-            onInlineTags: 'throw',
+            onInlineTags: 'warn',
           } satisfies BlogOptions,
           pages: {
             remarkPlugins: [npm2yarn],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -492,7 +492,10 @@ export default async function createConfigAsync() {
             blogDescription: 'Read blog posts about Docusaurus from the team',
             blogSidebarCount: 'ALL',
             blogSidebarTitle: 'All our posts',
-            onInlineTags: 'warn',
+            onInlineTags:
+              process.env.DOCUSAURUS_CURRENT_LOCALE !== defaultLocale
+                ? 'warn'
+                : 'throw',
           } satisfies BlogOptions,
           pages: {
             remarkPlugins: [npm2yarn],


### PR DESCRIPTION
## Motivation

i18n site should be less strict in terms of `onInlineTags` setting otherwise our current site can't build due to existing front matter tags being translated and not appearing in `tags.yml`

It is a temporary solution and would be better to translate the tags file instead of the tags front matter in the future.

## Test Plan

Site deploy works

### Test links

https://deploy-preview-10191--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/pull/10137
