### PR TITLE
refactor(mdx-loader): refactor mdx-loader, expose loader creation utils

### DIFF
--- a/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
+++ b/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
@@ -9,18 +9,27 @@ import {createProcessors} from './processor';
 import type {Options} from './loader';
 import type {RuleSetRule, RuleSetUseItem} from 'webpack';
 
-export async function createMDXLoaderItem(
-  options: Options,
-): Promise<RuleSetUseItem> {
+async function enhancedOptions(options: Options): Promise<Options> {
+  // Because Jest doesn't like ESM / createProcessors()
+  if (process.env.N0DE_ENV === 'test' || process.env.JEST_WORKER_ID) {
+    return options;
+  }
+
   // We create the processor earlier here, to avoid the lazy processor creating
   // Lazy creation messes-up with Rsdoctor ability to measure mdx-loader perf
   const newOptions: Options = options.processors
     ? options
     : {...options, processors: await createProcessors({options})};
 
+  return newOptions;
+}
+
+export async function createMDXLoaderItem(
+  options: Options,
+): Promise<RuleSetUseItem> {
   return {
     loader: require.resolve('@docusaurus/mdx-loader'),
-    options: newOptions,
+    options: await enhancedOptions(options),
   };
 }
 

--- a/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
+++ b/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
@@ -5,15 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {createProcessors} from './processor';
 import type {Options} from './loader';
 import type {RuleSetRule, RuleSetUseItem} from 'webpack';
 
 export async function createMDXLoaderItem(
   options: Options,
 ): Promise<RuleSetUseItem> {
+  // We create the processor earlier here, to avoid the lazy processor creating
+  // Lazy creation messes-up with Rsdoctor ability to measure mdx-loader perf
+  const newOptions: Options = options.processors
+    ? options
+    : {...options, processors: await createProcessors({options})};
+
   return {
     loader: require.resolve('@docusaurus/mdx-loader'),
-    options,
+    options: newOptions,
   };
 }
 

--- a/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
+++ b/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {Options} from './loader';
+import type {RuleSetRule, RuleSetUseItem} from 'webpack';
+
+export async function createMDXLoaderItem(
+  options: Options,
+): Promise<RuleSetUseItem> {
+  return {
+    loader: require.resolve('@docusaurus/mdx-loader'),
+    options,
+  };
+}
+
+export async function createMDXLoaderRule({
+  include,
+  options,
+}: {
+  include: RuleSetRule['include'];
+  options: Options;
+}): Promise<RuleSetRule> {
+  return {
+    test: /\.mdx?$/i,
+    include,
+    use: [await createMDXLoaderItem(options)],
+  };
+}

--- a/packages/docusaurus-mdx-loader/src/index.ts
+++ b/packages/docusaurus-mdx-loader/src/index.ts
@@ -9,6 +9,8 @@ import {mdxLoader} from './loader';
 
 import type {TOCItem as TOCItemImported} from './remark/toc/types';
 
+export {createMDXLoaderRule, createMDXLoaderItem} from './createMDXLoader';
+
 export default mdxLoader;
 
 export type TOCItem = TOCItemImported;

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -16,9 +16,12 @@ import {
 import stringifyObject from 'stringify-object';
 import preprocessor from './preprocessor';
 import {validateMDXFrontMatter} from './frontMatter';
-import {createProcessorCached} from './processor';
+import {
+  createProcessorCached,
+  type SimpleProcessors,
+  type MDXOptions,
+} from './processor';
 import type {ResolveMarkdownLink} from './remark/resolveMarkdownLinks';
-import type {MDXOptions} from './processor';
 
 import type {MarkdownConfig} from '@docusaurus/types';
 import type {LoaderContext} from 'webpack';
@@ -43,6 +46,9 @@ export type Options = Partial<MDXOptions> & {
     metadata: {[key: string]: unknown};
   }) => {[key: string]: unknown};
   resolveMarkdownLink?: ResolveMarkdownLink;
+
+  // Will usually be created by "createMDXLoaderItem"
+  processors?: SimpleProcessors;
 };
 
 /**

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -5,21 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs-extra';
 import logger from '@docusaurus/logger';
 import {
   DEFAULT_PARSE_FRONT_MATTER,
-  escapePath,
   getFileLoaderUtils,
   getWebpackLoaderCompilerName,
 } from '@docusaurus/utils';
 import stringifyObject from 'stringify-object';
-import preprocessor from './preprocessor';
-import {validateMDXFrontMatter} from './frontMatter';
 import {
-  createProcessorCached,
-  type SimpleProcessors,
-  type MDXOptions,
+  compileToJSX,
+  createAssetsExportCode,
+  extractContentTitleData,
+  readMetadataPath,
+} from './utils';
+import type {
+  SimpleProcessors,
+  MDXOptions,
+  SimpleProcessorResult,
 } from './processor';
 import type {ResolveMarkdownLink} from './remark/resolveMarkdownLinks';
 
@@ -51,96 +53,6 @@ export type Options = Partial<MDXOptions> & {
   processors?: SimpleProcessors;
 };
 
-/**
- * When this throws, it generally means that there's no metadata file associated
- * with this MDX document. It can happen when using MDX partials (usually
- * starting with _). That's why it's important to provide the `isMDXPartial`
- * function in config
- */
-async function readMetadataPath(metadataPath: string) {
-  try {
-    return await fs.readFile(metadataPath, 'utf8');
-  } catch (err) {
-    logger.error`MDX loader can't read MDX metadata file path=${metadataPath}. Maybe the isMDXPartial option function was not provided?`;
-    throw err;
-  }
-}
-
-/**
- * Converts assets an object with Webpack require calls code.
- * This is useful for mdx files to reference co-located assets using relative
- * paths. Those assets should enter the Webpack assets pipeline and be hashed.
- * For now, we only handle that for images and paths starting with `./`:
- *
- * `{image: "./myImage.png"}` => `{image: require("./myImage.png")}`
- */
-function createAssetsExportCode({
-  assets,
-  inlineMarkdownAssetImageFileLoader,
-}: {
-  assets: unknown;
-  inlineMarkdownAssetImageFileLoader: string;
-}) {
-  if (
-    typeof assets !== 'object' ||
-    !assets ||
-    Object.keys(assets).length === 0
-  ) {
-    return 'undefined';
-  }
-
-  // TODO implementation can be completed/enhanced
-  function createAssetValueCode(assetValue: unknown): string | undefined {
-    if (Array.isArray(assetValue)) {
-      const arrayItemCodes = assetValue.map(
-        (item: unknown) => createAssetValueCode(item) ?? 'undefined',
-      );
-      return `[${arrayItemCodes.join(', ')}]`;
-    }
-    // Only process string values starting with ./
-    // We could enhance this logic and check if file exists on disc?
-    if (typeof assetValue === 'string' && assetValue.startsWith('./')) {
-      // TODO do we have other use-cases than image assets?
-      // Probably not worth adding more support, as we want to move to Webpack 5 new asset system (https://github.com/facebook/docusaurus/pull/4708)
-      return `require("${inlineMarkdownAssetImageFileLoader}${escapePath(
-        assetValue,
-      )}").default`;
-    }
-    return undefined;
-  }
-
-  const assetEntries = Object.entries(assets);
-
-  const codeLines = assetEntries
-    .map(([key, value]: [string, unknown]) => {
-      const assetRequireCode = createAssetValueCode(value);
-      return assetRequireCode ? `"${key}": ${assetRequireCode},` : undefined;
-    })
-    .filter(Boolean);
-
-  return `{\n${codeLines.join('\n')}\n}`;
-}
-
-// TODO temporary, remove this after v3.1?
-// Some plugin authors use our mdx-loader, despite it not being public API
-// see https://github.com/facebook/docusaurus/issues/8298
-function ensureMarkdownConfig(reqOptions: Options) {
-  if (!reqOptions.markdownConfig) {
-    throw new Error(
-      'Docusaurus v3+ requires MDX loader options.markdownConfig - plugin authors using the MDX loader should make sure to provide that option',
-    );
-  }
-}
-
-/**
- * data.contentTitle is set by the remark contentTitle plugin
- */
-function extractContentTitleData(data: {
-  [key: string]: unknown;
-}): string | undefined {
-  return data.contentTitle as string | undefined;
-}
-
 export async function mdxLoader(
   this: LoaderContext<Options>,
   fileContent: string,
@@ -150,59 +62,25 @@ export async function mdxLoader(
   const filePath = this.resourcePath;
   const options: Options = this.getOptions();
 
-  ensureMarkdownConfig(options);
-
   const {frontMatter} = await options.markdownConfig.parseFrontMatter({
     filePath,
     fileContent,
     defaultParseFrontMatter: DEFAULT_PARSE_FRONT_MATTER,
   });
-  const mdxFrontMatter = validateMDXFrontMatter(frontMatter.mdx);
-
-  const preprocessedContent = preprocessor({
-    fileContent,
-    filePath,
-    admonitions: options.admonitions,
-    markdownConfig: options.markdownConfig,
-  });
 
   const hasFrontMatter = Object.keys(frontMatter).length > 0;
 
-  const processor = await createProcessorCached({
-    filePath,
-    options,
-    mdxFrontMatter,
-  });
-
-  let result: {content: string; data: {[key: string]: unknown}};
+  let result: SimpleProcessorResult;
   try {
-    result = await processor.process({
-      content: preprocessedContent,
+    result = await compileToJSX({
+      fileContent,
       filePath,
       frontMatter,
+      options,
       compilerName,
     });
-  } catch (errorUnknown) {
-    const error = errorUnknown as Error;
-
-    // MDX can emit errors that have useful extra attributes
-    const errorJSON = JSON.stringify(error, null, 2);
-    const errorDetails =
-      errorJSON === '{}'
-        ? // regular JS error case: print stacktrace
-          error.stack ?? 'N/A'
-        : // MDX error: print extra attributes + stacktrace
-          `${errorJSON}\n${error.stack}`;
-
-    return callback(
-      new Error(
-        `MDX compilation failed for file ${logger.path(filePath)}\nCause: ${
-          error.message
-        }\nDetails:\n${errorDetails}`,
-        // TODO error cause doesn't seem to be used by Webpack stats.errors :s
-        {cause: error},
-      ),
-    );
+  } catch (error) {
+    return callback(error as Error);
   }
 
   const contentTitle = extractContentTitleData(result.data);

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -240,6 +240,8 @@ async function createProcessorsCacheEntry({
     return compilers;
   }
 
+  console.log('createProcessorsCacheEntry - cache miss', ProcessorsCache.size);
+
   const compilerCacheEntry: ProcessorsCacheEntry = {
     mdProcessor: createProcessorSync({
       options,

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -31,10 +31,13 @@ import type {ProcessorOptions} from '@mdx-js/mdx';
 // See https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1517839391
 type Pluggable = any; // TODO fix this asap
 
-type SimpleProcessorResult = {content: string; data: {[key: string]: unknown}};
+export type SimpleProcessorResult = {
+  content: string;
+  data: {[key: string]: unknown};
+};
 
 // TODO alt interface because impossible to import type Processor (ESM + TS :/)
-type SimpleProcessor = {
+export type SimpleProcessor = {
   process: ({
     content,
     filePath,
@@ -260,7 +263,7 @@ async function createProcessorsCacheEntry({
   return processors;
 }
 
-export async function createProcessorCached({
+export async function getProcessor({
   filePath,
   mdxFrontMatter,
   options,

--- a/packages/docusaurus-mdx-loader/src/utils.ts
+++ b/packages/docusaurus-mdx-loader/src/utils.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import fs from 'fs-extra';
+import logger from '@docusaurus/logger';
+import {escapePath, type WebpackCompilerName} from '@docusaurus/utils';
+import {getProcessor, type SimpleProcessorResult} from './processor';
+import {validateMDXFrontMatter} from './frontMatter';
+import preprocessor from './preprocessor';
+import type {Options} from './loader';
+
+/**
+ * When this throws, it generally means that there's no metadata file associated
+ * with this MDX document. It can happen when using MDX partials (usually
+ * starting with _). That's why it's important to provide the `isMDXPartial`
+ * function in config
+ */
+export async function readMetadataPath(metadataPath: string): Promise<string> {
+  try {
+    return await fs.readFile(metadataPath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      logger.interpolate`MDX loader can't read MDX metadata file path=${metadataPath}. Maybe the isMDXPartial option function was not provided?`,
+      {cause: error as Error},
+    );
+  }
+}
+
+/**
+ * Converts assets an object with Webpack require calls code.
+ * This is useful for mdx files to reference co-located assets using relative
+ * paths. Those assets should enter the Webpack assets pipeline and be hashed.
+ * For now, we only handle that for images and paths starting with `./`:
+ *
+ * `{image: "./myImage.png"}` => `{image: require("./myImage.png")}`
+ */
+export function createAssetsExportCode({
+  assets,
+  inlineMarkdownAssetImageFileLoader,
+}: {
+  assets: unknown;
+  inlineMarkdownAssetImageFileLoader: string;
+}): string {
+  if (
+    typeof assets !== 'object' ||
+    !assets ||
+    Object.keys(assets).length === 0
+  ) {
+    return 'undefined';
+  }
+
+  // TODO implementation can be completed/enhanced
+  function createAssetValueCode(assetValue: unknown): string | undefined {
+    if (Array.isArray(assetValue)) {
+      const arrayItemCodes = assetValue.map(
+        (item: unknown) => createAssetValueCode(item) ?? 'undefined',
+      );
+      return `[${arrayItemCodes.join(', ')}]`;
+    }
+    // Only process string values starting with ./
+    // We could enhance this logic and check if file exists on disc?
+    if (typeof assetValue === 'string' && assetValue.startsWith('./')) {
+      // TODO do we have other use-cases than image assets?
+      // Probably not worth adding more support, as we want to move to Webpack 5 new asset system (https://github.com/facebook/docusaurus/pull/4708)
+      return `require("${inlineMarkdownAssetImageFileLoader}${escapePath(
+        assetValue,
+      )}").default`;
+    }
+    return undefined;
+  }
+
+  const assetEntries = Object.entries(assets);
+
+  const codeLines = assetEntries
+    .map(([key, value]: [string, unknown]) => {
+      const assetRequireCode = createAssetValueCode(value);
+      return assetRequireCode ? `"${key}": ${assetRequireCode},` : undefined;
+    })
+    .filter(Boolean);
+
+  return `{\n${codeLines.join('\n')}\n}`;
+}
+
+/**
+ * data.contentTitle is set by the remark contentTitle plugin
+ */
+export function extractContentTitleData(data: {
+  [key: string]: unknown;
+}): string | undefined {
+  return data.contentTitle as string | undefined;
+}
+
+export async function compileToJSX({
+  filePath,
+  fileContent,
+  frontMatter,
+  options,
+  compilerName,
+}: {
+  filePath: string;
+  fileContent: string;
+  frontMatter: Record<string, unknown>;
+  options: Options;
+  compilerName: WebpackCompilerName;
+}): Promise<SimpleProcessorResult> {
+  const preprocessedFileContent = preprocessor({
+    fileContent,
+    filePath,
+    admonitions: options.admonitions,
+    markdownConfig: options.markdownConfig,
+  });
+
+  const mdxFrontMatter = validateMDXFrontMatter(frontMatter.mdx);
+
+  const processor = await getProcessor({
+    filePath,
+    options,
+    mdxFrontMatter,
+  });
+
+  try {
+    return await processor.process({
+      content: preprocessedFileContent,
+      filePath,
+      frontMatter,
+      compilerName,
+    });
+  } catch (errorUnknown) {
+    const error = errorUnknown as Error;
+
+    // MDX can emit errors that have useful extra attributes
+    const errorJSON = JSON.stringify(error, null, 2);
+    const errorDetails =
+      errorJSON === '{}'
+        ? // regular JS error case: print stacktrace
+          error.stack ?? 'N/A'
+        : // MDX error: print extra attributes + stacktrace
+          `${errorJSON}\n${error.stack}`;
+
+    throw new Error(
+      `MDX compilation failed for file ${logger.path(filePath)}\nCause: ${
+        error.message
+      }\nDetails:\n${errorDetails}`,
+      // TODO error cause doesn't seem to be used by Webpack stats.errors :s
+      {cause: error},
+    );
+  }
+}

--- a/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/index.test.ts
@@ -107,6 +107,7 @@ const getPlugin = async (
     url: 'https://docusaurus.io',
     markdown,
     future: {},
+    staticDirectories: ['static'],
   } as DocusaurusConfig;
   return pluginContentBlog(
     {

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -23,6 +23,10 @@ import {
 } from '@docusaurus/utils';
 import {getTagsFilePathsToWatch} from '@docusaurus/utils-validation';
 import {
+  createMDXLoaderItem,
+  type Options as MDXLoaderOptions,
+} from '@docusaurus/mdx-loader';
+import {
   getBlogTags,
   paginateBlogPosts,
   shouldBeListed,
@@ -47,8 +51,7 @@ import type {
   BlogContent,
   BlogPaginated,
 } from '@docusaurus/plugin-content-blog';
-import type {Options as MDXLoaderOptions} from '@docusaurus/mdx-loader/lib/loader';
-import type {RuleSetUseItem} from 'webpack';
+import type {RuleSetRule, RuleSetUseItem} from 'webpack';
 
 const PluginName = 'docusaurus-plugin-content-blog';
 
@@ -126,6 +129,97 @@ export default async function pluginContentBlog(
   });
 
   const sourceToPermalinkHelper = createSourceToPermalinkHelper();
+
+  async function createBlogMDXLoaderRule(): Promise<RuleSetRule> {
+    const {
+      admonitions,
+      rehypePlugins,
+      remarkPlugins,
+      recmaPlugins,
+      truncateMarker,
+      beforeDefaultRemarkPlugins,
+      beforeDefaultRehypePlugins,
+    } = options;
+
+    const contentDirs = getContentPathList(contentPaths);
+
+    const loaderOptions: MDXLoaderOptions = {
+      admonitions,
+      remarkPlugins,
+      rehypePlugins,
+      recmaPlugins,
+      beforeDefaultRemarkPlugins: [
+        footnoteIDFixer,
+        ...beforeDefaultRemarkPlugins,
+      ],
+      beforeDefaultRehypePlugins,
+      staticDirs: siteConfig.staticDirectories.map((dir) =>
+        path.resolve(siteDir, dir),
+      ),
+      siteDir,
+      isMDXPartial: createAbsoluteFilePathMatcher(options.exclude, contentDirs),
+      metadataPath: (mdxPath: string) => {
+        // Note that metadataPath must be the same/in-sync as
+        // the path from createData for each MDX.
+        const aliasedPath = aliasedSitePath(mdxPath, siteDir);
+        return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
+      },
+      // For blog posts a title in markdown is always removed
+      // Blog posts title are rendered separately
+      removeContentTitle: true,
+      // Assets allow to convert some relative images paths to
+      // require() calls
+      // @ts-expect-error: TODO fix typing issue
+      createAssets: ({
+        frontMatter,
+        metadata,
+      }: {
+        frontMatter: BlogPostFrontMatter;
+        metadata: BlogPostMetadata;
+      }): Assets => ({
+        image: frontMatter.image,
+        authorsImageUrls: metadata.authors.map((author) => author.imageURL),
+      }),
+      markdownConfig: siteConfig.markdown,
+      resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+        const permalink = resolveMarkdownLinkPathname(linkPathname, {
+          sourceFilePath,
+          sourceToPermalink: sourceToPermalinkHelper.get(),
+          siteDir,
+          contentPaths,
+        });
+        if (permalink === null) {
+          logger.report(
+            onBrokenMarkdownLinks,
+          )`Blog markdown link couldn't be resolved: (url=${linkPathname}) in source file path=${sourceFilePath}`;
+        }
+        return permalink;
+      },
+    };
+
+    function createBlogMarkdownLoader(): RuleSetUseItem {
+      const markdownLoaderOptions: BlogMarkdownLoaderOptions = {
+        truncateMarker,
+      };
+      return {
+        loader: path.resolve(__dirname, './markdownLoader.js'),
+        options: markdownLoaderOptions,
+      };
+    }
+
+    return {
+      test: /\.mdx?$/i,
+      include: contentDirs
+        // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
+        .map(addTrailingPathSeparator),
+      use: [
+        await createMDXLoaderItem(loaderOptions),
+        createBlogMarkdownLoader(),
+      ],
+    };
+  }
+
+  const blogMDXLoaderRule = await createBlogMDXLoaderRule();
 
   return {
     name: PluginName,
@@ -273,91 +367,6 @@ export default async function pluginContentBlog(
     },
 
     configureWebpack() {
-      const {
-        admonitions,
-        rehypePlugins,
-        remarkPlugins,
-        recmaPlugins,
-        truncateMarker,
-        beforeDefaultRemarkPlugins,
-        beforeDefaultRehypePlugins,
-      } = options;
-
-      const contentDirs = getContentPathList(contentPaths);
-
-      function createMDXLoader(): RuleSetUseItem {
-        const loaderOptions: MDXLoaderOptions = {
-          admonitions,
-          remarkPlugins,
-          rehypePlugins,
-          recmaPlugins,
-          beforeDefaultRemarkPlugins: [
-            footnoteIDFixer,
-            ...beforeDefaultRemarkPlugins,
-          ],
-          beforeDefaultRehypePlugins,
-          staticDirs: siteConfig.staticDirectories.map((dir) =>
-            path.resolve(siteDir, dir),
-          ),
-          siteDir,
-          isMDXPartial: createAbsoluteFilePathMatcher(
-            options.exclude,
-            contentDirs,
-          ),
-          metadataPath: (mdxPath: string) => {
-            // Note that metadataPath must be the same/in-sync as
-            // the path from createData for each MDX.
-            const aliasedPath = aliasedSitePath(mdxPath, siteDir);
-            return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
-          },
-          // For blog posts a title in markdown is always removed
-          // Blog posts title are rendered separately
-          removeContentTitle: true,
-          // Assets allow to convert some relative images paths to
-          // require() calls
-          // @ts-expect-error: TODO fix typing issue
-          createAssets: ({
-            frontMatter,
-            metadata,
-          }: {
-            frontMatter: BlogPostFrontMatter;
-            metadata: BlogPostMetadata;
-          }): Assets => ({
-            image: frontMatter.image,
-            authorsImageUrls: metadata.authors.map((author) => author.imageURL),
-          }),
-          markdownConfig: siteConfig.markdown,
-          resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-            const permalink = resolveMarkdownLinkPathname(linkPathname, {
-              sourceFilePath,
-              sourceToPermalink: sourceToPermalinkHelper.get(),
-              siteDir,
-              contentPaths,
-            });
-            if (permalink === null) {
-              logger.report(
-                onBrokenMarkdownLinks,
-              )`Blog markdown link couldn't be resolved: (url=${linkPathname}) in source file path=${sourceFilePath}`;
-            }
-            return permalink;
-          },
-        };
-        return {
-          loader: require.resolve('@docusaurus/mdx-loader'),
-          options: loaderOptions,
-        };
-      }
-
-      function createBlogMarkdownLoader(): RuleSetUseItem {
-        const loaderOptions: BlogMarkdownLoaderOptions = {
-          truncateMarker,
-        };
-        return {
-          loader: path.resolve(__dirname, './markdownLoader.js'),
-          options: loaderOptions,
-        };
-      }
-
       return {
         resolve: {
           alias: {
@@ -365,15 +374,7 @@ export default async function pluginContentBlog(
           },
         },
         module: {
-          rules: [
-            {
-              test: /\.mdx?$/i,
-              include: contentDirs
-                // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
-                .map(addTrailingPathSeparator),
-              use: [createMDXLoader(), createBlogMarkdownLoader()],
-            },
-          ],
+          rules: [blogMDXLoaderRule],
         },
       };
     },

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -26,6 +26,10 @@ import {
   getTagsFile,
   getTagsFilePathsToWatch,
 } from '@docusaurus/utils-validation';
+import {
+  createMDXLoaderRule,
+  type Options as MDXLoaderOptions,
+} from '@docusaurus/mdx-loader';
 import {loadSidebars, resolveSidebarPathOption} from './sidebars';
 import {CategoryMetadataFilenamePattern} from './sidebars/generator';
 import {
@@ -49,7 +53,6 @@ import {
 } from './translations';
 import {createAllRoutes} from './routes';
 import {createSidebarsUtils} from './sidebars/utils';
-import type {Options as MDXLoaderOptions} from '@docusaurus/mdx-loader';
 
 import type {
   PluginOptions,
@@ -61,7 +64,7 @@ import type {
 } from '@docusaurus/plugin-content-docs';
 import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {DocFile, FullVersion} from './types';
-import type {RuleSetUseItem} from 'webpack';
+import type {RuleSetRule} from 'webpack';
 
 // TODO this is bad, we should have a better way to do this (new lifecycle?)
 //  The source to permalink is currently a mutable map passed to the mdx loader
@@ -113,6 +116,68 @@ export default async function pluginContentDocs(
   const env = process.env.NODE_ENV as DocEnv;
 
   const sourceToPermalinkHelper = createSourceToPermalinkHelper();
+
+  async function createDocsMDXLoaderRule(): Promise<RuleSetRule> {
+    const {
+      rehypePlugins,
+      remarkPlugins,
+      recmaPlugins,
+      beforeDefaultRehypePlugins,
+      beforeDefaultRemarkPlugins,
+    } = options;
+    const contentDirs = versionsMetadata
+      .flatMap(getContentPathList)
+      // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
+      .map(addTrailingPathSeparator);
+
+    const loaderOptions: MDXLoaderOptions = {
+      admonitions: options.admonitions,
+      remarkPlugins,
+      rehypePlugins,
+      recmaPlugins,
+      beforeDefaultRehypePlugins,
+      beforeDefaultRemarkPlugins,
+      staticDirs: siteConfig.staticDirectories.map((dir) =>
+        path.resolve(siteDir, dir),
+      ),
+      siteDir,
+      isMDXPartial: createAbsoluteFilePathMatcher(options.exclude, contentDirs),
+      metadataPath: (mdxPath: string) => {
+        // Note that metadataPath must be the same/in-sync as
+        // the path from createData for each MDX.
+        const aliasedPath = aliasedSitePath(mdxPath, siteDir);
+        return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
+      },
+      // Assets allow to convert some relative images paths to
+      // require(...) calls
+      createAssets: ({frontMatter}: {frontMatter: DocFrontMatter}) => ({
+        image: frontMatter.image,
+      }),
+      markdownConfig: siteConfig.markdown,
+      resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+        const version = getVersionFromSourceFilePath(
+          sourceFilePath,
+          versionsMetadata,
+        );
+        const permalink = resolveMarkdownLinkPathname(linkPathname, {
+          sourceFilePath,
+          sourceToPermalink: sourceToPermalinkHelper.get(),
+          siteDir,
+          contentPaths: version,
+        });
+        if (permalink === null) {
+          logger.report(
+            siteConfig.onBrokenMarkdownLinks,
+          )`Docs markdown link couldn't be resolved: (url=${linkPathname}) in source file path=${sourceFilePath} for version number=${version.versionName}`;
+        }
+        return permalink;
+      },
+    };
+
+    return createMDXLoaderRule({include: contentDirs, options: loaderOptions});
+  }
+
+  const docsMDXLoaderRule = await createDocsMDXLoaderRule();
 
   return {
     name: 'docusaurus-plugin-content-docs',
@@ -289,74 +354,7 @@ export default async function pluginContentDocs(
       });
     },
 
-    configureWebpack(_config, isServer, utils, content) {
-      const {
-        rehypePlugins,
-        remarkPlugins,
-        recmaPlugins,
-        beforeDefaultRehypePlugins,
-        beforeDefaultRemarkPlugins,
-      } = options;
-
-      const contentDirs = versionsMetadata
-        .flatMap(getContentPathList)
-        // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
-        .map(addTrailingPathSeparator);
-
-      function createMDXLoader(): RuleSetUseItem {
-        const loaderOptions: MDXLoaderOptions = {
-          admonitions: options.admonitions,
-          remarkPlugins,
-          rehypePlugins,
-          recmaPlugins,
-          beforeDefaultRehypePlugins,
-          beforeDefaultRemarkPlugins,
-          staticDirs: siteConfig.staticDirectories.map((dir) =>
-            path.resolve(siteDir, dir),
-          ),
-          siteDir,
-          isMDXPartial: createAbsoluteFilePathMatcher(
-            options.exclude,
-            contentDirs,
-          ),
-          metadataPath: (mdxPath: string) => {
-            // Note that metadataPath must be the same/in-sync as
-            // the path from createData for each MDX.
-            const aliasedPath = aliasedSitePath(mdxPath, siteDir);
-            return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
-          },
-          // Assets allow to convert some relative images paths to
-          // require(...) calls
-          createAssets: ({frontMatter}: {frontMatter: DocFrontMatter}) => ({
-            image: frontMatter.image,
-          }),
-          markdownConfig: siteConfig.markdown,
-          resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-            const version = getVersionFromSourceFilePath(
-              sourceFilePath,
-              content.loadedVersions,
-            );
-            const permalink = resolveMarkdownLinkPathname(linkPathname, {
-              sourceFilePath,
-              sourceToPermalink: sourceToPermalinkHelper.get(),
-              siteDir,
-              contentPaths: version,
-            });
-            if (permalink === null) {
-              logger.report(
-                siteConfig.onBrokenMarkdownLinks,
-              )`Docs markdown link couldn't be resolved: (url=${linkPathname}) in source file path=${sourceFilePath} for version number=${version.versionName}`;
-            }
-            return permalink;
-          },
-        };
-
-        return {
-          loader: require.resolve('@docusaurus/mdx-loader'),
-          options: loaderOptions,
-        };
-      }
-
+    configureWebpack() {
       return {
         ignoreWarnings: [
           // Suppress warnings about non-existing of versions file.
@@ -370,13 +368,7 @@ export default async function pluginContentDocs(
           },
         },
         module: {
-          rules: [
-            {
-              test: /\.mdx?$/i,
-              include: contentDirs,
-              use: [createMDXLoader()],
-            },
-          ],
+          rules: [docsMDXLoaderRule],
         },
       };
     },

--- a/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
+++ b/packages/docusaurus-plugin-content-pages/src/__tests__/index.test.ts
@@ -16,7 +16,7 @@ describe('docusaurus-plugin-content-pages', () => {
   it('loads simple pages', async () => {
     const siteDir = path.join(__dirname, '__fixtures__', 'website');
     const context = await loadContext({siteDir});
-    const plugin = pluginContentPages(
+    const plugin = await pluginContentPages(
       context,
       validateOptions({
         validate: normalizePluginOptions,
@@ -33,7 +33,7 @@ describe('docusaurus-plugin-content-pages', () => {
   it('loads simple pages with french translations', async () => {
     const siteDir = path.join(__dirname, '__fixtures__', 'website');
     const context = await loadContext({siteDir, locale: 'fr'});
-    const plugin = pluginContentPages(
+    const plugin = await pluginContentPages(
       context,
       validateOptions({
         validate: normalizePluginOptions,
@@ -50,7 +50,7 @@ describe('docusaurus-plugin-content-pages', () => {
   it('loads simple pages with last update', async () => {
     const siteDir = path.join(__dirname, '__fixtures__', 'website');
     const context = await loadContext({siteDir});
-    const plugin = pluginContentPages(
+    const plugin = await pluginContentPages(
       context,
       validateOptions({
         validate: normalizePluginOptions,

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -14,6 +14,10 @@ import {
   createAbsoluteFilePathMatcher,
   DEFAULT_PLUGIN_ID,
 } from '@docusaurus/utils';
+import {
+  createMDXLoaderRule,
+  type Options as MDXLoaderOptions,
+} from '@docusaurus/mdx-loader';
 import {createAllRoutes} from './routes';
 import {
   createPagesContentPaths,
@@ -26,13 +30,12 @@ import type {
   LoadedContent,
   PageFrontMatter,
 } from '@docusaurus/plugin-content-pages';
-import type {RuleSetUseItem} from 'webpack';
-import type {Options as MDXLoaderOptions} from '@docusaurus/mdx-loader/lib/loader';
+import type {RuleSetRule} from 'webpack';
 
-export default function pluginContentPages(
+export default async function pluginContentPages(
   context: LoadContext,
   options: PluginOptions,
-): Plugin<LoadedContent | null> {
+): Promise<Plugin<LoadedContent | null>> {
   const {siteConfig, siteDir, generatedFilesDir} = context;
 
   const contentPaths = createPagesContentPaths({context, options});
@@ -42,6 +45,53 @@ export default function pluginContentPages(
     'docusaurus-plugin-content-pages',
   );
   const dataDir = path.join(pluginDataDirRoot, options.id ?? DEFAULT_PLUGIN_ID);
+
+  async function createPagesMDXLoaderRule(): Promise<RuleSetRule> {
+    const {
+      admonitions,
+      rehypePlugins,
+      remarkPlugins,
+      recmaPlugins,
+      beforeDefaultRehypePlugins,
+      beforeDefaultRemarkPlugins,
+    } = options;
+    const contentDirs = getContentPathList(contentPaths);
+
+    const loaderOptions: MDXLoaderOptions = {
+      admonitions,
+      remarkPlugins,
+      rehypePlugins,
+      recmaPlugins,
+      beforeDefaultRehypePlugins,
+      beforeDefaultRemarkPlugins,
+      staticDirs: siteConfig.staticDirectories.map((dir) =>
+        path.resolve(siteDir, dir),
+      ),
+      siteDir,
+      isMDXPartial: createAbsoluteFilePathMatcher(options.exclude, contentDirs),
+      metadataPath: (mdxPath: string) => {
+        // Note that metadataPath must be the same/in-sync as
+        // the path from createData for each MDX.
+        const aliasedSource = aliasedSitePath(mdxPath, siteDir);
+        return path.join(dataDir, `${docuHash(aliasedSource)}.json`);
+      },
+      // Assets allow to convert some relative images paths to
+      // require(...) calls
+      createAssets: ({frontMatter}: {frontMatter: PageFrontMatter}) => ({
+        image: frontMatter.image,
+      }),
+      markdownConfig: siteConfig.markdown,
+    };
+
+    return createMDXLoaderRule({
+      include: contentDirs
+        // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
+        .map(addTrailingPathSeparator),
+      options: loaderOptions,
+    });
+  }
+
+  const pagesMDXLoaderRule = await createPagesMDXLoaderRule();
 
   return {
     name: 'docusaurus-plugin-content-pages',
@@ -68,63 +118,9 @@ export default function pluginContentPages(
     },
 
     configureWebpack() {
-      const {
-        admonitions,
-        rehypePlugins,
-        remarkPlugins,
-        recmaPlugins,
-        beforeDefaultRehypePlugins,
-        beforeDefaultRemarkPlugins,
-      } = options;
-      const contentDirs = getContentPathList(contentPaths);
-
-      function createMDXLoader(): RuleSetUseItem {
-        const loaderOptions: MDXLoaderOptions = {
-          admonitions,
-          remarkPlugins,
-          rehypePlugins,
-          recmaPlugins,
-          beforeDefaultRehypePlugins,
-          beforeDefaultRemarkPlugins,
-          staticDirs: siteConfig.staticDirectories.map((dir) =>
-            path.resolve(siteDir, dir),
-          ),
-          siteDir,
-          isMDXPartial: createAbsoluteFilePathMatcher(
-            options.exclude,
-            contentDirs,
-          ),
-          metadataPath: (mdxPath: string) => {
-            // Note that metadataPath must be the same/in-sync as
-            // the path from createData for each MDX.
-            const aliasedSource = aliasedSitePath(mdxPath, siteDir);
-            return path.join(dataDir, `${docuHash(aliasedSource)}.json`);
-          },
-          // Assets allow to convert some relative images paths to
-          // require(...) calls
-          createAssets: ({frontMatter}: {frontMatter: PageFrontMatter}) => ({
-            image: frontMatter.image,
-          }),
-          markdownConfig: siteConfig.markdown,
-        };
-
-        return {
-          loader: require.resolve('@docusaurus/mdx-loader'),
-          options: loaderOptions,
-        };
-      }
-
       return {
         module: {
-          rules: [
-            {
-              test: /\.mdx?$/i,
-              include: contentDirs
-                // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
-                .map(addTrailingPathSeparator),
-              use: [createMDXLoader()],
-            },
-          ],
+          rules: [pagesMDXLoaderRule],
         },
       };
     },

--- a/packages/docusaurus/src/server/plugins/__tests__/plugins.test.ts
+++ b/packages/docusaurus/src/server/plugins/__tests__/plugins.test.ts
@@ -28,6 +28,7 @@ async function testLoad({
       baseUrl: '/',
       trailingSlash: true,
       themeConfig: {},
+      staticDirectories: [],
       presets: [],
       plugins,
       themes,

--- a/packages/docusaurus/src/server/plugins/plugins.ts
+++ b/packages/docusaurus/src/server/plugins/plugins.ts
@@ -266,7 +266,7 @@ export async function loadPlugins(
     // TODO probably not the ideal place to hardcode those plugins
     initializedPlugins.push(
       createBootstrapPlugin(context),
-      createMDXFallbackPlugin(context),
+      await createMDXFallbackPlugin(context),
     );
 
     const plugins = await executeAllPluginsContentLoading({


### PR DESCRIPTION

## Motivation

Refactors mdx-loader
- improve `loader.ts` readability, extract support code to `utils.ts`
- expose async `createMDXLoader{Item,Rule}` APIs and use them in plugins
- fix processors caching system that does not work with Rsdoctor 


Note: `createMDXLoaderItem` APIs will be useful for upcoming encapsulation and perf optimizations


## Test Plan

CI + preview

Behavior should be similar to before

### Test links

https://deploy-preview-10450--docusaurus-2.netlify.app/

