### PR TITLE
chore(ci): retry `yarn install` to ignore temporary network errors

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: yarn || yarn
+        run: yarn || yarn || yarn
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn || yarn
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/build-blog-only.yml
+++ b/.github/workflows/build-blog-only.yml
@@ -29,6 +29,6 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
       - name: Build blog-only
         run: yarn workspace website build:blogOnly

--- a/.github/workflows/build-blog-only.yml
+++ b/.github/workflows/build-blog-only.yml
@@ -29,6 +29,6 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
       - name: Build blog-only
         run: yarn workspace website build:blogOnly

--- a/.github/workflows/build-hash-router.yml
+++ b/.github/workflows/build-hash-router.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
 
       - name: Build Hash Router
         run: yarn build:website:fast

--- a/.github/workflows/build-hash-router.yml
+++ b/.github/workflows/build-hash-router.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
 
       - name: Build Hash Router
         run: yarn build:website:fast

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -80,7 +80,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
 
       # Ensure build with a cold cache does not increase too much
       - name: Build (cold cache)

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -80,7 +80,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
 
       # Ensure build with a cold cache does not increase too much
       - name: Build (cold cache)

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
       - name: Publish Canary release
         run: |
           yarn canary

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       - name: Installation
-        run: yarn
+        run: yarn || yarn
       - name: Publish Canary release
         run: |
           yarn canary

--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -27,7 +27,7 @@ jobs:
           cache: yarn
 
       - name: Installation
-        run: yarn
+        run: yarn || yarn
 
       - name: Build packages
         run: yarn build:packages

--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -27,7 +27,7 @@ jobs:
           cache: yarn
 
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
 
       - name: Build packages
         run: yarn build:packages

--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: yarn || yarn
+        run: yarn || yarn || yarn
 
       - name: Build website fast
         run: yarn build:website:fast

--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn || yarn
 
       - name: Build website fast
         run: yarn build:website:fast

--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Installation
-        run: yarn
+        run: yarn || yarn
 
       - name: AutoFix Format
         run: yarn format

--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
 
       - name: AutoFix Format
         run: yarn format

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
-        # run: yarn install --immutable # Fails if yarn.lock is modified (unfortunately only works for Yarn 2, and --frozen-lockfile is not the same!)
+        run: yarn install --frozen-lockfile || yarn install --frozen-lockfile || yarn install --frozen-lockfile
       - name: Check immutable yarn.lock
         run: git diff --exit-code
 

--- a/.github/workflows/showcase-test.yml
+++ b/.github/workflows/showcase-test.yml
@@ -29,6 +29,6 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
       - name: Test
         run: yarn test website/src/data/__tests__/user.test.ts

--- a/.github/workflows/showcase-test.yml
+++ b/.github/workflows/showcase-test.yml
@@ -29,6 +29,6 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
       - name: Test
         run: yarn test website/src/data/__tests__/user.test.ts

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -48,11 +48,11 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
       - name: Generate test-website project against main branch
         run: yarn test:build:website -s
       - name: Install test-website project with Yarn v1
-        run: yarn install
+        run: yarn || yarn
         working-directory: ../test-website
         env:
           npm_config_registry: http://localhost:4873
@@ -89,7 +89,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn || yarn
       - name: Generate test-website project with ${{ matrix.variant }} against main branch
         run: yarn test:build:website ${{ matrix.variant }}
       - name: Install test-website project with Yarn Berry and nodeLinker = ${{ matrix.nodeLinker }}
@@ -105,7 +105,7 @@ jobs:
           # https://yarnpkg.com/features/pnp#fallback-mode
           yarn config set pnpFallbackMode none
 
-          yarn install
+          yarn || yarn || yarn
         working-directory: ../test-website
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false # Yarn berry should create the lockfile, despite CI env
@@ -158,7 +158,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
       - name: Generate test-website project against main branch
         run: yarn test:build:website -s
       - name: Install test-website project with npm
@@ -195,7 +195,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
       - name: Generate test-website project against main branch
         run: yarn test:build:website -s
       - name: Install test-website project with pnpm

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -48,11 +48,11 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
       - name: Generate test-website project against main branch
         run: yarn test:build:website -s
       - name: Install test-website project with Yarn v1
-        run: yarn || yarn
+        run: yarn || yarn || yarn
         working-directory: ../test-website
         env:
           npm_config_registry: http://localhost:4873
@@ -158,7 +158,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
       - name: Generate test-website project against main branch
         run: yarn test:build:website -s
       - name: Install test-website project with npm
@@ -195,7 +195,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
       - name: Generate test-website project against main branch
         run: yarn test:build:website -s
       - name: Install test-website project with pnpm

--- a/.github/workflows/tests-swizzle.yml
+++ b/.github/workflows/tests-swizzle.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn || yarn
+        run: yarn || yarn || yarn
 
       # Swizzle all the theme components
       - name: Swizzle (${{matrix.action}} - ${{matrix.variant}})

--- a/.github/workflows/tests-swizzle.yml
+++ b/.github/workflows/tests-swizzle.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: lts/*
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn
 
       # Swizzle all the theme components
       - name: Swizzle (${{matrix.action}} - ${{matrix.variant}})

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Installation
-        run: yarn || yarn || yarn # 3 attempts to avoid timeout errors...
+        run: yarn || yarn || yarn
       - name: Docusaurus Jest Tests
         run: yarn test
       - name: Create a deep path

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
       - name: Installation
-        run: yarn
+        run: yarn || yarn || yarn # 3 attempts to avoid timeout errors...
       - name: Test
         run: yarn test
       - name: Remove Theme Internal Re-export

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
       - name: Installation
-        run: yarn || yarn || yarn # 3 attempts to avoid timeout errors...
+        run: yarn || yarn || yarn
       - name: Test
         run: yarn test
       - name: Remove Theme Internal Re-export


### PR DESCRIPTION


## Motivation

CI jobs often fail due to random network errors/timeouts.

See https://x.com/sebastienlorber/status/1857356618314502149

![image](https://github.com/user-attachments/assets/3d2ea7ae-8b4d-426f-b12a-062854c1325b)


> sharp: Downloading https://github.com/lovell/sharp-libvips/releases/download/v8.14.5/libvips-8.14.5-linux-x64.tar.br
> sharp: Installation error: connect ETIMEDOUT 140.82.114.3:443

There are many other cases like https://github.com/facebook/docusaurus/actions/runs/11312636188/job/31460294187

It's annoying to restart them manually, so let's add 3 retry. We already had retries like this for Windows workflows, let's normalize this practice.

## Test Plan

CI
