### PR TITLE
fix(create-docusaurus): Improve init templates blog setup + fix warnings

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
+++ b/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
@@ -50,6 +50,10 @@ const config: Config = {
           // Remove this to remove the "edit this page" links.
           editUrl:
             'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          // Useful options to enforce blogging best practices
+          onInlineTags: 'warn',
+          onInlineAuthors: 'warn',
+          onUntruncatedBlogPosts: 'warn',
         },
         theme: {
           customCss: './src/css/custom.css',

--- a/packages/create-docusaurus/templates/classic/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/classic/docusaurus.config.js
@@ -56,6 +56,10 @@ const config = {
           // Remove this to remove the "edit this page" links.
           editUrl:
             'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          // Useful options to enforce blogging best practices
+          onInlineTags: 'warn',
+          onInlineAuthors: 'warn',
+          onUntruncatedBlogPosts: 'warn',
         },
         theme: {
           customCss: './src/css/custom.css',

--- a/packages/create-docusaurus/templates/shared/blog/2019-05-28-first-blog-post.md
+++ b/packages/create-docusaurus/templates/shared/blog/2019-05-28-first-blog-post.md
@@ -1,12 +1,12 @@
 ---
 slug: first-blog-post
 title: First Blog Post
-authors:
-  name: Gao Wei
-  title: Docusaurus Core Team
-  url: https://github.com/wgao19
-  image_url: https://github.com/wgao19.png
+authors: [slorber, yangshun]
 tags: [hola, docusaurus]
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet...
+
+<!-- truncate -->
+
+...consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet

--- a/packages/create-docusaurus/templates/shared/blog/2019-05-29-long-blog-post.md
+++ b/packages/create-docusaurus/templates/shared/blog/2019-05-29-long-blog-post.md
@@ -1,7 +1,7 @@
 ---
 slug: long-blog-post
 title: Long Blog Post
-authors: endi
+authors: yangshun
 tags: [hello, docusaurus]
 ---
 
@@ -9,7 +9,7 @@ This is the summary of a very long blog post,
 
 Use a `<!--` `truncate` `-->` comment to limit blog post size in the list view.
 
-<!--truncate-->
+<!-- truncate -->
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 

--- a/packages/create-docusaurus/templates/shared/blog/2021-08-01-mdx-blog-post.mdx
+++ b/packages/create-docusaurus/templates/shared/blog/2021-08-01-mdx-blog-post.mdx
@@ -11,10 +11,14 @@ Blog posts support [Docusaurus Markdown features](https://docusaurus.io/docs/mar
 
 Use the power of React to create interactive blog posts.
 
+:::
+
+{/* truncate */}
+
+For example, use JSX to create an interactive button:
+
 ```js
 <button onClick={() => alert('button clicked!')}>Click me!</button>
 ```
 
 <button onClick={() => alert('button clicked!')}>Click me!</button>
-
-:::

--- a/packages/create-docusaurus/templates/shared/blog/2021-08-26-welcome/index.md
+++ b/packages/create-docusaurus/templates/shared/blog/2021-08-26-welcome/index.md
@@ -7,6 +7,10 @@ tags: [facebook, hello, docusaurus]
 
 [Docusaurus blogging features](https://docusaurus.io/docs/blog) are powered by the [blog plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog).
 
+Here are a few tips you might find useful.
+
+<!-- truncate -->
+
 Simply add Markdown files (or folders) to the `blog` directory.
 
 Regular blog authors can be added to `authors.yml`.

--- a/packages/create-docusaurus/templates/shared/blog/authors.yml
+++ b/packages/create-docusaurus/templates/shared/blog/authors.yml
@@ -1,14 +1,9 @@
-endi:
-  name: Endilie Yacop Sucipto
-  title: Maintainer of Docusaurus
-  url: https://github.com/endiliey
-  image_url: https://github.com/endiliey.png
-
 yangshun:
   name: Yangshun Tay
   title: Front End Engineer @ Facebook
   url: https://github.com/yangshun
   image_url: https://github.com/yangshun.png
+  page: true
   socials:
     x: yangshunz
     github: yangshun
@@ -18,6 +13,9 @@ slorber:
   title: Docusaurus maintainer
   url: https://sebastienlorber.com
   image_url: https://github.com/slorber.png
+  page:
+    # customize the url of the author page at /blog/authors/<permalink>
+    permalink: '/all-sebastien-lorber-articles'
   socials:
     x: sebastienlorber
     linkedin: sebastienlorber

--- a/packages/create-docusaurus/templates/shared/blog/tags.yml
+++ b/packages/create-docusaurus/templates/shared/blog/tags.yml
@@ -2,14 +2,17 @@ facebook:
   label: Facebook
   permalink: /facebook
   description: Facebook tag description
+
 hello:
   label: Hello
   permalink: /hello
   description: Hello tag description
+
 docusaurus:
   label: Docusaurus
   permalink: /docusaurus
   description: Docusaurus tag description
+
 hola:
   label: Hola
   permalink: /hola

--- a/packages/docusaurus-plugin-content-blog/src/options.ts
+++ b/packages/docusaurus-plugin-content-blog/src/options.ts
@@ -68,9 +68,9 @@ export const DEFAULT_OPTIONS: PluginOptions = {
   showLastUpdateTime: false,
   showLastUpdateAuthor: false,
   processBlogPosts: async () => undefined,
-  onInlineTags: 'warn',
   tags: undefined,
   authorsBasePath: 'authors',
+  onInlineTags: 'warn',
   onInlineAuthors: 'warn',
   onUntruncatedBlogPosts: 'warn',
 };

--- a/project-words.txt
+++ b/project-words.txt
@@ -168,6 +168,7 @@ linkify
 Linkify
 Localizable
 lockb
+lorber
 Lorber
 Lorber's
 lqip


### PR DESCRIPTION

## Motivation

v3.5 templates do not lead to a great DX, printing the [2 new warnings](https://docusaurus.io/blog/releases/3.5#blog-consistency-options) we introduced recently:

![CleanShot 2024-08-12 at 13 30 12@2x](https://github.com/user-attachments/assets/a9e241c9-ae86-4c05-afd1-113fdd918d8a)

This PR improves the templates and other little things:
- Add truncation marker to all posts, with HTML + MDX comment
- Replace inline author with global author
- Add authors pages for all the global authors, one having a custom URL
- Add consistency options to the blog config by default so that it's easier for users to turn them off


## Test Plan

local, there's no way to test this in CI currently :/

### Test links

https://deploy-preview-10392--docusaurus-2.netlify.app/
