### PR TITLE
fix(npm-to-yarn): add missing npm-to-yarn converter for Bun

### DIFF
--- a/packages/docusaurus-remark-plugin-npm2yarn/README.md
+++ b/packages/docusaurus-remark-plugin-npm2yarn/README.md
@@ -63,11 +63,11 @@ module.exports = {
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
 | `sync` | `boolean` | `false` | Syncing tab choices (Yarn and npm). See https://docusaurus.io/docs/markdown-features/#syncing-tab-choices for details. |
-| `converters` | `array` | `'yarn'`, `'pnpm'` | The list of converters to use. The order of the converters is important, as the first converter will be used as the default choice. |
+| `converters` | `array` | `'yarn'`, `'pnpm'`, `'bun'` | The list of converters to use. The order of the converters is important, as the first converter will be used as the default choice. |
 
 ## Custom converters
 
-In case you want to convert npm commands to something else than `yarn` or `pnpm`, you can use custom converters:
+In case you want to convert npm commands to something else than `yarn`, `pnpm` or `bun`, you can use custom converters:
 
 ```ts
 type CustomConverter = [name: string, cb: (npmCode: string) => string];
@@ -83,6 +83,7 @@ type CustomConverter = [name: string, cb: (npmCode: string) => string];
         converters: [
           'yarn',
           'pnpm',
+          'bun',
           ['Turbo', (code) => code.replace(/npm/g, 'turbo')],
         ],
       },

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/__snapshots__/index.test.ts.snap
@@ -145,6 +145,30 @@ npm install --save docusaurus-plugin-name
 "
 `;
 
+exports[`npm2yarn plugin work with bun converter 1`] = `
+"import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+## Installing a plugin
+
+A plugin is usually a npm package, so you install them like other npm packages using npm.
+
+<Tabs>
+  <TabItem value="npm">
+    \`\`\`bash
+    npm install --save docusaurus-plugin-name
+    \`\`\`
+  </TabItem>
+
+  <TabItem value="bun" label="Bun">
+    \`\`\`bash
+    bun add docusaurus-plugin-name
+    \`\`\`
+  </TabItem>
+</Tabs>
+"
+`;
+
 exports[`npm2yarn plugin work with custom converter 1`] = `
 "import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.ts
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/__tests__/index.test.ts
@@ -109,6 +109,12 @@ describe('npm2yarn plugin', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('work with bun converter', async () => {
+    const result = await processFixture('plugin', {converters: ['bun']});
+
+    expect(result).toMatchSnapshot();
+  });
+
   it('work with custom converter', async () => {
     const result = await processFixture('plugin', {
       converters: [['Turbo', (code) => code.replace(/npm/g, 'turbo')]],

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
@@ -20,7 +20,7 @@ import type {Transformer} from 'unified';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type Plugin<T> = any; // TODO fix this asap
 
-type KnownConverter = 'yarn' | 'pnpm';
+type KnownConverter = 'yarn' | 'pnpm' | 'bun';
 
 type CustomConverter = [name: string, cb: (npmCode: string) => string];
 
@@ -90,7 +90,7 @@ const transformNode = (
         code: npmToYarn(npmCode, converter),
         node,
         value: converter,
-        label: converter === 'yarn' ? 'Yarn' : converter,
+        label: getLabelForConverter(converter),
       });
     }
     const [converterName, converterFn] = converter;
@@ -99,6 +99,17 @@ const transformNode = (
       node,
       value: converterName,
     });
+  }
+
+  function getLabelForConverter(converter: KnownConverter) {
+    switch (converter) {
+      case 'yarn':
+        return 'Yarn';
+      case 'bun':
+        return 'Bun';
+      default:
+        return converter;
+    }
   }
 
   return [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Hi there 👋

This PR enables passing `bun` to the `npm2yarn` converter. The option is already available to the underlying [`npm-to-yarn` package](https://github.com/nebrelbug/npm-to-yarn) since [v2.1.0](https://github.com/nebrelbug/npm-to-yarn/releases/tag/v2.1.0) (and we are already using v3.0.0).

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-10803--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
