### PR TITLE
refactor(core): replace serve-handler fork by official deps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Check for suspicious yarn.lock
         # for allowed aliases, see https://github.com/yargs/cliui/pull/139/files#r1670711112
-        run: yarn lockfile-lint --path yarn.lock --type yarn --allowed-hosts yarn --validate-https --validate-package-names --validate-integrity --empty-hostname=false --allowed-package-name-aliases serve-handler react-loadable string-width-cjs strip-ansi-cjs wrap-ansi-cjs
+        run: yarn lockfile-lint --path yarn.lock --type yarn --allowed-hosts yarn --validate-https --validate-package-names --validate-integrity --empty-hostname=false --allowed-package-name-aliases react-loadable string-width-cjs strip-ansi-cjs wrap-ansi-cjs
 
       - name: Lint
         run: |

--- a/admin/verdaccio.yaml
+++ b/admin/verdaccio.yaml
@@ -29,10 +29,6 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
-  '@docusaurus/serve-handler':
-    access: $all
-    publish: $all
-    proxy: npmjs
   # Group and isolate all local packages, avoid being proxy from outside
   '@docusaurus/*':
     access: $all

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -68,7 +68,7 @@
     "react-router-dom": "^5.3.4",
     "rtl-detect": "^1.0.4",
     "semver": "^7.5.4",
-    "serve-handler": "npm:@docusaurus/serve-handler@6.2.0",
+    "serve-handler": "^6.1.6",
     "shelljs": "^0.8.5",
     "tslib": "^2.6.0",
     "update-notifier": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13506,9 +13506,9 @@ path-to-regexp@3.3.0:
   integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
 
 path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
   dependencies:
     isarray "0.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13500,10 +13500,10 @@ path-to-regexp@0.1.10:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
   integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
 
-path-to-regexp@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
-  integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
+path-to-regexp@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
+  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
 
 path-to-regexp@^1.7.0:
   version "1.8.0"
@@ -15327,17 +15327,17 @@ serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-"serve-handler@npm:@docusaurus/serve-handler@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/serve-handler/-/serve-handler-6.2.0.tgz#64d3e58ff5e5eaf7caf97e20e6695fd2510b9e6d"
-  integrity sha512-bTu+jOVeSHjUjaaK1JYqzBCWRHVEOYoMtHrO+uhLYG71NxtwrtpnLsYVr4uSlEyGIqjhW1Ie49sGAfDoGUJa0A==
+serve-handler@^6.1.6:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.6.tgz#50803c1d3e947cd4a341d617f8209b22bd76cfa1"
+  integrity sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==
   dependencies:
     bytes "3.0.0"
     content-disposition "0.5.2"
     mime-types "2.1.18"
     minimatch "3.1.2"
     path-is-inside "1.0.2"
-    path-to-regexp "2.2.1"
+    path-to-regexp "3.3.0"
     range-parser "1.2.0"
 
 serve-index@^1.9.1:


### PR DESCRIPTION


## Motivation

We forked the lib to fix annoying Node 22 punycode warning: 

- https://github.com/facebook/docusaurus/pull/10442
- https://github.com/vercel/serve-handler/issues/204#issuecomment-2307892921

Now a Vercel maintainer has taken over the maintenance of the lib and just published a fix:
https://github.com/vercel/serve-handler/releases/tag/6.1.6

We can move back to the official dependency


## Test Plan

CI


