### PR TITLE
fix(core): disable Rspack incremental in dev

### DIFF
--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -142,7 +142,10 @@ export async function createBaseConfig({
         // Produces warnings in production builds
         // See https://github.com/web-infra-dev/rspack/pull/8311#issuecomment-2476014664
         // @ts-expect-error: Rspack-only
-        incremental: !isProd,
+        // incremental: !isProd,
+        // TODO restore incremental mode in dev + opt-in/opt-out flag?
+        //  temporarily disabled due to https://github.com/facebook/docusaurus/issues/10646#issuecomment-2490675451
+        incremental: undefined,
       };
     }
     return undefined;


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/10646

See https://github.com/facebook/docusaurus/issues/10646#issuecomment-2490675451, Rspack `experiments.incremental = true` in dev lead to HMR bugs.

Let's disable it for now, we may try to turn this on later once it's more stable. Eventually, add a Docusaurus Faster flag for it.



## Test Plan

nop 😅 
