### PR TITLE
feat(mdx-loader): wrap mdx content title (`# Title`) in `<header>` for concistency

### DIFF
--- a/argos/tests/screenshot.spec.ts
+++ b/argos/tests/screenshot.spec.ts
@@ -41,6 +41,8 @@ function isBlacklisted(pathname: string) {
     '/feature-requests',
     // Flaky because of dynamic canary version fetched from npm
     '/community/canary',
+    // Flaky because of screenshots being taken dynamically
+    '/showcase',
     // Long blog post with many image carousels, often timeouts
     '/blog/2022/08/01/announcing-docusaurus-2.0',
   ];

--- a/packages/docusaurus-mdx-loader/src/remark/contentTitle/__tests__/index.test.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/contentTitle/__tests__/index.test.ts
@@ -19,7 +19,8 @@ async function process(
 describe('contentTitle remark plugin', () => {
   describe('extracts data.contentTitle', () => {
     it('extracts h1 heading', async () => {
-      const result = await process(`
+      const result = await process(
+        `
 # contentTitle 1
 
 ## Heading Two {#custom-heading-two}
@@ -27,13 +28,16 @@ describe('contentTitle remark plugin', () => {
 # contentTitle 2
 
 some **markdown** *content*
-  `);
+  `,
+        {removeContentTitle: true},
+      );
 
       expect(result.data.contentTitle).toBe('contentTitle 1');
     });
 
     it('extracts h1 heading alt syntax', async () => {
-      const result = await process(`
+      const result = await process(
+        `
 contentTitle alt
 ===
 
@@ -44,7 +48,9 @@ contentTitle alt
 # contentTitle 2
 
 some **markdown** *content*
-  `);
+  `,
+        {removeContentTitle: true},
+      );
 
       expect(result.data.contentTitle).toBe('contentTitle alt');
     });
@@ -87,11 +93,14 @@ some **markdown** *content*
     });
 
     it('is able to decently serialize Markdown syntax', async () => {
-      const result = await process(`
+      const result = await process(
+        `
 # some **markdown** \`content\` _italic_
 
 some **markdown** *content*
-  `);
+  `,
+        {removeContentTitle: true},
+      );
 
       expect(result.data.contentTitle).toBe('some markdown content italic');
     });

--- a/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
@@ -7,7 +7,10 @@
 
 // @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer} from 'unified';
-import type {Heading, Parent, RootContent} from 'mdast';
+import type {Heading, Parent} from 'mdast';
+
+// @ts-expect-error: ES support...
+import type {MdxJsxFlowElement} from 'mdast-util-mdx';
 
 // TODO as of April 2023, no way to import/re-export this ESM type easily :/
 // TODO upgrade to TS 5.3
@@ -22,16 +25,15 @@ interface PluginOptions {
 function wrapHeadingInJsxHeader(
   headingNode: Heading,
   parent: Parent,
-  index: number | undefined,
+  index: number,
 ) {
-  const article: RootContent = {
+  const header: MdxJsxFlowElement = {
     type: 'mdxJsxFlowElement',
     name: 'header',
     attributes: [],
     children: [headingNode],
   };
-  // @ts-expect-error: TODO how to fix?
-  parent.children[index] = article;
+  parent.children[index] = header;
 }
 
 /**
@@ -48,7 +50,6 @@ const plugin: Plugin = function plugin(
   return async (root, vfile) => {
     const {toString} = await import('mdast-util-to-string');
     const {visit, EXIT} = await import('unist-util-visit');
-
     visit(root, ['heading', 'thematicBreak'], (node, index, parent) => {
       if (node.type === 'heading') {
         const headingNode = node as Heading;
@@ -60,7 +61,7 @@ const plugin: Plugin = function plugin(
             // @ts-expect-error: TODO how to fix?
             parent!.children.splice(index, 1);
           } else {
-            wrapHeadingInJsxHeader(headingNode, parent, index);
+            wrapHeadingInJsxHeader(headingNode, parent, index!);
           }
           return EXIT; // We only handle the very first heading
         }

--- a/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
@@ -61,6 +61,9 @@ const plugin: Plugin = function plugin(
             // @ts-expect-error: TODO how to fix?
             parent!.children.splice(index, 1);
           } else {
+            // TODO in the future it might be better to export contentTitle as
+            // as JSX node to keep this logic a theme concern?
+            // See https://github.com/facebook/docusaurus/pull/10335#issuecomment-2250187371
             wrapHeadingInJsxHeader(headingNode, parent, index!);
           }
           return EXIT; // We only handle the very first heading

--- a/packages/docusaurus-mdx-loader/src/remark/head/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/head/index.ts
@@ -8,7 +8,7 @@
 // @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer} from 'unified';
 
-// @ts-expect-error: ES support...
+// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {MdxJsxFlowElement} from 'mdast-util-mdx';
 
 // Transform <head> to <Head>


### PR DESCRIPTION

## Motivation

Fix #8476

For consistency, we want to wrap it all h1 in a `<header>` tag, for both of these cases:
- using `title: Title` front matter (already wrapped in `<header>`
- using `# Title` in the MDX doc (previously not wrapped in `<header>`, now fixed)


## Test Plan

CI & argos

### Test links

https://deploy-preview-10335--docusaurus-2.netlify.app/docs

![CleanShot 2024-07-25 at 14 14 57](https://github.com/user-attachments/assets/3df4f167-e4b8-47bf-a82c-20767eb8a950)

We now have `<header><h1>` and not just `<h1>`


Argos reports small visual changes on `# Title` immediately followed by `## Section`, but in practice this is an improvement, consistent with front matter title behavior (less spacing)
