### PR TITLE
create GiteeFileContent.js

### DIFF
--- a/website/src/components/GiteeFileContent.js
+++ b/website/src/components/GiteeFileContent.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import CodeBlock from '@theme/CodeBlock';
+
+const GiteeFileContent = ({ owner, repo, filePath, branch = 'main' }) => {
+  const [fileContent, setFileContent] = useState('');
+
+  useEffect(() => {
+    const fetchFileContent = async () => {
+      try {
+        const url = `https://gitee.com/api/v5/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+        const response = await fetch(url);
+        const data = await response.json();
+
+        const binaryString = atob(data.content);
+        const binaryArray = Uint8Array.from(binaryString, char => char.charCodeAt(0));
+        const decodedContent = new TextDecoder('utf-8').decode(binaryArray);
+
+        setFileContent(decodedContent);
+
+      } catch (error) {
+        console.error('Error fetching file content:', error);
+      }
+    };
+
+    fetchFileContent();
+  }, [owner, repo, filePath, branch]); // 监听这些参数的变化
+
+  return (
+    <CodeBlock language="java" title={filePath}>
+      {fileContent}
+    </CodeBlock>
+  );
+};
+
+export default GiteeFileContent;

--- a/website/src/components/GiteeFileContent.js
+++ b/website/src/components/GiteeFileContent.js
@@ -26,7 +26,7 @@ const GiteeFileContent = ({ owner, repo, filePath, branch = 'main' }) => {
   }, [owner, repo, filePath, branch]); // 监听这些参数的变化
 
   return (
-    <CodeBlock language="java" title={filePath}>
+    <CodeBlock language="java">
       {fileContent}
     </CodeBlock>
   );


### PR DESCRIPTION
新建一个Gitee组件，用于直接展示Gitee仓库代码，无需存放两份。

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

我希望可以直接调用gitee的api在页面上显示代码，无需存放两份，这很优雅，改动也会实时生效。

## Test Plan

我增加了一个组件，可以用于直接展示gitee代码，通过新建mdx文件你可以测试到我的组件
```markdown
import GiteeFileContent from '@site/src/components/GiteeFileContent';

# 显示 Gitee 文件内容
<GiteeFileContent 
  owner="ma5d" 
  repo="hello-quartz" 
  filePath="src/main/java/org/ma5d/MisFireTest.java" 
  branch="main" 
/>
```

### Test links

你可以在我的github pages 上看到我的使用：

[测试mdx](https://ma5d.asia/docs/%E6%B5%8B%E8%AF%95mdx/)

## Related issues/PRs


