### PR TITLE
docs: fix old base ts config ref

### DIFF
--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -304,7 +304,7 @@ To enable TypeScript support for Sass/SCSS modules, the TypeScript configuration
 
 ```diff
 {
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     ...
 +    "types": ["docusaurus-plugin-sass"]

--- a/website/versioned_docs/version-3.2.1/styling-layout.mdx
+++ b/website/versioned_docs/version-3.2.1/styling-layout.mdx
@@ -304,7 +304,7 @@ To enable TypeScript support for Sass/SCSS modules, the TypeScript configuration
 
 ```diff
 {
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     ...
 +    "types": ["docusaurus-plugin-sass"]

--- a/website/versioned_docs/version-3.3.2/styling-layout.mdx
+++ b/website/versioned_docs/version-3.3.2/styling-layout.mdx
@@ -304,7 +304,7 @@ To enable TypeScript support for Sass/SCSS modules, the TypeScript configuration
 
 ```diff
 {
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     ...
 +    "types": ["docusaurus-plugin-sass"]

--- a/website/versioned_docs/version-3.4.0/styling-layout.mdx
+++ b/website/versioned_docs/version-3.4.0/styling-layout.mdx
@@ -304,7 +304,7 @@ To enable TypeScript support for Sass/SCSS modules, the TypeScript configuration
 
 ```diff
 {
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     ...
 +    "types": ["docusaurus-plugin-sass"]

--- a/website/versioned_docs/version-3.5.2/styling-layout.mdx
+++ b/website/versioned_docs/version-3.5.2/styling-layout.mdx
@@ -304,7 +304,7 @@ To enable TypeScript support for Sass/SCSS modules, the TypeScript configuration
 
 ```diff
 {
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     ...
 +    "types": ["docusaurus-plugin-sass"]

--- a/website/versioned_docs/version-3.6.0/styling-layout.mdx
+++ b/website/versioned_docs/version-3.6.0/styling-layout.mdx
@@ -304,7 +304,7 @@ To enable TypeScript support for Sass/SCSS modules, the TypeScript configuration
 
 ```diff
 {
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     ...
 +    "types": ["docusaurus-plugin-sass"]


### PR DESCRIPTION

## Motivation

A docs page references the wrong/old base TS config to extend.

We have our own `@docusaurus/tsconfig` now
