### PR TITLE
fix(theme-classic): fix ThemeClassName reference

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Layout/index.tsx
@@ -48,7 +48,7 @@ export default function Layout(props: Props): ReactNode {
       <div
         id={SkipToContentFallbackId}
         className={clsx(
-          ThemeClassNames.layout.main,
+          ThemeClassNames.layout.main.container,
           ThemeClassNames.wrapper.main,
           styles.mainWrapper,
           wrapperClassName,


### PR DESCRIPTION
Fix a typo introduced by https://github.com/facebook/docusaurus/pull/10945. We are passing a key-value pair to clsx whose value is truthy, so its key, `container`, gets used as the class, which happens to be a valid class with its own properties 😅

This is causing rendering anomalies in prod:

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/ca630f7f-df24-4fb8-b966-6518e7dc579e" />
