### PR TITLE
fix(core): Use proper swc loader options

### DIFF
--- a/packages/docusaurus-bundler/src/importFaster.ts
+++ b/packages/docusaurus-bundler/src/importFaster.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {ConfigureWebpackUtils} from '@docusaurus/types';
 import type {
   MinimizerOptions as JsMinimizerOptions,
   CustomOptions,
@@ -34,11 +33,16 @@ export async function importRspack(): Promise<FasterModule['rspack']> {
   return faster.rspack;
 }
 
-export async function importSwcJsLoaderFactory(): Promise<
-  ConfigureWebpackUtils['getJSLoader']
+export async function importSwcLoader(): Promise<string> {
+  const faster = await ensureFaster();
+  return faster.swcLoader;
+}
+
+export async function importGetSwcLoaderOptions(): Promise<
+  FasterModule['getSwcLoaderOptions']
 > {
   const faster = await ensureFaster();
-  return faster.getSwcJsLoaderFactory;
+  return faster.getSwcLoaderOptions;
 }
 
 export async function importSwcJsMinimizerOptions(): Promise<
@@ -55,9 +59,11 @@ export async function importSwcHtmlMinifier(): Promise<
   return faster.getSwcHtmlMinifier();
 }
 
-export async function importBrowserslistQueries(): Promise<string[]> {
+export async function importGetBrowserslistQueries(): Promise<
+  FasterModule['getBrowserslistQueries']
+> {
   const faster = await ensureFaster();
-  return faster.getBrowserslistQueries();
+  return faster.getBrowserslistQueries;
 }
 
 export async function importLightningCssMinimizerOptions(): Promise<

--- a/packages/docusaurus-bundler/src/minification.ts
+++ b/packages/docusaurus-bundler/src/minification.ts
@@ -10,7 +10,7 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import {
   importSwcJsMinimizerOptions,
   importLightningCssMinimizerOptions,
-  importBrowserslistQueries,
+  importGetBrowserslistQueries,
 } from './importFaster';
 import {getCurrentBundlerAsRspack} from './currentBundler';
 import type {CustomOptions, CssNanoOptions} from 'css-minimizer-webpack-plugin';
@@ -141,7 +141,8 @@ async function getRspackMinimizers({
   currentBundler,
 }: MinimizersConfig): Promise<WebpackPluginInstance[]> {
   const rspack = getCurrentBundlerAsRspack({currentBundler});
-  const browserslistQueries = await importBrowserslistQueries();
+  const getBrowserslistQueries = await importGetBrowserslistQueries();
+  const browserslistQueries = getBrowserslistQueries({isServer: false});
   const swcJsMinimizerOptions = await importSwcJsMinimizerOptions();
   return [
     // See https://rspack.dev/plugins/rspack/swc-js-minimizer-rspack-plugin


### PR DESCRIPTION


## Motivation

Ensure SWC loader options are consistent for the SWC one and the Rspack built-in one.

Ensures SWC loader respects browserslist config like Babel does.

## Test Plan

CI
