### PR TITLE
chore: fix canary trigger

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,11 +1,14 @@
 name: Canary Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
       - docusaurus-v**
     paths:
+      - .github/workflows/canary-release.yml
+      - package.json
       - packages/**
 
 permissions:


### PR DESCRIPTION

## Motivation

Canary workflow didn't trigger after https://github.com/facebook/docusaurus/pull/10612

Let's fix that + allow manual trigger if needed
