### PR TITLE
docs: disable `plugin-debug` in production by default

### DIFF
--- a/website/docs/api/plugins/plugin-debug.mdx
+++ b/website/docs/api/plugins/plugin-debug.mdx
@@ -24,7 +24,7 @@ If you use a standalone plugin, you may need to achieve the same effect by check
 export default {
   plugins: [
     // highlight-next-line
-    process.env.NODE_ENV === 'production' && '@docusaurus/plugin-debug',
+    process.env.NODE_ENV !== 'production' && '@docusaurus/plugin-debug',
   ].filter(Boolean),
 };
 ```


### PR DESCRIPTION
## Motivation

Documentation says[^1]
- https://github.com/facebook/docusaurus/blob/0a89f48fcc632e7583025fc778fc821b846d2362/website/docs/api/plugins/plugin-debug.mdx?plain=1#L13-L21

But code snippet does the opposite. This change updates code snippet to disable plugin in production by default.

[^1]: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-debug