### PR TITLE
fix(core): restore Rspack ProgressBar colors

### DIFF
--- a/packages/docusaurus-bundler/src/currentBundler.ts
+++ b/packages/docusaurus-bundler/src/currentBundler.ts
@@ -87,17 +87,19 @@ export async function getProgressBarPlugin({
   currentBundler: CurrentBundler;
 }): Promise<typeof WebpackBar> {
   if (currentBundler.name === 'rspack') {
-    class CustomRspackProgressPlugin extends currentBundler.instance
-      .ProgressPlugin {
-      constructor({name}: {name: string}) {
-        // TODO add support for color
-        // Unfortunately the rspack.ProgressPlugin does not have a name option
+    const rspack = getCurrentBundlerAsRspack({currentBundler});
+    class CustomRspackProgressPlugin extends rspack.ProgressPlugin {
+      constructor({name, color = 'green'}: {name?: string; color?: string}) {
+        // Unfortunately rspack.ProgressPlugin does not have name/color options
         // See https://rspack.dev/plugins/webpack/progress-plugin
-        // @ts-expect-error: adapt Rspack ProgressPlugin constructor
-        super({prefix: name});
+        super({
+          prefix: name,
+          template: `● {prefix:.bold} {bar:50.${color}/white.dim} ({percent}%) {wide_msg:.dim}`,
+          progressChars: '■■',
+        });
       }
     }
-    return CustomRspackProgressPlugin as typeof WebpackBar;
+    return CustomRspackProgressPlugin as unknown as typeof WebpackBar;
   }
 
   return WebpackBar;

--- a/packages/docusaurus/src/webpack/client.ts
+++ b/packages/docusaurus/src/webpack/client.ts
@@ -65,6 +65,7 @@ async function createBaseClientConfig({
       new ChunkAssetPlugin(),
       new ProgressBarPlugin({
         name: 'Client',
+        color: 'green',
       }),
       await createStaticDirectoriesCopyPlugin({
         props,


### PR DESCRIPTION
## Motivation

Adjust code so that Rspack compilation progress bars can have same colors as before.

Unfortunately, their underlying Rust lib [indicatif](https://github.com/console-rs/indicatif) doesn't have the exact same interface as webpackbar, but the `template` option permits to restore former colors.

See also https://rspack.dev/plugins/webpack/progress-plugin for available Rspack options.

---

Also there's a bug in Rspack integration of Indicatif: when using multiple compiler configs (client/server) the progress bars do not look that great and are somehow merged in a weird way. 

![CleanShot 2024-10-31 at 12 45 11](https://github.com/user-attachments/assets/21a97986-6f2e-4254-8e80-d0e86436c9ce)


This issue won't fix that problem, we need Rspack to use Indicatif [MultiProgress](https://docs.rs/indicatif/latest/indicatif/struct.MultiProgress.html) in that case.

See also https://github.com/web-infra-dev/rspack/issues/4214
