### PR TITLE
fix(faster,utils): fix faster/types peerDependencies

### DIFF
--- a/packages/docusaurus-bundler/package.json
+++ b/packages/docusaurus-bundler/package.json
@@ -45,7 +45,7 @@
     "webpackbar": "^6.0.1"
   },
   "peerDependencies": {
-    "@docusaurus/faster": "3.5.2"
+    "@docusaurus/faster": "*"
   },
   "peerDependenciesMeta": {
     "@docusaurus/faster": {

--- a/packages/docusaurus-faster/package.json
+++ b/packages/docusaurus-faster/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/types": "3.6.0",
     "@rspack/core": "^1.0.14",
     "@swc/core": "^1.7.39",
     "@swc/html": "^1.7.39",
@@ -29,8 +30,5 @@
   },
   "engines": {
     "node": ">=18.0"
-  },
-  "peerDependencies": {
-    "@docusaurus/types": "*"
   }
 }

--- a/packages/docusaurus-utils-common/package.json
+++ b/packages/docusaurus-utils-common/package.json
@@ -19,15 +19,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@docusaurus/types": "3.6.0",
     "tslib": "^2.6.0"
-  },
-  "peerDependencies": {
-    "@docusaurus/types": "*"
-  },
-  "peerDependenciesMeta": {
-    "@docusaurus/types": {
-      "optional": true
-    }
   },
   "engines": {
     "node": ">=18.0"

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@docusaurus/logger": "3.6.0",
+    "@docusaurus/types": "3.6.0",
     "@docusaurus/utils-common": "3.6.0",
     "@svgr/webpack": "^8.1.0",
     "escape-string-regexp": "^4.0.0",
@@ -43,7 +44,6 @@
     "node": ">=18.0"
   },
   "devDependencies": {
-    "@docusaurus/types": "3.6.0",
     "@types/dedent": "^0.7.0",
     "@types/github-slugger": "^1.3.0",
     "@types/micromatch": "^4.0.2",

--- a/packages/docusaurus-utils/package.json
+++ b/packages/docusaurus-utils/package.json
@@ -50,13 +50,5 @@
     "@types/react-dom": "^18.2.7",
     "dedent": "^0.7.0",
     "tmp-promise": "^3.0.3"
-  },
-  "peerDependencies": {
-    "@docusaurus/types": "*"
-  },
-  "peerDependenciesMeta": {
-    "@docusaurus/types": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
## Motivation

Fix `@docusaurus/faster` peerDependency not using `*` range. For some reason when publishing, the version is not bumped, see https://github.com/facebook/docusaurus/discussions/10641#discussioncomment-11153736

Also removed `@docusaurus/types` from peerDependency. It's unclear why it has a peerDep for some packages and not others in the first place.


## Test Plan

CI

### Test links

https://deploy-preview-10649--docusaurus-2.netlify.app/
