### PR TITLE
Fix `title_meta` handling in doc front matter

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/__tests__/frontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-blog/src/__tests__/frontMatter.test.ts
@@ -119,7 +119,7 @@ describe('validateBlogPostFrontMatter title_meta', () => {
 
 describe('validateBlogPostFrontMatter sidebar_label', () => {
   testField({
-    prefix: 'title_meta',
+    prefix: 'sidebar_label',
     validFrontMatters: [
       {sidebar_label: undefined},
       {sidebar_label: ''},

--- a/packages/docusaurus-plugin-content-docs/src/__tests__/frontMatter.test.ts
+++ b/packages/docusaurus-plugin-content-docs/src/__tests__/frontMatter.test.ts
@@ -92,6 +92,21 @@ describe('validateDocFrontMatter title', () => {
   });
 });
 
+describe('validateDocFrontMatter title_meta', () => {
+  testField({
+    prefix: 'title_meta',
+    validFrontMatters: [
+      {title_meta: undefined},
+      {title_meta: ''},
+      {title_meta: 'title'},
+    ],
+    invalidFrontMatters: [
+      [{title_meta: null}, 'must be a string'],
+      [{title_meta: false}, 'must be a string'],
+    ],
+  });
+});
+
 describe('validateDocFrontMatter hide_title', () => {
   testField({
     prefix: 'hide_title',

--- a/packages/docusaurus-plugin-content-docs/src/frontMatter.ts
+++ b/packages/docusaurus-plugin-content-docs/src/frontMatter.ts
@@ -23,6 +23,7 @@ export const DocFrontMatterSchema = Joi.object<DocFrontMatter>({
   id: Joi.string(),
   // See https://github.com/facebook/docusaurus/issues/4591#issuecomment-822372398
   title: Joi.string().allow(''),
+  title_meta: Joi.string().allow(''),
   hide_title: Joi.boolean(),
   hide_table_of_contents: Joi.boolean(),
   keywords: Joi.array().items(Joi.string().required()),

--- a/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
+++ b/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts
@@ -309,6 +309,10 @@ declare module '@docusaurus/plugin-content-docs' {
      */
     title?: string;
     /**
+     * Will be used for SEO page metadata and override DocMetadata.title.
+     */
+    title_meta?: string;
+    /**
      * Front matter tags, unnormalized.
      * @see {@link DocMetadata.tags}
      */

--- a/packages/docusaurus-theme-classic/src/theme/DocItem/Metadata/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/DocItem/Metadata/index.tsx
@@ -13,7 +13,7 @@ export default function DocItemMetadata(): ReactNode {
   const {metadata, frontMatter, assets} = useDoc();
   return (
     <PageMetadata
-      title={metadata.title}
+      title={frontMatter.title_meta ?? metadata.title}
       description={metadata.description}
       keywords={frontMatter.keywords}
       image={assets.image ?? frontMatter.image}


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

 The `title_meta` field, as documented in the [docs](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#title_meta), should allow overriding `frontMatter.title` for SEO purposes. However, it doesn't work for doc pages, while it does work correctly for blog posts.

I tried to fix the issue in docs by following how it works for blog pages.

## Related issues/PRs

#10586, #10878
