### PR TITLE
fix(types): add missing ambiant TS declarations for .md / .mdx partials

### DIFF
--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -389,6 +389,22 @@ declare module '*.css' {
   export default src;
 }
 
+declare module '*.md' {
+  import type {ComponentType} from 'react';
+
+  const ReactComponent: ComponentType<unknown>;
+
+  export default ReactComponent;
+}
+
+declare module '*.mdx' {
+  import type {ComponentType} from 'react';
+
+  const ReactComponent: ComponentType<unknown>;
+
+  export default ReactComponent;
+}
+
 interface Window {
   docusaurus: {
     prefetch: (url: string) => false | Promise<void[]>;

--- a/website/_dogfooding/_pages tests/embeds.tsx
+++ b/website/_dogfooding/_pages tests/embeds.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import IframeWindow from '@site/src/components/BrowserWindow/IframeWindow';
+import PagePartial from './_pagePartial.mdx';
 
 // See https://github.com/facebook/docusaurus/issues/8672
 export default function Embeds(): JSX.Element {
@@ -16,14 +17,21 @@ export default function Embeds(): JSX.Element {
     <Layout>
       <div style={{padding: 10}}>
         <Heading as="h1">Test Embeds</Heading>
-        <div style={{display: 'flex', flexWrap: 'wrap'}}>
-          <IframeWindow url="/?docusaurus-theme=light" />
-          <IframeWindow url="/?docusaurus-theme=dark" />
-          <IframeWindow url="/?docusaurus-theme=unexpected-value" />
-          <IframeWindow url="/" />
-          <IframeWindow url="https://docusaurus.io/" />
-          <IframeWindow url="https://tutorial.docusaurus.io/" />
-        </div>
+        <section>
+          <Heading as="h2">MDX Embeds</Heading>
+          <PagePartial />
+        </section>
+        <section>
+          <Heading as="h2">Iframe Embeds</Heading>
+          <div style={{display: 'flex', flexWrap: 'wrap'}}>
+            <IframeWindow url="/?docusaurus-theme=light" />
+            <IframeWindow url="/?docusaurus-theme=dark" />
+            <IframeWindow url="/?docusaurus-theme=unexpected-value" />
+            <IframeWindow url="/" />
+            <IframeWindow url="https://docusaurus.io/" />
+            <IframeWindow url="https://tutorial.docusaurus.io/" />
+          </div>
+        </section>
       </div>
     </Layout>
   );


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/10640

This should type check by default without any error:

```tsx
import Partial from './_partial.mdx';

export default function MyPage() {
  return <Partial/>
}
```

## Test Plan

CI + dogfood

### Test links

https://deploy-preview-10693--docusaurus-2.netlify.app/
