### PR TITLE
chore: simplify TypeScript configs, use TS 5.5 configDir placeholder

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -58,9 +58,9 @@ jobs:
         run: yarn workspace website typecheck
       - name: TypeCheck website - min version - v5.1
         run: |
-          yarn add typescript@5.1.6 --exact -D -W
+          yarn add typescript@5.1.6 --exact -D -W --ignore-scripts
           yarn workspace website typecheck
       - name: TypeCheck website - max version - Latest
         run: |
-          yarn add typescript@latest --exact -D -W
+          yarn add typescript@latest --exact -D -W --ignore-scripts
           yarn workspace website typecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,9 +49,9 @@ jobs:
         run: yarn workspace website typecheck
       - name: TypeCheck website - min version - v5.1
         run: |
-          yarn add typescript@5.1.6 --exact -D -W
+          yarn add typescript@5.1.6 --exact -D -W --ignore-scripts
           yarn workspace website typecheck
       - name: TypeCheck website - max version - Latest
         run: |
-          yarn add typescript@latest --exact -D -W
+          yarn add typescript@latest --exact -D -W --ignore-scripts
           yarn workspace website typecheck

--- a/__tests__/validate-tsconfig.test.ts
+++ b/__tests__/validate-tsconfig.test.ts
@@ -35,15 +35,6 @@ const tsconfigSchema = Joi.object({
     '../../tsconfig.base.json',
     '../../tsconfig.base.client.json',
   ),
-  compilerOptions: Joi.object({
-    rootDir: Joi.valid('src').required(),
-    outDir: Joi.valid('lib').required(),
-    tsBuildInfoFile: Joi.valid(
-      'lib/.tsbuildinfo',
-      'lib/.tsbuildinfo-client',
-      'lib/.tsbuildinfo-worker',
-    ),
-  }).unknown(),
 }).unknown();
 
 describe('tsconfig files', () => {
@@ -52,7 +43,6 @@ describe('tsconfig files', () => {
 
     tsconfigFiles
       // Ignore noEmit configs
-      .filter((file) => !(file.content.compilerOptions!.noEmit === true))
       .forEach((file) => {
         try {
           Joi.attempt(file.content, tsconfigSchema);

--- a/packages/create-docusaurus/tsconfig.build.json
+++ b/packages/create-docusaurus/tsconfig.build.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "composite": true,
-    "incremental": true,
     "tsBuildInfoFile": "lib/.tsbuildinfo-build"
   },
   "include": ["src"],

--- a/packages/create-docusaurus/tsconfig.build.json
+++ b/packages/create-docusaurus/tsconfig.build.json
@@ -4,9 +4,7 @@
     "noEmit": false,
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "tsBuildInfoFile": "lib/.tsbuildinfo-build"
   },
   "include": ["src"],
   "exclude": ["templates/", "**/__tests__/**"]

--- a/packages/create-docusaurus/tsconfig.json
+++ b/packages/create-docusaurus/tsconfig.json
@@ -5,6 +5,6 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": ["bin"],
+  "include": ["package.json", "bin"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-cssnano-preset/tsconfig.json
+++ b/packages/docusaurus-cssnano-preset/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": false
   },
-  "include": ["package.json", "src"],
+  "include": ["src"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-cssnano-preset/tsconfig.json
+++ b/packages/docusaurus-cssnano-preset/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-cssnano-preset/tsconfig.json
+++ b/packages/docusaurus-cssnano-preset/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": false
   },
-  "include": ["src"],
+  "include": ["package.json", "src"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-cssnano-preset/tsconfig.json
+++ b/packages/docusaurus-cssnano-preset/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-logger/tsconfig.json
+++ b/packages/docusaurus-logger/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
     "sourceMap": true,
     "declarationMap": true
   },

--- a/packages/docusaurus-logger/tsconfig.json
+++ b/packages/docusaurus-logger/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
     "sourceMap": true,
-    "declarationMap": true,
-    "rootDir": "src",
-    "outDir": "lib"
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-mdx-loader/tsconfig.json
+++ b/packages/docusaurus-mdx-loader/tsconfig.json
@@ -3,12 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
     "sourceMap": true,
-    "declarationMap": true,
-    "rootDir": "src",
-    "outDir": "lib",
-    "types": []
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-mdx-loader/tsconfig.json
+++ b/packages/docusaurus-mdx-loader/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
     "sourceMap": true,
     "declarationMap": true
   },
-  "include": ["src"],
+  "include": ["package.json", "src"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-client-redirects/tsconfig.json
+++ b/packages/docusaurus-plugin-client-redirects/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-client-redirects/tsconfig.json
+++ b/packages/docusaurus-plugin-client-redirects/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-content-blog/tsconfig.client.json
+++ b/packages/docusaurus-plugin-content-blog/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/client", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-content-blog/tsconfig.json
+++ b/packages/docusaurus-plugin-content-blog/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/client", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-content-blog/tsconfig.json
+++ b/packages/docusaurus-plugin-content-blog/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/client", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-content-docs/tsconfig.client.json
+++ b/packages/docusaurus-plugin-content-docs/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/client", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-content-docs/tsconfig.json
+++ b/packages/docusaurus-plugin-content-docs/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/client", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-content-docs/tsconfig.json
+++ b/packages/docusaurus-plugin-content-docs/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/client", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-content-pages/tsconfig.json
+++ b/packages/docusaurus-plugin-content-pages/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-content-pages/tsconfig.json
+++ b/packages/docusaurus-plugin-content-pages/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-debug/tsconfig.client.json
+++ b/packages/docusaurus-plugin-debug/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/theme", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-debug/tsconfig.json
+++ b/packages/docusaurus-plugin-debug/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-debug/tsconfig.json
+++ b/packages/docusaurus-plugin-debug/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-google-analytics/tsconfig.client.json
+++ b/packages/docusaurus-plugin-google-analytics/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/analytics.ts", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-google-analytics/tsconfig.json
+++ b/packages/docusaurus-plugin-google-analytics/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/analytics.ts", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-google-analytics/tsconfig.json
+++ b/packages/docusaurus-plugin-google-analytics/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/analytics.ts", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.client.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/gtag.ts", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/gtag.ts", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-google-gtag/tsconfig.json
+++ b/packages/docusaurus-plugin-google-gtag/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/gtag.ts", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-google-tag-manager/tsconfig.client.json
+++ b/packages/docusaurus-plugin-google-tag-manager/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-google-tag-manager/tsconfig.json
+++ b/packages/docusaurus-plugin-google-tag-manager/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-google-tag-manager/tsconfig.json
+++ b/packages/docusaurus-plugin-google-tag-manager/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-ideal-image/tsconfig.client.json
+++ b/packages/docusaurus-plugin-ideal-image/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/theme", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-ideal-image/tsconfig.json
+++ b/packages/docusaurus-plugin-ideal-image/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-ideal-image/tsconfig.json
+++ b/packages/docusaurus-plugin-ideal-image/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-pwa/tsconfig.client.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": [
     "src/theme/",
     "src/*.d.ts",

--- a/packages/docusaurus-plugin-pwa/tsconfig.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.json
@@ -6,10 +6,7 @@
   ],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": [

--- a/packages/docusaurus-plugin-pwa/tsconfig.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.json
@@ -5,8 +5,7 @@
     {"path": "./tsconfig.worker.json"}
   ],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": [

--- a/packages/docusaurus-plugin-pwa/tsconfig.worker.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.worker.json
@@ -6,8 +6,6 @@
     "incremental": true,
     "lib": ["webworker", "esnext"],
     "tsBuildInfoFile": "lib/.tsbuildinfo-worker",
-    "rootDir": "src",
-    "outDir": "lib",
     "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext",

--- a/packages/docusaurus-plugin-pwa/tsconfig.worker.json
+++ b/packages/docusaurus-plugin-pwa/tsconfig.worker.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "composite": true,
-    "incremental": true,
     "lib": ["webworker", "esnext"],
     "tsBuildInfoFile": "lib/.tsbuildinfo-worker",
     "moduleResolution": "bundler",

--- a/packages/docusaurus-plugin-sitemap/tsconfig.json
+++ b/packages/docusaurus-plugin-sitemap/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-sitemap/tsconfig.json
+++ b/packages/docusaurus-plugin-sitemap/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-plugin-vercel-analytics/tsconfig.client.json
+++ b/packages/docusaurus-plugin-vercel-analytics/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/analytics.ts", "src/options.ts", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-plugin-vercel-analytics/tsconfig.json
+++ b/packages/docusaurus-plugin-vercel-analytics/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/analytics.ts", "**/__tests__/**"]

--- a/packages/docusaurus-plugin-vercel-analytics/tsconfig.json
+++ b/packages/docusaurus-plugin-vercel-analytics/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/analytics.ts", "**/__tests__/**"]

--- a/packages/docusaurus-preset-classic/tsconfig.json
+++ b/packages/docusaurus-preset-classic/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-preset-classic/tsconfig.json
+++ b/packages/docusaurus-preset-classic/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-remark-plugin-npm2yarn/tsconfig.json
+++ b/packages/docusaurus-remark-plugin-npm2yarn/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
     "sourceMap": true,
     "declarationMap": true
   },

--- a/packages/docusaurus-remark-plugin-npm2yarn/tsconfig.json
+++ b/packages/docusaurus-remark-plugin-npm2yarn/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
     "sourceMap": true,
-    "declarationMap": true,
-    "rootDir": "src",
-    "outDir": "lib"
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-theme-classic/tsconfig.client.json
+++ b/packages/docusaurus-theme-classic/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": [
     "src/nprogress.ts",
     "src/prism-include-languages.ts",

--- a/packages/docusaurus-theme-classic/tsconfig.json
+++ b/packages/docusaurus-theme-classic/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": [

--- a/packages/docusaurus-theme-classic/tsconfig.json
+++ b/packages/docusaurus-theme-classic/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": [

--- a/packages/docusaurus-theme-common/tsconfig.json
+++ b/packages/docusaurus-theme-common/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.base.client.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client",
     "sourceMap": true,
     "declarationMap": true
   },

--- a/packages/docusaurus-theme-live-codeblock/tsconfig.client.json
+++ b/packages/docusaurus-theme-live-codeblock/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/theme", "src/*.d.ts", "src/custom-buble.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-theme-live-codeblock/tsconfig.json
+++ b/packages/docusaurus-theme-live-codeblock/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/custom-buble.ts", "src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-theme-live-codeblock/tsconfig.json
+++ b/packages/docusaurus-theme-live-codeblock/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/custom-buble.ts", "src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-theme-mermaid/tsconfig.client.json
+++ b/packages/docusaurus-theme-mermaid/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/client", "src/theme", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-theme-mermaid/tsconfig.json
+++ b/packages/docusaurus-theme-mermaid/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/client", "src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-theme-mermaid/tsconfig.json
+++ b/packages/docusaurus-theme-mermaid/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/client", "src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-theme-search-algolia/tsconfig.client.json
+++ b/packages/docusaurus-theme-search-algolia/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/theme", "src/client", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus-theme-search-algolia/tsconfig.json
+++ b/packages/docusaurus-theme-search-algolia/tsconfig.json
@@ -3,10 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["src/client", "src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-theme-search-algolia/tsconfig.json
+++ b/packages/docusaurus-theme-search-algolia/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["src/client", "src/theme", "**/__tests__/**"]

--- a/packages/docusaurus-theme-translations/tsconfig.build.json
+++ b/packages/docusaurus-theme-translations/tsconfig.build.json
@@ -1,14 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo-build",
     "noEmit": false,
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
     "sourceMap": true,
-    "declarationMap": true,
-    "rootDir": "src",
-    "outDir": "lib"
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-theme-translations/tsconfig.build.json
+++ b/packages/docusaurus-theme-translations/tsconfig.build.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo-build",
     "noEmit": false,
-    "composite": true,
-    "incremental": true,
     "sourceMap": true,
     "declarationMap": true
   },

--- a/packages/docusaurus-theme-translations/tsconfig.json
+++ b/packages/docusaurus-theme-translations/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "references": [{"path": "./tsconfig.build.json"}],
   "compilerOptions": {
+    "rootDir": ".",
     "noEmit": true,
     "checkJs": true
   },

--- a/packages/docusaurus-utils-common/tsconfig.json
+++ b/packages/docusaurus-utils-common/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
     "sourceMap": true,
     "declarationMap": true,
     "noEmitHelpers": false

--- a/packages/docusaurus-utils-common/tsconfig.json
+++ b/packages/docusaurus-utils-common/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
     "sourceMap": true,
     "declarationMap": true,
-    "rootDir": "src",
-    "outDir": "lib",
     "noEmitHelpers": false
   },
   "include": ["src"],

--- a/packages/docusaurus-utils-validation/tsconfig.json
+++ b/packages/docusaurus-utils-validation/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
     "sourceMap": true,
     "declarationMap": true
   },

--- a/packages/docusaurus-utils-validation/tsconfig.json
+++ b/packages/docusaurus-utils-validation/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
     "sourceMap": true,
-    "declarationMap": true,
-    "rootDir": "src",
-    "outDir": "lib"
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus-utils/tsconfig.json
+++ b/packages/docusaurus-utils/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
     "sourceMap": true,
     "declarationMap": true
   },

--- a/packages/docusaurus-utils/tsconfig.json
+++ b/packages/docusaurus-utils/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
     "sourceMap": true,
-    "declarationMap": true,
-    "rootDir": "src",
-    "outDir": "lib"
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/docusaurus/tsconfig.client.json
+++ b/packages/docusaurus/tsconfig.client.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.base.client.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib",
-    "tsBuildInfoFile": "lib/.tsbuildinfo-client"
-  },
   "include": ["src/client", "src/*.d.ts"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus/tsconfig.json
+++ b/packages/docusaurus/tsconfig.json
@@ -9,6 +9,6 @@
     "checkJs": true,
     "rootDir": "."
   },
-  "include": ["bin"],
+  "include": ["package.json", "bin"],
   "exclude": ["**/__tests__/**"]
 }

--- a/packages/docusaurus/tsconfig.server.json
+++ b/packages/docusaurus/tsconfig.server.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "composite": true,
-    "incremental": true,
     "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo-server"
   },
   "include": ["src"],

--- a/packages/docusaurus/tsconfig.server.json
+++ b/packages/docusaurus/tsconfig.server.json
@@ -4,9 +4,7 @@
     "noEmit": false,
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo-server"
   },
   "include": ["src"],
   "exclude": ["src/client", "**/__tests__/**"]

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/lqip-loader/tsconfig.json
+++ b/packages/lqip-loader/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/lqip-loader/tsconfig.json
+++ b/packages/lqip-loader/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/stylelint-copyright/tsconfig.json
+++ b/packages/stylelint-copyright/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": false,
-    "incremental": true,
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
-    "rootDir": "src",
-    "outDir": "lib"
+    "incremental": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/stylelint-copyright/tsconfig.json
+++ b/packages/stylelint-copyright/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": true
+    "noEmit": false
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/tsconfig.base.client.json
+++ b/tsconfig.base.client.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo-client",
     "noEmit": false,
-    "composite": true,
-    "incremental": true,
     "moduleResolution": "bundler",
     "module": "esnext",
     "target": "esnext"

--- a/tsconfig.base.client.json
+++ b/tsconfig.base.client.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo-client",
     "noEmit": false,
     "composite": true,
     "incremental": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    // Base dirs
     "rootDir": "${configDir}/src",
     "outDir": "${configDir}/lib",
-    "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo",
+    "composite": true,
     "incremental": true,
+    "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo",
 
     /* Emit */
     "target": "ES2020",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,11 @@
 {
   "compilerOptions": {
+    // Base dirs
+    "rootDir": "${configDir}/src",
+    "outDir": "${configDir}/lib",
+    "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo",
+    "incremental": true,
+
     /* Emit */
     "target": "ES2020",
     "lib": ["ESNext"],


### PR DESCRIPTION

## Motivation

Avoids useless inheritance config file duplication

Use the new `${configDir}` placeholder in parent configs: 

https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-configdir-template-variable-for-configuration-files

## Test Plan

CI

### Test links


https://deploy-preview-10256--docusaurus-2.netlify.app/
