### PR TITLE
refactor(mdx-loader): remove useless usage of mdx loader this.query

### DIFF
--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -229,31 +229,29 @@ type ProcessorsCacheEntry = {
 const ProcessorsCache = new Map<string | Options, ProcessorsCacheEntry>();
 
 async function createProcessorsCacheEntry({
-  query,
-  reqOptions,
+  options,
 }: {
-  query: string | Options;
-  reqOptions: Options;
+  options: Options;
 }): Promise<ProcessorsCacheEntry> {
   const {createProcessorSync} = await createProcessorFactory();
 
-  const compilers = ProcessorsCache.get(query);
+  const compilers = ProcessorsCache.get(options);
   if (compilers) {
     return compilers;
   }
 
   const compilerCacheEntry: ProcessorsCacheEntry = {
     mdProcessor: createProcessorSync({
-      options: reqOptions,
+      options,
       format: 'md',
     }),
     mdxProcessor: createProcessorSync({
-      options: reqOptions,
+      options,
       format: 'mdx',
     }),
   };
 
-  ProcessorsCache.set(query, compilerCacheEntry);
+  ProcessorsCache.set(options, compilerCacheEntry);
 
   return compilerCacheEntry;
 }
@@ -261,20 +259,18 @@ async function createProcessorsCacheEntry({
 export async function createProcessorCached({
   filePath,
   mdxFrontMatter,
-  query,
-  reqOptions,
+  options,
 }: {
   filePath: string;
   mdxFrontMatter: MDXFrontMatter;
-  query: string | Options;
-  reqOptions: Options;
+  options: Options;
 }): Promise<SimpleProcessor> {
-  const compilers = await createProcessorsCacheEntry({query, reqOptions});
+  const compilers = await createProcessorsCacheEntry({options});
 
   const format = getFormat({
     filePath,
     frontMatterFormat: mdxFrontMatter.format,
-    markdownConfigFormat: reqOptions.markdownConfig.format,
+    markdownConfigFormat: options.markdownConfig.format,
   });
 
   return format === 'md' ? compilers.mdProcessor : compilers.mdxProcessor;


### PR DESCRIPTION


## Motivation

Webpack doc says about `this.query`: https://webpack.js.org/api/loaders/#thisquery


> If the loader was configured with an [options](https://webpack.js.org/configuration/module/#useentry) object, this will point to that object.
> If the loader has no options, but was invoked with a query string, this will be a string starting with ?.

This API we historically use is a bit confusing, and since mdx loader always has options, it always gives us the same as `this.getOptions()`. Let's only use once of these 2 APIs instead of a mix of both.

## Test Plan

CI keeps working

Tested locally that mdx processor caching still works as expected

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/

