### PR TITLE
fix(theme): fix `<DocCard>` height inconsistency

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -624,7 +624,9 @@ declare module '@theme/DocPaginator' {
   import type {PropNavigation} from '@docusaurus/plugin-content-docs';
 
   // May be simpler to provide a {navigation: PropNavigation} prop?
-  export interface Props extends PropNavigation {}
+  export interface Props extends PropNavigation {
+    className?: string;
+  }
 
   export default function DocPaginator(props: Props): ReactNode;
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocCard/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/styles.module.css
@@ -14,7 +14,6 @@
   border: 1px solid var(--ifm-color-emphasis-200);
   transition: all var(--ifm-transition-fast) ease;
   transition-property: border, box-shadow;
-  height: 100%;
 }
 
 .cardContainer:hover {

--- a/packages/docusaurus-theme-classic/src/theme/DocCard/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocCard/styles.module.css
@@ -14,6 +14,7 @@
   border: 1px solid var(--ifm-color-emphasis-200);
   transition: all var(--ifm-transition-fast) ease;
   transition-property: border, box-shadow;
+  height: 100%;
 }
 
 .cardContainer:hover {

--- a/packages/docusaurus-theme-classic/src/theme/DocCardList/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCardList/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {type ReactNode} from 'react';
+import React, {type ComponentProps, type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
   useCurrentSidebarSiblings,
@@ -13,10 +13,23 @@ import {
 } from '@docusaurus/plugin-content-docs/client';
 import DocCard from '@theme/DocCard';
 import type {Props} from '@theme/DocCardList';
+import styles from './styles.module.css';
 
 function DocCardListForCurrentSidebarCategory({className}: Props) {
   const items = useCurrentSidebarSiblings();
   return <DocCardList items={items} className={className} />;
+}
+
+function DocCardListItem({
+  item,
+}: {
+  item: ComponentProps<typeof DocCard>['item'];
+}) {
+  return (
+    <article className={clsx(styles.docCardListItem, 'col col--6')}>
+      <DocCard item={item} />
+    </article>
+  );
 }
 
 export default function DocCardList(props: Props): ReactNode {
@@ -26,11 +39,9 @@ export default function DocCardList(props: Props): ReactNode {
   }
   const filteredItems = filterDocCardListItems(items);
   return (
-    <section className={clsx('row', className)}>
+    <section className={clsx('row', 'margin-top--md', className)}>
       {filteredItems.map((item, index) => (
-        <article key={index} className="col col--6 margin-bottom--lg">
-          <DocCard item={item} />
-        </article>
+        <DocCardListItem key={index} item={item} />
       ))}
     </section>
   );

--- a/packages/docusaurus-theme-classic/src/theme/DocCardList/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCardList/index.tsx
@@ -39,7 +39,7 @@ export default function DocCardList(props: Props): ReactNode {
   }
   const filteredItems = filterDocCardListItems(items);
   return (
-    <section className={clsx('row', 'margin-top--md', className)}>
+    <section className={clsx('row', className)}>
       {filteredItems.map((item, index) => (
         <DocCardListItem key={index} item={item} />
       ))}

--- a/packages/docusaurus-theme-classic/src/theme/DocCardList/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocCardList/styles.module.css
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.docCardListItem {
+  margin-bottom: 2rem;
+}
+
+.docCardListItem > * {
+  height: 100%;
+}

--- a/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -50,10 +50,10 @@ function DocCategoryGeneratedIndexPageContent({
           <p>{categoryGeneratedIndex.description}</p>
         )}
       </header>
-      <article className="margin-top--lg">
+      <article className="margin-top--md">
         <DocCardList items={category.items} className={styles.list} />
       </article>
-      <footer className="margin-top--lg">
+      <footer>
         <DocPaginator
           previous={categoryGeneratedIndex.navigation.previous}
           next={categoryGeneratedIndex.navigation.next}

--- a/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -50,10 +50,10 @@ function DocCategoryGeneratedIndexPageContent({
           <p>{categoryGeneratedIndex.description}</p>
         )}
       </header>
-      <article className="margin-top--md">
+      <article className="margin-top--lg">
         <DocCardList items={category.items} className={styles.list} />
       </article>
-      <footer>
+      <footer className="margin-top--md">
         <DocPaginator
           previous={categoryGeneratedIndex.navigation.previous}
           next={categoryGeneratedIndex.navigation.next}

--- a/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
@@ -9,18 +9,10 @@
   .generatedIndexPage {
     max-width: 75% !important;
   }
-
-  .list article:nth-last-child(-n + 2) {
-    margin-bottom: 0 !important;
-  }
 }
 
 /* Duplicated from .markdown h1 */
 .title {
   --ifm-h1-font-size: 3rem;
   margin-bottom: calc(1.25 * var(--ifm-leading));
-}
-
-.list article:last-child {
-  margin-bottom: 0 !important;
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/Paginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/Paginator/index.tsx
@@ -15,5 +15,11 @@ import DocPaginator from '@theme/DocPaginator';
  */
 export default function DocItemPaginator(): ReactNode {
   const {metadata} = useDoc();
-  return <DocPaginator previous={metadata.previous} next={metadata.next} />;
+  return (
+    <DocPaginator
+      className="docusaurus-mt-lg"
+      previous={metadata.previous}
+      next={metadata.next}
+    />
+  );
 }

--- a/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocPaginator/index.tsx
@@ -6,15 +6,16 @@
  */
 
 import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
 import Translate, {translate} from '@docusaurus/Translate';
 import PaginatorNavLink from '@theme/PaginatorNavLink';
 import type {Props} from '@theme/DocPaginator';
 
 export default function DocPaginator(props: Props): ReactNode {
-  const {previous, next} = props;
+  const {className, previous, next} = props;
   return (
     <nav
-      className="pagination-nav docusaurus-mt-lg"
+      className={clsx(className, 'pagination-nav')}
       aria-label={translate({
         id: 'theme.docs.paginator.navAriaLabel',
         message: 'Docs pages',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

Ensure that the `<DocCard>` component maintains full height in its styles for better layout consistency.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

before
![image](https://github.com/user-attachments/assets/b4204003-4b1d-469f-8293-5327efc35d6e)

after
![image](https://github.com/user-attachments/assets/a6d6113a-fdcf-4d69-8839-a886cdbb5a27)


### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-10849--docusaurus-2.netlify.app/

Test links:
- https://deploy-preview-10849--docusaurus-2.netlify.app/tests/docs
- https://deploy-preview-10849--docusaurus-2.netlify.app/tests/docs/category/tests

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
