### PR TITLE
chore(ci): fix setup-node, use LTS by default

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: lts/*
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build-blog-only.yml
+++ b/.github/workflows/build-blog-only.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: lts/*
           cache: yarn
       - name: Installation
         run: yarn

--- a/.github/workflows/build-hash-router.yml
+++ b/.github/workflows/build-hash-router.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '18'
+          node-version: lts/*
           cache: yarn
       - name: Installation
         run: yarn

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: lts/*
           cache: yarn
       - name: Track build size changes
         uses: preactjs/compressed-size-action@f780fd104362cfce9e118f9198df2ee37d12946c # v2
@@ -64,6 +64,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
+          node-version: lts/*
           cache: yarn
       - name: Installation
         run: yarn

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: lts/*
           cache: yarn
       - name: Prepare git
         run: |

--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Set up Node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: lts/*
+          cache: yarn
+
       - name: Installation
         run: yarn
 
@@ -32,4 +38,4 @@ jobs:
           yarn create-docusaurus template/docusaurus-classic-ts classic --typescript -p npm
 
       - name: Release
-        run: npx pkg-pr-new publish './packages/*' --template './template/*' --compact --comment=off
+        run: npx pkg-pr-new@0.0.20 publish './packages/*' --template './template/*' --compact --comment=off

--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: lts/*
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: lts/*
           cache: yarn
       - name: Installation
         run: yarn

--- a/.github/workflows/showcase-test.yml
+++ b/.github/workflows/showcase-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
+          node-version: lts/*
           cache: yarn
       - name: Installation
         run: yarn

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18.0', '20', '22.4']
+        node: ['18.0', '20', '22']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node: ['18.0', '20', '22.4']
+        node: ['18.0', '20', '22']
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18.0', '20', '22.4']
+        node: ['18.0', '20', '22']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION

## Motivation

- fix continous-release not using setup-node, using Node 18 instead of Node 22
- consistently use lts everywhere when we don't care
- e2e matrix: restore usage of node 22 instead of 22.4 (due to 22.5.0 bug)

## Test Plan

CI

### Test links

https://deploy-preview-10438--docusaurus-2.netlify.app/
