### PR TITLE
fix(core): move @docusaurus/faster to bundler peerDeps

### DIFF
--- a/packages/docusaurus-bundler/package.json
+++ b/packages/docusaurus-bundler/package.json
@@ -21,7 +21,6 @@
     "@babel/core": "^7.23.3",
     "@docusaurus/babel": "3.5.2",
     "@docusaurus/cssnano-preset": "3.5.2",
-    "@docusaurus/faster": "3.5.2",
     "@docusaurus/logger": "3.5.2",
     "@docusaurus/types": "3.5.2",
     "@docusaurus/utils": "3.5.2",

--- a/packages/docusaurus-bundler/package.json
+++ b/packages/docusaurus-bundler/package.json
@@ -45,6 +45,14 @@
     "webpack": "^5.95.0",
     "webpackbar": "^6.0.1"
   },
+  "peerDependencies": {
+    "@docusaurus/faster": "3.5.2"
+  },
+  "peerDependenciesMeta": {
+    "@docusaurus/faster": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@total-typescript/shoehorn": "^0.1.2"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -93,15 +93,9 @@
     "tree-node-cli": "^1.6.0"
   },
   "peerDependencies": {
-    "@docusaurus/faster": "3.5.2",
     "@mdx-js/react": "^3.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@docusaurus/faster": {
-      "optional": true
-    }
   },
   "engines": {
     "node": ">=18.0"


### PR DESCRIPTION


## Motivation

`@docusaurus/faster` was supposed to be optional, but it was not due to my mistake after extracting the `@docusaurus/bundler` package.


## Test Plan

CI
