### PR TITLE
fix(docs): fix sidebar item visibility bug for category index

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsUtils.test.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/__tests__/docsUtils.test.tsx
@@ -440,6 +440,7 @@ describe('isVisibleSidebarItem', () => {
   it('works with category', () => {
     const subCategoryAllUnlisted = testCategory({
       href: '/sub-category-path',
+      linkUnlisted: true,
       items: [
         {
           type: 'link',
@@ -455,6 +456,7 @@ describe('isVisibleSidebarItem', () => {
         },
         testCategory({
           href: '/sub-sub-category-path',
+          linkUnlisted: true,
           items: [
             {
               type: 'link',
@@ -499,6 +501,22 @@ describe('isVisibleSidebarItem', () => {
     );
     expect(
       isVisibleSidebarItem(categorySomeUnlisted, categorySomeUnlisted.href!),
+    ).toBe(true);
+
+    const categoryOnlyIndexListed = testCategory({
+      href: '/category-only-index-listed',
+      items: [
+        {
+          type: 'link',
+          href: '/sub-link-path',
+          label: 'Label',
+          unlisted: true,
+        },
+        subCategoryAllUnlisted,
+      ],
+    });
+    expect(
+      isVisibleSidebarItem(categoryOnlyIndexListed, '/nonexistentPath'),
     ).toBe(true);
   });
 });

--- a/packages/docusaurus-plugin-content-docs/src/client/docsUtils.tsx
+++ b/packages/docusaurus-plugin-content-docs/src/client/docsUtils.tsx
@@ -168,6 +168,7 @@ export function isVisibleSidebarItem(
     case 'category':
       return (
         isActiveSidebarItem(item, activePath) ||
+        (typeof item.href !== 'undefined' && !item.linkUnlisted) ||
         item.items.some((subItem) => isVisibleSidebarItem(subItem, activePath))
       );
     case 'link':

--- a/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/subcategory-with-listed-index/index.mdx
+++ b/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/subcategory-with-listed-index/index.mdx
@@ -1,11 +1,11 @@
 ---
-unlisted: true
+unlisted: false
 tags: [visibility, unlisted]
 ---
 
-# Subcategory index unlisted
+# Subcategory index listed
 
-Doc with unlisted front matter
+Doc index, **listed**, but all the other category items are unlisted
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/subcategory-with-listed-index/unlisted1.mdx
+++ b/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/subcategory-with-listed-index/unlisted1.mdx
@@ -1,0 +1,8 @@
+---
+unlisted: true
+tags: [visibility, unlisted]
+---
+
+# Unlisted 1
+
+Doc with unlisted front matter

--- a/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/subcategory-with-listed-index/unlisted2.mdx
+++ b/website/_dogfooding/_docs tests/tests/visibility/some-unlisteds/subcategory-with-listed-index/unlisted2.mdx
@@ -1,0 +1,8 @@
+---
+unlisted: true
+tags: [visibility, unlisted]
+---
+
+# Unlisted 2
+
+Doc with unlisted front matter


### PR DESCRIPTION

## Motivation

Fix bug where category with listed doc index is hidden instead of staying visible

Fix https://github.com/facebook/docusaurus/issues/10749

## Test Plan

Unit tests + dogfood

### Test links

https://deploy-preview-10754--docusaurus-2.netlify.app/tests/docs/tests/visibility

https://deploy-preview-10754--docusaurus-2.netlify.app/tests/docs/tests/visibility/some-unlisteds/subcategory-with-listed-index
