### PR TITLE
fix(create-docusaurus): add ts exclude to TS init template

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
+++ b/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
@@ -3,5 +3,6 @@
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": "."
-  }
+  },
+  "exclude": ["build", ".docusaurus"]
 }

--- a/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
+++ b/packages/create-docusaurus/templates/classic-typescript/tsconfig.json
@@ -4,5 +4,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "exclude": ["build", ".docusaurus"]
+  "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION

## Motivation

TypeScript should not try to typecheck the `.docusaurus` and `build` folders. It can slow TS down after a site build.

For now I'm adding this to our init template TS config.
(note, I already did that on our own website)

The plan is to move this to our base preset, but this requires using TS 5.5+ configDir variable placeholder:
https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-configdir-template-variable-for-configuration-files


## Test Plan

CI
