### PR TITLE
refactor: prepare types for React 19

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures/index.tsx
+++ b/packages/create-docusaurus/templates/classic-typescript/src/components/HomepageFeatures/index.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
@@ -5,7 +6,7 @@ import styles from './styles.module.css';
 type FeatureItem = {
   title: string;
   Svg: React.ComponentType<React.ComponentProps<'svg'>>;
-  description: JSX.Element;
+  description: ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
@@ -55,7 +56,7 @@ function Feature({title, Svg, description}: FeatureItem) {
   );
 }
 
-export default function HomepageFeatures(): JSX.Element {
+export default function HomepageFeatures(): ReactNode {
   return (
     <section className={styles.features}>
       <div className="container">

--- a/packages/create-docusaurus/templates/classic-typescript/src/pages/index.tsx
+++ b/packages/create-docusaurus/templates/classic-typescript/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -28,7 +29,7 @@ function HomepageHeader() {
   );
 }
 
-export default function Home(): JSX.Element {
+export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout

--- a/packages/docusaurus-mdx-loader/src/index.ts
+++ b/packages/docusaurus-mdx-loader/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReactNode} from 'react';
+
 import {mdxLoader} from './loader';
 
 import type {TOCItem as TOCItemImported} from './remark/toc/types';
@@ -34,7 +36,7 @@ export type LoadedMDXContent<FrontMatter, Metadata, Assets = undefined> = {
    * in priority.
    */
   readonly assets: Assets;
-  (): JSX.Element;
+  (): ReactNode;
 };
 
 export type {MDXPlugin} from './loader';

--- a/packages/docusaurus-module-type-aliases/src/index.d.ts
+++ b/packages/docusaurus-module-type-aliases/src/index.d.ts
@@ -84,10 +84,11 @@ declare module '@theme-original/*';
 declare module '@theme-init/*';
 
 declare module '@theme/Error' {
+  import type {ReactNode} from 'react';
   import type {FallbackParams} from '@docusaurus/ErrorBoundary';
 
   export interface Props extends FallbackParams {}
-  export default function Error(props: Props): JSX.Element;
+  export default function Error(props: Props): ReactNode;
 }
 
 declare module '@theme/Layout' {
@@ -96,17 +97,20 @@ declare module '@theme/Layout' {
   export interface Props {
     readonly children?: ReactNode;
   }
-  export default function Layout(props: Props): JSX.Element;
+  export default function Layout(props: Props): ReactNode;
 }
 
 declare module '@theme/Loading' {
+  import type {ReactNode} from 'react';
   import type {LoadingComponentProps} from 'react-loadable';
 
-  export default function Loading(props: LoadingComponentProps): JSX.Element;
+  export default function Loading(props: LoadingComponentProps): ReactNode;
 }
 
 declare module '@theme/NotFound' {
-  export default function NotFound(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NotFound(): ReactNode;
 }
 
 declare module '@theme/Root' {
@@ -115,11 +119,13 @@ declare module '@theme/Root' {
   export interface Props {
     readonly children: ReactNode;
   }
-  export default function Root({children}: Props): JSX.Element;
+  export default function Root({children}: Props): ReactNode;
 }
 
 declare module '@theme/SiteMetadata' {
-  export default function SiteMetadata(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function SiteMetadata(): ReactNode;
 }
 
 declare module '@docusaurus/constants' {
@@ -134,13 +140,13 @@ declare module '@docusaurus/ErrorBoundary' {
     readonly tryAgain: () => void;
   };
 
-  export type FallbackFunction = (params: FallbackParams) => JSX.Element;
+  export type FallbackFunction = (params: FallbackParams) => ReactNode;
 
   export interface Props {
     readonly fallback?: FallbackFunction;
     readonly children: ReactNode;
   }
-  export default function ErrorBoundary(props: Props): JSX.Element;
+  export default function ErrorBoundary(props: Props): ReactNode;
 }
 
 declare module '@docusaurus/Head' {
@@ -149,11 +155,11 @@ declare module '@docusaurus/Head' {
 
   export type Props = HelmetProps & {children: ReactNode};
 
-  export default function Head(props: Props): JSX.Element;
+  export default function Head(props: Props): ReactNode;
 }
 
 declare module '@docusaurus/Link' {
-  import type {CSSProperties, ComponentProps} from 'react';
+  import type {CSSProperties, ComponentProps, ReactNode} from 'react';
   import type {NavLinkProps as RRNavLinkProps} from 'react-router-dom';
 
   type NavLinkProps = Partial<RRNavLinkProps>;
@@ -169,7 +175,7 @@ declare module '@docusaurus/Link' {
       /** Escape hatch in case broken links check doesn't make sense. */
       readonly 'data-noBrokenLinkCheck'?: boolean;
     };
-  export default function Link(props: Props): JSX.Element;
+  export default function Link(props: Props): ReactNode;
 }
 
 declare module '@docusaurus/Interpolate' {
@@ -203,7 +209,7 @@ declare module '@docusaurus/Interpolate' {
 
   export default function Interpolate<Str extends string>(
     props: InterpolateProps<Str>,
-  ): JSX.Element;
+  ): ReactNode;
 }
 
 declare module '@docusaurus/Translate' {
@@ -241,7 +247,7 @@ declare module '@docusaurus/Translate' {
 
   export default function Translate<Str extends string>(
     props: TranslateProps<Str>,
-  ): JSX.Element;
+  ): ReactNode;
 }
 
 declare module '@docusaurus/router' {
@@ -318,11 +324,13 @@ declare module '@docusaurus/ComponentCreator' {
 }
 
 declare module '@docusaurus/BrowserOnly' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
-    readonly children?: () => JSX.Element;
-    readonly fallback?: JSX.Element;
+    readonly children?: () => ReactNode;
+    readonly fallback?: ReactNode;
   }
-  export default function BrowserOnly(props: Props): JSX.Element | null;
+  export default function BrowserOnly(props: Props): ReactNode | null;
 }
 
 declare module '@docusaurus/isInternalUrl' {

--- a/packages/docusaurus-plugin-content-blog/src/client/contexts.tsx
+++ b/packages/docusaurus-plugin-content-blog/src/client/contexts.tsx
@@ -74,7 +74,7 @@ export function BlogPostProvider({
   children: ReactNode;
   content: PropBlogPostContent;
   isBlogPostPage?: boolean;
-}): JSX.Element {
+}): ReactNode {
   const contextValue = useContextValue({content, isBlogPostPage});
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;
 }

--- a/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
+++ b/packages/docusaurus-plugin-content-blog/src/plugin-content-blog.d.ts
@@ -663,6 +663,7 @@ declare module '@docusaurus/plugin-content-blog' {
 }
 
 declare module '@theme/BlogPostPage' {
+  import type {ReactNode} from 'react';
   import type {
     BlogPostFrontMatter,
     BlogSidebar,
@@ -683,18 +684,23 @@ declare module '@theme/BlogPostPage' {
     readonly blogMetadata: BlogMetadata;
   }
 
-  export default function BlogPostPage(props: Props): JSX.Element;
+  export default function BlogPostPage(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostPage/Metadata' {
-  export default function BlogPostPageMetadata(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function BlogPostPageMetadata(): ReactNode;
 }
 
 declare module '@theme/BlogPostPage/StructuredData' {
-  export default function BlogPostStructuredData(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function BlogPostStructuredData(): ReactNode;
 }
 
 declare module '@theme/BlogListPage' {
+  import type {ReactNode} from 'react';
   import type {Content} from '@theme/BlogPostPage';
   import type {
     BlogSidebar,
@@ -713,10 +719,11 @@ declare module '@theme/BlogListPage' {
     readonly items: readonly {readonly content: Content}[];
   }
 
-  export default function BlogListPage(props: Props): JSX.Element;
+  export default function BlogListPage(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogListPage/StructuredData' {
+  import type {ReactNode} from 'react';
   import type {Content} from '@theme/BlogPostPage';
   import type {
     BlogSidebar,
@@ -735,10 +742,11 @@ declare module '@theme/BlogListPage/StructuredData' {
     readonly items: readonly {readonly content: Content}[];
   }
 
-  export default function BlogListPageStructuredData(props: Props): JSX.Element;
+  export default function BlogListPageStructuredData(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogTagsListPage' {
+  import type {ReactNode} from 'react';
   import type {BlogSidebar} from '@docusaurus/plugin-content-blog';
   import type {TagsListItem} from '@docusaurus/utils';
 
@@ -749,10 +757,11 @@ declare module '@theme/BlogTagsListPage' {
     readonly tags: TagsListItem[];
   }
 
-  export default function BlogTagsListPage(props: Props): JSX.Element;
+  export default function BlogTagsListPage(props: Props): ReactNode;
 }
 
 declare module '@theme/Blog/Pages/BlogAuthorsListPage' {
+  import type {ReactNode} from 'react';
   import type {
     AuthorItemProp,
     BlogSidebar,
@@ -765,10 +774,11 @@ declare module '@theme/Blog/Pages/BlogAuthorsListPage' {
     readonly authors: AuthorItemProp[];
   }
 
-  export default function BlogAuthorsListPage(props: Props): JSX.Element;
+  export default function BlogAuthorsListPage(props: Props): ReactNode;
 }
 
 declare module '@theme/Blog/Pages/BlogAuthorsPostsPage' {
+  import type {ReactNode} from 'react';
   import type {Content} from '@theme/BlogPostPage';
   import type {
     AuthorItemProp,
@@ -790,10 +800,11 @@ declare module '@theme/Blog/Pages/BlogAuthorsPostsPage' {
     readonly items: readonly {readonly content: Content}[];
   }
 
-  export default function BlogAuthorsPostsPage(props: Props): JSX.Element;
+  export default function BlogAuthorsPostsPage(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogTagsPostsPage' {
+  import type {ReactNode} from 'react';
   import type {Content} from '@theme/BlogPostPage';
   import type {
     BlogSidebar,
@@ -815,10 +826,11 @@ declare module '@theme/BlogTagsPostsPage' {
     readonly items: readonly {readonly content: Content}[];
   }
 
-  export default function BlogTagsPostsPage(props: Props): JSX.Element;
+  export default function BlogTagsPostsPage(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogArchivePage' {
+  import type {ReactNode} from 'react';
   import type {Content} from '@theme/BlogPostPage';
 
   /** We may add extra metadata or prune some metadata from here */
@@ -832,5 +844,5 @@ declare module '@theme/BlogArchivePage' {
     };
   }
 
-  export default function BlogArchivePage(props: Props): JSX.Element;
+  export default function BlogArchivePage(props: Props): ReactNode;
 }

--- a/packages/docusaurus-plugin-content-docs/src/client/doc.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/doc.tsx
@@ -50,7 +50,7 @@ export function DocProvider({
 }: {
   children: ReactNode;
   content: PropDocContent;
-}): JSX.Element {
+}): ReactNode {
   const contextValue = useContextValue(content);
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;
 }

--- a/packages/docusaurus-plugin-content-docs/src/client/docSidebarItemsExpandedState.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/docSidebarItemsExpandedState.tsx
@@ -36,7 +36,7 @@ export function DocSidebarItemsExpandedStateProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const [expandedItem, setExpandedItem] = useState<number | null>(null);
   const contextValue = useMemo(
     () => ({expandedItem, setExpandedItem}),

--- a/packages/docusaurus-plugin-content-docs/src/client/docsPreferredVersion.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsPreferredVersion.tsx
@@ -163,7 +163,7 @@ function DocsPreferredVersionContextProviderUnsafe({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const value = useContextValue();
   return <Context.Provider value={value}>{children}</Context.Provider>;
 }
@@ -176,7 +176,7 @@ export function DocsPreferredVersionContextProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   return (
     <DocsPreferredVersionContextProviderUnsafe>
       {children}

--- a/packages/docusaurus-plugin-content-docs/src/client/docsSidebar.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsSidebar.tsx
@@ -30,7 +30,7 @@ export function DocsSidebarProvider({
   children: ReactNode;
   name: string | undefined;
   items: PropSidebar | undefined;
-}): JSX.Element {
+}): ReactNode {
   const stableValue: ContextValue | null = useMemo(
     () => (name && items ? {name, items} : null),
     [name, items],

--- a/packages/docusaurus-plugin-content-docs/src/client/docsUtils.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsUtils.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {useMemo} from 'react';
+import {type ReactNode, useMemo} from 'react';
 import {matchPath, useLocation} from '@docusaurus/router';
 import renderRoutes from '@docusaurus/renderRoutes';
 import {
@@ -363,7 +363,7 @@ Available doc ids are:
  */
 export function useDocRootMetadata({route}: DocRootProps): null | {
   /** The element that should be rendered at the current location. */
-  docElement: JSX.Element;
+  docElement: ReactNode;
   /**
    * The name of the sidebar associated with the current doc. `sidebarName` and
    * `sidebarItems` correspond to the value of {@link useDocsSidebar}.

--- a/packages/docusaurus-plugin-content-docs/src/client/docsVersion.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsVersion.tsx
@@ -20,7 +20,7 @@ export function DocsVersionProvider({
 }: {
   children: ReactNode;
   version: PropVersionMetadata | null;
-}): JSX.Element {
+}): ReactNode {
   return <Context.Provider value={version}>{children}</Context.Provider>;
 }
 

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -562,10 +562,11 @@ declare module '@docusaurus/plugin-content-docs' {
 }
 
 declare module '@theme/DocItem' {
+  import type {ReactNode} from 'react';
   import type {PropDocContent} from '@docusaurus/plugin-content-docs';
 
   export type DocumentRoute = {
-    readonly component: () => JSX.Element;
+    readonly component: () => ReactNode;
     readonly exact: boolean;
     readonly path: string;
     readonly sidebar?: string;
@@ -576,10 +577,11 @@ declare module '@theme/DocItem' {
     readonly content: PropDocContent;
   }
 
-  export default function DocItem(props: Props): JSX.Element;
+  export default function DocItem(props: Props): ReactNode;
 }
 
 declare module '@theme/DocCategoryGeneratedIndexPage' {
+  import type {ReactNode} from 'react';
   import type {PropCategoryGeneratedIndex} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
@@ -588,39 +590,45 @@ declare module '@theme/DocCategoryGeneratedIndexPage' {
 
   export default function DocCategoryGeneratedIndexPage(
     props: Props,
-  ): JSX.Element;
+  ): ReactNode;
 }
 
 declare module '@theme/DocTagsListPage' {
+  import type {ReactNode} from 'react';
   import type {PropTagsListPage} from '@docusaurus/plugin-content-docs';
 
   export interface Props extends PropTagsListPage {}
-  export default function DocTagsListPage(props: Props): JSX.Element;
+  export default function DocTagsListPage(props: Props): ReactNode;
 }
 
 declare module '@theme/DocTagDocListPage' {
+  import type {ReactNode} from 'react';
   import type {PropTagDocList} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
     readonly tag: PropTagDocList;
   }
-  export default function DocTagDocListPage(props: Props): JSX.Element;
+  export default function DocTagDocListPage(props: Props): ReactNode;
 }
 
 declare module '@theme/DocBreadcrumbs' {
-  export default function DocBreadcrumbs(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DocBreadcrumbs(): ReactNode;
 }
 
 declare module '@theme/DocsRoot' {
+  import type {ReactNode} from 'react';
   import type {RouteConfigComponentProps} from 'react-router-config';
   import type {Required} from 'utility-types';
 
   export interface Props extends Required<RouteConfigComponentProps, 'route'> {}
 
-  export default function DocsRoot(props: Props): JSX.Element;
+  export default function DocsRoot(props: Props): ReactNode;
 }
 
 declare module '@theme/DocVersionRoot' {
+  import type {ReactNode} from 'react';
   import type {PropVersionMetadata} from '@docusaurus/plugin-content-docs';
   import type {RouteConfigComponentProps} from 'react-router-config';
   import type {Required} from 'utility-types';
@@ -629,14 +637,15 @@ declare module '@theme/DocVersionRoot' {
     readonly version: PropVersionMetadata;
   }
 
-  export default function DocVersionRoot(props: Props): JSX.Element;
+  export default function DocVersionRoot(props: Props): ReactNode;
 }
 
 declare module '@theme/DocRoot' {
+  import type {ReactNode} from 'react';
   import type {RouteConfigComponentProps} from 'react-router-config';
   import type {Required} from 'utility-types';
 
   export interface Props extends Required<RouteConfigComponentProps, 'route'> {}
 
-  export default function DocRoot(props: Props): JSX.Element;
+  export default function DocRoot(props: Props): ReactNode;
 }

--- a/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
+++ b/packages/docusaurus-plugin-content-pages/src/plugin-content-pages.d.ts
@@ -85,6 +85,7 @@ declare module '@docusaurus/plugin-content-pages' {
 }
 
 declare module '@theme/MDXPage' {
+  import type {ReactNode} from 'react';
   import type {LoadedMDXContent} from '@docusaurus/mdx-loader';
   import type {
     MDXPageMetadata,
@@ -100,5 +101,5 @@ declare module '@theme/MDXPage' {
     >;
   }
 
-  export default function MDXPage(props: Props): JSX.Element;
+  export default function MDXPage(props: Props): ReactNode;
 }

--- a/packages/docusaurus-plugin-debug/src/plugin-debug.d.ts
+++ b/packages/docusaurus-plugin-debug/src/plugin-debug.d.ts
@@ -14,46 +14,57 @@ declare module '@docusaurus/plugin-debug' {
 }
 
 declare module '@theme/DebugConfig' {
-  export default function DebugMetadata(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DebugMetadata(): ReactNode;
 }
 
 declare module '@theme/DebugContent' {
+  import type {ReactNode} from 'react';
   import type {AllContent} from '@docusaurus/types';
 
   export interface Props {
     readonly allContent: AllContent;
   }
-  export default function DebugContent(props: Props): JSX.Element;
+  export default function DebugContent(props: Props): ReactNode;
 }
 
 declare module '@theme/DebugGlobalData' {
-  export default function DebugGlobalData(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DebugGlobalData(): ReactNode;
 }
 
 declare module '@theme/DebugJsonView' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly src: unknown;
     readonly collapseDepth?: number;
   }
-  export default function DebugJsonView(props: Props): JSX.Element;
+  export default function DebugJsonView(props: Props): ReactNode;
 }
 
 declare module '@theme/DebugLayout' {
   import type {ReactNode} from 'react';
 
-  export default function DebugLayout(props: {
-    children: ReactNode;
-  }): JSX.Element;
+  export default function DebugLayout(props: {children: ReactNode}): ReactNode;
 }
 
 declare module '@theme/DebugRegistry' {
-  export default function DebugRegistry(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DebugRegistry(): ReactNode;
 }
 
 declare module '@theme/DebugRoutes' {
-  export default function DebugRoutes(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DebugRoutes(): ReactNode;
 }
 
 declare module '@theme/DebugSiteMetadata' {
-  export default function DebugSiteMetadata(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DebugSiteMetadata(): ReactNode;
 }

--- a/packages/docusaurus-plugin-debug/src/theme/DebugConfig/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugConfig/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import DebugLayout from '@theme/DebugLayout';
 import DebugJsonView from '@theme/DebugJsonView';
 
-export default function DebugMetadata(): JSX.Element {
+export default function DebugMetadata(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
     <DebugLayout>

--- a/packages/docusaurus-plugin-debug/src/theme/DebugContent/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugContent/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import DebugLayout from '@theme/DebugLayout';
 import DebugJsonView from '@theme/DebugJsonView';
@@ -52,7 +52,7 @@ function PluginContent({
   );
 }
 
-export default function DebugContent({allContent}: Props): JSX.Element {
+export default function DebugContent({allContent}: Props): ReactNode {
   return (
     <DebugLayout>
       <h2>Plugin content</h2>

--- a/packages/docusaurus-plugin-debug/src/theme/DebugGlobalData/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugGlobalData/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import useGlobalData from '@docusaurus/useGlobalData';
 import DebugLayout from '@theme/DebugLayout';
 import DebugJsonView from '@theme/DebugJsonView';
 
-export default function DebugMetadata(): JSX.Element {
+export default function DebugMetadata(): ReactNode {
   const globalData = useGlobalData();
   return (
     <DebugLayout>

--- a/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {
   JsonView,
   defaultStyles,
@@ -32,10 +32,7 @@ const paraisoStyles: JsonViewProps['style'] = {
   collapsedContent: styles.collapseContentParaiso!,
 };
 
-export default function DebugJsonView({
-  src,
-  collapseDepth,
-}: Props): JSX.Element {
+export default function DebugJsonView({src, collapseDepth}: Props): ReactNode {
   return (
     <JsonView
       data={src as object}

--- a/packages/docusaurus-plugin-debug/src/theme/DebugLayout/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugLayout/index.tsx
@@ -29,7 +29,7 @@ export default function DebugLayout({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   return (
     <>
       <Head>

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRegistry/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import registry from '@generated/registry';
 import DebugLayout from '@theme/DebugLayout';
 import styles from './styles.module.css';
 
-export default function DebugRegistry(): JSX.Element {
+export default function DebugRegistry(): ReactNode {
   return (
     <DebugLayout>
       <h2>Registry</h2>

--- a/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugRoutes/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import routes from '@generated/routes';
 import DebugLayout from '@theme/DebugLayout';
 import DebugJsonView from '@theme/DebugJsonView';
 import styles from './styles.module.css';
 
-export default function DebugRoutes(): JSX.Element {
+export default function DebugRoutes(): ReactNode {
   return (
     <DebugLayout>
       <h2>Routes</h2>

--- a/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugSiteMetadata/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import DebugLayout from '@theme/DebugLayout';
 import styles from './styles.module.css';
 
-export default function DebugMetadata(): JSX.Element {
+export default function DebugMetadata(): ReactNode {
   const {siteMetadata} = useDocusaurusContext();
   return (
     <DebugLayout>

--- a/packages/docusaurus-plugin-ideal-image/src/deps.d.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/deps.d.ts
@@ -13,7 +13,12 @@
  * full state object.
  */
 declare module '@slorber/react-ideal-image' {
-  import type {ComponentProps, ComponentType, CSSProperties} from 'react';
+  import type {
+    ComponentProps,
+    ComponentType,
+    CSSProperties,
+    ReactNode,
+  } from 'react';
 
   export type LoadingState = 'initial' | 'loading' | 'loaded' | 'error';
 
@@ -115,5 +120,5 @@ declare module '@slorber/react-ideal-image' {
     width: number;
   }
 
-  export default function IdealImage(props: ImageProps): JSX.Element;
+  export default function IdealImage(props: ImageProps): ReactNode;
 }

--- a/packages/docusaurus-plugin-ideal-image/src/plugin-ideal-image.d.ts
+++ b/packages/docusaurus-plugin-ideal-image/src/plugin-ideal-image.d.ts
@@ -52,7 +52,7 @@ declare module '@docusaurus/plugin-ideal-image' {
 }
 
 declare module '@theme/IdealImage' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export type SrcType = {
     width: number;
@@ -72,5 +72,5 @@ declare module '@theme/IdealImage' {
   export interface Props extends ComponentProps<'img'> {
     readonly img: {default: string} | {src: SrcImage; preSrc: string} | string;
   }
-  export default function IdealImage(props: Props): JSX.Element;
+  export default function IdealImage(props: Props): ReactNode;
 }

--- a/packages/docusaurus-plugin-ideal-image/src/theme/IdealImage/index.tsx
+++ b/packages/docusaurus-plugin-ideal-image/src/theme/IdealImage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import ReactIdealImage, {
   type IconKey,
   type State,
@@ -80,7 +80,7 @@ function getMessage(icon: IconKey, state: State) {
   }
 }
 
-export default function IdealImage(props: Props): JSX.Element {
+export default function IdealImage(props: Props): ReactNode {
   const {img, ...propsRest} = props;
 
   // In dev env just use regular img with original file

--- a/packages/docusaurus-plugin-pwa/src/plugin-pwa.d.ts
+++ b/packages/docusaurus-plugin-pwa/src/plugin-pwa.d.ts
@@ -76,6 +76,8 @@ declare module '@docusaurus/plugin-pwa' {
 }
 
 declare module '@theme/PwaReloadPopup' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     /**
      * The popup should call this callback when the `reload` button is clicked.
@@ -84,5 +86,5 @@ declare module '@theme/PwaReloadPopup' {
      */
     readonly onReload: () => void;
   }
-  export default function PwaReloadPopup(props: Props): JSX.Element;
+  export default function PwaReloadPopup(props: Props): ReactNode;
 }

--- a/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/index.tsx
+++ b/packages/docusaurus-plugin-pwa/src/theme/PwaReloadPopup/index.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState} from 'react';
+import React, {type ReactNode, useState} from 'react';
 import clsx from 'clsx';
 import Translate, {translate} from '@docusaurus/Translate';
 import type {Props} from '@theme/PwaReloadPopup';
 
 import styles from './styles.module.css';
 
-export default function PwaReloadPopup({onReload}: Props): JSX.Element | false {
+export default function PwaReloadPopup({onReload}: Props): ReactNode {
   const [isVisible, setIsVisible] = useState(true);
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -50,51 +50,57 @@ declare module '@theme/Admonition' {
     readonly className?: string;
   }
 
-  export default function Admonition(props: Props): JSX.Element;
+  export default function Admonition(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Type/Note' {
+  import type {ReactNode} from 'react';
   import type {Props as AdmonitionProps} from '@theme/Admonition';
 
   export interface Props extends AdmonitionProps {}
-  export default function AdmonitionTypeNote(props: Props): JSX.Element;
+  export default function AdmonitionTypeNote(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Type/Info' {
+  import type {ReactNode} from 'react';
   import type {Props as AdmonitionProps} from '@theme/Admonition';
 
   export interface Props extends AdmonitionProps {}
-  export default function AdmonitionTypeInfo(props: Props): JSX.Element;
+  export default function AdmonitionTypeInfo(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Type/Tip' {
+  import type {ReactNode} from 'react';
   import type {Props as AdmonitionProps} from '@theme/Admonition';
 
   export interface Props extends AdmonitionProps {}
-  export default function AdmonitionTypeTip(props: Props): JSX.Element;
+  export default function AdmonitionTypeTip(props: Props): ReactNode;
 }
 
 // TODO remove before v4: Caution replaced by Warning
 // see https://github.com/facebook/docusaurus/issues/7558
 declare module '@theme/Admonition/Type/Caution' {
+  import type {ReactNode} from 'react';
   import type {Props as AdmonitionProps} from '@theme/Admonition';
 
   export interface Props extends AdmonitionProps {}
-  export default function AdmonitionTypeCaution(props: Props): JSX.Element;
+  export default function AdmonitionTypeCaution(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Type/Warning' {
+  import type {ReactNode} from 'react';
   import type {Props as AdmonitionProps} from '@theme/Admonition';
 
   export interface Props extends AdmonitionProps {}
-  export default function AdmonitionTypeWarning(props: Props): JSX.Element;
+  export default function AdmonitionTypeWarning(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Type/Danger' {
+  import type {ReactNode} from 'react';
   import type {Props as AdmonitionProps} from '@theme/Admonition';
 
   export interface Props extends AdmonitionProps {}
-  export default function AdmonitionTypeDanger(props: Props): JSX.Element;
+  export default function AdmonitionTypeDanger(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Types' {
@@ -118,74 +124,79 @@ declare module '@theme/Admonition/Layout' {
     readonly title?: ReactNode;
     readonly className?: string;
   }
-  export default function AdmonitionLayout(props: Props): JSX.Element;
+  export default function AdmonitionLayout(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Icon/Note' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function AdmonitionIconNote(props: Props): JSX.Element;
+  export default function AdmonitionIconNote(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Icon/Tip' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function AdmonitionIconTip(props: Props): JSX.Element;
+  export default function AdmonitionIconTip(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Icon/Warning' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function AdmonitionIconWarning(props: Props): JSX.Element;
+  export default function AdmonitionIconWarning(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Icon/Danger' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function AdmonitionIconDanger(props: Props): JSX.Element;
+  export default function AdmonitionIconDanger(props: Props): ReactNode;
 }
 
 declare module '@theme/Admonition/Icon/Info' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function AdmonitionIconInfo(props: Props): JSX.Element;
+  export default function AdmonitionIconInfo(props: Props): ReactNode;
 }
 
 declare module '@theme/AnnouncementBar' {
-  export default function AnnouncementBar(): JSX.Element | null;
+  import type {ReactNode} from 'react';
+
+  export default function AnnouncementBar(): ReactNode | null;
 }
 
 declare module '@theme/AnnouncementBar/Content' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'div'> {}
 
-  export default function AnnouncementBarContent(props: Props): JSX.Element;
+  export default function AnnouncementBarContent(props: Props): ReactNode;
 }
 
 declare module '@theme/AnnouncementBar/CloseButton' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'button'> {}
 
-  export default function AnnouncementBarCloseButton(props: Props): JSX.Element;
+  export default function AnnouncementBarCloseButton(props: Props): ReactNode;
 }
 
 declare module '@theme/BackToTopButton' {
-  export default function BackToTopButton(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function BackToTopButton(): ReactNode;
 }
 
 declare module '@theme/Blog/Components/Author' {
+  import type {ReactNode} from 'react';
   import type {Author} from '@docusaurus/plugin-content-blog';
 
   export interface Props {
@@ -195,10 +206,11 @@ declare module '@theme/Blog/Components/Author' {
     readonly count?: number;
   }
 
-  export default function BlogAuthor(props: Props): JSX.Element;
+  export default function BlogAuthor(props: Props): ReactNode;
 }
 
 declare module '@theme/Blog/Components/Author/Socials' {
+  import type {ReactNode} from 'react';
   import type {Author} from '@docusaurus/plugin-content-blog';
 
   export interface Props {
@@ -206,16 +218,17 @@ declare module '@theme/Blog/Components/Author/Socials' {
     readonly className?: string;
   }
 
-  export default function BlogAuthorSocials(props: Props): JSX.Element;
+  export default function BlogAuthorSocials(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogListPaginator' {
+  import type {ReactNode} from 'react';
   import type {BlogPaginatedMetadata} from '@docusaurus/plugin-content-blog';
 
   export interface Props {
     readonly metadata: BlogPaginatedMetadata;
   }
-  export default function BlogListPaginator(props: Props): JSX.Element;
+  export default function BlogListPaginator(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogSidebar/Content' {
@@ -232,33 +245,36 @@ declare module '@theme/BlogSidebar/Content' {
 }
 
 declare module '@theme/BlogSidebar/Desktop' {
+  import type {ReactNode} from 'react';
   import type {BlogSidebar} from '@docusaurus/plugin-content-blog';
 
   export interface Props {
     readonly sidebar: BlogSidebar;
   }
 
-  export default function BlogSidebarDesktop(props: Props): JSX.Element;
+  export default function BlogSidebarDesktop(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogSidebar/Mobile' {
+  import type {ReactNode} from 'react';
   import type {BlogSidebar} from '@docusaurus/plugin-content-blog';
 
   export interface Props {
     readonly sidebar: BlogSidebar;
   }
 
-  export default function BlogSidebarMobile(props: Props): JSX.Element;
+  export default function BlogSidebarMobile(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogSidebar' {
+  import type {ReactNode} from 'react';
   import type {BlogSidebar} from '@docusaurus/plugin-content-blog';
 
   export interface Props {
     readonly sidebar?: BlogSidebar;
   }
 
-  export default function BlogSidebar(props: Props): JSX.Element;
+  export default function BlogSidebar(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostItem' {
@@ -269,7 +285,7 @@ declare module '@theme/BlogPostItem' {
     className?: string;
   }
 
-  export default function BlogPostItem(props: Props): JSX.Element;
+  export default function BlogPostItem(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostItems' {
@@ -281,7 +297,7 @@ declare module '@theme/BlogPostItems' {
     component?: ComponentType<{children: ReactNode}>;
   }
 
-  export default function BlogPostItem(props: Props): JSX.Element;
+  export default function BlogPostItem(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostItem/Container' {
@@ -292,35 +308,43 @@ declare module '@theme/BlogPostItem/Container' {
     className?: string;
   }
 
-  export default function BlogPostItemContainer(props: Props): JSX.Element;
+  export default function BlogPostItemContainer(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostItem/Header' {
-  export default function BlogPostItemHeader(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function BlogPostItemHeader(): ReactNode;
 }
 
 declare module '@theme/BlogPostItem/Header/Title' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     className?: string;
   }
 
-  export default function BlogPostItemHeaderTitle(props: Props): JSX.Element;
+  export default function BlogPostItemHeaderTitle(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostItem/Header/Info' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     className?: string;
   }
 
-  export default function BlogPostItemHeaderInfo(): JSX.Element;
+  export default function BlogPostItemHeaderInfo(): ReactNode;
 }
 
 declare module '@theme/BlogPostItem/Header/Authors' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly className?: string;
   }
 
-  export default function BlogPostItemHeaderAuthors(props: Props): JSX.Element;
+  export default function BlogPostItemHeaderAuthors(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostItem/Content' {
@@ -331,14 +355,17 @@ declare module '@theme/BlogPostItem/Content' {
     className?: string;
   }
 
-  export default function BlogPostItemContent(props: Props): JSX.Element;
+  export default function BlogPostItemContent(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogPostItem/Footer' {
-  export default function BlogPostItemFooter(): JSX.Element | null;
+  import type {ReactNode} from 'react';
+
+  export default function BlogPostItemFooter(): ReactNode | null;
 }
 
 declare module '@theme/BlogPostItem/Footer/ReadMoreLink' {
+  import type {ReactNode} from 'react';
   import type {Props as LinkProps} from '@docusaurus/Link';
 
   export type Props = LinkProps & {
@@ -347,10 +374,12 @@ declare module '@theme/BlogPostItem/Footer/ReadMoreLink' {
 
   export default function BlogPostItemFooterReadMoreLink(
     props: Props,
-  ): JSX.Element | null;
+  ): ReactNode | null;
 }
 
 declare module '@theme/BlogPostPaginator' {
+  import type {ReactNode} from 'react';
+
   type Item = {readonly title: string; readonly permalink: string};
 
   export interface Props {
@@ -358,7 +387,7 @@ declare module '@theme/BlogPostPaginator' {
     readonly prevItem?: Item;
   }
 
-  export default function BlogPostPaginator(props: Props): JSX.Element;
+  export default function BlogPostPaginator(props: Props): ReactNode;
 }
 
 declare module '@theme/BlogLayout' {
@@ -371,7 +400,7 @@ declare module '@theme/BlogLayout' {
     readonly toc?: ReactNode;
   }
 
-  export default function BlogLayout(props: Props): JSX.Element;
+  export default function BlogLayout(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeBlock' {
@@ -386,54 +415,60 @@ declare module '@theme/CodeBlock' {
     readonly showLineNumbers?: boolean;
   }
 
-  export default function CodeBlock(props: Props): JSX.Element;
+  export default function CodeBlock(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeInline' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'code'> {}
 
-  export default function CodeInline(props: Props): JSX.Element;
+  export default function CodeInline(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeBlock/CopyButton' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly code: string;
     readonly className?: string;
   }
 
-  export default function CopyButton(props: Props): JSX.Element;
+  export default function CopyButton(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeBlock/Container' {
+  import type {ReactNode} from 'react';
   import type {ComponentProps} from 'react';
 
   export default function CodeBlockContainer<T extends 'div' | 'pre'>({
     as: As,
     ...props
-  }: {as: T} & ComponentProps<T>): JSX.Element;
+  }: {as: T} & ComponentProps<T>): ReactNode;
 }
 
 declare module '@theme/CodeBlock/Content/Element' {
+  import type {ReactNode} from 'react';
   import type {Props} from '@theme/CodeBlock';
 
   export type {Props};
 
-  export default function CodeBlockElementContent(props: Props): JSX.Element;
+  export default function CodeBlockElementContent(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeBlock/Content/String' {
+  import type {ReactNode} from 'react';
   import type {Props as CodeBlockProps} from '@theme/CodeBlock';
 
   export interface Props extends Omit<CodeBlockProps, 'children'> {
     readonly children: string;
   }
 
-  export default function CodeBlockStringContent(props: Props): JSX.Element;
+  export default function CodeBlockStringContent(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeBlock/Line' {
+  import type {ReactNode} from 'react';
   import type {
     LineInputProps,
     LineOutputProps,
@@ -450,30 +485,34 @@ declare module '@theme/CodeBlock/Line' {
     readonly getTokenProps: (input: TokenInputProps) => TokenOutputProps;
   }
 
-  export default function CodeBlockLine(props: Props): JSX.Element;
+  export default function CodeBlockLine(props: Props): ReactNode;
 }
 
 declare module '@theme/CodeBlock/WordWrapButton' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly className?: string;
     readonly onClick: React.MouseEventHandler;
     readonly isEnabled: boolean;
   }
 
-  export default function WordWrapButton(props: Props): JSX.Element;
+  export default function WordWrapButton(props: Props): ReactNode;
 }
 
 declare module '@theme/DocCard' {
+  import type {ReactNode} from 'react';
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
     readonly item: PropSidebarItem;
   }
 
-  export default function DocCard(props: Props): JSX.Element;
+  export default function DocCard(props: Props): ReactNode;
 }
 
 declare module '@theme/DocCardList' {
+  import type {ReactNode} from 'react';
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
@@ -481,43 +520,57 @@ declare module '@theme/DocCardList' {
     readonly className?: string;
   }
 
-  export default function DocCardList(props: Props): JSX.Element;
+  export default function DocCardList(props: Props): ReactNode;
 }
 
 declare module '@theme/DocItem/Layout' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
-    readonly children: JSX.Element;
+    readonly children: ReactNode;
   }
 
-  export default function DocItemLayout(props: Props): JSX.Element;
+  export default function DocItemLayout(props: Props): ReactNode;
 }
 
 declare module '@theme/DocItem/Metadata' {
-  export default function DocItemMetadata(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DocItemMetadata(): ReactNode;
 }
 
 declare module '@theme/DocItem/Content' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
-    readonly children: JSX.Element;
+    readonly children: ReactNode;
   }
 
-  export default function DocItemContent(props: Props): JSX.Element;
+  export default function DocItemContent(props: Props): ReactNode;
 }
 
 declare module '@theme/DocItem/TOC/Mobile' {
-  export default function DocItemTOCMobile(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DocItemTOCMobile(): ReactNode;
 }
 
 declare module '@theme/DocItem/TOC/Desktop' {
-  export default function DocItemTOCDesktop(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DocItemTOCDesktop(): ReactNode;
 }
 
 declare module '@theme/DocItem/Paginator' {
-  export default function DocItemPaginator(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DocItemPaginator(): ReactNode;
 }
 
 declare module '@theme/DocItem/Footer' {
-  export default function DocItemFooter(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DocItemFooter(): ReactNode;
 }
 
 declare module '@theme/DocRoot/Layout' {
@@ -527,11 +580,11 @@ declare module '@theme/DocRoot/Layout' {
     readonly children: ReactNode;
   }
 
-  export default function DocRootLayout(props: Props): JSX.Element;
+  export default function DocRootLayout(props: Props): ReactNode;
 }
 
 declare module '@theme/DocRoot/Layout/Sidebar' {
-  import type {Dispatch, SetStateAction} from 'react';
+  import type {Dispatch, SetStateAction, ReactNode} from 'react';
   import type {PropSidebar} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
@@ -540,17 +593,19 @@ declare module '@theme/DocRoot/Layout/Sidebar' {
     readonly setHiddenSidebarContainer: Dispatch<SetStateAction<boolean>>;
   }
 
-  export default function DocRootLayoutSidebar(props: Props): JSX.Element;
+  export default function DocRootLayoutSidebar(props: Props): ReactNode;
 }
 
 declare module '@theme/DocRoot/Layout/Sidebar/ExpandButton' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     toggleSidebar: () => void;
   }
 
   export default function DocRootLayoutSidebarExpandButton(
     props: Props,
-  ): JSX.Element;
+  ): ReactNode;
 }
 
 declare module '@theme/DocRoot/Layout/Main' {
@@ -561,19 +616,21 @@ declare module '@theme/DocRoot/Layout/Main' {
     readonly children: ReactNode;
   }
 
-  export default function DocRootLayoutMain(props: Props): JSX.Element;
+  export default function DocRootLayoutMain(props: Props): ReactNode;
 }
 
 declare module '@theme/DocPaginator' {
+  import type {ReactNode} from 'react';
   import type {PropNavigation} from '@docusaurus/plugin-content-docs';
 
   // May be simpler to provide a {navigation: PropNavigation} prop?
   export interface Props extends PropNavigation {}
 
-  export default function DocPaginator(props: Props): JSX.Element;
+  export default function DocPaginator(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebar' {
+  import type {ReactNode} from 'react';
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
@@ -583,26 +640,29 @@ declare module '@theme/DocSidebar' {
     readonly isHidden: boolean;
   }
 
-  export default function DocSidebar(props: Props): JSX.Element;
+  export default function DocSidebar(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebar/Mobile' {
+  import type {ReactNode} from 'react';
   import type {Props as DocSidebarProps} from '@theme/DocSidebar';
 
   export interface Props extends DocSidebarProps {}
 
-  export default function DocSidebarMobile(props: Props): JSX.Element;
+  export default function DocSidebarMobile(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebar/Desktop' {
+  import type {ReactNode} from 'react';
   import type {Props as DocSidebarProps} from '@theme/DocSidebar';
 
   export interface Props extends DocSidebarProps {}
 
-  export default function DocSidebarDesktop(props: Props): JSX.Element;
+  export default function DocSidebarDesktop(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebar/Desktop/Content' {
+  import type {ReactNode} from 'react';
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
@@ -611,18 +671,21 @@ declare module '@theme/DocSidebar/Desktop/Content' {
     readonly sidebar: readonly PropSidebarItem[];
   }
 
-  export default function Content(props: Props): JSX.Element;
+  export default function Content(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebar/Desktop/CollapseButton' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly onClick: React.MouseEventHandler;
   }
 
-  export default function CollapseButton(props: Props): JSX.Element;
+  export default function CollapseButton(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebarItem' {
+  import type {ReactNode} from 'react';
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 
   export interface Props {
@@ -634,10 +697,11 @@ declare module '@theme/DocSidebarItem' {
     readonly index: number;
   }
 
-  export default function DocSidebarItem(props: Props): JSX.Element;
+  export default function DocSidebarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebarItem/Link' {
+  import type {ReactNode} from 'react';
   import type {Props as DocSidebarItemProps} from '@theme/DocSidebarItem';
 
   import type {PropSidebarItemLink} from '@docusaurus/plugin-content-docs';
@@ -646,10 +710,11 @@ declare module '@theme/DocSidebarItem/Link' {
     readonly item: PropSidebarItemLink;
   }
 
-  export default function DocSidebarItemLink(props: Props): JSX.Element;
+  export default function DocSidebarItemLink(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebarItem/Html' {
+  import type {ReactNode} from 'react';
   import type {Props as DocSidebarItemProps} from '@theme/DocSidebarItem';
   import type {PropSidebarItemHtml} from '@docusaurus/plugin-content-docs';
 
@@ -657,10 +722,11 @@ declare module '@theme/DocSidebarItem/Html' {
     readonly item: PropSidebarItemHtml;
   }
 
-  export default function DocSidebarItemHtml(props: Props): JSX.Element;
+  export default function DocSidebarItemHtml(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebarItem/Category' {
+  import type {ReactNode} from 'react';
   import type {Props as DocSidebarItemProps} from '@theme/DocSidebarItem';
   import type {PropSidebarItemCategory} from '@docusaurus/plugin-content-docs';
 
@@ -668,10 +734,11 @@ declare module '@theme/DocSidebarItem/Category' {
     readonly item: PropSidebarItemCategory;
   }
 
-  export default function DocSidebarItemCategory(props: Props): JSX.Element;
+  export default function DocSidebarItemCategory(props: Props): ReactNode;
 }
 
 declare module '@theme/DocSidebarItems' {
+  import type {ReactNode} from 'react';
   import type {Props as DocSidebarItemProps} from '@theme/DocSidebarItem';
   import type {PropSidebarItem} from '@docusaurus/plugin-content-docs';
 
@@ -679,44 +746,54 @@ declare module '@theme/DocSidebarItems' {
     readonly items: readonly PropSidebarItem[];
   }
 
-  export default function DocSidebarItems(props: Props): JSX.Element;
+  export default function DocSidebarItems(props: Props): ReactNode;
 }
 
 declare module '@theme/DocVersionBanner' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly className?: string;
   }
 
-  export default function DocVersionBanner(props: Props): JSX.Element;
+  export default function DocVersionBanner(props: Props): ReactNode;
 }
 
 declare module '@theme/DocVersionBadge' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly className?: string;
   }
 
-  export default function DocVersionBadge(props: Props): JSX.Element;
+  export default function DocVersionBadge(props: Props): ReactNode;
 }
 
 declare module '@theme/DocVersionSuggestions' {
-  export default function DocVersionSuggestions(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function DocVersionSuggestions(): ReactNode;
 }
 
 declare module '@theme/EditMetaRow' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly className: string;
     readonly editUrl: string | null | undefined;
     readonly lastUpdatedAt: number | undefined;
     readonly lastUpdatedBy: string | undefined;
   }
-  export default function EditMetaRow(props: Props): JSX.Element;
+  export default function EditMetaRow(props: Props): ReactNode;
 }
 
 declare module '@theme/EditThisPage' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly editUrl: string;
   }
-  export default function EditThisPage(props: Props): JSX.Element;
+  export default function EditThisPage(props: Props): ReactNode;
 }
 
 declare module '@theme/ErrorPageContent' {
@@ -727,35 +804,43 @@ declare module '@theme/ErrorPageContent' {
 }
 
 declare module '@theme/Footer' {
-  export default function Footer(): JSX.Element | null;
+  import type {ReactNode} from 'react';
+
+  export default function Footer(): ReactNode | null;
 }
 
 declare module '@theme/Footer/Logo' {
+  import type {ReactNode} from 'react';
+
   import type {FooterLogo} from '@docusaurus/theme-common';
 
   export interface Props {
     readonly logo: FooterLogo;
   }
 
-  export default function FooterLogo(props: Props): JSX.Element;
+  export default function FooterLogo(props: Props): ReactNode;
 }
 
 declare module '@theme/Footer/Copyright' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly copyright: string;
   }
 
-  export default function FooterCopyright(props: Props): JSX.Element;
+  export default function FooterCopyright(props: Props): ReactNode;
 }
 
 declare module '@theme/Footer/LinkItem' {
+  import type {ReactNode} from 'react';
+
   import type {FooterLinkItem} from '@docusaurus/theme-common';
 
   export interface Props {
     readonly item: FooterLinkItem;
   }
 
-  export default function FooterLinkItem(props: Props): JSX.Element;
+  export default function FooterLinkItem(props: Props): ReactNode;
 }
 
 declare module '@theme/Footer/Layout' {
@@ -768,41 +853,44 @@ declare module '@theme/Footer/Layout' {
     readonly copyright: ReactNode;
   }
 
-  export default function FooterLayout(props: Props): JSX.Element;
+  export default function FooterLayout(props: Props): ReactNode;
 }
 
 declare module '@theme/Footer/Links' {
+  import type {ReactNode} from 'react';
   import type {Footer} from '@docusaurus/theme-common';
 
   export interface Props {
     readonly links: Footer['links'];
   }
 
-  export default function FooterLinks(props: Props): JSX.Element;
+  export default function FooterLinks(props: Props): ReactNode;
 }
 
 declare module '@theme/Footer/Links/MultiColumn' {
+  import type {ReactNode} from 'react';
   import type {MultiColumnFooter} from '@docusaurus/theme-common';
 
   export interface Props {
     readonly columns: MultiColumnFooter['links'];
   }
 
-  export default function FooterLinksMultiColumn(props: Props): JSX.Element;
+  export default function FooterLinksMultiColumn(props: Props): ReactNode;
 }
 
 declare module '@theme/Footer/Links/Simple' {
+  import type {ReactNode} from 'react';
   import type {SimpleFooter} from '@docusaurus/theme-common';
 
   export interface Props {
     readonly links: SimpleFooter['links'];
   }
 
-  export default function FooterLinksSimple(props: Props): JSX.Element;
+  export default function FooterLinksSimple(props: Props): ReactNode;
 }
 
 declare module '@theme/Heading' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
@@ -810,15 +898,17 @@ declare module '@theme/Heading' {
     readonly as: HeadingType;
   }
 
-  export default function Heading(props: Props): JSX.Element;
+  export default function Heading(props: Props): ReactNode;
 }
 
 declare module '@theme/NotFound/Content' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly className?: string;
   }
 
-  export default function NotFoundContent(props: Props): JSX.Element;
+  export default function NotFoundContent(props: Props): ReactNode;
 }
 
 declare module '@theme/Layout' {
@@ -834,7 +924,7 @@ declare module '@theme/Layout' {
     readonly description?: string;
   }
 
-  export default function Layout(props: Props): JSX.Element;
+  export default function Layout(props: Props): ReactNode;
 }
 
 declare module '@theme/Layout/Provider' {
@@ -844,99 +934,105 @@ declare module '@theme/Layout/Provider' {
     readonly children: ReactNode;
   }
 
-  export default function LayoutProvider(props: Props): JSX.Element;
+  export default function LayoutProvider(props: Props): ReactNode;
 }
 
 declare module '@theme/SearchMetadata' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly locale?: string;
     readonly version?: string;
     readonly tag?: string;
   }
 
-  export default function SearchMetadata(props: Props): JSX.Element;
+  export default function SearchMetadata(props: Props): ReactNode;
 }
 
 declare module '@theme/LastUpdated' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly lastUpdatedAt?: number;
     readonly lastUpdatedBy?: string;
   }
 
-  export default function LastUpdated(props: Props): JSX.Element;
+  export default function LastUpdated(props: Props): ReactNode;
 }
 
 declare module '@theme/SkipToContent' {
-  export default function SkipToContent(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function SkipToContent(): ReactNode;
 }
 
 declare module '@theme/MDXComponents/A' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'a'> {}
 
-  export default function MDXA(props: Props): JSX.Element;
+  export default function MDXA(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents/Code' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'code'> {}
 
-  export default function MDXCode(props: Props): JSX.Element;
+  export default function MDXCode(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents/Details' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'details'> {}
 
-  export default function MDXDetails(props: Props): JSX.Element;
+  export default function MDXDetails(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents/Ul' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'ul'> {}
 
-  export default function MDXUl(props: Props): JSX.Element;
+  export default function MDXUl(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents/Li' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'li'> {}
 
-  export default function MDXLi(props: Props): JSX.Element;
+  export default function MDXLi(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents/Img' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'img'> {}
 
-  export default function MDXImg(props: Props): JSX.Element;
+  export default function MDXImg(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents/Heading' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
   import type Heading from '@theme/Heading';
 
   export interface Props extends ComponentProps<typeof Heading> {}
 
-  export default function MDXHeading(props: Props): JSX.Element;
+  export default function MDXHeading(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents/Pre' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'pre'> {}
 
-  export default function MDXPre(props: Props): JSX.Element;
+  export default function MDXPre(props: Props): ReactNode;
 }
 
 declare module '@theme/MDXComponents' {
-  import type {ComponentType, ComponentProps} from 'react';
+  import type {ComponentType, ComponentProps, ReactNode} from 'react';
 
   import type MDXCode from '@theme/MDXComponents/Code';
   import type MDXA from '@theme/MDXComponents/A';
@@ -962,12 +1058,12 @@ declare module '@theme/MDXComponents' {
     readonly pre: typeof MDXPre;
     readonly ul: typeof MDXUl;
     readonly img: typeof MDXImg;
-    readonly h1: (props: ComponentProps<'h1'>) => JSX.Element;
-    readonly h2: (props: ComponentProps<'h2'>) => JSX.Element;
-    readonly h3: (props: ComponentProps<'h3'>) => JSX.Element;
-    readonly h4: (props: ComponentProps<'h4'>) => JSX.Element;
-    readonly h5: (props: ComponentProps<'h5'>) => JSX.Element;
-    readonly h6: (props: ComponentProps<'h6'>) => JSX.Element;
+    readonly h1: (props: ComponentProps<'h1'>) => ReactNode;
+    readonly h2: (props: ComponentProps<'h2'>) => ReactNode;
+    readonly h3: (props: ComponentProps<'h3'>) => ReactNode;
+    readonly h4: (props: ComponentProps<'h4'>) => ReactNode;
+    readonly h5: (props: ComponentProps<'h5'>) => ReactNode;
+    readonly h6: (props: ComponentProps<'h6'>) => ReactNode;
     readonly admonition: typeof Admonition;
     readonly mermaid: typeof Mermaid;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -985,41 +1081,51 @@ declare module '@theme/MDXContent' {
     readonly children: ReactNode;
   }
 
-  export default function MDXContent(props: Props): JSX.Element;
+  export default function MDXContent(props: Props): ReactNode;
 }
 
 declare module '@theme/Navbar' {
-  export default function Navbar(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function Navbar(): ReactNode;
 }
 
 declare module '@theme/Navbar/ColorModeToggle' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly className?: string;
   }
 
-  export default function NavbarColorModeToggle(
-    props: Props,
-  ): JSX.Element | null;
+  export default function NavbarColorModeToggle(props: Props): ReactNode | null;
 }
 
 declare module '@theme/Navbar/Logo' {
-  export default function NavbarLogo(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NavbarLogo(): ReactNode;
 }
 
 declare module '@theme/Navbar/Content' {
-  export default function NavbarContent(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NavbarContent(): ReactNode;
 }
 
 declare module '@theme/Navbar/Layout' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly children: React.ReactNode;
   }
 
-  export default function NavbarLayout(props: Props): JSX.Element;
+  export default function NavbarLayout(props: Props): ReactNode;
 }
 
 declare module '@theme/Navbar/MobileSidebar' {
-  export default function NavbarMobileSidebar(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NavbarMobileSidebar(): ReactNode;
 }
 
 declare module '@theme/Navbar/MobileSidebar/Layout' {
@@ -1031,23 +1137,31 @@ declare module '@theme/Navbar/MobileSidebar/Layout' {
     readonly secondaryMenu: ReactNode;
   }
 
-  export default function NavbarMobileSidebarLayout(props: Props): JSX.Element;
+  export default function NavbarMobileSidebarLayout(props: Props): ReactNode;
 }
 
 declare module '@theme/Navbar/MobileSidebar/Toggle' {
-  export default function NavbarMobileSidebarToggle(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NavbarMobileSidebarToggle(): ReactNode;
 }
 
 declare module '@theme/Navbar/MobileSidebar/PrimaryMenu' {
-  export default function NavbarMobileSidebarPrimaryMenu(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NavbarMobileSidebarPrimaryMenu(): ReactNode;
 }
 
 declare module '@theme/Navbar/MobileSidebar/SecondaryMenu' {
-  export default function NavbarMobileSidebarSecondaryMenu(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NavbarMobileSidebarSecondaryMenu(): ReactNode;
 }
 
 declare module '@theme/Navbar/MobileSidebar/Header' {
-  export default function NavbarMobileSidebarHeader(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function NavbarMobileSidebarHeader(): ReactNode;
 }
 
 declare module '@theme/Navbar/Search' {
@@ -1058,10 +1172,11 @@ declare module '@theme/Navbar/Search' {
     readonly className?: string;
   }
 
-  export default function NavbarSearch(props: Props): JSX.Element;
+  export default function NavbarSearch(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/DefaultNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as NavbarNavLinkProps} from '@theme/NavbarItem/NavbarNavLink';
 
   export type DesktopOrMobileNavBarItemProps = NavbarNavLinkProps & {
@@ -1074,7 +1189,7 @@ declare module '@theme/NavbarItem/DefaultNavbarItem' {
     readonly mobile?: boolean;
   }
 
-  export default function DefaultNavbarItem(props: Props): JSX.Element;
+  export default function DefaultNavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/NavbarNavLink' {
@@ -1091,10 +1206,11 @@ declare module '@theme/NavbarItem/NavbarNavLink' {
     readonly isDropdownLink?: boolean;
   }
 
-  export default function NavbarNavLink(props: Props): JSX.Element;
+  export default function NavbarNavLink(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/DropdownNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as NavbarNavLinkProps} from '@theme/NavbarItem/NavbarNavLink';
   import type {LinkLikeNavbarItemProps} from '@theme/NavbarItem';
 
@@ -1108,19 +1224,22 @@ declare module '@theme/NavbarItem/DropdownNavbarItem' {
     readonly mobile?: boolean;
   }
 
-  export default function DropdownNavbarItem(props: Props): JSX.Element;
+  export default function DropdownNavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/SearchNavbarItem' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly mobile?: boolean;
     readonly className?: string;
   }
 
-  export default function SearchNavbarItem(props: Props): JSX.Element;
+  export default function SearchNavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/LocaleDropdownNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as DropdownNavbarItemProps} from '@theme/NavbarItem/DropdownNavbarItem';
   import type {LinkLikeNavbarItemProps} from '@theme/NavbarItem';
 
@@ -1130,10 +1249,11 @@ declare module '@theme/NavbarItem/LocaleDropdownNavbarItem' {
     readonly queryString?: string;
   }
 
-  export default function LocaleDropdownNavbarItem(props: Props): JSX.Element;
+  export default function LocaleDropdownNavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/DocsVersionDropdownNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as DropdownNavbarItemProps} from '@theme/NavbarItem/DropdownNavbarItem';
   import type {LinkLikeNavbarItemProps} from '@theme/NavbarItem';
 
@@ -1146,20 +1266,22 @@ declare module '@theme/NavbarItem/DocsVersionDropdownNavbarItem' {
 
   export default function DocsVersionDropdownNavbarItem(
     props: Props,
-  ): JSX.Element;
+  ): ReactNode;
 }
 
 declare module '@theme/NavbarItem/DocsVersionNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
 
   export interface Props extends DefaultNavbarItemProps {
     readonly docsPluginId?: string;
   }
 
-  export default function DocsVersionNavbarItem(props: Props): JSX.Element;
+  export default function DocsVersionNavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/DocNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
 
   export interface Props extends DefaultNavbarItemProps {
@@ -1167,12 +1289,11 @@ declare module '@theme/NavbarItem/DocNavbarItem' {
     readonly docsPluginId?: string;
   }
 
-  export default function DocsSidebarNavbarItem(
-    props: Props,
-  ): JSX.Element | null;
+  export default function DocsSidebarNavbarItem(props: Props): ReactNode | null;
 }
 
 declare module '@theme/NavbarItem/DocSidebarNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
 
   export interface Props extends DefaultNavbarItemProps {
@@ -1180,17 +1301,18 @@ declare module '@theme/NavbarItem/DocSidebarNavbarItem' {
     readonly docsPluginId?: string;
   }
 
-  export default function DocSidebarNavbarItem(props: Props): JSX.Element;
+  export default function DocSidebarNavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/HtmlNavbarItem' {
+  import type {ReactNode} from 'react';
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
 
   export interface Props extends DefaultNavbarItemProps {
     readonly value: string;
   }
 
-  export default function HtmlNavbarItem(props: Props): JSX.Element;
+  export default function HtmlNavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/NavbarItem/ComponentTypes' {
@@ -1225,7 +1347,7 @@ declare module '@theme/NavbarItem/ComponentTypes' {
 }
 
 declare module '@theme/NavbarItem' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
   import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
   import type {Props as DocNavbarItemProps} from '@theme/NavbarItem/DocNavbarItem';
   import type {Props as DocSidebarNavbarItemProps} from '@theme/NavbarItem/DocSidebarNavbarItem';
@@ -1259,7 +1381,7 @@ declare module '@theme/NavbarItem' {
 
   export type NavbarItemType = Props['type'];
 
-  export default function NavbarItem(props: Props): JSX.Element;
+  export default function NavbarItem(props: Props): ReactNode;
 }
 
 declare module '@theme/PaginatorNavLink' {
@@ -1268,43 +1390,50 @@ declare module '@theme/PaginatorNavLink' {
 
   export interface Props extends Omit<PropNavigationLink, 'title'> {
     readonly title: ReactNode;
-    readonly subLabel?: JSX.Element;
+    readonly subLabel?: ReactNode;
     readonly isNext?: boolean;
   }
 
-  export default function PaginatorNavLink(props: Props): JSX.Element;
+  export default function PaginatorNavLink(props: Props): ReactNode;
 }
 
 declare module '@theme/SearchBar' {
-  export default function SearchBar(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function SearchBar(): ReactNode;
 }
 
 declare module '@theme/Mermaid' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     value: string;
   }
 
-  export default function Mermaid(props: Props): JSX.Element;
+  export default function Mermaid(props: Props): ReactNode;
 }
 
 declare module '@theme/TabItem' {
+  import type {ReactNode} from 'react';
+
   import type {TabItemProps} from '@docusaurus/theme-common/internal';
 
   export interface Props extends TabItemProps {}
 
-  export default function TabItem(props: Props): JSX.Element;
+  export default function TabItem(props: Props): ReactNode;
 }
 
 declare module '@theme/Tabs' {
+  import type {ReactNode} from 'react';
   import type {TabsProps} from '@docusaurus/theme-common/internal';
 
   export interface Props extends TabsProps {}
 
-  export default function Tabs(props: Props): JSX.Element;
+  export default function Tabs(props: Props): ReactNode;
 }
 
 declare module '@theme/ThemedImage' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends Omit<ComponentProps<'img'>, 'src'> {
     readonly sources: {
@@ -1313,7 +1442,7 @@ declare module '@theme/ThemedImage' {
     };
   }
 
-  export default function ThemedImage(props: Props): JSX.Element;
+  export default function ThemedImage(props: Props): ReactNode;
 }
 
 declare module '@theme/Details' {
@@ -1324,6 +1453,7 @@ declare module '@theme/Details' {
 }
 
 declare module '@theme/TOCItems' {
+  import type {ReactNode} from 'react';
   import type {TOCItem} from '@docusaurus/mdx-loader';
 
   export interface Props {
@@ -1335,10 +1465,11 @@ declare module '@theme/TOCItems' {
     readonly linkActiveClassName?: string;
   }
 
-  export default function TOCItems(props: Props): JSX.Element;
+  export default function TOCItems(props: Props): ReactNode;
 }
 
 declare module '@theme/TOCItems/Tree' {
+  import type {ReactNode} from 'react';
   import type {TOCTreeNode} from '@docusaurus/theme-common/internal';
 
   export interface Props {
@@ -1348,10 +1479,11 @@ declare module '@theme/TOCItems/Tree' {
     readonly isChild?: boolean;
   }
 
-  export default function TOCItems(props: Props): JSX.Element;
+  export default function TOCItems(props: Props): ReactNode;
 }
 
 declare module '@theme/TOC' {
+  import type {ReactNode} from 'react';
   import type {TOCItem} from '@docusaurus/mdx-loader';
 
   // `minHeadingLevel` only comes from doc/post front matter, and won't have a
@@ -1363,10 +1495,11 @@ declare module '@theme/TOC' {
     readonly className?: string;
   }
 
-  export default function TOC(props: Props): JSX.Element;
+  export default function TOC(props: Props): ReactNode;
 }
 
 declare module '@theme/TOCInline' {
+  import type {ReactNode} from 'react';
   import type {TOCItem} from '@docusaurus/mdx-loader';
 
   export interface Props {
@@ -1375,10 +1508,11 @@ declare module '@theme/TOCInline' {
     readonly maxHeadingLevel?: number;
   }
 
-  export default function TOCInline(props: Props): JSX.Element;
+  export default function TOCInline(props: Props): ReactNode;
 }
 
 declare module '@theme/TOCCollapsible' {
+  import type {ReactNode} from 'react';
   import type {TOCItem} from '@docusaurus/mdx-loader';
 
   export interface Props {
@@ -1388,22 +1522,21 @@ declare module '@theme/TOCCollapsible' {
     readonly toc: readonly TOCItem[];
   }
 
-  export default function TOCCollapsible(props: Props): JSX.Element;
+  export default function TOCCollapsible(props: Props): ReactNode;
 }
 
 declare module '@theme/TOCCollapsible/CollapseButton' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'button'> {
     collapsed: boolean;
   }
 
-  export default function TOCCollapsibleCollapseButton(
-    props: Props,
-  ): JSX.Element;
+  export default function TOCCollapsibleCollapseButton(props: Props): ReactNode;
 }
 
 declare module '@theme/ColorModeToggle' {
+  import type {ReactNode} from 'react';
   import type {ColorMode} from '@docusaurus/theme-common';
 
   export interface Props {
@@ -1417,192 +1550,197 @@ declare module '@theme/ColorModeToggle' {
     readonly onChange: (colorMode: ColorMode) => void;
   }
 
-  export default function ColorModeToggle(props: Props): JSX.Element;
+  export default function ColorModeToggle(props: Props): ReactNode;
 }
 
 declare module '@theme/Logo' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'a'> {
     readonly imageClassName?: string;
     readonly titleClassName?: string;
   }
 
-  export default function Logo(props: Props): JSX.Element;
+  export default function Logo(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Arrow' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconArrow(props: Props): JSX.Element;
+  export default function IconArrow(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/DarkMode' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconDarkMode(props: Props): JSX.Element;
+  export default function IconDarkMode(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Edit' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconEdit(props: Props): JSX.Element;
+  export default function IconEdit(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Home' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconHome(props: Props): JSX.Element;
+  export default function IconHome(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/LightMode' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconLightMode(props: Props): JSX.Element;
+  export default function IconLightMode(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Menu' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconMenu(props: Props): JSX.Element;
+  export default function IconMenu(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Close' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconClose(props: Props): JSX.Element;
+  export default function IconClose(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Copy' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconCopy(props: Props): JSX.Element;
+  export default function IconCopy(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Language' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconLanguage(props: Props): JSX.Element;
+  export default function IconLanguage(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Success' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconSuccess(props: Props): JSX.Element;
+  export default function IconSuccess(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/ExternalLink' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconExternalLink(props: Props): JSX.Element;
+  export default function IconExternalLink(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/WordWrap' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function IconWordWrap(props: Props): JSX.Element;
+  export default function IconWordWrap(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Socials/Twitter' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function Twitter(props: Props): JSX.Element;
+  export default function Twitter(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Socials/GitHub' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function Github(props: Props): JSX.Element;
+  export default function Github(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Socials/X' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function X(props: Props): JSX.Element;
+  export default function X(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Socials/LinkedIn' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function LinkedIn(props: Props): JSX.Element;
+  export default function LinkedIn(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Socials/Default' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function DefaultSocialIcon(props: Props): JSX.Element;
+  export default function DefaultSocialIcon(props: Props): ReactNode;
 }
 
 declare module '@theme/Icon/Socials/StackOverflow' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {}
 
-  export default function StackOverflow(props: Props): JSX.Element;
+  export default function StackOverflow(props: Props): ReactNode;
 }
 
 declare module '@theme/TagsListByLetter' {
+  import type {ReactNode} from 'react';
   import type {TagsListItem} from '@docusaurus/utils';
 
   export interface Props {
     readonly tags: readonly TagsListItem[];
   }
-  export default function TagsListByLetter(props: Props): JSX.Element;
+  export default function TagsListByLetter(props: Props): ReactNode;
 }
 
 declare module '@theme/TagsListInline' {
+  import type {ReactNode} from 'react';
   import type {Tag} from '@docusaurus/utils';
 
   export interface Props {
     readonly tags: readonly Tag[];
   }
-  export default function TagsListInline(props: Props): JSX.Element;
+  export default function TagsListInline(props: Props): ReactNode;
 }
 
 declare module '@theme/Tag' {
+  import type {ReactNode} from 'react';
   import type {TagsListItem} from '@docusaurus/utils';
   import type {Optional} from 'utility-types';
 
   export interface Props extends Optional<TagsListItem, 'count'> {}
 
-  export default function Tag(props: Props): JSX.Element;
+  export default function Tag(props: Props): ReactNode;
 }
 
 declare module '@theme/ContentVisibility' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     readonly metadata: {
       // the visibility metadata our 3 content plugins share in common
@@ -1611,23 +1749,27 @@ declare module '@theme/ContentVisibility' {
     };
   }
 
-  export default function ContentVisibility(props: Props): JSX.Element;
+  export default function ContentVisibility(props: Props): ReactNode;
 }
 
 declare module '@theme/ContentVisibility/Unlisted' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     className?: string;
   }
 
-  export default function Unlisted(props: Props): JSX.Element;
+  export default function Unlisted(props: Props): ReactNode;
 }
 
 declare module '@theme/ContentVisibility/Draft' {
+  import type {ReactNode} from 'react';
+
   export interface Props {
     className?: string;
   }
 
-  export default function Draft(props: Props): JSX.Element;
+  export default function Draft(props: Props): ReactNode;
 }
 
 declare module '@theme/prism-include-languages' {
@@ -1639,5 +1781,7 @@ declare module '@theme/prism-include-languages' {
 }
 
 declare module '@theme/DocBreadcrumbs/Items/Home' {
-  export default function HomeBreadcrumbItem(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function HomeBreadcrumbItem(): ReactNode;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Danger.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Danger.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Admonition/Icon/Danger';
 
-export default function AdmonitionIconDanger(props: Props): JSX.Element {
+export default function AdmonitionIconDanger(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 12 16" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Info.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Info.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Admonition/Icon/Info';
 
-export default function AdmonitionIconInfo(props: Props): JSX.Element {
+export default function AdmonitionIconInfo(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 14 16" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Note.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Note.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Admonition/Icon/Note';
 
-export default function AdmonitionIconNote(props: Props): JSX.Element {
+export default function AdmonitionIconNote(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 14 16" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Tip.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Tip.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Admonition/Icon/Tip';
 
-export default function AdmonitionIconTip(props: Props): JSX.Element {
+export default function AdmonitionIconTip(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 12 16" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Warning.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Icon/Warning.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Admonition/Icon/Warning';
 
-export default function AdmonitionIconCaution(props: Props): JSX.Element {
+export default function AdmonitionIconCaution(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 16 16" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Layout/index.tsx
@@ -46,7 +46,7 @@ function AdmonitionContent({children}: Pick<Props, 'children'>) {
   ) : null;
 }
 
-export default function AdmonitionLayout(props: Props): JSX.Element {
+export default function AdmonitionLayout(props: Props): ReactNode {
   const {type, icon, title, children, className} = props;
   return (
     <AdmonitionContainer type={type} className={className}>

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Caution.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Caution.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/Admonition/Type/Caution';
@@ -27,7 +27,7 @@ const defaultProps = {
 
 // TODO remove before v4: Caution replaced by Warning
 // see https://github.com/facebook/docusaurus/issues/7558
-export default function AdmonitionTypeCaution(props: Props): JSX.Element {
+export default function AdmonitionTypeCaution(props: Props): ReactNode {
   return (
     <AdmonitionLayout
       {...defaultProps}

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Danger.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Danger.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/Admonition/Type/Danger';
@@ -25,7 +25,7 @@ const defaultProps = {
   ),
 };
 
-export default function AdmonitionTypeDanger(props: Props): JSX.Element {
+export default function AdmonitionTypeDanger(props: Props): ReactNode {
   return (
     <AdmonitionLayout
       {...defaultProps}

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Info.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Info.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/Admonition/Type/Info';
@@ -25,7 +25,7 @@ const defaultProps = {
   ),
 };
 
-export default function AdmonitionTypeInfo(props: Props): JSX.Element {
+export default function AdmonitionTypeInfo(props: Props): ReactNode {
   return (
     <AdmonitionLayout
       {...defaultProps}

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Note.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Note.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/Admonition/Type/Note';
@@ -25,7 +25,7 @@ const defaultProps = {
   ),
 };
 
-export default function AdmonitionTypeNote(props: Props): JSX.Element {
+export default function AdmonitionTypeNote(props: Props): ReactNode {
   return (
     <AdmonitionLayout
       {...defaultProps}

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Tip.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Tip.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/Admonition/Type/Tip';
@@ -25,7 +25,7 @@ const defaultProps = {
   ),
 };
 
-export default function AdmonitionTypeTip(props: Props): JSX.Element {
+export default function AdmonitionTypeTip(props: Props): ReactNode {
   return (
     <AdmonitionLayout
       {...defaultProps}

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Warning.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/Type/Warning.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/Admonition/Type/Warning';
@@ -25,7 +25,7 @@ const defaultProps = {
   ),
 };
 
-export default function AdmonitionTypeWarning(props: Props): JSX.Element {
+export default function AdmonitionTypeWarning(props: Props): ReactNode {
   return (
     <AdmonitionLayout
       {...defaultProps}

--- a/packages/docusaurus-theme-classic/src/theme/Admonition/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Admonition/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentType} from 'react';
+import React, {type ComponentType, type ReactNode} from 'react';
 import {processAdmonitionProps} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Admonition';
 import AdmonitionTypes from '@theme/Admonition/Types';
@@ -21,7 +21,7 @@ function getAdmonitionTypeComponent(type: string): ComponentType<Props> {
   return AdmonitionTypes.info!;
 }
 
-export default function Admonition(unprocessedProps: Props): JSX.Element {
+export default function Admonition(unprocessedProps: Props): ReactNode {
   const props = processAdmonitionProps(unprocessedProps);
   const AdmonitionTypeComponent = getAdmonitionTypeComponent(props.type);
   return <AdmonitionTypeComponent {...props} />;

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/CloseButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/CloseButton/index.tsx
@@ -5,16 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import IconClose from '@theme/Icon/Close';
 import type {Props} from '@theme/AnnouncementBar/CloseButton';
 import styles from './styles.module.css';
 
-export default function AnnouncementBarCloseButton(
-  props: Props,
-): JSX.Element | null {
+export default function AnnouncementBarCloseButton(props: Props): ReactNode {
   return (
     <button
       type="button"

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/Content/index.tsx
@@ -5,15 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import type {Props} from '@theme/AnnouncementBar/Content';
 import styles from './styles.module.css';
 
-export default function AnnouncementBarContent(
-  props: Props,
-): JSX.Element | null {
+export default function AnnouncementBarContent(props: Props): ReactNode {
   const {announcementBar} = useThemeConfig();
   const {content} = announcementBar!;
   return (

--- a/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/AnnouncementBar/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import {useAnnouncementBar} from '@docusaurus/theme-common/internal';
 import AnnouncementBarCloseButton from '@theme/AnnouncementBar/CloseButton';
@@ -13,7 +13,7 @@ import AnnouncementBarContent from '@theme/AnnouncementBar/Content';
 
 import styles from './styles.module.css';
 
-export default function AnnouncementBar(): JSX.Element | null {
+export default function AnnouncementBar(): ReactNode {
   const {announcementBar} = useThemeConfig();
   const {isActive, close} = useAnnouncementBar();
   if (!isActive) {

--- a/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BackToTopButton/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
@@ -13,7 +13,7 @@ import {useBackToTopButton} from '@docusaurus/theme-common/internal';
 
 import styles from './styles.module.css';
 
-export default function BackToTopButton(): JSX.Element {
+export default function BackToTopButton(): ReactNode {
   const {shown, scrollToTop} = useBackToTopButton({threshold: 300});
   return (
     <button

--- a/packages/docusaurus-theme-classic/src/theme/Blog/Components/Author/Socials/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Blog/Components/Author/Socials/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {ComponentType} from 'react';
+import type {ComponentType, ReactNode} from 'react';
 import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
@@ -54,7 +54,7 @@ export default function BlogAuthorSocials({
   author,
 }: {
   author: Props['author'];
-}): JSX.Element {
+}): ReactNode {
   const entries = Object.entries(author.socials ?? {});
   return (
     <div className={styles.authorSocials}>

--- a/packages/docusaurus-theme-classic/src/theme/Blog/Components/Author/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Blog/Components/Author/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link, {type Props as LinkProps} from '@docusaurus/Link';
 import AuthorSocials from '@theme/Blog/Components/Author/Socials';
@@ -13,7 +13,7 @@ import type {Props} from '@theme/Blog/Components/Author';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
-function MaybeLink(props: LinkProps): JSX.Element {
+function MaybeLink(props: LinkProps): ReactNode {
   if (props.href) {
     return <Link {...props} />;
   }
@@ -53,7 +53,7 @@ export default function BlogAuthor({
   author,
   className,
   count,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {name, title, url, imageURL, email, page} = author;
   const link =
     page?.permalink || url || (email && `mailto:${email}`) || undefined;

--- a/packages/docusaurus-theme-classic/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   PageMetadata,
@@ -26,7 +26,7 @@ import type {Props} from '@theme/Blog/Pages/BlogAuthorsPostsPage';
 import BlogPostItems from '@theme/BlogPostItems';
 import Author from '@theme/Blog/Components/Author';
 
-function Metadata({author}: Props): JSX.Element {
+function Metadata({author}: Props): ReactNode {
   const title = useBlogAuthorPageTitle(author);
   return (
     <>
@@ -45,7 +45,7 @@ function ViewAllAuthorsLink() {
   );
 }
 
-function Content({author, items, sidebar, listMetadata}: Props): JSX.Element {
+function Content({author, items, sidebar, listMetadata}: Props): ReactNode {
   return (
     <BlogLayout sidebar={sidebar}>
       <header className="margin-bottom--xl">
@@ -68,7 +68,7 @@ function Content({author, items, sidebar, listMetadata}: Props): JSX.Element {
   );
 }
 
-export default function BlogAuthorsPostsPage(props: Props): JSX.Element {
+export default function BlogAuthorsPostsPage(props: Props): ReactNode {
   return (
     <HtmlClassNameProvider
       className={clsx(

--- a/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogArchivePage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import {translate} from '@docusaurus/Translate';
 import {PageMetadata} from '@docusaurus/theme-common';
@@ -76,7 +76,7 @@ function listPostsByYears(blogPosts: readonly ArchiveBlogPost[]): YearProp[] {
   }));
 }
 
-export default function BlogArchive({archive}: Props): JSX.Element {
+export default function BlogArchive({archive}: Props): ReactNode {
   const title = translate({
     id: 'theme.blog.archive.title',
     message: 'Archive',

--- a/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogLayout/index.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import BlogSidebar from '@theme/BlogSidebar';
 
 import type {Props} from '@theme/BlogLayout';
 
-export default function BlogLayout(props: Props): JSX.Element {
+export default function BlogLayout(props: Props): ReactNode {
   const {sidebar, toc, children, ...layoutProps} = props;
   const hasSidebar = sidebar && sidebar.items.length > 0;
 

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/StructuredData/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/StructuredData/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Head from '@docusaurus/Head';
 import {useBlogListPageStructuredData} from '@docusaurus/plugin-content-blog/client';
 import type {Props} from '@theme/BlogListPage/StructuredData';
 
-export default function BlogListPageStructuredData(props: Props): JSX.Element {
+export default function BlogListPageStructuredData(props: Props): ReactNode {
   const structuredData = useBlogListPageStructuredData(props);
   return (
     <Head>

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -21,7 +21,7 @@ import type {Props} from '@theme/BlogListPage';
 import BlogPostItems from '@theme/BlogPostItems';
 import BlogListPageStructuredData from '@theme/BlogListPage/StructuredData';
 
-function BlogListPageMetadata(props: Props): JSX.Element {
+function BlogListPageMetadata(props: Props): ReactNode {
   const {metadata} = props;
   const {
     siteConfig: {title: siteTitle},
@@ -37,7 +37,7 @@ function BlogListPageMetadata(props: Props): JSX.Element {
   );
 }
 
-function BlogListPageContent(props: Props): JSX.Element {
+function BlogListPageContent(props: Props): ReactNode {
   const {metadata, items, sidebar} = props;
   return (
     <BlogLayout sidebar={sidebar}>
@@ -47,7 +47,7 @@ function BlogListPageContent(props: Props): JSX.Element {
   );
 }
 
-export default function BlogListPage(props: Props): JSX.Element {
+export default function BlogListPage(props: Props): ReactNode {
   return (
     <HtmlClassNameProvider
       className={clsx(

--- a/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogListPaginator/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import PaginatorNavLink from '@theme/PaginatorNavLink';
 import type {Props} from '@theme/BlogListPaginator';
 
-export default function BlogListPaginator(props: Props): JSX.Element {
+export default function BlogListPaginator(props: Props): ReactNode {
   const {metadata} = props;
   const {previousPage, nextPage} = metadata;
 

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Container/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/BlogPostItem/Container';
 
 export default function BlogPostItemContainer({
   children,
   className,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return <article className={className}>{children}</article>;
 }

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Content/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {blogPostContainerID} from '@docusaurus/utils-common';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
@@ -15,7 +15,7 @@ import type {Props} from '@theme/BlogPostItem/Content';
 export default function BlogPostItemContent({
   children,
   className,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {isBlogPostPage} = useBlogPost();
   return (
     <div

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
 import type {Props} from '@theme/BlogPostItem/Footer/ReadMoreLink';
@@ -24,7 +24,7 @@ function ReadMoreLabel() {
 
 export default function BlogPostItemFooterReadMoreLink(
   props: Props,
-): JSX.Element {
+): ReactNode {
   const {blogPostTitle, ...linkProps} = props;
   return (
     <Link

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Footer/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import {ThemeClassNames} from '@docusaurus/theme-common';
@@ -13,7 +13,7 @@ import EditMetaRow from '@theme/EditMetaRow';
 import TagsListInline from '@theme/TagsListInline';
 import ReadMoreLink from '@theme/BlogPostItem/Footer/ReadMoreLink';
 
-export default function BlogPostItemFooter(): JSX.Element | null {
+export default function BlogPostItemFooter(): ReactNode {
   const {metadata, isBlogPostPage} = useBlogPost();
   const {
     tags,

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Authors/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Authors/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import BlogAuthor from '@theme/Blog/Components/Author';
@@ -15,7 +15,7 @@ import styles from './styles.module.css';
 // Component responsible for the authors layout
 export default function BlogPostItemHeaderAuthors({
   className,
-}: Props): JSX.Element | null {
+}: Props): ReactNode {
   const {
     metadata: {authors},
     assets,

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import {usePluralForm} from '@docusaurus/theme-common';
@@ -54,9 +54,7 @@ function Spacer() {
   return <>{' · '}</>;
 }
 
-export default function BlogPostItemHeaderInfo({
-  className,
-}: Props): JSX.Element {
+export default function BlogPostItemHeaderInfo({className}: Props): ReactNode {
   const {metadata} = useBlogPost();
   const {date, readingTime} = metadata;
 

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
@@ -13,9 +13,7 @@ import type {Props} from '@theme/BlogPostItem/Header/Title';
 
 import styles from './styles.module.css';
 
-export default function BlogPostItemHeaderTitle({
-  className,
-}: Props): JSX.Element {
+export default function BlogPostItemHeaderTitle({className}: Props): ReactNode {
   const {metadata, isBlogPostPage} = useBlogPost();
   const {permalink, title} = metadata;
   const TitleHeading = isBlogPostPage ? 'h1' : 'h2';

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/Header/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import BlogPostItemHeaderTitle from '@theme/BlogPostItem/Header/Title';
 import BlogPostItemHeaderInfo from '@theme/BlogPostItem/Header/Info';
 import BlogPostItemHeaderAuthors from '@theme/BlogPostItem/Header/Authors';
 
-export default function BlogPostItemHeader(): JSX.Element {
+export default function BlogPostItemHeader(): ReactNode {
   return (
     <header>
       <BlogPostItemHeaderTitle />

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItem/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import BlogPostItemContainer from '@theme/BlogPostItem/Container';
@@ -20,10 +20,7 @@ function useContainerClassName() {
   return !isBlogPostPage ? 'margin-bottom--xl' : undefined;
 }
 
-export default function BlogPostItem({
-  children,
-  className,
-}: Props): JSX.Element {
+export default function BlogPostItem({children, className}: Props): ReactNode {
   const containerClassName = useContainerClassName();
   return (
     <BlogPostItemContainer className={clsx(containerClassName, className)}>

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostItems/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostItems/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {BlogPostProvider} from '@docusaurus/plugin-content-blog/client';
 import BlogPostItem from '@theme/BlogPostItem';
 import type {Props} from '@theme/BlogPostItems';
@@ -13,7 +13,7 @@ import type {Props} from '@theme/BlogPostItems';
 export default function BlogPostItems({
   items,
   component: BlogPostItemComponent = BlogPostItem,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <>
       {items.map(({content: BlogPostContent}) => (

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/Metadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/Metadata/index.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {PageMetadata} from '@docusaurus/theme-common';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 
-export default function BlogPostPageMetadata(): JSX.Element {
+export default function BlogPostPageMetadata(): ReactNode {
   const {assets, metadata} = useBlogPost();
   const {title, description, date, tags, authors, frontMatter} = metadata;
 

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/StructuredData/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/StructuredData/index.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Head from '@docusaurus/Head';
 import {useBlogPostStructuredData} from '@docusaurus/plugin-content-blog/client';
 
-export default function BlogPostStructuredData(): JSX.Element {
+export default function BlogPostStructuredData(): ReactNode {
   const structuredData = useBlogPostStructuredData();
   return (
     <Head>

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPage/index.tsx
@@ -28,7 +28,7 @@ function BlogPostPageContent({
 }: {
   sidebar: BlogSidebar;
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const {metadata, toc} = useBlogPost();
   const {nextItem, prevItem, frontMatter} = metadata;
   const {
@@ -59,7 +59,7 @@ function BlogPostPageContent({
   );
 }
 
-export default function BlogPostPage(props: Props): JSX.Element {
+export default function BlogPostPage(props: Props): ReactNode {
   const BlogPostContent = props.content;
   return (
     <BlogPostProvider content={props.content} isBlogPostPage>

--- a/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogPostPaginator/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import PaginatorNavLink from '@theme/PaginatorNavLink';
 import type {Props} from '@theme/BlogPostPaginator';
 
-export default function BlogPostPaginator(props: Props): JSX.Element {
+export default function BlogPostPaginator(props: Props): ReactNode {
   const {nextItem, prevItem} = props;
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/Mobile/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/Mobile/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {memo} from 'react';
+import React, {memo, type ReactNode} from 'react';
 import {
   useVisibleBlogSidebarItems,
   BlogSidebarItemList,
@@ -29,7 +29,7 @@ const ListComponent: BlogSidebarContentProps['ListComponent'] = ({items}) => {
   );
 };
 
-function BlogSidebarMobileSecondaryMenu({sidebar}: Props): JSX.Element {
+function BlogSidebarMobileSecondaryMenu({sidebar}: Props): ReactNode {
   const items = useVisibleBlogSidebarItems(sidebar.items);
   return (
     <BlogSidebarContent
@@ -40,7 +40,7 @@ function BlogSidebarMobileSecondaryMenu({sidebar}: Props): JSX.Element {
   );
 }
 
-function BlogSidebarMobile(props: Props): JSX.Element {
+function BlogSidebarMobile(props: Props): ReactNode {
   return (
     <NavbarSecondaryMenuFiller
       component={BlogSidebarMobileSecondaryMenu}

--- a/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogSidebar/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useWindowSize} from '@docusaurus/theme-common';
 import BlogSidebarDesktop from '@theme/BlogSidebar/Desktop';
 import BlogSidebarMobile from '@theme/BlogSidebar/Mobile';
 import type {Props} from '@theme/BlogSidebar';
 
-export default function BlogSidebar({sidebar}: Props): JSX.Element | null {
+export default function BlogSidebar({sidebar}: Props): ReactNode {
   const windowSize = useWindowSize();
   if (!sidebar?.items.length) {
     return null;

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsListPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   PageMetadata,
@@ -19,7 +19,7 @@ import type {Props} from '@theme/BlogTagsListPage';
 import SearchMetadata from '@theme/SearchMetadata';
 import Heading from '@theme/Heading';
 
-export default function BlogTagsListPage({tags, sidebar}: Props): JSX.Element {
+export default function BlogTagsListPage({tags, sidebar}: Props): ReactNode {
   const title = translateTagsPageTitle();
   return (
     <HtmlClassNameProvider

--- a/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/BlogTagsPostsPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import {
@@ -23,7 +23,7 @@ import BlogPostItems from '@theme/BlogPostItems';
 import Unlisted from '@theme/ContentVisibility/Unlisted';
 import Heading from '@theme/Heading';
 
-function BlogTagsPostsPageMetadata({tag}: Props): JSX.Element {
+function BlogTagsPostsPageMetadata({tag}: Props): ReactNode {
   const title = useBlogTagsPostsPageTitle(tag);
   return (
     <>
@@ -38,7 +38,7 @@ function BlogTagsPostsPageContent({
   items,
   sidebar,
   listMetadata,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const title = useBlogTagsPostsPageTitle(tag);
   return (
     <BlogLayout sidebar={sidebar}>
@@ -59,7 +59,7 @@ function BlogTagsPostsPageContent({
     </BlogLayout>
   );
 }
-export default function BlogTagsPostsPage(props: Props): JSX.Element {
+export default function BlogTagsPostsPage(props: Props): ReactNode {
   return (
     <HtmlClassNameProvider
       className={clsx(

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Container/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps} from 'react';
+import React, {type ComponentProps, type ReactNode} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames, usePrismTheme} from '@docusaurus/theme-common';
 import {getPrismCssVariables} from '@docusaurus/theme-common/internal';
@@ -14,7 +14,7 @@ import styles from './styles.module.css';
 export default function CodeBlockContainer<T extends 'div' | 'pre'>({
   as: As,
   ...props
-}: {as: T} & ComponentProps<T>): JSX.Element {
+}: {as: T} & ComponentProps<T>): ReactNode {
   const prismTheme = usePrismTheme();
   const prismCssVariables = getPrismCssVariables(prismTheme);
   return (

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/Element.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/Element.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Container from '@theme/CodeBlock/Container';
 import type {Props} from '@theme/CodeBlock/Content/Element';
@@ -15,10 +15,7 @@ import styles from './styles.module.css';
 // <pre> tags in markdown map to CodeBlocks. They may contain JSX children. When
 // the children is not a simple string, we just return a styled block without
 // actually highlighting.
-export default function CodeBlockJSX({
-  children,
-  className,
-}: Props): JSX.Element {
+export default function CodeBlockJSX({children, className}: Props): ReactNode {
   return (
     <Container
       as="pre"

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig, usePrismTheme} from '@docusaurus/theme-common';
 import {
@@ -38,7 +38,7 @@ export default function CodeBlockString({
   title: titleProp,
   showLineNumbers: showLineNumbersProp,
   language: languageProp,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {
     prism: {defaultLanguage, magicComments},
   } = useThemeConfig();

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/CopyButton/index.tsx
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useCallback, useState, useRef, useEffect} from 'react';
+import React, {
+  useCallback,
+  useState,
+  useRef,
+  useEffect,
+  type ReactNode,
+} from 'react';
 import clsx from 'clsx';
 import copy from 'copy-text-to-clipboard';
 import {translate} from '@docusaurus/Translate';
@@ -15,7 +21,7 @@ import IconSuccess from '@theme/Icon/Success';
 
 import styles from './styles.module.css';
 
-export default function CopyButton({code, className}: Props): JSX.Element {
+export default function CopyButton({code, className}: Props): ReactNode {
   const [isCopied, setIsCopied] = useState(false);
   const copyTimeout = useRef<number | undefined>(undefined);
   const handleCopyCode = useCallback(() => {

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Line/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/CodeBlock/Line';
 
@@ -17,7 +17,7 @@ export default function CodeBlockLine({
   showLineNumbers,
   getLineProps,
   getTokenProps,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   if (line.length === 1 && line[0]!.content === '\n') {
     line[0]!.content = '';
   }

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/WordWrapButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/WordWrapButton/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import type {Props} from '@theme/CodeBlock/WordWrapButton';
@@ -17,7 +17,7 @@ export default function WordWrapButton({
   className,
   onClick,
   isEnabled,
-}: Props): JSX.Element | null {
+}: Props): ReactNode {
   const title = translate({
     id: 'theme.CodeBlock.wordWrapToggle',
     message: 'Toggle word wrap',

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
@@ -28,7 +28,7 @@ function maybeStringifyChildren(children: ReactNode): ReactNode {
 export default function CodeBlock({
   children: rawChildren,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   // The Prism theme on SSR is always the default theme but the site theme can
   // be in a different mode. React hydration doesn't update DOM styles that come
   // from SSR. Hence force a re-render after mounting to apply the current

--- a/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeInline/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/CodeInline';
 
 // Simple component used to render inline code blocks
 // its purpose is to be swizzled and customized
 // MDX 1 used to have a inlineCode comp, see https://mdxjs.com/migrating/v2/
-export default function CodeInline(props: Props): JSX.Element {
+export default function CodeInline(props: Props): ReactNode {
   return <code {...props} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import {translate} from '@docusaurus/Translate';
@@ -20,7 +20,7 @@ function ColorModeToggle({
   buttonClassName,
   value,
   onChange,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const isBrowser = useIsBrowser();
 
   const title = translate(

--- a/packages/docusaurus-theme-classic/src/theme/ContentVisibility/Draft/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ContentVisibility/Draft/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   ThemeClassNames,
@@ -15,7 +15,7 @@ import {
 import Admonition from '@theme/Admonition';
 import type {Props} from '@theme/ContentVisibility/Draft';
 
-export default function Draft({className}: Props): JSX.Element | null {
+export default function Draft({className}: Props): ReactNode {
   return (
     <Admonition
       type="caution"

--- a/packages/docusaurus-theme-classic/src/theme/ContentVisibility/Unlisted/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ContentVisibility/Unlisted/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   ThemeClassNames,
@@ -27,7 +27,7 @@ function UnlistedBanner({className}: Props) {
   );
 }
 
-export default function Unlisted(props: Props): JSX.Element | null {
+export default function Unlisted(props: Props): ReactNode {
   return (
     <>
       {/*

--- a/packages/docusaurus-theme-classic/src/theme/ContentVisibility/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ContentVisibility/index.tsx
@@ -5,15 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import type {Props} from '@theme/ContentVisibility';
 import Draft from '@theme/ContentVisibility/Draft';
 import Unlisted from '@theme/ContentVisibility/Unlisted';
 
-export default function ContentVisibility({
-  metadata,
-}: Props): JSX.Element | null {
+export default function ContentVisibility({metadata}: Props): ReactNode {
   const {unlisted, frontMatter} = metadata;
   // Reading draft/unlisted status from frontMatter is useful to display
   // the banners in dev mode (in dev, metadata.unlisted is always false)

--- a/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Details/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {Details as DetailsGeneric} from '@docusaurus/theme-common/Details';
 import type {Props} from '@theme/Details';
@@ -16,7 +16,7 @@ import styles from './styles.module.css';
 // alert classes?
 const InfimaClasses = 'alert alert--info';
 
-export default function Details({...props}: Props): JSX.Element {
+export default function Details({...props}: Props): ReactNode {
   return (
     <DetailsGeneric
       {...props}

--- a/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/Items/Home/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/Items/Home/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import {translate} from '@docusaurus/Translate';
@@ -13,7 +13,7 @@ import IconHome from '@theme/Icon/Home';
 
 import styles from './styles.module.css';
 
-export default function HomeBreadcrumbItem(): JSX.Element {
+export default function HomeBreadcrumbItem(): ReactNode {
   const homeHref = useBaseUrl('/');
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocBreadcrumbs/index.tsx
@@ -25,7 +25,7 @@ function BreadcrumbsItemLink({
   children: ReactNode;
   href: string | undefined;
   isLast: boolean;
-}): JSX.Element {
+}): ReactNode {
   const className = 'breadcrumbs__link';
   if (isLast) {
     return (
@@ -59,7 +59,7 @@ function BreadcrumbsItem({
   active?: boolean;
   index: number;
   addMicrodata: boolean;
-}): JSX.Element {
+}): ReactNode {
   return (
     <li
       {...(addMicrodata && {
@@ -76,7 +76,7 @@ function BreadcrumbsItem({
   );
 }
 
-export default function DocBreadcrumbs(): JSX.Element | null {
+export default function DocBreadcrumbs(): ReactNode {
   const breadcrumbs = useSidebarBreadcrumbs();
   const homePageRoute = useHomePageRoute();
 

--- a/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/index.tsx
@@ -48,7 +48,7 @@ function CardContainer({
 }: {
   href: string;
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   return (
     <Link
       href={href}
@@ -68,7 +68,7 @@ function CardLayout({
   icon: ReactNode;
   title: string;
   description?: string;
-}): JSX.Element {
+}): ReactNode {
   return (
     <CardContainer href={href}>
       <Heading
@@ -88,11 +88,7 @@ function CardLayout({
   );
 }
 
-function CardCategory({
-  item,
-}: {
-  item: PropSidebarItemCategory;
-}): JSX.Element | null {
+function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
   const href = findFirstSidebarItemLink(item);
   const categoryItemsPlural = useCategoryItemsPlural();
 
@@ -111,7 +107,7 @@ function CardCategory({
   );
 }
 
-function CardLink({item}: {item: PropSidebarItemLink}): JSX.Element {
+function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
   const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
   const doc = useDocById(item.docId ?? undefined);
   return (
@@ -124,7 +120,7 @@ function CardLink({item}: {item: PropSidebarItemLink}): JSX.Element {
   );
 }
 
-export default function DocCard({item}: Props): JSX.Element {
+export default function DocCard({item}: Props): ReactNode {
   switch (item.type) {
     case 'link':
       return <CardLink item={item} />;

--- a/packages/docusaurus-theme-classic/src/theme/DocCardList/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCardList/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   useCurrentSidebarCategory,
@@ -19,7 +19,7 @@ function DocCardListForCurrentSidebarCategory({className}: Props) {
   return <DocCardList items={category.items} className={className} />;
 }
 
-export default function DocCardList(props: Props): JSX.Element {
+export default function DocCardList(props: Props): ReactNode {
   const {items, className} = props;
   if (!items) {
     return <DocCardListForCurrentSidebarCategory {...props} />;

--- a/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {PageMetadata} from '@docusaurus/theme-common';
 import {useCurrentSidebarCategory} from '@docusaurus/plugin-content-docs/client';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -21,7 +21,7 @@ import styles from './styles.module.css';
 
 function DocCategoryGeneratedIndexPageMetadata({
   categoryGeneratedIndex,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <PageMetadata
       title={categoryGeneratedIndex.title}
@@ -35,7 +35,7 @@ function DocCategoryGeneratedIndexPageMetadata({
 
 function DocCategoryGeneratedIndexPageContent({
   categoryGeneratedIndex,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const category = useCurrentSidebarCategory();
   return (
     <div className={styles.generatedIndexPage}>
@@ -63,9 +63,7 @@ function DocCategoryGeneratedIndexPageContent({
   );
 }
 
-export default function DocCategoryGeneratedIndexPage(
-  props: Props,
-): JSX.Element {
+export default function DocCategoryGeneratedIndexPage(props: Props): ReactNode {
   return (
     <>
       <DocCategoryGeneratedIndexPageMetadata {...props} />

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/Content/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
@@ -33,7 +33,7 @@ function useSyntheticTitle(): string | null {
   return metadata.title;
 }
 
-export default function DocItemContent({children}: Props): JSX.Element {
+export default function DocItemContent({children}: Props): ReactNode {
   const syntheticTitle = useSyntheticTitle();
   return (
     <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/Footer/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
@@ -13,7 +13,7 @@ import TagsListInline from '@theme/TagsListInline';
 
 import EditMetaRow from '@theme/EditMetaRow';
 
-export default function DocItemFooter(): JSX.Element | null {
+export default function DocItemFooter(): ReactNode {
   const {metadata} = useDoc();
   const {editUrl, lastUpdatedAt, lastUpdatedBy, tags} = metadata;
 

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/Layout/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useWindowSize} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
@@ -46,7 +46,7 @@ function useDocTOC() {
   };
 }
 
-export default function DocItemLayout({children}: Props): JSX.Element {
+export default function DocItemLayout({children}: Props): ReactNode {
   const docTOC = useDocTOC();
   const {metadata} = useDoc();
   return (

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/Metadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/Metadata/index.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {PageMetadata} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 
-export default function DocItemMetadata(): JSX.Element {
+export default function DocItemMetadata(): ReactNode {
   const {metadata, frontMatter, assets} = useDoc();
   return (
     <PageMetadata

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/Paginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/Paginator/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import DocPaginator from '@theme/DocPaginator';
 
@@ -13,7 +13,7 @@ import DocPaginator from '@theme/DocPaginator';
  * This extra component is needed, because <DocPaginator> should remain generic.
  * DocPaginator is used in non-docs contexts too: generated-index pages...
  */
-export default function DocItemPaginator(): JSX.Element {
+export default function DocItemPaginator(): ReactNode {
   const {metadata} = useDoc();
   return <DocPaginator previous={metadata.previous} next={metadata.next} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/TOC/Desktop/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/TOC/Desktop/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 
 import TOC from '@theme/TOC';
 
-export default function DocItemTOCDesktop(): JSX.Element {
+export default function DocItemTOCDesktop(): ReactNode {
   const {toc, frontMatter} = useDoc();
   return (
     <TOC

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/TOC/Mobile/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/TOC/Mobile/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
@@ -14,7 +14,7 @@ import TOCCollapsible from '@theme/TOCCollapsible';
 
 import styles from './styles.module.css';
 
-export default function DocItemTOCMobile(): JSX.Element {
+export default function DocItemTOCMobile(): ReactNode {
   const {toc, frontMatter} = useDoc();
   return (
     <TOCCollapsible

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {HtmlClassNameProvider} from '@docusaurus/theme-common';
 import {DocProvider} from '@docusaurus/plugin-content-docs/client';
 import DocItemMetadata from '@theme/DocItem/Metadata';
 import DocItemLayout from '@theme/DocItem/Layout';
 import type {Props} from '@theme/DocItem';
 
-export default function DocItem(props: Props): JSX.Element {
+export default function DocItem(props: Props): ReactNode {
   const docHtmlClassName = `docs-doc-id-${props.content.metadata.id}`;
   const MDXComponent = props.content;
   return (

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import PaginatorNavLink from '@theme/PaginatorNavLink';
 import type {Props} from '@theme/DocPaginator';
 
-export default function DocPaginator(props: Props): JSX.Element {
+export default function DocPaginator(props: Props): ReactNode {
   const {previous, next} = props;
   return (
     <nav

--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Main/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Main/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
 import type {Props} from '@theme/DocRoot/Layout/Main';
@@ -15,7 +15,7 @@ import styles from './styles.module.css';
 export default function DocRootLayoutMain({
   hiddenSidebarContainer,
   children,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const sidebar = useDocsSidebar();
   return (
     <main

--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {translate} from '@docusaurus/Translate';
 import IconArrow from '@theme/Icon/Arrow';
 import type {Props} from '@theme/DocRoot/Layout/Sidebar/ExpandButton';
@@ -14,7 +14,7 @@ import styles from './styles.module.css';
 
 export default function DocRootLayoutSidebarExpandButton({
   toggleSidebar,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <div
       className={styles.expandButton}

--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -32,7 +32,7 @@ export default function DocRootLayoutSidebar({
   sidebar,
   hiddenSidebarContainer,
   setHiddenSidebarContainer,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {pathname} = useLocation();
 
   const [hiddenSidebar, setHiddenSidebar] = useState(false);

--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/Layout/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState} from 'react';
+import React, {type ReactNode, useState} from 'react';
 import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
 import BackToTopButton from '@theme/BackToTopButton';
 import DocRootLayoutSidebar from '@theme/DocRoot/Layout/Sidebar';
@@ -14,7 +14,7 @@ import type {Props} from '@theme/DocRoot/Layout';
 
 import styles from './styles.module.css';
 
-export default function DocRootLayout({children}: Props): JSX.Element {
+export default function DocRootLayout({children}: Props): ReactNode {
   const sidebar = useDocsSidebar();
   const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
   return (

--- a/packages/docusaurus-theme-classic/src/theme/DocRoot/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocRoot/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {HtmlClassNameProvider, ThemeClassNames} from '@docusaurus/theme-common';
 import {
@@ -16,7 +16,7 @@ import DocRootLayout from '@theme/DocRoot/Layout';
 import NotFoundContent from '@theme/NotFound/Content';
 import type {Props} from '@theme/DocRoot';
 
-export default function DocRoot(props: Props): JSX.Element {
+export default function DocRoot(props: Props): ReactNode {
   const currentDocRouteMetadata = useDocRootMetadata(props);
   if (!currentDocRouteMetadata) {
     // We only render the not found content to avoid a double layout

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/CollapseButton/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import IconArrow from '@theme/Icon/Arrow';
@@ -13,7 +13,7 @@ import type {Props} from '@theme/DocSidebar/Desktop/CollapseButton';
 
 import styles from './styles.module.css';
 
-export default function CollapseButton({onClick}: Props): JSX.Element {
+export default function CollapseButton({onClick}: Props): ReactNode {
   return (
     <button
       type="button"

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState} from 'react';
+import React, {type ReactNode, useState} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {
@@ -37,7 +37,7 @@ export default function DocSidebarDesktopContent({
   path,
   sidebar,
   className,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const showAnnouncementBar = useShowAnnouncementBar();
 
   return (

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebar/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useWindowSize} from '@docusaurus/theme-common';
 import DocSidebarDesktop from '@theme/DocSidebar/Desktop';
 import DocSidebarMobile from '@theme/DocSidebar/Mobile';
 import type {Props} from '@theme/DocSidebar';
 
-export default function DocSidebar(props: Props): JSX.Element {
+export default function DocSidebar(props: Props): ReactNode {
   const windowSize = useWindowSize();
 
   // Desktop sidebar visible on hydration: need SSR rendering

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Category/index.tsx
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps, useEffect, useMemo} from 'react';
+import React, {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+} from 'react';
 import clsx from 'clsx';
 import {
   ThemeClassNames,
@@ -116,7 +121,7 @@ export default function DocSidebarItemCategory({
   level,
   index,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {items, label, collapsible, className, href} = item;
   const {
     docs: {

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Html/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Html/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import type {Props} from '@theme/DocSidebarItem/Html';
@@ -16,7 +16,7 @@ export default function DocSidebarItemHtml({
   item,
   level,
   index,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {value, defaultStyle, className} = item;
   return (
     <li

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Link/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Link/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {isActiveSidebarItem} from '@docusaurus/plugin-content-docs/client';
@@ -23,7 +23,7 @@ export default function DocSidebarItemLink({
   level,
   index,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {href, label, className, autoAddBaseUrl} = item;
   const isActive = isActiveSidebarItem(item, activePath);
   const isInternalLink = isInternalUrl(href);

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/index.tsx
@@ -5,16 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import DocSidebarItemCategory from '@theme/DocSidebarItem/Category';
 import DocSidebarItemLink from '@theme/DocSidebarItem/Link';
 import DocSidebarItemHtml from '@theme/DocSidebarItem/Html';
 import type {Props} from '@theme/DocSidebarItem';
 
-export default function DocSidebarItem({
-  item,
-  ...props
-}: Props): JSX.Element | null {
+export default function DocSidebarItem({item, ...props}: Props): ReactNode {
   switch (item.type) {
     case 'category':
       return <DocSidebarItemCategory item={item} {...props} />;

--- a/packages/docusaurus-theme-classic/src/theme/DocSidebarItems/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocSidebarItems/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {memo} from 'react';
+import React, {memo, type ReactNode} from 'react';
 import {
   DocSidebarItemsExpandedStateProvider,
   useVisibleSidebarItems,
@@ -14,7 +14,7 @@ import DocSidebarItem from '@theme/DocSidebarItem';
 
 import type {Props} from '@theme/DocSidebarItems';
 
-function DocSidebarItems({items, ...props}: Props): JSX.Element {
+function DocSidebarItems({items, ...props}: Props): ReactNode {
   const visibleItems = useVisibleSidebarItems(items, props.activePath);
   return (
     <DocSidebarItemsExpandedStateProvider>

--- a/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocTagDocListPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {
@@ -50,7 +50,7 @@ function usePageTitle(props: Props): string {
   );
 }
 
-function DocItem({doc}: {doc: Props['tag']['items'][number]}): JSX.Element {
+function DocItem({doc}: {doc: Props['tag']['items'][number]}): ReactNode {
   return (
     <article className="margin-vert--lg">
       <Link to={doc.permalink}>
@@ -64,7 +64,7 @@ function DocItem({doc}: {doc: Props['tag']['items'][number]}): JSX.Element {
 function DocTagDocListPageMetadata({
   title,
   tag,
-}: Props & {title: string}): JSX.Element {
+}: Props & {title: string}): ReactNode {
   return (
     <>
       <PageMetadata title={title} description={tag.description} />
@@ -76,7 +76,7 @@ function DocTagDocListPageMetadata({
 function DocTagDocListPageContent({
   tag,
   title,
-}: Props & {title: string}): JSX.Element {
+}: Props & {title: string}): ReactNode {
   return (
     <HtmlClassNameProvider
       className={clsx(ThemeClassNames.page.docsTagDocListPage)}>
@@ -107,7 +107,7 @@ function DocTagDocListPageContent({
   );
 }
 
-export default function DocTagDocListPage(props: Props): JSX.Element {
+export default function DocTagDocListPage(props: Props): ReactNode {
   const title = usePageTitle(props);
   return (
     <>

--- a/packages/docusaurus-theme-classic/src/theme/DocTagsListPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocTagsListPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   PageMetadata,
@@ -18,9 +18,7 @@ import SearchMetadata from '@theme/SearchMetadata';
 import type {Props} from '@theme/DocTagsListPage';
 import Heading from '@theme/Heading';
 
-function DocTagsListPageMetadata({
-  title,
-}: Props & {title: string}): JSX.Element {
+function DocTagsListPageMetadata({title}: Props & {title: string}): ReactNode {
   return (
     <>
       <PageMetadata title={title} />
@@ -32,7 +30,7 @@ function DocTagsListPageMetadata({
 function DocTagsListPageContent({
   tags,
   title,
-}: Props & {title: string}): JSX.Element {
+}: Props & {title: string}): ReactNode {
   return (
     <HtmlClassNameProvider
       className={clsx(ThemeClassNames.page.docsTagsListPage)}>
@@ -48,7 +46,7 @@ function DocTagsListPageContent({
   );
 }
 
-export default function DocTagsListPage(props: Props): JSX.Element {
+export default function DocTagsListPage(props: Props): ReactNode {
   const title = translateTagsPageTitle();
   return (
     <>

--- a/packages/docusaurus-theme-classic/src/theme/DocVersionBadge/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocVersionBadge/index.tsx
@@ -5,16 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDocsVersion} from '@docusaurus/plugin-content-docs/client';
 import type {Props} from '@theme/DocVersionBadge';
 
-export default function DocVersionBadge({
-  className,
-}: Props): JSX.Element | null {
+export default function DocVersionBadge({className}: Props): ReactNode {
   const versionMetadata = useDocsVersion();
   if (versionMetadata.badge) {
     return (

--- a/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocVersionBanner/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentType} from 'react';
+import React, {type ComponentType, type ReactNode} from 'react';
 import clsx from 'clsx';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
@@ -121,7 +121,7 @@ function DocVersionBannerEnabled({
   versionMetadata,
 }: Props & {
   versionMetadata: PropVersionMetadata;
-}): JSX.Element {
+}): ReactNode {
   const {
     siteConfig: {title: siteTitle},
   } = useDocusaurusContext();
@@ -162,9 +162,7 @@ function DocVersionBannerEnabled({
   );
 }
 
-export default function DocVersionBanner({
-  className,
-}: Props): JSX.Element | null {
+export default function DocVersionBanner({className}: Props): ReactNode {
   const versionMetadata = useDocsVersion();
   if (versionMetadata.banner) {
     return (

--- a/packages/docusaurus-theme-classic/src/theme/DocVersionRoot/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocVersionRoot/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {HtmlClassNameProvider, PageMetadata} from '@docusaurus/theme-common';
 import {
   getDocsVersionSearchTag,
@@ -16,7 +16,7 @@ import SearchMetadata from '@theme/SearchMetadata';
 
 import type {Props} from '@theme/DocVersionRoot';
 
-function DocVersionRootMetadata(props: Props): JSX.Element {
+function DocVersionRootMetadata(props: Props): ReactNode {
   const {version} = props;
   return (
     <>
@@ -31,7 +31,7 @@ function DocVersionRootMetadata(props: Props): JSX.Element {
   );
 }
 
-function DocVersionRootContent(props: Props): JSX.Element {
+function DocVersionRootContent(props: Props): ReactNode {
   const {version, route} = props;
   return (
     <HtmlClassNameProvider className={version.className}>
@@ -41,7 +41,7 @@ function DocVersionRootContent(props: Props): JSX.Element {
     </HtmlClassNameProvider>
   );
 }
-export default function DocVersionRoot(props: Props): JSX.Element {
+export default function DocVersionRoot(props: Props): ReactNode {
   return (
     <>
       <DocVersionRootMetadata {...props} />

--- a/packages/docusaurus-theme-classic/src/theme/DocsRoot/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocsRoot/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {ThemeClassNames, HtmlClassNameProvider} from '@docusaurus/theme-common';
 import renderRoutes from '@docusaurus/renderRoutes';
@@ -13,7 +13,7 @@ import Layout from '@theme/Layout';
 
 import type {Props} from '@theme/DocVersionRoot';
 
-export default function DocsRoot(props: Props): JSX.Element {
+export default function DocsRoot(props: Props): ReactNode {
   return (
     <HtmlClassNameProvider className={clsx(ThemeClassNames.wrapper.docsPages)}>
       <Layout>{renderRoutes(props.route.routes!)}</Layout>

--- a/packages/docusaurus-theme-classic/src/theme/EditMetaRow/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/EditMetaRow/index.tsx
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import EditThisPage from '@theme/EditThisPage';
 import type {Props} from '@theme/EditMetaRow';
@@ -17,7 +17,7 @@ export default function EditMetaRow({
   editUrl,
   lastUpdatedAt,
   lastUpdatedBy,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <div className={clsx('row', className)}>
       <div className="col">{editUrl && <EditThisPage editUrl={editUrl} />}</div>

--- a/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/EditThisPage/index.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import Link from '@docusaurus/Link';
 import IconEdit from '@theme/Icon/Edit';
 import type {Props} from '@theme/EditThisPage';
 
-export default function EditThisPage({editUrl}: Props): JSX.Element {
+export default function EditThisPage({editUrl}: Props): ReactNode {
   return (
     <Link to={editUrl} className={ThemeClassNames.common.editThisPage}>
       <IconEdit />

--- a/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ErrorPageContent.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
 import {
   ErrorBoundaryError,
@@ -14,10 +14,7 @@ import {
 import type {Props} from '@theme/Error';
 import Heading from '@theme/Heading';
 
-export default function ErrorPageContent({
-  error,
-  tryAgain,
-}: Props): JSX.Element {
+export default function ErrorPageContent({error, tryAgain}: Props): ReactNode {
   return (
     <main className="container margin-vert--xl">
       <div className="row">

--- a/packages/docusaurus-theme-classic/src/theme/Footer/Copyright/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/Copyright/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Footer/Copyright';
 
-export default function FooterCopyright({copyright}: Props): JSX.Element {
+export default function FooterCopyright({copyright}: Props): ReactNode {
   return (
     <div
       className="footer__copyright"

--- a/packages/docusaurus-theme-classic/src/theme/Footer/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/Layout/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/Footer/Layout';
 
@@ -14,7 +14,7 @@ export default function FooterLayout({
   links,
   logo,
   copyright,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <footer
       className={clsx('footer', {

--- a/packages/docusaurus-theme-classic/src/theme/Footer/LinkItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/LinkItem/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -13,7 +13,7 @@ import isInternalUrl from '@docusaurus/isInternalUrl';
 import IconExternalLink from '@theme/Icon/ExternalLink';
 import type {Props} from '@theme/Footer/LinkItem';
 
-export default function FooterLinkItem({item}: Props): JSX.Element {
+export default function FooterLinkItem({item}: Props): ReactNode {
   const {to, href, label, prependBaseUrlToHref, ...props} = item;
   const toUrl = useBaseUrl(to);
   const normalizedHref = useBaseUrl(href, {forcePrependBaseUrl: true});

--- a/packages/docusaurus-theme-classic/src/theme/Footer/Links/MultiColumn/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/Links/MultiColumn/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import LinkItem from '@theme/Footer/LinkItem';
 import type {Props} from '@theme/Footer/Links/MultiColumn';
 
@@ -40,7 +40,7 @@ function Column({column}: {column: ColumnType}) {
   );
 }
 
-export default function FooterLinksMultiColumn({columns}: Props): JSX.Element {
+export default function FooterLinksMultiColumn({columns}: Props): ReactNode {
   return (
     <div className="row footer__links">
       {columns.map((column, i) => (

--- a/packages/docusaurus-theme-classic/src/theme/Footer/Links/Simple/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/Links/Simple/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import LinkItem from '@theme/Footer/LinkItem';
 import type {Props} from '@theme/Footer/Links/Simple';
 
@@ -26,7 +26,7 @@ function SimpleLinkItem({item}: {item: Props['links'][number]}) {
   );
 }
 
-export default function FooterLinksSimple({links}: Props): JSX.Element {
+export default function FooterLinksSimple({links}: Props): ReactNode {
   return (
     <div className="footer__links text--center">
       <div className="footer__links">

--- a/packages/docusaurus-theme-classic/src/theme/Footer/Links/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/Links/index.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import {isMultiColumnFooterLinks} from '@docusaurus/theme-common';
 import FooterLinksMultiColumn from '@theme/Footer/Links/MultiColumn';
 import FooterLinksSimple from '@theme/Footer/Links/Simple';
 import type {Props} from '@theme/Footer/Links';
 
-export default function FooterLinks({links}: Props): JSX.Element {
+export default function FooterLinks({links}: Props): ReactNode {
   return isMultiColumnFooterLinks(links) ? (
     <FooterLinksMultiColumn columns={links} />
   ) : (

--- a/packages/docusaurus-theme-classic/src/theme/Footer/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/Logo/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
@@ -32,7 +32,7 @@ function LogoImage({logo}: Props) {
   );
 }
 
-export default function FooterLogo({logo}: Props): JSX.Element {
+export default function FooterLogo({logo}: Props): ReactNode {
   return logo.href ? (
     <Link
       href={logo.href}

--- a/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Footer/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import {useThemeConfig} from '@docusaurus/theme-common';
 import FooterLinks from '@theme/Footer/Links';
@@ -13,7 +13,7 @@ import FooterLogo from '@theme/Footer/Logo';
 import FooterCopyright from '@theme/Footer/Copyright';
 import FooterLayout from '@theme/Footer/Layout';
 
-function Footer(): JSX.Element | null {
+function Footer(): ReactNode {
   const {footer} = useThemeConfig();
   if (!footer) {
     return null;

--- a/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Heading/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {translate} from '@docusaurus/Translate';
 import {useThemeConfig} from '@docusaurus/theme-common';
@@ -15,7 +15,7 @@ import type {Props} from '@theme/Heading';
 
 import styles from './styles.module.css';
 
-export default function Heading({as: As, id, ...props}: Props): JSX.Element {
+export default function Heading({as: As, id, ...props}: Props): ReactNode {
   const brokenLinks = useBrokenLinks();
   const {
     navbar: {hideOnScroll},

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Arrow/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Arrow/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/Arrow';
 
-export default function IconArrow(props: Props): JSX.Element {
+export default function IconArrow(props: Props): ReactNode {
   return (
     <svg width="20" height="20" aria-hidden="true" {...props}>
       <g fill="#7a7a7a">

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Close/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Close/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/Close';
 
 export default function IconClose({
@@ -15,7 +15,7 @@ export default function IconClose({
   strokeWidth = 1.2,
   className,
   ...restProps
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <svg viewBox="0 0 15 15" width={width} height={height} {...restProps}>
       <g stroke={color} strokeWidth={strokeWidth}>

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Copy/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Copy/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/Copy';
 
-export default function IconCopy(props: Props): JSX.Element {
+export default function IconCopy(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 24 24" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Icon/DarkMode/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/DarkMode/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/DarkMode';
 
-export default function IconDarkMode(props: Props): JSX.Element {
+export default function IconDarkMode(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 24 24" width={24} height={24} {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Edit/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Edit/index.tsx
@@ -5,16 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/Icon/Edit';
 
 import styles from './styles.module.css';
 
-export default function IconEdit({
-  className,
-  ...restProps
-}: Props): JSX.Element {
+export default function IconEdit({className, ...restProps}: Props): ReactNode {
   return (
     <svg
       fill="currentColor"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/ExternalLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/ExternalLink/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/ExternalLink';
 
 import styles from './styles.module.css';
@@ -13,7 +13,7 @@ import styles from './styles.module.css';
 export default function IconExternalLink({
   width = 13.5,
   height = 13.5,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <svg
       width={width}

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Home/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Home/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/Home';
 
-export default function IconHome(props: Props): JSX.Element {
+export default function IconHome(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 24 24" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Language/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Language/index.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/Language';
 
 export default function IconLanguage({
   width = 20,
   height = 20,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <svg
       viewBox="0 0 24 24"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/LightMode/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/LightMode/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/LightMode';
 
-export default function IconLightMode(props: Props): JSX.Element {
+export default function IconLightMode(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 24 24" width={24} height={24} {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Menu/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Menu/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/Menu';
 
 export default function IconMenu({
@@ -13,7 +13,7 @@ export default function IconMenu({
   height = 30,
   className,
   ...restProps
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <svg
       className={className}

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Socials/Default/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Socials/Default/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {SVGProps} from 'react';
+import type {ReactNode, SVGProps} from 'react';
 
 // SVG Source: https://tabler.io/
-function DefaultSocial(props: SVGProps<SVGSVGElement>): JSX.Element {
+function DefaultSocial(props: SVGProps<SVGSVGElement>): ReactNode {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Socials/GitHub/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Socials/GitHub/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {SVGProps} from 'react';
+import type {ReactNode, SVGProps} from 'react';
 
 import clsx from 'clsx';
 import styles from './styles.module.css';
 
 // SVG Source: https://svgl.app/
-function GitHub(props: SVGProps<SVGSVGElement>): JSX.Element {
+function GitHub(props: SVGProps<SVGSVGElement>): ReactNode {
   return (
     <svg
       viewBox="0 0 256 250"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Socials/LinkedIn/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Socials/LinkedIn/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {SVGProps} from 'react';
+import type {ReactNode, SVGProps} from 'react';
 
 // SVG Source: https://svgl.app/
-function LinkedIn(props: SVGProps<SVGSVGElement>): JSX.Element {
+function LinkedIn(props: SVGProps<SVGSVGElement>): ReactNode {
   return (
     <svg
       width="1em"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Socials/StackOverflow/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Socials/StackOverflow/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {SVGProps} from 'react';
+import type {ReactNode, SVGProps} from 'react';
 
 // SVG Source: https://svgl.app/
-function StackOverflow(props: SVGProps<SVGSVGElement>): JSX.Element {
+function StackOverflow(props: SVGProps<SVGSVGElement>): ReactNode {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Socials/Twitter/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Socials/Twitter/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {SVGProps} from 'react';
+import type {ReactNode, SVGProps} from 'react';
 
 // SVG Source: https://svgl.app/
-function Twitter(props: SVGProps<SVGSVGElement>): JSX.Element {
+function Twitter(props: SVGProps<SVGSVGElement>): ReactNode {
   return (
     <svg
       viewBox="0 0 256 209"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Socials/X/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Socials/X/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {SVGProps} from 'react';
+import type {ReactNode, SVGProps} from 'react';
 
 import clsx from 'clsx';
 import styles from './styles.module.css';
 
 // SVG Source: https://svgl.app/
-function X(props: SVGProps<SVGSVGElement>): JSX.Element {
+function X(props: SVGProps<SVGSVGElement>): ReactNode {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/docusaurus-theme-classic/src/theme/Icon/Success/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/Success/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/Success';
 
-export default function IconSuccess(props: Props): JSX.Element {
+export default function IconSuccess(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 24 24" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/Icon/WordWrap/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/WordWrap/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Icon/WordWrap';
 
-export default function IconWordWrap(props: Props): JSX.Element {
+export default function IconWordWrap(props: Props): ReactNode {
   return (
     <svg viewBox="0 0 24 24" {...props}>
       <path

--- a/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/LastUpdated/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {useDateTimeFormat} from '@docusaurus/theme-common/internal';
@@ -15,7 +15,7 @@ function LastUpdatedAtDate({
   lastUpdatedAt,
 }: {
   lastUpdatedAt: number;
-}): JSX.Element {
+}): ReactNode {
   const atDate = new Date(lastUpdatedAt);
 
   const dateTimeFormat = useDateTimeFormat({
@@ -49,7 +49,7 @@ function LastUpdatedByUser({
   lastUpdatedBy,
 }: {
   lastUpdatedBy: string;
-}): JSX.Element {
+}): ReactNode {
   return (
     <Translate
       id="theme.lastUpdated.byUser"
@@ -65,7 +65,7 @@ function LastUpdatedByUser({
 export default function LastUpdated({
   lastUpdatedAt,
   lastUpdatedBy,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <span className={ThemeClassNames.common.lastUpdated}>
       <Translate

--- a/packages/docusaurus-theme-classic/src/theme/Layout/Provider/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/Provider/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {composeProviders} from '@docusaurus/theme-common';
 import {
   ColorModeProvider,
@@ -26,6 +26,6 @@ const Provider = composeProviders([
   NavbarProvider,
 ]);
 
-export default function LayoutProvider({children}: Props): JSX.Element {
+export default function LayoutProvider({children}: Props): ReactNode {
   return <Provider>{children}</Provider>;
 }

--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import {
@@ -23,7 +23,7 @@ import ErrorPageContent from '@theme/ErrorPageContent';
 import type {Props} from '@theme/Layout';
 import styles from './styles.module.css';
 
-export default function Layout(props: Props): JSX.Element {
+export default function Layout(props: Props): ReactNode {
   const {
     children,
     noFooter,

--- a/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Logo/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -46,7 +46,7 @@ function LogoThemedImage({
   );
 }
 
-export default function Logo(props: Props): JSX.Element {
+export default function Logo(props: Props): ReactNode {
   const {
     siteConfig: {title},
   } = useDocusaurusContext();

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/A.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/A.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import type {Props} from '@theme/MDXComponents/A';
 
-export default function MDXA(props: Props): JSX.Element {
+export default function MDXA(props: Props): ReactNode {
   return <Link {...props} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Code.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {ComponentProps} from 'react';
+import type {ComponentProps, ReactNode} from 'react';
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import CodeInline from '@theme/CodeInline';
@@ -22,7 +22,7 @@ function shouldBeInline(props: Props) {
   );
 }
 
-export default function MDXCode(props: Props): JSX.Element {
+export default function MDXCode(props: Props): ReactNode {
   return shouldBeInline(props) ? (
     <CodeInline {...props} />
   ) : (

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Details.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Details.tsx
@@ -5,11 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps, type ReactElement} from 'react';
+import React, {
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import Details from '@theme/Details';
 import type {Props} from '@theme/MDXComponents/Details';
 
-export default function MDXDetails(props: Props): JSX.Element {
+export default function MDXDetails(props: Props): ReactNode {
   const items = React.Children.toArray(props.children);
   // Split summary item from the rest to pass it as a separate prop to the
   // Details theme component

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Heading.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Heading.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Heading from '@theme/Heading';
 import type {Props} from '@theme/MDXComponents/Heading';
 
-export default function MDXHeading(props: Props): JSX.Element {
+export default function MDXHeading(props: Props): ReactNode {
   return <Heading {...props} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Img/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/MDXComponents/Img';
 
@@ -15,7 +15,7 @@ function transformImgClassName(className?: string): string {
   return clsx(className, styles.img);
 }
 
-export default function MDXImg(props: Props): JSX.Element {
+export default function MDXImg(props: Props): ReactNode {
   return (
     // eslint-disable-next-line jsx-a11y/alt-text
     <img

--- a/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXComponents/Ul/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/MDXComponents/Ul';
 
@@ -25,6 +25,6 @@ function transformUlClassName(className?: string): string | undefined {
   );
 }
 
-export default function MDXUl(props: Props): JSX.Element {
+export default function MDXUl(props: Props): ReactNode {
   return <ul {...props} className={transformUlClassName(props.className)} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXContent/index.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {MDXProvider} from '@mdx-js/react';
 import MDXComponents from '@theme/MDXComponents';
 import type {Props} from '@theme/MDXContent';
 
-export default function MDXContent({children}: Props): JSX.Element {
+export default function MDXContent({children}: Props): ReactNode {
   return <MDXProvider components={MDXComponents}>{children}</MDXProvider>;
 }

--- a/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/MDXPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   PageMetadata,
@@ -21,7 +21,7 @@ import type {Props} from '@theme/MDXPage';
 import EditMetaRow from '@theme/EditMetaRow';
 import styles from './styles.module.css';
 
-export default function MDXPage(props: Props): JSX.Element {
+export default function MDXPage(props: Props): ReactNode {
   const {content: MDXPageContent} = props;
   const {metadata, assets} = MDXPageContent;
   const {

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/ColorModeToggle/index.tsx
@@ -5,15 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useColorMode, useThemeConfig} from '@docusaurus/theme-common';
 import ColorModeToggle from '@theme/ColorModeToggle';
 import type {Props} from '@theme/Navbar/ColorModeToggle';
 import styles from './styles.module.css';
 
-export default function NavbarColorModeToggle({
-  className,
-}: Props): JSX.Element | null {
+export default function NavbarColorModeToggle({className}: Props): ReactNode {
   const navbarStyle = useThemeConfig().navbar.style;
   const disabled = useThemeConfig().colorMode.disableSwitch;
   const {colorMode, setColorMode} = useColorMode();

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Content/index.tsx
@@ -25,7 +25,7 @@ function useNavbarItems() {
   return useThemeConfig().navbar.items as NavbarItemConfig[];
 }
 
-function NavbarItems({items}: {items: NavbarItemConfig[]}): JSX.Element {
+function NavbarItems({items}: {items: NavbarItemConfig[]}): ReactNode {
   return (
     <>
       {items.map((item, i) => (
@@ -61,7 +61,7 @@ function NavbarContentLayout({
   );
 }
 
-export default function NavbarContent(): JSX.Element {
+export default function NavbarContent(): ReactNode {
   const mobileSidebar = useNavbarMobileSidebar();
 
   const items = useNavbarItems();

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Layout/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps} from 'react';
+import React, {type ComponentProps, type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import {
@@ -28,7 +28,7 @@ function NavbarBackdrop(props: ComponentProps<'div'>) {
   );
 }
 
-export default function NavbarLayout({children}: Props): JSX.Element {
+export default function NavbarLayout({children}: Props): ReactNode {
   const {
     navbar: {hideOnScroll, style},
   } = useThemeConfig();

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Logo/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Logo/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Logo from '@theme/Logo';
 
-export default function NavbarLogo(): JSX.Element {
+export default function NavbarLogo(): ReactNode {
   return (
     <Logo
       className="navbar__brand"

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Header/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Header/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
@@ -29,7 +29,7 @@ function CloseButton() {
   );
 }
 
-export default function NavbarMobileSidebarHeader(): JSX.Element {
+export default function NavbarMobileSidebarHeader(): ReactNode {
   return (
     <div className="navbar-sidebar__brand">
       <NavbarLogo />

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
 import type {Props} from '@theme/Navbar/MobileSidebar/Layout';
@@ -14,7 +14,7 @@ export default function NavbarMobileSidebarLayout({
   header,
   primaryMenu,
   secondaryMenu,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {shown: secondaryMenuShown} = useNavbarSecondaryMenu();
   return (
     <div className="navbar-sidebar">

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
 import NavbarItem, {type Props as NavbarItemConfig} from '@theme/NavbarItem';
@@ -16,7 +16,7 @@ function useNavbarItems() {
 }
 
 // The primary menu displays the navbar items
-export default function NavbarMobilePrimaryMenu(): JSX.Element {
+export default function NavbarMobilePrimaryMenu(): ReactNode {
   const mobileSidebar = useNavbarMobileSidebar();
 
   // TODO how can the order be defined for mobile?

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps} from 'react';
+import React, {type ComponentProps, type ReactNode} from 'react';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
 import Translate from '@docusaurus/Translate';
@@ -24,7 +24,7 @@ function SecondaryMenuBackButton(props: ComponentProps<'button'>) {
 
 // The secondary menu slides from the right and shows contextual information
 // such as the docs sidebar
-export default function NavbarMobileSidebarSecondaryMenu(): JSX.Element | null {
+export default function NavbarMobileSidebarSecondaryMenu(): ReactNode {
   const isPrimaryMenuEmpty = useThemeConfig().navbar.items.length === 0;
   const secondaryMenu = useNavbarSecondaryMenu();
   return (

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import IconMenu from '@theme/Icon/Menu';
 
-export default function MobileSidebarToggle(): JSX.Element {
+export default function MobileSidebarToggle(): ReactNode {
   const {toggle, shown} = useNavbarMobileSidebar();
   return (
     <button

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/MobileSidebar/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {
   useLockBodyScroll,
   useNavbarMobileSidebar,
@@ -15,7 +15,7 @@ import NavbarMobileSidebarHeader from '@theme/Navbar/MobileSidebar/Header';
 import NavbarMobileSidebarPrimaryMenu from '@theme/Navbar/MobileSidebar/PrimaryMenu';
 import NavbarMobileSidebarSecondaryMenu from '@theme/Navbar/MobileSidebar/SecondaryMenu';
 
-export default function NavbarMobileSidebar(): JSX.Element | null {
+export default function NavbarMobileSidebar(): ReactNode {
   const mobileSidebar = useNavbarMobileSidebar();
   useLockBodyScroll(mobileSidebar.shown);
 

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/Search/index.tsx
@@ -5,16 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/Navbar/Search';
 
 import styles from './styles.module.css';
 
-export default function NavbarSearch({
-  children,
-  className,
-}: Props): JSX.Element {
+export default function NavbarSearch({children, className}: Props): ReactNode {
   return (
     <div className={clsx(className, styles.navbarSearchContainer)}>
       {children}

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/index.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import NavbarLayout from '@theme/Navbar/Layout';
 import NavbarContent from '@theme/Navbar/Content';
 
-export default function Navbar(): JSX.Element {
+export default function Navbar(): ReactNode {
   return (
     <NavbarLayout>
       <NavbarContent />

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import NavbarNavLink from '@theme/NavbarItem/NavbarNavLink';
 import type {
@@ -52,7 +52,7 @@ export default function DefaultNavbarItem({
   mobile = false,
   position, // Need to destructure position from props so that it doesn't get passed on.
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const Comp = mobile ? DefaultNavbarItemMobile : DefaultNavbarItemDesktop;
   return (
     <Comp

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {
   useActiveDocContext,
   useLayoutDoc,
@@ -18,7 +18,7 @@ export default function DocNavbarItem({
   label: staticLabel,
   docsPluginId,
   ...props
-}: Props): JSX.Element | null {
+}: Props): ReactNode {
   const {activeDoc} = useActiveDocContext(docsPluginId);
   const doc = useLayoutDoc(docId, docsPluginId);
   const pageActive = activeDoc?.path === doc?.path;

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocSidebarNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocSidebarNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {
   useActiveDocContext,
   useLayoutDocsSidebar,
@@ -18,7 +18,7 @@ export default function DocSidebarNavbarItem({
   label,
   docsPluginId,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {activeDoc} = useActiveDocContext(docsPluginId);
   const sidebarLink = useLayoutDocsSidebar(sidebarId, docsPluginId).link;
   if (!sidebarLink) {

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {
   useVersions,
   useActiveDocContext,
@@ -47,7 +47,7 @@ export default function DocsVersionDropdownNavbarItem({
   dropdownItemsBefore,
   dropdownItemsAfter,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {search, hash} = useLocation();
   const activeDocContext = useActiveDocContext(docsPluginId);
   const versions = useVersions(docsPluginId);

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useDocsVersionCandidates} from '@docusaurus/plugin-content-docs/client';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import type {Props} from '@theme/NavbarItem/DocsVersionNavbarItem';
@@ -19,7 +19,7 @@ export default function DocsVersionNavbarItem({
   to: staticTo,
   docsPluginId,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const version = useDocsVersionCandidates(docsPluginId)[0];
   const label = staticLabel ?? version.label;
   const path = staticTo ?? getVersionMainDoc(version).path;

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DropdownNavbarItem/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState, useRef, useEffect} from 'react';
+import React, {useState, useRef, useEffect, type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   isRegexpStringMatch,
@@ -177,7 +177,7 @@ function DropdownNavbarItemMobile({
 export default function DropdownNavbarItem({
   mobile = false,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const Comp = mobile ? DropdownNavbarItemMobile : DropdownNavbarItemDesktop;
   return <Comp {...props} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/HtmlNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/HtmlNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 
 import type {Props} from '@theme/NavbarItem/HtmlNavbarItem';
@@ -15,7 +15,7 @@ export default function HtmlNavbarItem({
   className,
   mobile = false,
   isDropdownItem = false,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const Comp = isDropdownItem ? 'li' : 'div';
   return (
     <Comp

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useAlternatePageUtils} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
@@ -23,7 +23,7 @@ export default function LocaleDropdownNavbarItem({
   dropdownItemsAfter,
   queryString = '',
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {
     i18n: {currentLocale, locales, localeConfigs},
   } = useDocusaurusContext();

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import isInternalUrl from '@docusaurus/isInternalUrl';
@@ -23,7 +23,7 @@ export default function NavbarNavLink({
   isDropdownLink,
   prependBaseUrlToHref,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   // TODO all this seems hacky
   // {to: 'version'} should probably be forbidden, in favor of {to: '/version'}
   const toUrl = useBaseUrl(to);

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/SearchNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import SearchBar from '@theme/SearchBar';
 import NavbarSearch from '@theme/Navbar/Search';
 import type {Props} from '@theme/NavbarItem/SearchNavbarItem';
@@ -13,7 +13,7 @@ import type {Props} from '@theme/NavbarItem/SearchNavbarItem';
 export default function SearchNavbarItem({
   mobile,
   className,
-}: Props): JSX.Element | null {
+}: Props): ReactNode {
   if (mobile) {
     return null;
   }

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import ComponentTypes from '@theme/NavbarItem/ComponentTypes';
 import type {NavbarItemType, Props} from '@theme/NavbarItem';
 
@@ -18,7 +18,7 @@ function normalizeComponentType(type: NavbarItemType, props: object) {
   return type;
 }
 
-export default function NavbarItem({type, ...props}: Props): JSX.Element {
+export default function NavbarItem({type, ...props}: Props): ReactNode {
   const componentType = normalizeComponentType(type, props);
   const NavbarItemComponent = ComponentTypes[componentType];
   if (!NavbarItemComponent) {

--- a/packages/docusaurus-theme-classic/src/theme/NotFound/Content/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NotFound/Content/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/NotFound/Content';
 import Heading from '@theme/Heading';
 
-export default function NotFoundContent({className}: Props): JSX.Element {
+export default function NotFoundContent({className}: Props): ReactNode {
   return (
     <main className={clsx('container margin-vert--xl', className)}>
       <div className="row">

--- a/packages/docusaurus-theme-classic/src/theme/NotFound/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NotFound/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {translate} from '@docusaurus/Translate';
 import {PageMetadata} from '@docusaurus/theme-common';
 import Layout from '@theme/Layout';
 import NotFoundContent from '@theme/NotFound/Content';
 
-export default function Index(): JSX.Element {
+export default function Index(): ReactNode {
   const title = translate({
     id: 'theme.NotFound.title',
     message: 'Page Not Found',

--- a/packages/docusaurus-theme-classic/src/theme/PaginatorNavLink/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/PaginatorNavLink/index.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import type {Props} from '@theme/PaginatorNavLink';
 
-export default function PaginatorNavLink(props: Props): JSX.Element {
+export default function PaginatorNavLink(props: Props): ReactNode {
   const {permalink, title, subLabel, isNext} = props;
   return (
     <Link

--- a/packages/docusaurus-theme-classic/src/theme/SearchMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SearchMetadata/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import Head from '@docusaurus/Head';
 import type {Props} from '@theme/SearchMetadata';
@@ -19,7 +19,7 @@ export default function SearchMetadata({
   locale,
   version,
   tag,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   // Seems safe to consider here the locale is the language, as the existing
   // docsearch:language filter is afaik a regular string-based filter
   const language = locale;

--- a/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -23,7 +23,7 @@ import SearchMetadata from '@theme/SearchMetadata';
 // Useful for i18n/SEO
 // See https://developers.google.com/search/docs/advanced/crawling/localized-versions
 // See https://github.com/facebook/docusaurus/issues/3317
-function AlternateLangHeaders(): JSX.Element {
+function AlternateLangHeaders(): ReactNode {
   const {
     i18n: {currentLocale, defaultLocale, localeConfigs},
   } = useDocusaurusContext();
@@ -115,7 +115,7 @@ function CanonicalUrlHeaders({permalink}: {permalink?: string}) {
   );
 }
 
-export default function SiteMetadata(): JSX.Element {
+export default function SiteMetadata(): ReactNode {
   const {
     i18n: {currentLocale},
   } = useDocusaurusContext();

--- a/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/SkipToContent/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {SkipToContentLink} from '@docusaurus/theme-common';
 import styles from './styles.module.css';
 
-export default function SkipToContent(): JSX.Element {
+export default function SkipToContent(): ReactNode {
   return <SkipToContentLink className={styles.skipToContent} />;
 }

--- a/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOC/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import TOCItems from '@theme/TOCItems';
 import type {Props} from '@theme/TOC';
@@ -17,7 +17,7 @@ import styles from './styles.module.css';
 const LINK_CLASS_NAME = 'table-of-contents__link toc-highlight';
 const LINK_ACTIVE_CLASS_NAME = 'table-of-contents__link--active';
 
-export default function TOC({className, ...props}: Props): JSX.Element {
+export default function TOC({className, ...props}: Props): ReactNode {
   return (
     <div className={clsx(styles.tableOfContents, 'thin-scrollbar', className)}>
       <TOCItems

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/CollapseButton/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/CollapseButton/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import type {Props} from '@theme/TOCCollapsible/CollapseButton';
@@ -15,7 +15,7 @@ import styles from './styles.module.css';
 export default function TOCCollapsibleCollapseButton({
   collapsed,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <button
       type="button"

--- a/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCCollapsible/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useCollapsible, Collapsible} from '@docusaurus/theme-common';
 import TOCItems from '@theme/TOCItems';
@@ -19,7 +19,7 @@ export default function TOCCollapsible({
   className,
   minHeadingLevel,
   maxHeadingLevel,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {collapsed, toggleCollapsed} = useCollapsible({
     initialState: true,
   });

--- a/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCInline/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import TOCItems from '@theme/TOCItems';
 import type {Props} from '@theme/TOCInline';
 
@@ -15,7 +15,7 @@ export default function TOCInline({
   toc,
   minHeadingLevel,
   maxHeadingLevel,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <div className={styles.tableOfContentsInline}>
       <TOCItems

--- a/packages/docusaurus-theme-classic/src/theme/TOCItems/Tree.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCItems/Tree.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import type {Props} from '@theme/TOCItems/Tree';
 
@@ -15,7 +15,7 @@ function TOCItemTree({
   className,
   linkClassName,
   isChild,
-}: Props): JSX.Element | null {
+}: Props): ReactNode {
   if (!toc.length) {
     return null;
   }

--- a/packages/docusaurus-theme-classic/src/theme/TOCItems/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TOCItems/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useMemo} from 'react';
+import React, {type ReactNode, useMemo} from 'react';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import {
   useTOCHighlight,
@@ -23,7 +23,7 @@ export default function TOCItems({
   minHeadingLevel: minHeadingLevelOption,
   maxHeadingLevel: maxHeadingLevelOption,
   ...props
-}: Props): JSX.Element | null {
+}: Props): ReactNode {
   const themeConfig = useThemeConfig();
 
   const minHeadingLevel =

--- a/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TabItem/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import type {Props} from '@theme/TabItem';
 
@@ -15,7 +15,7 @@ export default function TabItem({
   children,
   hidden,
   className,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <div
       role="tabpanel"

--- a/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tabs/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {cloneElement, type ReactElement} from 'react';
+import React, {cloneElement, type ReactElement, type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   useScrollPositionBlocker,
@@ -87,7 +87,9 @@ function TabList({
           tabIndex={selectedValue === value ? 0 : -1}
           aria-selected={selectedValue === value}
           key={value}
-          ref={(tabControl) => tabRefs.push(tabControl)}
+          ref={(tabControl) => {
+            tabRefs.push(tabControl);
+          }}
           onKeyDown={handleKeydown}
           onClick={handleTabChange}
           {...attributes}
@@ -138,7 +140,7 @@ function TabContent({
   );
 }
 
-function TabsComponent(props: Props): JSX.Element {
+function TabsComponent(props: Props): ReactNode {
   const tabs = useTabs(props);
   return (
     <div className={clsx('tabs-container', styles.tabList)}>
@@ -148,7 +150,7 @@ function TabsComponent(props: Props): JSX.Element {
   );
 }
 
-export default function Tabs(props: Props): JSX.Element {
+export default function Tabs(props: Props): ReactNode {
   const isBrowser = useIsBrowser();
   return (
     <TabsComponent

--- a/packages/docusaurus-theme-classic/src/theme/Tag/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Tag/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import type {Props} from '@theme/Tag';
@@ -17,7 +17,7 @@ export default function Tag({
   label,
   count,
   description,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <Link
       href={permalink}

--- a/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListByLetter/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {listTagsByLetters, type TagLetterEntry} from '@docusaurus/theme-common';
 import Tag from '@theme/Tag';
 import type {Props} from '@theme/TagsListByLetter';
@@ -30,7 +30,7 @@ function TagLetterEntryItem({letterEntry}: {letterEntry: TagLetterEntry}) {
   );
 }
 
-export default function TagsListByLetter({tags}: Props): JSX.Element {
+export default function TagsListByLetter({tags}: Props): ReactNode {
   const letterList = listTagsByLetters(tags);
   return (
     <section className="margin-vert--lg">

--- a/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/TagsListInline/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import Tag from '@theme/Tag';
@@ -13,7 +13,7 @@ import type {Props} from '@theme/TagsListInline';
 
 import styles from './styles.module.css';
 
-export default function TagsListInline({tags}: Props): JSX.Element {
+export default function TagsListInline({tags}: Props): ReactNode {
   return (
     <>
       <b>

--- a/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ThemedImage/index.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {ThemedComponent} from '@docusaurus/theme-common';
 import type {Props} from '@theme/ThemedImage';
 
-export default function ThemedImage(props: Props): JSX.Element {
+export default function ThemedImage(props: Props): ReactNode {
   const {sources, className: parentClassName, alt, ...propsRest} = props;
   return (
     <ThemedComponent className={parentClassName}>

--- a/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Collapsible/index.tsx
@@ -92,7 +92,7 @@ function useCollapseAnimation({
   collapsed,
   animation,
 }: {
-  collapsibleRef: RefObject<HTMLElement>;
+  collapsibleRef: RefObject<HTMLElement | null>;
   collapsed: boolean;
   animation?: CollapsibleAnimationConfig;
 }) {
@@ -263,7 +263,7 @@ type CollapsibleProps = CollapsibleBaseProps & {
  * component will be invisible (zero height) when collapsed. Doesn't provide
  * interactivity by itself: collapse state is toggled through props.
  */
-export function Collapsible({lazy, ...props}: CollapsibleProps): JSX.Element {
+export function Collapsible({lazy, ...props}: CollapsibleProps): ReactNode {
   const Comp = lazy ? CollapsibleLazy : CollapsibleBase;
   return <Comp {...props} />;
 }

--- a/packages/docusaurus-theme-common/src/components/Details/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/Details/index.tsx
@@ -10,6 +10,7 @@ import React, {
   useState,
   type ComponentProps,
   type ReactElement,
+  type ReactNode,
 } from 'react';
 import clsx from 'clsx';
 import useBrokenLinks from '@docusaurus/useBrokenLinks';
@@ -47,7 +48,7 @@ export function Details({
   summary,
   children,
   ...props
-}: DetailsProps): JSX.Element {
+}: DetailsProps): ReactNode {
   useBrokenLinks().collectAnchor(props.id);
 
   const isBrowser = useIsBrowser();

--- a/packages/docusaurus-theme-common/src/components/ThemedComponent/index.tsx
+++ b/packages/docusaurus-theme-common/src/components/ThemedComponent/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import {useColorMode} from '../../contexts/colorMode';
@@ -44,7 +44,7 @@ type Props = {
 export default function ThemedComponent({
   className,
   children,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const isBrowser = useIsBrowser();
   const {colorMode} = useColorMode();
 

--- a/packages/docusaurus-theme-common/src/contexts/announcementBar.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/announcementBar.tsx
@@ -103,7 +103,7 @@ export function AnnouncementBarProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const value = useContextValue();
   return <Context.Provider value={value}>{children}</Context.Provider>;
 }

--- a/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
@@ -181,7 +181,7 @@ export function ColorModeProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const value = useContextValue();
   return <Context.Provider value={value}>{children}</Context.Provider>;
 }

--- a/packages/docusaurus-theme-common/src/contexts/navbarMobileSidebar.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/navbarMobileSidebar.tsx
@@ -85,7 +85,7 @@ export function NavbarMobileSidebarProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const value = useContextValue();
   return <Context.Provider value={value}>{children}</Context.Provider>;
 }

--- a/packages/docusaurus-theme-common/src/contexts/navbarSecondaryMenu/content.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/navbarSecondaryMenu/content.tsx
@@ -43,7 +43,7 @@ export function NavbarSecondaryMenuContentProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const value = useState({component: null, props: null});
   return (
     // @ts-expect-error: this context is hard to type
@@ -76,7 +76,7 @@ export function NavbarSecondaryMenuFiller<P extends object>({
 }: {
   component: NavbarSecondaryMenuComponent<P>;
   props: P;
-}): JSX.Element | null {
+}): ReactNode {
   const context = useContext(Context);
   if (!context) {
     throw new ReactContextError('NavbarSecondaryMenuContentProvider');

--- a/packages/docusaurus-theme-common/src/contexts/navbarSecondaryMenu/display.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/navbarSecondaryMenu/display.tsx
@@ -62,12 +62,12 @@ export function NavbarSecondaryMenuDisplayProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const value = useContextValue();
   return <Context.Provider value={value}>{children}</Context.Provider>;
 }
 
-function renderElement(content: Content): JSX.Element | undefined {
+function renderElement(content: Content): ReactNode {
   if (content.component) {
     const Comp = content.component;
     return <Comp {...content.props} />;
@@ -85,7 +85,7 @@ export function useNavbarSecondaryMenu(): {
    */
   hide: () => void;
   /** The content returned from the current secondary menu filler. */
-  content: JSX.Element | undefined;
+  content: ReactNode;
 } {
   const value = useContext(Context);
   if (!value) {

--- a/packages/docusaurus-theme-common/src/hooks/useCodeWordWrap.ts
+++ b/packages/docusaurus-theme-common/src/hooks/useCodeWordWrap.ts
@@ -11,7 +11,7 @@ import {useMutationObserver} from './useMutationObserver';
 // Callback fires when the "hidden" attribute of a tabpanel changes
 // See https://github.com/facebook/docusaurus/pull/7485
 function useTabBecameVisibleCallback(
-  codeBlockRef: RefObject<HTMLPreElement>,
+  codeBlockRef: RefObject<HTMLPreElement | null>,
   callback: () => void,
 ) {
   const [hiddenTabElement, setHiddenTabElement] = useState<
@@ -53,7 +53,7 @@ function useTabBecameVisibleCallback(
 }
 
 export function useCodeWordWrap(): {
-  readonly codeBlockRef: RefObject<HTMLPreElement>;
+  readonly codeBlockRef: RefObject<HTMLPreElement | null>;
   readonly isEnabled: boolean;
   readonly isCodeScrollable: boolean;
   readonly toggle: () => void;

--- a/packages/docusaurus-theme-common/src/hooks/useCodeWordWrap.ts
+++ b/packages/docusaurus-theme-common/src/hooks/useCodeWordWrap.ts
@@ -11,7 +11,7 @@ import {useMutationObserver} from './useMutationObserver';
 // Callback fires when the "hidden" attribute of a tabpanel changes
 // See https://github.com/facebook/docusaurus/pull/7485
 function useTabBecameVisibleCallback(
-  codeBlockRef: RefObject<HTMLPreElement | null>,
+  codeBlockRef: RefObject<HTMLPreElement>,
   callback: () => void,
 ) {
   const [hiddenTabElement, setHiddenTabElement] = useState<
@@ -53,7 +53,7 @@ function useTabBecameVisibleCallback(
 }
 
 export function useCodeWordWrap(): {
-  readonly codeBlockRef: RefObject<HTMLPreElement | null>;
+  readonly codeBlockRef: RefObject<HTMLPreElement>;
   readonly isEnabled: boolean;
   readonly isCodeScrollable: boolean;
   readonly toggle: () => void;

--- a/packages/docusaurus-theme-common/src/translations/contentVisibilityTranslations.tsx
+++ b/packages/docusaurus-theme-common/src/translations/contentVisibilityTranslations.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
 import Head from '@docusaurus/Head';
 
-export function UnlistedBannerTitle(): JSX.Element {
+export function UnlistedBannerTitle(): ReactNode {
   return (
     <Translate
       id="theme.contentVisibility.unlistedBanner.title"
@@ -19,7 +19,7 @@ export function UnlistedBannerTitle(): JSX.Element {
   );
 }
 
-export function UnlistedBannerMessage(): JSX.Element {
+export function UnlistedBannerMessage(): ReactNode {
   return (
     <Translate
       id="theme.contentVisibility.unlistedBanner.message"
@@ -32,7 +32,7 @@ export function UnlistedBannerMessage(): JSX.Element {
 
 // TODO Docusaurus v4 breaking change (since it's v3 public theme-common API :/)
 //  Move this to theme/ContentVisibility/Unlisted
-export function UnlistedMetadata(): JSX.Element {
+export function UnlistedMetadata(): ReactNode {
   return (
     <Head>
       <meta name="robots" content="noindex, nofollow" />
@@ -40,7 +40,7 @@ export function UnlistedMetadata(): JSX.Element {
   );
 }
 
-export function DraftBannerTitle(): JSX.Element {
+export function DraftBannerTitle(): ReactNode {
   return (
     <Translate
       id="theme.contentVisibility.draftBanner.title"
@@ -50,7 +50,7 @@ export function DraftBannerTitle(): JSX.Element {
   );
 }
 
-export function DraftBannerMessage(): JSX.Element {
+export function DraftBannerMessage(): ReactNode {
   return (
     <Translate
       id="theme.contentVisibility.draftBanner.message"

--- a/packages/docusaurus-theme-common/src/utils/admonitionUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/admonitionUtils.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ReactNode} from 'react';
+import React, {type ReactNode, type ReactElement} from 'react';
 
 // Workaround because it's difficult in MDX v1 to provide a MDX title as props
 // See https://github.com/facebook/docusaurus/pull/7152#issuecomment-1145779682
@@ -16,7 +16,7 @@ function extractMDXAdmonitionTitle(children: ReactNode): {
   const items = React.Children.toArray(children);
   const mdxAdmonitionTitleWrapper = items.find(
     (item) => React.isValidElement(item) && item.type === 'mdxAdmonitionTitle',
-  ) as JSX.Element | undefined;
+  ) as ReactElement<{children: ReactNode}> | undefined;
 
   const rest = items.filter((item) => item !== mdxAdmonitionTitleWrapper);
 

--- a/packages/docusaurus-theme-common/src/utils/errorBoundaryUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/errorBoundaryUtils.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps} from 'react';
+import React, {type ComponentProps, type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
 import {getErrorCausalChain} from '@docusaurus/utils-common';
 import type {Props as ErrorProps} from '@theme/Error';
@@ -13,7 +13,7 @@ import styles from './errorBoundaryUtils.module.css';
 
 export function ErrorBoundaryTryAgainButton(
   props: ComponentProps<'button'>,
-): JSX.Element {
+): ReactNode {
   return (
     <button type="button" {...props}>
       <Translate
@@ -29,7 +29,7 @@ export function ErrorBoundaryTryAgainButton(
 export function ErrorBoundaryErrorMessageFallback({
   error,
   tryAgain,
-}: ErrorProps): JSX.Element {
+}: ErrorProps): ReactNode {
   return (
     <div className={styles.errorBoundaryFallback}>
       <p>{error.message}</p>
@@ -38,7 +38,7 @@ export function ErrorBoundaryErrorMessageFallback({
   );
 }
 
-export function ErrorBoundaryError({error}: {error: Error}): JSX.Element {
+export function ErrorBoundaryError({error}: {error: Error}): ReactNode {
   const causalChain = getErrorCausalChain(error);
   const fullMessage = causalChain.map((e) => e.message).join('\n\nCause:\n');
   return <p className={styles.errorBoundaryError}>{fullMessage}</p>;

--- a/packages/docusaurus-theme-common/src/utils/metadataUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/metadataUtils.tsx
@@ -30,7 +30,7 @@ export function PageMetadata({
   keywords,
   image,
   children,
-}: PageMetadataProps): JSX.Element {
+}: PageMetadataProps): ReactNode {
   const pageTitle = useTitleFormatter(title);
   const {withBaseUrl} = useBaseUrlUtils();
   const pageImage = image ? withBaseUrl(image, {absolute: true}) : undefined;
@@ -75,7 +75,7 @@ export function HtmlClassNameProvider({
 }: {
   className: string;
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const classNameContext = React.useContext(HtmlClassNameContext);
   const className = clsx(classNameContext, classNameProp);
   return (
@@ -103,7 +103,7 @@ export function PluginHtmlClassNameProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const routeContext = useRouteContext();
   const nameClass = pluginNameToClassName(routeContext.plugin.name);
   const idClass = `plugin-id-${routeContext.plugin.id}`;

--- a/packages/docusaurus-theme-common/src/utils/navbarUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/navbarUtils.tsx
@@ -32,7 +32,7 @@ export function splitNavbarItems<T extends {position?: 'left' | 'right'}>(
  * Composes multiple navbar state providers that are mutually dependent and
  * hence can't be re-ordered.
  */
-export function NavbarProvider({children}: {children: ReactNode}): JSX.Element {
+export function NavbarProvider({children}: {children: ReactNode}): ReactNode {
   return (
     <NavbarSecondaryMenuContentProvider>
       <NavbarMobileSidebarProvider>

--- a/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
@@ -44,7 +44,7 @@ export function useEvent<T extends (...args: never[]) => unknown>(
  * Gets `value` from the last render.
  */
 export function usePrevious<T>(value: T): T | undefined {
-  const ref = useRef<T>();
+  const ref = useRef<T>(undefined);
 
   useIsomorphicLayoutEffect(() => {
     ref.current = value;

--- a/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/reactUtils.tsx
@@ -44,7 +44,7 @@ export function useEvent<T extends (...args: never[]) => unknown>(
  * Gets `value` from the last render.
  */
 export function usePrevious<T>(value: T): T | undefined {
-  const ref = useRef<T>(undefined);
+  const ref = useRef<T>();
 
   useIsomorphicLayoutEffect(() => {
     ref.current = value;

--- a/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/scrollUtils.tsx
@@ -20,7 +20,7 @@ import {useEvent, ReactContextError} from './reactUtils';
 
 type ScrollController = {
   /** A boolean ref tracking whether scroll events are enabled. */
-  scrollEventsEnabledRef: React.MutableRefObject<boolean>;
+  scrollEventsEnabledRef: React.RefObject<boolean>;
   /** Enable scroll events in `useScrollPosition`. */
   enableScrollEvents: () => void;
   /** Disable scroll events in `useScrollPosition`. */
@@ -52,7 +52,7 @@ export function ScrollControllerProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const value = useScrollControllerContextValue();
   return (
     <ScrollMonitorContext.Provider value={value}>

--- a/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
@@ -52,7 +52,7 @@ function useSkipToContent(): {
    * so that keyboard navigators can instantly interact with the link and jump
    * to content.
    */
-  containerRef: React.RefObject<HTMLDivElement | null>;
+  containerRef: React.RefObject<HTMLDivElement>;
   /**
    * Callback fired when the skip to content link has been clicked.
    * It will programmatically focus the main content.

--- a/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
+++ b/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useCallback, useRef, type ComponentProps} from 'react';
+import React, {
+  useCallback,
+  useRef,
+  type ComponentProps,
+  type ReactNode,
+} from 'react';
 import {useHistory} from '@docusaurus/router';
 import {translate} from '@docusaurus/Translate';
 import {useLocationChange} from './useLocationChange';
@@ -47,7 +52,7 @@ function useSkipToContent(): {
    * so that keyboard navigators can instantly interact with the link and jump
    * to content.
    */
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   /**
    * Callback fired when the skip to content link has been clicked.
    * It will programmatically focus the main content.
@@ -85,7 +90,7 @@ const DefaultSkipToContentLabel = translate({
 
 type SkipToContentLinkProps = Omit<ComponentProps<'a'>, 'href' | 'onClick'>;
 
-export function SkipToContentLink(props: SkipToContentLinkProps): JSX.Element {
+export function SkipToContentLink(props: SkipToContentLinkProps): ReactNode {
   const linkLabel = props.children ?? DefaultSkipToContentLabel;
   const {containerRef, onClick} = useSkipToContent();
   return (

--- a/packages/docusaurus-theme-live-codeblock/src/theme-live-codeblock.d.ts
+++ b/packages/docusaurus-theme-live-codeblock/src/theme-live-codeblock.d.ts
@@ -17,6 +17,7 @@ declare module '@docusaurus/theme-live-codeblock' {
 }
 
 declare module '@theme/Playground' {
+  import type {ReactNode} from 'react';
   import type {Props as BaseProps} from '@theme/CodeBlock';
   import type {LiveProvider} from 'react-live';
 
@@ -27,7 +28,7 @@ declare module '@theme/Playground' {
     // Allow empty live playgrounds
     children?: string;
   }
-  export default function Playground(props: LiveProviderProps): JSX.Element;
+  export default function Playground(props: LiveProviderProps): ReactNode;
 }
 
 declare module '@theme/ReactLiveScope' {

--- a/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
+++ b/packages/docusaurus-theme-live-codeblock/src/theme/Playground/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import {LiveProvider, LiveEditor, LiveError, LivePreview} from 'react-live';
@@ -23,7 +23,7 @@ import type {ThemeConfig} from '@docusaurus/theme-live-codeblock';
 
 import styles from './styles.module.css';
 
-function Header({children}: {children: React.ReactNode}) {
+function Header({children}: {children: ReactNode}) {
   return <div className={clsx(styles.playgroundHeader)}>{children}</div>;
 }
 
@@ -106,7 +106,7 @@ export default function Playground({
   children,
   transformCode,
   ...props
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const {
     siteConfig: {themeConfig},
   } = useDocusaurusContext();

--- a/packages/docusaurus-theme-mermaid/src/theme-mermaid.d.ts
+++ b/packages/docusaurus-theme-mermaid/src/theme-mermaid.d.ts
@@ -27,9 +27,11 @@ declare module '@docusaurus/theme-mermaid' {
 }
 
 declare module '@theme/Mermaid' {
+  import {type ReactNode} from 'react';
+
   export interface Props {
     value: string;
   }
 
-  export default function Mermaid(props: Props): JSX.Element;
+  export default function Mermaid(props: Props): ReactNode;
 }

--- a/packages/docusaurus-theme-mermaid/src/theme/Mermaid/index.tsx
+++ b/packages/docusaurus-theme-mermaid/src/theme/Mermaid/index.tsx
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect, useRef} from 'react';
-import type {ReactNode} from 'react';
+import React, {useEffect, useRef, type ReactNode} from 'react';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import {ErrorBoundaryErrorMessageFallback} from '@docusaurus/theme-common';
 import {
@@ -22,7 +21,7 @@ function MermaidRenderResult({
   renderResult,
 }: {
   renderResult: RenderResult;
-}): JSX.Element {
+}): ReactNode {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -48,7 +47,7 @@ function MermaidRenderer({value}: Props): ReactNode {
   return <MermaidRenderResult renderResult={renderResult} />;
 }
 
-export default function Mermaid(props: Props): JSX.Element {
+export default function Mermaid(props: Props): ReactNode {
   return (
     <ErrorBoundary
       fallback={(params) => <ErrorBoundaryErrorMessageFallback {...params} />}>

--- a/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
+++ b/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
@@ -38,11 +38,15 @@ declare module '@docusaurus/theme-search-algolia/client' {
 }
 
 declare module '@theme/SearchPage' {
-  export default function SearchPage(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function SearchPage(): ReactNode;
 }
 
 declare module '@theme/SearchBar' {
-  export default function SearchBar(): JSX.Element;
+  import type {ReactNode} from 'react';
+
+  export default function SearchBar(): ReactNode;
 }
 
 declare module '@theme/SearchTranslations' {

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import {createPortal} from 'react-dom';
 import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
 import Head from '@docusaurus/Head';
@@ -114,7 +120,8 @@ function DocSearch({
 
   const history = useHistory();
   const searchContainer = useRef<HTMLDivElement | null>(null);
-  const searchButtonRef = useRef<HTMLButtonElement>(null);
+  // TODO remove after React 19 upgrade?
+  const searchButtonRef = useRef<HTMLButtonElement>(null as any);
   const [isOpen, setIsOpen] = useState(false);
   const [initialQuery, setInitialQuery] = useState<string | undefined>(
     undefined,
@@ -196,7 +203,7 @@ function DocSearch({
     useMemo(
       () =>
         // eslint-disable-next-line react/no-unstable-nested-components
-        (footerProps: Omit<ResultsFooterProps, 'onClose'>): JSX.Element =>
+        (footerProps: Omit<ResultsFooterProps, 'onClose'>): ReactNode =>
           <ResultsFooter {...footerProps} onClose={closeModal} />,
       [closeModal],
     );
@@ -269,7 +276,7 @@ function DocSearch({
   );
 }
 
-export default function SearchBar(): JSX.Element {
+export default function SearchBar(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return <DocSearch {...(siteConfig.themeConfig.algolia as DocSearchProps)} />;
 }

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -199,6 +199,7 @@ function DocSearch({
           })),
   ).current;
 
+  // @ts-expect-error: TODO fix lib issue after React 19, using JSX.Element
   const resultsFooterComponent: DocSearchProps['resultsFooterComponent'] =
     useMemo(
       () =>

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/index.tsx
@@ -7,7 +7,13 @@
 
 /* eslint-disable jsx-a11y/no-autofocus */
 
-import React, {useEffect, useReducer, useRef, useState} from 'react';
+import React, {
+  type ReactNode,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
 import clsx from 'clsx';
 
 import algoliaSearchHelper from 'algoliasearch-helper';
@@ -154,7 +160,7 @@ type ResultDispatcher =
   | {type: 'update'; value: ResultDispatcherState}
   | {type: 'advance'; value?: undefined};
 
-function SearchPageContent(): JSX.Element {
+function SearchPageContent(): ReactNode {
   const {
     i18n: {currentLocale},
   } = useDocusaurusContext();
@@ -530,7 +536,7 @@ function SearchPageContent(): JSX.Element {
   );
 }
 
-export default function SearchPage(): JSX.Element {
+export default function SearchPage(): ReactNode {
   return (
     <HtmlClassNameProvider className="search-page-wrapper">
       <SearchPageContent />

--- a/packages/docusaurus-types/src/swizzle.d.ts
+++ b/packages/docusaurus-types/src/swizzle.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {JSXElementConstructor} from 'react';
+import type {JSX, JSXElementConstructor} from 'react';
 
 export type SwizzleAction = 'eject' | 'wrap';
 export type SwizzleActionStatus = 'safe' | 'unsafe' | 'forbidden';

--- a/packages/docusaurus/src/client/App.tsx
+++ b/packages/docusaurus/src/client/App.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import '@generated/client-modules';
 
 import routes from '@generated/routes';
@@ -37,7 +37,7 @@ function AppNavigation() {
   );
 }
 
-export default function App(): JSX.Element {
+export default function App(): ReactNode {
   return (
     <ErrorBoundary>
       <DocusaurusContextProvider>

--- a/packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx
+++ b/packages/docusaurus/src/client/BaseUrlIssueBanner/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useLocation} from '@docusaurus/router';
 import Head from '@docusaurus/Head';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
@@ -95,7 +95,7 @@ function BaseUrlIssueBanner() {
  *
  * @see https://github.com/facebook/docusaurus/pull/3621
  */
-export default function MaybeBaseUrlIssueBanner(): JSX.Element | null {
+export default function MaybeBaseUrlIssueBanner(): ReactNode {
   const {
     siteConfig: {baseUrl, baseUrlIssueBanner},
   } = useDocusaurusContext();

--- a/packages/docusaurus/src/client/BrokenLinksContext.tsx
+++ b/packages/docusaurus/src/client/BrokenLinksContext.tsx
@@ -46,6 +46,6 @@ export function BrokenLinksProvider({
 }: {
   children: ReactNode;
   brokenLinks: BrokenLinks;
-}): JSX.Element {
+}): ReactNode {
   return <Context.Provider value={brokenLinks}>{children}</Context.Provider>;
 }

--- a/packages/docusaurus/src/client/ClientLifecyclesDispatcher.tsx
+++ b/packages/docusaurus/src/client/ClientLifecyclesDispatcher.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {type ReactElement} from 'react';
+import type {ReactElement, ReactNode} from 'react';
 import clientModules from '@generated/client-modules';
 import useIsomorphicLayoutEffect from './exports/useIsomorphicLayoutEffect';
 import type {ClientModule} from '@docusaurus/types';
@@ -66,7 +66,7 @@ function ClientLifecyclesDispatcher({
   children: ReactElement;
   location: Location;
   previousLocation: Location | null;
-}): JSX.Element {
+}): ReactNode {
   useIsomorphicLayoutEffect(() => {
     if (previousLocation !== location) {
       scrollAfterNavigation({location, previousLocation});

--- a/packages/docusaurus/src/client/PendingNavigation.tsx
+++ b/packages/docusaurus/src/client/PendingNavigation.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {Route} from 'react-router-dom';
 import ClientLifecyclesDispatcher, {
   dispatchLifecycleAction,
@@ -16,7 +16,7 @@ import type {Location} from 'history';
 
 type Props = {
   readonly location: Location;
-  readonly children: JSX.Element;
+  readonly children: ReactNode;
 };
 type State = {
   nextRouteHasLoaded: boolean;
@@ -80,7 +80,7 @@ class PendingNavigation extends React.Component<Props, State> {
     return false;
   }
 
-  override render(): JSX.Element {
+  override render(): ReactNode {
     const {children, location} = this.props;
     // Use a controlled <Route> to trick all descendants into rendering the old
     // location.

--- a/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
+++ b/packages/docusaurus/src/client/SiteMetadataDefaults.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-export default function SiteMetadataDefaults(): JSX.Element {
+export default function SiteMetadataDefaults(): ReactNode {
   const {
     siteConfig: {favicon, title, noIndex},
     i18n: {currentLocale, localeConfigs},

--- a/packages/docusaurus/src/client/browserContext.tsx
+++ b/packages/docusaurus/src/client/browserContext.tsx
@@ -22,7 +22,7 @@ export function BrowserContextProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const [isBrowser, setIsBrowser] = useState(false);
 
   useEffect(() => {

--- a/packages/docusaurus/src/client/docusaurusContext.tsx
+++ b/packages/docusaurus/src/client/docusaurusContext.tsx
@@ -29,6 +29,6 @@ export function DocusaurusContextProvider({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;
 }

--- a/packages/docusaurus/src/client/exports/BrowserOnly.tsx
+++ b/packages/docusaurus/src/client/exports/BrowserOnly.tsx
@@ -5,16 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {isValidElement} from 'react';
+import React, {isValidElement, type ReactNode} from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import type {Props} from '@docusaurus/BrowserOnly';
 
 // Similar comp to the one described here:
 // https://www.joshwcomeau.com/react/the-perils-of-rehydration/#abstractions
-export default function BrowserOnly({
-  children,
-  fallback,
-}: Props): JSX.Element | null {
+export default function BrowserOnly({children, fallback}: Props): ReactNode {
   const isBrowser = useIsBrowser();
 
   if (isBrowser) {

--- a/packages/docusaurus/src/client/exports/ComponentCreator.tsx
+++ b/packages/docusaurus/src/client/exports/ComponentCreator.tsx
@@ -37,7 +37,7 @@ export default function ComponentCreator(
           <RouteContextProvider
             // Do we want a better name than native-default?
             value={{plugin: {name: 'native', id: 'default'}}}>
-            <NotFound {...(props as JSX.IntrinsicAttributes)} />
+            <NotFound {...(props as React.JSX.IntrinsicAttributes)} />
           </RouteContextProvider>
         );
       },

--- a/packages/docusaurus/src/client/exports/Head.tsx
+++ b/packages/docusaurus/src/client/exports/Head.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {Helmet} from 'react-helmet-async';
 import type {Props} from '@docusaurus/Head';
 
-export default function Head(props: Props): JSX.Element {
+export default function Head(props: Props): ReactNode {
   return <Helmet {...props} />;
 }

--- a/packages/docusaurus/src/client/exports/Interpolate.tsx
+++ b/packages/docusaurus/src/client/exports/Interpolate.tsx
@@ -58,7 +58,7 @@ export function interpolate<Str extends string, Value extends ReactNode>(
 export default function Interpolate<Str extends string>({
   children,
   values,
-}: InterpolateProps<Str>): JSX.Element {
+}: InterpolateProps<Str>): ReactNode {
   if (typeof children !== 'string') {
     throw new Error(
       `The Docusaurus <Interpolate> component only accept simple string values. Received: ${

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -10,6 +10,7 @@ import React, {
   useImperativeHandle,
   useRef,
   type ComponentType,
+  type ReactNode,
 } from 'react';
 import {NavLink, Link as RRLink} from 'react-router-dom';
 import {applyTrailingSlash} from '@docusaurus/utils-common';
@@ -39,7 +40,7 @@ function Link(
     ...props
   }: Props,
   forwardedRef: React.ForwardedRef<HTMLAnchorElement>,
-): JSX.Element {
+): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   const {trailingSlash, baseUrl} = siteConfig;
   const router = siteConfig.future.experimental_router;
@@ -99,7 +100,7 @@ function Link(
 
   const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
 
-  const ioRef = useRef<IntersectionObserver>();
+  const ioRef = useRef<IntersectionObserver>(undefined);
 
   const handleRef = (el: HTMLAnchorElement | null) => {
     innerRef.current = el;

--- a/packages/docusaurus/src/client/exports/Link.tsx
+++ b/packages/docusaurus/src/client/exports/Link.tsx
@@ -100,7 +100,7 @@ function Link(
 
   const IOSupported = ExecutionEnvironment.canUseIntersectionObserver;
 
-  const ioRef = useRef<IntersectionObserver>(undefined);
+  const ioRef = useRef<IntersectionObserver>();
 
   const handleRef = (el: HTMLAnchorElement | null) => {
     innerRef.current = el;

--- a/packages/docusaurus/src/client/exports/Translate.tsx
+++ b/packages/docusaurus/src/client/exports/Translate.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {interpolate, type InterpolateValues} from '@docusaurus/Interpolate';
 // Can't read it from context, due to exposing imperative API
 import codeTranslations from '@generated/codeTranslations';
@@ -45,7 +45,7 @@ export default function Translate<Str extends string>({
   children,
   id,
   values,
-}: TranslateProps<Str>): JSX.Element {
+}: TranslateProps<Str>): ReactNode {
   if (children && typeof children !== 'string') {
     console.warn('Illegal <Translate> children', children);
     throw new Error(

--- a/packages/docusaurus/src/client/hasHydratedDataAttribute.tsx
+++ b/packages/docusaurus/src/client/hasHydratedDataAttribute.tsx
@@ -5,13 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReactNode} from 'react';
 import React from 'react';
 import Head from '@docusaurus/Head';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
 // See https://github.com/facebook/docusaurus/pull/9256
 // Docusaurus adds a <html data-has-hydrated="true"> after hydration
-export default function HasHydratedDataAttribute(): JSX.Element {
+export default function HasHydratedDataAttribute(): ReactNode {
   const isBrowser = useIsBrowser();
   return (
     <Head>

--- a/packages/docusaurus/src/client/routeContext.tsx
+++ b/packages/docusaurus/src/client/routeContext.tsx
@@ -46,7 +46,7 @@ export function RouteContextProvider({
   children: ReactNode;
   // Only topmost route has the `plugin` attribute
   value: PluginRouteContext | RouteContext | null;
-}): JSX.Element {
+}): ReactNode {
   const parent = React.useContext(Context);
 
   const mergedValue = useMemo(

--- a/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Error/index.tsx
@@ -16,7 +16,7 @@ import Layout from '@theme/Layout';
 import type {Props} from '@theme/Error';
 import {RouteContextProvider} from '../../routeContext';
 
-function ErrorDisplay({error, tryAgain}: Props): JSX.Element {
+function ErrorDisplay({error, tryAgain}: Props): ReactNode {
   return (
     <div
       style={{
@@ -49,7 +49,7 @@ function ErrorDisplay({error, tryAgain}: Props): JSX.Element {
   );
 }
 
-function ErrorBoundaryError({error}: {error: Error}): JSX.Element {
+function ErrorBoundaryError({error}: {error: Error}): ReactNode {
   const causalChain = getErrorCausalChain(error);
   const fullMessage = causalChain.map((e) => e.message).join('\n\nCause:\n');
   return <p style={{whiteSpace: 'pre-wrap'}}>{fullMessage}</p>;
@@ -70,7 +70,7 @@ function ErrorRouteContextProvider({children}: {children: ReactNode}) {
   );
 }
 
-export default function Error({error, tryAgain}: Props): JSX.Element {
+export default function Error({error, tryAgain}: Props): ReactNode {
   // We wrap the error in its own error boundary because the layout can actually
   // throw too... Only the ErrorDisplay component is simple enough to be
   // considered safe to never throw

--- a/packages/docusaurus/src/client/theme-fallback/Layout/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Layout/index.tsx
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Layout';
 
-export default function Layout({children}: Props): JSX.Element {
+export default function Layout({children}: Props): ReactNode {
   return <>{children}</>;
 }

--- a/packages/docusaurus/src/client/theme-fallback/Loading/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Loading/index.tsx
@@ -8,14 +8,14 @@
 // Should we translate theme-fallback?
 /* eslint-disable @docusaurus/no-untranslated-text */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {LoadingComponentProps} from 'react-loadable';
 
 export default function Loading({
   error,
   retry,
   pastDelay,
-}: LoadingComponentProps): JSX.Element | null {
+}: LoadingComponentProps): ReactNode {
   if (error) {
     return (
       <div

--- a/packages/docusaurus/src/client/theme-fallback/NotFound/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/NotFound/index.tsx
@@ -8,11 +8,11 @@
 // Should we translate theme-fallback?
 /* eslint-disable @docusaurus/no-untranslated-text */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 
-export default function NotFound(): JSX.Element {
+export default function NotFound(): ReactNode {
   return (
     <>
       <Head>

--- a/packages/docusaurus/src/client/theme-fallback/Root/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/Root/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Root';
 
 // Wrapper at the very top of the app, that is applied constantly
@@ -15,6 +15,6 @@ import type {Props} from '@theme/Root';
 // and these providers won't reset state when we navigate
 //
 // See https://github.com/facebook/docusaurus/issues/3919
-export default function Root({children}: Props): JSX.Element {
+export default function Root({children}: Props): ReactNode {
   return <>{children}</>;
 }

--- a/packages/docusaurus/src/client/theme-fallback/SiteMetadata/index.tsx
+++ b/packages/docusaurus/src/client/theme-fallback/SiteMetadata/index.tsx
@@ -4,8 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import type {ReactNode} from 'react';
 
 // To be implemented by the theme with <Head>
-export default function SiteMetadata(): JSX.Element | null {
+export default function SiteMetadata(): ReactNode {
   return null;
 }

--- a/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/JsComponent/index.d.ts
+++ b/packages/docusaurus/src/commands/swizzle/__tests__/__fixtures__/theme/JsComponent/index.d.ts
@@ -1,1 +1,3 @@
-export default function JsComponent(props: {}): JSX.Element;
+import type {ReactNode} from 'react';
+
+export default function JsComponent(props: {}): ReactNode;

--- a/website/_dogfooding/_pages tests/analytics.tsx
+++ b/website/_dogfooding/_pages tests/analytics.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 
 // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647
-export default function Analytics(): JSX.Element {
+export default function Analytics(): ReactNode {
   return (
     <Layout>
       <Heading as="h1">Test Analytics</Heading>

--- a/website/_dogfooding/_pages tests/crashTest.tsx
+++ b/website/_dogfooding/_pages tests/crashTest.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 
@@ -35,7 +35,7 @@ function BoomComponent() {
   return <>{boom && boomParent()}</>;
 }
 
-export default function CrashTestPage(): JSX.Element {
+export default function CrashTestPage(): ReactNode {
   return (
     <Layout>
       {/* eslint-disable-next-line @docusaurus/prefer-docusaurus-heading */}

--- a/website/_dogfooding/_pages tests/embeds.tsx
+++ b/website/_dogfooding/_pages tests/embeds.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import IframeWindow from '@site/src/components/BrowserWindow/IframeWindow';
 import PagePartial from './_pagePartial.mdx';
 
 // See https://github.com/facebook/docusaurus/issues/8672
-export default function Embeds(): JSX.Element {
+export default function Embeds(): ReactNode {
   return (
     <Layout>
       <div style={{padding: 10}}>

--- a/website/_dogfooding/_pages tests/error-boundary-tests.tsx
+++ b/website/_dogfooding/_pages tests/error-boundary-tests.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Interpolate from '@docusaurus/Interpolate';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import ErrorBoundaryTestButton from '@site/src/components/ErrorBoundaryTestButton';
 
-export default function ErrorBoundaryTests(): JSX.Element {
+export default function ErrorBoundaryTests(): ReactNode {
   return (
     <>
       <ErrorBoundaryTestButton>Crash outside layout</ErrorBoundaryTestButton>

--- a/website/_dogfooding/_pages tests/hydration-tests.tsx
+++ b/website/_dogfooding/_pages tests/hydration-tests.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 
@@ -21,7 +21,7 @@ function BuggyText() {
   );
 }
 
-export default function Home(): JSX.Element {
+export default function Home(): ReactNode {
   return (
     <Layout>
       <BuggyText />

--- a/website/_dogfooding/_pages tests/layout-no-children.tsx
+++ b/website/_dogfooding/_pages tests/layout-no-children.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Layout from '@theme/Layout';
 
 // See https://github.com/facebook/docusaurus/issues/6337#issuecomment-1012913647
-export default function LayoutNoChildren(): JSX.Element {
+export default function LayoutNoChildren(): ReactNode {
   return <Layout />;
 }

--- a/website/_dogfooding/_pages tests/link-tests.tsx
+++ b/website/_dogfooding/_pages tests/link-tests.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useRef} from 'react';
+import React, {type ReactNode, useRef} from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 
-export default function LinkTest(): JSX.Element {
+export default function LinkTest(): ReactNode {
   const anchorRef = useRef<HTMLAnchorElement>(null);
   return (
     <Layout>

--- a/website/_dogfooding/_pages tests/react-18/_components/heavyComponent.tsx
+++ b/website/_dogfooding/_pages tests/react-18/_components/heavyComponent.tsx
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
-export default function HeavyComponent(): JSX.Element {
+export default function HeavyComponent(): ReactNode {
   return (
     <div style={{border: 'solid', margin: 10, padding: 10}}>
       <button type="button" onClick={() => alert('click')}>

--- a/website/_dogfooding/_pages tests/react-18/index.tsx
+++ b/website/_dogfooding/_pages tests/react-18/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {Suspense} from 'react';
+import React, {type ReactNode, Suspense} from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
@@ -14,7 +14,7 @@ const HeavyComponentLazy = React.lazy(
   () => import('./_components/heavyComponent'),
 );
 
-export default function React18Tests(): JSX.Element {
+export default function React18Tests(): ReactNode {
   return (
     <Layout>
       <main style={{padding: 30}}>

--- a/website/_dogfooding/_pages tests/z-index-tests.tsx
+++ b/website/_dogfooding/_pages tests/z-index-tests.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Layout from '@theme/Layout';
 
-export default function zIndexTest(): JSX.Element {
+export default function zIndexTest(): ReactNode {
   return (
     <Layout>
       <p id="z-index-test">This should have a z-index of 100</p>

--- a/website/blog/2022/08-01-announcing-docusaurus-2.0/ShowcaseCarousel.tsx
+++ b/website/blog/2022/08-01-announcing-docusaurus-2.0/ShowcaseCarousel.tsx
@@ -7,7 +7,7 @@
 
 /* eslint-disable global-require */
 
-import React, {type ComponentProps} from 'react';
+import React, {type ComponentProps, type ReactNode} from 'react';
 import {
   CarouselProvider,
   Slider,
@@ -48,7 +48,7 @@ export default function ShowcaseCarousel({
 }: {
   sites: Site[];
   aspectRatio: number;
-}): JSX.Element {
+}): ReactNode {
   return (
     <CarouselProvider
       naturalSlideWidth={1}
@@ -72,7 +72,7 @@ export default function ShowcaseCarousel({
   );
 }
 
-export function ShowcaseCarouselV1(): JSX.Element {
+export function ShowcaseCarouselV1(): ReactNode {
   return (
     <ShowcaseCarousel
       aspectRatio={1072 / 584}
@@ -107,7 +107,7 @@ export function ShowcaseCarouselV1(): JSX.Element {
   );
 }
 
-export function ShowcaseCarouselV2(): JSX.Element {
+export function ShowcaseCarouselV2(): ReactNode {
   return (
     <ShowcaseCarousel
       aspectRatio={2148 / 1194}
@@ -172,7 +172,7 @@ export function ShowcaseCarouselV2(): JSX.Element {
   );
 }
 
-export function ShowcaseCarouselV2Theming(): JSX.Element {
+export function ShowcaseCarouselV2Theming(): ReactNode {
   return (
     <ShowcaseCarousel
       aspectRatio={2148 / 1194}

--- a/website/src/components/APITable/index.tsx
+++ b/website/src/components/APITable/index.tsx
@@ -84,7 +84,7 @@ const APITableRowComp = React.forwardRef(APITableRow);
  * assumptions about how the children looks; however, those assumptions
  * should be generally correct in the MDX context.
  */
-export default function APITable({children, name}: Props): JSX.Element {
+export default function APITable({children, name}: Props): ReactNode {
   if (children.type !== 'table') {
     throw new Error(
       'Bad usage of APITable component.\nIt is probably that your Markdown table is malformed.\nMake sure to double-check you have the appropriate number of columns for each table row.',

--- a/website/src/components/BrowserWindow/IframeWindow.tsx
+++ b/website/src/components/BrowserWindow/IframeWindow.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import BrowserWindow from './index';
 
 // Quick and dirty component, to improve later if needed
-export default function IframeWindow({url}: {url: string}): JSX.Element {
+export default function IframeWindow({url}: {url: string}): ReactNode {
   return (
     <div style={{padding: 10}}>
       <BrowserWindow

--- a/website/src/components/BrowserWindow/index.tsx
+++ b/website/src/components/BrowserWindow/index.tsx
@@ -24,7 +24,7 @@ export default function BrowserWindow({
   url = 'http://localhost:3000',
   style,
   bodyStyle,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <div className={styles.browserWindow} style={{...style, minHeight}}>
       <div className={styles.browserWindowHeader}>

--- a/website/src/components/ColorGenerator/index.tsx
+++ b/website/src/components/ColorGenerator/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect, useState} from 'react';
+import React, {type ReactNode, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Color from 'color';
 import Link from '@docusaurus/Link';
@@ -33,7 +33,7 @@ function wcagContrast(foreground: string, background: string) {
   return contrast > 7 ? 'AAA 🏅' : contrast > 4.5 ? 'AA 👍' : 'Fail 🔴';
 }
 
-export default function ColorGenerator(): JSX.Element {
+export default function ColorGenerator(): ReactNode {
   const {colorMode, setColorMode} = useColorMode();
 
   const isDarkTheme = colorMode === 'dark';

--- a/website/src/components/ConfigTabs.tsx
+++ b/website/src/components/ConfigTabs.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import {useActiveVersion} from '@docusaurus/plugin-content-docs/client';
 import Translate, {translate} from '@docusaurus/Translate';
@@ -25,7 +25,7 @@ export default function ConfigTabs({
   code,
   pluginName,
   presetOptionName,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const versionPath = useActiveVersion(docsPluginId)!.path;
 
   return (

--- a/website/src/components/ErrorBoundaryTestButton/index.tsx
+++ b/website/src/components/ErrorBoundaryTestButton/index.tsx
@@ -15,7 +15,7 @@ export default function ErrorBoundaryTestButton({
   children?: ReactNode;
   message?: string;
   cause?: string;
-}): JSX.Element {
+}): ReactNode {
   const [state, setState] = useState(false);
   if (state) {
     throw new Error(message, {

--- a/website/src/components/HackerNewsIcon.tsx
+++ b/website/src/components/HackerNewsIcon.tsx
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 
 export default function HackerNewsIcon({
   size = 54,
 }: {
   size?: number;
-}): JSX.Element {
+}): ReactNode {
   return (
     <Link
       to="https://news.ycombinator.com/item?id=32303052"

--- a/website/src/components/Highlight.tsx
+++ b/website/src/components/Highlight.tsx
@@ -13,7 +13,7 @@ export default function Highlight({
 }: {
   children: ReactNode;
   color: string;
-}): JSX.Element {
+}): ReactNode {
   return (
     <span
       style={{

--- a/website/src/components/NavbarItems/CustomDogfoodNavbarItem.tsx
+++ b/website/src/components/NavbarItems/CustomDogfoodNavbarItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useLocation} from '@docusaurus/router';
 
 // used to dogfood custom navbar elements are possible
@@ -13,7 +13,7 @@ import {useLocation} from '@docusaurus/router';
 export default function CustomDogfoodNavbarItem(props: {
   content: string;
   mobile?: boolean;
-}): JSX.Element | null {
+}): ReactNode {
   const {pathname} = useLocation();
   const shouldRender = pathname === '/tests' || pathname.startsWith('/tests/');
   if (!shouldRender) {

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -7,7 +7,7 @@
 
 /* eslint-disable global-require */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
@@ -56,7 +56,7 @@ interface Props {
   image: string;
   url: string;
   urlTS: string;
-  description: JSX.Element;
+  description: ReactNode;
 }
 
 function PlaygroundCard({name, image, url, urlTS, description}: Props) {
@@ -92,7 +92,7 @@ function PlaygroundCard({name, image, url, urlTS, description}: Props) {
   );
 }
 
-export function PlaygroundCardsRow(): JSX.Element {
+export function PlaygroundCardsRow(): ReactNode {
   return (
     <div className="row">
       {Playgrounds.map((playground) => (

--- a/website/src/components/ProductHuntCard.tsx
+++ b/website/src/components/ProductHuntCard.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {ComponentProps} from 'react';
+import type {ComponentProps, ReactNode} from 'react';
 import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
@@ -16,7 +16,7 @@ export default function ProductHuntCard({
 }: {
   className?: string;
   style?: ComponentProps<'a'>['style'];
-}): JSX.Element {
+}): ReactNode {
   return (
     <Link
       to="https://www.producthunt.com/posts/docusaurus-2-0?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-docusaurus-2-0"

--- a/website/src/components/Svg/index.tsx
+++ b/website/src/components/Svg/index.tsx
@@ -18,7 +18,7 @@ export type SvgIconProps = ComponentProps<'svg'> & {
   children: ReactNode; // Node passed into the SVG element.
 };
 
-export default function Svg(props: SvgIconProps): JSX.Element {
+export default function Svg(props: SvgIconProps): ReactNode {
   const {
     svgClass,
     colorAttr,

--- a/website/src/components/TeamProfileCards/index.tsx
+++ b/website/src/components/TeamProfileCards/index.tsx
@@ -78,7 +78,7 @@ function TeamProfileCardCol(props: ProfileProps) {
   );
 }
 
-export function ActiveTeamRow(): JSX.Element {
+export function ActiveTeamRow(): ReactNode {
   return (
     <div className="row">
       <TeamProfileCardCol
@@ -117,7 +117,7 @@ export function ActiveTeamRow(): JSX.Element {
   );
 }
 
-export function HonoraryAlumniTeamRow(): JSX.Element {
+export function HonoraryAlumniTeamRow(): ReactNode {
   return (
     <div className="row">
       <TeamProfileCardCol
@@ -168,7 +168,7 @@ export function HonoraryAlumniTeamRow(): JSX.Element {
   );
 }
 
-export function StudentFellowsTeamRow(): JSX.Element {
+export function StudentFellowsTeamRow(): ReactNode {
   return (
     <div className="row">
       <TeamProfileCardCol

--- a/website/src/components/Tweet/index.tsx
+++ b/website/src/components/Tweet/index.tsx
@@ -28,7 +28,7 @@ export default function Tweet({
   content,
   date,
   githubUsername,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   return (
     <div className={clsx('card', styles.tweet)}>
       <div className="card__header">

--- a/website/src/components/TweetQuote/index.tsx
+++ b/website/src/components/TweetQuote/index.tsx
@@ -26,7 +26,7 @@ export default function TweetQuote({
   name,
   job,
   children,
-}: Props): JSX.Element {
+}: Props): ReactNode {
   const avatar = `https://unavatar.io/x/${handle}`;
   const profileUrl = `https://x.com/${handle}`;
   return (

--- a/website/src/components/UpgradeGuide/index.tsx
+++ b/website/src/components/UpgradeGuide/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {
   useLatestVersion,
   useActiveDocContext,
@@ -114,7 +114,7 @@ function VersionNotice() {
   return null;
 }
 
-export default function UpgradeGuide(): JSX.Element {
+export default function UpgradeGuide(): ReactNode {
   return (
     <>
       <VersionNotice />

--- a/website/src/components/Versions.tsx
+++ b/website/src/components/Versions.tsx
@@ -27,11 +27,7 @@ type ContextValue = {
 
 const Context = React.createContext<ContextValue | null>(null);
 
-export function VersionsProvider({
-  children,
-}: {
-  children: ReactNode;
-}): JSX.Element {
+export function VersionsProvider({children}: {children: ReactNode}): ReactNode {
   const [canaryVersion, setCanaryVersion] = useState<ContextValue | null>(null);
   const mounted = useRef(true);
   useEffect(() => {
@@ -70,7 +66,7 @@ function useStableVersion(): string {
     : lastVersion;
 }
 
-export function CanaryVersion(): JSX.Element {
+export function CanaryVersion(): ReactNode {
   const canaryVersion = useContext(Context);
   // Show a sensible name
   return canaryVersion ? (
@@ -90,7 +86,7 @@ export function CanaryVersion(): JSX.Element {
   );
 }
 
-export function StableVersion(): JSX.Element {
+export function StableVersion(): ReactNode {
   const currentVersion = useStableVersion();
   return <span>{currentVersion}</span>;
 }
@@ -104,17 +100,17 @@ function useStableMajorVersionNumber(): number {
   return useNextMajorVersionNumber() - 1;
 }
 
-export function NextMajorVersion(): JSX.Element {
+export function NextMajorVersion(): ReactNode {
   const majorVersionNumber = useNextMajorVersionNumber();
   return <span>{majorVersionNumber}</span>;
 }
 
-export function StableMajorVersion(): JSX.Element {
+export function StableMajorVersion(): ReactNode {
   const majorVersionNumber = useStableMajorVersionNumber();
   return <span>{majorVersionNumber}</span>;
 }
 
-function GitBranchLink({branch}: {branch: string}): JSX.Element {
+function GitBranchLink({branch}: {branch: string}): ReactNode {
   return (
     <Link to={`https://github.com/facebook/docusaurus/tree/${branch}`}>
       <code>{branch}</code>
@@ -122,13 +118,13 @@ function GitBranchLink({branch}: {branch: string}): JSX.Element {
   );
 }
 
-export function StableMajorBranchLink(): JSX.Element {
+export function StableMajorBranchLink(): ReactNode {
   const majorVersionNumber = useStableMajorVersionNumber();
   const branch = `docusaurus-v${majorVersionNumber}`;
   return <GitBranchLink branch={branch} />;
 }
 
-export function NextMajorBranchLink(): JSX.Element {
+export function NextMajorBranchLink(): ReactNode {
   return <GitBranchLink branch="main" />;
 }
 
@@ -156,7 +152,7 @@ export function InsertIfCanaryVersionKnown({
   return null;
 }
 
-export function PackageJSONDiff(): JSX.Element {
+export function PackageJSONDiff(): ReactNode {
   const canaryVersion = useContext(Context)?.name ?? '0.0.0-4922';
   const stableVersion = useStableVersion();
   return (
@@ -170,7 +166,7 @@ export function PackageJSONDiff(): JSX.Element {
   );
 }
 
-export function PublishTime(): JSX.Element | null {
+export function PublishTime(): ReactNode {
   const time = useContext(Context)?.time;
   if (!time) {
     return null;

--- a/website/src/data/features.tsx
+++ b/website/src/data/features.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 
 export type FeatureItem = {
@@ -15,7 +15,7 @@ export type FeatureItem = {
     width: number;
     height: number;
   };
-  text: JSX.Element;
+  text: ReactNode;
 };
 
 const FEATURES: FeatureItem[] = [

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -23,6 +23,7 @@ import Heading from '@theme/Heading';
 
 import styles from './styles.module.css';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
+import type {ReactNode} from 'react';
 
 function HeroBanner() {
   return (
@@ -257,7 +258,7 @@ function TopBanner() {
   );
 }
 
-export default function Home(): JSX.Element {
+export default function Home(): ReactNode {
   const {
     siteConfig: {customFields, tagline},
   } = useDocusaurusContext();

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import Link from '@docusaurus/Link';
@@ -23,7 +24,6 @@ import Heading from '@theme/Heading';
 
 import styles from './styles.module.css';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
-import type {ReactNode} from 'react';
 
 function HeroBanner() {
   return (

--- a/website/src/pages/showcase/index.tsx
+++ b/website/src/pages/showcase/index.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 
 import Link from '@docusaurus/Link';
@@ -35,7 +36,7 @@ function ShowcaseHeader() {
   );
 }
 
-export default function Showcase(): JSX.Element {
+export default function Showcase(): ReactNode {
   return (
     <Layout title={TITLE} description={DESCRIPTION}>
       <main className="margin-vert--lg">

--- a/website/src/pages/versions.tsx
+++ b/website/src/pages/versions.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReactNode} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
@@ -34,7 +35,7 @@ function ReleaseNotesLabel() {
   );
 }
 
-export default function Version(): JSX.Element {
+export default function Version(): ReactNode {
   const {
     siteConfig: {organizationName, projectName},
   } = useDocusaurusContext();

--- a/website/src/plugins/changelog/theme/ChangelogItem/Header/Author/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogItem/Header/Author/index.tsx
@@ -5,17 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import type {Props} from '@theme/Blog/Components/Author';
 
 import styles from './styles.module.css';
 
-export default function ChangelogAuthor({
-  author,
-  className,
-}: Props): JSX.Element {
+export default function ChangelogAuthor({author, className}: Props): ReactNode {
   const {name, url, imageURL} = author;
   return (
     <div className={clsx('avatar margin-bottom--sm', className)}>

--- a/website/src/plugins/changelog/theme/ChangelogItem/Header/Authors/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogItem/Header/Authors/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState} from 'react';
+import React, {type ReactNode, useState} from 'react';
 import clsx from 'clsx';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import ChangelogItemHeaderAuthor from '@theme/ChangelogItem/Header/Author';
@@ -15,9 +15,7 @@ import type {Props} from '@theme/BlogPostItem/Header/Authors';
 import styles from './styles.module.css';
 
 // Component responsible for the authors layout
-export default function BlogPostAuthors({
-  className,
-}: Props): JSX.Element | null {
+export default function BlogPostAuthors({className}: Props): ReactNode {
   const {
     metadata: {authors},
     assets,

--- a/website/src/plugins/changelog/theme/ChangelogItem/Header/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogItem/Header/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 
 import BlogPostItemHeaderTitle from '@theme/BlogPostItem/Header/Title';
@@ -24,7 +24,7 @@ function ChangelogTitle() {
   );
 }
 
-export default function ChangelogItemHeader(): JSX.Element {
+export default function ChangelogItemHeader(): ReactNode {
   return (
     <header>
       <ChangelogTitle />

--- a/website/src/plugins/changelog/theme/ChangelogItem/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogItem/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import ChangelogItemHeader from '@theme/ChangelogItem/Header';
 import type {Props} from '@theme/BlogPostItem';
 import BlogPostItemContainer from '@theme/BlogPostItem/Container';
@@ -13,7 +13,7 @@ import BlogPostItemContent from '@theme/BlogPostItem/Content';
 
 import styles from './styles.module.css';
 
-export default function ChangelogItem({children}: Props): JSX.Element {
+export default function ChangelogItem({children}: Props): ReactNode {
   return (
     <BlogPostItemContainer className={styles.changelogItemContainer}>
       <ChangelogItemHeader />

--- a/website/src/plugins/changelog/theme/ChangelogList/Header/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogList/Header/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
@@ -61,7 +61,7 @@ export default function ChangelogListHeader({
   blogTitle,
 }: {
   blogTitle: string;
-}): JSX.Element {
+}): ReactNode {
   return (
     <header className="margin-bottom--lg">
       <Heading as="h1" style={{fontSize: '3rem'}}>

--- a/website/src/plugins/changelog/theme/ChangelogList/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogList/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   PageMetadata,
@@ -20,7 +20,7 @@ import ChangelogItem from '@theme/ChangelogItem';
 import ChangelogListHeader from '@theme/ChangelogList/Header';
 import type {Props} from '@theme/BlogListPage';
 
-function ChangelogListMetadata(props: Props): JSX.Element {
+function ChangelogListMetadata(props: Props): ReactNode {
   const {metadata} = props;
   const {blogTitle, blogDescription} = metadata;
   return (
@@ -31,7 +31,7 @@ function ChangelogListMetadata(props: Props): JSX.Element {
   );
 }
 
-function ChangelogListContent(props: Props): JSX.Element {
+function ChangelogListContent(props: Props): ReactNode {
   const {metadata, items, sidebar} = props;
   const {blogTitle} = metadata;
   return (
@@ -43,7 +43,7 @@ function ChangelogListContent(props: Props): JSX.Element {
   );
 }
 
-export default function ChangelogList(props: Props): JSX.Element {
+export default function ChangelogList(props: Props): ReactNode {
   return (
     <HtmlClassNameProvider
       className={clsx(

--- a/website/src/plugins/changelog/theme/ChangelogPage/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogPage/index.tsx
@@ -39,7 +39,7 @@ function ChangelogPageContent({
 }: {
   sidebar: BlogSidebar;
   children: ReactNode;
-}): JSX.Element {
+}): ReactNode {
   const {metadata, toc} = useBlogPost();
   const {nextItem, prevItem, frontMatter} = metadata;
   const {
@@ -73,7 +73,7 @@ function ChangelogPageContent({
 // This page doesn't change anything. It's just swapping BlogPostItem with our
 // own ChangelogItem. We don't want to apply the swizzled item to the actual
 // blog.
-export default function ChangelogPage(props: Props): JSX.Element {
+export default function ChangelogPage(props: Props): ReactNode {
   const ChangelogContent = props.content;
   return (
     <BlogPostProvider content={props.content} isBlogPostPage>

--- a/website/src/plugins/changelog/theme/ChangelogPaginator/index.tsx
+++ b/website/src/plugins/changelog/theme/ChangelogPaginator/index.tsx
@@ -7,12 +7,12 @@
 
 // Changed the text labels.
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import PaginatorNavLink from '@theme/PaginatorNavLink';
 import type {Props} from '@theme/BlogPostPaginator';
 
-export default function ChangelogPaginator(props: Props): JSX.Element {
+export default function ChangelogPaginator(props: Props): ReactNode {
   const {nextItem, prevItem} = props;
 
   return (

--- a/website/src/plugins/changelog/theme/Icon/Expand/index.tsx
+++ b/website/src/plugins/changelog/theme/Icon/Expand/index.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 
 import type {Props} from '@theme/Icon/Expand';
 
-export default function IconExpand({expanded, ...props}: Props): JSX.Element {
+export default function IconExpand({expanded, ...props}: Props): ReactNode {
   if (expanded) {
     return (
       <svg

--- a/website/src/plugins/changelog/theme/types.d.ts
+++ b/website/src/plugins/changelog/theme/types.d.ts
@@ -16,11 +16,11 @@ declare module '@theme/ChangelogList';
 declare module '@theme/ChangelogList/Header';
 
 declare module '@theme/Icon/Expand' {
-  import type {ComponentProps} from 'react';
+  import type {ComponentProps, ReactNode} from 'react';
 
   export interface Props extends ComponentProps<'svg'> {
     expanded?: boolean;
   }
 
-  export default function IconExpand(props: Props): JSX.Element;
+  export default function IconExpand(props: Props): ReactNode;
 }

--- a/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
+++ b/website/src/plugins/featureRequests/FeatureRequestsPage.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect} from 'react';
+import React, {type ReactNode, useEffect} from 'react';
 import clsx from 'clsx';
 import {useColorMode} from '@docusaurus/theme-common';
 import Layout from '@theme/Layout';
@@ -48,7 +48,7 @@ export default function FeatureRequests({
   basePath,
 }: {
   basePath: string;
-}): JSX.Element {
+}): ReactNode {
   return (
     <Layout title="Feedback" description="Docusaurus 2 Feature Requests page">
       <CannyWidget basePath={basePath} />

--- a/website/src/theme/Admonition/Types.tsx
+++ b/website/src/theme/Admonition/Types.tsx
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import type {Props} from '@theme/Admonition';
 import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
 import Heading from '@theme/Heading';
 
-function MyCustomAdmonition(props: Props): JSX.Element {
+function MyCustomAdmonition(props: Props): ReactNode {
   return (
     <div style={{border: 'solid red', padding: 10}}>
       <Heading as="h5" style={{color: 'blue', fontSize: 30}}>

--- a/website/src/theme/CodeBlock/index.tsx
+++ b/website/src/theme/CodeBlock/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import CodeBlock from '@theme-original/CodeBlock';
 import type {Props} from '@theme/CodeBlock';
 
 // This component does nothing on purpose
 // Dogfood: wrapping a theme component already enhanced by another theme
 // See https://github.com/facebook/docusaurus/pull/5983
-export default function CodeBlockWrapper(props: Props): JSX.Element {
+export default function CodeBlockWrapper(props: Props): ReactNode {
   return <CodeBlock {...props} />;
 }

--- a/website/src/theme/ColorModeToggle.tsx
+++ b/website/src/theme/ColorModeToggle.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import OriginalToggle from '@theme-original/ColorModeToggle';
 import {
   lightStorage,
@@ -24,7 +24,7 @@ import type {Props} from '@theme/ColorModeToggle';
 // session storage, and we need to apply the same style when toggling modes even
 // when we are not on the styling-layout page. The only way to do this so far is
 // by hooking into the Toggle component.
-export default function ColorModeToggle(props: Props): JSX.Element {
+export default function ColorModeToggle(props: Props): ReactNode {
   return (
     <OriginalToggle
       {...props}

--- a/website/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/website/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import {useLayoutDoc} from '@docusaurus/plugin-content-docs/client';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
@@ -34,7 +34,7 @@ function HintFooter() {
 
 export default function DocCategoryGeneratedIndexPageWrapper(
   props: Props,
-): JSX.Element {
+): ReactNode {
   return (
     <>
       <DocCategoryGeneratedIndexPage {...props} />

--- a/website/src/theme/Layout/index.tsx
+++ b/website/src/theme/Layout/index.tsx
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Layout from '@theme-original/Layout';
 import type {Props} from '@theme/Layout';
 
 // This component is only used to test for CSS insertion order
 import './styles.module.css';
 
-export default function LayoutWrapper(props: Props): JSX.Element {
+export default function LayoutWrapper(props: Props): ReactNode {
   return <Layout {...props} />;
 }

--- a/website/src/theme/ReactLiveScope/components.tsx
+++ b/website/src/theme/ReactLiveScope/components.tsx
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ComponentProps} from 'react';
+import React, {type ComponentProps, type ReactNode} from 'react';
 
-export function ButtonExample(props: ComponentProps<'button'>): JSX.Element {
+export function ButtonExample(props: ComponentProps<'button'>): ReactNode {
   return (
     <button
       type="button"


### PR DESCRIPTION
## Motivation

This is quite verbose, but a v3 retro-compatible change to prepare for v4 React 19 (https://github.com/facebook/docusaurus/pull/10745) and reduce the diff of that PR

Avoid using `JSX.Element`, use `ReactNode` instead.

See also:
- https://react.dev/blog/2024/04/25/react-19-upgrade-guide#typescript-changes
- https://www.totaltypescript.com/jsx-element-vs-react-reactnode


## Test Plan

CI

### Test links

https://deploy-preview-10746--docusaurus-2.netlify.app/
