### PR TITLE
fix(core): always use hash for CSS module class names

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -231,6 +231,8 @@ export async function createBaseConfig({
           test: CSS_MODULE_REGEX,
           use: getStyleLoaders(isServer, {
             modules: {
+              // Using the same CSS Module class pattern in dev/prod on purpose
+              // See https://github.com/facebook/docusaurus/pull/10423
               localIdentName: `[local]_[contenthash:base64:4]`,
               exportOnlyLocals: isServer,
             },

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -231,9 +231,7 @@ export async function createBaseConfig({
           test: CSS_MODULE_REGEX,
           use: getStyleLoaders(isServer, {
             modules: {
-              localIdentName: isProd
-                ? `[local]_[contenthash:base64:4]`
-                : `[local]_[path][name]`,
+              localIdentName: `[local]_[contenthash:base64:4]`,
               exportOnlyLocals: isServer,
             },
             importLoaders: 1,

--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -63,7 +63,7 @@ If you want to add CSS to any element, you can open the DevTools in your browser
 
 - **Theme class names**. These class names are listed exhaustively in [the next subsection](#theme-class-names). They don't have any default properties. You should always prioritize targeting those stable class names in your custom CSS.
 - **Infima class names**. These class names are found in the classic theme and usually follow the [BEM convention](http://getbem.com/naming/) of `block__element--modifier`. They are usually stable but are still considered implementation details, so you should generally avoid targeting them. However, you can [modify Infima CSS variables](#styling-your-site-with-infima).
-- **CSS module class names**. These class names have a hash in production (`codeBlockContainer_RIuc`) and are appended with a long file path in development. They are considered implementation details and you should almost always avoid targeting them in your custom CSS. If you must, you can use an [attribute selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) (`[class*='codeBlockContainer']`) that ignores the hash.
+- **CSS module class names**. These class names end with a hash which may change over time (`codeBlockContainer_RIuc`). They are considered implementation details and you should almost always avoid targeting them in your custom CSS. If you must, you can use an [attribute selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) (`[class*='codeBlockContainer']`) that ignores the hash.
 
 ### Theme Class Names {#theme-class-names}
 


### PR DESCRIPTION
## Motivation

For CSS modules, using clean class names in dev and hash in prod is confusing.

Users write CSS locally with selectors that only break after they deploy to production.

I believe it's better to have hashed class names in both environments to avoid this issue.

I consider this as a bugfix and an implementation detail.

## Test Plan

CI + Argos

### Test links

https://deploy-preview-10423--docusaurus-2.netlify.app/

