### PR TITLE
chore: upgrade monorepo to TS 5.8

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -85,14 +85,15 @@ jobs:
       # Ensure build with a cold cache does not increase too much
       - name: Build (cold cache)
         run: yarn build:website:fast
-        timeout-minutes: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 3 || 1  }}
+        timeout-minutes: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 3 || 2  }}
         env:
           DOCUSAURUS_SLOWER: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 'true' || 'false'  }}
 
       # Ensure build with a warm cache does not increase too much
       - name: Build (warm cache)
         run: yarn build:website:fast
-        timeout-minutes: 1
+        # Temporary: upper value for Rspack until incremental cache works better
+        timeout-minutes: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 1 || 2  }}
         env:
           DOCUSAURUS_SLOWER: ${{ matrix.DOCUSAURUS_INFRA == 'SLOWER' && 'true' || 'false'  }}
 

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "stylelint": "^14.16.1",
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-standard": "^29.0.0",
-    "typescript": "~5.7.2"
+    "typescript": "~5.8.2"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/docusaurus-cssnano-preset/src/index.ts
+++ b/packages/docusaurus-cssnano-preset/src/index.ts
@@ -26,4 +26,5 @@ const preset: typeof advancedBasePreset = function preset(opts) {
   return advancedPreset;
 };
 
-export default preset;
+// @ts-expect-error: TODO fix later
+export = preset;

--- a/packages/docusaurus-cssnano-preset/src/index.ts
+++ b/packages/docusaurus-cssnano-preset/src/index.ts
@@ -26,4 +26,4 @@ const preset: typeof advancedBasePreset = function preset(opts) {
   return advancedPreset;
 };
 
-export = preset;
+export default preset;

--- a/packages/docusaurus-mdx-loader/src/processor.ts
+++ b/packages/docusaurus-mdx-loader/src/processor.ts
@@ -22,8 +22,6 @@ import type {WebpackCompilerName} from '@docusaurus/utils';
 import type {MDXFrontMatter} from './frontMatter';
 import type {Options} from './options';
 import type {AdmonitionOptions} from './remark/admonitions';
-
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {ProcessorOptions} from '@mdx-js/mdx';
 
 // TODO as of April 2023, no way to import/re-export this ESM type easily :/

--- a/packages/docusaurus-mdx-loader/src/remark/admonitions/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/admonitions/index.ts
@@ -4,10 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer, Plugin} from 'unified';
-
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {ContainerDirective} from 'mdast-util-directive';
 import type {Parent, Root} from 'mdast';
 

--- a/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/contentTitle/index.ts
@@ -4,11 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer, Plugin} from 'unified';
 import type {Heading, Parent, Root} from 'mdast';
-
-// @ts-expect-error: ES support...
 import type {MdxJsxFlowElement} from 'mdast-util-mdx';
 
 interface PluginOptions {

--- a/packages/docusaurus-mdx-loader/src/remark/details/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/details/index.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer} from 'unified';
 
 import type {Root} from 'mdast';

--- a/packages/docusaurus-mdx-loader/src/remark/head/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/head/index.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer} from 'unified';
 
 import type {Root} from 'mdast';

--- a/packages/docusaurus-mdx-loader/src/remark/headings/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/headings/index.ts
@@ -8,7 +8,6 @@
 /* Based on remark-slug (https://github.com/remarkjs/remark-slug) and gatsby-remark-autolink-headers (https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-autolink-headers) */
 
 import {parseMarkdownHeadingId, createSlugger} from '@docusaurus/utils';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Plugin, Transformer} from 'unified';
 import type {Root, Text} from 'mdast';
 

--- a/packages/docusaurus-mdx-loader/src/remark/mdx1Compat/codeCompatPlugin.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/mdx1Compat/codeCompatPlugin.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer, Plugin} from 'unified';
 import type {Root} from 'mdast';
 

