### PR TITLE
fix(core): use `os.availableParallelism()` for SSG worker threads count

### DIFF
--- a/packages/docusaurus/src/ssg/ssgExecutor.ts
+++ b/packages/docusaurus/src/ssg/ssgExecutor.ts
@@ -80,11 +80,17 @@ function getNumberOfThreads(pathnames: string[]) {
   if (typeof SSGWorkerThreadCount !== 'undefined') {
     return SSGWorkerThreadCount;
   }
+
+  // See also https://github.com/tinylibs/tinypool/pull/108
+  const cpuCount =
+    // TODO Docusaurus v4: bump node, availableParallelism() now always exists
+    typeof os.availableParallelism === 'function'
+      ? os.availableParallelism()
+      : os.cpus().length;
+
   return inferNumberOfThreads({
     pageCount: pathnames.length,
-    // TODO use "physical CPUs" instead of "logical CPUs" (like Tinypool does)
-    // See also https://github.com/tinylibs/tinypool/pull/108
-    cpuCount: os.cpus().length,
+    cpuCount,
     // These are "magic value" that we should refine based on user feedback
     // Local tests show that it's not worth spawning new workers for few pages
     minPagesPerCpu: 100,


### PR DESCRIPTION


## Motivation

We should create the number of worker threads based on `os.availableParallelism()` using the physical CPU count instead of the logical CPU count.

This is what Vitest does under the hood

See also https://github.com/tinylibs/tinypool/pull/108

## Test Plan

ci

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/
