### PR TITLE
fix(theme): fix `useColorMode().colorMode` leading to React hydration mismatches

### DIFF
--- a/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
+++ b/packages/docusaurus-theme-common/src/utils/useThemeConfig.ts
@@ -9,6 +9,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import type {PrismTheme} from 'prism-react-renderer';
 import type {DeepPartial} from 'utility-types';
 import type {MagicCommentConfig} from './codeBlockUtils';
+import type {ColorMode} from '../contexts/colorMode';
 
 export type DocsVersionPersistence = 'localStorage' | 'none';
 
@@ -44,7 +45,7 @@ export type Navbar = {
 };
 
 export type ColorModeConfig = {
-  defaultMode: 'light' | 'dark';
+  defaultMode: ColorMode;
   disableSwitch: boolean;
   respectPrefersColorScheme: boolean;
 };


### PR DESCRIPTION

## Motivation

It's not safe to init `useState(getPersistedColorModeIfBrowser())`, and can lead to React hydration mismatches.

We notably had one visible in `docusaurus build --dev` when loading a page in dark mode:


```bash
ColorModeToggle

+                               title="Switch between dark and light mode (currently dark mode)"
-                               title="Switch between dark and light mode (currently light mode)"
+                               aria-label="Switch between dark and light mode (currently dark mode)"
-                               aria-label="Switch between dark and light mode (currently light mode)"
                                aria-live="polite"
+                               aria-pressed="true"
-                               aria-pressed="false"
```


Using this code is safe and prevents hydration mismatches by using the exact same value that was used during SSG.

```js
const [state, setState] = useState(defaultMode);

useEffect(() => {
  setState(getPersistedColorModeIfBrowser());
},[])
```

Yes the state lags behind, but this is on purpose. Related to https://github.com/facebook/docusaurus/issues/7986

If users need to know the color mode without lag, they can't use that in their React render code or they'll create themselves hydration errors. 

If they really know what they are doing and need a fresh value, they can read `document.documentElement.getAttribute('data-theme')` directly, but we don't want to encourage that pattern as it's unsafe to do so.

## Test Plan

CI + preview

### Test links

https://deploy-preview-10954--docusaurus-2.netlify.app/

