### PR TITLE
refactor(theme-common): change storageUtils useSyncExternalCode getSnapshot workaround

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/storageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/storageUtils.ts
@@ -228,13 +228,7 @@ export function useStorageSlot(
 
   const currentValue = useSyncExternalStore(
     listen,
-    () => {
-      // TODO this check should be useless after React 18
-      if (typeof window === 'undefined') {
-        return null;
-      }
-      return storageSlot.get();
-    },
+    () => storageSlot.get(),
     () => null,
   );
 

--- a/packages/docusaurus-theme-common/src/utils/storageUtils.ts
+++ b/packages/docusaurus-theme-common/src/utils/storageUtils.ts
@@ -228,7 +228,13 @@ export function useStorageSlot(
 
   const currentValue = useSyncExternalStore(
     listen,
-    () => storageSlot.get(),
+    () => {
+      // react-test-renderer (deprecated) never call getServerSnapshot() :/
+      if (process.env.NODE_ENV === 'test') {
+        return null;
+      }
+      return storageSlot.get();
+    },
     () => null,
   );
 


### PR DESCRIPTION

## Motivation

This workaround shouldn't be needed anymore since we use React 18

## Test Plan

CI

### Test links

https://deploy-preview-10728--docusaurus-2.netlify.app/


