### PR TITLE
fix: escape period

### DIFF
--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -80,7 +80,7 @@ export async function serve(
     if (baseUrl !== '/') {
       // Not super robust, but should be good enough for our use case
       // See https://github.com/facebook/docusaurus/pull/10090
-      const looksLikeAsset = !!req.url.match(/.[a-zA-Z\d]{1,4}$/);
+      const looksLikeAsset = !!req.url.match(/\.[a-zA-Z\d]{1,4}$/);
       if (!looksLikeAsset) {
         const normalizedUrl = applyTrailingSlash(req.url, {
           trailingSlash,


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] ~**If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.~

## Motivation

I believe the intended purpose of `looksLikeAsset` is to check for request URLs that ends with a file extension (e.g. `.mp4`). But without escaping the period, it will match every URL that ends with a sequence of 4 alphanumeric characters.

## Test Plan

N/A

### Test links

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

The related code was added in #10142