### PR TITLE
fix(theme): light & dark mode checkbox doesn't announce state switches

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
@@ -60,7 +60,7 @@ function ColorModeToggle({
         title={title}
         aria-label={title}
         aria-live="polite"
-        aria-pressed={(value==='dark' ?  'true' : 'false')}>
+        aria-pressed={value === 'dark' ? 'true' : 'false'}>
         <IconLightMode
           className={clsx(styles.toggleIcon, styles.lightToggleIcon)}
         />

--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
@@ -59,7 +59,8 @@ function ColorModeToggle({
         disabled={!isBrowser}
         title={title}
         aria-label={title}
-        aria-live="polite">
+        aria-live="polite"
+        aria-pressed={(value==='dark' ?  'true' : 'false')}>
         <IconLightMode
           className={clsx(styles.toggleIcon, styles.lightToggleIcon)}
         />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [X ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

yarn start
open webpage and use nvda to test that the aria-pressed is saying if the button is pressed or if the button is not pressed




### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

 https://deploy-preview-10585--docusaurus-2.netlify.app/
