### PR TITLE
refactor(faster,bundler,core): improve js loader DX

### DIFF
--- a/packages/docusaurus-bundler/src/loaders/__tests__/jsLoader.test.ts
+++ b/packages/docusaurus-bundler/src/loaders/__tests__/jsLoader.test.ts
@@ -10,19 +10,19 @@ import {createJsLoaderFactory} from '../jsLoader';
 
 import type {RuleSetRule} from 'webpack';
 
+type SiteConfigSlice = Parameters<
+  typeof createJsLoaderFactory
+>[0]['siteConfig'];
+
 describe('createJsLoaderFactory', () => {
-  function testJsLoaderFactory(
-    siteConfig?: PartialDeep<
-      Parameters<typeof createJsLoaderFactory>[0]['siteConfig']
-    >,
-  ) {
+  function testJsLoaderFactory(siteConfig?: {
+    webpack?: SiteConfigSlice['webpack'];
+    future?: PartialDeep<SiteConfigSlice['future']>;
+  }) {
     return createJsLoaderFactory({
       siteConfig: {
         ...siteConfig,
-        webpack: {
-          jsLoader: 'babel',
-          ...siteConfig?.webpack,
-        },
+        webpack: siteConfig?.webpack,
         future: fromPartial({
           ...siteConfig?.future,
           experimental_faster: fromPartial({
@@ -41,6 +41,52 @@ describe('createJsLoaderFactory', () => {
     expect(createJsLoader({isServer: false}).loader).toBe(
       require.resolve('babel-loader'),
     );
+  });
+
+  it('createJsLoaderFactory accepts babel loader preset', async () => {
+    const createJsLoader = await testJsLoaderFactory({
+      webpack: {jsLoader: 'babel'},
+    });
+    expect(createJsLoader({isServer: true}).loader).toBe(
+      require.resolve('babel-loader'),
+    );
+    expect(createJsLoader({isServer: false}).loader).toBe(
+      require.resolve('babel-loader'),
+    );
+  });
+
+  it('createJsLoaderFactory accepts custom loader', async () => {
+    const createJsLoader = await testJsLoaderFactory({
+      webpack: {
+        jsLoader: (isServer) => {
+          return {loader: `my-loader-${isServer ? 'server' : 'client'}`};
+        },
+      },
+    });
+    expect(createJsLoader({isServer: true}).loader).toBe('my-loader-server');
+    expect(createJsLoader({isServer: false}).loader).toBe('my-loader-client');
+  });
+
+  it('createJsLoaderFactory rejects custom loader when using faster swc loader', async () => {
+    await expect(() =>
+      testJsLoaderFactory({
+        future: {
+          experimental_faster: {
+            swcJsLoader: true,
+          },
+        },
+        webpack: {
+          jsLoader: (isServer) => {
+            return {loader: `my-loader-${isServer ? 'server' : 'client'}`};
+          },
+        },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "You can't use siteConfig.webpack.jsLoader and siteConfig.future.experimental_faster.swcJsLoader at the same time.
+      To avoid any configuration ambiguity, you must make an explicit choice:
+      - If you want to use Docusaurus Faster and SWC (recommended), remove siteConfig.webpack.jsLoader
+      - If you want to use a custom JS loader, use siteConfig.future.experimental_faster.swcJsLoader: false"
+    `);
   });
 
   it('createJsLoaderFactory accepts loaders with preset', async () => {

--- a/packages/docusaurus-types/src/config.d.ts
+++ b/packages/docusaurus-types/src/config.d.ts
@@ -431,7 +431,7 @@ export type DocusaurusConfig = {
     // TODO Docusaurus v4
     //  Use an object type ({isServer}) so that it conforms to jsLoaderFactory
     //  Eventually deprecate this if swc loader becomes stable?
-    jsLoader: 'babel' | ((isServer: boolean) => RuleSetRule);
+    jsLoader?: 'babel' | ((isServer: boolean) => RuleSetRule);
   };
   /** Markdown-related options. */
   markdown: MarkdownConfig;

--- a/packages/docusaurus/src/server/__tests__/__fixtures__/siteMessages/siteWithBabelConfigFile/babel.config.js
+++ b/packages/docusaurus/src/server/__tests__/__fixtures__/siteMessages/siteWithBabelConfigFile/babel.config.js
@@ -1,0 +1,1 @@
+content doesn't matter

--- a/packages/docusaurus/src/server/__tests__/siteMessages.test.ts
+++ b/packages/docusaurus/src/server/__tests__/siteMessages.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import {fromPartial} from '@total-typescript/shoehorn';
+import {collectAllSiteMessages} from '../siteMessages';
+
+function siteDirFixture(name: string) {
+  return path.resolve(__dirname, '__fixtures__', 'siteMessages', name);
+}
+
+describe('collectAllSiteMessages', () => {
+  describe('uselessBabelConfigMessages', () => {
+    async function getMessagesFor({
+      siteDir,
+      swcJsLoader,
+    }: {
+      siteDir: string;
+      swcJsLoader: boolean;
+    }) {
+      return collectAllSiteMessages(
+        fromPartial({
+          site: {
+            props: {
+              siteDir,
+              siteConfig: {
+                future: {
+                  experimental_faster: {
+                    swcJsLoader,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+    }
+
+    it('warns for useless babel config file when SWC enabled', async () => {
+      const messages = await getMessagesFor({
+        siteDir: siteDirFixture('siteWithBabelConfigFile'),
+        swcJsLoader: true,
+      });
+      expect(messages).toMatchInlineSnapshot(`
+              [
+                {
+                  "message": "Your site is using the SWC js loader. You can safely remove the Babel config file at \`packages/docusaurus/src/server/__tests__/__fixtures__/siteMessages/siteWithBabelConfigFile/babel.config.js\`.",
+                  "type": "warning",
+                },
+              ]
+          `);
+    });
+
+    it('does not warn for babel config file when SWC disabled', async () => {
+      const messages = await getMessagesFor({
+        siteDir: siteDirFixture('siteWithBabelConfigFile'),
+        swcJsLoader: false,
+      });
+      expect(messages).toMatchInlineSnapshot(`[]`);
+    });
+  });
+});

--- a/packages/docusaurus/src/server/siteMessages.ts
+++ b/packages/docusaurus/src/server/siteMessages.ts
@@ -37,7 +37,9 @@ const uselessBabelConfigMessages: SiteMessageCreator = async ({site}) => {
   return [];
 };
 
-async function collectAllSiteMessages(params: Params): Promise<SiteMessage[]> {
+export async function collectAllSiteMessages(
+  params: Params,
+): Promise<SiteMessage[]> {
   const messageCreators: SiteMessageCreator[] = [uselessBabelConfigMessages];
   return (
     await Promise.all(

--- a/packages/docusaurus/src/server/siteMessages.ts
+++ b/packages/docusaurus/src/server/siteMessages.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import _ from 'lodash';
+import {getCustomBabelConfigFilePath} from '@docusaurus/babel';
+import logger from '@docusaurus/logger';
+import type {Site} from './site';
+
+type Params = {site: Site};
+
+type SiteMessage = {type: 'warning' | 'error'; message: string};
+
+type SiteMessageCreator = (params: Params) => Promise<SiteMessage[]>;
+
+const uselessBabelConfigMessages: SiteMessageCreator = async ({site}) => {
+  const {
+    props: {siteDir, siteConfig},
+  } = site;
+  if (siteConfig.future.experimental_faster.swcJsLoader) {
+    const babelConfigFilePath = await getCustomBabelConfigFilePath(siteDir);
+    if (babelConfigFilePath) {
+      return [
+        {
+          type: 'warning',
+          message: `Your site is using the SWC js loader. You can safely remove the Babel config file at ${logger.code(
+            path.relative(process.cwd(), babelConfigFilePath),
+          )}.`,
+        },
+      ];
+    }
+  }
+  return [];
+};
+
+async function collectAllSiteMessages(params: Params): Promise<SiteMessage[]> {
+  const messageCreators: SiteMessageCreator[] = [uselessBabelConfigMessages];
+  return (
+    await Promise.all(
+      messageCreators.map((createMessages) => createMessages(params)),
+    )
+  ).flat();
+}
+
+function printSiteMessages(siteMessages: SiteMessage[]): void {
+  const [errors, warnings] = _.partition(
+    siteMessages,
+    (sm) => sm.type === 'error',
+  );
+  if (errors.length > 0) {
+    logger.error(`Docusaurus site errors:
+- ${errors.map((sm) => sm.message).join('\n- ')}`);
+  }
+  if (warnings.length > 0) {
+    logger.warn(`Docusaurus site warnings:
+- ${warnings.map((sm) => sm.message).join('\n- ')}`);
+  }
+}
+
+export async function emitSiteMessages(params: Params): Promise<void> {
+  const siteMessages = await collectAllSiteMessages(params);
+  printSiteMessages(siteMessages);
+}


### PR DESCRIPTION

## Motivation

We want to:
- prevent usage of both `webpack.jsLoader` and `faster.swcJsLoader` at the same time to avoid ambiguity (easy to forget to delete `webpack.jsLoader`, see https://github.com/remotion-dev/remotion/pull/4460#discussion_r1827947848)
- encourage users to delete the useless `babel.config.js` file once Docusaurus Faster is enabled

## Test Plan

CI

https://deploy-preview-10655--docusaurus-2.netlify.app/
