### PR TITLE
refactor(create-docusaurus): add `future.v4` flag to init templates

### DIFF
--- a/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
+++ b/packages/create-docusaurus/templates/classic-typescript/docusaurus.config.ts
@@ -9,6 +9,11 @@ const config: Config = {
   tagline: 'Dinosaurs are cool',
   favicon: 'img/favicon.ico',
 
+  // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
+  future: {
+    v4: true, // Improve compatibility with the upcoming Docusaurus v4
+  },
+
   // Set the production url of your site here
   url: 'https://your-docusaurus-site.example.com',
   // Set the /<baseUrl>/ pathname under which your site is served

--- a/packages/create-docusaurus/templates/classic/docusaurus.config.js
+++ b/packages/create-docusaurus/templates/classic/docusaurus.config.js
@@ -14,6 +14,11 @@ const config = {
   tagline: 'Dinosaurs are cool',
   favicon: 'img/favicon.ico',
 
+  // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
+  future: {
+    v4: true, // Improve compatibility with the upcoming Docusaurus v4
+  },
+
   // Set the production url of your site here
   url: 'https://your-docusaurus-site.example.com',
   // Set the /<baseUrl>/ pathname under which your site is served


### PR DESCRIPTION

## Motivation

We want newly initialized sites to be compatible with Docusaurus v4 by default.

Adding the future flag v4 permits to ensure those sites do not introduce any incompatibility.

## Test Plan

CI

### Test links

https://deploy-preview-10871--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/pull/10850