--- a/packages/docusaurus-mdx-loader/src/remark/mermaid/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/mermaid/index.ts
@@ -7,7 +7,6 @@
 
 import {transformNode} from '../utils';
 
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer} from 'unified';
 import type {Root} from 'mdast';
 

--- a/packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/resolveMarkdownLinks/index.ts
@@ -11,7 +11,6 @@ import {
   type URLPath,
 } from '@docusaurus/utils';
 
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Plugin, Transformer} from 'unified';
 import type {Definition, Link, Root} from 'mdast';
 

--- a/packages/docusaurus-mdx-loader/src/remark/toc/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/index.ts
@@ -14,13 +14,8 @@ import {
   isNamedExport,
 } from './utils';
 import type {Heading, Root} from 'mdast';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Plugin, Transformer} from 'unified';
-import type {
-  MdxjsEsm,
-  MdxJsxFlowElement,
-  // @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
-} from 'mdast-util-mdx';
+import type {MdxjsEsm, MdxJsxFlowElement} from 'mdast-util-mdx';
 import type {TOCItems} from './types';
 import type {ImportDeclaration} from 'estree';
 

--- a/packages/docusaurus-mdx-loader/src/remark/toc/utils.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/toc/utils.ts
@@ -7,10 +7,7 @@
 
 import {toValue} from '../utils';
 import type {Node} from 'unist';
-import type {
-  MdxjsEsm,
-  // @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
-} from 'mdast-util-mdx';
+import type {MdxjsEsm} from 'mdast-util-mdx';
 import type {TOCHeading, TOCItem, TOCItems, TOCSlice} from './types';
 import type {
   Program,

--- a/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformImage/index.ts
@@ -20,9 +20,7 @@ import escapeHtml from 'escape-html';
 import sizeOf from 'image-size';
 import logger from '@docusaurus/logger';
 import {assetRequireAttributeValue, transformNode} from '../utils';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Plugin, Transformer} from 'unified';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {MdxJsxTextElement} from 'mdast-util-mdx';
 import type {Image, Root} from 'mdast';
 import type {Parent} from 'unist';

--- a/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/transformLinks/index.ts
@@ -17,9 +17,7 @@ import {
 } from '@docusaurus/utils';
 import escapeHtml from 'escape-html';
 import {assetRequireAttributeValue, transformNode} from '../utils';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Plugin, Transformer} from 'unified';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {MdxJsxTextElement} from 'mdast-util-mdx';
 import type {Parent} from 'unist';
 import type {Link, Literal, Root} from 'mdast';

--- a/packages/docusaurus-mdx-loader/src/remark/unusedDirectives/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/unusedDirectives/index.ts
@@ -10,14 +10,9 @@ import logger from '@docusaurus/logger';
 import {posixPath} from '@docusaurus/utils';
 import {transformNode} from '../utils';
 import type {Root} from 'mdast';
-
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
-import type {Transformer, Processor, Parent, Plugin} from 'unified';
-import type {
-  Directives,
-  TextDirective,
-  // @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
-} from 'mdast-util-directive';
+import type {Parent} from 'unist';
+import type {Transformer, Processor, Plugin} from 'unified';
+import type {Directives, TextDirective} from 'mdast-util-directive';
 
 type DirectiveType = Directives['type'];
 
