### PR TITLE
fix(theme-live-codeblock): fix live editor border-radius

### DIFF
--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/styles.module.css
@@ -34,6 +34,10 @@
   direction: ltr;
 }
 
+.playgroundEditor pre {
+  border-radius: 0;
+}
+
 .playgroundPreview {
   padding: 1rem;
   background-color: var(--ifm-pre-background);


### PR DESCRIPTION
## Motivation

Infima applies `border-radius` by default to `pre` elements, leading to unexpected radius here:

![image](https://github.com/user-attachments/assets/7a975730-313f-4a00-a6d8-4c7408186f54)

See https://github.com/facebook/docusaurus/issues/6032#issuecomment-2481803877



## Test Plan

CI + argos

### Test links

https://deploy-preview-10689--docusaurus-2.netlify.app/

