### PR TITLE
fix(core): fix sites unable to start/build without a static dir

### DIFF
--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -51,7 +51,7 @@ async function createBaseClientConfig({
         name: 'Client',
       }),
       await createStaticDirectoriesCopyPlugin({props}),
-    ],
+    ].filter(Boolean),
   });
 }
 


### PR DESCRIPTION

## Motivation

A site should be able to start/build without a `/static` dir

Fix https://github.com/facebook/docusaurus/issues/10212

Fix regression introduced with refactor in https://github.com/facebook/docusaurus/pull/9859

## Test Plan

local test 😅 
