### PR TITLE
docs(theme-live-codeblock): update versioned docs to include link to react-live

### DIFF
--- a/website/versioned_docs/version-2.x/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-2.x/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.0.1/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.0.1/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.1.1/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.1.1/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.2.1/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.2.1/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.3.2/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.3.2/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.4.0/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.4.0/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.5.2/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.5.2/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.6.3/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.6.3/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock

--- a/website/versioned_docs/version-3.7.0/api/themes/theme-live-codeblock.mdx
+++ b/website/versioned_docs/version-3.7.0/api/themes/theme-live-codeblock.mdx
@@ -5,7 +5,7 @@ slug: /api/themes/@docusaurus/theme-live-codeblock
 
 # 📦 theme-live-codeblock
 
-This theme provides a `@theme/CodeBlock` component that is powered by react-live. You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
+This theme provides a `@theme/CodeBlock` component that is powered by [react-live](https://commerce.nearform.com/open-source/react-live/). You can read more on [interactive code editor](../../guides/markdown-features/markdown-features-code-blocks.mdx#interactive-code-editor) documentation.
 
 ```bash npm2yarn
 npm install --save @docusaurus/theme-live-codeblock


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.


## Motivation
Original [PR](#10874) left out versioned docs. This PR updates these docs with the same change.
> Links out directly to package so consumers can find it easily.

## Test Plan
Check links work from doc site

### Test links


Deploy preview (versions): 
- 3.7.0: https://deploy-preview-10902--docusaurus-2.netlify.app/docs/3.7.0/api/themes/@docusaurus/theme-live-codeblock/
- 3.6.3: https://deploy-preview-10902--docusaurus-2.netlify.app/docs/3.6.3/api/themes/@docusaurus/theme-live-codeblock/

## Related issues/PRs
- Related to PR: #10874 