### PR TITLE
refactor(core): remove useless build forceTerminate exit

### DIFF
--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -48,11 +48,6 @@ export type BuildCLIOptions = Pick<
 export async function build(
   siteDirParam: string = '.',
   cliOptions: Partial<BuildCLIOptions> = {},
-  // When running build, we force terminate the process to prevent async
-  // operations from never returning. However, if run as part of docusaurus
-  // deploy, we have to let deploy finish.
-  // See https://github.com/facebook/docusaurus/pull/2496
-  forceTerminate: boolean = true,
 ): Promise<void> {
   process.env.BABEL_ENV = 'production';
   process.env.NODE_ENV = 'production';
@@ -98,18 +93,11 @@ export async function build(
 
   await PerfLogger.async(`Build`, () =>
     mapAsyncSequential(locales, async (locale) => {
-      const isLastLocale = locales.indexOf(locale) === locales.length - 1;
       await tryToBuildLocale({locale});
-      if (isLastLocale) {
-        logger.info`Use code=${'npm run serve'} command to test your build locally.`;
-      }
-
-      // TODO do we really need this historical forceTerminate exit???
-      if (forceTerminate && isLastLocale && !cliOptions.bundleAnalyzer) {
-        process.exit(0);
-      }
     }),
   );
+
+  logger.info`Use code=${'npm run serve'} command to test your build locally.`;
 }
 
 async function getLocalesToBuild({

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -256,7 +256,7 @@ You can also set the deploymentBranch property in docusaurus.config.js .`);
   if (!cliOptions.skipBuild) {
     // Build site, then push to deploymentBranch branch of specified repo.
     try {
-      await build(siteDir, cliOptions, false);
+      await build(siteDir, cliOptions);
       await runDeploy(outDir);
     } catch (err) {
       logger.error('Deployment of the build output failed.');

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -42,14 +42,10 @@ export async function serve(
   const outDir = path.resolve(siteDir, buildDir);
 
   if (cliOptions.build) {
-    await build(
-      siteDir,
-      {
-        config: cliOptions.config,
-        outDir,
-      },
-      false,
-    );
+    await build(siteDir, {
+      config: cliOptions.config,
+      outDir,
+    });
   }
 
   const {host, port} = await getHostPort(cliOptions);


### PR DESCRIPTION

## Motivation

Calling `exit(0)` this way at the end of the build is annoying for various reasons:
- it prevents adding custom bundle analyzer plugins, and any other thing that should keep the process alive
- it hides potential problems and memory leaks

It was introduced a long time ago in https://github.com/facebook/docusaurus/pull/2443 due to the build being stuck. I believe the underlying problem has been solved now. 

And if user code does a weird thing that gets the build stuck, they should rather know about it.

We'll see if that cause troubles in practice but I'd like to take my bet a remove this code for now. We'll eventually find an alternative solution if this becomes a problem.


## Test Plan

CI

### Test links

https://deploy-preview-10410--docusaurus-2.netlify.app/

