### PR TITLE
fix(docs): fix mdx loader cache invalidation bug on versions changes

### DIFF
--- a/packages/docusaurus-mdx-loader/src/loader.ts
+++ b/packages/docusaurus-mdx-loader/src/loader.ts
@@ -218,6 +218,7 @@ export async function mdxLoader(
   const compilerName = getWebpackLoaderCompilerName(this);
   const callback = this.async();
   const options: Options = this.getOptions();
+  options.dependencies?.forEach(this.addDependency);
   try {
     const result = await loadMDXWithCaching({
       resource: this.resource,

--- a/packages/docusaurus-mdx-loader/src/options.ts
+++ b/packages/docusaurus-mdx-loader/src/options.ts
@@ -11,6 +11,8 @@ import type {ResolveMarkdownLink} from './remark/resolveMarkdownLinks';
 import type {PromiseWithResolvers} from './utils';
 
 export type Options = Partial<MDXOptions> & {
+  dependencies?: string[];
+
   markdownConfig: MarkdownConfig;
   staticDirs: string[];
   siteDir: string;


### PR DESCRIPTION
## Motivation

We have a bundler cache invalidation problem, that I discovered while working on https://github.com/facebook/docusaurus/pull/10931


The following works:

```bash
DOCUSAURUS_SLOWER=true 

yarn clear:website
yarn build:website --locale en
yarn build:website --locale en

yarn clear:website
yarn build:website:fast
yarn build:website:fast
```

But the following fails with broken link errors:

```bash
DOCUSAURUS_SLOWER=true 

yarn clear:website
yarn build:website --locale en
yarn build:website:fast
```

```bash
  Exhaustive list of all broken links found:
  - Broken link on source page path = /docs:
     -> linking to /docs/next/migration
  - Broken link on source page path = /docs/advanced:
     -> linking to /docs/next/api/plugin-methods
  - Broken link on source page path = /docs/advanced/architecture:
     -> linking to /docs/next/docusaurus-core#useDocusaurusContext
  - Broken link on source page path = /docs/advanced/client:
     -> linking to /docs/next/swizzling#wrapping
     -> linking to /docs/next/api/plugin-methods/lifecycle-apis#getClientModules
     -> linking to /docs/next/api/docusaurus-config#clientModules
     -> linking to /docs/next/advanced/ssg#escape-hatches
     -> linking to /docs/next/styling-layout#global-styles
     -> linking to /docs/next/swizzling
  - Broken link on source page path = /docs/advanced/plugins:
     -> linking to /docs/next/api/plugin-methods
     -> linking to /docs/next/api/plugin-methods/lifecycle-apis#addRoute
     -> linking to /docs/next/api/plugin-methods/lifecycle-apis#setGlobalData
     -> linking to /docs/next/advanced/architecture
     -> linking to /docs/next/api/plugin-methods/lifecycle-apis#loadContent
     -> linking to /docs/next/api/plugin-methods/extend-infrastructure#getThemePath

...
```

This is because our docs plugin has:

```js
const isBuildFast = !!process.env.BUILD_FAST;

docsOptions.lastVersion: isBuildFast ? 'current' : getLastStableVersion(),`
```

This option affects the URLs of the versions/docs through an env variable, which in turn affect the MDX loader `resolveMarkdownLink`.

Depending on env variables, `@site/docs/my-doc.md` might resolve to:
- /docs/my-doc
- /docs/next/my-doc
- /docs/<otherVersion>/my-doc

Problem, the MDX loader cache entries are not invalidated when this happens, leading to "reusing" stale cache hits.


---

Our MDX loader uses `this.cacheable(true)` (default) but is non-deterministic and the same input doesn't always lead to the same output (depending on plugin/loader options).

https://webpack.js.org/api/loaders/#thiscacheable

> A cacheable loader must have a deterministic result when inputs and dependencies haven't changed. This means the loader shouldn't have dependencies other than those specified with `this.addDependency`.

Most options are passed through `docusaurus.config.js`, and this file is declared as a Webpack `buildDependency`: changing it will invalidate the whole cache. 

However, it remains possible to change plugin options without modifying `docusaurus.config.js`. For example, when using env variables, the config file is not updated and the site cache isn't invalidated. And there are even more ways to have a stale cache that doesn't invalidate properly, such as cutting a new docs version. 

---

Unfortunately, Webpack loader API is not super convenient to help us invalidate its cached entries. 

I thought entries would get invalidated automatically on options change, but it doesn't look to be the case. Also, there's no `cache.version` on the loader like there is globally, and we need to write a file to disk and add it to `this.addDependency(file)` so that our MDX files are evicted from the cache.

The solution I'm adding is to add a new mdx-loader `dependencies` object to trigger cache invalidations, and pass it a `__mdx-loader-dependency.json` file that will contain anything that should lead to cache invalidation (using plugin options and versions).

This solves the problem on the docs plugin. The persistent cache still works, when options/versions don't change, but invalidates properly. The repro case above now works without error:

```bash
DOCUSAURUS_SLOWER=true 

yarn clear:website
yarn build:website --locale en
yarn build:website:fast
```
---

I'm not 100% sure this is the perfect solution, but at least it solves the problem above. This PR is mostly here to document the problem and get it out of my head so that we can come back to it later.

We'll figure out a way to generalize this solution to our other plugins, and how to help third-party plugin authors ensure the cache gets invalidated properly too. 

There are likely many other edge cases to consider:
- changing `siteConfig.markdown` options with env variables
- changing other content plugin options with env variables
- changing the behavior of a custom remark plugin with env variables
- using `fs.readFile` in `docusaurus.config.js` and use the file content to alter the Docusaurus site config
- 3rd party plugins using our MDX loader
- any env variable used in any loader

Most likely, we need to expose APIs to the end user to be able to control cache invalidation on their own, because it's impossible to cover all cases automatically.

Fortunately, `docusaurus clear` remains a good workaround


## Test Plan

local, not easy to cover in CI 😅 

### Test links

https://deploy-preview-10934--docusaurus-2.netlify.app/

## Related issues/PRs

https://github.com/facebook/docusaurus/pull/10931