### PR TITLE
feat(core): add Node.js memory perf logging

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -137,7 +137,7 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=250'
+          NODE_OPTIONS: '--max-old-space-size=300'
           DOCUSAURUS_PERF_LOGGER: 'true'
         working-directory: ../test-website
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -63,6 +63,10 @@ jobs:
           E2E_TEST: true
       - name: Build test-website project
         run: yarn build
+        env:
+          # Our website should build even with limited memory
+          # See https://github.com/facebook/docusaurus/pull/10590
+          NODE_OPTIONS: '--max-old-space-size=150'
         working-directory: ../test-website
 
   yarn-berry:
@@ -129,6 +133,10 @@ jobs:
 
       - name: Build test-website project
         run: yarn build
+        env:
+          # Our website should build even with limited memory
+          # See https://github.com/facebook/docusaurus/pull/10590
+          NODE_OPTIONS: '--max-old-space-size=150'
         working-directory: ../test-website
 
   npm:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -66,7 +66,8 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=150'
+          NODE_OPTIONS: '--max-old-space-size=200'
+          DOCUSAURUS_PERF_LOGGER: 'true'
         working-directory: ../test-website
 
   yarn-berry:
@@ -136,7 +137,8 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=150'
+          NODE_OPTIONS: '--max-old-space-size=200'
+          DOCUSAURUS_PERF_LOGGER: 'true'
         working-directory: ../test-website
 
   npm:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=200'
+          NODE_OPTIONS: '--max-old-space-size=250'
           DOCUSAURUS_PERF_LOGGER: 'true'
         working-directory: ../test-website
 
@@ -137,7 +137,7 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=200'
+          NODE_OPTIONS: '--max-old-space-size=250'
           DOCUSAURUS_PERF_LOGGER: 'true'
         working-directory: ../test-website
 
@@ -169,6 +169,11 @@ jobs:
           E2E_TEST: true
       - name: Build test-website project
         run: npm run build
+        env:
+          # Our website should build even with limited memory
+          # See https://github.com/facebook/docusaurus/pull/10590
+          NODE_OPTIONS: '--max-old-space-size=250'
+          DOCUSAURUS_PERF_LOGGER: 'true'
         working-directory: ../test-website
 
   pnpm:
@@ -202,4 +207,9 @@ jobs:
           E2E_TEST: true
       - name: Build test-website project
         run: pnpm run build
+        env:
+          # Our website should build even with limited memory
+          # See https://github.com/facebook/docusaurus/pull/10590
+          NODE_OPTIONS: '--max-old-space-size=250'
+          DOCUSAURUS_PERF_LOGGER: 'true'
         working-directory: ../test-website

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=300'
+          NODE_OPTIONS: '--max-old-space-size=200'
       - name: Docusaurus site CSS order
         run: yarn workspace website test:css-order
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,10 @@ jobs:
         run: yarn workspace @docusaurus/theme-common removeThemeInternalReexport
       - name: Docusaurus Build
         run: yarn build:website:fast
+        env:
+          # Our website should build even with limited memory
+          # See https://github.com/facebook/docusaurus/pull/10590
+          NODE_OPTIONS: '--max-old-space-size=300'
       - name: Docusaurus site CSS order
         run: yarn workspace website test:css-order
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,8 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=200'
+          NODE_OPTIONS: '--max-old-space-size=350'
+          DOCUSAURUS_PERF_LOGGER: 'true'
       - name: Docusaurus site CSS order
         run: yarn workspace website test:css-order
 

--- a/packages/docusaurus-logger/src/logger.ts
+++ b/packages/docusaurus-logger/src/logger.ts
@@ -178,6 +178,7 @@ const logger = {
   red: (msg: string | number): string => chalk.red(msg),
   yellow: (msg: string | number): string => chalk.yellow(msg),
   green: (msg: string | number): string => chalk.green(msg),
+  cyan: (msg: string | number): string => chalk.cyan(msg),
   bold: (msg: string | number): string => chalk.bold(msg),
   dim: (msg: string | number): string => chalk.dim(msg),
   path,


### PR DESCRIPTION
## Motivation

Related to https://github.com/facebook/docusaurus/issues/4765

Follow-up of https://github.com/facebook/docusaurus/pull/9975

This enhance the `DOCUSAURUS_PERF_LOGGER=true` env variable described in https://github.com/facebook/docusaurus/issues/4765#issuecomment-2066227919


Our infrastructure should make it easy to figure out which step consumes Node.js heap memory:

![CleanShot 2024-10-17 at 18 38 40@2x](https://github.com/user-attachments/assets/74b4ed2b-0a40-47c7-aca6-a8439242fd5f)


For now, it only logs before/after memory, but we could enhance this later with sampling and add an average memory consumption for each recorded step.

Note I'd also like to wire all this to our CI in the future so that PRs can report memory usage regressions, similar to what Astro is doing here:
- https://github.com/withastro/astro/pull/9603#issuecomment-1876740130
- https://github.com/withastro/astro/blob/main/.github/workflows/benchmark.yml
- https://github.com/withastro/astro/blob/main/benchmark/bench/memory.js
- https://github.com/withastro/astro/blob/main/packages/astro/src/core/config/timer.ts


## Test Plan

local

