### PR TITLE
feat(theme): add option to use language as title for code blocks

### DIFF
--- a/packages/docusaurus-theme-classic/src/options.ts
+++ b/packages/docusaurus-theme-classic/src/options.ts
@@ -78,6 +78,9 @@ export const DEFAULT_CONFIG: ThemeConfig = {
     minHeadingLevel: 2,
     maxHeadingLevel: 3,
   },
+  codeBlock: {
+    useLanguageAsTitle: false,
+  },
 };
 
 const NavbarItemPosition = Joi.string().equal('left', 'right').default('left');

--- a/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/String.tsx
@@ -41,6 +41,7 @@ export default function CodeBlockString({
 }: Props): ReactNode {
   const {
     prism: {defaultLanguage, magicComments},
+    codeBlock: {useLanguageAsTitle},
   } = useThemeConfig();
   const language = normalizeLanguage(
     languageProp ?? parseLanguage(blockClassName) ?? defaultLanguage,
@@ -52,7 +53,10 @@ export default function CodeBlockString({
   // We still parse the metastring in case we want to support more syntax in the
   // future. Note that MDX doesn't strip quotes when parsing metastring:
   // "title=\"xyz\"" => title: "\"xyz\""
-  const title = parseCodeBlockTitle(metastring) || titleProp;
+  const title =
+    parseCodeBlockTitle(metastring) ||
+    titleProp ||
+    (useLanguageAsTitle && language);
 
   const {lineClassNames, code} = parseLines(children, {
     metastring,

--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -103,6 +103,10 @@ export type TableOfContents = {
   maxHeadingLevel: number;
 };
 
+export type CodeBlock = {
+  useLanguageAsTitle: boolean;
+};
+
 // Theme config after validation/normalization
 export type ThemeConfig = {
   docs: {
@@ -132,6 +136,7 @@ export type ThemeConfig = {
   image?: string;
   metadata: {[key: string]: string}[];
   tableOfContents: TableOfContents;
+  codeBlock: CodeBlock;
 };
 
 // User-provided theme config, unnormalized

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -561,6 +561,7 @@ export default async function createConfigAsync() {
     ],
 
     themeConfig: {
+      codeBlock: {useLanguageAsTitle: true},
       liveCodeBlock: {
         playgroundPosition: 'bottom',
       },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #10808) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Currently, Docusaurus renders the language specified in a codeblock as part of its syntax highlighting, but it doesn't allow using the language as the container title. This proposal suggests adding an option to display the codeblock's language as the title of the container for improved clarity and user experience.

When documenting code examples, it's often helpful to explicitly label the codeblocks with their language for better readability and context. While custom titles can be added using the title attribute in fenced codeblocks, it would be beneficial to have a built-in feature that automatically uses the language as the container title.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