@@ -133,21 +128,18 @@ const plugin: Plugin<unknown[], Root> = function plugin(
 
     const unusedDirectives: Directives[] = [];
 
-    visit<Parent, DirectiveType[]>(
-      tree,
-      directiveTypes,
-      (directive: Directives) => {
-        // If directive data is set (hName/hProperties set by admonitions)
-        // this usually means the directive has been handled by another plugin
-        if (isUnusedDirective(directive)) {
-          if (isSimpleTextDirective(directive)) {
-            transformSimpleTextDirectiveToString(directive);
-          } else {
-            unusedDirectives.push(directive);
-          }
+    // @ts-expect-error: TODO fix type
+    visit<Parent, Directives>(tree, directiveTypes, (directive: Directives) => {
+      // If directive data is set (hName/hProperties set by admonitions)
+      // this usually means the directive has been handled by another plugin
+      if (isUnusedDirective(directive)) {
+        if (isSimpleTextDirective(directive)) {
+          transformSimpleTextDirectiveToString(directive);
+        } else {
+          unusedDirectives.push(directive);
         }
-      },
-    );
+      }
+    });
 
     // We only enable these warnings for the client compiler
     // This avoids emitting duplicate warnings in prod mode

--- a/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
+++ b/packages/docusaurus-mdx-loader/src/remark/utils/index.ts
@@ -12,7 +12,6 @@ import type {
   MdxJsxAttribute,
   MdxJsxAttributeValueExpression,
   MdxJsxTextElement,
-  // @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 } from 'mdast-util-mdx';
 
 /**

--- a/packages/docusaurus-plugin-content-blog/src/remark/footnoteIDFixer.ts
+++ b/packages/docusaurus-plugin-content-blog/src/remark/footnoteIDFixer.ts
@@ -6,7 +6,6 @@
  */
 
 import {simpleHash} from '@docusaurus/utils';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {Transformer} from 'unified';
 import type {FootnoteReference, FootnoteDefinition} from 'mdast';
 

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
@@ -7,18 +7,9 @@
 
 import npmToYarn from 'npm-to-yarn';
 import type {Code, Literal} from 'mdast';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
 import type {MdxJsxFlowElement, MdxJsxAttribute} from 'mdast-util-mdx';
 import type {Node, Parent} from 'unist';
-// @ts-expect-error: TODO see https://github.com/microsoft/TypeScript/issues/49721
-import type {Transformer} from 'unified';
-
-// TODO as of April 2023, no way to import/re-export this ESM type easily :/
-// This might change soon, likely after TS 5.2
-// See https://github.com/microsoft/TypeScript/issues/49721#issuecomment-1517839391
-// import type {Plugin} from 'unified';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type Plugin<T> = any; // TODO fix this asap
+import type {Transformer, Plugin} from 'unified';
 
 type KnownConverter = 'yarn' | 'pnpm' | 'bun';
 
@@ -181,7 +172,6 @@ function createImportNode() {
 }
 
 const plugin: Plugin<[PluginOptions?]> = (options = {}): Transformer => {
-  // @ts-expect-error: todo temporary
   const {sync = false, converters = ['yarn', 'pnpm']} = options;
   return async (root) => {
     const {visit} = await import('unist-util-visit');

--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
@@ -208,4 +208,5 @@ const plugin: Plugin<[PluginOptions?]> = (options = {}): Transformer => {
 
 // To continue supporting `require('npm2yarn')` without the `.default` ㄟ(▔,▔)ㄏ
 // TODO change to export default after migrating to ESM
+// @ts-expect-error: Docusaurus v4: remove
 export = plugin;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,6 +7,7 @@
 
 import rules from './rules';
 
+// @ts-expect-error: TODO try to remove later
 export = {
   rules,
   configs: {

--- a/packages/stylelint-copyright/src/index.ts
+++ b/packages/stylelint-copyright/src/index.ts
@@ -58,4 +58,4 @@ rule.messages = messages;
 
 const plugin = stylelint.createPlugin(ruleName, rule);
 
-export = plugin;
+export default plugin;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,7 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": "${configDir}/lib/.tsbuildinfo",
-
+    "erasableSyntaxOnly": true,
     /* Emit */
     "target": "ES2020",
     "lib": ["ESNext"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -17520,10 +17520,10 @@ typescript@~5.6.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
-typescript@~5.7.2:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
-  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
+typescript@~5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 ufo@^1.5.3:
   version "1.5.4"


### PR DESCRIPTION
## Motivation

See https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/

Looks like we can get rid of various TS errors related to importing ESM types from CJS modules (mostly in the MDX loader)

Also enables the new `erasableSyntaxOnly` for possible future native TS usage

## Test Plan

CI

### Test links

https://deploy-preview-10966--docusaurus-2.netlify.app/


