### PR TITLE
refactor(core): use webpack's builtin prefetch & preload abilities to do prefetch & preload

### DIFF
--- a/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/ChunkAssetPlugin.ts
@@ -5,75 +5,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import webpack, {type Compiler} from 'webpack';
-
-// Adds a custom Docusaurus Webpack runtime function `__webpack_require__.gca`
-// gca = Get Chunk Asset, it converts a chunkName to a JS asset URL
-// It is called in Core client/docusaurus.ts for chunk preloading/prefetching
-// Example: gca("814f3328") = "/baseUrl/assets/js/814f3328.03fcc178.js"
-// See also: https://github.com/facebook/docusaurus/pull/10485
-
-// The name of the custom Docusaurus Webpack runtime function
-const DocusaurusGetChunkAssetFn = '__webpack_require__.gca';
+import {type Compiler} from 'webpack';
 
 const PluginName = 'Docusaurus-ChunkAssetPlugin';
-
-function generateGetChunkAssetRuntimeCode(chunk: webpack.Chunk): string {
-  const chunkIdToName = chunk.getChunkMaps(false).name;
-  const chunkNameToId = Object.fromEntries(
-    Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [
-      chunkName,
-      chunkId,
-    ]),
-  );
-
-  const {
-    // publicPath = __webpack_require__.p
-    // Example: "/" or "/baseUrl/"
-    // https://github.com/webpack/webpack/blob/v5.94.0/lib/runtime/PublicPathRuntimeModule.js
-    publicPath,
-
-    // getChunkScriptFilename = __webpack_require__.u
-    // Example: getChunkScriptFilename("814f3328") = "814f3328.03fcc178.js"
-    // https://github.com/webpack/webpack/blob/v5.94.0/lib/runtime/GetChunkFilenameRuntimeModule.js
-    getChunkScriptFilename,
-  } = webpack.RuntimeGlobals;
-
-  const code = `// Docusaurus function to get chunk asset
-${DocusaurusGetChunkAssetFn} = function(chunkId) { chunkId = ${JSON.stringify(
-    chunkNameToId,
-  )}[chunkId]||chunkId; return ${publicPath} + ${getChunkScriptFilename}(chunkId); };`;
-
-  return webpack.Template.asString(code);
-}
 
 /*
  Note: we previously used `MainTemplate.hooks.requireExtensions.tap()`
  But it will be removed in Webpack 6 and is not supported by Rspack
- So instead we use equivalent code inspired by:
- - https://github.com/webpack/webpack/blob/v5.94.0/lib/RuntimePlugin.js#L462
- - https://github.com/webpack/webpack/blob/v5.94.0/lib/runtime/CompatRuntimeModule.js
+ So instead we use Webpack's builtin prefetch & preload abilities
  */
 export default class ChunkAssetPlugin {
   apply(compiler: Compiler): void {
     compiler.hooks.thisCompilation.tap(PluginName, (compilation) => {
       compilation.hooks.additionalTreeRuntimeRequirements.tap(
         PluginName,
-        (chunk) => {
-          compilation.addRuntimeModule(chunk, new ChunkAssetRuntimeModule());
+        (_, set) => {
+          // webpack doesn't support auto inject prefetch & preload runtimeModule, so need to inject it manually
+          set.add(compiler.webpack.RuntimeGlobals.prefetchChunk);
+          set.add(compiler.webpack.RuntimeGlobals.preloadChunk);
         },
       );
     });
-  }
-}
-
-// Inspired by https://github.com/webpack/webpack/blob/v5.94.0/lib/runtime/CompatRuntimeModule.js
-class ChunkAssetRuntimeModule extends webpack.RuntimeModule {
-  constructor() {
-    super('ChunkAssetRuntimeModule', webpack.RuntimeModule.STAGE_ATTACH);
-    this.fullHash = true;
-  }
-  override generate() {
-    return generateGetChunkAssetRuntimeCode(this.chunk!);
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation
it seems ChunkAssetPlugin provides same functionalities like webpack's builtin prefetch & preload abilities, so try using webpack's builtin prefetch & preload runtimeModule and it's also compatible with rspack
<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan
It's a refactor so it can use the original prefetch & preload test
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

related to #10402  #10485