### PR TITLE
refactor(core): Restore null-loader

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -77,6 +77,7 @@
     "leven": "^3.1.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^2.7.6",
+    "null-loader": "^4.0.1",
     "p-map": "^4.0.0",
     "postcss": "^8.4.26",
     "postcss-loader": "^7.3.3",

--- a/packages/docusaurus/src/webpack/utils.ts
+++ b/packages/docusaurus/src/webpack/utils.ts
@@ -55,6 +55,8 @@ export function getStyleLoaders(
     ...cssOptionsArg,
   };
 
+  // On the server we don't really need to extract/emit CSS
+  // We only need to transform CSS module imports to a styles object
   if (isServer) {
     return cssOptions.modules
       ? [
@@ -63,20 +65,8 @@ export function getStyleLoaders(
             options: cssOptions,
           },
         ]
-      : [
-          {
-            loader: MiniCssExtractPlugin.loader,
-            options: {
-              // Don't emit CSS files for SSR (previously used null-loader)
-              // See https://github.com/webpack-contrib/mini-css-extract-plugin/issues/90#issuecomment-811991738
-              emit: false,
-            },
-          },
-          {
-            loader: require.resolve('css-loader'),
-            options: cssOptions,
-          },
-        ];
+      : // Ignore regular CSS files
+        [{loader: require.resolve('null-loader')}];
   }
 
   return [
@@ -90,6 +80,12 @@ export function getStyleLoaders(
       loader: require.resolve('css-loader'),
       options: cssOptions,
     },
+
+    // TODO apart for configurePostCss(), do we really need this loader?
+    // Note: using postcss here looks inefficient/duplicate
+    // But in practice, it's not a big deal because css-loader also uses postcss
+    // and is able to reuse the parsed AST from postcss-loader
+    // See https://github.com/webpack-contrib/css-loader/blob/master/src/index.js#L159
     {
       // Options for PostCSS as we reference these options twice
       // Adds vendor prefixing based on your specified browser support in

--- a/yarn.lock
+++ b/yarn.lock
@@ -12688,6 +12688,14 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 nwsapi@^2.2.2:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"


### PR DESCRIPTION
## Motivation

Before [migrating to Webpack 5](https://github.com/facebook/docusaurus/pull/4089), we used `null-loader` to ignore CSS files on the server.

Technically `null-loader` is deprecated as Webpack 5 recommends using `resolve.alias.pkgName = false` to ignore a dependency, our migrated code did not "ignore" the CSS files on the server like before. Unfortunately, I don't see how we could use `resolve.alias` to express what we want: we want to process `.module.css` files on the server (so that we inject a `styles` object into JS files, but ignore regular CSS imports (which we don't do anymore after the Webpack 5 upgrade).

Restoring `null-loader` permits restoring the former (Docusaurus Webpack 4) behavior and ignores regular CSS on the server to only consider CSS modules. 

It shouldn't change behavior because technically we don't emit CSS files on the server. 
At best it has marginal performance benefits but the main reason for me to do this is mostly to be explicit. The previously present CSS loaders confused me and I was wondering why we would need them. In reality: we don't.


## Test Plan

CI + preview

### Test links

https://deploy-preview-10448--docusaurus-2.netlify.app/
