### PR TITLE
fix(algolia): properly forward placeholder/translations to DocSearch components

### DIFF
--- a/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
+++ b/packages/docusaurus-theme-search-algolia/src/theme-search-algolia.d.ts
@@ -7,23 +7,36 @@
 
 declare module '@docusaurus/theme-search-algolia' {
   import type {DeepPartial} from 'utility-types';
+  import type {DocSearchProps} from '@docsearch/react';
 
-  export type ThemeConfig = {
-    algolia: {
-      contextualSearch: boolean;
-      externalUrlRegex?: string;
-      appId: string;
-      apiKey: string;
-      indexName: string;
-      searchParameters: {[key: string]: unknown};
-      searchPagePath: string | false | null;
-      replaceSearchResultPathname?: {
-        from: string;
-        to: string;
-      };
-      insights?: boolean;
+  // DocSearch props that Docusaurus exposes directly through props forwarding
+  type DocusaurusDocSearchProps = Pick<
+    DocSearchProps,
+    | 'appId'
+    | 'apiKey'
+    | 'indexName'
+    | 'placeholder'
+    | 'translations'
+    | 'searchParameters'
+    | 'insights'
+    | 'initialQuery'
+  >;
+
+  type ThemeConfigAlgolia = DocusaurusDocSearchProps & {
+    // Docusaurus custom options, not coming from DocSearch
+    contextualSearch: boolean;
+    externalUrlRegex?: string;
+    searchPagePath: string | false | null;
+    replaceSearchResultPathname?: {
+      from: string;
+      to: string;
     };
   };
+
+  export type ThemeConfig = DocusaurusDocSearchProps & {
+    algolia: ThemeConfigAlgolia;
+  };
+
   export type UserThemeConfig = DeepPartial<ThemeConfig>;
 }
 

--- a/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -242,7 +242,7 @@ function DocSearch({
         onMouseOver={importDocSearchModalIfNeeded}
         onClick={openModal}
         ref={searchButtonRef}
-        translations={translations.button}
+        translations={props.translations?.button ?? translations.button}
       />
 
       {isOpen &&
@@ -260,10 +260,10 @@ function DocSearch({
             {...(props.searchPagePath && {
               resultsFooterComponent,
             })}
-            {...props}
-            searchParameters={searchParameters}
             placeholder={translations.placeholder}
-            translations={translations.modal}
+            {...props}
+            translations={props.translations?.modal ?? translations.modal}
+            searchParameters={searchParameters}
           />,
           searchContainer.current,
         )}

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -613,12 +613,6 @@ export default async function createConfigAsync() {
         appId: 'X1Z85QJPUV',
         apiKey: 'bf7211c161e8205da2f933a02534105a',
         indexName: 'docusaurus-2',
-        placeholder: 'TEST',
-        translations: {
-          button: {
-            buttonText: 'BUT',
-          },
-        },
         replaceSearchResultPathname:
           isDev || isDeployPreview
             ? {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -613,6 +613,12 @@ export default async function createConfigAsync() {
         appId: 'X1Z85QJPUV',
         apiKey: 'bf7211c161e8205da2f933a02534105a',
         indexName: 'docusaurus-2',
+        placeholder: 'TEST',
+        translations: {
+          button: {
+            buttonText: 'BUT',
+          },
+        },
         replaceSearchResultPathname:
           isDev || isDeployPreview
             ? {


### PR DESCRIPTION
## Motivation

Although placeholder/button/modal translations are provided through our i18n support (`docusaurus write-translations`), it should be possible for non-localized sites to provide labels through `themeConfig.algolia` since it's more convenient.

Fix https://github.com/facebook/docusaurus/issues/10774



## Test Plan

Dogfood locally:

```ts
      algolia: {
        appId: 'X1Z85QJPUV',
        apiKey: 'bf7211c161e8205da2f933a02534105a',
        indexName: 'docusaurus-2',
        placeholder: 'TEST',
        translations: {
          button: {
            buttonText: 'BUT',
          },
        },
```

![CleanShot 2024-12-26 at 16 14 13](https://github.com/user-attachments/assets/e084ea1e-1769-46de-aafd-4fa68343d8c7)

![CleanShot 2024-12-26 at 16 14 22](https://github.com/user-attachments/assets/b19f0cfa-8479-48a3-b80d-f8937929fbc5)



### Test links

Before dogfood revert: 
https://676d73221292100008784f50--docusaurus-2.netlify.app/

PR:
https://deploy-preview-10799--docusaurus-2.netlify.app/

