### PR TITLE
fix(core): Fix React rendering null chars in HTML output - Use `renderToReadableStream`

### DIFF
--- a/packages/docusaurus-bundler/src/minifyHtml.ts
+++ b/packages/docusaurus-bundler/src/minifyHtml.ts
@@ -105,7 +105,7 @@ async function getSwcMinifier(): Promise<HtmlMinifier> {
           const ignoredErrors: string[] = [
             // TODO Docusaurus seems to emit NULL chars, and minifier detects it
             //  see https://github.com/facebook/docusaurus/issues/9985
-            'Unexpected null character',
+            // 'Unexpected null character',
           ];
           result.errors = result.errors.filter(
             (diagnostic) => !ignoredErrors.includes(diagnostic.message),

--- a/packages/docusaurus/src/client/renderToHtml.tsx
+++ b/packages/docusaurus/src/client/renderToHtml.tsx
@@ -6,75 +6,23 @@
  */
 
 import type {ReactNode} from 'react';
-import {renderToPipeableStream} from 'react-dom/server';
-import {Writable} from 'stream';
+// @ts-expect-error: see https://github.com/facebook/react/issues/31134
+import {renderToReadableStream as renderToReadableStreamImpl} from 'react-dom/server.browser';
+import type {renderToReadableStream as renderToReadableStreamType} from 'react-dom/server';
+import {text} from 'stream/consumers';
+
+const renderToReadableStream: typeof renderToReadableStreamType =
+  renderToReadableStreamImpl;
 
 export async function renderToHtml(app: ReactNode): Promise<string> {
-  // Inspired from
-  // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
-  // https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/static-entry.js
-  const writableStream = new WritableAsPromise();
-
-  const {pipe} = renderToPipeableStream(app, {
-    onError(error) {
-      writableStream.destroy(error as Error);
-    },
-    onAllReady() {
-      pipe(writableStream);
-    },
+  return new Promise((resolve, reject) => {
+    renderToReadableStream(app, {
+      onError: (error) => reject(error),
+    }).then(async (stream) => {
+      await stream.allReady;
+      // @ts-expect-error: it works fine
+      const html = text(stream);
+      resolve(html);
+    }, reject);
   });
-
-  return writableStream.getPromise();
-}
-
-// WritableAsPromise inspired by https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/server-utils/writable-as-promise.js
-
-/* eslint-disable no-underscore-dangle */
-class WritableAsPromise extends Writable {
-  private _output: string;
-  private _deferred: {
-    promise: Promise<string> | null;
-    resolve: (value: string) => void;
-    reject: (reason: Error) => void;
-  };
-
-  constructor() {
-    super();
-    this._output = ``;
-    this._deferred = {
-      promise: null,
-      resolve: () => null,
-      reject: () => null,
-    };
-    this._deferred.promise = new Promise((resolve, reject) => {
-      this._deferred.resolve = resolve;
-      this._deferred.reject = reject;
-    });
-  }
-
-  override _write(
-    chunk: {toString: () => string},
-    _enc: unknown,
-    next: () => void,
-  ) {
-    this._output += chunk.toString();
-    next();
-  }
-
-  override _destroy(error: Error | null, next: (error?: Error | null) => void) {
-    if (error instanceof Error) {
-      this._deferred.reject(error);
-    } else {
-      next();
-    }
-  }
-
-  override end() {
-    this._deferred.resolve(this._output);
-    return this.destroy();
-  }
-
-  getPromise(): Promise<string> {
-    return this._deferred.promise!;
-  }
 }

--- a/packages/docusaurus/src/client/renderToHtml.tsx
+++ b/packages/docusaurus/src/client/renderToHtml.tsx
@@ -8,7 +8,10 @@
 import type {ReactNode} from 'react';
 // @ts-expect-error: see https://github.com/facebook/react/issues/31134
 import {renderToReadableStream as renderToReadableStreamImpl} from 'react-dom/server.browser';
-import type {renderToReadableStream as renderToReadableStreamType} from 'react-dom/server';
+import {
+  renderToString,
+  type renderToReadableStream as renderToReadableStreamType,
+} from 'react-dom/server';
 import {text} from 'stream/consumers';
 
 const renderToReadableStream: typeof renderToReadableStreamType =
@@ -21,7 +24,13 @@ export async function renderToHtml(app: ReactNode): Promise<string> {
     }).then(async (stream) => {
       await stream.allReady;
       // @ts-expect-error: it works fine
-      const html = text(stream);
+      const html = await text(stream);
+
+      // TODO remove this test
+      if (html !== renderToString(app)) {
+        throw new Error('Bad');
+      }
+
       resolve(html);
     }, reject);
   });


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/9985

Replace `renderToPipeableStream` with `renderToReadableStream` because the former emit NULL chars unexpectedly, which might be a React bug.

Note: the setup is not super clean in terms of TS/exports, but it should work for all versions of Node we cover or the CI would report it.

Note: I benchmarked this locally and I doubt this has a significant impact on Docusaurus build times: it's approximately the same. The app rendering phase is not our main bottleneck currently, even with the new [Docusaurus Faster](https://github.com/facebook/docusaurus/issues/10556) options.


Related links:
- React Core bug report: https://github.com/facebook/react/issues/31134
- Bug repro: https://github.com/slorber/react-bug-repro-null-chars
- Twitter conversations: https://x.com/sebastienlorber/status/1842252053390709058

## Test Plan

CI

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/
