### PR TITLE
fix(theme): Restore former globalThis.Prism

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
+++ b/packages/docusaurus-theme-classic/src/theme/prism-include-languages.ts
@@ -23,6 +23,8 @@ export default function prismIncludeLanguages(
   // avoid polluting global namespace.
   // You can mutate PrismObject: registering plugins, deleting languages... As
   // long as you don't re-assign it
+
+  const PrismBefore = globalThis.Prism;
   globalThis.Prism = PrismObject;
 
   additionalLanguages.forEach((lang) => {
@@ -34,5 +36,9 @@ export default function prismIncludeLanguages(
     require(`prismjs/components/prism-${lang}`);
   });
 
+  // Clean up and eventually restore former globalThis.Prism object (if any)
   delete (globalThis as Optional<typeof globalThis, 'Prism'>).Prism;
+  if (typeof PrismBefore !== 'undefined') {
+    globalThis.Prism = PrismObject;
+  }
 }


### PR DESCRIPTION
## Motivation

While trying to upgrade Redocusaurus to Docusaurus Faster (https://github.com/rohit-gohri/redocusaurus/pull/385) I have weird SSG errors after trying to build with swc instead of babel-loader.

Redoc also uses Prism and those errors go away if we restore the Prism global namespace pollution after the prism-react-renderer init. This code should rather keep the pollution in place if something else is working with Prism.


## Test Plan

Not sure how to test this 😅 

https://deploy-preview-10618--docusaurus-2.netlify.app/


---

For context, those SSG errors were:

```bash
[PERF] Build > en > SSG > Generate static files > Load App renderer - 39.85 ms - (169mb -> 180mb)
[PERF][KO] Build > en > SSG > Generate static files - 369.23 ms - (169mb -> 187mb)
[PERF][KO] Build > en > SSG - 369.75 ms - (169mb -> 187mb)
[PERF][KO] Build > en - 1.68 seconds! - (64mb -> 187mb)
[PERF][KO] Build - 1.68 seconds! - (64mb -> 187mb)

[ERROR] Error: Unable to build website for locale en.
    at tryToBuildLocale (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:78:15)
    at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
    at async mapAsyncSequential (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/utils/lib/jsUtils.js:21:24)
    at async Object.async (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/logger/lib/perfLogger.js:106:28)
    at async Command.build (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:33:5) {
  [cause]: Error: Docusaurus static site generation failed for 10 paths:
  - "/examples/client-only/"
  - "/examples/custom-layout/"
  - "/examples/custom-page/"
  - "/examples/using-multi-file-yaml"
  - "/examples/using-remote-url/"
  - "/examples/using-single-yaml"
  - "/examples/using-swagger-json"
  - "/docs/guides/schema-imports"
  - "/docs/nested/nested-1"
  - "/docs/nested/nested-2"
      at generateStaticFiles (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:129:15)
      at async Object.async (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/logger/lib/perfLogger.js:106:28)
      ... 7 lines matching cause stack trace ...
      at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9 {
    [cause]: AggregateError
        at generateStaticFiles (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:130:20)
        at async Object.async (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/logger/lib/perfLogger.js:106:28)
        at async executeSSG (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssgExecutor.js:29:23)
        at async Object.async (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/logger/lib/perfLogger.js:106:28)
        at async buildLocale (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:60:31)
        at async runBuildLocaleTask (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:93:5)
        at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:74:13
        at async Object.async (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/logger/lib/perfLogger.js:106:28)
        at async tryToBuildLocale (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:70:9)
        at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9 {
      [errors]: [
        Error: Can't render static file for pathname "/examples/client-only/"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: TypeError: Cannot set properties of undefined (setting 'markup-templating')
              at server.bundle.js:1944:63
              at 13109 (server.bundle.js:2054:2)
              at __webpack_require__ (server.bundle.js:21311:31)
              at /Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:53830:10766
              at /Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:55614:3806
              at /Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:55614:3811
              at /Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:53791:37
              at 70200 (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:53791:43)
              at __webpack_require__ (server.bundle.js:21311:31)
              at 91833 (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64657:17)
        },
        Error: Can't render static file for pathname "/examples/custom-layout/"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_Redoc' before initialization
              at Object.Z (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64645:27)
              at CustomPage (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/e45aaca6.efd52944.js:64981:147)
              at Uc (server.bundle.js:2822:44)
              at Xc (server.bundle.js:2824:253)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2824:481)
              at Z (server.bundle.js:2830:89)
              at Vc (server.bundle.js:2822:473)
        },
        Error: Can't render static file for pathname "/examples/custom-page/"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_ApiDoc' before initialization
              at Module.default (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/f0ad3fbb.3167a289.js:64426:35)
              at CustomPage (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/f986e481.674c9217.js:65044:123)
              at Uc (server.bundle.js:2822:44)
              at Xc (server.bundle.js:2824:253)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2824:481)
              at Z (server.bundle.js:2830:89)
              at Vc (server.bundle.js:2822:473)
        },
        Error: Can't render static file for pathname "/examples/using-multi-file-yaml"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_ApiDoc' before initialization
              at Module.default (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/f0ad3fbb.3167a289.js:64426:35)
              at server.bundle.js:17102:41
              at Array.forEach (<anonymous>)
              at Object.render (server.bundle.js:17098:36)
              at LoadableComponent.render (server.bundle.js:3309:21)
              at Vc (server.bundle.js:2822:130)
              at Xc (server.bundle.js:2824:210)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
        },
        Error: Can't render static file for pathname "/examples/using-remote-url/"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_ApiDoc' before initialization
              at Module.default (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/f0ad3fbb.3167a289.js:64426:35)
              at server.bundle.js:17102:41
              at Array.forEach (<anonymous>)
              at Object.render (server.bundle.js:17098:36)
              at LoadableComponent.render (server.bundle.js:3309:21)
              at Vc (server.bundle.js:2822:130)
              at Xc (server.bundle.js:2824:210)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
        },
        Error: Can't render static file for pathname "/examples/using-single-yaml"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_ApiDoc' before initialization
              at Module.default (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/f0ad3fbb.3167a289.js:64426:35)
              at server.bundle.js:17102:41
              at Array.forEach (<anonymous>)
              at Object.render (server.bundle.js:17098:36)
              at LoadableComponent.render (server.bundle.js:3309:21)
              at Vc (server.bundle.js:2822:130)
              at Xc (server.bundle.js:2824:210)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
        },
        Error: Can't render static file for pathname "/examples/using-swagger-json"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_ApiDoc' before initialization
              at Module.default (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/f0ad3fbb.3167a289.js:64426:35)
              at server.bundle.js:17102:41
              at Array.forEach (<anonymous>)
              at Object.render (server.bundle.js:17098:36)
              at LoadableComponent.render (server.bundle.js:3309:21)
              at Vc (server.bundle.js:2822:130)
              at Xc (server.bundle.js:2824:210)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
        },
        Error: Can't render static file for pathname "/docs/guides/schema-imports"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: TypeError: redoc__WEBPACK_IMPORTED_MODULE_4__.AppStore is not a constructor
              at /Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64941:24
              at Object.Ic [as useMemo] (server.bundle.js:2815:240)
              at __webpack_modules__.41535.exports.useMemo (server.bundle.js:4834:48)
              at useSpec (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64936:64)
              at ApiSchema_ApiSchema (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/124171a0.48b0a782.js:205:43)
              at Uc (server.bundle.js:2822:44)
              at Xc (server.bundle.js:2824:253)
              at Z (server.bundle.js:2830:89)
              at Yc (server.bundle.js:2833:98)
              at $c (server.bundle.js:2832:140)
        },
        Error: Can't render static file for pathname "/docs/nested/nested-1"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_Redoc' before initialization
              at Object.Z (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64645:27)
              at ApiDocMdx (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64568:65)
              at Uc (server.bundle.js:2822:44)
              at Xc (server.bundle.js:2824:253)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2824:481)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2824:481)
        },
        Error: Can't render static file for pathname "/docs/nested/nested-2"
            at generateStaticFile (/Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/@docusaurus/core/lib/ssg/ssg.js:167:15)
            at processTicksAndRejections (node:internal/process/task_queues:95:5)
            at runNextTicks (node:internal/process/task_queues:64:3)
            at process.processImmediate (node:internal/timers:449:9)
            at process.callbackTrampoline (node:internal/async_hooks:130:17)
            at async /Users/sebastienlorber/Desktop/projects/redocusaurus/node_modules/p-map/index.js:57:22 {
          [cause]: ReferenceError: Cannot access 'theme_Redoc' before initialization
              at Object.Z (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64645:27)
              at ApiDocMdx (/Users/sebastienlorber/Desktop/projects/redocusaurus/website/build/__server/assets/js/257de05e.234109a6.js:64568:65)
              at Uc (server.bundle.js:2822:44)
              at Xc (server.bundle.js:2824:253)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2824:481)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2828:231)
              at Z (server.bundle.js:2830:89)
              at Xc (server.bundle.js:2824:481)
        }
      ]
    }
  }
}
```