### PR TITLE
feat(core): allow plugins to self-disable by returning null

### DIFF
--- a/packages/docusaurus-plugin-client-redirects/src/index.ts
+++ b/packages/docusaurus-plugin-client-redirects/src/index.ts
@@ -21,7 +21,7 @@ const PluginName = 'docusaurus-plugin-client-redirects';
 export default function pluginClientRedirectsPages(
   context: LoadContext,
   options: PluginOptions,
-): Plugin<void> {
+): Plugin<void> | null {
   const {trailingSlash} = context.siteConfig;
   const router = context.siteConfig.future.experimental_router;
 
@@ -29,7 +29,7 @@ export default function pluginClientRedirectsPages(
     logger.warn(
       `${PluginName} does not support the Hash Router and will be disabled.`,
     );
-    return {name: PluginName};
+    return null;
   }
 
   return {

--- a/packages/docusaurus-plugin-google-analytics/src/index.ts
+++ b/packages/docusaurus-plugin-google-analytics/src/index.ts
@@ -18,21 +18,21 @@ import type {PluginOptions, Options} from './options';
 export default function pluginGoogleAnalytics(
   context: LoadContext,
   options: PluginOptions,
-): Plugin {
+): Plugin | null {
+  if (process.env.NODE_ENV !== 'production') {
+    return null;
+  }
+
   const {trackingID, anonymizeIP} = options;
-  const isProd = process.env.NODE_ENV === 'production';
 
   return {
     name: 'docusaurus-plugin-google-analytics',
 
     getClientModules() {
-      return isProd ? ['./analytics'] : [];
+      return ['./analytics'];
     },
 
     injectHtmlTags() {
-      if (!isProd) {
-        return {};
-      }
       return {
         headTags: [
           {

--- a/packages/docusaurus-plugin-google-gtag/src/index.ts
+++ b/packages/docusaurus-plugin-google-gtag/src/index.ts
@@ -32,8 +32,10 @@ function createConfigSnippets({
 export default function pluginGoogleGtag(
   context: LoadContext,
   options: PluginOptions,
-): Plugin {
-  const isProd = process.env.NODE_ENV === 'production';
+): Plugin | null {
+  if (process.env.NODE_ENV !== 'production') {
+    return null;
+  }
 
   const firstTrackingId = options.trackingID[0];
 
@@ -45,13 +47,10 @@ export default function pluginGoogleGtag(
     },
 
     getClientModules() {
-      return isProd ? ['./gtag'] : [];
+      return ['./gtag'];
     },
 
     injectHtmlTags() {
-      if (!isProd) {
-        return {};
-      }
       return {
         // Gtag includes GA by default, so we also preconnect to
         // google-analytics.

--- a/packages/docusaurus-plugin-google-tag-manager/src/index.ts
+++ b/packages/docusaurus-plugin-google-tag-manager/src/index.ts
@@ -16,10 +16,12 @@ import type {PluginOptions, Options} from './options';
 export default function pluginGoogleAnalytics(
   context: LoadContext,
   options: PluginOptions,
-): Plugin {
-  const {containerId} = options;
-  const isProd = process.env.NODE_ENV === 'production';
+): Plugin | null {
+  if (process.env.NODE_ENV !== 'production') {
+    return null;
+  }
 
+  const {containerId} = options;
   return {
     name: 'docusaurus-plugin-google-tag-manager',
 
@@ -28,9 +30,6 @@ export default function pluginGoogleAnalytics(
     },
 
     injectHtmlTags() {
-      if (!isProd) {
-        return {};
-      }
       return {
         preBodyTags: [
           {

--- a/packages/docusaurus-plugin-pwa/src/index.ts
+++ b/packages/docusaurus-plugin-pwa/src/index.ts
@@ -47,12 +47,17 @@ export default function pluginPWA(
   if (process.env.NODE_ENV !== 'production') {
     return null;
   }
+  if (context.siteConfig.future.experimental_router === 'hash') {
+    logger.warn(
+      `${PluginName} does not support the Hash Router and will be disabled.`,
+    );
+    return null;
+  }
 
   const {
     outDir,
     baseUrl,
     i18n: {currentLocale},
-    siteConfig,
   } = context;
   const {
     debug,
@@ -62,13 +67,6 @@ export default function pluginPWA(
     swCustom,
     swRegister,
   } = options;
-
-  if (siteConfig.future.experimental_router === 'hash') {
-    logger.warn(
-      `${PluginName} does not support the Hash Router and will be disabled.`,
-    );
-    return null;
-  }
 
   return {
     name: PluginName,

--- a/packages/docusaurus-plugin-sitemap/src/index.ts
+++ b/packages/docusaurus-plugin-sitemap/src/index.ts
@@ -17,12 +17,12 @@ const PluginName = 'docusaurus-plugin-sitemap';
 export default function pluginSitemap(
   context: LoadContext,
   options: PluginOptions,
-): Plugin<void> {
+): Plugin<void> | null {
   if (context.siteConfig.future.experimental_router === 'hash') {
     logger.warn(
       `${PluginName} does not support the Hash Router and will be disabled.`,
     );
-    return {name: PluginName};
+    return null;
   }
 
   return {

--- a/packages/docusaurus-plugin-vercel-analytics/src/index.ts
+++ b/packages/docusaurus-plugin-vercel-analytics/src/index.ts
@@ -11,14 +11,15 @@ import type {PluginOptions, Options} from './options';
 export default function pluginVercelAnalytics(
   context: LoadContext,
   options: PluginOptions,
-): Plugin {
-  const isProd = process.env.NODE_ENV === 'production';
-
+): Plugin | null {
+  if (process.env.NODE_ENV !== 'production') {
+    return null;
+  }
   return {
     name: 'docusaurus-plugin-vercel-analytics',
 
     getClientModules() {
-      return isProd ? ['./analytics'] : [];
+      return ['./analytics'];
     },
 
     contentLoaded({actions}) {

--- a/packages/docusaurus-types/src/plugin.d.ts
+++ b/packages/docusaurus-types/src/plugin.d.ts
@@ -191,7 +191,10 @@ export type LoadedPlugin = InitializedPlugin & {
 export type PluginModule<Content = unknown> = {
   (context: LoadContext, options: unknown):
     | Plugin<Content>
-    | Promise<Plugin<Content>>;
+    | Promise<Plugin<Content>>
+    | null
+    | Promise<null>;
+
   validateOptions?: <T, U>(data: OptionValidationContext<T, U>) => U;
   validateThemeConfig?: <T>(data: ThemeConfigValidationContext<T>) => T;
 

--- a/packages/docusaurus/src/commands/swizzle/context.ts
+++ b/packages/docusaurus/src/commands/swizzle/context.ts
@@ -18,6 +18,8 @@ export async function initSwizzleContext(
   const plugins = await initPlugins(context);
   const pluginConfigs = await loadPluginConfigs(context);
 
+  // TODO same index assumption is now wrong!
+
   return {
     plugins: plugins.map((plugin, pluginIndex) => ({
       plugin: pluginConfigs[pluginIndex]!,

--- a/packages/docusaurus/src/commands/swizzle/context.ts
+++ b/packages/docusaurus/src/commands/swizzle/context.ts
@@ -6,24 +6,41 @@
  */
 
 import {loadContext} from '../../server/site';
-import {initPlugins} from '../../server/plugins/init';
+import {initPluginsConfigs} from '../../server/plugins/init';
 import {loadPluginConfigs} from '../../server/plugins/configs';
-import type {SwizzleCLIOptions, SwizzleContext} from './common';
+import type {SwizzleCLIOptions, SwizzleContext, SwizzlePlugin} from './common';
+import type {LoadContext} from '@docusaurus/types';
+
+async function getSwizzlePlugins(
+  context: LoadContext,
+): Promise<SwizzlePlugin[]> {
+  const pluginConfigs = await loadPluginConfigs(context);
+  const pluginConfigInitResults = await initPluginsConfigs(
+    context,
+    pluginConfigs,
+  );
+
+  return pluginConfigInitResults.flatMap((initResult) => {
+    // Ignore self-disabling plugins returning null
+    if (initResult.plugin === null) {
+      return [];
+    }
+    return [
+      // TODO this is a bit confusing, need refactor
+      {
+        plugin: initResult.config,
+        instance: initResult.plugin,
+      },
+    ];
+  });
+}
 
 export async function initSwizzleContext(
   siteDir: string,
   options: SwizzleCLIOptions,
 ): Promise<SwizzleContext> {
   const context = await loadContext({siteDir, config: options.config});
-  const plugins = await initPlugins(context);
-  const pluginConfigs = await loadPluginConfigs(context);
-
-  // TODO same index assumption is now wrong!
-
   return {
-    plugins: plugins.map((plugin, pluginIndex) => ({
-      plugin: pluginConfigs[pluginIndex]!,
-      instance: plugin,
-    })),
+    plugins: await getSwizzlePlugins(context),
   };
 }

--- a/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-undefined-plugin/docusaurus.config.js
+++ b/packages/docusaurus/src/server/plugins/__tests__/__fixtures__/site-with-undefined-plugin/docusaurus.config.js
@@ -13,22 +13,7 @@ module.exports = {
   favicon: 'img/favicon.ico',
   plugins: [
     function (context, options) {
-      return {name: 'first-plugin'};
+      return undefined;
     },
-    [
-      function (context, options) {
-        return {name: 'second-plugin'};
-      },
-      {it: 'should work'},
-    ],
-    function (context, options) {
-      // it's ok for a plugin to self-disable
-      return null;
-    },
-    './plugin3.js',
-    ['./plugin4.js', {}],
-    './pluginEsm',
-    './pluginTypeScript',
   ],
-  presets: ['./preset.js'],
 };

--- a/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/init.test.ts
@@ -24,7 +24,7 @@ async function loadSite(
 describe('initPlugins', () => {
   it('parses plugins correctly and loads them in correct order', async () => {
     const {context, plugins} = await loadSite('site-with-plugin');
-    expect(context.siteConfig.plugins).toHaveLength(6);
+    expect(context.siteConfig.plugins).toHaveLength(7);
     expect(plugins).toHaveLength(10);
 
     expect(plugins[0]!.name).toBe('preset-plugin1');
@@ -83,6 +83,15 @@ describe('initPlugins', () => {
       .toThrowErrorMatchingInlineSnapshot(`
       "A Docusaurus plugin is missing a 'name' property.
       Note that even inline/anonymous plugin functions require a 'name' property."
+    `);
+  });
+
+  it('throws user-friendly error message for plugins returning undefined', async () => {
+    await expect(() => loadSite('site-with-undefined-plugin')).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      "A Docusaurus plugin returned 'undefined', which is forbidden.
+      A plugin is expected to return an object having at least a 'name' property.
+      If you want a plugin to self-disable depending on context/options, you can explicitly return 'null' instead of 'undefined'"
     `);
   });
 });

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -114,11 +114,22 @@ export async function initPlugins(
     );
     const pluginOptions = doValidatePluginOptions(normalizedPluginConfig);
 
+    // Side-effect: merge the normalized theme config in the original one
+    // Note: it's important to do this before calling the plugin constructor
+    // Example: the theme classic plugin will read siteConfig.themeConfig
+    context.siteConfig.themeConfig = {
+      ...context.siteConfig.themeConfig,
+      ...doValidateThemeConfig(normalizedPluginConfig),
+    };
+
     const pluginInstance = await normalizedPluginConfig.plugin(
       context,
       pluginOptions,
     );
 
+    // Returning null has been explicitly allowed
+    // It's a way for plugins to self-disable depending on context
+    // See https://github.com/facebook/docusaurus/pull/10286
     if (pluginInstance === null) {
       return null;
     }
@@ -129,12 +140,6 @@ export async function initPlugins(
 Note that even inline/anonymous plugin functions require a 'name' property.`,
       );
     }
-
-    // Side-effect: merge the normalized theme config in the original one
-    context.siteConfig.themeConfig = {
-      ...context.siteConfig.themeConfig,
-      ...doValidateThemeConfig(normalizedPluginConfig),
-    };
 
     return {
       ...pluginInstance,

--- a/packages/docusaurus/src/server/plugins/init.ts
+++ b/packages/docusaurus/src/server/plugins/init.ts
@@ -133,6 +133,13 @@ export async function initPlugins(
     if (pluginInstance === null) {
       return null;
     }
+    if (pluginInstance === undefined) {
+      throw new Error(
+        `A Docusaurus plugin returned 'undefined', which is forbidden.
+A plugin is expected to return an object having at least a 'name' property.
+If you want a plugin to self-disable depending on context/options, you can explicitly return 'null' instead of 'undefined'`,
+      );
+    }
 
     if (!pluginInstance?.name) {
       throw new Error(


### PR DESCRIPTION

## Motivation

A plugin should be able to self-disable depending on context/options by returning `null`

We actually need this for our own plugins:

```ts
export default function pluginPWA(
  context: LoadContext,
  options: PluginOptions,
): Plugin<void> | null {
  if (process.env.NODE_ENV !== 'production') {
    return null;
  }
  if (context.siteConfig.future.experimental_router === 'hash') {
    logger.warn(
      `${PluginName} does not support the Hash Router and will be disabled.`,
    );
    return null;
  }
  
  return {
    name: PluginName, 
    // rest of plugin here...
  }
}
```

See also https://github.com/facebook/docusaurus/issues/10228#issuecomment-2217854540

## Test Plan

unit tests

### Test links

https://deploy-preview-10286--docusaurus-2.netlify.app/
