### PR TITLE
fix(core): bundler should not minimize static assets

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -21,3 +21,4 @@ packages/create-docusaurus/lib/*
 packages/create-docusaurus/templates/facebook
 
 website/_dogfooding/_swizzle_theme_tests
+website/_dogfooding/_asset-tests/badSyntax.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,3 +29,4 @@ website/static/katex/katex.min.css
 
 website/changelog
 website/_dogfooding/_swizzle_theme_tests
+website/_dogfooding/_asset-tests/badSyntax.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -30,3 +30,4 @@ website/static/katex/katex.min.css
 website/changelog
 website/_dogfooding/_swizzle_theme_tests
 website/_dogfooding/_asset-tests/badSyntax.js
+website/_dogfooding/_asset-tests/badSyntax.css

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -13,5 +13,6 @@ packages/docusaurus-*/lib/*
 packages/create-docusaurus/lib/*
 packages/create-docusaurus/templates/
 website/static/katex/katex.min.css
+website/_dogfooding/_asset-tests/badSyntax.css
 
 jest/vendor

--- a/packages/docusaurus/src/webpack/plugins/StaticDirectoriesCopyPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/StaticDirectoriesCopyPlugin.ts
@@ -54,6 +54,12 @@ export async function createStaticDirectoriesCopyPlugin({
       from: dir,
       to: outDir,
       toType: 'dir',
+      info: {
+        // Prevents Webpack from minimizing static files (js/css)
+        // see https://github.com/facebook/docusaurus/issues/10460
+        // see https://github.com/webpack-contrib/copy-webpack-plugin#skip-running-javascript-files-through-a-minimizer
+        minimized: true,
+      },
     })),
   });
 }

--- a/packages/docusaurus/src/webpack/plugins/StaticDirectoriesCopyPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/StaticDirectoriesCopyPlugin.ts
@@ -56,7 +56,7 @@ export async function createStaticDirectoriesCopyPlugin({
       toType: 'dir',
       info: {
         // Prevents Webpack from minimizing static files (js/css)
-        // see https://github.com/facebook/docusaurus/issues/10460
+        // see https://github.com/facebook/docusaurus/pull/10658
         // see https://github.com/webpack-contrib/copy-webpack-plugin#skip-running-javascript-files-through-a-minimizer
         minimized: true,
       },

--- a/website/_dogfooding/_asset-tests/badSyntax.css
+++ b/website/_dogfooding/_asset-tests/badSyntax.css
@@ -1,0 +1,7 @@
+
+
+See https://github.com/facebook/docusaurus/issues/10460
+
+Using bad JS syntax on purpose, this file shouldn't be processed and cause build errors, it should just be copied over.
+
+import export with }{>< default switch

--- a/website/_dogfooding/_asset-tests/badSyntax.js
+++ b/website/_dogfooding/_asset-tests/badSyntax.js
@@ -1,0 +1,7 @@
+
+
+See https://github.com/facebook/docusaurus/issues/10460
+
+Using bad JS syntax on purpose, this file shouldn't be processed and cause build errors, it should just be copied over.
+
+import export with }{>< default switch

--- a/website/_dogfooding/_asset-tests/badSyntax.js
+++ b/website/_dogfooding/_asset-tests/badSyntax.js
@@ -1,7 +1,8 @@
 
-
-See https://github.com/facebook/docusaurus/issues/10460
-
 Using bad JS syntax on purpose, this file shouldn't be processed and cause build errors, it should just be copied over.
 
 import export with }{>< default switch
+
+  See https://github.com/facebook/docusaurus/issues/10460
+
+    See https://github.com/facebook/docusaurus/pull/10658

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -36,5 +36,5 @@
     "skipLibCheck": false,
     "types": ["jest"]
   },
-  "exclude": ["src/sw.js"]
+  "exclude": ["build", ".docusaurus", "src/sw.js", "_dogfooding/_asset-tests"]
 }


### PR DESCRIPTION
## Motivation

We are using Webpack [copy-webpack-plugin](https://webpack.js.org/plugins/copy-webpack-plugin/) to expose static assets from the `website/static` dir.

These files are supposed to be exposed as-is, not being modified.

Unfortunately, we had a regression in Docusaurus v3.4 and the css/js minimizes started to be applied to these files as well. This is because I moved the copy plugin from webpack server config (minimizers disabled) to the client config (minimizers enabled): 
https://github.com/facebook/docusaurus/commit/17f3e02a4244b1893b7624ec3c948bfa926feacd

(there are good reasons to do so, in particular now that the server is built into a `__server` subfolder)



## Test Plan

CI + added a dogfood test to prevent regressions (site failed to build before I apply the fix)

### Test links


https://deploy-preview-10658--docusaurus-2.netlify.app/

## Related issues/PRs

fix https://github.com/facebook/docusaurus/issues/10460

fix https://github.com/facebook/docusaurus/issues/10334