### PR TITLE
fix(theme-common): restore useContextualSearchFilters public API for retrocompatibility

### DIFF
--- a/packages/docusaurus-theme-common/src/index.ts
+++ b/packages/docusaurus-theme-common/src/index.ts
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {DEFAULT_SEARCH_TAG} from './utils/searchUtils';
+
 // TODO Docusaurus v4: remove these workarounds as a breaking change
 //  and remove docs plugin peerDeps in theme-common/package.json
 //  This is public API surface that we need to keep for v3
@@ -26,6 +29,14 @@ export function useDocsPreferredVersion(...args: unknown[]): unknown {
   return require('@docusaurus/plugin-content-docs/client').useDocsPreferredVersion(
     ...args,
   );
+}
+export function useContextualSearchFilters() {
+  const {i18n} = useDocusaurusContext();
+  const docsTags =
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('@docusaurus/plugin-content-docs/client').useDocsContextualSearchTags();
+  const tags = [DEFAULT_SEARCH_TAG, ...docsTags];
+  return {locale: i18n.currentLocale, tags};
 }
 
 /*


### PR DESCRIPTION

## Motivation

Restore theme-common API that we consider public.

This reverts an inadvertent breaking change I did while refactoring (https://github.com/facebook/docusaurus/pull/10316)

This breaking change breaks a local search plugin: https://github.com/cmfcmf/docusaurus-search-local/issues/217

This will be released as v3.5.2

## Test Plan

local

### Test links

https://deploy-preview-10397--docusaurus-2.netlify.app/
