### PR TITLE
fix(mdx-loader): fix cross-compiler cache randomly loading mdx with client/server envs

### DIFF
--- a/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
+++ b/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
@@ -33,11 +33,7 @@ async function normalizeOptions(
   // We don't want to cache in dev mode (docusaurus start)
   // We only have multiple compilers in production mode (docusaurus build)
   // TODO wrong but good enough for now (example: "docusaurus build --dev")
-  if (
-    process.env.DOCUSAURUS_AB_BENCHMARK === 'true' &&
-    options.useCrossCompilerCache &&
-    process.env.NODE_ENV === 'production'
-  ) {
+  if (options.useCrossCompilerCache && process.env.NODE_ENV === 'production') {
     options = {
       ...options,
       crossCompilerCache: new Map(),

--- a/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
+++ b/packages/docusaurus-mdx-loader/src/createMDXLoader.ts
@@ -33,7 +33,11 @@ async function normalizeOptions(
   // We don't want to cache in dev mode (docusaurus start)
   // We only have multiple compilers in production mode (docusaurus build)
   // TODO wrong but good enough for now (example: "docusaurus build --dev")
-  if (options.useCrossCompilerCache && process.env.NODE_ENV === 'production') {
+  if (
+    process.env.DOCUSAURUS_AB_BENCHMARK === 'true' &&
+    options.useCrossCompilerCache &&
+    process.env.NODE_ENV === 'production'
+  ) {
     options = {
       ...options,
       crossCompilerCache: new Map(),

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -150,9 +150,7 @@ async function loadMDXWithCaching({
   // Note: once we introduce RSCs we'll probably have 3 compilations
   // Note: we can't use string keys in WeakMap
   // But we could eventually use WeakRef for the values
-  function deleteCacheEntry() {
-    options.crossCompilerCache?.delete(cacheKey);
-  }
+  const deleteCacheEntry = () => options.crossCompilerCache?.delete(cacheKey);
 
   const cacheEntry = options.crossCompilerCache?.get(cacheKey);
 
@@ -187,7 +185,9 @@ async function loadMDXWithCaching({
       });
     }
     return promise;
-  } else if (compilerName === 'server') {
+  }
+  // Server compilation always uses the result of the client compilation above
+  else if (compilerName === 'server') {
     if (cacheEntry) {
       deleteCacheEntry();
       return cacheEntry.promise;

--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -162,6 +162,10 @@ async function loadMDXWithCaching({
   // Notably: the server compilation does not emit file-loader assets
   // Using the server compilation otherwise leads to broken images
   // See https://github.com/facebook/docusaurus/issues/10544#issuecomment-2390943794
+  // See https://github.com/facebook/docusaurus/pull/10553
+  // TODO a problem with this: server bundle will use client inline loaders
+  //  This means server bundle will use ?emit=true for assets
+  //  We should try to get rid of inline loaders to cleanup this caching logic
   if (compilerName === 'client') {
     const promise = loadMDX({
       fileContent,

--- a/packages/docusaurus-mdx-loader/src/options.ts
+++ b/packages/docusaurus-mdx-loader/src/options.ts
@@ -8,6 +8,7 @@
 import type {MDXOptions, SimpleProcessors} from './processor';
 import type {MarkdownConfig} from '@docusaurus/types';
 import type {ResolveMarkdownLink} from './remark/resolveMarkdownLinks';
+import type {PromiseWithResolvers} from './utils';
 
 export type Options = Partial<MDXOptions> & {
   markdownConfig: MarkdownConfig;
@@ -25,5 +26,7 @@ export type Options = Partial<MDXOptions> & {
 
   // Will usually be created by "createMDXLoaderItem"
   processors?: SimpleProcessors;
-  crossCompilerCache?: Map<string, Promise<string>>; // MDX => Promise<JSX> cache
+  crossCompilerCache?: Map<string, CrossCompilerCacheEntry>; // MDX => Promise<JSX> cache
 };
+
+type CrossCompilerCacheEntry = PromiseWithResolvers<string>;

--- a/packages/docusaurus-mdx-loader/src/remark/unusedDirectives/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/unusedDirectives/index.ts
@@ -155,6 +155,7 @@ const plugin: Plugin = function plugin(this: Processor): Transformer {
     // We only enable these warnings for the client compiler
     // This avoids emitting duplicate warnings in prod mode
     // Note: the client compiler is used in both dev/prod modes
+    // Also: the client compiler is what gets used when using crossCompilerCache
     if (file.data.compilerName === 'client') {
       logUnusedDirectivesWarning({
         directives: unusedDirectives,

--- a/packages/docusaurus-mdx-loader/src/utils.ts
+++ b/packages/docusaurus-mdx-loader/src/utils.ts
@@ -132,3 +132,20 @@ export async function compileToJSX({
     );
   }
 }
+
+// TODO Docusaurus v4, remove temporary polyfill when upgrading to Node 22+
+export interface PromiseWithResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+}
+// TODO Docusaurus v4, remove temporary polyfill when upgrading to Node 22+
+export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
+  // @ts-expect-error: it's fine
+  const out: PromiseWithResolvers<T> = {};
+  out.promise = new Promise((resolve, reject) => {
+    out.resolve = resolve;
+    out.reject = reject;
+  });
+  return out;
+}


### PR DESCRIPTION
## Motivation

Fix https://github.com/facebook/docusaurus/issues/10544


The MDX cross-compiler cache is an experimental feature introduced in https://github.com/facebook/docusaurus/pull/10479

It permits us to avoid transforming twice the same MD/MDX source file for both client/server environments.

It takes the assumption that both environments will compile exactly the same. This is mostly true, apart from a tiny detail that led to broken images in productions: inline file loaders.

Since the MDX compilation for both envs is run in parallel, a file might be compiled in client or server mode depending on which env compilation started first and got cached. This leads to some image inline loaders to have `?emit=true` or `?emit=false` randomly for the client-side app, while we always want it to have `?emit=true`.

The solution implemented here is a bit complex but fixes our image problem. The idea is to always give priority to the client compilation as the source of truth. Even if the server compilation starts sooner, it will "wait" for the client compilation and use its result.


⚠️ **But there's a catch!** This also means that now, our server environment will use `?emit=true`, which will lead to images being emitted in `build/__server/assets/images`. It's not a big deal in practice: the `__server` folder is deleted in the build process, and it doesn't have a significant perf impact. We'll try to get rid of these inline loaders later but we can ship with this solution now.

Note: the impact of cross-compiler cache is quite significant, particularly more visible under Rspack where bundling goes from ~10s to ~7s. It's more significant than what we lose by emitting useless image assets.



## Test Plan

CI + Argos + deploy preview

I'm not sure how to easily unit-test this 😅 . It's experimental for now, we'll figure out a way later if the experiment is successful.

### Test links

https://deploy-preview-10553--docusaurus-2.netlify.app/


