### PR TITLE
feat(core): faster JS minimizer - `siteConfig.future.experimental_faster.swcJsMinimizer`

### DIFF
--- a/packages/docusaurus-faster/src/index.ts
+++ b/packages/docusaurus-faster/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type {RuleSetRule} from 'webpack';
+import type {JsMinifyOptions} from '@swc/core';
 
 export function getSwcJsLoaderFactory({
   isServer,
@@ -30,6 +31,27 @@ export function getSwcJsLoaderFactory({
       module: {
         type: isServer ? 'commonjs' : 'es6',
       },
+    },
+  };
+}
+
+// Note: these options are similar to what we use in core
+// They should rather be kept in sync for now to avoid any unexpected behavior
+// The goal of faster minifier is not to fine-tune options but only to be faster
+// See core minification.ts
+export function getSwcJsMinifierOptions(): JsMinifyOptions {
+  return {
+    ecma: 2020,
+    compress: {
+      ecma: 5,
+    },
+    module: true,
+    mangle: true,
+    safari10: true,
+    format: {
+      ecma: 5,
+      comments: false,
+      ascii_only: true,
     },
   };
 }

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -125,6 +125,7 @@ export type StorageConfig = {
 
 export type FasterConfig = {
   swcJsLoader: boolean;
+  swcJsMinimizer: boolean;
 };
 
 export type FutureConfig = {

--- a/packages/docusaurus-types/src/index.d.ts
+++ b/packages/docusaurus-types/src/index.d.ts
@@ -14,6 +14,7 @@ export {
   ParseFrontMatter,
   DocusaurusConfig,
   FutureConfig,
+  FasterConfig,
   StorageConfig,
   Config,
 } from './config';

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -92,7 +92,7 @@
     "semver": "^7.5.4",
     "serve-handler": "^6.1.5",
     "shelljs": "^0.8.5",
-    "terser-webpack-plugin": "^5.3.9",
+    "terser-webpack-plugin": "^5.3.10",
     "tslib": "^2.6.0",
     "update-notifier": "^6.0.2",
     "url-loader": "^4.1.1",

--- a/packages/docusaurus/src/commands/build.ts
+++ b/packages/docusaurus/src/commands/build.ts
@@ -334,6 +334,7 @@ async function getBuildClientConfig({
   const result = await createBuildClientConfig({
     props,
     minify: cliOptions.minify ?? true,
+    faster: props.siteConfig.future.experimental_faster,
     bundleAnalyzer: cliOptions.bundleAnalyzer ?? false,
   });
   let {config} = result;

--- a/packages/docusaurus/src/commands/start/webpack.ts
+++ b/packages/docusaurus/src/commands/start/webpack.ts
@@ -136,6 +136,7 @@ async function getStartClientConfig({
   let {clientConfig: config} = await createStartClientConfig({
     props,
     minify,
+    faster: props.siteConfig.future.experimental_faster,
     poll,
   });
   config = executePluginsConfigureWebpack({

--- a/packages/docusaurus/src/faster.ts
+++ b/packages/docusaurus/src/faster.ts
@@ -6,6 +6,7 @@
  */
 
 import type {ConfigureWebpackUtils} from '@docusaurus/types';
+import type {MinimizerOptions, CustomOptions} from 'terser-webpack-plugin';
 
 async function importFaster() {
   return import('@docusaurus/faster');
@@ -22,9 +23,16 @@ async function ensureFaster() {
   }
 }
 
-export async function getSwcJsLoaderFactory(): Promise<
+export async function importSwcJsLoaderFactory(): Promise<
   ConfigureWebpackUtils['getJSLoader']
 > {
   const faster = await ensureFaster();
   return faster.getSwcJsLoaderFactory;
+}
+
+export async function importSwcJsMinifierOptions(): Promise<
+  MinimizerOptions<CustomOptions>
+> {
+  const faster = await ensureFaster();
+  return faster.getSwcJsMinifierOptions() as MinimizerOptions<CustomOptions>;
 }

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -10,6 +10,7 @@ exports[`loadSiteConfig website with .cjs siteConfig 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -74,6 +75,7 @@ exports[`loadSiteConfig website with ts + js config 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -138,6 +140,7 @@ exports[`loadSiteConfig website with valid JS CJS config 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -202,6 +205,7 @@ exports[`loadSiteConfig website with valid JS ESM config 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -266,6 +270,7 @@ exports[`loadSiteConfig website with valid TypeScript CJS config 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -330,6 +335,7 @@ exports[`loadSiteConfig website with valid TypeScript ESM config 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -394,6 +400,7 @@ exports[`loadSiteConfig website with valid async config 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -460,6 +467,7 @@ exports[`loadSiteConfig website with valid async config creator function 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -526,6 +534,7 @@ exports[`loadSiteConfig website with valid config creator function 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {
@@ -595,6 +604,7 @@ exports[`loadSiteConfig website with valid siteConfig 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -80,6 +80,7 @@ exports[`load loads props for site with custom i18n path 1`] = `
     "future": {
       "experimental_faster": {
         "swcJsLoader": false,
+        "swcJsMinimizer": false,
       },
       "experimental_router": "browser",
       "experimental_storage": {

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -742,6 +742,7 @@ describe('future', () => {
     const future: DocusaurusConfig['future'] = {
       experimental_faster: {
         swcJsLoader: true,
+        swcJsMinimizer: true,
       },
       experimental_storage: {
         type: 'sessionStorage',

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -47,6 +47,7 @@ describe('normalizeConfig', () => {
       future: {
         experimental_faster: {
           swcJsLoader: true,
+          swcJsMinimizer: true,
         },
         experimental_storage: {
           type: 'sessionStorage',
@@ -1196,6 +1197,76 @@ describe('future', () => {
           }),
         ).toThrowErrorMatchingInlineSnapshot(`
           ""future.experimental_faster.swcJsLoader" must be a boolean
+          "
+        `);
+      });
+    });
+    describe('swcJsMinimizer', () => {
+      it('accepts - undefined', () => {
+        const faster: Partial<FasterConfig> = {
+          swcJsMinimizer: undefined,
+        };
+        expect(
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toEqual(fasterContaining({swcJsMinimizer: false}));
+      });
+
+      it('accepts - true', () => {
+        const faster: Partial<FasterConfig> = {
+          swcJsMinimizer: true,
+        };
+        expect(
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toEqual(fasterContaining({swcJsMinimizer: true}));
+      });
+
+      it('accepts - false', () => {
+        const faster: Partial<FasterConfig> = {
+          swcJsMinimizer: false,
+        };
+        expect(
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toEqual(fasterContaining({swcJsMinimizer: false}));
+      });
+
+      it('rejects - null', () => {
+        // @ts-expect-error: invalid
+        const faster: Partial<FasterConfig> = {swcJsMinimizer: 42};
+        expect(() =>
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(`
+          ""future.experimental_faster.swcJsMinimizer" must be a boolean
+          "
+        `);
+      });
+
+      it('rejects - number', () => {
+        // @ts-expect-error: invalid
+        const faster: Partial<FasterConfig> = {swcJsMinimizer: 42};
+        expect(() =>
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(`
+          ""future.experimental_faster.swcJsMinimizer" must be a boolean
           "
         `);
       });

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -43,11 +43,13 @@ export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
 
 export const DEFAULT_FASTER_CONFIG: FasterConfig = {
   swcJsLoader: false,
+  swcJsMinimizer: false,
 };
 
 // When using the "faster: true" shortcut
 export const DEFAULT_FASTER_CONFIG_TRUE: FasterConfig = {
   swcJsLoader: true,
+  swcJsMinimizer: true,
 };
 
 export const DEFAULT_FUTURE_CONFIG: FutureConfig = {
@@ -212,6 +214,9 @@ const FASTER_CONFIG_SCHEMA = Joi.alternatives()
   .try(
     Joi.object<FasterConfig>({
       swcJsLoader: Joi.boolean().default(DEFAULT_FASTER_CONFIG.swcJsLoader),
+      swcJsMinimizer: Joi.boolean().default(
+        DEFAULT_FASTER_CONFIG.swcJsMinimizer,
+      ),
     }),
     Joi.boolean()
       .required()

--- a/packages/docusaurus/src/webpack/__tests__/base.test.ts
+++ b/packages/docusaurus/src/webpack/__tests__/base.test.ts
@@ -11,7 +11,10 @@ import _ from 'lodash';
 import * as utils from '@docusaurus/utils/lib/webpackUtils';
 import {posixPath} from '@docusaurus/utils';
 import {excludeJS, clientDir, createBaseConfig} from '../base';
-import {DEFAULT_FUTURE_CONFIG} from '../../server/configValidation';
+import {
+  DEFAULT_FASTER_CONFIG,
+  DEFAULT_FUTURE_CONFIG,
+} from '../../server/configValidation';
 import type {Props} from '@docusaurus/types';
 
 describe('babel transpilation exclude logic', () => {
@@ -107,7 +110,12 @@ describe('base webpack config', () => {
 
   it('creates webpack aliases', async () => {
     const aliases = ((
-      await createBaseConfig({props, isServer: true, minify: true})
+      await createBaseConfig({
+        props,
+        isServer: true,
+        minify: true,
+        faster: DEFAULT_FASTER_CONFIG,
+      })
     ).resolve?.alias ?? {}) as {[alias: string]: string};
     // Make aliases relative so that test work on all computers
     const relativeAliases = _.mapValues(aliases, (a) =>
@@ -123,7 +131,12 @@ describe('base webpack config', () => {
       .spyOn(utils, 'getFileLoaderUtils')
       .mockImplementation(() => fileLoaderUtils);
 
-    await createBaseConfig({props, isServer: false, minify: false});
+    await createBaseConfig({
+      props,
+      isServer: false,
+      minify: false,
+      faster: DEFAULT_FASTER_CONFIG,
+    });
     expect(mockSvg).toHaveBeenCalled();
   });
 });

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -14,10 +14,10 @@ import {
   getStyleLoaders,
   getCustomBabelConfigFilePath,
 } from './utils';
-import {getMinimizer} from './minification';
+import {getMinimizers} from './minification';
 import {loadThemeAliases, loadDocusaurusAliases} from './aliases';
 import type {Configuration} from 'webpack';
-import type {Props} from '@docusaurus/types';
+import type {FasterConfig, Props} from '@docusaurus/types';
 
 const CSS_REGEX = /\.css$/i;
 const CSS_MODULE_REGEX = /\.module\.css$/i;
@@ -57,10 +57,12 @@ export async function createBaseConfig({
   props,
   isServer,
   minify,
+  faster,
 }: {
   props: Props;
   isServer: boolean;
   minify: boolean;
+  faster: FasterConfig;
 }): Promise<Configuration> {
   const {
     outDir,
@@ -172,7 +174,7 @@ export async function createBaseConfig({
       // Only minimize client bundle in production because server bundle is only
       // used for static site generation
       minimize: minimizeEnabled,
-      minimizer: minimizeEnabled ? getMinimizer() : undefined,
+      minimizer: minimizeEnabled ? await getMinimizers({faster}) : undefined,
       splitChunks: isServer
         ? false
         : {

--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -17,19 +17,26 @@ import ChunkAssetPlugin from './plugins/ChunkAssetPlugin';
 import CleanWebpackPlugin from './plugins/CleanWebpackPlugin';
 import ForceTerminatePlugin from './plugins/ForceTerminatePlugin';
 import {createStaticDirectoriesCopyPlugin} from './plugins/StaticDirectoriesCopyPlugin';
-import type {Props} from '@docusaurus/types';
+import type {FasterConfig, Props} from '@docusaurus/types';
 import type {Configuration} from 'webpack';
 
 async function createBaseClientConfig({
   props,
   hydrate,
   minify,
+  faster,
 }: {
   props: Props;
   hydrate: boolean;
   minify: boolean;
+  faster: FasterConfig;
 }): Promise<Configuration> {
-  const baseConfig = await createBaseConfig({props, isServer: false, minify});
+  const baseConfig = await createBaseConfig({
+    props,
+    isServer: false,
+    minify,
+    faster,
+  });
 
   return merge(baseConfig, {
     // Useless, disabled on purpose (errors on existing sites with no
@@ -60,10 +67,12 @@ export async function createStartClientConfig({
   props,
   minify,
   poll,
+  faster,
 }: {
   props: Props;
   minify: boolean;
   poll: number | boolean | undefined;
+  faster: FasterConfig;
 }): Promise<{clientConfig: Configuration}> {
   const {siteConfig, headTags, preBodyTags, postBodyTags} = props;
 
@@ -72,6 +81,7 @@ export async function createStartClientConfig({
       props,
       minify,
       hydrate: false,
+      faster,
     }),
     {
       watchOptions: {
@@ -105,10 +115,12 @@ export async function createStartClientConfig({
 export async function createBuildClientConfig({
   props,
   minify,
+  faster,
   bundleAnalyzer,
 }: {
   props: Props;
   minify: boolean;
+  faster: FasterConfig;
   bundleAnalyzer: boolean;
 }): Promise<{config: Configuration; clientManifestPath: string}> {
   // Apply user webpack config.
@@ -125,7 +137,7 @@ export async function createBuildClientConfig({
   );
 
   const config: Configuration = merge(
-    await createBaseClientConfig({props, minify, hydrate}),
+    await createBaseClientConfig({props, minify, faster, hydrate}),
     {
       plugins: [
         new ForceTerminatePlugin(),

--- a/packages/docusaurus/src/webpack/server.ts
+++ b/packages/docusaurus/src/webpack/server.ts
@@ -21,9 +21,8 @@ export default async function createServerConfig(params: {
   const baseConfig = await createBaseConfig({
     props,
     isServer: true,
-
-    // Minification of server bundle reduces size but doubles bundle time :/
     minify: false,
+    faster: props.siteConfig.future.experimental_faster,
   });
 
   const outputFilename = 'server.bundle.js';

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -13,7 +13,7 @@ import {BABEL_CONFIG_FILE_NAME} from '@docusaurus/utils';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import webpack, {type Configuration, type RuleSetRule} from 'webpack';
 import formatWebpackMessages from 'react-dev-utils/formatWebpackMessages';
-import {getSwcJsLoaderFactory} from '../faster';
+import {importSwcJsLoaderFactory} from '../faster';
 import type {ConfigureWebpackUtils, DocusaurusConfig} from '@docusaurus/types';
 import type {TransformOptions} from '@babel/core';
 
@@ -180,7 +180,7 @@ export async function createJsLoaderFactory({
     return ({isServer}) => jsLoader(isServer);
   }
   if (siteConfig.future?.experimental_faster.swcJsLoader) {
-    return getSwcJsLoaderFactory();
+    return importSwcJsLoaderFactory();
   }
   if (jsLoader === 'babel') {
     return BabelJsLoaderFactory;

--- a/website/docs/api/docusaurus.config.js.mdx
+++ b/website/docs/api/docusaurus.config.js.mdx
@@ -199,6 +199,7 @@ export default {
   future: {
     experimental_faster: {
       swcJsLoader: true,
+      swcJsMinimizer: true,
     },
     experimental_storage: {
       type: 'localStorage',
@@ -210,7 +211,8 @@ export default {
 ```
 
 - `experimental_faster`: An object containing feature flags to make the Docusaurus build faster. This requires adding the `@docusaurus/faster` package to your site's dependencies. Use `true` as a shorthand to enable all flags.
-  - `swcJsLoader`: Use `true` to replace the default [Babel](https://babeljs.io/) JS loader by [SWC](https://swc.rs/) loader to speed up the bundling phase.
+  - `swcJsLoader`: Use `true` to replace the default [Babel](https://babeljs.io/) JS loader by the [SWC](https://swc.rs/) JS loader to speed up the bundling phase.
+  - `swcJsMinimizer`: Use `true` to replace the default [`terser-webpack-plugin`](https://github.com/webpack-contrib/terser-webpack-plugin) JS minimizer ([Terser](https://terser.org/)) by the [SWC JS minimizer](https://swc.rs/docs/configuration/minification) to speed up the bundling minification phase.
 - `experimental_storage`: Site-wide browser storage options that theme authors should strive to respect.
   - `type`: The browser storage theme authors should use. Possible values are `localStorage` and `sessionStorage`. Defaults to `localStorage`.
   - `namespace`: Whether to namespace the browser storage keys to avoid storage key conflicts when Docusaurus sites are hosted under the same domain, or on localhost. Possible values are `string | boolean`. The namespace is appended at the end of the storage keys `key-namespace`. Use `true` to automatically generate a random namespace from your site `url + baseUrl`. Defaults to `false` (no namespace, historical behavior).

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,7 +2002,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
@@ -16091,7 +16091,7 @@ terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.7, terser-webpack-plug
     serialize-javascript "^6.0.1"
     terser "^5.26.0"
 
-terser@^5.0.0, terser@^5.10.0, terser@^5.15.1, terser@^5.16.8, terser@^5.26.0:
+terser@^5.0.0, terser@^5.10.0, terser@^5.15.1, terser@^5.26.0:
   version "5.31.6"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.6.tgz#c63858a0f0703988d0266a82fcbf2d7ba76422b1"
   integrity sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16080,7 +16080,7 @@ tempy@^0.6.0:
     type-fest "^0.16.0"
     unique-string "^2.0.0"
 
-terser-webpack-plugin@^5.3.10:
+terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.7, terser-webpack-plugin@^5.3.9:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
@@ -16091,28 +16091,7 @@ terser-webpack-plugin@^5.3.10:
     serialize-javascript "^6.0.1"
     terser "^5.26.0"
 
-terser-webpack-plugin@^5.3.7, terser-webpack-plugin@^5.3.9:
-  version "5.3.9"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
-  integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
-  dependencies:
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jest-worker "^27.4.5"
-    schema-utils "^3.1.1"
-    serialize-javascript "^6.0.1"
-    terser "^5.16.8"
-
-terser@^5.0.0, terser@^5.10.0, terser@^5.15.1, terser@^5.16.8:
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.0.tgz#7b3137b01226bdd179978207b9c8148754a6da9c"
-  integrity sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.8.2"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
-
-terser@^5.26.0:
+terser@^5.0.0, terser@^5.10.0, terser@^5.15.1, terser@^5.16.8, terser@^5.26.0:
   version "5.31.6"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.6.tgz#c63858a0f0703988d0266a82fcbf2d7ba76422b1"
   integrity sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,7 +2002,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
@@ -16080,6 +16080,17 @@ tempy@^0.6.0:
     type-fest "^0.16.0"
     unique-string "^2.0.0"
 
+terser-webpack-plugin@^5.3.10:
+  version "5.3.10"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
+  integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.20"
+    jest-worker "^27.4.5"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.1"
+    terser "^5.26.0"
+
 terser-webpack-plugin@^5.3.7, terser-webpack-plugin@^5.3.9:
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
@@ -16095,6 +16106,16 @@ terser@^5.0.0, terser@^5.10.0, terser@^5.15.1, terser@^5.16.8:
   version "5.19.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.0.tgz#7b3137b01226bdd179978207b9c8148754a6da9c"
   integrity sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@^5.26.0:
+  version "5.31.6"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.6.tgz#c63858a0f0703988d0266a82fcbf2d7ba76422b1"
+  integrity sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"


### PR DESCRIPTION
## Motivation

Docusaurus Faster project - part 2 - faster js minifier

(see [part 1](https://github.com/facebook/docusaurus/pull/10435))

Add experimental swcJsMinimizer option to make js minification faster.

It turns out `terser-webpack-plugin` default minimizer is slow and a real bottleneck representing 20-30% of total build time! 

The plugin offers an option to use a swc-based minimizer instead, which you can now toggle thanks to a new feature flag `siteConfig.future.experimental_faster.swcJsMinimizer`

Time to minimize JS on our website:
- Before: 18s
- After: 3s 🔥

I'm not sure the options are ideal, but I was conservative and only used a different tool with similar options, instead of fine-tuning the existing options. We

Note: in the future we'll be able to use the built-in [Rspack swc minimizer plugin](https://rspack.dev/plugins/rspack/swc-js-minimizer-rspack-plugin) (even faster, no extra JS<->Rust cost)



## Test Plan

CI

### Test links



https://deploy-preview-10441--docusaurus-2.netlify.app/
