### PR TITLE
chore: Rename Twitter links/labels to X

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -396,6 +396,7 @@ module.exports = {
           '@',
           'WebContainers',
           'Twitter',
+          'X',
           'GitHub',
           'Dev.to',
           '1.x',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ There are many ways to contribute to Docusaurus, and many of them do not involve
 - Read through the [Docusaurus docs](https://docusaurus.io/docs/installation). If you find anything that is confusing or can be improved, you can click "Edit this page" at the bottom of most docs, which takes you to the GitHub interface to make and propose changes.
 - Take a look at the [features requested](https://github.com/facebook/docusaurus/labels/feature) by others in the community and consider opening a pull request if you see something you want to work on.
 
-Contributions are very welcome. If you think you need help planning your contribution, please ping us on Twitter at [@docusaurus](https://twitter.com/docusaurus) and let us know you are looking for a bit of help.
+Contributions are very welcome. If you think you need help planning your contribution, please ping us on X at [@docusaurus](https://x.com/docusaurus) and let us know you are looking for a bit of help.
 
 ### Join our Discord Channel
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We have a few channels for contact:
 - [Discord](https://discord.gg/docusaurus):
   - `#general` for those using Docusaurus.
   - `#contributors` for those wanting to contribute to the Docusaurus core.
-- [@docusaurus](https://x.com/docusaurus) X (Twitter)
+- [@docusaurus](https://x.com/docusaurus) X
 - [GitHub Issues](https://github.com/facebook/docusaurus/issues)
 
 ## Contributors

--- a/admin/publish.md
+++ b/admin/publish.md
@@ -218,7 +218,7 @@ Create a separate branch/PR and run `yarn examples:generate`
 
 ### 9. Notify people about new release (optional but desirable)
 
-After new release, it is cool to notify our users about this in the Discord chat (`#announcements` channel) and write summaries on Twitter using the following templates.
+After new release, it is cool to notify our users about this in the Discord chat (`#announcements` channel) and write summaries on X using the following templates.
 
 For Discord:
 
@@ -227,7 +227,7 @@ A new version %VER% is available now! 🎉
 See release notes at the following link https://github.com/facebook/docusaurus/releases/tag/%VER%
 ```
 
-For Twitter:
+For X:
 
 ```
 💥 A new version %VER% is available now! 💥

--- a/examples/classic-typescript/docusaurus.config.ts
+++ b/examples/classic-typescript/docusaurus.config.ts
@@ -110,8 +110,8 @@ const config: Config = {
               href: 'https://discordapp.com/invite/docusaurus',
             },
             {
-              label: 'Twitter',
-              href: 'https://twitter.com/docusaurus',
+              label: 'X',
+              href: 'https://x.com/docusaurus',
             },
           ],
         },

--- a/examples/classic/docusaurus.config.js
+++ b/examples/classic/docusaurus.config.js
@@ -118,8 +118,8 @@ const config = {
                 href: 'https://discordapp.com/invite/docusaurus',
               },
               {
-                label: 'Twitter',
-                href: 'https://twitter.com/docusaurus',
+                label: 'X',
+                href: 'https://x.com/docusaurus',
               },
             ],
           },

--- a/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
+++ b/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
@@ -110,8 +110,8 @@ const config: Config = {
               href: 'https://discordapp.com/invite/docusaurus',
             },
             {
-              label: 'Twitter',
-              href: 'https://twitter.com/docusaurus',
+              label: 'X',
+              href: 'https://x.com/docusaurus',
             },
           ],
         },

--- a/packages/create-docusaurus/templates/classic/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/classic/docusaurus.config.js
@@ -118,8 +118,8 @@ const config = {
                 href: 'https://discordapp.com/invite/docusaurus',
               },
               {
-                label: 'Twitter',
-                href: 'https://twitter.com/docusaurus',
+                label: 'X',
+                href: 'https://x.com/docusaurus',
               },
             ],
           },

--- a/packages/docusaurus-plugin-pwa/src/index.ts
+++ b/packages/docusaurus-plugin-pwa/src/index.ts
@@ -31,7 +31,7 @@ function getSWBabelLoader() {
           {
             useBuiltIns: 'entry',
             corejs: '3',
-            // See https://twitter.com/jeffposnick/status/1280223070876315649
+            // See https://x.com/jeffposnick/status/1280223070876315649
             targets: 'chrome >= 56',
           },
         ],

--- a/packages/docusaurus-plugin-pwa/src/sw.ts
+++ b/packages/docusaurus-plugin-pwa/src/sw.ts
@@ -20,7 +20,7 @@ function parseSwParams() {
 
 // Doc advises against dynamic imports in SW
 // https://developers.google.com/web/tools/workbox/guides/using-bundlers#code_splitting_and_dynamic_imports
-// https://twitter.com/sebastienlorber/status/1280155204575518720
+// https://x.com/sebastienlorber/status/1280155204575518720
 // but looks it's working fine as it's inlined by webpack, need to double check
 async function runSWCustomCode(params: {offlineMode: boolean; debug: boolean}) {
   if (process.env.PWA_SW_CUSTOM) {

--- a/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css
@@ -8,7 +8,7 @@
 /*
 When the navbar is sticky, ensure that on anchor click,
 the browser does not scroll that anchor behind the navbar
-See https://twitter.com/JoshWComeau/status/1332015868725891076
+See https://x.com/JoshWComeau/status/1332015868725891076
  */
 .anchorWithStickyNavbar {
   scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);

--- a/packages/docusaurus-theme-common/src/utils/usePluralForm.ts
+++ b/packages/docusaurus-theme-common/src/utils/usePluralForm.ts
@@ -10,7 +10,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 // We want to ensurer a stable plural form order in all cases
 // It is more convenient and natural to handle "small values" first
-// See https://twitter.com/sebastienlorber/status/1366820663261077510
+// See https://x.com/sebastienlorber/status/1366820663261077510
 const OrderedPluralForms: Intl.LDMLPluralRule[] = [
   'zero',
   'one',

--- a/packages/docusaurus-theme-mermaid/src/client/index.ts
+++ b/packages/docusaurus-theme-mermaid/src/client/index.ts
@@ -103,7 +103,7 @@ export function useMermaidRenderResult({
       .then(setResult)
       .catch((e) => {
         // Funky way to trigger parent React error boundary
-        // See https://twitter.com/sebastienlorber/status/1628340871899893768
+        // See https://x.com/sebastienlorber/status/1628340871899893768
         setResult(() => {
           throw e;
         });

--- a/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/markdownUtils.test.ts
@@ -1098,7 +1098,7 @@ describe('escapeMarkdownHeadingIds', () => {
 
         ## News {#news}
 
-        For the latest news about Docusaurus, [follow **@docusaurus** on Twitter](https://twitter.com/docusaurus) and the [official Docusaurus blog](/blog) on this website.
+        For the latest news about Docusaurus, [follow **@docusaurus** on X](https://x.com/docusaurus) and the [official Docusaurus blog](/blog) on this website.
     `),
     ).toEqual(dedent`
         # Support
@@ -1128,7 +1128,7 @@ describe('escapeMarkdownHeadingIds', () => {
 
         ## News \{#news}
 
-        For the latest news about Docusaurus, [follow **@docusaurus** on Twitter](https://twitter.com/docusaurus) and the [official Docusaurus blog](/blog) on this website.
+        For the latest news about Docusaurus, [follow **@docusaurus** on X](https://x.com/docusaurus) and the [official Docusaurus blog](/blog) on this website.
     `);
   });
 });

--- a/packages/docusaurus-utils/src/urlUtils.ts
+++ b/packages/docusaurus-utils/src/urlUtils.ts
@@ -211,7 +211,7 @@ export function toURLPath(url: URL): URLPath {
 
 /**
  * Let's name the concept of (pathname + search + hash) as URLPath
- * See also https://twitter.com/kettanaito/status/1741768992866308120
+ * See also https://x.com/kettanaito/status/1741768992866308120
  * Note: this function also resolves relative pathnames while parsing!
  */
 export function parseURLPath(urlPath: string, fromPath?: string): URLPath {

--- a/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
+++ b/packages/docusaurus/src/server/__tests__/brokenLinks.test.ts
@@ -920,7 +920,7 @@ describe('handleBrokenLinks', () => {
     // We try to minimize the calls to this expensive function
     // Otherwise large sites will have super long execution times
     // See https://github.com/facebook/docusaurus/issues/9754
-    // See https://twitter.com/sebastienlorber/status/1749392773415858587
+    // See https://x.com/sebastienlorber/status/1749392773415858587
     // We expect no more matchRoutes calls than number of dynamic route links
     expect(matchRoutesMock).toHaveBeenCalledTimes(scale * 2);
     // We expect matchRoutes to be called with a reduced number of routes

--- a/packages/docusaurus/src/server/translations/translationsExtractor.ts
+++ b/packages/docusaurus/src/server/translations/translationsExtractor.ts
@@ -156,7 +156,7 @@ export async function extractSourceCodeFileTranslations(
       ast: true,
       // filename is important, because babel does not process the same files
       // according to their js/ts extensions.
-      // See https://twitter.com/NicoloRibaudo/status/1321130735605002243
+      // See https://x.com/NicoloRibaudo/status/1321130735605002243
       filename: sourceCodeFilePath,
     }) as Node;
 

--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -52,7 +52,7 @@ async function createBaseClientConfig({
     entry: path.resolve(__dirname, '../client/clientEntry.js'),
     optimization: {
       // Keep the runtime chunk separated to enable long term caching
-      // https://twitter.com/wSokra/status/969679223278505985
+      // https://x.com/wSokra/status/969679223278505985
       runtimeChunk: true,
     },
     plugins: [

--- a/packages/eslint-plugin/src/rules/__tests__/no-html-links.test.ts
+++ b/packages/eslint-plugin/src/rules/__tests__/no-html-links.test.ts
@@ -25,14 +25,14 @@ ruleTester.run('prefer-docusaurus-link', rule, {
       code: '<Link to="/test">test</Link>',
     },
     {
-      code: '<Link to="https://twitter.com/docusaurus">Twitter</Link>',
+      code: '<Link to="https://x.com/docusaurus">X</Link>',
     },
     {
-      code: '<a href="https://twitter.com/docusaurus">Twitter</a>',
+      code: '<a href="https://x.com/docusaurus">X</a>',
       options: [{ignoreFullyResolved: true}],
     },
     {
-      code: '<a href={`https://twitter.com/docusaurus`}>Twitter</a>',
+      code: '<a href={`https://x.com/docusaurus`}>X</a>',
       options: [{ignoreFullyResolved: true}],
     },
     {
@@ -50,11 +50,11 @@ ruleTester.run('prefer-docusaurus-link', rule, {
       errors: errorsJSX,
     },
     {
-      code: '<a href="https://twitter.com/docusaurus" target="_blank">test</a>',
+      code: '<a href="https://x.com/docusaurus" target="_blank">test</a>',
       errors: errorsJSX,
     },
     {
-      code: '<a href="https://twitter.com/docusaurus" target="_blank" rel="noopener noreferrer">test</a>',
+      code: '<a href="https://x.com/docusaurus" target="_blank" rel="noopener noreferrer">test</a>',
       errors: errorsJSX,
     },
     {
@@ -82,7 +82,7 @@ ruleTester.run('prefer-docusaurus-link', rule, {
       // TODO we might want to make this test pass
       // Can template literals be statically pre-evaluated? (Babel can do it)
       // eslint-disable-next-line no-template-curly-in-string
-      code: '<a href={`https://twitter.com/${"docu" + "saurus"} ${"rex"}`}>Twitter</a>',
+      code: '<a href={`https://x.com/${"docu" + "saurus"} ${"rex"}`}>Twitter</a>',
       options: [{ignoreFullyResolved: true}],
       errors: errorsJSX,
     },

--- a/website/_dogfooding/_blog tests/2024-07-03-dual-author.mdx
+++ b/website/_dogfooding/_blog tests/2024-07-03-dual-author.mdx
@@ -4,7 +4,7 @@ authors:
   - name: Sébastien Lorber
     imageURL: https://github.com/slorber.png
     socials:
-      twitter: https://twitter.com/sebastienlorber
+      x: https://x.com/sebastienlorber
       github: https://github.com/slorber
       linkedin: https://www.linkedin.com/in/sebastienlorber/
       newsletter: https://thisweekinreact.com/newsletter

--- a/website/_dogfooding/_blog tests/2024-07-03-multiple-authors.mdx
+++ b/website/_dogfooding/_blog tests/2024-07-03-multiple-authors.mdx
@@ -5,7 +5,6 @@ authors:
     imageURL: https://github.com/slorber.png
     title: Docusaurus Maintainer and This Week In React editor editor editor editor editor editor editor editor
     socials:
-      twitter: https://twitter.com/sebastienlorber
       x: https://x.com/sebastienlorber
       github: https://github.com/slorber
       stackoverflow: https://stackoverflow.com/users/82609/sebastien-lorber
@@ -14,7 +13,7 @@ authors:
   - name: Sébastien Lorber
     imageURL: https://github.com/slorber.png
     socials:
-      twitter: https://x.com/sebastienlorber
+      x: https://x.com/sebastienlorber
   - name: Sébastien Lorber
     imageURL: https://github.com/slorber.png
     title: Docusaurus Maintainer and This Week In React editor
@@ -28,14 +27,13 @@ authors:
     imageURL: https://github.com/slorber.png
     socials:
       github: https://github.com/slorber
-      twitter: https://twitter.com/sebastienlorber
       x: https://x.com/sebastienlorber
   - name: Sébastien Lorber
     imageURL: https://github.com/slorber.png
     title: Docusaurus Maintainer and This Week In React editor editor editor editor editor editor editor editor
     socials:
       github: https://github.com/slorber
-      twitter: https://x.com/sebastienlorber
+      x: https://x.com/sebastienlorber
   - name: Sébastien Lorber
     imageURL: https://github.com/slorber.png
     socials:

--- a/website/_dogfooding/_blog tests/2024-07-03-single-author.mdx
+++ b/website/_dogfooding/_blog tests/2024-07-03-single-author.mdx
@@ -6,7 +6,6 @@ authors:
     title: Docusaurus Maintainer and This Week In React editor editor editor editor editor editor editor editor editor editor editor editor editor editor
     socials:
       x: https://x.com/sebastienlorber
-      twitter: https://twitter.com/sebastienlorber
       github: https://github.com/slorber
       linkedin: https://www.linkedin.com/in/sebastienlorber/
       newsletter: https://thisweekinreact.com/newsletter

--- a/website/_dogfooding/_blog tests/authors.yml
+++ b/website/_dogfooding/_blog tests/authors.yml
@@ -3,8 +3,9 @@ slorber:
   title: Docusaurus maintainer
   url: https://sebastienlorber.com
   image_url: https://github.com/slorber.png
-  twitter: sebastienlorber
   page: true
+  socials:
+    x: sebastienlorber
 
 ozaki:
   name: ozaki

--- a/website/blog/2017/12-14-introducing-docusaurus.mdx
+++ b/website/blog/2017/12-14-introducing-docusaurus.mdx
@@ -129,7 +129,7 @@ build
 
 ![](/img/docusaurus.svg)
 
-We welcome your [contributions](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to Docusaurus, whether you want to use it for your own site, you want to [contribute](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to the Docusaurus core or just have questions. Follow us on [GitHub](https://github.com/facebook/docusaurus) and [X (formerly Twitter)](https://x.com/docusaurus).
+We welcome your [contributions](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to Docusaurus, whether you want to use it for your own site, you want to [contribute](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md) to the Docusaurus core or just have questions. Follow us on [GitHub](https://github.com/facebook/docusaurus) and [X)](https://x.com/docusaurus).
 
 ## Acknowledgements
 
@@ -151,6 +151,6 @@ Without their dedication to creating or migrating their websites over to the pla
 ## Resources
 
 - [Read our documentation](https://v1.docusaurus.io)
-- [Follow our X (formerly Twitter) feed](https://x.com/docusaurus)
+- [Follow our X feed](https://x.com/docusaurus)
 - [Follow us on GitHub](https://github.com/facebook/docusaurus)
 - [About Slash, the Docusaurus mascot](https://v1.docusaurus.io/about-slash.html)

--- a/website/blog/2018/09-11-Towards-Docusaurus-2.mdx
+++ b/website/blog/2018/09-11-Towards-Docusaurus-2.mdx
@@ -114,13 +114,13 @@ If you've read the post up until to this point, you should be able to notice tha
 
 The exact list of breaking changes is not totally known yet as development is not 100% finalized. However, one thing that I will highlight is that we will deprecate a lot of options in `siteConfig.js` and we plan to keep it as lean as possible. For example, the `cleanUrl` siteConfig will be deprecated as all the URL for Docusaurus 2 sites will be without the `.html` suffix.
 
-Our goal is that most sites should be able to upgrade to Docusaurus 2 without a lot of pain. We will also include a migration guide when we release Docusaurus 2. When the times come, feel free to ping us on [Discord](https://discord.gg/docusaurus) or [Twitter](https://twitter.com/docusaurus) for questions and help.
+Our goal is that most sites should be able to upgrade to Docusaurus 2 without a lot of pain. We will also include a migration guide when we release Docusaurus 2. When the times come, feel free to ping us on [Discord](https://discord.gg/docusaurus) or [X](https://x.com/docusaurus) for questions and help.
 
 ### When is the release of Docusaurus 2?
 
 As of now, we do not have an exact date planned for the release. I personally estimate that we might be able to release an alpha version in the next one to two months, but this is, of course, just an estimate.
 
-One thing that I would like to share is that while Docusaurus is part of [Facebook Open Source](https://opensource.fb.com/) and most of the team are Facebook employees, the maintenance and development work is mostly done outside of normal working hours. I am currently a final year undergraduate student at [NTU Singapore](https://twitter.com/NTUsg), so I had to juggle between doing my coursework, my final year project and maintaining/developing Docusaurus. However, that does not mean that we do not want to make Docusaurus better. In fact, **we want to make it as awesome as possible**.
+One thing that I would like to share is that while Docusaurus is part of [Facebook Open Source](https://opensource.fb.com/) and most of the team are Facebook employees, the maintenance and development work is mostly done outside of normal working hours. I am currently a final year undergraduate student at [NTU Singapore](https://x.com/NTUsg), so I had to juggle between doing my coursework, my final year project and maintaining/developing Docusaurus. However, that does not mean that we do not want to make Docusaurus better. In fact, **we want to make it as awesome as possible**.
 
 For now, the actual Docusaurus 2 work is still hosted in a private repository. In the near future, we will move them into the [public repository](https://github.com/facebook/docusaurus). When that time arrives, I encourage everyone to look into it and hopefully contribute in some way. Before then, please stay tuned 😉!
 
@@ -136,4 +136,4 @@ If you are using Docusaurus, you are part of our community; keep letting us know
 
 > If you are sponsoring our work on [Open Collective](https://opencollective.com/Docusaurus), we'll personally offer you a helping hand for maintenance and upgrading of Docusaurus website.
 
-Lastly, if you haven't done so already, click the **star** and **watch** button on [GitHub](https://github.com/facebook/docusaurus), and follow us on [Twitter](https://twitter.com/docusaurus).
+Lastly, if you haven't done so already, click the **star** and **watch** button on [GitHub](https://github.com/facebook/docusaurus), and follow us on [X](https://x.com/docusaurus).

--- a/website/blog/2018/12-14-Happy-First-Birthday-Slash.mdx
+++ b/website/blog/2018/12-14-Happy-First-Birthday-Slash.mdx
@@ -12,8 +12,8 @@ Docusaurus [went live](https://v1.docusaurus.io/blog/2017/12/14/introducing-docu
 
 <!--truncate-->
 
-We now have nearly [60 known users of Docusaurus](https://v1.docusaurus.io/en/users), and probably more that we don't know about. We have [9K GitHub stars](https://github.com/facebook/docusaurus) and an active community, particularly [Yangshun Tay](https://twitter.com/yangshunz) and [Endilie Yacop Sucipto](https://twitter.com/endiliey), both of whom are the lead maintainers helping keep this project [moving forward](https://docusaurus.io/blog/2018/09/11/Towards-Docusaurus-2).
+We now have nearly [60 known users of Docusaurus](https://v1.docusaurus.io/en/users), and probably more that we don't know about. We have [9K GitHub stars](https://github.com/facebook/docusaurus) and an active community, particularly [Yangshun Tay](https://x.com/yangshunz) and [Endilie Yacop Sucipto](https://x.com/endiliey), both of whom are the lead maintainers helping keep this project [moving forward](https://docusaurus.io/blog/2018/09/11/Towards-Docusaurus-2).
 
 Thank you to everyone for your support and use of this project! I am super proud of how far this project has come in just a year.
 
-> Special thanks to [Eric Nakagawa](https://twitter.com/ericnakagawa), creator of Slash, for creating this 1-year image of Slash enjoying cake. The Slash brand has been a boon for us!
+> Special thanks to [Eric Nakagawa](https://x.com/ericnakagawa), creator of Slash, for creating this 1-year image of Slash enjoying cake. The Slash brand has been a boon for us!

--- a/website/blog/2020/01-07-tribute-to-endi.mdx
+++ b/website/blog/2020/01-07-tribute-to-endi.mdx
@@ -12,11 +12,11 @@ It is impossible to overstate Endi's impact on this project:
 
 - Docusaurus' top contributor, [by far](https://github.com/facebook/docusaurus/graphs/contributors).
 - [Lead developer](https://docusaurus.io/blog/2018/09/11/Towards-Docusaurus-2) on the nearly complete [version 2 of Docusaurus](https://docusaurus.io/blog/2019/12/30/docusaurus-2019-recap).
-- Overall passionate advocate of the project on [Twitter](https://twitter.com/endiliey), [Discord](https://discord.gg/docusaurus) and other social media
+- Overall passionate advocate of the project on [X](https://x.com/endiliey), [Discord](https://discord.gg/docusaurus) and other social media
 
 Thinking about it now, it is absolutely amazing how much Endi accomplished on Docusaurus given what he was battling with his health.
 
-We are working on ways to honor Endi's contributions - a commemorative sticker, possibly - and we are open to ideas. Leave a comment here or [tweet](https://twitter.com/docusaurus) if you have a suggestion.
+We are working on ways to honor Endi's contributions - a commemorative sticker, possibly - and we are open to ideas. Leave a comment here or [tweet](https://x.com/docusaurus) if you have a suggestion.
 
 The Docusaurus project will not be the same without Endi, and those of us who worked with him will miss him greatly. 😔
 

--- a/website/blog/2021/01-19-docusaurus-2020-recap.mdx
+++ b/website/blog/2021/01-19-docusaurus-2020-recap.mdx
@@ -126,7 +126,7 @@ We still have a few **major features** that we would like to work on:
 Huge thanks to the community for [their contributions in 2020](https://github.com/facebook/docusaurus/graphs/contributors?from=2020-01-01&to=2021-01-01&type=c), especially:
 
 - [Joel Marcey](https://github.com/JoelMarcey) for creating Docusaurus and supporting the project all this time
-- the core team - [Alexey Pyltsyn](https://github.com/lex111), [Sébastien Lorber](https://sebastienlorber.com), [Yangshun Tay](https://twitter.com/yangshunz)
+- the core team - [Alexey Pyltsyn](https://github.com/lex111), [Sébastien Lorber](https://sebastienlorber.com), [Yangshun Tay](https://x.com/yangshunz)
 - the Major League Hacking and Facebook interns for their significant impact
 - the Algolia team for DocSearch 3 and their support
 - [Bartosz Kaszubowski](https://github.com/Simek) for his investment in the React Native migration

--- a/website/blog/2021/05-12-announcing-docusaurus-two-beta/index.mdx
+++ b/website/blog/2021/05-12-announcing-docusaurus-two-beta/index.mdx
@@ -84,7 +84,7 @@ To get there, we will continue to **fix bugs** and implement the **most wanted f
 
 This is an exciting time for Docusaurus.
 
-We are inspired by the [positive feedback](https://twitter.com/sebastienlorber/timelines/1392048416872706049) about Docusaurus, and discover new sites online every single day.
+We are inspired by the [positive feedback](https://x.com/sebastienlorber/timelines/1392048416872706049) about Docusaurus, and discover new sites online every single day.
 
 We are so excited for this beta release. We strove for quality and stability while continuing to try to increase the adoption of Docusaurus. For those that have been on the fence from migrating an existing Docusaurus site to Docusaurus 2, it is a great time to upgrade. We want you running on the latest infrastructure when we deprecate Docusaurus 1 at the end of this beta period. Let us know how we can help.
 

--- a/website/blog/2022/01-24-docusaurus-2021-recap/index.mdx
+++ b/website/blog/2022/01-24-docusaurus-2021-recap/index.mdx
@@ -87,7 +87,7 @@ The creativity of Docusaurus users is beyond our imagination 🤩 We look forwar
 
 As an active moderator on [Discord](https://discord.gg/docusaurus), I can clearly see the community thriving. Many frequently asked questions are now integrated into our documentation, and some feature requests have been implemented as well. The project and the community reciprocally benefit each other – case in point, I was formerly a community contributor before becoming a maintainer.
 
-We are constantly mentioned on Twitter with inspirational feedback:
+We are constantly mentioned on X with inspirational feedback:
 
 > **@docusaurus** is amazing! cant believe it's THAT simple to use.
 
@@ -95,7 +95,7 @@ We are constantly mentioned on Twitter with inspirational feedback:
 
 > I love **@docusaurus**. I couldn't have built the APIs, tutorials, and blogs contained in my site efficiently and beautifully in my workflow without Docusaurus.
 
-And we keep every one of them in [our little box](https://twitter.com/sebastienlorber/timelines/1392048416872706049) 😄 If you enjoy Docusaurus yourself, keep tagging us with your comments!
+And we keep every one of them in [our little box](https://x.com/sebastienlorber/timelines/1392048416872706049) 😄 If you enjoy Docusaurus yourself, keep tagging us with your comments!
 
 As we approach the official release, we are interested in knowing more about what people are doing out there: [plugin authors](https://github.com/facebook/docusaurus/discussions/4025), [creators of customized sites](https://github.com/facebook/docusaurus/discussions/5468), and [all new users](https://github.com/facebook/docusaurus/discussions/4610) – please keep us posted about your achievements so we can steer our development to better serve your needs.
 

--- a/website/blog/2022/08-01-announcing-docusaurus-2.0/index.mdx
+++ b/website/blog/2022/08-01-announcing-docusaurus-2.0/index.mdx
@@ -64,7 +64,7 @@ Docusaurus is **full-featured** and very **flexible**: we ship with well-designe
 The Docusaurus philosophy is akin to the **Pareto principle**: you can get **80% of the results** for **20% of the effort**. This enables you to compete with top-notch documentation sites with **minimal effort**.
 
 <TweetQuote
-  url="https://twitter.com/rachelnabors/status/1452697991039660038"
+  url="https://x.com/rachelnabors/status/1452697991039660038"
   handle="rachelnabors"
   name="Rachel Nabors"
   job="Former ReactJS & React-Native docs manager">
@@ -75,7 +75,7 @@ The Docusaurus philosophy is akin to the **Pareto principle**: you can get **80%
 Docusaurus aims to be the **best documentation tool**, but you can use it for **other use-cases** as well: a blog, a knowledge base, a developer portfolio, a second brain, or even to scaffold landing pages!
 
 <TweetQuote
-  url="https://twitter.com/johnny_reilly/status/1551861926334025728"
+  url="https://x.com/johnny_reilly/status/1551861926334025728"
   handle="johnny_reilly"
   name="Johnny Reilly"
   job="Group Principal Engineer at Investec">
@@ -143,7 +143,7 @@ Our GitHub star trend is very positive, competing with major frameworks:
 
 Today, Docusaurus v2 has already been a great success even before its launch:
 
-- We received so many [lovely testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)
+- We received so many [lovely testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)
 - Companies like [1Password](https://blog.1password.com/docusaurus-documentation-framework/) and [Courier](https://www.courier.com/blog/how-we-built-our-documentation/) are writing down their positive experience
 - Our [site showcase](/showcase) references hundreds of sites, and this is only the tip of the iceberg.
 
@@ -158,7 +158,7 @@ Please add your site to our [site showcase](/showcase)! It only takes a few seco
 :::
 
 <TweetQuote
-  url="https://twitter.com/maxlynch/status/1549415692704825346"
+  url="https://x.com/maxlynch/status/1549415692704825346"
   handle="maxlynch"
   name="Max Lynch"
   job="Ionic co-founder and CEO">
@@ -166,7 +166,7 @@ Please add your site to our [site showcase](/showcase)! It only takes a few seco
 </TweetQuote>
 
 <TweetQuote
-  url="https://twitter.com/supabase/status/1328960757149671425"
+  url="https://x.com/supabase/status/1328960757149671425"
   handle="supabase"
   name="Supabase"
   job="Open Source Firebase alternative">
@@ -174,7 +174,7 @@ Please add your site to our [site showcase](/showcase)! It only takes a few seco
 </TweetQuote>
 
 <TweetQuote
-  url="https://twitter.com/gabrielcsapo/status/1415061312917233665"
+  url="https://x.com/gabrielcsapo/status/1415061312917233665"
   handle="gabrielcsapo"
   name="Gabriel Csapo"
   job="Staff Software Engineer at LinkedIn">
@@ -183,7 +183,7 @@ Please add your site to our [site showcase](/showcase)! It only takes a few seco
 </TweetQuote>
 
 <TweetQuote
-  url="https://twitter.com/ItWasMattGregg/status/1526682295075102721"
+  url="https://x.com/ItWasMattGregg/status/1526682295075102721"
   handle="ItWasMattGregg"
   name="Matt Gregg"
   job="Senior Front End Developer at Shopify">
@@ -225,7 +225,7 @@ MDX has its own [plugin system](https://mdxjs.com/docs/extending-mdx/). You to c
 :::
 
 <TweetQuote
-  url="https://twitter.com/HamelHusain/status/1551962275250053123"
+  url="https://x.com/HamelHusain/status/1551962275250053123"
   handle="HamelHusain"
   name="Hamel Husain"
   job="Head Of Data Science at Outerbounds">
@@ -249,7 +249,7 @@ Our goal is to make Docusaurus very **intuitive** to use. We added file system c
 <br />
 
 <TweetQuote
-  url="https://twitter.com/paularmstrong/status/1552005085168865281"
+  url="https://x.com/paularmstrong/status/1552005085168865281"
   handle="paularmstrong"
   name="Paul Armstrong"
   job="Principal Engineer at Microsoft">
@@ -274,7 +274,7 @@ Let's highlight some examples:
 ![shiki-twoslash plugin example](./img/plugins/shiki-twoslash.png)
 
 <TweetQuote
-  url="https://twitter.com/orta"
+  url="https://x.com/orta"
   handle="orta"
   name="Orta Therox"
   job="Former TypeScript core team at Microsoft">
@@ -293,7 +293,7 @@ We have a curated list of outstanding plugins in our [community resources](/comm
 :::
 
 <TweetQuote
-  url="https://twitter.com/jodyheavener/status/1551974535452311552"
+  url="https://x.com/jodyheavener/status/1551974535452311552"
   handle="jodyheavener"
   name="Jody Heavener"
   job="Senior Developer at 1Password">
@@ -313,7 +313,7 @@ Docusaurus theming gives a lot of **flexibility** on multiple levels:
 - **Override any React component** provided by our default theme: we call this [swizzling](https://docusaurus.io/docs/swizzling)
 
 <TweetQuote
-  url="https://twitter.com/hung_dev/status/1546918275065741312"
+  url="https://x.com/hung_dev/status/1546918275065741312"
   handle="hung_dev"
   name="
 Hung Viet Nguyen"
@@ -328,7 +328,7 @@ This enables users willing to invest a bit more time on **customizations** to bu
 <ShowcaseCarouselV2Theming />
 
 <TweetQuote
-  url="https://twitter.com/dabit3/status/1382855449813389315"
+  url="https://x.com/dabit3/status/1382855449813389315"
   handle="dabit3"
   name="Nader Dabit"
   job="Web3 developer, Developer DAO founder">
@@ -358,7 +358,7 @@ Docusaurus 2 comes with a very long list of useful features:
 - Tests: Docusaurus is well-tested, we dogfood features and ensure they keep working
 
 <TweetQuote
-  url="https://twitter.com/alexbdebrie/status/1540010328335032320"
+  url="https://x.com/alexbdebrie/status/1540010328335032320"
   handle="alexbdebrie"
   name="Alex DeBrie"
   job="AWS Data Hero, author of The DynamoDB Book">

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,7 +1,7 @@
 JMarcey:
   name: Joel Marcey
   title: Developer Advocate at Meta
-  url: https://twitter.com/JoelMarcey
+  url: https://x.com/JoelMarcey
   image_url: https://github.com/JoelMarcey.png
   page: true
   socials:

--- a/website/community/0-support.mdx
+++ b/website/community/0-support.mdx
@@ -25,4 +25,4 @@ For new feature requests, you can create a post on our [feature requests board (
 
 ## News {#news}
 
-For the latest news about Docusaurus, [follow **@docusaurus** on Twitter](https://twitter.com/docusaurus) and the [official Docusaurus blog](/blog) on this website.
+For the latest news about Docusaurus, [follow **@docusaurus** on X](https://x.com/docusaurus) and the [official Docusaurus blog](/blog) on this website.

--- a/website/docs/api/misc/eslint-plugin/no-html-links.mdx
+++ b/website/docs/api/misc/eslint-plugin/no-html-links.mdx
@@ -17,7 +17,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <a href="/page">go to page!</a>
 
-<a href="https://twitter.com/docusaurus" target="_blank">Twitter</a>
+<a href="https://x.com/docusaurus" target="_blank">X</a>
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link'
 
 <Link to="/page">go to page!</Link>
 
-<Link to="https://twitter.com/docusaurus">Twitter</Link>
+<Link to="https://x.com/docusaurus">X</Link>
 ```
 
 ## Rule Configuration {#configuration}

--- a/website/docs/api/plugins/plugin-content-blog.mdx
+++ b/website/docs/api/plugins/plugin-content-blog.mdx
@@ -246,7 +246,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -1014,8 +1014,8 @@ export default {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -1050,8 +1050,8 @@ export default {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -130,7 +130,7 @@ The high-level overview of Docusaurus configuration can be categorized into:
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/docs/docusaurus-core.mdx
+++ b/website/docs/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [X (formerly Twitter)](https://x.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -545,7 +545,7 @@ export default async function createConfigAsync() {
       },
       announcementBar: {
         id: `announcementBar-v${announcedVersion}`,
-        // content: `⭐️ If you like Docusaurus, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/facebook/docusaurus">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/docusaurus">Twitter ${TwitterSvg}</a>`,
+        // content: `⭐️ If you like Docusaurus, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/facebook/docusaurus">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://x.com/docusaurus">X ${TwitterSvg}</a>`,
         content: `🎉️ <b><a target="_blank" href="https://docusaurus.io/blog/releases/${announcedVersion}">Docusaurus v${announcedVersion}</a> is out!</b> 🥳️`,
       },
       prism: {
@@ -751,8 +751,8 @@ export default async function createConfigAsync() {
                 href: 'https://github.com/facebook/docusaurus',
               },
               {
-                label: 'Twitter',
-                href: 'https://twitter.com/docusaurus',
+                label: 'X',
+                href: 'https://x.com/docusaurus',
               },
               {
                 html: `

--- a/website/src/components/TeamProfileCards/index.tsx
+++ b/website/src/components/TeamProfileCards/index.tsx
@@ -25,7 +25,7 @@ type ProfileProps = {
   name: string;
   children: ReactNode;
   githubUrl: string;
-  twitterUrl?: string;
+  xUrl?: string;
 };
 
 function TeamProfileCard({
@@ -33,7 +33,7 @@ function TeamProfileCard({
   name,
   children,
   githubUrl,
-  twitterUrl,
+  xUrl,
 }: ProfileProps) {
   return (
     <div className={className}>
@@ -60,9 +60,9 @@ function TeamProfileCard({
                 GitHub
               </Link>
             )}
-            {twitterUrl && (
-              <Link className="button button--secondary" href={twitterUrl}>
-                Twitter
+            {xUrl && (
+              <Link className="button button--secondary" href={xUrl}>
+                X
               </Link>
             )}
           </div>
@@ -84,7 +84,7 @@ export function ActiveTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Sébastien Lorber"
         githubUrl="https://github.com/slorber"
-        twitterUrl="https://twitter.com/sebastienlorber">
+        xUrl="https://x.com/sebastienlorber">
         <Translate
           id="team.profile.Sebastien Lorber.body"
           values={{
@@ -99,7 +99,7 @@ export function ActiveTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Sida Chen"
         githubUrl="https://github.com/Josh-Cena"
-        twitterUrl="https://twitter.com/SidaChen63">
+        xUrl="https://x.com/SidaChen63">
         <Translate id="team.profile.Sida Chen.body">
           Student from Shanghai, China. Enthusiastic open-source project
           creator, but never actually works hard on those projects he created.
@@ -123,7 +123,7 @@ export function HonoraryAlumniTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Joel Marcey"
         githubUrl="https://github.com/JoelMarcey"
-        twitterUrl="https://twitter.com/joelmarcey">
+        xUrl="https://x.com/joelmarcey">
         <Translate id="team.profile.Joel Marcey.body">
           Docusaurus founder and now ever grateful Docusaurus cheerleader to
           those who actually write code for it.
@@ -140,7 +140,7 @@ export function HonoraryAlumniTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Yangshun Tay"
         githubUrl="https://github.com/yangshun"
-        twitterUrl="https://twitter.com/yangshunz">
+        xUrl="https://x.com/yangshunz">
         <Translate id="team.profile.Yangshun Tay.body">
           Full Front End Stack developer who likes working on the Jamstack.
           Working on Docusaurus made him Facebook&apos;s unofficial part-time
@@ -150,7 +150,7 @@ export function HonoraryAlumniTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Endilie Yacop Sucipto"
         githubUrl="https://github.com/endiliey"
-        twitterUrl="https://twitter.com/endiliey">
+        xUrl="https://x.com/endiliey">
         <Translate id="team.profile.Endilie Yacop Sucipto.body">
           Maintainer @docusaurus · 🔥🔥🔥
         </Translate>
@@ -158,7 +158,7 @@ export function HonoraryAlumniTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Wei Gao"
         githubUrl="https://github.com/wgao19"
-        twitterUrl="https://twitter.com/wgao19">
+        xUrl="https://x.com/wgao19">
         <Translate id="team.profile.Wei Gao.body">
           🏻‍🌾 Work in progress React developer, maintains Docusaurus, writes
           docs and spams this world with many websites.
@@ -174,7 +174,7 @@ export function StudentFellowsTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Anshul Goyal"
         githubUrl="https://github.com/anshulrgoyal"
-        twitterUrl="https://twitter.com/ar_goyal">
+        xUrl="https://x.com/ar_goyal">
         <Translate
           id="team.profile.Anshul Goyal.body"
           values={{
@@ -202,7 +202,7 @@ export function StudentFellowsTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Fanny Vieira"
         githubUrl="https://github.com/fanny"
-        twitterUrl="https://twitter.com/fannyvieiira">
+        xUrl="https://x.com/fannyvieiira">
         <Translate
           id="team.profile.Fanny Vieira.body"
           values={{
@@ -229,7 +229,7 @@ export function StudentFellowsTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Sam Zhou"
         githubUrl="https://github.com/SamChou19815"
-        twitterUrl="https://twitter.com/SamChou19815">
+        xUrl="https://x.com/SamChou19815">
         <Translate
           id="team.profile.Sam Zhou.body"
           values={{
@@ -263,7 +263,7 @@ export function StudentFellowsTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Tan Teik Jun"
         githubUrl="https://github.com/teikjun"
-        twitterUrl="https://twitter.com/teik_jun">
+        xUrl="https://x.com/teik_jun">
         <Translate id="team.profile.Tan Teik Jun.body">
           Open-source enthusiast who aims to become as awesome as the other
           humans on this page. Working on Docusaurus brought him closer to his
@@ -273,7 +273,7 @@ export function StudentFellowsTeamRow(): JSX.Element {
       <TeamProfileCardCol
         name="Nisarag Bhatt"
         githubUrl="https://github.com/FocalChord"
-        twitterUrl="https://twitter.com/focalchord_">
+        xUrl="https://x.com/focalchord_">
         <Translate id="team.profile.Nisarag Bhatt.body">
           Fullstack web developer who loves learning new technologies and
           applying them! Loves contributing to open source as well as writing

--- a/website/src/components/Tweet/index.tsx
+++ b/website/src/components/Tweet/index.tsx
@@ -36,7 +36,7 @@ export default function Tweet({
           <img
             alt={name}
             className="avatar__photo"
-            src={`https://unavatar.io/twitter/${handle}?fallback=https://github.com/${githubUsername}.png`}
+            src={`https://unavatar.io/x/${handle}?fallback=https://github.com/${githubUsername}.png`}
             width="48"
             height="48"
             loading="lazy"

--- a/website/src/components/TweetQuote/index.tsx
+++ b/website/src/components/TweetQuote/index.tsx
@@ -27,8 +27,8 @@ export default function TweetQuote({
   job,
   children,
 }: Props): JSX.Element {
-  const avatar = `https://unavatar.io/twitter/${handle}`;
-  const profileUrl = `https://twitter.com/${handle}`;
+  const avatar = `https://unavatar.io/x/${handle}`;
+  const profileUrl = `https://x.com/${handle}`;
   return (
     <figure className={styles.tweetQuote}>
       <blockquote>

--- a/website/src/data/tweets.tsx
+++ b/website/src/data/tweets.tsx
@@ -17,7 +17,7 @@ export type TweetItem = Tweet & {
 
 const TWEETS: TweetItem[] = [
   {
-    url: 'https://twitter.com/acemarke/status/1452725153998245891',
+    url: 'https://x.com/acemarke/status/1452725153998245891',
     handle: 'acemarke',
     name: 'Mark Erikson',
     date: 'Oct 26, 2021',
@@ -33,7 +33,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'markerikson',
   },
   {
-    url: 'https://twitter.com/arcanis/status/1351620354561732608',
+    url: 'https://x.com/arcanis/status/1351620354561732608',
     handle: 'arcanis',
     name: 'Maël',
     date: 'Jan 20, 2021',
@@ -47,7 +47,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'arcanis',
   },
   {
-    url: 'https://twitter.com/maxlynch/status/1375113166007455748',
+    url: 'https://x.com/maxlynch/status/1375113166007455748',
     handle: 'maxlynch',
     name: 'Max Lynch',
     date: 'Mar 25, 2021',
@@ -61,7 +61,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'mlynch',
   },
   {
-    url: 'https://twitter.com/supabase/status/1328960757149671425',
+    url: 'https://x.com/supabase/status/1328960757149671425',
     handle: 'supabase',
     name: 'Supabase',
     date: 'Nov 18, 2020',
@@ -78,7 +78,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'supabase',
   },
   {
-    url: 'https://twitter.com/paularmstrong/status/1387059593373700100',
+    url: 'https://x.com/paularmstrong/status/1387059593373700100',
     handle: 'paularmstrong',
     name: 'Paul Armstrong',
     date: 'Apr 27, 2021',
@@ -93,7 +93,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'paularmstrong',
   },
   {
-    url: 'https://twitter.com/sanketsahu/status/1328677366642528257',
+    url: 'https://x.com/sanketsahu/status/1328677366642528257',
     handle: 'sanketsahu',
     name: 'Sanket Sahu',
     date: 'Nov 17, 2020',
@@ -106,7 +106,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'sanketsahu',
   },
   {
-    url: 'https://twitter.com/debs_obrien/status/1374615572298801155',
+    url: 'https://x.com/debs_obrien/status/1374615572298801155',
     handle: 'debs_obrien',
     name: "Debbie O'Brien",
     date: 'Mar 24, 2021',
@@ -122,7 +122,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'debs-obrien',
   },
   {
-    url: 'https://twitter.com/Dr_Electron/status/1443635328376508433',
+    url: 'https://x.com/Dr_Electron/status/1443635328376508433',
     handle: 'Dr_Electron',
     name: 'Dr.Electron',
     date: 'Oct 11, 2021',
@@ -139,7 +139,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'Dr-Electron',
   },
   {
-    url: 'https://twitter.com/kentcdodds/status/1323806816019468288',
+    url: 'https://x.com/kentcdodds/status/1323806816019468288',
     handle: 'kentcdodds',
     name: 'Kent C. Dodds',
     date: 'Nov 4, 2020',
@@ -157,7 +157,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'kentcdodds',
   },
   {
-    url: 'https://twitter.com/bantg/status/1463608561368457225',
+    url: 'https://x.com/bantg/status/1463608561368457225',
     handle: 'bantg',
     name: 'banteg',
     date: 'Nov 25, 2021',
@@ -166,7 +166,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'banteg',
   },
   {
-    url: 'https://twitter.com/swyx/status/1418405515684581378',
+    url: 'https://x.com/swyx/status/1418405515684581378',
     handle: 'swyx',
     name: 'swyx',
     date: 'Jul 23, 2021',
@@ -185,7 +185,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'sw-yx',
   },
   {
-    url: 'https://twitter.com/rachelnabors/status/1478490902037467137',
+    url: 'https://x.com/rachelnabors/status/1478490902037467137',
     handle: 'rachelnabors',
     name: "R 'Nearest' Nabors 💙",
     date: 'Jan 5, 2022',
@@ -198,7 +198,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'rachelnabors',
   },
   {
-    url: 'https://twitter.com/dabit3/status/1394685348375052295',
+    url: 'https://x.com/dabit3/status/1394685348375052295',
     handle: 'dabit3',
     name: 'Nader Dabit',
     date: 'May 19, 2021',
@@ -212,7 +212,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'dabit3',
   },
   {
-    url: 'https://twitter.com/johnny_reilly/status/1469238609266028545',
+    url: 'https://x.com/johnny_reilly/status/1469238609266028545',
     handle: 'johnny_reilly',
     name: 'John Reilly',
     date: 'Dec 10, 2021',
@@ -230,7 +230,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'johnnyreilly',
   },
   {
-    url: 'https://twitter.com/tinkertim/status/1423358665726304260',
+    url: 'https://x.com/tinkertim/status/1423358665726304260',
     handle: 'tinkertim',
     name: 'Tim Post 💉💉💉',
     date: 'Aug 6, 2021',
@@ -248,7 +248,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'tinkertim',
   },
   {
-    url: 'https://twitter.com/sebastienlorber/status/1321784071815680000',
+    url: 'https://x.com/sebastienlorber/status/1321784071815680000',
     handle: 'sebastienlorber',
     name: 'Sebastien Lorber',
     date: 'Oct 29, 2020',
@@ -271,7 +271,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'slorber',
   },
   {
-    url: 'https://twitter.com/iansu/status/1184149586048245760',
+    url: 'https://x.com/iansu/status/1184149586048245760',
     handle: 'iansu',
     name: 'Ian Sutherland',
     date: 'Oct 16, 2019',
@@ -291,7 +291,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'iansu',
   },
   {
-    url: 'https://twitter.com/mweststrate/status/1181276252293853186',
+    url: 'https://x.com/mweststrate/status/1181276252293853186',
     handle: 'mweststrate',
     name: 'Michel Weststrate',
     date: 'Oct 8, 2019',
@@ -311,7 +311,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'mweststrate',
   },
   {
-    url: 'https://twitter.com/verdaccio_npm/status/1420187249145118722',
+    url: 'https://x.com/verdaccio_npm/status/1420187249145118722',
     handle: 'verdaccio_npm',
     name: 'verdaccio',
     date: 'Jul 28, 2021',
@@ -328,7 +328,7 @@ const TWEETS: TweetItem[] = [
   },
 
   {
-    url: 'https://twitter.com/yangshunz/status/1284536949718478848',
+    url: 'https://x.com/yangshunz/status/1284536949718478848',
     handle: 'yangshunz',
     name: 'Yangshun Tay',
     date: 'Jul 19, 2020',
@@ -344,7 +344,7 @@ const TWEETS: TweetItem[] = [
   },
 
   {
-    url: 'https://twitter.com/pierregillesl/status/1372839188698001408',
+    url: 'https://x.com/pierregillesl/status/1372839188698001408',
     handle: 'pierregillesl',
     name: 'Pierre-Gilles Leymarie',
     date: 'Mar 19, 2021',
@@ -365,7 +365,7 @@ const TWEETS: TweetItem[] = [
     githubUsername: 'Pierre-Gilles',
   },
   {
-    url: 'https://twitter.com/biantris_/status/1480259279487741953',
+    url: 'https://x.com/biantris_/status/1480259279487741953',
     handle: 'biantris_',
     name: 'biazita',
     date: 'Jan 10, 2022',

--- a/website/src/plugins/changelog/theme/ChangelogList/Header/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogList/Header/index.tsx
@@ -11,10 +11,10 @@ import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
-function TwitterLink() {
+function XLink() {
   return (
-    <Link href="https://twitter.com/docusaurus" className={styles.twitter}>
-      <b>Twitter</b>
+    <Link href="https://x.com/docusaurus" className={styles.x}>
+      <b>X</b>
       <svg
         style={{
           fill: '#1da1f2',
@@ -71,11 +71,11 @@ export default function ChangelogListHeader({
         <Translate
           id="changelog.description"
           values={{
-            twitterLink: <TwitterLink />,
+            xLink: <XLink />,
             rssLink: <RssLink />,
           }}>
           {
-            'Subscribe through {rssLink} or follow us on {twitterLink} to stay up-to-date with new releases!'
+            'Subscribe through {rssLink} or follow us on {xLink} to stay up-to-date with new releases!'
           }
         </Translate>
       </p>

--- a/website/src/plugins/changelog/theme/ChangelogList/Header/styles.module.css
+++ b/website/src/plugins/changelog/theme/ChangelogList/Header/styles.module.css
@@ -10,7 +10,7 @@
   color: #f26522;
 }
 
-.twitter,
-.twitter:hover {
+.x,
+.x:hover {
   color: #1da1f2;
 }

--- a/website/versioned_docs/version-2.x/api/plugins/plugin-content-blog.mdx
+++ b/website/versioned_docs/version-2.x/api/plugins/plugin-content-blog.mdx
@@ -206,7 +206,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/versioned_docs/version-2.x/api/themes/theme-configuration.mdx
+++ b/website/versioned_docs/version-2.x/api/themes/theme-configuration.mdx
@@ -943,8 +943,8 @@ module.exports = {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -979,8 +979,8 @@ module.exports = {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/versioned_docs/version-2.x/configuration.mdx
+++ b/website/versioned_docs/version-2.x/configuration.mdx
@@ -26,7 +26,7 @@ For exact reference to each of the configurable fields, you may refer to [**`doc
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/versioned_docs/version-2.x/docusaurus-core.mdx
+++ b/website/versioned_docs/version-2.x/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/versioned_docs/version-2.x/installation.mdx
+++ b/website/versioned_docs/version-2.x/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/versioned_docs/version-2.x/introduction.mdx
+++ b/website/versioned_docs/version-2.x/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)**.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [Twitter](https://twitter.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!

--- a/website/versioned_docs/version-3.0.1/api/misc/eslint-plugin/no-html-links.mdx
+++ b/website/versioned_docs/version-3.0.1/api/misc/eslint-plugin/no-html-links.mdx
@@ -17,7 +17,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <a href="/page">go to page!</a>
 
-<a href="https://twitter.com/docusaurus" target="_blank">Twitter</a>
+<a href="https://x.com/docusaurus" target="_blank">X</a>
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link'
 
 <Link to="/page">go to page!</Link>
 
-<Link to="https://twitter.com/docusaurus">Twitter</Link>
+<Link to="https://x.com/docusaurus">X</Link>
 ```
 
 ## Rule Configuration {#configuration}

--- a/website/versioned_docs/version-3.0.1/api/plugins/plugin-content-blog.mdx
+++ b/website/versioned_docs/version-3.0.1/api/plugins/plugin-content-blog.mdx
@@ -207,7 +207,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/versioned_docs/version-3.0.1/api/themes/theme-configuration.mdx
+++ b/website/versioned_docs/version-3.0.1/api/themes/theme-configuration.mdx
@@ -946,8 +946,8 @@ export default {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -982,8 +982,8 @@ export default {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/versioned_docs/version-3.0.1/configuration.mdx
+++ b/website/versioned_docs/version-3.0.1/configuration.mdx
@@ -130,7 +130,7 @@ The high-level overview of Docusaurus configuration can be categorized into:
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/versioned_docs/version-3.0.1/docusaurus-core.mdx
+++ b/website/versioned_docs/version-3.0.1/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/versioned_docs/version-3.0.1/installation.mdx
+++ b/website/versioned_docs/version-3.0.1/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/versioned_docs/version-3.0.1/introduction.mdx
+++ b/website/versioned_docs/version-3.0.1/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)**.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [Twitter](https://twitter.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!

--- a/website/versioned_docs/version-3.1.1/api/misc/eslint-plugin/no-html-links.mdx
+++ b/website/versioned_docs/version-3.1.1/api/misc/eslint-plugin/no-html-links.mdx
@@ -17,7 +17,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <a href="/page">go to page!</a>
 
-<a href="https://twitter.com/docusaurus" target="_blank">Twitter</a>
+<a href="https://x.com/docusaurus" target="_blank">X</a>
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link'
 
 <Link to="/page">go to page!</Link>
 
-<Link to="https://twitter.com/docusaurus">Twitter</Link>
+<Link to="https://x.com/docusaurus">X</Link>
 ```
 
 ## Rule Configuration {#configuration}

--- a/website/versioned_docs/version-3.1.1/api/plugins/plugin-content-blog.mdx
+++ b/website/versioned_docs/version-3.1.1/api/plugins/plugin-content-blog.mdx
@@ -207,7 +207,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/versioned_docs/version-3.1.1/api/themes/theme-configuration.mdx
+++ b/website/versioned_docs/version-3.1.1/api/themes/theme-configuration.mdx
@@ -946,8 +946,8 @@ export default {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -982,8 +982,8 @@ export default {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/versioned_docs/version-3.1.1/configuration.mdx
+++ b/website/versioned_docs/version-3.1.1/configuration.mdx
@@ -130,7 +130,7 @@ The high-level overview of Docusaurus configuration can be categorized into:
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/versioned_docs/version-3.1.1/docusaurus-core.mdx
+++ b/website/versioned_docs/version-3.1.1/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/versioned_docs/version-3.1.1/installation.mdx
+++ b/website/versioned_docs/version-3.1.1/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/versioned_docs/version-3.1.1/introduction.mdx
+++ b/website/versioned_docs/version-3.1.1/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)**.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [Twitter](https://twitter.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!

--- a/website/versioned_docs/version-3.2.1/api/misc/eslint-plugin/no-html-links.mdx
+++ b/website/versioned_docs/version-3.2.1/api/misc/eslint-plugin/no-html-links.mdx
@@ -17,7 +17,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <a href="/page">go to page!</a>
 
-<a href="https://twitter.com/docusaurus" target="_blank">Twitter</a>
+<a href="https://x.com/docusaurus" target="_blank">X</a>
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link'
 
 <Link to="/page">go to page!</Link>
 
-<Link to="https://twitter.com/docusaurus">Twitter</Link>
+<Link to="https://x.com/docusaurus">X</Link>
 ```
 
 ## Rule Configuration {#configuration}

--- a/website/versioned_docs/version-3.2.1/api/plugins/plugin-content-blog.mdx
+++ b/website/versioned_docs/version-3.2.1/api/plugins/plugin-content-blog.mdx
@@ -219,7 +219,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/versioned_docs/version-3.2.1/api/themes/theme-configuration.mdx
+++ b/website/versioned_docs/version-3.2.1/api/themes/theme-configuration.mdx
@@ -946,8 +946,8 @@ export default {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -982,8 +982,8 @@ export default {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/versioned_docs/version-3.2.1/configuration.mdx
+++ b/website/versioned_docs/version-3.2.1/configuration.mdx
@@ -130,7 +130,7 @@ The high-level overview of Docusaurus configuration can be categorized into:
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/versioned_docs/version-3.2.1/docusaurus-core.mdx
+++ b/website/versioned_docs/version-3.2.1/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/versioned_docs/version-3.2.1/installation.mdx
+++ b/website/versioned_docs/version-3.2.1/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/versioned_docs/version-3.2.1/introduction.mdx
+++ b/website/versioned_docs/version-3.2.1/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)**.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [Twitter](https://twitter.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!

--- a/website/versioned_docs/version-3.3.2/api/misc/eslint-plugin/no-html-links.mdx
+++ b/website/versioned_docs/version-3.3.2/api/misc/eslint-plugin/no-html-links.mdx
@@ -17,7 +17,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <a href="/page">go to page!</a>
 
-<a href="https://twitter.com/docusaurus" target="_blank">Twitter</a>
+<a href="https://x.com/docusaurus" target="_blank">X</a>
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link'
 
 <Link to="/page">go to page!</Link>
 
-<Link to="https://twitter.com/docusaurus">Twitter</Link>
+<Link to="https://x.com/docusaurus">X</Link>
 ```
 
 ## Rule Configuration {#configuration}

--- a/website/versioned_docs/version-3.3.2/api/plugins/plugin-content-blog.mdx
+++ b/website/versioned_docs/version-3.3.2/api/plugins/plugin-content-blog.mdx
@@ -219,7 +219,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/versioned_docs/version-3.3.2/api/themes/theme-configuration.mdx
+++ b/website/versioned_docs/version-3.3.2/api/themes/theme-configuration.mdx
@@ -946,8 +946,8 @@ export default {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -982,8 +982,8 @@ export default {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/versioned_docs/version-3.3.2/configuration.mdx
+++ b/website/versioned_docs/version-3.3.2/configuration.mdx
@@ -130,7 +130,7 @@ The high-level overview of Docusaurus configuration can be categorized into:
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/versioned_docs/version-3.3.2/docusaurus-core.mdx
+++ b/website/versioned_docs/version-3.3.2/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/versioned_docs/version-3.3.2/installation.mdx
+++ b/website/versioned_docs/version-3.3.2/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/versioned_docs/version-3.3.2/introduction.mdx
+++ b/website/versioned_docs/version-3.3.2/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)**.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [Twitter](https://twitter.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!

--- a/website/versioned_docs/version-3.4.0/api/misc/eslint-plugin/no-html-links.mdx
+++ b/website/versioned_docs/version-3.4.0/api/misc/eslint-plugin/no-html-links.mdx
@@ -17,7 +17,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <a href="/page">go to page!</a>
 
-<a href="https://twitter.com/docusaurus" target="_blank">Twitter</a>
+<a href="https://x.com/docusaurus" target="_blank">X</a>
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link'
 
 <Link to="/page">go to page!</Link>
 
-<Link to="https://twitter.com/docusaurus">Twitter</Link>
+<Link to="https://x.com/docusaurus">X</Link>
 ```
 
 ## Rule Configuration {#configuration}

--- a/website/versioned_docs/version-3.4.0/api/plugins/plugin-content-blog.mdx
+++ b/website/versioned_docs/version-3.4.0/api/plugins/plugin-content-blog.mdx
@@ -221,7 +221,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/versioned_docs/version-3.4.0/api/themes/theme-configuration.mdx
+++ b/website/versioned_docs/version-3.4.0/api/themes/theme-configuration.mdx
@@ -946,8 +946,8 @@ export default {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -982,8 +982,8 @@ export default {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/versioned_docs/version-3.4.0/configuration.mdx
+++ b/website/versioned_docs/version-3.4.0/configuration.mdx
@@ -130,7 +130,7 @@ The high-level overview of Docusaurus configuration can be categorized into:
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/versioned_docs/version-3.4.0/docusaurus-core.mdx
+++ b/website/versioned_docs/version-3.4.0/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/versioned_docs/version-3.4.0/installation.mdx
+++ b/website/versioned_docs/version-3.4.0/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/versioned_docs/version-3.4.0/introduction.mdx
+++ b/website/versioned_docs/version-3.4.0/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)**.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [Twitter](https://twitter.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!

--- a/website/versioned_docs/version-3.5.2/api/misc/eslint-plugin/no-html-links.mdx
+++ b/website/versioned_docs/version-3.5.2/api/misc/eslint-plugin/no-html-links.mdx
@@ -17,7 +17,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <a href="/page">go to page!</a>
 
-<a href="https://twitter.com/docusaurus" target="_blank">Twitter</a>
+<a href="https://x.com/docusaurus" target="_blank">X</a>
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link'
 
 <Link to="/page">go to page!</Link>
 
-<Link to="https://twitter.com/docusaurus">Twitter</Link>
+<Link to="https://x.com/docusaurus">X</Link>
 ```
 
 ## Rule Configuration {#configuration}

--- a/website/versioned_docs/version-3.5.2/api/plugins/plugin-content-blog.mdx
+++ b/website/versioned_docs/version-3.5.2/api/plugins/plugin-content-blog.mdx
@@ -246,7 +246,7 @@ Accepted fields:
 | --- | --- | --- | --- |
 | `authors` | `Authors` | `undefined` | List of blog post authors (or unique author). Read the [`authors` guide](../../blog.mdx#blog-post-authors) for more explanations. Prefer `authors` over the `author_*` front matter fields, even for single author blog posts. |
 | `author` | `string` | `undefined` | ⚠️ Prefer using `authors`. The blog post author's name. |
-| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, Twitter, Facebook profile URL, etc. |
+| `author_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL that the author's name will be linked to. This could be a GitHub, X, Facebook profile URL, etc. |
 | `author_image_url` | `string` | `undefined` | ⚠️ Prefer using `authors`. The URL to the author's thumbnail image. |
 | `author_title` | `string` | `undefined` | ⚠️ Prefer using `authors`. A description of the author. |
 | `title` | `string` | Markdown title | The blog post title. |

--- a/website/versioned_docs/version-3.5.2/api/themes/theme-configuration.mdx
+++ b/website/versioned_docs/version-3.5.2/api/themes/theme-configuration.mdx
@@ -1014,8 +1014,8 @@ export default {
             href: 'https://discordapp.com/invite/docusaurus',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/docusaurus',
+            label: 'X',
+            href: 'https://x.com/docusaurus',
           },
           {
             html: `
@@ -1050,8 +1050,8 @@ export default {
         href: 'https://discordapp.com/invite/docusaurus',
       },
       {
-        label: 'Twitter',
-        href: 'https://twitter.com/docusaurus',
+        label: 'X',
+        href: 'https://x.com/docusaurus',
       },
       {
         html: `

--- a/website/versioned_docs/version-3.5.2/configuration.mdx
+++ b/website/versioned_docs/version-3.5.2/configuration.mdx
@@ -130,7 +130,7 @@ The high-level overview of Docusaurus configuration can be categorized into:
 
 Site metadata contains the essential global metadata such as `title`, `url`, `baseUrl`, and `favicon`.
 
-They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, Twitter) information or even to generate the correct path to serve your static files.
+They are used in several places such as your site's title and headings, browser tab icon, social sharing (Facebook, X) information or even to generate the correct path to serve your static files.
 
 ### Deployment configurations {#deployment-configurations}
 

--- a/website/versioned_docs/version-3.5.2/docusaurus-core.mdx
+++ b/website/versioned_docs/version-3.5.2/docusaurus-core.mdx
@@ -137,7 +137,7 @@ const Page = () => (
     </p>
     <p>
       {/* highlight-next-line */}
-      Follow me on <Link to="https://twitter.com/docusaurus">Twitter</Link>!
+      Follow me on <Link to="https://x.com/docusaurus">X</Link>!
     </p>
   </div>
 );

--- a/website/versioned_docs/version-3.5.2/installation.mdx
+++ b/website/versioned_docs/version-3.5.2/installation.mdx
@@ -185,4 +185,4 @@ Use new unreleased features of Docusaurus with the [`@canary` npm dist tag](/com
 
 ## Problems? {#problems}
 
-Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [Twitter](https://twitter.com/docusaurus).
+Ask for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/docusaurus), on our [GitHub repository](https://github.com/facebook/docusaurus), our [Discord server](https://discordapp.com/invite/docusaurus), or [X](https://x.com/docusaurus).

--- a/website/versioned_docs/version-3.5.2/introduction.mdx
+++ b/website/versioned_docs/version-3.5.2/introduction.mdx
@@ -11,7 +11,7 @@ slug: /
 
 💥 Ready for more? Use **advanced features** like versioning, i18n, search and theme customizations.
 
-💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://twitter.com/sebastienlorber/timelines/1392048416872706049)**.
+💅 Check the **[best Docusaurus sites](/showcase?tags=favorite)** for inspiration and read some **[testimonials](https://x.com/sebastienlorber/timelines/1392048416872706049)**.
 
 🧐 Docusaurus is a **static-site generator**. It builds a **single-page application** with fast client-side navigation, leveraging the full power of **React** to make your site interactive. It provides out-of-the-box **documentation features** but can be used to create **any kind of site** (personal website, product, blog, marketing landing pages, etc).
 
@@ -183,12 +183,12 @@ In comparison with statically generated HTML and interactivity added using `<scr
 ## Staying informed {#staying-informed}
 
 - [GitHub](https://github.com/facebook/docusaurus)
-- [Twitter](https://twitter.com/docusaurus)
+- [X](https://x.com/docusaurus)
 - [Blog](/blog)
 - [Discord](https://discord.gg/docusaurus)
 
 ## Something missing? {#something-missing}
 
-If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://twitter.com/docusaurus) Twitter account.
+If you find issues with the documentation or have suggestions on how to improve the documentation or the project in general, please [file an issue](https://github.com/facebook/docusaurus) for us, or send a tweet mentioning the [@docusaurus](https://x.com/docusaurus) X account.
 
 For new feature requests, you can create a post on our [feature requests board (Canny)](/feature-requests), which is a handy tool for road-mapping and allows for sorting by upvotes, which gives the core team a better indicator of what features are in high demand, as compared to GitHub issues which are harder to triage. Refrain from making a Pull Request for new features (especially large ones) as someone might already be working on it or will be part of our roadmap. Talk to us first!


### PR DESCRIPTION
## Motivation

Instead of many small PRs to rename Twitter to X here and there, let's rename Twitter to X all at once.

I still kept a few minor Twitter references, notably for retrocompatibility (`authors[].socials.twitter` for example, we'll deprecate this API later once X name is a bit more established)

## Test Plan

CI + preview + Argos

### Test links

https://deploy-preview-10509--docusaurus-2.netlify.app/

