### PR TITLE
fix: perflogger mark detail bug

### DIFF
--- a/packages/docusaurus-logger/src/perfLogger.ts
+++ b/packages/docusaurus-logger/src/perfLogger.ts
@@ -114,12 +114,24 @@ function createPerfLogger(): PerfLoggerAPI {
       },
     });
 
-  const end: PerfLoggerAPI['end'] = (label) => {
-    const {
-      duration,
-      detail: {memoryUsage},
-    } = performance.measure(label);
+  const readMark = (label: string) => {
+    const startMark = performance.getEntriesByName(
+      label,
+      'mark',
+    )?.[0] as PerformanceMark;
+    if (!startMark) {
+      throw new Error(`No performance start mark for label=${label}`);
+    }
     performance.clearMarks(label);
+    return startMark;
+  };
+
+  const end: PerfLoggerAPI['end'] = (label) => {
+    const startMark = readMark(label);
+    const duration = performance.now() - startMark.startTime;
+    const {
+      detail: {memoryUsage},
+    } = startMark;
     printPerfLog({
       label: applyParentPrefix(label),
       duration,


### PR DESCRIPTION

## Motivation

This is mostly internal code but my perflogger start/end system wasn't working properly due to bad assumption I had of how `performance.measure()` works. It was only visible when building with the hash router because most code is using `perflogger.async()` instead of `start() / end()`


## Test Plan

local 😅 
