### PR TITLE
chore: upgrade npm-to-yarn to v3

### DIFF
--- a/packages/docusaurus-remark-plugin-npm2yarn/package.json
+++ b/packages/docusaurus-remark-plugin-npm2yarn/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "mdast-util-mdx": "^3.0.0",
-    "npm-to-yarn": "^2.2.1",
+    "npm-to-yarn": "^3.0.0",
     "tslib": "^2.6.0",
     "unified": "^11.0.3",
     "unist-util-visit": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12651,10 +12651,10 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-npm-to-yarn@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-2.2.1.tgz#048843a6630621daffc6a239dfc89698b8abf7e8"
-  integrity sha512-O/j/ROyX0KGLG7O6Ieut/seQ0oiTpHF2tXAcFbpdTLQFiaNtkyTXXocM1fwpaa60dg1qpWj0nHlbNhx6qwuENQ==
+npm-to-yarn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-3.0.0.tgz#05006d97359e285f0316e249dbbe56f377ca1182"
+  integrity sha512-76YnmsbfrYp0tMsWxM0RNX0Vs+x8JxpJGu6B/jDn4lW8+laiTcKmKi9MeMh4UikO4RkJ1oqURoDy9bXJmMXS6A==
 
 npmlog@6.0.2, npmlog@^6.0.0, npmlog@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION

## Motivation

The upgrade should be retrocompatible and permit users to benefit from new `npx` conversions ([feature PR](https://github.com/nebrelbug/npm-to-yarn/pull/53))

Note: we won't use it on the Docusaurus website because `yarn dlx` is not supported by Yarn v1 😅 and there are too many Yarn 1 users (including ourselves). I think it's better to stick to `npx` for now.

## Test Plan

CI + argos

### Test links

https://deploy-preview-10454--docusaurus-2.netlify.app/
