### PR TITLE
feat(core): faster CSS minimizer - `siteConfig.future.experimental_faster.lightningCssMinimizer`

### DIFF
--- a/admin/scripts/formatLighthouseReport.js
+++ b/admin/scripts/formatLighthouseReport.js
@@ -64,8 +64,7 @@ const createMarkdownTableHeader = () => [
  * @param {Record<string, string>} param0.links
  * @param {{url: string, summary: LighthouseSummary}[]} param0.results
  */
-export default function createLighthouseReport({results, links}) {
-  console.log('createLighthouseReport', {results, links});
+const createLighthouseReport = ({results, links}) => {
   const tableHeader = createMarkdownTableHeader();
   const tableBody = results.map((result) => {
     const testUrl = /** @type {string} */ (
@@ -87,4 +86,6 @@ export default function createLighthouseReport({results, links}) {
     '',
   ];
   return comment.join('\n');
-}
+};
+
+export default createLighthouseReport;

--- a/admin/scripts/formatLighthouseReport.js
+++ b/admin/scripts/formatLighthouseReport.js
@@ -64,7 +64,8 @@ const createMarkdownTableHeader = () => [
  * @param {Record<string, string>} param0.links
  * @param {{url: string, summary: LighthouseSummary}[]} param0.results
  */
-const createLighthouseReport = ({results, links}) => {
+export default function createLighthouseReport({results, links}) {
+  console.log('createLighthouseReport', {results, links});
   const tableHeader = createMarkdownTableHeader();
   const tableBody = results.map((result) => {
     const testUrl = /** @type {string} */ (
@@ -86,6 +87,4 @@ const createLighthouseReport = ({results, links}) => {
     '',
   ];
   return comment.join('\n');
-};
-
-export default createLighthouseReport;
+}

--- a/packages/docusaurus-bundler/src/importFaster.ts
+++ b/packages/docusaurus-bundler/src/importFaster.ts
@@ -34,11 +34,11 @@ export async function importSwcJsLoaderFactory(): Promise<
   return faster.getSwcJsLoaderFactory;
 }
 
-export async function importSwcJsMinifierOptions(): Promise<
+export async function importSwcJsMinimizerOptions(): Promise<
   JsMinimizerOptions<CustomOptions>
 > {
   const faster = await ensureFaster();
-  return faster.getSwcJsMinifierOptions() as JsMinimizerOptions<CustomOptions>;
+  return faster.getSwcJsMinimizerOptions() as JsMinimizerOptions<CustomOptions>;
 }
 
 export async function importLightningCssMinimizerOptions(): Promise<

--- a/packages/docusaurus-bundler/src/importFaster.ts
+++ b/packages/docusaurus-bundler/src/importFaster.ts
@@ -6,7 +6,11 @@
  */
 
 import type {ConfigureWebpackUtils} from '@docusaurus/types';
-import type {MinimizerOptions, CustomOptions} from 'terser-webpack-plugin';
+import type {
+  MinimizerOptions as JsMinimizerOptions,
+  CustomOptions,
+} from 'terser-webpack-plugin';
+import type {MinimizerOptions as CssMinimizerOptions} from 'css-minimizer-webpack-plugin';
 
 async function importFaster() {
   return import('@docusaurus/faster');
@@ -31,8 +35,15 @@ export async function importSwcJsLoaderFactory(): Promise<
 }
 
 export async function importSwcJsMinifierOptions(): Promise<
-  MinimizerOptions<CustomOptions>
+  JsMinimizerOptions<CustomOptions>
 > {
   const faster = await ensureFaster();
-  return faster.getSwcJsMinifierOptions() as MinimizerOptions<CustomOptions>;
+  return faster.getSwcJsMinifierOptions() as JsMinimizerOptions<CustomOptions>;
+}
+
+export async function importLightningCssMinimizerOptions(): Promise<
+  CssMinimizerOptions<CustomOptions>
+> {
+  const faster = await ensureFaster();
+  return faster.getLightningCssMinimizerOptions() as CssMinimizerOptions<CustomOptions>;
 }

--- a/packages/docusaurus-faster/package.json
+++ b/packages/docusaurus-faster/package.json
@@ -18,9 +18,11 @@
   },
   "license": "MIT",
   "dependencies": {
-    "webpack": "^5.88.1",
     "@swc/core": "^1.7.14",
-    "swc-loader": "^0.2.6"
+    "browserslist": "^4.24.0",
+    "lightningcss": "^1.27.0",
+    "swc-loader": "^0.2.6",
+    "webpack": "^5.88.1"
   },
   "engines": {
     "node": ">=18.0"

--- a/packages/docusaurus-faster/src/index.ts
+++ b/packages/docusaurus-faster/src/index.ts
@@ -41,7 +41,7 @@ export function getSwcJsLoaderFactory({
 // They should rather be kept in sync for now to avoid any unexpected behavior
 // The goal of faster minifier is not to fine-tune options but only to be faster
 // See core minification.ts
-export function getSwcJsMinifierOptions(): JsMinifyOptions {
+export function getSwcJsMinimizerOptions(): JsMinifyOptions {
   return {
     ecma: 2020,
     compress: {

--- a/packages/docusaurus-faster/src/index.ts
+++ b/packages/docusaurus-faster/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as lightningcss from 'lightningcss';
+import browserslist from 'browserslist';
 import type {RuleSetRule} from 'webpack';
 import type {JsMinifyOptions} from '@swc/core';
 
@@ -54,4 +56,17 @@ export function getSwcJsMinifierOptions(): JsMinifyOptions {
       ascii_only: true,
     },
   };
+}
+
+// LightningCSS doesn't expose any type for css-minimizer-webpack-plugin setup
+// So we derive it ourselves
+// see https://lightningcss.dev/docs.html#with-webpack
+type LightningCssMinimizerOptions = Omit<
+  lightningcss.TransformOptions<never>,
+  'filename' | 'code'
+>;
+
+export function getLightningCssMinimizerOptions(): LightningCssMinimizerOptions {
+  const queries = browserslist();
+  return {targets: lightningcss.browserslistToTargets(queries)};
 }

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -126,6 +126,7 @@ export type StorageConfig = {
 export type FasterConfig = {
   swcJsLoader: boolean;
   swcJsMinimizer: boolean;
+  lightningCssMinimizer: boolean;
   mdxCrossCompilerCache: boolean;
   rspackBundler: boolean;
 };

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/config.test.ts.snap
@@ -9,6 +9,7 @@ exports[`loadSiteConfig website with .cjs siteConfig 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -76,6 +77,7 @@ exports[`loadSiteConfig website with ts + js config 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -143,6 +145,7 @@ exports[`loadSiteConfig website with valid JS CJS config 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -210,6 +213,7 @@ exports[`loadSiteConfig website with valid JS ESM config 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -277,6 +281,7 @@ exports[`loadSiteConfig website with valid TypeScript CJS config 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -344,6 +349,7 @@ exports[`loadSiteConfig website with valid TypeScript ESM config 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -411,6 +417,7 @@ exports[`loadSiteConfig website with valid async config 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -480,6 +487,7 @@ exports[`loadSiteConfig website with valid async config creator function 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -549,6 +557,7 @@ exports[`loadSiteConfig website with valid config creator function 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,
@@ -621,6 +630,7 @@ exports[`loadSiteConfig website with valid siteConfig 1`] = `
     "favicon": "img/docusaurus.ico",
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,

--- a/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
+++ b/packages/docusaurus/src/server/__tests__/__snapshots__/site.test.ts.snap
@@ -83,6 +83,7 @@ exports[`load loads props for site with custom i18n path 1`] = `
     "customFields": {},
     "future": {
       "experimental_faster": {
+        "lightningCssMinimizer": false,
         "mdxCrossCompilerCache": false,
         "rspackBundler": false,
         "swcJsLoader": false,

--- a/packages/docusaurus/src/server/__tests__/configValidation.test.ts
+++ b/packages/docusaurus/src/server/__tests__/configValidation.test.ts
@@ -48,6 +48,7 @@ describe('normalizeConfig', () => {
         experimental_faster: {
           swcJsLoader: true,
           swcJsMinimizer: true,
+          lightningCssMinimizer: true,
           mdxCrossCompilerCache: true,
           rspackBundler: true,
         },
@@ -745,6 +746,7 @@ describe('future', () => {
       experimental_faster: {
         swcJsLoader: true,
         swcJsMinimizer: true,
+        lightningCssMinimizer: true,
         mdxCrossCompilerCache: true,
         rspackBundler: true,
       },
@@ -1096,6 +1098,7 @@ describe('future', () => {
       const faster: FasterConfig = {
         swcJsLoader: true,
         swcJsMinimizer: true,
+        lightningCssMinimizer: true,
         mdxCrossCompilerCache: true,
         rspackBundler: true,
       };
@@ -1276,6 +1279,77 @@ describe('future', () => {
           }),
         ).toThrowErrorMatchingInlineSnapshot(`
           ""future.experimental_faster.swcJsMinimizer" must be a boolean
+          "
+        `);
+      });
+    });
+
+    describe('lightningCssMinimizer', () => {
+      it('accepts - undefined', () => {
+        const faster: Partial<FasterConfig> = {
+          lightningCssMinimizer: undefined,
+        };
+        expect(
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toEqual(fasterContaining({lightningCssMinimizer: false}));
+      });
+
+      it('accepts - true', () => {
+        const faster: Partial<FasterConfig> = {
+          lightningCssMinimizer: true,
+        };
+        expect(
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toEqual(fasterContaining({lightningCssMinimizer: true}));
+      });
+
+      it('accepts - false', () => {
+        const faster: Partial<FasterConfig> = {
+          lightningCssMinimizer: false,
+        };
+        expect(
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toEqual(fasterContaining({lightningCssMinimizer: false}));
+      });
+
+      it('rejects - null', () => {
+        // @ts-expect-error: invalid
+        const faster: Partial<FasterConfig> = {lightningCssMinimizer: 42};
+        expect(() =>
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(`
+          ""future.experimental_faster.lightningCssMinimizer" must be a boolean
+          "
+        `);
+      });
+
+      it('rejects - number', () => {
+        // @ts-expect-error: invalid
+        const faster: Partial<FasterConfig> = {lightningCssMinimizer: 42};
+        expect(() =>
+          normalizeConfig({
+            future: {
+              experimental_faster: faster,
+            },
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(`
+          ""future.experimental_faster.lightningCssMinimizer" must be a boolean
           "
         `);
       });

--- a/packages/docusaurus/src/server/configValidation.ts
+++ b/packages/docusaurus/src/server/configValidation.ts
@@ -44,6 +44,7 @@ export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
 export const DEFAULT_FASTER_CONFIG: FasterConfig = {
   swcJsLoader: false,
   swcJsMinimizer: false,
+  lightningCssMinimizer: false,
   mdxCrossCompilerCache: false,
   rspackBundler: false,
 };
@@ -52,6 +53,7 @@ export const DEFAULT_FASTER_CONFIG: FasterConfig = {
 export const DEFAULT_FASTER_CONFIG_TRUE: FasterConfig = {
   swcJsLoader: true,
   swcJsMinimizer: true,
+  lightningCssMinimizer: true,
   mdxCrossCompilerCache: true,
   rspackBundler: true,
 };
@@ -220,6 +222,9 @@ const FASTER_CONFIG_SCHEMA = Joi.alternatives()
       swcJsLoader: Joi.boolean().default(DEFAULT_FASTER_CONFIG.swcJsLoader),
       swcJsMinimizer: Joi.boolean().default(
         DEFAULT_FASTER_CONFIG.swcJsMinimizer,
+      ),
+      lightningCssMinimizer: Joi.boolean().default(
+        DEFAULT_FASTER_CONFIG.lightningCssMinimizer,
       ),
       mdxCrossCompilerCache: Joi.boolean().default(
         DEFAULT_FASTER_CONFIG.mdxCrossCompilerCache,

--- a/project-words.txt
+++ b/project-words.txt
@@ -164,6 +164,7 @@ lastmod
 Lastmod
 lifecycles
 Lifecycles
+lightningcss
 linkify
 Linkify
 Localizable

--- a/website/testCSSOrder.mjs
+++ b/website/testCSSOrder.mjs
@@ -29,11 +29,11 @@ const EXPECTED_CSS_MARKERS = [
   // Note, Infima and site classes are optimized/deduplicated and put at the top
   // We don't agree yet on what should be the order for those classes
   // See https://github.com/facebook/docusaurus/pull/6222
-  '.markdown>h2',
-  '.button--outline.button--active',
   '--ifm-color-scheme:light',
   '.col[class*=col--]',
   '.padding-vert--xl',
+  '.markdown>h2',
+  '.button--outline.button--active',
   '.footer__link-item',
   '.navbar__title',
   '.pagination__item',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4959,13 +4959,13 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0, browserslist@^4.18.1, browserslist@^4.21.10, browserslist@^4.23.0, browserslist@^4.23.1, browserslist@^4.23.3:
-  version "4.23.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.3.tgz#debb029d3c93ebc97ffbc8d9cbb03403e227c800"
-  integrity sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==
+browserslist@^4.0.0, browserslist@^4.18.1, browserslist@^4.21.10, browserslist@^4.23.0, browserslist@^4.23.1, browserslist@^4.23.3, browserslist@^4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.0.tgz#a1325fe4bc80b64fda169629fc01b3d6cecd38d4"
+  integrity sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==
   dependencies:
-    caniuse-lite "^1.0.30001646"
-    electron-to-chromium "^1.5.4"
+    caniuse-lite "^1.0.30001663"
+    electron-to-chromium "^1.5.28"
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.0"
 
@@ -5186,10 +5186,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646:
-  version "1.0.30001651"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz#52de59529e8b02b1aedcaaf5c05d9e23c0c28138"
-  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001663:
+  version "1.0.30001664"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz#d588d75c9682d3301956b05a3749652a80677df4"
+  integrity sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -6897,6 +6897,11 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==
 
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+
 detect-libc@^2.0.0, detect-libc@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
@@ -7103,10 +7108,10 @@ ejs@^3.1.6, ejs@^3.1.7:
   dependencies:
     jake "^10.8.5"
 
-electron-to-chromium@^1.5.4:
-  version "1.5.13"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz#1abf0410c5344b2b829b7247e031f02810d442e6"
-  integrity sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==
+electron-to-chromium@^1.5.28:
+  version "1.5.29"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz#aa592a3caa95d07cc26a66563accf99fa573a1ee"
+  integrity sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -10736,6 +10741,74 @@ libnpmpublish@7.1.4:
     semver "^7.3.7"
     sigstore "^1.4.0"
     ssri "^10.0.1"
+
+lightningcss-darwin-arm64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz#565bd610533941cba648a70e105987578d82f996"
+  integrity sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==
+
+lightningcss-darwin-x64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz#c906a267237b1c7fe08bff6c5ac032c099bc9482"
+  integrity sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==
+
+lightningcss-freebsd-x64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz#a7c3c4d6ee18dffeb8fa69f14f8f9267f7dc0c34"
+  integrity sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==
+
+lightningcss-linux-arm-gnueabihf@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz#c7c16432a571ec877bf734fe500e4a43d48c2814"
+  integrity sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==
+
+lightningcss-linux-arm64-gnu@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz#cfd9e18df1cd65131da286ddacfa3aee6862a752"
+  integrity sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==
+
+lightningcss-linux-arm64-musl@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz#6682ff6b9165acef9a6796bd9127a8e1247bb0ed"
+  integrity sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==
+
+lightningcss-linux-x64-gnu@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz#714221212ad184ddfe974bbb7dbe9300dfde4bc0"
+  integrity sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==
+
+lightningcss-linux-x64-musl@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz#247958daf622a030a6dc2285afa16b7184bdf21e"
+  integrity sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==
+
+lightningcss-win32-arm64-msvc@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz#64cfe473c264ef5dc275a4d57a516d77fcac6bc9"
+  integrity sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==
+
+lightningcss-win32-x64-msvc@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz#237d0dc87d9cdc9cf82536bcbc07426fa9f3f422"
+  integrity sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==
+
+lightningcss@^1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.27.0.tgz#d4608e63044343836dd9769f6c8b5d607867649a"
+  integrity sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==
+  dependencies:
+    detect-libc "^1.0.3"
+  optionalDependencies:
+    lightningcss-darwin-arm64 "1.27.0"
+    lightningcss-darwin-x64 "1.27.0"
+    lightningcss-freebsd-x64 "1.27.0"
+    lightningcss-linux-arm-gnueabihf "1.27.0"
+    lightningcss-linux-arm64-gnu "1.27.0"
+    lightningcss-linux-arm64-musl "1.27.0"
+    lightningcss-linux-x64-gnu "1.27.0"
+    lightningcss-linux-x64-musl "1.27.0"
+    lightningcss-win32-arm64-msvc "1.27.0"
+    lightningcss-win32-x64-msvc "1.27.0"
 
 lilconfig@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Motivation

Docusaurus Faster project - part 3 - faster CSS minimizer using LightningCSS

(see [part 1](https://github.com/facebook/docusaurus/pull/10435), [part2](https://github.com/facebook/docusaurus/pull/10441))

[LightningCSS](https://lightningcss.dev/) is built in Rust and a much faster alternative to many tools we use today: PostCSS, cssnano...

I don't expect CSS minification to be a major bottleneck in terms of build time, but as part of [adding Rspack support](https://github.com/facebook/docusaurus/pull/10402) it will become even faster by using Rust tooling for the whole CSS chain, using a built-in lightningCSS integration.

Also, I'm adding this option so that users can turn LightningCSS on independently from Rspack. It's possible that depending on feedback we'll activate Lightning CSS as a default minimizer on the next major version, and yet keep Rspack experimental, so it's worth having the option to collect feedback because this change can have subtle CSS side effects.


I also think our legacy Css Nano preset is way too complex and we should move back to a simpler targets / browserslist-based setup.


## Test Plan

CI + Argos

### Test links

https://deploy-preview-10522--docusaurus-2.netlify.app/


### CSS impact analysis

Replacing NanoCSS + CleanCSS with LightningCSS had the following impact:
- No visual change detected by Argos
- CSS bundle increase from 103Kb to 119Kb (+6Kb)

From manual analysis of the before/after CSS bundle, this increase is notably due to our former setup that "re-organize" the CSS file and try to factorize common repeated rules under shared selectors.

See the before/after files here: https://gist.github.com/slorber/2cea4d3fc8d6e0b50dcebdc58596d514

CleanCSS has [level 2](https://github.com/clean-css/clean-css#what-level-2-optimizations-do) optimizations that can "restructure" the CSS so that it takes less space

For example it will extract duplicate rules and create a shared declaration at the top:

```css
.DocSearch-Hit-content-wrapper,
.button,
.buttons_uHc7,
.dropdown__link,
.screen-reader-only,
.text--truncate {
  white-space: nowrap;
}
```

Although it decreases a bit the file size, it also changes the order of the CSS and is less predictable and could cause side effects (in our case apparently it hasn't been a problem though). 

We may restore these CleanCSS optimizations later but for now I'd like to use LightningCSS directly so that we can later only use Rust tooling and remove all the slower JS tools from our pipeline. 

+6Kb seems acceptable, and devs that really want to keep it can use the [clean-css-cli](https://github.com/clean-css/clean-css-cli) on top of the already-built website.

For reference here are the options we currently use:


```js
{
        inline: false,
        level: {
          1: {
            all: false,
            removeWhitespace: true,
          },
          2: {
            all: true,
            restructureRules: true,
            removeUnusedAtRules: false,
          },
        },
},
```


