### PR TITLE
chore(plugin-debug): upgrade react-json-view-lite to v2, prepare for React 19

### DIFF
--- a/packages/docusaurus-plugin-debug/package.json
+++ b/packages/docusaurus-plugin-debug/package.json
@@ -24,7 +24,7 @@
     "@docusaurus/types": "3.7.0",
     "@docusaurus/utils": "3.7.0",
     "fs-extra": "^11.1.1",
-    "react-json-view-lite": "^1.2.0",
+    "react-json-view-lite": "^2.1.0",
     "tslib": "^2.6.0"
   },
   "peerDependencies": {

--- a/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/index.tsx
@@ -30,6 +30,7 @@ const paraisoStyles: JsonViewProps['style'] = {
   collapseIcon: styles.collapseIconParaiso!,
   expandIcon: styles.expandIconParaiso!,
   collapsedContent: styles.collapseContentParaiso!,
+  childFieldsContainer: styles.childFieldsContainerParaiso!,
 };
 
 export default function DebugJsonView({src, collapseDepth}: Props): ReactNode {

--- a/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/styles.module.css
+++ b/packages/docusaurus-plugin-debug/src/theme/DebugJsonView/styles.module.css
@@ -99,3 +99,12 @@
 .collapseContentParaiso::after {
   content: '...';
 }
+
+/*
+Overrides default ul style from Infima
+See https://github.com/AnyRoad/react-json-view-lite/issues/38
+*/
+.childFieldsContainerParaiso {
+  margin: 0;
+  padding: 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15124,10 +15124,10 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-json-view-lite@^1.2.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/react-json-view-lite/-/react-json-view-lite-1.5.0.tgz#377cc302821717ac79a1b6d099e1891df54c8662"
-  integrity sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==
+react-json-view-lite@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-json-view-lite/-/react-json-view-lite-2.1.0.tgz#6fa02c92f34d85766b0219633597924c5ac02888"
+  integrity sha512-4JdlXC+dWPRXPL4fK/NsK6W103+mmpXDeWCHJGhgjPSvuyHnpwQUJ+ClUj4MFlLb4cPxi3T0/PW414JlTKMCJg==
 
 react-lite-youtube-embed@^2.3.52:
   version "2.4.0"


### PR DESCRIPTION
## Motivation

React 19 support is expected to be released in the next v2.x of that lib. 

It just a peerDeps declaration normally: https://github.com/AnyRoad/react-json-view-lite/pull/43

So let's upgrade to v2 so that we'll benefit from the React support once it's released. There shouldn't be any side effects since v2 only bumps React to v18+ which we already run on.

I'll consider it resolved from our side, although users can track the external issue to know when the peerDeps problem is fixed: https://github.com/AnyRoad/react-json-view-lite/issues/34. Will eventually reopen if the lib doesn't ship v2.x with React 19 support.

fix https://github.com/facebook/docusaurus/issues/10817


## Test Plan

CI + preview

### Test links

https://deploy-preview-10819--docusaurus-2.netlify.app/__docusaurus/debug
