### PR TITLE
docs: remove deprecated partial toc warning

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -327,12 +327,6 @@ import PartialExample from './_markdown-partial-example.mdx';
 
 This way, you can reuse content among multiple pages and avoid duplicating materials.
 
-:::warning
-
-Currently, the table of contents does not contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
-
-:::
-
 ## Available exports {#available-exports}
 
 Within the MDX page, the following variables are available as globals:

--- a/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-react.mdx
@@ -327,12 +327,6 @@ import PartialExample from './_markdown-partial-example.mdx';
 
 This way, you can reuse content among multiple pages and avoid duplicating materials.
 
-:::warning
-
-Currently, the table of contents does not contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
-
-:::
-
 ## Available exports {#available-exports}
 
 Within the MDX page, the following variables are available as globals:

--- a/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-react.mdx
@@ -327,12 +327,6 @@ import PartialExample from './_markdown-partial-example.mdx';
 
 This way, you can reuse content among multiple pages and avoid duplicating materials.
 
-:::warning
-
-Currently, the table of contents does not contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
-
-:::
-
 ## Available exports {#available-exports}
 
 Within the MDX page, the following variables are available as globals:

--- a/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-react.mdx
@@ -327,12 +327,6 @@ import PartialExample from './_markdown-partial-example.mdx';
 
 This way, you can reuse content among multiple pages and avoid duplicating materials.
 
-:::warning
-
-Currently, the table of contents does not contain the imported Markdown headings. This is a technical limitation that we are trying to solve ([issue](https://github.com/facebook/docusaurus/issues/3915)).
-
-:::
-
 ## Available exports {#available-exports}
 
 Within the MDX page, the following variables are available as globals:


### PR DESCRIPTION


## Motivation

Warning is now useless because we fixed the limitation

replaces https://github.com/facebook/docusaurus/pull/10306