### PR TITLE
feat(theme): add `versions` attribute to `docsVersionDropdown` navbar item

### DIFF
--- a/packages/docusaurus-theme-classic/src/__tests__/options.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/options.test.ts
@@ -844,6 +844,24 @@ describe('themeConfig', () => {
         testValidateThemeConfig(config);
       });
 
+      it('rejects empty array of strings', () => {
+        const config = {
+          navbar: {
+            items: [
+              {
+                type: 'docsVersionDropdown',
+                versions: [],
+              },
+            ],
+          },
+        };
+        expect(() =>
+          testValidateThemeConfig(config),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `""navbar.items[0].versions" must contain at least 1 items"`,
+        );
+      });
+
       it('rejects array of non-strings', () => {
         const config = {
           navbar: {
@@ -874,6 +892,24 @@ describe('themeConfig', () => {
           },
         };
         testValidateThemeConfig(config);
+      });
+
+      it('rejects empty dictionary of objects', () => {
+        const config = {
+          navbar: {
+            items: [
+              {
+                type: 'docsVersionDropdown',
+                versions: {},
+              },
+            ],
+          },
+        };
+        expect(() =>
+          testValidateThemeConfig(config),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `""navbar.items[0].versions" must have at least 1 key"`,
+        );
       });
 
       it('rejects dictionary of invalid objects', () => {

--- a/packages/docusaurus-theme-classic/src/__tests__/options.test.ts
+++ b/packages/docusaurus-theme-classic/src/__tests__/options.test.ts
@@ -827,6 +827,74 @@ describe('themeConfig', () => {
       );
     });
   });
+
+  describe('docsVersionDropdown', () => {
+    describe('versions', () => {
+      it('accepts array of strings', () => {
+        const config = {
+          navbar: {
+            items: [
+              {
+                type: 'docsVersionDropdown',
+                versions: ['current', '1.0'],
+              },
+            ],
+          },
+        };
+        testValidateThemeConfig(config);
+      });
+
+      it('rejects array of non-strings', () => {
+        const config = {
+          navbar: {
+            items: [
+              {
+                type: 'docsVersionDropdown',
+                versions: [1, 2],
+              },
+            ],
+          },
+        };
+        expect(() =>
+          testValidateThemeConfig(config),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `""navbar.items[0].versions[0]" must be a string"`,
+        );
+      });
+
+      it('accepts dictionary of version objects', () => {
+        const config = {
+          navbar: {
+            items: [
+              {
+                type: 'docsVersionDropdown',
+                versions: {current: {}, '1.0': {label: '1.x'}},
+              },
+            ],
+          },
+        };
+        testValidateThemeConfig(config);
+      });
+
+      it('rejects dictionary of invalid objects', () => {
+        const config = {
+          navbar: {
+            items: [
+              {
+                type: 'docsVersionDropdown',
+                versions: {current: {}, '1.0': {invalid: '1.x'}},
+              },
+            ],
+          },
+        };
+        expect(() =>
+          testValidateThemeConfig(config),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `""navbar.items[0].versions.1.0.invalid" is not allowed"`,
+        );
+      });
+    });
+  });
 });
 
 describe('validateOptions', () => {

--- a/packages/docusaurus-theme-classic/src/options.ts
+++ b/packages/docusaurus-theme-classic/src/options.ts
@@ -7,11 +7,11 @@
 
 import {themes} from 'prism-react-renderer';
 import {Joi, URISchema} from '@docusaurus/utils-validation';
-import type {Options, PluginOptions} from '@docusaurus/theme-classic';
 import type {
   PropVersionItem,
   PropVersionItems,
 } from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
+import type {Options, PluginOptions} from '@docusaurus/theme-classic';
 import type {ThemeConfig} from '@docusaurus/theme-common';
 import type {
   ThemeConfigValidationContext,

--- a/packages/docusaurus-theme-classic/src/options.ts
+++ b/packages/docusaurus-theme-classic/src/options.ts
@@ -215,13 +215,15 @@ const DocsVersionDropdownNavbarItemSchema = NavbarItemBaseSchema.append({
   dropdownItemsBefore: Joi.array().items(DropdownSubitemSchema).default([]),
   dropdownItemsAfter: Joi.array().items(DropdownSubitemSchema).default([]),
   versions: Joi.alternatives().try(
-    Joi.array().items(Joi.string().min(1)),
-    Joi.object<PropVersionItems>().pattern(
-      Joi.string().min(1),
-      Joi.object<PropVersionItem>({
-        label: Joi.string().min(1),
-      }),
-    ),
+    Joi.array().items(Joi.string().min(1)).min(1),
+    Joi.object<PropVersionItems>()
+      .pattern(
+        Joi.string().min(1),
+        Joi.object<PropVersionItem>({
+          label: Joi.string().min(1),
+        }),
+      )
+      .min(1),
   ),
 });
 

--- a/packages/docusaurus-theme-classic/src/options.ts
+++ b/packages/docusaurus-theme-classic/src/options.ts
@@ -8,6 +8,10 @@
 import {themes} from 'prism-react-renderer';
 import {Joi, URISchema} from '@docusaurus/utils-validation';
 import type {Options, PluginOptions} from '@docusaurus/theme-classic';
+import type {
+  PropVersionItem,
+  PropVersionItems,
+} from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
 import type {ThemeConfig} from '@docusaurus/theme-common';
 import type {
   ThemeConfigValidationContext,
@@ -204,12 +208,23 @@ const DropdownNavbarItemSchema = NavbarItemBaseSchema.append({
   items: Joi.array().items(DropdownSubitemSchema).required(),
 });
 
+const DocsVersionNameSchema = Joi.string().min(1);
+
 const DocsVersionDropdownNavbarItemSchema = NavbarItemBaseSchema.append({
   type: Joi.string().equal('docsVersionDropdown').required(),
   docsPluginId: Joi.string(),
   dropdownActiveClassDisabled: Joi.boolean(),
   dropdownItemsBefore: Joi.array().items(DropdownSubitemSchema).default([]),
   dropdownItemsAfter: Joi.array().items(DropdownSubitemSchema).default([]),
+  versions: Joi.alternatives().try(
+    Joi.array().items(DocsVersionNameSchema),
+    Joi.object<PropVersionItems>().pattern(
+      DocsVersionNameSchema,
+      Joi.object<PropVersionItem>({
+        label: Joi.string().min(1),
+      }),
+    ),
+  ),
 });
 
 const LocaleDropdownNavbarItemSchema = NavbarItemBaseSchema.append({

--- a/packages/docusaurus-theme-classic/src/options.ts
+++ b/packages/docusaurus-theme-classic/src/options.ts
@@ -208,8 +208,6 @@ const DropdownNavbarItemSchema = NavbarItemBaseSchema.append({
   items: Joi.array().items(DropdownSubitemSchema).required(),
 });
 
-const DocsVersionNameSchema = Joi.string().min(1);
-
 const DocsVersionDropdownNavbarItemSchema = NavbarItemBaseSchema.append({
   type: Joi.string().equal('docsVersionDropdown').required(),
   docsPluginId: Joi.string(),
@@ -217,9 +215,9 @@ const DocsVersionDropdownNavbarItemSchema = NavbarItemBaseSchema.append({
   dropdownItemsBefore: Joi.array().items(DropdownSubitemSchema).default([]),
   dropdownItemsAfter: Joi.array().items(DropdownSubitemSchema).default([]),
   versions: Joi.alternatives().try(
-    Joi.array().items(DocsVersionNameSchema),
+    Joi.array().items(Joi.string().min(1)),
     Joi.object<PropVersionItems>().pattern(
-      DocsVersionNameSchema,
+      Joi.string().min(1),
       Joi.object<PropVersionItem>({
         label: Joi.string().min(1),
       }),

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -1257,11 +1257,22 @@ declare module '@theme/NavbarItem/DocsVersionDropdownNavbarItem' {
   import type {Props as DropdownNavbarItemProps} from '@theme/NavbarItem/DropdownNavbarItem';
   import type {LinkLikeNavbarItemProps} from '@theme/NavbarItem';
 
+  type PropVersionItem = {
+    readonly label?: string;
+  };
+
+  type PropVersionItems = {
+    readonly [version: string]: PropVersionItem;
+  };
+
+  type PropVersions = string[] | PropVersionItems;
+
   export interface Props extends DropdownNavbarItemProps {
     readonly docsPluginId?: string;
     readonly dropdownActiveClassDisabled?: boolean;
     readonly dropdownItemsBefore: LinkLikeNavbarItemProps[];
     readonly dropdownItemsAfter: LinkLikeNavbarItemProps[];
+    readonly versions?: PropVersions;
   }
 
   export default function DocsVersionDropdownNavbarItem(

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -45,33 +45,26 @@ function getVersionItems(
       versions.map((version) => [version.name, version]),
     );
 
-    // eslint-disable-next-line no-inner-declarations
-    function getVersionItem(
+    const toVersionItem = (
       name: string,
       config?: PropVersionItem,
-    ): VersionItem | undefined {
+    ): VersionItem => {
       const version = versionMap.get(name);
       if (!version) {
-        // A version configuration references a non-existing version, ignore it
-        return undefined;
+        throw new Error(`No docs version exist for name '${name}', please verify your 'docsVersionDropdown' navbar item versions config.
+Available version names:\n- ${versions.map((v) => `${v.name}`).join('\n- ')}`);
       }
       return {version, config};
-    }
+    };
 
-    // Keep only versions specified in configuration, reorder them accordingly
-    let versionItems: (VersionItem | undefined)[];
     if (Array.isArray(configs)) {
-      versionItems = configs.map((name) => getVersionItem(name, undefined));
+      return configs.map((name) => toVersionItem(name, undefined));
     } else {
-      versionItems = Object.entries(configs).map(([name, config]) =>
-        getVersionItem(name, config),
+      return Object.entries(configs).map(([name, config]) =>
+        toVersionItem(name, config),
       );
     }
-
-    // Filter out ignored items
-    return versionItems.filter((x) => x !== undefined);
   } else {
-    // The versions are not configured
     return versions.map((version) => {
       return {version, config: undefined};
     });
@@ -85,7 +78,8 @@ function useVersionItems({
   docsPluginId: Props['docsPluginId'];
   configs: Props['versions'];
 }): VersionItem[] {
-  return getVersionItems(useVersions(docsPluginId), configs);
+  const versions = useVersions(docsPluginId);
+  return getVersionItems(versions, configs);
 }
 
 function getVersionMainDoc(version: GlobalVersion): GlobalDoc {

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -102,15 +102,12 @@ function useDisplayedVersionItem({
   docsPluginId: Props['docsPluginId'];
   versionItems: VersionItem[];
 }): VersionItem {
+  // The order of the candidates matters!
   const candidates = useDocsVersionCandidates(docsPluginId);
-  const displayedVersion =
-    candidates.find((candidate) =>
-      versionItems.some((vi) => vi.version === candidate),
-    ) ?? versionItems[0]!.version;
-  const displayedVersionItem = versionItems.find(
-    (vi) => vi.version === displayedVersion,
-  )!;
-  return displayedVersionItem;
+  const candidateItems = candidates
+    .map((candidate) => versionItems.find((vi) => vi.version === candidate))
+    .filter((vi) => vi !== undefined);
+  return candidateItems[0] ?? versionItems[0]!;
 }
 
 export default function DocsVersionDropdownNavbarItem({

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -33,7 +33,7 @@ type VersionItem = {
   config?: PropVersionItem;
 };
 
-function getDropdownVersions(
+function getVersionItems(
   versions: GlobalVersion[],
   configs?: PropVersions,
 ): VersionItem[] {
@@ -45,6 +45,7 @@ function getDropdownVersions(
       versions.map((version) => [version.name, version]),
     );
 
+    // eslint-disable-next-line no-inner-declarations
     function getVersionItem(
       name: string,
       config?: PropVersionItem,
@@ -77,6 +78,16 @@ function getDropdownVersions(
   }
 }
 
+function useVersionItems({
+  docsPluginId,
+  configs,
+}: {
+  docsPluginId: Props['docsPluginId'];
+  configs: Props['versions'];
+}): VersionItem[] {
+  return getVersionItems(useVersions(docsPluginId), configs);
+}
+
 function getVersionMainDoc(version: GlobalVersion): GlobalDoc {
   return version.docs.find((doc) => doc.id === version.mainDocId)!;
 }
@@ -99,24 +110,18 @@ export default function DocsVersionDropdownNavbarItem({
   dropdownActiveClassDisabled,
   dropdownItemsBefore,
   dropdownItemsAfter,
-  versions: versionConfigs,
+  versions: configs,
   ...props
 }: Props): ReactNode {
-  // Build version list
-  const dropdownVersions = getDropdownVersions(
-    useVersions(docsPluginId),
-    versionConfigs,
-  );
-
-  // Build item list
   const {search, hash} = useLocation();
   const activeDocContext = useActiveDocContext(docsPluginId);
   const {savePreferredVersionName} = useDocsPreferredVersion(docsPluginId);
+  const versionItems = useVersionItems({docsPluginId, configs});
 
-  function versionToLink(
-    version: GlobalVersion,
-    config?: PropVersionItem,
-  ): LinkLikeNavbarItemProps {
+  function versionItemToLink({
+    version,
+    config,
+  }: VersionItem): LinkLikeNavbarItemProps {
     const targetDoc = getVersionTargetDoc(version, activeDocContext);
     return {
       label: config?.label ?? version.label,
@@ -129,7 +134,7 @@ export default function DocsVersionDropdownNavbarItem({
 
   const items: LinkLikeNavbarItemProps[] = [
     ...dropdownItemsBefore,
-    ...dropdownVersions.map((item) => versionToLink(item.version, item.config)),
+    ...versionItems.map(versionItemToLink),
     ...dropdownItemsAfter,
   ];
 

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -33,7 +33,7 @@ type VersionConfiguration = {name: string} & PropVersionItem;
 function getVersionConfigurations(
   versions: PropVersions,
 ): VersionConfiguration[] {
-  if (versions instanceof Array) {
+  if (Array.isArray(versions)) {
     return versions.map((name): VersionConfiguration => {
       return {name};
     });

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -56,7 +56,7 @@ function configureVersions(
   staticVersions?: PropVersions,
 ): ConfiguredVersion[] {
   if (staticVersions) {
-    // The versions are configured.
+    // The versions are configured
 
     // Collect all the versions we have
     const versionMap = new Map<string, GlobalVersion>(
@@ -68,7 +68,7 @@ function configureVersions(
     for (const version of versions) {
       // 'version.name' has special conventions for current and next versions,
       // that's why we use 'version.label' as a secondary version identifier
-      // that can be referenced in configuration.
+      // that can be referenced in configuration
       const label = version.label;
       if (!versionMap.has(label)) versionMap.set(label, version);
     }
@@ -76,7 +76,7 @@ function configureVersions(
     // Keep only versions specified in configuration, reorder them accordingly
     const configuredVersions: ConfiguredVersion[] = [];
     for (const configuration of getVersionConfigurations(staticVersions)) {
-      let version = versionMap.get(configuration.name);
+      const version = versionMap.get(configuration.name);
       if (!version) {
         // A version configuration references a non-existing version, ignore it
         continue;

--- a/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -63,16 +63,6 @@ function configureVersions(
       versions.map((version) => [version.name, version]),
     );
 
-    // Add secondary version identifiers to make the configuration process
-    // more natural to a user
-    for (const version of versions) {
-      // 'version.name' has special conventions for current and next versions,
-      // that's why we use 'version.label' as a secondary version identifier
-      // that can be referenced in configuration
-      const label = version.label;
-      if (!versionMap.has(label)) versionMap.set(label, version);
-    }
-
     // Keep only versions specified in configuration, reorder them accordingly
     const configuredVersions: ConfiguredVersion[] = [];
     for (const configuration of getVersionConfigurations(staticVersions)) {

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -597,7 +597,7 @@ Accepted fields:
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
-| `versions` | <code>string[] \| object</code> | `undefined` | Specify a custom list of versions to include in the dropdown, or an object with more detailed version configurations. |
+| `versions` | <code>string[] \| object</code> | `undefined` | Specify a custom list of versions to include in the dropdown, or specify an object with detailed version configurations. |
 
 ```mdx-code-block
 </APITable>
@@ -658,7 +658,7 @@ For example, if you are using semantic versioning, you may have versions such as
 1.0.0
 ```
 
-And maybe you want to have in the dropdown:
+And maybe you want to have them in the dropdown as:
 
 ```
 2.1
@@ -666,7 +666,7 @@ And maybe you want to have in the dropdown:
 1.0
 ```
 
-Or maybe just:
+or maybe just:
 
 ```
 1.x
@@ -685,8 +685,8 @@ export default {
           position: 'left',
           // highlight-start
           versions: {
-            "1.0.1": {label: "1.x"},
-            "2.1.1": {label: "2.x"},
+            '1.0.1': {label: '1.x'},
+            '2.1.1': {label: '2.x'},
           },
           // highlight-end
         },
@@ -704,7 +704,7 @@ The fields accepted by the custom version configuration:
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `label` | `string` | Optional | The name to be shown for this version. |
+| `label` | `string` | Optional | The custom name to be shown for this version. |
 
 ```mdx-code-block
 </APITable>

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -704,7 +704,7 @@ The fields accepted by the custom version configuration:
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `label` | `string` | Optional | The custom name to be shown for this version. |
+| `label` | `string` | Optional | The custom name to be shown in the dropdown for this version. |
 
 ```mdx-code-block
 </APITable>

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -597,7 +597,7 @@ Accepted fields:
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
-| `versions` | `DropdownVersions` | `undefined` | Specify a custom list of versions to include in the dropdown. See [the versioning guide](../../../versioning#configuring-representation) for details. |
+| `versions` | `DropdownVersions` | `undefined` | Specify a custom list of versions to include in the dropdown. See [the versioning guide](../../guides/docs/versioning.mdx#docsVersionDropdown) for details. |
 
 ```mdx-code-block
 </APITable>

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -597,10 +597,21 @@ Accepted fields:
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
-| `versions` | <code>string[] \| object</code> | `undefined` | Specify a custom list of versions to include in the dropdown, or specify an object with detailed version configurations. |
+| `versions` | `DropdownVersions` | `undefined` | Specify a custom list of versions to include in the dropdown. See [the versioning guide](../../versioning#configuring-representation) for details. |
 
 ```mdx-code-block
 </APITable>
+```
+
+Types:
+
+```ts
+type DropdownVersion = {
+  /** The custom name to be shown in the dropdown for this version. */
+  label?: string;
+};
+
+type DropdownVersions = string[] | {[versionName: string]: DropdownVersion};
 ```
 
 Example configuration:
@@ -622,90 +633,6 @@ export default {
     },
   },
 };
-```
-
-By default, the version dropdown displays all the versions provided by the docs.
-However, sometimes it may be beneficial to restrict the number of displayed versions to declutter the UI.
-To achieve that, it is possible to specify a custom list of versions that should be offered in the dropdown:
-
-```js title="docusaurus.config.js"
-export default {
-  themeConfig: {
-    navbar: {
-      items: [
-        {
-          type: 'docsVersionDropdown',
-          // highlight-start
-          versions: ['2024.3', '2024.2', '2024.1', '2023.4'],
-          // highlight-end
-        },
-      ],
-    },
-  },
-};
-```
-
-Some versioning schemes may benefit from an even more detailed configuration of displayed versions.
-For example, if you are using semantic versioning, you may have versions such as:
-
-```
-2.1.1
-2.1.0
-2.0.1
-2.0.0
-1.0.1
-1.0.0
-```
-
-And maybe you want to have them in the dropdown as:
-
-```
-2.1
-2.0
-1.0
-```
-
-or maybe just:
-
-```
-1.x
-2.x
-```
-
-To achieve that, you can specify a custom configuration for every version that should be displayed in the dropdown:
-
-```js title="docusaurus.config.js"
-export default {
-  themeConfig: {
-    navbar: {
-      items: [
-        {
-          type: 'docsVersionDropdown',
-          // highlight-start
-          versions: {
-            '1.0.1': {label: '1.x'},
-            '2.1.1': {label: '2.x'},
-          },
-          // highlight-end
-        },
-      ],
-    },
-  },
-};
-```
-
-The fields accepted by the custom version configuration:
-
-```mdx-code-block
-<APITable name="navbar-docs-version-dropdown-configuration">
-```
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `label` | `string` | Optional | The custom name to be shown in the dropdown for this version. |
-
-```mdx-code-block
-</APITable>
 ```
 
 #### Navbar docs version {#navbar-docs-version}

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -635,7 +635,6 @@ export default {
       items: [
         {
           type: 'docsVersionDropdown',
-          position: 'left',
           // highlight-start
           versions: ['2024.3', '2024.2', '2024.1', '2023.4'],
           // highlight-end
@@ -682,7 +681,6 @@ export default {
       items: [
         {
           type: 'docsVersionDropdown',
-          position: 'left',
           // highlight-start
           versions: {
             '1.0.1': {label: '1.x'},

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -597,6 +597,7 @@ Accepted fields:
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
+| `versions` | `string[] | object` | `undefined` | Specify a custom list of versions to include in the dropdown, or an object with more detailed version configurations. |
 
 ```mdx-code-block
 </APITable>
@@ -621,6 +622,92 @@ export default {
     },
   },
 };
+```
+
+By default, the version dropdown displays all the versions provided by the docs.
+However, sometimes it may be beneficial to restrict the number of displayed versions to declutter the UI.
+To achieve that, it is possible to specify a custom list of versions that should be offered in the dropdown:
+
+```js title="docusaurus.config.js"
+export default {
+  themeConfig: {
+    navbar: {
+      items: [
+        {
+          type: 'docsVersionDropdown',
+          position: 'left',
+          // highlight-start
+          versions: ['2024.3', '2024.2', '2024.1', '2023.4'],
+          // highlight-end
+        },
+      ],
+    },
+  },
+};
+```
+
+Some versioning schemes may benefit from an even more detailed configuration of displayed versions.
+For example, if you are using semantic versioning, you may have versions such as:
+
+```
+2.1.1
+2.1.0
+2.0.1
+2.0.0
+1.0.1
+1.0.0
+```
+
+And maybe you want to have in the dropdown:
+
+```
+2.1
+2.0
+1.0
+```
+
+Or maybe just:
+
+```
+1.x
+2.x
+```
+
+To achieve that, you can specify a custom configuration for every version that should be displayed in the dropdown:
+
+```js title="docusaurus.config.js"
+export default {
+  themeConfig: {
+    navbar: {
+      items: [
+        {
+          type: 'docsVersionDropdown',
+          position: 'left',
+          // highlight-start
+          versions: {
+            "1.0.1": {label: "1.x"},
+            "2.1.1": {label: "2.x"},
+          },
+          // highlight-end
+        },
+      ],
+    },
+  },
+};
+```
+
+The fields accepted by the custom version configuration:
+
+```mdx-code-block
+<APITable name="navbar-link">
+```
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `label` | `string` | Optional | The name to be shown for this version. |
+
+```mdx-code-block
+</APITable>
 ```
 
 #### Navbar docs version {#navbar-docs-version}

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -699,7 +699,7 @@ export default {
 The fields accepted by the custom version configuration:
 
 ```mdx-code-block
-<APITable name="navbar-link">
+<APITable name="navbar-docs-version-dropdown-configuration">
 ```
 
 | Name | Type | Default | Description |

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -607,7 +607,7 @@ Types:
 
 ```ts
 type DropdownVersion = {
-  /** The custom name to be shown in the dropdown for this version. */
+  /** Allows you to provide a custom display label for each version. */
   label?: string;
 };
 

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -597,7 +597,7 @@ Accepted fields:
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
-| `versions` | `string[] | object` | `undefined` | Specify a custom list of versions to include in the dropdown, or an object with more detailed version configurations. |
+| `versions` | <code>string[] \| object</code> | `undefined` | Specify a custom list of versions to include in the dropdown, or an object with more detailed version configurations. |
 
 ```mdx-code-block
 </APITable>

--- a/website/docs/api/themes/theme-configuration.mdx
+++ b/website/docs/api/themes/theme-configuration.mdx
@@ -597,7 +597,7 @@ Accepted fields:
 | `dropdownItemsAfter` | <code>[LinkLikeItem](#navbar-dropdown)[]</code> | `[]` | Add additional dropdown items at the end of the dropdown. |
 | `docsPluginId` | `string` | `'default'` | The ID of the docs plugin that the doc versioning belongs to. |
 | `dropdownActiveClassDisabled` | `boolean` | `false` | Do not add the link active class when browsing docs. |
-| `versions` | `DropdownVersions` | `undefined` | Specify a custom list of versions to include in the dropdown. See [the versioning guide](../../versioning#configuring-representation) for details. |
+| `versions` | `DropdownVersions` | `undefined` | Specify a custom list of versions to include in the dropdown. See [the versioning guide](../../../versioning#configuring-representation) for details. |
 
 ```mdx-code-block
 </APITable>

--- a/website/docs/guides/docs/versioning.mdx
+++ b/website/docs/guides/docs/versioning.mdx
@@ -258,7 +258,7 @@ See [docs plugin configuration](../../api/plugins/plugin-content-docs.mdx#config
 
 ## Navbar items {#navbar-items}
 
-We offer several navbar items to help you quickly set up navigation without worrying about versioned routes.
+We offer several docs navbar items to help you quickly set up navigation without worrying about versioned routes.
 
 - [`doc`](../../api/themes/theme-configuration.mdx#navbar-doc-link): a link to a doc.
 - [`docSidebar`](../../api/themes/theme-configuration.mdx#navbar-doc-sidebar): a link to the first item in a sidebar.
@@ -273,7 +273,9 @@ These links would all look for an appropriate version to link to, in the followi
 
 ## `docsVersionDropdown` {#docsVersionDropdown}
 
-By default, the [`docsVersionDropdown`](../../api/themes/theme-configuration.mdx#navbar-docs-version-dropdown) displays all the versions provided by the docs. However, sometimes it may be beneficial to restrict the number of displayed versions to simplify the user experience. To achieve that, it is possible to specify a custom list of versions that should be offered in the dropdown:
+By default, the [`docsVersionDropdown`](../../api/themes/theme-configuration.mdx#navbar-docs-version-dropdown) displays a dropdown with all the available docs versions.
+
+The `versions` attribute allows you to display a subset of the available docs versions in a given order:
 
 ```js title="docusaurus.config.js"
 export default {
@@ -283,7 +285,7 @@ export default {
         {
           type: 'docsVersionDropdown',
           // highlight-start
-          versions: ['current', '2024.2', '2024.1', '2023.4'],
+          versions: ['current', '3.0', '2.0'],
           // highlight-end
         },
       ],
@@ -292,33 +294,7 @@ export default {
 };
 ```
 
-Some versioning schemes may benefit from an even more detailed configuration of displayed versions. For example, if you are using semantic versioning, you may have versions such as:
-
-```
-2.1.1
-2.1.0
-2.0.1
-2.0.0
-1.0.1
-1.0.0
-```
-
-And maybe you want to have them in the dropdown as:
-
-```
-2.1
-2.0
-1.0
-```
-
-or maybe just:
-
-```
-1.x
-2.x
-```
-
-To achieve that, you can specify a custom configuration for every version that should be displayed in the dropdown:
+Passing a `versions` object, lets you override the display label of each version:
 
 ```js title="docusaurus.config.js"
 export default {
@@ -329,8 +305,9 @@ export default {
           type: 'docsVersionDropdown',
           // highlight-start
           versions: {
-            '1.0.1': {label: '1.x'},
-            '2.1.1': {label: '2.x'},
+            current: {label: 'Version 4.0'},
+            '3.0': {label: 'Version 3.0'},
+            '2.0': {label: 'Version 2.0'},
           },
           // highlight-end
         },

--- a/website/docs/guides/docs/versioning.mdx
+++ b/website/docs/guides/docs/versioning.mdx
@@ -271,11 +271,9 @@ These links would all look for an appropriate version to link to, in the followi
 2. **Preferred version**: the version that the user last viewed. If there's no history, fall back to...
 3. **Latest version**: the default version that we navigate to, configured by the `lastVersion` option.
 
-## Configuring representation of versions {#configuring-representation}
+## `docsVersionDropdown` {#docsVersionDropdown}
 
-By default, the [`docsVersionDropdown`](../../api/themes/theme-configuration.mdx#navbar-docs-version-dropdown) displays all the versions provided by the docs.
-However, sometimes it may be beneficial to restrict the number of displayed versions to simplify the user experience.
-To achieve that, it is possible to specify a custom list of versions that should be offered in the dropdown:
+By default, the [`docsVersionDropdown`](../../api/themes/theme-configuration.mdx#navbar-docs-version-dropdown) displays all the versions provided by the docs. However, sometimes it may be beneficial to restrict the number of displayed versions to simplify the user experience. To achieve that, it is possible to specify a custom list of versions that should be offered in the dropdown:
 
 ```js title="docusaurus.config.js"
 export default {
@@ -294,8 +292,7 @@ export default {
 };
 ```
 
-Some versioning schemes may benefit from an even more detailed configuration of displayed versions.
-For example, if you are using semantic versioning, you may have versions such as:
+Some versioning schemes may benefit from an even more detailed configuration of displayed versions. For example, if you are using semantic versioning, you may have versions such as:
 
 ```
 2.1.1

--- a/website/docs/guides/docs/versioning.mdx
+++ b/website/docs/guides/docs/versioning.mdx
@@ -271,7 +271,7 @@ These links would all look for an appropriate version to link to, in the followi
 2. **Preferred version**: the version that the user last viewed. If there's no history, fall back to...
 3. **Latest version**: the default version that we navigate to, configured by the `lastVersion` option.
 
-## Configuring versioning representation {#configuring-versioning-representation}
+## Configuring representation of versions {#configuring-representation}
 
 By default, the [`docsVersionDropdown`](../../api/themes/theme-configuration.mdx#navbar-docs-version-dropdown) displays all the versions provided by the docs.
 However, sometimes it may be beneficial to restrict the number of displayed versions to simplify the user experience.

--- a/website/docs/guides/docs/versioning.mdx
+++ b/website/docs/guides/docs/versioning.mdx
@@ -271,6 +271,78 @@ These links would all look for an appropriate version to link to, in the followi
 2. **Preferred version**: the version that the user last viewed. If there's no history, fall back to...
 3. **Latest version**: the default version that we navigate to, configured by the `lastVersion` option.
 
+## Configuring versioning representation {#configuring-versioning-representation}
+
+By default, the [`docsVersionDropdown`](../../api/themes/theme-configuration.mdx#navbar-docs-version-dropdown) displays all the versions provided by the docs.
+However, sometimes it may be beneficial to restrict the number of displayed versions to simplify the user experience.
+To achieve that, it is possible to specify a custom list of versions that should be offered in the dropdown:
+
+```js title="docusaurus.config.js"
+export default {
+  themeConfig: {
+    navbar: {
+      items: [
+        {
+          type: 'docsVersionDropdown',
+          // highlight-start
+          versions: ['2024.3', '2024.2', '2024.1', '2023.4'],
+          // highlight-end
+        },
+      ],
+    },
+  },
+};
+```
+
+Some versioning schemes may benefit from an even more detailed configuration of displayed versions.
+For example, if you are using semantic versioning, you may have versions such as:
+
+```
+2.1.1
+2.1.0
+2.0.1
+2.0.0
+1.0.1
+1.0.0
+```
+
+And maybe you want to have them in the dropdown as:
+
+```
+2.1
+2.0
+1.0
+```
+
+or maybe just:
+
+```
+1.x
+2.x
+```
+
+To achieve that, you can specify a custom configuration for every version that should be displayed in the dropdown:
+
+```js title="docusaurus.config.js"
+export default {
+  themeConfig: {
+    navbar: {
+      items: [
+        {
+          type: 'docsVersionDropdown',
+          // highlight-start
+          versions: {
+            '1.0.1': {label: '1.x'},
+            '2.1.1': {label: '2.x'},
+          },
+          // highlight-end
+        },
+      ],
+    },
+  },
+};
+```
+
 ## Recommended practices {#recommended-practices}
 
 ### Version your documentation only when needed {#version-your-documentation-only-when-needed}

--- a/website/docs/guides/docs/versioning.mdx
+++ b/website/docs/guides/docs/versioning.mdx
@@ -283,7 +283,7 @@ export default {
         {
           type: 'docsVersionDropdown',
           // highlight-start
-          versions: ['2024.3', '2024.2', '2024.1', '2023.4'],
+          versions: ['current', '2024.2', '2024.1', '2023.4'],
           // highlight-end
         },
       ],


### PR DESCRIPTION

## Motivation

Fix https://github.com/facebook/docusaurus/issues/10833

The `docsVersionDropdown` navbar item supports a new `versions` attribute to filter/whitelist displayed versions. Only the provided versions will be displayed.

Example:


```js
{
  type: 'docsVersionDropdown',
  versions: ['1.0.1', '2.1.1']
},
```

Also gives the ability to override version attributes (for now, only display `label`) by providing an object.

```js
{
  type: 'docsVersionDropdown',
  versions: {
  '1.0.1': {label: '1.x'},
  '2.1.1': {label: '2.x'},
},
```

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

1. Go to the [deploy preview](https://gp-temp-docusaurus-app1.netlify.app/eazfuscator.net) website
2. Locate the docs version dropdown in the upper part of the website
3. Click on the dropdown
4. Notice how the version titles are customized
5. Notice how the list of versions are customized to display just a subset of versions
6. Visit [Docusaurus documentation preview](https://deploy-preview-10852--docusaurus-2.netlify.app/docs/api/themes/configuration/#navbar-docs-version-dropdown) to take a look at the documentation for new functionality

### Test links

https://deploy-preview-10852--docusaurus-2.netlify.app/

Docs:
- https://deploy-preview-10852--docusaurus-2.netlify.app/docs/versioning/#docsVersionDropdown
- https://deploy-preview-10852--docusaurus-2.netlify.app/docs/api/themes/configuration/#navbar-docs-version-dropdown

Preview on another site: https://gp-temp-docusaurus-app1.netlify.app/eazfuscator.net
