### PR TITLE
fix(cli): Fix bad docusaurus CLI behavior on for --version, -V, --help, -h

### DIFF
--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -257,7 +257,7 @@ function isInternalCommand(command) {
 
 // There is no subcommand
 // TODO: can we use commander to handle this case?
-if (process.argv.length < 3 || process.argv[2]?.startsWith('--')) {
+if (process.argv.length < 3 || process.argv[2]?.startsWith('--') && process.argv[2]?!="--version") {
   cli.outputHelp();
   process.exit(1);
 }

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -254,6 +254,14 @@ function isExternalCommand(command) {
   return !!(command && !isInternalCommand(command) && !command.startsWith('-'));
 }
 
+// No command? We print the help message because Commander doesn't
+// Note argv looks like this: ['../node','../docusaurus.mjs','<command>',...rest]
+if (process.argv.length < 3) {
+  logger.error("You haven't provided any Docusaurus CLI command.");
+  cli.outputHelp();
+  process.exit(1);
+}
+
 // There is an unrecognized subcommand
 // Let plugins extend the CLI before parsing
 if (isExternalCommand(process.argv[2])) {

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -247,24 +247,16 @@ function isInternalCommand(command) {
   );
 }
 
-// process.argv always looks like this:
-// [
-//   '/path/to/node',
-//   '/path/to/docusaurus.mjs',
-//   '<subcommand>',
-//   ...subcommandArgs
-// ]
-
-// There is no subcommand
-// TODO: can we use commander to handle this case?
-if (process.argv.length < 3 || process.argv[2]?.startsWith('--') && process.argv[2]?!="--version") {
-  cli.outputHelp();
-  process.exit(1);
+/**
+ * @param {string | undefined} command
+ */
+function isExternalCommand(command) {
+  return !!(command && !isInternalCommand(command) && !command.startsWith('-'));
 }
 
 // There is an unrecognized subcommand
 // Let plugins extend the CLI before parsing
-if (!isInternalCommand(process.argv[2])) {
+if (isExternalCommand(process.argv[2])) {
   // TODO: in this step, we must assume default site structure because there's
   // no way to know the siteDir/config yet. Maybe the root cli should be
   // responsible for parsing these arguments?

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -222,7 +222,8 @@ cli
 
 cli.arguments('<command>').action((cmd) => {
   cli.outputHelp();
-  logger.error`    Unknown command name=${cmd}.`;
+  logger.error`Unknown Docusaurus CLI command name=${cmd}.`;
+  process.exit(1);
 });
 
 // === The above is the commander configuration ===
@@ -257,8 +258,8 @@ function isExternalCommand(command) {
 // No command? We print the help message because Commander doesn't
 // Note argv looks like this: ['../node','../docusaurus.mjs','<command>',...rest]
 if (process.argv.length < 3) {
-  logger.error("You haven't provided any Docusaurus CLI command.");
   cli.outputHelp();
+  logger.error`Please provide a Docusaurus CLI command.`;
   process.exit(1);
 }
 


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/10367

- `docusaurus -h/--help` should exit with status code 0 instead of 1
- `docusaurus -V/--version` should print the version and not the help, and should exit with status code 0 instead of 1

This lets Commander handle version/help properly, and remove useless workaround code

## Test Plan

local test by @slorber 

```bash
yarn workspace website docusaurus
yarn workspace website docusaurus --version
yarn workspace website docusaurus -V

yarn workspace website docusaurus -h
yarn workspace website docusaurus --help

yarn workspace website docusaurus start
yarn workspace website docusaurus build

yarn workspace website docusaurus docs:version myVersion

yarn workspace website docusaurus badCommand
yarn workspace website docusaurus --badOption
```

