### PR TITLE
fix(create-docusaurus): Fix TS issues on newly initialized sites

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -208,6 +208,9 @@ jobs:
         working-directory: ../test-website
         env:
           npm_config_registry: http://localhost:4873
+      - name: TypeCheck website
+        working-directory: ../test-website
+        run: yarn typecheck
       - name: Start test-website project
         run: pnpm start --no-open
         working-directory: ../test-website

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -160,12 +160,15 @@ jobs:
       - name: Installation
         run: yarn || yarn || yarn
       - name: Generate test-website project against main branch
-        run: yarn test:build:website -s
+        run: yarn test:build:website -st
       - name: Install test-website project with npm
         run: npm install
         working-directory: ../test-website
         env:
           npm_config_registry: http://localhost:4873
+      - name: TypeCheck website
+        working-directory: ../test-website
+        run: yarn typecheck
       - name: Start test-website project
         run: npm run start -- --no-open
         working-directory: ../test-website
@@ -197,12 +200,11 @@ jobs:
       - name: Installation
         run: yarn || yarn || yarn
       - name: Generate test-website project against main branch
-        run: yarn test:build:website -s
+        run: yarn test:build:website -st
       - name: Install test-website project with pnpm
         run: |
           npm install -g pnpm
-          # Fix some peer dependencies errors
-          pnpm add @algolia/client-search @types/react@17 typescript
+          pnpm install
         working-directory: ../test-website
         env:
           npm_config_registry: http://localhost:4873

--- a/packages/docusaurus-tsconfig/tsconfig.json
+++ b/packages/docusaurus-tsconfig/tsconfig.json
@@ -11,11 +11,6 @@
     "moduleResolution": "bundler",
     "module": "esnext",
     "noEmit": true,
-    "types": [
-      "node",
-      "@docusaurus/module-type-aliases",
-      "@docusaurus/theme-classic"
-    ],
     "baseUrl": ".",
     "paths": {
       "@site/*": ["./*"]


### PR DESCRIPTION


## Motivation

Surprisingly, our e2e test suite only runs TS type-check for yarn berry (node linker only).

CI e2e tests should type-check the newly initialized sites to ensure no site is initialized with any TS errors

Fix https://github.com/facebook/docusaurus/issues/9080


## Test Plan

CI
