### PR TITLE
test(argos): skip screenshot for /tests/pages/react-18

### DIFF
--- a/argos/tests/screenshot.spec.ts
+++ b/argos/tests/screenshot.spec.ts
@@ -52,6 +52,7 @@ function isBlacklisted(pathname: string) {
     // Console errors
     '/tests/pages/diagrams',
     '/tests/pages/markdown-tests-md',
+    '/tests/pages/react-18',
     // Flaky because of hydration error
     '/tests/blog/archive',
     '/tests/docs/tests/custom-props',


### PR DESCRIPTION


## Motivation

Argos screenshot fails due to expected console errors

We don't need to screenshot that page anyway
