### PR TITLE
feat(cli): build/deploy should allow multiple `--locale` options

### DIFF
--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -33,6 +33,15 @@ process.env.NODE_ENV ??= 'development';
 
 await beforeCli();
 
+/**
+ * @param {string} locale
+ * @param {string[]} locales
+ * @returns {string[]}
+ */
+function concatLocaleOptions(locale, locales = []) {
+  return locales.concat(locale);
+}
+
 cli.version(DOCUSAURUS_VERSION).usage('<command> [options]');
 
 cli
@@ -55,8 +64,9 @@ cli
     'path to docusaurus config file (default: `[siteDir]/docusaurus.config.js`)',
   )
   .option(
-    '-l, --locale <locale>',
+    '-l, --locale <locale...>',
     'build the site in a specified locale. Build all known locales otherwise',
+    concatLocaleOptions,
   )
   .option(
     '--no-minify',
@@ -102,6 +112,7 @@ cli
   .option(
     '-l, --locale <locale>',
     'deploy the site in a specified locale. Deploy all known locales otherwise',
+    concatLocaleOptions,
   )
   .option(
     '--out-dir <dir>',

--- a/packages/docusaurus/bin/docusaurus.mjs
+++ b/packages/docusaurus/bin/docusaurus.mjs
@@ -65,7 +65,7 @@ cli
   )
   .option(
     '-l, --locale <locale...>',
-    'build the site in a specified locale. Build all known locales otherwise',
+    'build the site in the specified locale(s). Build all known locales otherwise',
     concatLocaleOptions,
   )
   .option(
@@ -111,7 +111,7 @@ cli
   .description('Deploy website to GitHub pages.')
   .option(
     '-l, --locale <locale>',
-    'deploy the site in a specified locale. Deploy all known locales otherwise',
+    'deploy the site in the specified locale(s). Deploy all known locales otherwise',
     concatLocaleOptions,
   )
   .option(

--- a/packages/docusaurus/src/commands/build/buildLocale.ts
+++ b/packages/docusaurus/src/commands/build/buildLocale.ts
@@ -51,7 +51,7 @@ export async function buildLocale({
       outDir: cliOptions.outDir,
       config: cliOptions.config,
       locale,
-      localizePath: cliOptions.locale ? false : undefined,
+      localizePath: cliOptions.locale?.length === 1 ? false : undefined,
     }),
   );
 

--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -14,10 +14,8 @@ import {hasSSHProtocol, buildSshUrl, buildHttpsUrl} from '@docusaurus/utils';
 import {loadContext, type LoadContextParams} from '../server/site';
 import {build} from './build/build';
 
-export type DeployCLIOptions = Pick<
-  LoadContextParams,
-  'config' | 'locale' | 'outDir'
-> & {
+export type DeployCLIOptions = Pick<LoadContextParams, 'config' | 'outDir'> & {
+  locale?: [string, ...string[]];
   skipBuild?: boolean;
   targetDir?: string;
 };

--- a/packages/docusaurus/src/server/i18n.ts
+++ b/packages/docusaurus/src/server/i18n.ts
@@ -88,11 +88,11 @@ export function getDefaultLocaleConfig(locale: string): I18nLocaleConfig {
 
 export async function loadI18n(
   config: DocusaurusConfig,
-  options: Pick<LoadContextParams, 'locale'>,
+  options?: Pick<LoadContextParams, 'locale'>,
 ): Promise<I18n> {
   const {i18n: i18nConfig} = config;
 
-  const currentLocale = options.locale ?? i18nConfig.defaultLocale;
+  const currentLocale = options?.locale ?? i18nConfig.defaultLocale;
 
   if (!i18nConfig.locales.includes(currentLocale)) {
     logger.warn`The locale name=${currentLocale} was not found in your site configuration: Available locales are: ${i18nConfig.locales}

--- a/website/docs/cli.mdx
+++ b/website/docs/cli.mdx
@@ -90,7 +90,7 @@ Compiles your site for production.
 | `--bundle-analyzer` | `false` | Analyze your bundle with the [webpack bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer). |
 | `--out-dir` | `build` | The full path for the new output directory, relative to the current workspace. |
 | `--config` | `undefined` | Path to Docusaurus config file, default to `[siteDir]/docusaurus.config.js` |
-| `--locale` |  | Build the site in the specified locale. If not specified, all known locales are built. |
+| `--locale` |  | Build the site in the specified locale(s). If not specified, all known locales are built. |
 | `--no-minify` | `false` | Build website without minimizing JS/CSS bundles. |
 
 :::info
@@ -141,7 +141,7 @@ Deploys your site with [GitHub Pages](https://pages.github.com/). Check out the 
 
 | Name | Default | Description |
 | --- | --- | --- |
-| `--locale` |  | Deploy the site in the specified locale. If not specified, all known locales are deployed. |
+| `--locale` |  | Deploy the site in the specified locale(s). If not specified, all known locales are deployed. |
 | `--out-dir` | `build` | The full path for the new output directory, relative to the current workspace. |
 | `--skip-build` | `false` | Deploy website without building it. This may be useful when using a custom deploy script. |
 | `--target-dir` | `.` | Path to the target directory to deploy to. |


### PR DESCRIPTION

## Motivation


We already support:

- `docusaurus build` (all locales)
- `docusaurus build --locale fr` (single locale)

This adds support for:

- `docusaurus build --locale fr --locale en`

Same for `docusaurus deploy`

Note: we don't plan to support this for other commands like `docusaurus start` due to technical limitations.

## Test Plan

local test only 😅 

### Test links

https://deploy-preview-10600--docusaurus-2.netlify.app/

