### PR TITLE
fix: reduce number of concurrent git processes spawned

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -63,6 +63,12 @@ import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {DocFile, FullVersion} from './types';
 import type {RuleSetUseItem} from 'webpack';
 
+// Reduces number of concurrent Git processes spawned to get file commit date
+// See https://github.com/facebook/docusaurus/issues/10348
+const Concurrency = process.env.DOCUSAURUS_GIT_CONCURRENCY
+  ? parseInt(process.env.DOCUSAURUS_GIT_CONCURRENCY, 10)
+  : 100;
+
 // TODO this is bad, we should have a better way to do this (new lifecycle?)
 //  The source to permalink is currently a mutable map passed to the mdx loader
 //  for link resolution
@@ -191,7 +197,15 @@ export default async function pluginContentDocs(
             tagsFile,
           });
         }
-        return Promise.all(docFiles.map(processVersionDoc));
+        const results = [];
+        while (docFiles.length > 0) {
+          results.push(
+            ...(await Promise.all(
+              docFiles.splice(0, Concurrency).map(processVersionDoc),
+            )),
+          );
+        }
+        return results;
       }
 
       async function doLoadVersion(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
Fixes #10348 by adding an environment variable `DOCUSAURUS_GIT_CONCURRENCY` which defaults to 100.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
I ran `yarn clear:website && yarn build:website --locale en` and the before/after time were the same.

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
