### PR TITLE
fix(core): fix i18n sites SSG memory leak - require.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ package-lock.json
 .eslintcache
 
 yarn-error.log
-build
+website/build
 coverage
 .docusaurus
 .cache-loader

--- a/packages/docusaurus/src/client/serverEntry.tsx
+++ b/packages/docusaurus/src/client/serverEntry.tsx
@@ -18,7 +18,7 @@ import {
 } from './BrokenLinksContext';
 import type {PageCollectedData, AppRenderer} from '../common';
 
-const render: AppRenderer = async ({pathname}) => {
+const render: AppRenderer['render'] = async ({pathname}) => {
   await preload(pathname);
 
   const modules = new Set<string>();

--- a/packages/docusaurus/src/commands/build/build.ts
+++ b/packages/docusaurus/src/commands/build/build.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import fs from 'fs-extra';
+import logger, {PerfLogger} from '@docusaurus/logger';
+import {mapAsyncSequential} from '@docusaurus/utils';
+import {loadContext, type LoadContextParams} from '../../server/site';
+import {loadI18n} from '../../server/i18n';
+import {buildLocale} from './buildLocale';
+
+export type BuildCLIOptions = Pick<
+  LoadContextParams,
+  'config' | 'locale' | 'outDir'
+> & {
+  bundleAnalyzer?: boolean;
+  minify?: boolean;
+  dev?: boolean;
+};
+
+export async function build(
+  siteDirParam: string = '.',
+  cliOptions: Partial<BuildCLIOptions> = {},
+): Promise<void> {
+  process.env.BABEL_ENV = 'production';
+  process.env.NODE_ENV = 'production';
+  process.env.DOCUSAURUS_CURRENT_LOCALE = cliOptions.locale;
+  if (cliOptions.dev) {
+    logger.info`Building in dev mode`;
+    process.env.BABEL_ENV = 'development';
+    process.env.NODE_ENV = 'development';
+  }
+
+  const siteDir = await fs.realpath(siteDirParam);
+
+  ['SIGINT', 'SIGTERM'].forEach((sig) => {
+    process.on(sig, () => process.exit());
+  });
+
+  const locales = await PerfLogger.async('Get locales to build', () =>
+    getLocalesToBuild({siteDir, cliOptions}),
+  );
+
+  if (locales.length > 1) {
+    logger.info`Website will be built for all these locales: ${locales}`;
+  }
+
+  await PerfLogger.async(`Build`, () =>
+    mapAsyncSequential(locales, async (locale) => {
+      await tryToBuildLocale({siteDir, locale, cliOptions});
+    }),
+  );
+
+  logger.info`Use code=${'npm run serve'} command to test your build locally.`;
+}
+
+async function getLocalesToBuild({
+  siteDir,
+  cliOptions,
+}: {
+  siteDir: string;
+  cliOptions: BuildCLIOptions;
+}): Promise<[string, ...string[]]> {
+  if (cliOptions.locale) {
+    return [cliOptions.locale];
+  }
+
+  const context = await loadContext({
+    siteDir,
+    outDir: cliOptions.outDir,
+    config: cliOptions.config,
+    locale: cliOptions.locale,
+    localizePath: cliOptions.locale ? false : undefined,
+  });
+  const i18n = await loadI18n(context.siteConfig, {
+    locale: cliOptions.locale,
+  });
+  if (i18n.locales.length > 1) {
+    logger.info`Website will be built for all these locales: ${i18n.locales}`;
+  }
+
+  // We need the default locale to always be the 1st in the list. If we build it
+  // last, it would "erase" the localized sites built in sub-folders
+  return [
+    i18n.defaultLocale,
+    ...i18n.locales.filter((locale) => locale !== i18n.defaultLocale),
+  ];
+}
+
+async function tryToBuildLocale({
+  siteDir,
+  locale,
+  cliOptions,
+}: {
+  siteDir: string;
+  locale: string;
+  cliOptions: BuildCLIOptions;
+}) {
+  try {
+    await PerfLogger.async(`${logger.name(locale)}`, async () => {
+      await buildLocale({
+        siteDir,
+        locale,
+        cliOptions,
+      });
+    });
+  } catch (err) {
+    throw new Error(
+      logger.interpolate`Unable to build website for locale name=${locale}.`,
+      {
+        cause: err,
+      },
+    );
+  }
+}

--- a/packages/docusaurus/src/commands/build/buildLocale.ts
+++ b/packages/docusaurus/src/commands/build/buildLocale.ts
@@ -10,122 +10,24 @@ import path from 'path';
 import _ from 'lodash';
 import {compile} from '@docusaurus/bundler';
 import logger, {PerfLogger} from '@docusaurus/logger';
-import {mapAsyncSequential} from '@docusaurus/utils';
-import {loadSite, loadContext, type LoadContextParams} from '../server/site';
-import {handleBrokenLinks} from '../server/brokenLinks';
-import {createBuildClientConfig} from '../webpack/client';
-import createServerConfig from '../webpack/server';
+import {loadSite} from '../../server/site';
+import {handleBrokenLinks} from '../../server/brokenLinks';
+import {createBuildClientConfig} from '../../webpack/client';
+import createServerConfig from '../../webpack/server';
 import {
   createConfigureWebpackUtils,
   executePluginsConfigureWebpack,
-} from '../webpack/configure';
-import {loadI18n} from '../server/i18n';
-import {executeSSG} from '../ssg/ssgExecutor';
+} from '../../webpack/configure';
+import {executeSSG} from '../../ssg/ssgExecutor';
 import type {
   ConfigureWebpackUtils,
   LoadedPlugin,
   Props,
 } from '@docusaurus/types';
-import type {SiteCollectedData} from '../common';
+import type {SiteCollectedData} from '../../common';
+import {BuildCLIOptions} from './build';
 
-export type BuildCLIOptions = Pick<
-  LoadContextParams,
-  'config' | 'locale' | 'outDir'
-> & {
-  bundleAnalyzer?: boolean;
-  minify?: boolean;
-  dev?: boolean;
-};
-
-export async function build(
-  siteDirParam: string = '.',
-  cliOptions: Partial<BuildCLIOptions> = {},
-): Promise<void> {
-  process.env.BABEL_ENV = 'production';
-  process.env.NODE_ENV = 'production';
-  process.env.DOCUSAURUS_CURRENT_LOCALE = cliOptions.locale;
-  if (cliOptions.dev) {
-    logger.info`Building in dev mode`;
-    process.env.BABEL_ENV = 'development';
-    process.env.NODE_ENV = 'development';
-  }
-
-  const siteDir = await fs.realpath(siteDirParam);
-
-  ['SIGINT', 'SIGTERM'].forEach((sig) => {
-    process.on(sig, () => process.exit());
-  });
-
-  async function tryToBuildLocale({locale}: {locale: string}) {
-    try {
-      await PerfLogger.async(`${logger.name(locale)}`, () =>
-        buildLocale({
-          siteDir,
-          locale,
-          cliOptions,
-        }),
-      );
-    } catch (err) {
-      throw new Error(
-        logger.interpolate`Unable to build website for locale name=${locale}.`,
-        {
-          cause: err,
-        },
-      );
-    }
-  }
-
-  const locales = await PerfLogger.async('Get locales to build', () =>
-    getLocalesToBuild({siteDir, cliOptions}),
-  );
-
-  if (locales.length > 1) {
-    logger.info`Website will be built for all these locales: ${locales}`;
-  }
-
-  await PerfLogger.async(`Build`, () =>
-    mapAsyncSequential(locales, async (locale) => {
-      await tryToBuildLocale({locale});
-    }),
-  );
-
-  logger.info`Use code=${'npm run serve'} command to test your build locally.`;
-}
-
-async function getLocalesToBuild({
-  siteDir,
-  cliOptions,
-}: {
-  siteDir: string;
-  cliOptions: BuildCLIOptions;
-}): Promise<[string, ...string[]]> {
-  if (cliOptions.locale) {
-    return [cliOptions.locale];
-  }
-
-  const context = await loadContext({
-    siteDir,
-    outDir: cliOptions.outDir,
-    config: cliOptions.config,
-    locale: cliOptions.locale,
-    localizePath: cliOptions.locale ? false : undefined,
-  });
-  const i18n = await loadI18n(context.siteConfig, {
-    locale: cliOptions.locale,
-  });
-  if (i18n.locales.length > 1) {
-    logger.info`Website will be built for all these locales: ${i18n.locales}`;
-  }
-
-  // We need the default locale to always be the 1st in the list. If we build it
-  // last, it would "erase" the localized sites built in sub-folders
-  return [
-    i18n.defaultLocale,
-    ...i18n.locales.filter((locale) => locale !== i18n.defaultLocale),
-  ];
-}
-
-async function buildLocale({
+export async function buildLocale({
   siteDir,
   locale,
   cliOptions,

--- a/packages/docusaurus/src/commands/build/buildLocale.ts
+++ b/packages/docusaurus/src/commands/build/buildLocale.ts
@@ -27,15 +27,17 @@ import type {
 import type {SiteCollectedData} from '../../common';
 import {BuildCLIOptions} from './build';
 
+export type BuildLocaleParams = {
+  siteDir: string;
+  locale: string;
+  cliOptions: Partial<BuildCLIOptions>;
+};
+
 export async function buildLocale({
   siteDir,
   locale,
   cliOptions,
-}: {
-  siteDir: string;
-  locale: string;
-  cliOptions: Partial<BuildCLIOptions>;
-}): Promise<void> {
+}: BuildLocaleParams): Promise<void> {
   // Temporary workaround to unlock the ability to translate the site config
   // We'll remove it if a better official API can be designed
   // See https://github.com/facebook/docusaurus/issues/4542

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -12,7 +12,7 @@ import logger from '@docusaurus/logger';
 import shell from 'shelljs';
 import {hasSSHProtocol, buildSshUrl, buildHttpsUrl} from '@docusaurus/utils';
 import {loadContext, type LoadContextParams} from '../server/site';
-import {build} from './build';
+import {build} from './build/build';
 
 export type DeployCLIOptions = Pick<
   LoadContextParams,

--- a/packages/docusaurus/src/commands/serve.ts
+++ b/packages/docusaurus/src/commands/serve.ts
@@ -14,7 +14,7 @@ import serveHandler from 'serve-handler';
 import openBrowser from 'react-dev-utils/openBrowser';
 import {applyTrailingSlash} from '@docusaurus/utils-common';
 import {loadSiteConfig} from '../server/config';
-import {build} from './build';
+import {build} from './build/build';
 import {getHostPort, type HostPortOptions} from '../server/getHostPort';
 import type {LoadContextParams} from '../server/site';
 

--- a/packages/docusaurus/src/common.d.ts
+++ b/packages/docusaurus/src/common.d.ts
@@ -15,9 +15,13 @@ export type AppRenderResult = {
   collectedData: PageCollectedData;
 };
 
-export type AppRenderer = (params: {
-  pathname: string;
-}) => Promise<AppRenderResult>;
+export type AppRenderer = {
+  render: (params: {pathname: string}) => Promise<AppRenderResult>;
+
+  // It's important to shut down the app renderer
+  // Otherwise Node.js require cache leaks memory
+  shutdown: () => Promise<void>;
+};
 
 export type PageCollectedData = {
   // TODO Docusaurus v4 refactor: helmet state is non-serializable

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export {build} from './commands/build';
+export {build} from './commands/build/build';
 export {clear} from './commands/clear';
 export {deploy} from './commands/deploy';
 export {externalCommand} from './commands/external';

--- a/packages/docusaurus/src/ssg/ssg.ts
+++ b/packages/docusaurus/src/ssg/ssg.ts
@@ -9,7 +9,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import _ from 'lodash';
 // TODO eval is archived / unmaintained: https://github.com/pierrec/node-eval
-//  We should internalize/modernise it
+//  We should internalize/modernize it
 import evaluate from 'eval';
 import pMap from 'p-map';
 import logger, {PerfLogger} from '@docusaurus/logger';

--- a/packages/docusaurus/src/ssg/ssg.ts
+++ b/packages/docusaurus/src/ssg/ssg.ts
@@ -8,6 +8,8 @@
 import fs from 'fs-extra';
 import path from 'path';
 import _ from 'lodash';
+// TODO eval is archived / unmaintained: https://github.com/pierrec/node-eval
+//  We should internalize/modernise it
 import evaluate from 'eval';
 import pMap from 'p-map';
 import logger, {PerfLogger} from '@docusaurus/logger';

--- a/packages/docusaurus/src/ssg/ssgNodeRequire.ts
+++ b/packages/docusaurus/src/ssg/ssgNodeRequire.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {createRequire} from 'module';
+
+export type SSGNodeRequire = {
+  require: NodeJS.Require;
+  cleanup: () => void;
+};
+
+// The eval/vm.Script used for running the server bundle need a require() impl
+// This impl has to be relative to the server bundler path
+// This enables the server bundle to resolve relative paths such as:
+// - require('./assets/js/some-chunk.123456.js')
+//
+// Unfortunately, Node.js vm.Script doesn't isolate memory / require.cache
+// This means that if we build multiple Docusaurus localized sites in a row
+// The Node.js require cache will keep growing and retain in memory the JS
+// assets of the former SSG builds
+// We have to clean up the node require cache manually to avoid leaking memory!
+// See also https://x.com/sebastienlorber/status/1848399310116831702
+export function createSSGRequire(serverBundlePath: string): SSGNodeRequire {
+  const realRequire = createRequire(serverBundlePath);
+
+  const allRequiredIds: string[] = [];
+
+  const ssgRequireFunction: NodeJS.Require = (id) => {
+    const module = realRequire(id);
+    allRequiredIds.push(id);
+    return module;
+  };
+
+  const cleanup = () => {
+    allRequiredIds.forEach((id) => {
+      delete realRequire.cache[realRequire.resolve(id)];
+    });
+  };
+
+  ssgRequireFunction.resolve = realRequire.resolve;
+  ssgRequireFunction.cache = realRequire.cache;
+  ssgRequireFunction.extensions = realRequire.extensions;
+  ssgRequireFunction.main = realRequire.main;
+
+  return {require: ssgRequireFunction, cleanup};
+}

--- a/project-words.txt
+++ b/project-words.txt
@@ -206,7 +206,6 @@ Mindmap
 mkdn
 mkdocs
 mkdown
-modernise
 moesif
 Moesif
 msapplication

--- a/project-words.txt
+++ b/project-words.txt
@@ -206,6 +206,7 @@ Mindmap
 mkdn
 mkdocs
 mkdown
+modernise
 moesif
 Moesif
 msapplication


### PR DESCRIPTION
## Motivation

When building a localized Docusaurus site, the memory would keep growing as we iterate sequentially over the locales to build. This can lead to potential out-of-memory errors for locales at the end.

Each localized site would keep a lot of strings in memory, related to the server bundle modules. This is because we run SSG using [node-eval](https://github.com/pierrec/node-eval) which is a tiny wrapper around `vm.Script`. 

Unfortunately, `vm.Script` doesn't really isolate memory like workers or subprocesses. At the end of the SSG process, many strings remain retained in memory related to the localized server-side JS modules loaded during the SSG process.

When we run SSG, the `require()` calls in the server bundle are using the `createRequire(serverBundlePath)` we provide to globals. The thing is, Node.js `require()` and `createRequire()` share a global cache that keeps server-side loaded modules for a given locale in memory, even after the site of that locale as finished building.

The solution was to force the cleanup of the cache manually after the SSG process.


## Other attempts

I tried to isolate the SSG process in a `worker_threads` but it couldn't work because some data structured we need can't be serialized (helmet state, we need a breaking change to refactor that).

I also tried to build sequentially the localized sites in distinct `worker_threads` but got weird SIGSEGV / SIGBUS errors, which might be because of N-API usage in Rspack. 

I tried building localized sites in `child_process` and it worked, but I'd prefer not to for now because we would need to add other options that let users define the node parameters of that subprocess, including memory usage like `--max-old-space-size` which is not automatically forwarded from main to subprocess (and both processes might not use the same value 🤷‍♂️ )

Cleaning up the require cache works even though it doesn't totally solve the isolation problem. 

## Test Plan

CI + local tests 

### Test links


https://deploy-preview-10599--docusaurus-2.netlify.app/




## Details

Here's what a heap dump looks like after building 4 locales, by putting `require('v8').writeHeapSnapshot();` at the end of `build.ts`

![image](https://github.com/user-attachments/assets/92a6e126-058d-4e70-b61e-35acdaa2948e)


Here's a failing build of 2 locales without the fix:

```bash
NODE_OPTIONS="--max-old-space-size=300 --expose-gc" BUILD_FAST=true I18N_STAGING=true yarn build:website
yarn run v1.22.22
$ yarn workspace website build
$ docusaurus build
[INFO] Website will be built for all these locales:
- en
- ja
[PERF] Get locales to build - 276.59 ms - (39mb -> 58mb)
[INFO] Website will be built for all these locales:
- en
- ja
[INFO] [en] Creating an optimized production build...
[PERF] Build > en > Load site > Load context - 31.82 ms - (58mb -> 59mb)
[PERF] Build > en > Load site > Load plugins > Init plugins - 447.40 ms - (59mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default > loadContent() - 409.61 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > loadContent() - 399.81 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default > loadContent() - 391.22 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default > loadContent() - 381.22 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > loadContent() - 371.16 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default > loadContent() - 320.64 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default > loadContent() - 310.70 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default > loadContent() - 301.38 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default > loadContent() - 291.38 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > loadContent() - 281.27 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default > loadContent() - 209.10 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default > loadContent() - 199.11 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > loadContent() - 189.27 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > loadContent() - 179.59 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > loadContent() - 169.84 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default > translatePluginContent() - 168.12 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > translatePluginContent() - 167.62 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default > translatePluginContent() - 167.79 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > translatePluginContent() - 156.96 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default > translatePluginContent() - 157.28 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default > translatePluginContent() - 157.87 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default > translatePluginContent() - 157.82 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default > translatePluginContent() - 157.78 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > translatePluginContent() - 158.07 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default > translatePluginContent() - 158.22 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default > translatePluginContent() - 158.51 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > translatePluginContent() - 159.35 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > translatePluginContent() - 163.26 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > translatePluginContent() - 163.69 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default > getDefaultCodeTranslationMessages() - 157.22 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > getDefaultCodeTranslationMessages() - 157.32 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default > getDefaultCodeTranslationMessages() - 157.98 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default > getDefaultCodeTranslationMessages() - 147.14 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default > getDefaultCodeTranslationMessages() - 126.69 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > getDefaultCodeTranslationMessages() - 127.14 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default > getDefaultCodeTranslationMessages() - 127.82 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > getDefaultCodeTranslationMessages() - 117.73 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > getDefaultCodeTranslationMessages() - 118.93 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > getDefaultCodeTranslationMessages() - 119.21 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default - 1.15 seconds! - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default - 1.12 seconds! - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default - 1.03 seconds! - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default - 975.53 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default - 882.58 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default - 851.86 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default - 842.10 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default - 832.60 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default > translatePluginContent() - 631.03 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > getDefaultCodeTranslationMessages() - 347.55 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default > getDefaultCodeTranslationMessages() - 337.21 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default - 1.12 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default > getDefaultCodeTranslationMessages() - 348.24 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default - 1.12 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default > getDefaultCodeTranslationMessages() - 328.02 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default - 996.92 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > contentLoaded() - 20.74 ms - (84mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default - 1.34 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default > getDefaultCodeTranslationMessages() - 146.30 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default - 1.33 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > contentLoaded() - 22.35 ms - (90mb -> 90mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default - 1.36 seconds! - (83mb -> 90mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > contentLoaded() - 96.93 ms - (84mb -> 90mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default - 1.24 seconds! - (83mb -> 90mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > loadContent() - 1.70 seconds! - (83mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > translatePluginContent() - 22.33 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > getDefaultCodeTranslationMessages() - 22.50 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > loadContent() - 1.45 seconds! - (83mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > translatePluginContent() - 22.72 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > getDefaultCodeTranslationMessages() - 22.48 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > loadContent() - 1.69 seconds! - (83mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > translatePluginContent() - 132.40 ms - (93mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > getDefaultCodeTranslationMessages() - 22.79 ms - (93mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > loadContent() - 1.72 seconds! - (83mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > translatePluginContent() - 47.99 ms - (93mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > getDefaultCodeTranslationMessages() - 23.15 ms - (93mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > loadContent() - 2.21 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > contentLoaded() - 171.86 ms - (93mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests - 1.91 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > contentLoaded() - 185.41 ms - (93mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default - 2.24 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > translatePluginContent() - 85.03 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > getDefaultCodeTranslationMessages() - 24.78 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > contentLoaded() - 199.10 ms - (93mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community - 2.18 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > loadContent() - 2.36 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > translatePluginContent() - 23.61 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > getDefaultCodeTranslationMessages() - 22.89 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > loadContent() - 2.30 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > translatePluginContent() - 23.30 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > getDefaultCodeTranslationMessages() - 22.95 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > loadContent() - 2.25 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > translatePluginContent() - 39.46 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > getDefaultCodeTranslationMessages() - 23.26 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > contentLoaded() - 134.14 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default - 2.67 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > contentLoaded() - 415.67 ms - (94mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests - 2.38 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > contentLoaded() - 54.41 ms - (94mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests - 2.43 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > contentLoaded() - 170.32 ms - (95mb -> 96mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default - 2.75 seconds! - (83mb -> 96mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > contentLoaded() - 156.86 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default - 2.64 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content - 2.83 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@default - 277.40 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@default - 277.85 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@default - 277.36 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - google-gtag@default - 265.31 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - sitemap@default - 265.86 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - classic@default - 266.60 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - search-algolia@default - 266.96 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - changelog@default - 267.31 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@community - 267.62 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-redirects@default - 268.06 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - ideal-image@default - 268.65 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pwa@default - 269.04 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - mermaid@default - 269.99 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - feature-requests@default - 270.49 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@docs-tests - 271.56 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@blog-tests - 271.90 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@pages-tests - 272.49 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-module-test@default - 273.11 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - live-codeblock@default - 273.77 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - swizzle-theme-tests@default - 273.86 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-bootstrap@default - 274.10 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-mdx-fallback@default - 274.72 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - debug@default - 505.81 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() - 565.40 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins - 3.86 seconds! - (59mb -> 95mb)
[PERF] Build > en > Load site > Create site files - 45.58 ms - (95mb -> 95mb)
[PERF] Build > en > Load site - 3.96 seconds! - (58mb -> 95mb)
[PERF] Build > en > Creating rspack bundler configs - 691.33 ms - (95mb -> 101mb)
●  ━━━━━━━━━━━━━━━━━━━━━━━━━ (8%) setup compilation                                                                                                                                                               ● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (32%) building json|/Users/sebastienlorber/Desktop/projects/docusaurus/website/.docusaurus/changelog-plugin/default/site-changelog-source-2-0-● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (32%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (35%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (35%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (37%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (37%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (38%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (38%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (42%) building /Users/sebastienlorber/Desktop/projects/docusaurus/packages/docusaurus-mdx-load● Client ━━● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (100%) emitting after emit                                                                    [PERF] Build > en > Bundling with rspack - 7.24 seconds! - (100mb -> 123mb)
[PERF] Build > en > SSG > Read client manifest - 39.73 ms - (123mb -> 123mb)
[PERF] Build > en > SSG > Generate static files > Compile SSG template - 40.96 ms - (124mb -> 124mb)
[PERF] Build > en > SSG > Generate static files > Load HTML minifier - 81.56 ms - (124mb -> 124mb)
[PERF] Build > en > SSG > Generate static files > Load App renderer > Load server bundle - 127.32 ms - (124mb -> 123mb)
[PERF] Build > en > SSG > Generate static files > Load App renderer > Server bundle size = 1.538 MB
[PERF] Build > en > SSG > Generate static files > Load App renderer > Evaluate server bundle - 111.42 ms - (123mb -> 132mb)
[PERF] Build > en > SSG > Generate static files > Load App renderer - 281.15 ms - (124mb -> 132mb)
[PERF] Build > en > SSG > Generate static files - 5.51 seconds! - (124mb -> 256mb)
[PERF] Build > en > SSG - 5.64 seconds! - (123mb -> 256mb)
[WARNING] Will NOT delete server bundle because DOCUSAURUS_KEEP_SERVER_BUNDLE is set to 'true'
[WARNING] Cannot infer the update date for some files, as they are not tracked by git.
● Service Worker ━━━━━━━━━━━━━━━━━━━━━━━━━ (100%) emitting after emit                                                                                                                                             [PERF] Build > en > postBuild() - 2.55 seconds! - (256mb -> 255mb)
[PERF] Build > en > Broken links checker - 82.12 ms - (255mb -> 255mb)
[SUCCESS] Generated static files in "build".
[PERF] Build > en - 20.20 seconds! - (58mb -> 222mb)
[INFO] [ja] Creating an optimized production build...
[PERF] Build > ja > Load site > Load context - 90.54 ms - (222mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Init plugins - 51.19 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default > loadContent() - 750.65 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > loadContent() - 732.40 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default > loadContent() - 714.25 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default > loadContent() - 696.45 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > loadContent() - 677.77 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default > loadContent() - 584.21 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default > loadContent() - 565.79 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default > loadContent() - 547.32 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default > loadContent() - 529.13 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > loadContent() - 510.45 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default > loadContent() - 380.44 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default > loadContent() - 362.20 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > loadContent() - 343.37 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > loadContent() - 325.50 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > loadContent() - 306.46 ms - (223mb -> 223mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default > translatePluginContent() - 300.86 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > translatePluginContent() - 300.28 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default > translatePluginContent() - 300.31 ms - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > translatePluginContent() - 281.55 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default > translatePluginContent() - 281.54 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default > translatePluginContent() - 281.77 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default > translatePluginContent() - 282.48 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default > translatePluginContent() - 283.06 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > translatePluginContent() - 283.26 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default > translatePluginContent() - 283.47 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default > translatePluginContent() - 284.36 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > translatePluginContent() - 284.90 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > translatePluginContent() - 285.82 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > translatePluginContent() - 286.70 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default > getDefaultCodeTranslationMessages() - 286.94 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > getDefaultCodeTranslationMessages() - 286.70 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default > getDefaultCodeTranslationMessages() - 286.92 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default > getDefaultCodeTranslationMessages() - 266.15 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default > getDefaultCodeTranslationMessages() - 229.10 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > getDefaultCodeTranslationMessages() - 229.68 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default > getDefaultCodeTranslationMessages() - 230.48 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > getDefaultCodeTranslationMessages() - 210.85 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > getDefaultCodeTranslationMessages() - 210.80 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > getDefaultCodeTranslationMessages() - 211.57 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default - 2.07 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default - 2.01 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default - 1.84 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default - 1.75 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default - 1.58 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default - 1.53 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default - 1.51 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default - 1.49 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default > translatePluginContent() - 1.13 seconds! - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > getDefaultCodeTranslationMessages() - 634.95 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default > getDefaultCodeTranslationMessages() - 616.07 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default - 2.02 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default > getDefaultCodeTranslationMessages() - 636.29 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default - 2.02 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > contentLoaded() - 38.05 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default - 2.38 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default > getDefaultCodeTranslationMessages() - 657.43 ms - (224mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default - 1.86 seconds! - (223mb -> 224mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default > getDefaultCodeTranslationMessages() - 264.53 ms - (224mb -> 227mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default - 2.40 seconds! - (223mb -> 227mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > contentLoaded() - 285.12 ms - (224mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default - 2.14 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > contentLoaded() - 39.28 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default - 2.46 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > loadContent() - 2.84 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > translatePluginContent() - 38.78 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > getDefaultCodeTranslationMessages() - 38.33 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > loadContent() - 2.38 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > translatePluginContent() - 38.48 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > getDefaultCodeTranslationMessages() - 38.21 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > loadContent() - 2.78 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > translatePluginContent() - 58.44 ms - (228mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > getDefaultCodeTranslationMessages() - 39.26 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > loadContent() - 2.77 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > translatePluginContent() - 59.70 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > getDefaultCodeTranslationMessages() - 38.70 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > contentLoaded() - 213.36 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default - 3.49 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > contentLoaded() - 195.92 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests - 2.99 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > loadContent() - 3.67 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > contentLoaded() - 235.99 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community - 3.41 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > translatePluginContent() - 78.50 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > getDefaultCodeTranslationMessages() - 38.42 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > loadContent() - 3.79 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > translatePluginContent() - 63.70 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > getDefaultCodeTranslationMessages() - 39.37 ms - (229mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > loadContent() - 3.65 seconds! - (223mb -> 227mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > translatePluginContent() - 38.65 ms - (227mb -> 227mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > getDefaultCodeTranslationMessages() - 40.00 ms - (227mb -> 227mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > loadContent() - 3.57 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > contentLoaded() - 145.16 ms - (227mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default - 4.21 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > translatePluginContent() - 79.53 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > getDefaultCodeTranslationMessages() - 39.33 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > contentLoaded() - 653.23 ms - (229mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests - 3.71 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > contentLoaded() - 42.39 ms - (228mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests - 3.81 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > contentLoaded() - 325.67 ms - (228mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default - 4.38 seconds! - (223mb -> 229mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > contentLoaded() - 355.91 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default - 4.17 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content - 4.51 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@default - 469.50 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@default - 470.62 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@default - 472.78 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - google-gtag@default - 454.22 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - sitemap@default - 454.34 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - classic@default - 455.11 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - search-algolia@default - 456.61 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - changelog@default - 458.89 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@community - 459.49 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-redirects@default - 460.30 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - ideal-image@default - 459.98 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pwa@default - 460.43 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - mermaid@default - 460.56 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - feature-requests@default - 460.75 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@docs-tests - 461.89 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@blog-tests - 462.60 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@pages-tests - 463.12 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-module-test@default - 463.17 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - live-codeblock@default - 463.70 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - swizzle-theme-tests@default - 463.81 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-bootstrap@default - 463.94 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-mdx-fallback@default - 462.74 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - debug@default - 851.70 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() - 951.34 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site > Load plugins - 5.55 seconds! - (223mb -> 228mb)
[PERF] Build > ja > Load site > Create site files - 59.08 ms - (228mb -> 228mb)
[PERF] Build > ja > Load site - 5.74 seconds! - (222mb -> 228mb)
[PERF] Build > ja > Creating rspack bundler configs - 67.85 ms - (228mb -> 229mb)
●  ━━━━━━━━━━━━━━━━━━━━━━━━━ (8%) setup compilation                                                                                                                                                               ● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (100%) emitting after emit                                                                                                                                                     [PERF] Build > ja > Bundling with rspack - 8.09 seconds! - (229mb -> 231mb)
[PERF] Build > ja > SSG > Read client manifest - 87.17 ms - (231mb -> 231mb)
[PERF] Build > ja > SSG > Generate static files > Compile SSG template - 80.00 ms - (231mb -> 231mb)
[PERF] Build > ja > SSG > Generate static files > Load HTML minifier - 152.55 ms - (231mb -> 231mb)
[PERF] Build > ja > SSG > Generate static files > Load App renderer > Load server bundle - 222.94 ms - (231mb -> 231mb)
[PERF] Build > ja > SSG > Generate static files > Load App renderer > Server bundle size = 1.550 MB
[PERF] Build > ja > SSG > Generate static files > Load App renderer > Evaluate server bundle - 151.44 ms - (231mb -> 239mb)
[PERF] Build > ja > SSG > Generate static files > Load App renderer - 456.93 ms - (231mb -> 239mb)

<--- Last few GCs --->

[14960:0x120008000]    38076 ms: Mark-Compact 293.0 (313.6) -> 288.4 (313.1) MB, pooled: 2 MB, 51.08 / 0.00 ms  (average mu = 0.219, current mu = 0.136) allocation failure; scavenge might not succeed
[14960:0x120008000]    38140 ms: Mark-Compact 292.9 (313.5) -> 289.2 (313.5) MB, pooled: 2 MB, 50.21 / 0.00 ms  (average mu = 0.212, current mu = 0.205) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0x104648038 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 2: 0x10481401c v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 3: 0x1049eb414 v8::internal::Heap::stack() [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 4: 0x1049ff59c v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags)::$_7::operator()() const [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 5: 0x1049fee54 void heap::base::Stack::SetMarkerAndCallbackImpl<v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags)::$_7>(heap::base::Stack*, void*, void const*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 6: 0x1052335ec PushAllRegistersAndIterateStack [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 7: 0x1049e97d8 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 8: 0x1049ded68 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
 9: 0x1049df594 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
10: 0x1049b4680 v8::internal::FactoryBase<v8::internal::Factory>::NewRawTwoByteString(int, v8::internal::AllocationType) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
11: 0x104cd5744 v8::internal::String::SlowFlatten(v8::internal::Isolate*, v8::internal::Handle<v8::internal::ConsString>, v8::internal::AllocationType) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
12: 0x10482b820 v8::String::Utf8Length(v8::Isolate*) const [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
13: 0x10461dfbc node::Buffer::(anonymous namespace)::SlowByteLengthUtf8(v8::FunctionCallbackInfo<v8::Value> const&) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
14: 0x10529f118 Builtins_CallApiCallbackGeneric [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
15: 0x10c6cfa9c
16: 0x10be92e28
17: 0x10ccb61b0
18: 0x10c99ced0
19: 0x1052d9410 Builtins_AsyncFunctionAwaitResolveClosure [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
20: 0x1053a4578 Builtins_PromiseFulfillReactionJob [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
21: 0x1052c9714 Builtins_RunMicrotasks [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
22: 0x10529aaf4 Builtins_JSRunMicrotasksEntry [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
23: 0x104943e00 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
24: 0x104944290 v8::internal::(anonymous namespace)::InvokeWithTryCatch(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
25: 0x1049443cc v8::internal::Execution::TryRunMicrotasks(v8::internal::Isolate*, v8::internal::MicrotaskQueue*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
26: 0x10496e48c v8::internal::MicrotaskQueue::RunMicrotasks(v8::internal::Isolate*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
27: 0x10496ec2c v8::internal::MicrotaskQueue::PerformCheckpoint(v8::Isolate*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
28: 0x10529f118 Builtins_CallApiCallbackGeneric [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
29: 0x10b84aea8
30: 0x10cfeed24
31: 0x10baf0e78
32: 0x10c21a870
33: 0x10529ac0c Builtins_JSEntryTrampoline [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
34: 0x10529a8f4 Builtins_JSEntry [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
35: 0x104943e28 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
36: 0x1049433a0 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
37: 0x10482a258 v8::Function::Call(v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
38: 0x10456cfc0 node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
39: 0x10456d2b8 node::MakeCallback(v8::Isolate*, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
40: 0x1045e83c4 node::Environment::CheckImmediate(uv_check_s*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
41: 0x10528316c uv__run_check [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
42: 0x10527cb98 uv_run [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
43: 0x10456d714 node::SpinEventLoopInternal(node::Environment*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
44: 0x104689070 node::NodeMainInstance::Run(node::ExitCode*, node::Environment*) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
45: 0x104688d84 node::NodeMainInstance::Run() [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
46: 0x10461016c node::Start(int, char**) [/Users/sebastienlorber/Library/Application Support/fnm/node-versions/v22.3.0/installation/bin/node]
47: 0x18bb750e0 start [/usr/lib/dyld]
error Command failed with signal "SIGABRT".
```

Here's a successful build of 2 locales with this fix:

```bash
NODE_OPTIONS="--max-old-space-size=300 --expose-gc" BUILD_FAST=true I18N_STAGING=true yarn build:website
yarn run v1.22.22
$ yarn workspace website build
$ docusaurus build
[INFO] Website will be built for all these locales:
- en
- ja
[PERF] Get locales to build - 235.50 ms - (39mb -> 58mb)
[INFO] Website will be built for all these locales:
- en
- ja
[INFO] [en] Creating an optimized production build...
[PERF] Build > en > Load site > Load context - 32.72 ms - (58mb -> 59mb)
[PERF] Build > en > Load site > Load plugins > Init plugins - 423.31 ms - (59mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default > loadContent() - 423.20 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > loadContent() - 413.33 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default > loadContent() - 403.48 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default > loadContent() - 392.57 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > loadContent() - 382.56 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default > loadContent() - 330.78 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default > loadContent() - 319.78 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default > loadContent() - 309.56 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default > loadContent() - 298.64 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > loadContent() - 289.11 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default > loadContent() - 214.69 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default > loadContent() - 204.56 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > loadContent() - 193.55 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > loadContent() - 183.12 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > loadContent() - 172.87 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default > translatePluginContent() - 218.67 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > translatePluginContent() - 219.68 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default > translatePluginContent() - 220.73 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > translatePluginContent() - 209.92 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default > translatePluginContent() - 210.99 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default > translatePluginContent() - 211.83 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default > translatePluginContent() - 213.46 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default > translatePluginContent() - 212.91 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > translatePluginContent() - 209.65 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default > translatePluginContent() - 196.56 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default > translatePluginContent() - 192.81 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > translatePluginContent() - 188.61 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > translatePluginContent() - 182.61 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > translatePluginContent() - 177.10 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default > getDefaultCodeTranslationMessages() - 168.68 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > getDefaultCodeTranslationMessages() - 169.51 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default > getDefaultCodeTranslationMessages() - 171.94 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default > getDefaultCodeTranslationMessages() - 160.79 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default > getDefaultCodeTranslationMessages() - 138.46 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > getDefaultCodeTranslationMessages() - 138.13 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default > getDefaultCodeTranslationMessages() - 136.53 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > getDefaultCodeTranslationMessages() - 125.39 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > getDefaultCodeTranslationMessages() - 124.28 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > getDefaultCodeTranslationMessages() - 123.85 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load debug@default - 1.23 seconds! - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load sitemap@default - 1.20 seconds! - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-redirects@default - 1.11 seconds! - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load mermaid@default - 1.06 seconds! - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load client-module-test@default - 959.78 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default - 927.81 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default - 918.02 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default - 908.75 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default > translatePluginContent() - 703.72 ms - (83mb -> 83mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > getDefaultCodeTranslationMessages() - 363.65 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default > getDefaultCodeTranslationMessages() - 341.80 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pwa@default - 1.18 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default > getDefaultCodeTranslationMessages() - 376.02 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load ideal-image@default - 1.23 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default > getDefaultCodeTranslationMessages() - 342.09 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load live-codeblock@default - 1.08 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default > contentLoaded() - 23.36 ms - (84mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load google-gtag@default - 1.43 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default > getDefaultCodeTranslationMessages() - 154.25 ms - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load classic@default - 1.43 seconds! - (83mb -> 84mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default > contentLoaded() - 21.46 ms - (89mb -> 89mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load search-algolia@default - 1.46 seconds! - (83mb -> 89mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default > contentLoaded() - 104.87 ms - (84mb -> 90mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load feature-requests@default - 1.34 seconds! - (83mb -> 89mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > loadContent() - 1.80 seconds! - (83mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > translatePluginContent() - 23.12 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > getDefaultCodeTranslationMessages() - 23.32 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > loadContent() - 1.55 seconds! - (84mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > translatePluginContent() - 54.36 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > getDefaultCodeTranslationMessages() - 30.84 ms - (92mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > loadContent() - 1.82 seconds! - (83mb -> 92mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > translatePluginContent() - 159.31 ms - (92mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > getDefaultCodeTranslationMessages() - 22.59 ms - (93mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > loadContent() - 1.88 seconds! - (83mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > translatePluginContent() - 36.84 ms - (93mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > getDefaultCodeTranslationMessages() - 22.53 ms - (93mb -> 93mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default > contentLoaded() - 179.21 ms - (93mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@default - 2.30 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests > contentLoaded() - 171.60 ms - (93mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load pages@pages-tests - 2.07 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community > contentLoaded() - 146.40 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@community - 2.28 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > loadContent() - 2.45 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > loadContent() - 2.50 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > translatePluginContent() - 50.69 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > getDefaultCodeTranslationMessages() - 23.03 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > translatePluginContent() - 59.74 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > getDefaultCodeTranslationMessages() - 23.67 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > loadContent() - 2.46 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > translatePluginContent() - 23.47 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > getDefaultCodeTranslationMessages() - 23.34 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > loadContent() - 2.41 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > translatePluginContent() - 26.13 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > getDefaultCodeTranslationMessages() - 23.85 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default > contentLoaded() - 122.82 ms - (94mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@default - 2.83 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests > contentLoaded() - 414.17 ms - (94mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@blog-tests - 2.52 seconds! - (83mb -> 94mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests > contentLoaded() - 31.47 ms - (94mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load docs@docs-tests - 2.58 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default > contentLoaded() - 229.14 ms - (94mb -> 96mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load blog@default - 2.90 seconds! - (83mb -> 96mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default > contentLoaded() - 158.26 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content > Load changelog@default - 2.79 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > Load plugins content - 2.98 seconds! - (83mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@default - 278.42 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@default - 278.28 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@default - 278.53 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - google-gtag@default - 274.52 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - sitemap@default - 275.97 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - classic@default - 276.73 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - search-algolia@default - 277.31 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - changelog@default - 278.11 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@community - 277.70 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-redirects@default - 278.28 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - ideal-image@default - 278.50 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pwa@default - 278.83 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - mermaid@default - 279.42 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - feature-requests@default - 280.03 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@docs-tests - 280.15 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@blog-tests - 280.65 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@pages-tests - 281.22 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-module-test@default - 281.47 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - live-codeblock@default - 281.29 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - swizzle-theme-tests@default - 281.70 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-bootstrap@default - 281.48 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-mdx-fallback@default - 281.73 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() > allContentLoaded() - debug@default - 513.99 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins > allContentLoaded() - 573.08 ms - (95mb -> 95mb)
[PERF] Build > en > Load site > Load plugins - 4.00 seconds! - (59mb -> 95mb)
[PERF] Build > en > Load site > Create site files - 50.29 ms - (95mb -> 95mb)
[PERF] Build > en > Load site - 4.11 seconds! - (58mb -> 95mb)
[PERF] Build > en > Creating rspack bundler configs - 163.53 ms - (95mb -> 101mb)
●  ━━━━━━━━━━━━━━━━━━━━━━━━━ (8%) setup compilation                                                                                                                                                               ● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (100%) emitting after emit                                                                                                                                                     [PERF] Build > en > Bundling with rspack - 8.16 seconds! - (100mb -> 123mb)
[PERF] Build > en > SSG > Read client manifest - 33.55 ms - (123mb -> 124mb)
[PERF] Build > en > SSG > Generate static files > Compile SSG template - 32.38 ms - (124mb -> 124mb)
[PERF] Build > en > SSG > Generate static files > Load HTML minifier - 66.29 ms - (124mb -> 124mb)
[PERF] Build > en > SSG > Generate static files > Load App renderer > Load server bundle - 100.45 ms - (124mb -> 123mb)
[PERF] Build > en > SSG > Generate static files > Load App renderer > Server bundle size = 1.538 MB
[PERF] Build > en > SSG > Generate static files > Load App renderer > Evaluate server bundle - 96.18 ms - (123mb -> 132mb)
[PERF] Build > en > SSG > Generate static files > Load App renderer - 230.26 ms - (124mb -> 132mb)
[PERF] Build > en > SSG > Generate static files - 3.29 seconds! - (124mb -> 259mb)
[PERF] Build > en > SSG - 3.36 seconds! - (123mb -> 258mb)
[WARNING] Will NOT delete server bundle because DOCUSAURUS_KEEP_SERVER_BUNDLE is set to 'true'
●  ━━━━━━━━━━━━━━━━━━━━━━━━━ (8%) setup compilation                                                                                                                                                               [WARNING] Cannot infer the update date for some files, as they are not tracked by git.
● Service Worker ━━━━━━━━━━━━━━━━━━━━━━━━━ (100%) emitting after emit                                                                                                                                             [PERF] Build > en > postBuild() - 1.65 seconds! - (258mb -> 255mb)
[PERF] Build > en > Broken links checker - 73.64 ms - (255mb -> 255mb)
[SUCCESS] Generated static files in "build".
[PERF] Build > en - 17.54 seconds! - (58mb -> 127mb)
[INFO] [ja] Creating an optimized production build...
[PERF] Build > ja > Load site > Load context - 86.52 ms - (127mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Init plugins - 49.36 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default > loadContent() - 691.19 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > loadContent() - 673.61 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default > loadContent() - 656.67 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default > loadContent() - 640.09 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > loadContent() - 623.23 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default > loadContent() - 537.85 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default > loadContent() - 520.76 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default > loadContent() - 503.63 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default > loadContent() - 485.69 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > loadContent() - 468.51 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default > loadContent() - 348.55 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default > loadContent() - 331.14 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > loadContent() - 315.28 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > loadContent() - 305.63 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > loadContent() - 287.34 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default > translatePluginContent() - 274.22 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > translatePluginContent() - 273.50 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default > translatePluginContent() - 273.38 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > translatePluginContent() - 255.15 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default > translatePluginContent() - 255.62 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default > translatePluginContent() - 256.00 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default > translatePluginContent() - 257.07 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default > translatePluginContent() - 257.35 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > translatePluginContent() - 257.46 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default > translatePluginContent() - 258.13 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default > translatePluginContent() - 258.76 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > translatePluginContent() - 259.63 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > translatePluginContent() - 260.39 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > translatePluginContent() - 260.97 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default > getDefaultCodeTranslationMessages() - 255.61 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > getDefaultCodeTranslationMessages() - 255.25 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default > getDefaultCodeTranslationMessages() - 255.23 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default > getDefaultCodeTranslationMessages() - 237.73 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default > getDefaultCodeTranslationMessages() - 203.94 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > getDefaultCodeTranslationMessages() - 204.33 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default > getDefaultCodeTranslationMessages() - 204.15 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default > getDefaultCodeTranslationMessages() - 187.75 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default > getDefaultCodeTranslationMessages() - 188.62 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default > getDefaultCodeTranslationMessages() - 189.09 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load debug@default - 1.89 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load sitemap@default - 1.84 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-redirects@default - 1.69 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load mermaid@default - 1.60 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load client-module-test@default - 1.44 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load swizzle-theme-tests@default - 1.39 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-bootstrap@default - 1.38 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docusaurus-mdx-fallback@default - 1.36 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default > translatePluginContent() - 1.02 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default > contentLoaded() - 33.78 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load google-gtag@default - 2.09 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default > getDefaultCodeTranslationMessages() - 571.01 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pwa@default - 1.85 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > getDefaultCodeTranslationMessages() - 658.71 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default > getDefaultCodeTranslationMessages() - 557.57 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load live-codeblock@default - 1.66 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default > getDefaultCodeTranslationMessages() - 678.04 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load ideal-image@default - 1.97 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default > getDefaultCodeTranslationMessages() - 237.70 ms - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load classic@default - 2.18 seconds! - (129mb -> 129mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default > contentLoaded() - 262.26 ms - (129mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load feature-requests@default - 1.95 seconds! - (129mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default > contentLoaded() - 36.21 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load search-algolia@default - 2.25 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > loadContent() - 2.62 seconds! - (129mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > translatePluginContent() - 35.21 ms - (134mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > getDefaultCodeTranslationMessages() - 35.59 ms - (134mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > loadContent() - 2.20 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > translatePluginContent() - 36.25 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > getDefaultCodeTranslationMessages() - 35.64 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > loadContent() - 2.57 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > translatePluginContent() - 73.97 ms - (133mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > getDefaultCodeTranslationMessages() - 35.17 ms - (134mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > loadContent() - 2.58 seconds! - (129mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > translatePluginContent() - 55.93 ms - (135mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > getDefaultCodeTranslationMessages() - 59.22 ms - (135mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default > contentLoaded() - 351.88 ms - (134mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@default - 3.23 seconds! - (129mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests > contentLoaded() - 199.98 ms - (135mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load pages@pages-tests - 2.80 seconds! - (129mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community > contentLoaded() - 154.89 ms - (134mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@community - 3.17 seconds! - (129mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > loadContent() - 3.48 seconds! - (129mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > translatePluginContent() - 49.45 ms - (135mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > getDefaultCodeTranslationMessages() - 36.67 ms - (135mb -> 135mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > loadContent() - 3.33 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > loadContent() - 3.62 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > translatePluginContent() - 85.70 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > getDefaultCodeTranslationMessages() - 36.25 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > translatePluginContent() - 94.06 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > getDefaultCodeTranslationMessages() - 35.51 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > loadContent() - 3.39 seconds! - (129mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > translatePluginContent() - 40.51 ms - (134mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > getDefaultCodeTranslationMessages() - 36.08 ms - (134mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests > contentLoaded() - 633.56 ms - (135mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@blog-tests - 3.48 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default > contentLoaded() - 250.51 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@default - 4.07 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests > contentLoaded() - 40.84 ms - (133mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load docs@docs-tests - 3.62 seconds! - (129mb -> 134mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default > contentLoaded() - 341.42 ms - (134mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load changelog@default - 3.91 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default > contentLoaded() - 358.57 ms - (134mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content > Load blog@default - 4.18 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > Load plugins content - 4.25 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@default - 437.94 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@default - 438.43 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@default - 439.04 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - google-gtag@default - 424.42 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - sitemap@default - 424.83 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - classic@default - 425.03 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - search-algolia@default - 423.30 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - changelog@default - 423.90 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@community - 424.01 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-redirects@default - 425.26 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - ideal-image@default - 426.38 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pwa@default - 427.55 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - mermaid@default - 428.31 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - feature-requests@default - 428.94 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docs@docs-tests - 429.22 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - blog@blog-tests - 430.38 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - pages@pages-tests - 430.59 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - client-module-test@default - 427.86 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - live-codeblock@default - 427.97 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - swizzle-theme-tests@default - 427.03 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-bootstrap@default - 425.43 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - docusaurus-mdx-fallback@default - 426.16 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() > allContentLoaded() - debug@default - 791.82 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins > allContentLoaded() - 880.86 ms - (133mb -> 133mb)
[PERF] Build > ja > Load site > Load plugins - 5.22 seconds! - (129mb -> 133mb)
[PERF] Build > ja > Load site > Create site files - 63.57 ms - (133mb -> 134mb)
[PERF] Build > ja > Load site - 5.41 seconds! - (127mb -> 134mb)
[PERF] Build > ja > Creating rspack bundler configs - 68.38 ms - (134mb -> 135mb)
●  ━━━━━━━━━━━━━━━━━━━━━━━━━ (8%) setup compilation                                                                                                                                                               ● Client ━━━━━━━━━━━━━━━━━━━━━━━━━ (100%) emitting after emit                                                                                                                                                     [PERF] Build > ja > Bundling with rspack - 10.03 seconds! - (135mb -> 137mb)
[PERF] Build > ja > SSG > Read client manifest - 47.54 ms - (137mb -> 137mb)
[PERF] Build > ja > SSG > Generate static files > Compile SSG template - 37.32 ms - (137mb -> 137mb)
[PERF] Build > ja > SSG > Generate static files > Load HTML minifier - 77.70 ms - (137mb -> 137mb)
[PERF] Build > ja > SSG > Generate static files > Load App renderer > Load server bundle - 130.20 ms - (137mb -> 137mb)
[PERF] Build > ja > SSG > Generate static files > Load App renderer > Server bundle size = 1.550 MB
[PERF] Build > ja > SSG > Generate static files > Load App renderer > Evaluate server bundle - 119.96 ms - (137mb -> 145mb)
[PERF] Build > ja > SSG > Generate static files > Load App renderer - 304.51 ms - (137mb -> 145mb)
For locale=ja, a maximum of 1 plural forms are expected (other), but the message contains 2: 1 site|275 sites
[PERF] Build > ja > SSG > Generate static files - 3.50 seconds! - (137mb -> 267mb)
[PERF] Build > ja > SSG - 3.61 seconds! - (137mb -> 266mb)
[WARNING] Will NOT delete server bundle because DOCUSAURUS_KEEP_SERVER_BUNDLE is set to 'true'
● Service Worker ━━━━━━━━━━━━━━━━━━━━━━━━━ (100%) emitting after emit                                                                                                                                             [PERF] Build > ja > postBuild() - 1.70 seconds! - (266mb -> 265mb)
[PERF] Build > ja > Broken links checker - 79.65 ms - (265mb -> 265mb)
[SUCCESS] Generated static files in "build/ja".
[PERF] Build > ja - 20.94 seconds! - (127mb -> 137mb)
[PERF] Build - 38.51 seconds! - (58mb -> 136mb)
[INFO] Use `npm run serve` command to test your build locally.
✨  Done in 40.22s.
```
