### PR TITLE
chore: fix formatLighthouseReport() CI

### DIFF
--- a/admin/scripts/formatLighthouseReport.js
+++ b/admin/scripts/formatLighthouseReport.js
@@ -41,16 +41,22 @@ function createURL(url) {
  * @param {Object} param0
  * @param {string} param0.url
  * @param {LighthouseSummary} param0.summary
- * @param {string} param0.reportUrl
+ * @param {string | undefined} param0.reportUrl
+ * @return {string}
  */
-const createMarkdownTableRow = ({url, summary, reportUrl}) =>
-  [
-    `| [${createURL(url).pathname}](${url})`,
+const createMarkdownTableRow = ({url, summary, reportUrl}) => {
+  const columns = [
+    `[${createURL(url).pathname}](${url})`,
+
     .../** @type {(keyof LighthouseSummary)[]} */ (
       Object.keys(summaryKeys)
     ).map((k) => scoreEntry(summary[k])),
-    `[Report](${reportUrl}) |`,
-  ].join(' | ');
+
+    reportUrl ? `Report N/A` : `[Report](${reportUrl})`,
+  ];
+
+  return `| ${columns.join(' | ')} |`;
+};
 
 const createMarkdownTableHeader = () => [
   ['| URL', ...Object.values(summaryKeys), 'Report |'].join(' | '),
@@ -64,18 +70,15 @@ const createMarkdownTableHeader = () => [
  * @param {Record<string, string>} param0.links
  * @param {{url: string, summary: LighthouseSummary}[]} param0.results
  */
-const createLighthouseReport = ({results, links}) => {
+export default function formatLighthouseReport({results, links}) {
   const tableHeader = createMarkdownTableHeader();
   const tableBody = results.map((result) => {
-    const testUrl = /** @type {string} */ (
-      Object.keys(links).find((key) => key === result.url)
-    );
-    const reportPublicUrl = /** @type {string} */ (links[testUrl]);
-
+    const {url, summary} = result;
+    const reportUrl = /** @type {string | undefined} */ (links[result.url]);
     return createMarkdownTableRow({
-      url: testUrl,
-      summary: result.summary,
-      reportUrl: reportPublicUrl,
+      url,
+      summary,
+      reportUrl,
     });
   });
   const comment = [
@@ -86,6 +89,4 @@ const createLighthouseReport = ({results, links}) => {
     '',
   ];
   return comment.join('\n');
-};
-
-export default createLighthouseReport;
+}


### PR DESCRIPTION
## Motivation

Google won't store Lighthouse reports anymore (temporarily or definitively? 🤷‍♂️ ) leading to the `links` parameter being always empty `{}`.

I refactored the Markdown comment formatting function so that it can handle that case and temporarily fix the CI until we know more about Google plans

See:
- https://github.com/treosh/lighthouse-ci-action/issues/144
- https://github.com/GoogleChrome/lighthouse-ci/issues/1072
- https://github.com/GoogleChrome/lighthouse-ci/issues/1073



## Test Plan

CI

### Test links

https://deploy-preview-10527--docusaurus-2.netlify.app/
