### PR TITLE
docs: Add @getcanary/docusaurus-pagefind in docs

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -108,6 +108,7 @@ FOUC
 froms
 funboxteam
 gabrielcsapo
+getcanary
 Gifs
 Goss
 Goyal
@@ -237,6 +238,8 @@ Outerbounds
 overrideable
 ozaki
 ozakione
+pagefind
+Pagefind
 pageview
 palenight
 Palenight

--- a/website/community/2-resources.mdx
+++ b/website/community/2-resources.mdx
@@ -43,6 +43,7 @@ See the <a href={require('@docusaurus/useBaseUrl').default('showcase')}>showcase
 - [meilisearch-docsearch](https://github.com/tauri-apps/meilisearch-docsearch) - Docusaurus plugin for [Meilisearch](https://www.meilisearch.com)
 - [@orama/plugin-docusaurus](https://github.com/askorama/orama/tree/main/packages/plugin-docusaurus) - [Orama](https://askorama.ai/) plugin for Docusaurus v2
 - [@orama/plugin-docusaurus-v3](https://github.com/askorama/orama/tree/main/packages/plugin-docusaurus-v3) - [Orama](https://askorama.ai/) plugin for Docusaurus v3
+- [@getcanary/docusaurus-pagefind](https://getcanary.dev/docs/integrations/docusaurus.html) - Create [Pagefind](https://pagefind.app/) index and use [Canary](https://github.com/fastrepl/canary) as UI primitives.
 
 ### Integrations {#integrations}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation
Add `@getcanary/docusaurus-pagefind` in docs.

This is useful for users who 
1. want to use `Pagefind` as search index. 
2. want customizable search UI

## Test Plan

None

### Test links

None

## Related issues/PRs

None
