### PR TITLE
fix(core): restore core svg file-loader

### DIFF
--- a/packages/docusaurus-plugin-svgr/src/index.ts
+++ b/packages/docusaurus-plugin-svgr/src/index.ts
@@ -17,7 +17,6 @@ export default function pluginSVGR(
     name: 'docusaurus-plugin-svgr',
     configureWebpack: (config, isServer) => {
       enhanceConfig(config, {isServer, svgrConfig: options.svgrConfig});
-      return {};
     },
   };
 }

--- a/packages/docusaurus-plugin-svgr/src/index.ts
+++ b/packages/docusaurus-plugin-svgr/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {createLoader} from './svgrLoader';
+import {enhanceConfig} from './svgrLoader';
 import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {PluginOptions, Options} from './options';
 
@@ -16,11 +16,8 @@ export default function pluginSVGR(
   return {
     name: 'docusaurus-plugin-svgr',
     configureWebpack: (config, isServer) => {
-      return {
-        module: {
-          rules: [createLoader({isServer, svgrConfig: options.svgrConfig})],
-        },
-      };
+      enhanceConfig(config, {isServer, svgrConfig: options.svgrConfig});
+      return {};
     },
   };
 }

--- a/packages/docusaurus-types/src/plugin.d.ts
+++ b/packages/docusaurus-types/src/plugin.d.ts
@@ -140,7 +140,7 @@ export type Plugin<Content = unknown> = {
     isServer: boolean,
     configureWebpackUtils: ConfigureWebpackUtils,
     content: Content,
-  ) => ConfigureWebpackResult;
+  ) => ConfigureWebpackResult | void;
   configurePostCss?: (options: PostCssOptions) => PostCssOptions;
   getThemePath?: () => string;
   getTypeScriptThemePath?: () => string;

--- a/packages/docusaurus-utils/src/webpackUtils.ts
+++ b/packages/docusaurus-utils/src/webpackUtils.ts
@@ -120,7 +120,10 @@ function createFileLoaderUtils({
       test: /\.(?:ico|jpe?g|png|gif|webp|avif)(?:\?.*)?$/i,
     }),
 
-    // SVG rule is isolated on purpose: our SVGR plugin enhances it
+    /**
+     * The SVG rule is isolated on purpose: our SVGR plugin enhances it
+     * See https://github.com/facebook/docusaurus/pull/10820
+     */
     svgs: () => ({
       use: [loaders.url({folder: 'images'})],
       test: /\.svg$/i,

--- a/packages/docusaurus-utils/src/webpackUtils.ts
+++ b/packages/docusaurus-utils/src/webpackUtils.ts
@@ -43,6 +43,7 @@ type FileLoaderUtils = {
   };
   rules: {
     images: () => RuleSetRule;
+    svgs: () => RuleSetRule;
     fonts: () => RuleSetRule;
     media: () => RuleSetRule;
     otherAssets: () => RuleSetRule;
@@ -117,6 +118,12 @@ function createFileLoaderUtils({
     images: () => ({
       use: [loaders.url({folder: 'images'})],
       test: /\.(?:ico|jpe?g|png|gif|webp|avif)(?:\?.*)?$/i,
+    }),
+
+    // SVG rule is isolated on purpose: our SVGR plugin enhances it
+    svgs: () => ({
+      use: [loaders.url({folder: 'images'})],
+      test: /\.svg$/i,
     }),
 
     fonts: () => ({

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -251,6 +251,7 @@ export async function createBaseConfig({
     module: {
       rules: [
         fileLoaderUtils.rules.images(),
+        fileLoaderUtils.rules.svgs(),
         fileLoaderUtils.rules.fonts(),
         fileLoaderUtils.rules.media(),
         fileLoaderUtils.rules.otherAssets(),

--- a/project-words.txt
+++ b/project-words.txt
@@ -323,6 +323,7 @@ Sucipto
 sunsetting
 supabase
 Supabase
+svgs
 swizzlable
 Tagkey
 Teik

--- a/website/_dogfooding/dogfooding.css
+++ b/website/_dogfooding/dogfooding.css
@@ -10,6 +10,15 @@ html {
     &.plugin-docs.plugin-id-docs-tests {
       .red > a {
         color: red;
+
+        &::after {
+          background-image: url('./red.svg');
+          background-size: contain;
+          margin-left: 0.5rem;
+          width: 1rem;
+          height: 1rem;
+          content: ' ';
+        }
       }
 
       .navbar {

--- a/website/_dogfooding/red.svg
+++ b/website/_dogfooding/red.svg
@@ -1,0 +1,4 @@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <path d="M0,0h1v1H0" fill="#f00"/>
+</svg>


### PR DESCRIPTION
## Motivation

When I extracted our v3.7 SVGR plugin from Docusaurus core (https://github.com/facebook/docusaurus/pull/10677), I also removed default support for SVG file loaders.

Users rely on it to reference local SVG files from CSS:
https://github.com/facebook/docusaurus/pull/10677#issuecomment-2572243680

Although the v3.7.0 SVGR plugin brings that support, it's not really its responsibility to do so.

This PR restores file-loader support for SVGs, even if sites do not use the SVGR plugin (which is included by default in our preset). Asking sites not using SVGR to use the SVGR plugin so that they benefit from SVG file-loader would be a bit awkward.


Unfortunately, the underlying solution is not super elegant due to how Webpack rules work, and registering a second svg rule will not "override" the first, but both rules will be applied subsequently from last to first. I had to make the plugin "enhance" the existing core rule. 





## Test Plan

Dogfood test with a SVG referenced inside a CSS file

Our existing site pages using SVGR

### Test links

https://deploy-preview-10820--docusaurus-2.netlify.app/tests/docs

https://deploy-preview-10820--docusaurus-2.netlify.app/docs/markdown-features/assets#inline-svgs