### PR TITLE
fix(theme): fix DocsVersionDropdownNavbarItem version link target

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import {
   useVersions,
-  useActiveDocContext
+  useActiveDocContext,
 } from '@docusaurus/plugin-content-docs/client';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 import {useDocsVersionCandidates} from '@docusaurus/theme-common/internal';
@@ -18,9 +18,11 @@ import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
 import type {Props} from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
 import type {LinkLikeNavbarItemProps} from '@theme/NavbarItem';
-import type {GlobalVersion,
+import type {
+  GlobalVersion,
   GlobalDoc,
-  ActiveDocContext} from '@docusaurus/plugin-content-docs/client';
+  ActiveDocContext,
+} from '@docusaurus/plugin-content-docs/client';
 
 function getVersionMainDoc(version: GlobalVersion): GlobalDoc {
   return version.docs.find((doc) => doc.id === version.mainDocId)!;

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import {
   useVersions,
-  useActiveDocContext,
+  useActiveDocContext
 } from '@docusaurus/plugin-content-docs/client';
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 import {useDocsVersionCandidates} from '@docusaurus/theme-common/internal';
@@ -17,10 +17,26 @@ import {useLocation} from '@docusaurus/router';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
 import type {Props} from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
-import type {GlobalVersion} from '@docusaurus/plugin-content-docs/client';
+import type {LinkLikeNavbarItemProps} from '@theme/NavbarItem';
+import type {GlobalVersion,
+  GlobalDoc,
+  ActiveDocContext} from '@docusaurus/plugin-content-docs/client';
 
-const getVersionMainDoc = (version: GlobalVersion) =>
-  version.docs.find((doc) => doc.id === version.mainDocId)!;
+function getVersionMainDoc(version: GlobalVersion): GlobalDoc {
+  return version.docs.find((doc) => doc.id === version.mainDocId)!;
+}
+
+function getVersionTargetDoc(
+  version: GlobalVersion,
+  activeDocContext: ActiveDocContext,
+): GlobalDoc {
+  // We try to link to the same doc, in another version
+  // When not possible, fallback to the "main doc" of the version
+  return (
+    activeDocContext.alternateDocVersions[version.name] ??
+    getVersionMainDoc(version)
+  );
+}
 
 export default function DocsVersionDropdownNavbarItem({
   mobile,
@@ -34,23 +50,21 @@ export default function DocsVersionDropdownNavbarItem({
   const activeDocContext = useActiveDocContext(docsPluginId);
   const versions = useVersions(docsPluginId);
   const {savePreferredVersionName} = useDocsPreferredVersion(docsPluginId);
-  const versionLinks = versions.map((version) => {
-    // We try to link to the same doc, in another version
-    // When not possible, fallback to the "main doc" of the version
-    const versionDoc =
-      activeDocContext.alternateDocVersions[version.name] ??
-      getVersionMainDoc(version);
+
+  function versionToLink(version: GlobalVersion): LinkLikeNavbarItemProps {
+    const targetDoc = getVersionTargetDoc(version, activeDocContext);
     return {
       label: version.label,
       // preserve ?search#hash suffix on version switches
-      to: `${versionDoc.path}${search}${hash}`,
+      to: `${targetDoc.path}${search}${hash}`,
       isActive: () => version === activeDocContext.activeVersion,
       onClick: () => savePreferredVersionName(version.name),
     };
-  });
-  const items = [
+  }
+
+  const items: LinkLikeNavbarItemProps[] = [
     ...dropdownItemsBefore,
-    ...versionLinks,
+    ...versions.map(versionToLink),
     ...dropdownItemsAfter,
   ];
 
@@ -69,7 +83,7 @@ export default function DocsVersionDropdownNavbarItem({
   const dropdownTo =
     mobile && items.length > 1
       ? undefined
-      : getVersionMainDoc(dropdownVersion).path;
+      : getVersionTargetDoc(dropdownVersion, activeDocContext).path;
 
   // We don't want to render a version dropdown with 0 or 1 item. If we build
   // the site with a single docs version (onlyIncludeVersions: ['1.0.0']),


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/10206

This ensures that the version dropdown "button" and the list item element are consistent and link to the same URL (the current doc, in that version)


![CleanShot 2024-07-10 at 17 37 37](https://github.com/facebook/docusaurus/assets/749374/8ffdc59b-edf5-42d4-9d9d-bc77f7b55a8c)

Previously, the "button" would link to the root of the docs while the list item would link to the doc.

## Test Plan

preview

### Test links

https://deploy-preview-10288--docusaurus-2.netlify.app/
