### PR TITLE
perf(ci): Add CI checks to prevent memory, build-time and build-size regressions

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        DOCUSAURUS_FASTER: ['true', 'false']
+        DOCUSAURUS_INFRA: ['SLOWER', 'FASTER']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -59,9 +59,9 @@ jobs:
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 30
           compression: none
-          comment-key: DOCUSAURUS_FASTER-${{ secrets.DOCUSAURUS_FASTER }}
+          comment-key: DOCUSAURUS_INFRA_${{ secrets.DOCUSAURUS_INFRA }}
         env:
-          DOCUSAURUS_FASTER: ${{ matrix.DOCUSAURUS_FASTER }}
+          DOCUSAURUS_SLOWER: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 'true' || 'false'  }}
 
   # Ensures build times stay under reasonable thresholds
   build-time:
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        DOCUSAURUS_FASTER: ['true', 'false']
+        DOCUSAURUS_INFRA: ['SLOWER', 'FASTER']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -87,13 +87,13 @@ jobs:
         run: yarn build:website:fast
         timeout-minutes: 2
         env:
-          DOCUSAURUS_FASTER: ${{ matrix.DOCUSAURUS_FASTER }}
+          DOCUSAURUS_SLOWER: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 'true' || 'false'  }}
 
       # Ensure build with a warm cache does not increase too much
       - name: Build (warm cache)
         run: yarn build:website:fast
         timeout-minutes: 2
         env:
-          DOCUSAURUS_FASTER: ${{ matrix.DOCUSAURUS_FASTER }}
+          DOCUSAURUS_SLOWER: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 'true' || 'false'  }}
 
     # TODO post a GitHub comment with build with perf warnings?

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -11,6 +11,7 @@ on:
       - main
       - docusaurus-v**
     paths:
+      - .github/workflows/build-perf.yml
       - package.json
       - yarn.lock
       - packages/**

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -85,14 +85,14 @@ jobs:
       # Ensure build with a cold cache does not increase too much
       - name: Build (cold cache)
         run: yarn build:website:fast
-        timeout-minutes: 2
+        timeout-minutes: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 3 || 1  }}
         env:
           DOCUSAURUS_SLOWER: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 'true' || 'false'  }}
 
       # Ensure build with a warm cache does not increase too much
       - name: Build (warm cache)
         run: yarn build:website:fast
-        timeout-minutes: 2
+        timeout-minutes: 1
         env:
           DOCUSAURUS_SLOWER: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 'true' || 'false'  }}
 

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -25,6 +25,7 @@ permissions:
   contents: read
 
 jobs:
+  # Posts a PR comment with build size differences from PR vs main branches
   build-size:
     permissions:
       checks: write # for preactjs/compressed-size-action to create and update the checks
@@ -34,6 +35,9 @@ jobs:
     name: Build Size Report
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        DOCUSAURUS_FASTER: ['true', 'false']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -54,10 +58,18 @@ jobs:
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 30
           compression: none
+          comment-key: DOCUSAURUS_FASTER-${{ secrets.GITHUB_TOKEN }}
+        env:
+          DOCUSAURUS_FASTER: ${{ matrix.DOCUSAURUS_FASTER }}
+
+  # Ensures build times stay under reasonable thresholds
   build-time:
     name: Build Time Perf
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        DOCUSAURUS_FASTER: ['true', 'false']
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -72,10 +84,15 @@ jobs:
       # Ensure build with a cold cache does not increase too much
       - name: Build (cold cache)
         run: yarn build:website:fast
-        timeout-minutes: 8
+        timeout-minutes: 2
+        env:
+          DOCUSAURUS_FASTER: ${{ matrix.DOCUSAURUS_FASTER }}
 
       # Ensure build with a warm cache does not increase too much
       - name: Build (warm cache)
         run: yarn build:website:fast
         timeout-minutes: 2
+        env:
+          DOCUSAURUS_FASTER: ${{ matrix.DOCUSAURUS_FASTER }}
+
     # TODO post a GitHub comment with build with perf warnings?

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -59,7 +59,7 @@ jobs:
           strip-hash: '\.([^;]\w{7})\.'
           minimum-change-threshold: 30
           compression: none
-          comment-key: DOCUSAURUS_FASTER-${{ secrets.GITHUB_TOKEN }}
+          comment-key: DOCUSAURUS_FASTER-${{ secrets.DOCUSAURUS_FASTER }}
         env:
           DOCUSAURUS_FASTER: ${{ matrix.DOCUSAURUS_FASTER }}
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -62,7 +62,9 @@ jobs:
         env:
           E2E_TEST: true
       - name: Build test-website project
-        run: yarn build
+        # We build 2 locales to ensure a localized site doesn't leak memory
+        # See https://github.com/facebook/docusaurus/pull/10599
+        run: yarn build --locale en --locale fr
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
@@ -133,7 +135,9 @@ jobs:
           yarn typecheck
 
       - name: Build test-website project
-        run: yarn build
+        # We build 2 locales to ensure a localized site doesn't leak memory
+        # See https://github.com/facebook/docusaurus/pull/10599
+        run: yarn build --locale en --locale fr
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
@@ -168,7 +172,9 @@ jobs:
         env:
           E2E_TEST: true
       - name: Build test-website project
-        run: npm run build
+        # We build 2 locales to ensure a localized site doesn't leak memory
+        # See https://github.com/facebook/docusaurus/pull/10599
+        run: npm run build --locale en --locale fr
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
@@ -206,7 +212,9 @@ jobs:
         env:
           E2E_TEST: true
       - name: Build test-website project
-        run: pnpm run build
+        # We build 2 locales to ensure a localized site doesn't leak memory
+        # See https://github.com/facebook/docusaurus/pull/10599
+        run: pnpm run build --locale en --locale fr
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Build test-website project
         # We build 2 locales to ensure a localized site doesn't leak memory
         # See https://github.com/facebook/docusaurus/pull/10599
-        run: npm run build --locale en --locale fr
+        run: npm run build -- --locale en --locale fr
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590
-          NODE_OPTIONS: '--max-old-space-size=350'
+          NODE_OPTIONS: '--max-old-space-size=400'
           DOCUSAURUS_PERF_LOGGER: 'true'
       - name: Docusaurus site CSS order
         run: yarn workspace website test:css-order

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Remove Theme Internal Re-export
         run: yarn workspace @docusaurus/theme-common removeThemeInternalReexport
       - name: Docusaurus Build
-        run: yarn build:website:fast
+        # We build 2 locales to ensure a localized site doesn't leak memory
+        # See https://github.com/facebook/docusaurus/pull/10599
+        run: yarn build:website:fast --locale en --locale fr
         env:
           # Our website should build even with limited memory
           # See https://github.com/facebook/docusaurus/pull/10590


### PR DESCRIPTION
## Motivation

Add CI checks to ensure that the perf gains from [Docusaurus Faster](https://github.com/facebook/docusaurus/issues/10556) remain permanent.


This notably ensures that:
- We track build sizes for both faster/slower builds (Webpack/Rspack) because both setups can regress
- Rspack is fast even in cold builds
- Building 2 locales in a row doesn't leak memory (see https://github.com/facebook/docusaurus/pull/10599)

## Test Plan

CI

### Test links

https://deploy-preview-10601--docusaurus-2.netlify.app/
