### PR TITLE
docs: fix v3.5 blog post typo - `onUntruncatedBlogPosts`

### DIFF
--- a/website/blog/releases/3.5/index.mdx
+++ b/website/blog/releases/3.5/index.mdx
@@ -113,11 +113,11 @@ We believe large multi-blogs are easier to manage by using [global authors](/doc
 
 In [#10224](https://github.com/facebook/docusaurus/pull/10224), we added the `onInlineAuthors` option. Use `onInlineAuthors: 'throw'` to forbid [inline authors](/docs/blog#inline-authors), and enforce a consistent usage of [global authors](/docs/blog#global-authors).
 
-#### `onUntruncatedBlogPost`
+#### `onUntruncatedBlogPosts`
 
 We believe blog posts are better using [truncation markers](/docs/blog#blog-list) (`<!-- truncate -->` or `{/* truncate */}`). On paginated lists (blog home, tags pages, authors pages), this permits to render a more concise preview of the blog post instead of a full blog post.
 
-In [#10375](https://github.com/facebook/docusaurus/pull/10375), we added the `onUntruncatedBlogPost` option. Use `onUntruncatedBlogPost: 'throw'` to enforce a consistent usage of [truncation markers](/docs/blog#blog-list).
+In [#10375](https://github.com/facebook/docusaurus/pull/10375), we added the `onUntruncatedBlogPosts` option. Use `onUntruncatedBlogPosts: 'throw'` to enforce a consistent usage of [truncation markers](/docs/blog#blog-list).
 
 ## Translations
 


### PR DESCRIPTION
Fix blog post typo, the plugin option ends with `s`