### PR TITLE
docs: fix frontMatter.mdx.format docs

### DIFF
--- a/website/docs/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-intro.mdx
@@ -41,7 +41,7 @@ The MDX compiler supports [2 formats](https://mdxjs.com/packages/mdx/#optionsfor
 
 By default, **Docusaurus v3 uses the MDX format for all files** (including `.md` files) for historical reasons.
 
-It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `format: md` front matter.
+It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `mdx.format: md` front matter.
 
 :::tip how to use CommonMark
 

--- a/website/docs/guides/markdown-features/markdown-features-react.mdx
+++ b/website/docs/guides/markdown-features/markdown-features-react.mdx
@@ -248,7 +248,7 @@ Some valid CommonMark features won't work with MDX ([more info](https://mdxjs.co
 
 Docusaurus v3 makes it possible to opt-in for a less strict, standard [CommonMark](https://commonmark.org/) support with the following options:
 
-- The `format: md` front matter
+- The `mdx.format: md` front matter
 - The `.md` file extension combined with the `siteConfig.markdown.format: "detect"` configuration
 
 This feature is **experimental** and currently has a few [limitations](https://github.com/facebook/docusaurus/issues/9092).

--- a/website/versioned_docs/version-3.0.1/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/versioned_docs/version-3.0.1/guides/markdown-features/markdown-features-intro.mdx
@@ -41,7 +41,7 @@ The MDX compiler supports [2 formats](https://mdxjs.com/packages/mdx/#optionsfor
 
 By default, **Docusaurus v3 uses the MDX format for all files** (including `.md` files) for historical reasons.
 
-It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `format: md` front matter.
+It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `mdx.format: md` front matter.
 
 :::tip how to use CommonMark
 

--- a/website/versioned_docs/version-3.0.1/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.0.1/guides/markdown-features/markdown-features-react.mdx
@@ -242,7 +242,7 @@ Some valid CommonMark features won't work with MDX ([more info](https://mdxjs.co
 
 Docusaurus v3 makes it possible to opt-in for a less strict, standard [CommonMark](https://commonmark.org/) support with the following options:
 
-- The `format: md` front matter
+- The `mdx.format: md` front matter
 - The `.md` file extension combined with the `siteConfig.markdown.format: "detect"` configuration
 
 This feature is **experimental** and currently has a few [limitations](https://github.com/facebook/docusaurus/issues/9092).

--- a/website/versioned_docs/version-3.1.1/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/versioned_docs/version-3.1.1/guides/markdown-features/markdown-features-intro.mdx
@@ -41,7 +41,7 @@ The MDX compiler supports [2 formats](https://mdxjs.com/packages/mdx/#optionsfor
 
 By default, **Docusaurus v3 uses the MDX format for all files** (including `.md` files) for historical reasons.
 
-It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `format: md` front matter.
+It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `mdx.format: md` front matter.
 
 :::tip how to use CommonMark
 

--- a/website/versioned_docs/version-3.1.1/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.1.1/guides/markdown-features/markdown-features-react.mdx
@@ -248,7 +248,7 @@ Some valid CommonMark features won't work with MDX ([more info](https://mdxjs.co
 
 Docusaurus v3 makes it possible to opt-in for a less strict, standard [CommonMark](https://commonmark.org/) support with the following options:
 
-- The `format: md` front matter
+- The `mdx.format: md` front matter
 - The `.md` file extension combined with the `siteConfig.markdown.format: "detect"` configuration
 
 This feature is **experimental** and currently has a few [limitations](https://github.com/facebook/docusaurus/issues/9092).

--- a/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-intro.mdx
@@ -41,7 +41,7 @@ The MDX compiler supports [2 formats](https://mdxjs.com/packages/mdx/#optionsfor
 
 By default, **Docusaurus v3 uses the MDX format for all files** (including `.md` files) for historical reasons.
 
-It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `format: md` front matter.
+It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `mdx.format: md` front matter.
 
 :::tip how to use CommonMark
 

--- a/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.2.1/guides/markdown-features/markdown-features-react.mdx
@@ -248,7 +248,7 @@ Some valid CommonMark features won't work with MDX ([more info](https://mdxjs.co
 
 Docusaurus v3 makes it possible to opt-in for a less strict, standard [CommonMark](https://commonmark.org/) support with the following options:
 
-- The `format: md` front matter
+- The `mdx.format: md` front matter
 - The `.md` file extension combined with the `siteConfig.markdown.format: "detect"` configuration
 
 This feature is **experimental** and currently has a few [limitations](https://github.com/facebook/docusaurus/issues/9092).

--- a/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-intro.mdx
@@ -41,7 +41,7 @@ The MDX compiler supports [2 formats](https://mdxjs.com/packages/mdx/#optionsfor
 
 By default, **Docusaurus v3 uses the MDX format for all files** (including `.md` files) for historical reasons.
 
-It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `format: md` front matter.
+It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `mdx.format: md` front matter.
 
 :::tip how to use CommonMark
 

--- a/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.3.2/guides/markdown-features/markdown-features-react.mdx
@@ -248,7 +248,7 @@ Some valid CommonMark features won't work with MDX ([more info](https://mdxjs.co
 
 Docusaurus v3 makes it possible to opt-in for a less strict, standard [CommonMark](https://commonmark.org/) support with the following options:
 
-- The `format: md` front matter
+- The `mdx.format: md` front matter
 - The `.md` file extension combined with the `siteConfig.markdown.format: "detect"` configuration
 
 This feature is **experimental** and currently has a few [limitations](https://github.com/facebook/docusaurus/issues/9092).

--- a/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-intro.mdx
@@ -41,7 +41,7 @@ The MDX compiler supports [2 formats](https://mdxjs.com/packages/mdx/#optionsfor
 
 By default, **Docusaurus v3 uses the MDX format for all files** (including `.md` files) for historical reasons.
 
-It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `format: md` front matter.
+It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `mdx.format: md` front matter.
 
 :::tip how to use CommonMark
 

--- a/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.4.0/guides/markdown-features/markdown-features-react.mdx
@@ -248,7 +248,7 @@ Some valid CommonMark features won't work with MDX ([more info](https://mdxjs.co
 
 Docusaurus v3 makes it possible to opt-in for a less strict, standard [CommonMark](https://commonmark.org/) support with the following options:
 
-- The `format: md` front matter
+- The `mdx.format: md` front matter
 - The `.md` file extension combined with the `siteConfig.markdown.format: "detect"` configuration
 
 This feature is **experimental** and currently has a few [limitations](https://github.com/facebook/docusaurus/issues/9092).

--- a/website/versioned_docs/version-3.5.2/guides/markdown-features/markdown-features-intro.mdx
+++ b/website/versioned_docs/version-3.5.2/guides/markdown-features/markdown-features-intro.mdx
@@ -41,7 +41,7 @@ The MDX compiler supports [2 formats](https://mdxjs.com/packages/mdx/#optionsfor
 
 By default, **Docusaurus v3 uses the MDX format for all files** (including `.md` files) for historical reasons.
 
-It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `format: md` front matter.
+It is possible to **opt-in for CommonMark** using the [`siteConfig.markdown.format`](../../api/docusaurus.config.js.mdx#markdown) setting or the `mdx.format: md` front matter.
 
 :::tip how to use CommonMark
 

--- a/website/versioned_docs/version-3.5.2/guides/markdown-features/markdown-features-react.mdx
+++ b/website/versioned_docs/version-3.5.2/guides/markdown-features/markdown-features-react.mdx
@@ -248,7 +248,7 @@ Some valid CommonMark features won't work with MDX ([more info](https://mdxjs.co
 
 Docusaurus v3 makes it possible to opt-in for a less strict, standard [CommonMark](https://commonmark.org/) support with the following options:
 
-- The `format: md` front matter
+- The `mdx.format: md` front matter
 - The `.md` file extension combined with the `siteConfig.markdown.format: "detect"` configuration
 
 This feature is **experimental** and currently has a few [limitations](https://github.com/facebook/docusaurus/issues/9092).


### PR DESCRIPTION


## Motivation

Current doc was wrong, it's `frontMatter.mdx.format` and not `frontMatter.format`.

Fix https://github.com/facebook/docusaurus/issues/10628

Also edited all the related GitHub issues to not mislead anyone.
