### PR TITLE
feat(theme): Allow resetting colorMode to System/OS value

### DIFF
--- a/packages/docusaurus-theme-classic/src/inlineScripts.ts
+++ b/packages/docusaurus-theme-classic/src/inlineScripts.ts
@@ -30,43 +30,22 @@ export function getThemeInlineScript({
   return `(function() {
     var defaultMode = '${defaultMode}';
     var respectPrefersColorScheme = ${respectPrefersColorScheme};
-
-    function setDataThemeAttribute(theme) {
-      document.documentElement.setAttribute('data-theme', theme);
-    }
+    var systemColorMode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
     function getQueryStringTheme() {
       try {
         return new URLSearchParams(window.location.search).get('${ThemeQueryStringKey}')
-      } catch (e) {
-      }
+      } catch (e) {}
     }
-
     function getStoredTheme() {
       try {
         return window['${siteStorage.type}'].getItem('${themeStorageKey}');
-      } catch (err) {
-      }
+      } catch (err) {}
     }
 
     var initialTheme = getQueryStringTheme() || getStoredTheme();
-    if (initialTheme !== null) {
-      setDataThemeAttribute(initialTheme);
-    } else {
-      if (
-        respectPrefersColorScheme &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches
-      ) {
-        setDataThemeAttribute('dark');
-      } else if (
-        respectPrefersColorScheme &&
-        window.matchMedia('(prefers-color-scheme: light)').matches
-      ) {
-        setDataThemeAttribute('light');
-      } else {
-        setDataThemeAttribute(defaultMode === 'dark' ? 'dark' : 'light');
-      }
-    }
+    document.documentElement.setAttribute('data-theme', initialTheme || (respectPrefersColorScheme ? getSystemColorMode() : defaultMode));
+    document.documentElement.setAttribute('data-theme-choice', initialTheme || (respectPrefersColorScheme ? 'auto' : defaultMode));
   })();`;
 }
 

--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -1555,12 +1555,12 @@ declare module '@theme/ColorModeToggle' {
   export interface Props {
     readonly className?: string;
     readonly buttonClassName?: string;
-    readonly value: ColorMode;
+    readonly value: ColorMode | null;
     /**
      * The parameter represents the "to-be" value. For example, if currently in
-     * dark mode, clicking the button should call `onChange("light")`
+     * light mode, clicking the button should call `onChange("dark")`
      */
-    readonly onChange: (colorMode: ColorMode) => void;
+    readonly onChange: (colorMode: ColorMode | null) => void;
   }
 
   export default function ColorModeToggle(props: Props): ReactNode;
@@ -1615,6 +1615,14 @@ declare module '@theme/Icon/LightMode' {
   export interface Props extends ComponentProps<'svg'> {}
 
   export default function IconLightMode(props: Props): ReactNode;
+}
+
+declare module '@theme/Icon/SystemColorMode' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'svg'> {}
+
+  export default function IconSystemColorMode(props: Props): JSX.Element;
 }
 
 declare module '@theme/Icon/Menu' {

--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/index.tsx
@@ -11,9 +11,26 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import {translate} from '@docusaurus/Translate';
 import IconLightMode from '@theme/Icon/LightMode';
 import IconDarkMode from '@theme/Icon/DarkMode';
+import IconSystemColorMode from '@theme/Icon/SystemColorMode';
 import type {Props} from '@theme/ColorModeToggle';
+import type {ColorMode} from '@docusaurus/theme-common';
 
 import styles from './styles.module.css';
+
+// TODO only display 2 values if respectPrefersColorScheme = false?
+// The order of color modes is defined here, and can be customized with swizzle
+function getNextColorMode(colorMode: ColorMode | null) {
+  switch (colorMode) {
+    case null:
+      return 'light';
+    case 'light':
+      return 'dark';
+    case 'dark':
+      return null;
+    default:
+      return null;
+  }
+}
 
 function ColorModeToggle({
   className,
@@ -23,6 +40,7 @@ function ColorModeToggle({
 }: Props): ReactNode {
   const isBrowser = useIsBrowser();
 
+  // TODO bad title
   const title = translate(
     {
       message: 'Switch between dark and light mode (currently {mode})',
@@ -55,17 +73,21 @@ function ColorModeToggle({
           buttonClassName,
         )}
         type="button"
-        onClick={() => onChange(value === 'dark' ? 'light' : 'dark')}
+        onClick={() => onChange(getNextColorMode(value))}
         disabled={!isBrowser}
         title={title}
         aria-label={title}
         aria-live="polite"
+        // TODO bad aria value
         aria-pressed={value === 'dark' ? 'true' : 'false'}>
         <IconLightMode
           className={clsx(styles.toggleIcon, styles.lightToggleIcon)}
         />
         <IconDarkMode
           className={clsx(styles.toggleIcon, styles.darkToggleIcon)}
+        />
+        <IconSystemColorMode
+          className={clsx(styles.toggleIcon, styles.systemToggleIcon)}
         />
       </button>
     </div>

--- a/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/styles.module.css
+++ b/packages/docusaurus-theme-classic/src/theme/ColorModeToggle/styles.module.css
@@ -25,9 +25,14 @@
   background: var(--ifm-color-emphasis-200);
 }
 
-[data-theme='light'] .darkToggleIcon,
-[data-theme='dark'] .lightToggleIcon {
+.toggleIcon {
   display: none;
+}
+
+[data-theme-choice='auto'] .systemToggleIcon,
+[data-theme-choice='light'] .lightToggleIcon,
+[data-theme-choice='dark'] .darkToggleIcon {
+  display: initial;
 }
 
 .toggleButtonDisabled {

--- a/packages/docusaurus-theme-classic/src/theme/Icon/SystemColorMode/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Icon/SystemColorMode/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {ReactNode} from 'react';
+import type {Props} from '@theme/Icon/SystemColorMode';
+
+export default function IconSystemColorMode(props: Props): ReactNode {
+  return (
+    <svg viewBox="0 0 24 24" width={24} height={24} {...props}>
+      <path
+        fill="currentColor"
+        d="m12 21c4.971 0 9-4.029 9-9s-4.029-9-9-9-9 4.029-9 9 4.029 9 9 9zm4.95-13.95c1.313 1.313 2.05 3.093 2.05 4.95s-0.738 3.637-2.05 4.95c-1.313 1.313-3.093 2.05-4.95 2.05v-14c1.857 0 3.637 0.737 4.95 2.05z"
+      />
+    </svg>
+  );
+}

--- a/packages/docusaurus-theme-classic/src/theme/Navbar/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme-classic/src/theme/Navbar/ColorModeToggle/index.tsx
@@ -14,7 +14,7 @@ import styles from './styles.module.css';
 export default function NavbarColorModeToggle({className}: Props): ReactNode {
   const navbarStyle = useThemeConfig().navbar.style;
   const disabled = useThemeConfig().colorMode.disableSwitch;
-  const {colorMode, setColorMode} = useColorMode();
+  const {colorModeChoice, setColorMode} = useColorMode();
 
   if (disabled) {
     return null;
@@ -26,7 +26,7 @@ export default function NavbarColorModeToggle({className}: Props): ReactNode {
       buttonClassName={
         navbarStyle === 'dark' ? styles.darkNavbarColorModeToggle : undefined
       }
-      value={colorMode}
+      value={colorModeChoice}
       onChange={setColorMode}
     />
   );

--- a/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
+++ b/packages/docusaurus-theme-common/src/contexts/colorMode.tsx
@@ -11,19 +11,49 @@ import React, {
   useEffect,
   useContext,
   useMemo,
-  useRef,
   type ReactNode,
 } from 'react';
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import {ReactContextError} from '../utils/reactUtils';
 import {createStorageSlot} from '../utils/storageUtils';
 import {useThemeConfig} from '../utils/useThemeConfig';
 
+// The "effective" color mode
+export type ColorMode = 'light' | 'dark';
+
+// The color mode explicitly chosen by the user
+// null => no choice has been made, or the choice has been reverted to OS value
+export type ColorModeChoice = ColorMode | null;
+
+function getSystemColorMode(): ColorMode {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+function subscribeToMedia(
+  query: string,
+  listener: (event: MediaQueryListEvent) => void,
+): () => void {
+  const mql = window.matchMedia(query);
+  mql.addEventListener('change', listener);
+  return () => mql.removeEventListener('change', listener);
+}
+
+function subscribeToSystemColorModeChange(
+  onChange: (newSystemColorMode: ColorMode) => void,
+): () => void {
+  return subscribeToMedia('(prefers-color-scheme: dark)', () =>
+    onChange(getSystemColorMode()),
+  );
+}
+
 type ContextValue = {
-  /** Current color mode. */
+  /** The effective color mode. */
   readonly colorMode: ColorMode;
+  /** The explicitly chosen color mode */
+  readonly colorModeChoice: ColorModeChoice;
   /** Set new color mode. */
-  readonly setColorMode: (colorMode: ColorMode) => void;
+  readonly setColorMode: (colorMode: ColorModeChoice) => void;
 
   // TODO Docusaurus v4
   //  legacy APIs kept for retro-compatibility: deprecate them
@@ -37,16 +67,13 @@ const Context = React.createContext<ContextValue | undefined>(undefined);
 const ColorModeStorageKey = 'theme';
 const ColorModeStorage = createStorageSlot(ColorModeStorageKey);
 
-const ColorModes = {
-  light: 'light',
-  dark: 'dark',
-} as const;
-
-export type ColorMode = (typeof ColorModes)[keyof typeof ColorModes];
-
 // Ensure to always return a valid colorMode even if input is invalid
-const coerceToColorMode = (colorMode?: string | null): ColorMode =>
-  colorMode === ColorModes.dark ? ColorModes.dark : ColorModes.light;
+const coerceToColorMode = (colorMode: string | null): ColorMode =>
+  colorMode === 'dark' ? 'dark' : 'light';
+const coerceToColorModeChoice = (colorMode: string | null): ColorModeChoice =>
+  colorMode === null || colorMode === 'auto'
+    ? null
+    : coerceToColorMode(colorMode);
 
 const ColorModeAttribute = {
   get: () => {
@@ -62,15 +89,26 @@ const ColorModeAttribute = {
   },
 };
 
-const readInitialColorMode = (): ColorMode => {
-  if (!ExecutionEnvironment.canUseDOM) {
-    throw new Error("Can't read initial color mode on the server");
-  }
-  return ColorModeAttribute.get();
+const ColorModeChoiceAttribute = {
+  get: () => {
+    return coerceToColorModeChoice(
+      document.documentElement.getAttribute('data-theme-choice'),
+    );
+  },
+  set: (colorMode: ColorModeChoice) => {
+    document.documentElement.setAttribute(
+      'data-theme-choice',
+      coerceToColorModeChoice(colorMode) ?? 'auto',
+    );
+  },
 };
 
-const storeColorMode = (newColorMode: ColorMode) => {
-  ColorModeStorage.set(coerceToColorMode(newColorMode));
+const persistColorModeChoice = (newColorMode: ColorModeChoice) => {
+  if (newColorMode === null) {
+    ColorModeStorage.del();
+  } else {
+    ColorModeStorage.set(coerceToColorMode(newColorMode));
+  }
 };
 
 // The color mode state is initialized in useEffect on purpose
@@ -83,20 +121,33 @@ function useColorModeState() {
     colorMode: {defaultMode},
   } = useThemeConfig();
 
-  const [colorMode, setColorModeState] = useState(defaultMode);
+  const [colorMode, setColorModeState] = useState<ColorMode>(defaultMode);
+  const [colorModeChoice, setColorModeChoiceState] =
+    useState<ColorModeChoice>(null);
 
   useEffect(() => {
-    setColorModeState(readInitialColorMode());
+    setColorModeState(ColorModeAttribute.get());
+    setColorModeChoiceState(ColorModeChoiceAttribute.get());
   }, []);
 
-  return [colorMode, setColorModeState] as const;
+  return {
+    colorMode,
+    setColorModeState,
+    colorModeChoice,
+    setColorModeChoiceState,
+  } as const;
 }
 
 function useContextValue(): ContextValue {
   const {
     colorMode: {defaultMode, disableSwitch, respectPrefersColorScheme},
   } = useThemeConfig();
-  const [colorMode, setColorModeState] = useColorModeState();
+  const {
+    colorMode,
+    setColorModeState,
+    colorModeChoice,
+    setColorModeChoiceState,
+  } = useColorModeState();
 
   useEffect(() => {
     // A site is deployed without disableSwitch
@@ -109,67 +160,70 @@ function useContextValue(): ContextValue {
   }, [disableSwitch]);
 
   const setColorMode = useCallback(
-    (newColorMode: ColorMode | null, options: {persist?: boolean} = {}) => {
+    (
+      newColorModeChoice: ColorModeChoice,
+      options: {persist?: boolean} = {},
+    ) => {
       const {persist = true} = options;
 
-      if (newColorMode) {
+      // Reset to system/default color mode
+      if (newColorModeChoice === null) {
+        // Set the effective color
+        const newColorMode = respectPrefersColorScheme
+          ? getSystemColorMode()
+          : defaultMode;
         ColorModeAttribute.set(newColorMode);
         setColorModeState(newColorMode);
-        if (persist) {
-          storeColorMode(newColorMode);
-        }
-      } else {
-        if (respectPrefersColorScheme) {
-          const osColorMode = window.matchMedia('(prefers-color-scheme: dark)')
-            .matches
-            ? ColorModes.dark
-            : ColorModes.light;
-          ColorModeAttribute.set(osColorMode);
-          setColorModeState(osColorMode);
-        } else {
-          ColorModeAttribute.set(defaultMode);
-          setColorModeState(defaultMode);
-        }
-        ColorModeStorage.del();
+        // Set the chosen color
+        ColorModeChoiceAttribute.set(null);
+        setColorModeChoiceState(null);
+      }
+      // Happy case, when an explicit color is provided
+      else {
+        ColorModeAttribute.set(newColorModeChoice);
+        ColorModeChoiceAttribute.set(newColorModeChoice);
+        setColorModeState(newColorModeChoice);
+        setColorModeChoiceState(newColorModeChoice);
+      }
+
+      if (persist) {
+        persistColorModeChoice(newColorModeChoice);
       }
     },
-    [setColorModeState, respectPrefersColorScheme, defaultMode],
+    [
+      setColorModeState,
+      setColorModeChoiceState,
+      respectPrefersColorScheme,
+      defaultMode,
+    ],
   );
 
+  // Synchronize theme color/choice mode with browser storage
   useEffect(() => {
-    if (disableSwitch) {
-      return undefined;
-    }
     return ColorModeStorage.listen((e) => {
-      setColorMode(coerceToColorMode(e.newValue));
+      setColorMode(coerceToColorModeChoice(e.newValue));
     });
-  }, [disableSwitch, setColorMode]);
+  }, [setColorMode]);
 
-  // PCS is coerced to light mode when printing, which causes the color mode to
-  // be reset to dark when exiting print mode, disregarding user settings. When
-  // the listener fires only because of a print/screen switch, we don't change
-  // color mode. See https://github.com/facebook/docusaurus/pull/6490
-  const previousMediaIsPrint = useRef(false);
-
+  // Synchronize theme color with system color
   useEffect(() => {
-    if (disableSwitch && !respectPrefersColorScheme) {
+    if (colorModeChoice !== null || !respectPrefersColorScheme) {
       return undefined;
     }
-    const mql = window.matchMedia('(prefers-color-scheme: dark)');
-    const onChange = () => {
-      if (window.matchMedia('print').matches || previousMediaIsPrint.current) {
-        previousMediaIsPrint.current = window.matchMedia('print').matches;
-        return;
-      }
-      setColorMode(null);
-    };
-    mql.addListener(onChange);
-    return () => mql.removeListener(onChange);
-  }, [setColorMode, disableSwitch, respectPrefersColorScheme]);
+    return subscribeToSystemColorModeChange((newSystemColorMode) => {
+      // Note: we don't use "setColorMode" on purpose
+      // The system changes should never be considered an explicit theme choice
+      // They only affect the "effective" color, and should never be persisted
+      // Note: this listener also fire when printing, see https://github.com/facebook/docusaurus/pull/6490
+      setColorModeState(newSystemColorMode);
+      ColorModeAttribute.set(newSystemColorMode);
+    });
+  }, [respectPrefersColorScheme, colorModeChoice, setColorModeState]);
 
   return useMemo(
     () => ({
       colorMode,
+      colorModeChoice,
       setColorMode,
       get isDarkTheme() {
         if (process.env.NODE_ENV === 'development') {
@@ -177,7 +231,7 @@ function useContextValue(): ContextValue {
             '`useColorMode().isDarkTheme` is deprecated. Please use `useColorMode().colorMode === "dark"` instead.',
           );
         }
-        return colorMode === ColorModes.dark;
+        return colorMode === 'dark';
       },
       setLightTheme() {
         if (process.env.NODE_ENV === 'development') {
@@ -185,7 +239,7 @@ function useContextValue(): ContextValue {
             '`useColorMode().setLightTheme` is deprecated. Please use `useColorMode().setColorMode("light")` instead.',
           );
         }
-        setColorMode(ColorModes.light);
+        setColorMode('light');
       },
       setDarkTheme() {
         if (process.env.NODE_ENV === 'development') {
@@ -193,10 +247,10 @@ function useContextValue(): ContextValue {
             '`useColorMode().setDarkTheme` is deprecated. Please use `useColorMode().setColorMode("dark")` instead.',
           );
         }
-        setColorMode(ColorModes.dark);
+        setColorMode('dark');
       },
     }),
-    [colorMode, setColorMode],
+    [colorMode, colorModeChoice, setColorMode],
   );
 }
 


### PR DESCRIPTION

## Motivation

Introduce a 3rd value in the color mode toggle to reset to System/OS color mode value

Fix https://github.com/facebook/docusaurus/issues/8074

![CleanShot 2025-03-13 at 14 03 44](https://github.com/user-attachments/assets/da0b3d5e-07f6-49ff-a517-1f78c3878497)


To handle FOUC in the toggle button before React hydration, we introduce a `data-theme-choice` attribute. Users can also rely on this to implement their own toggle button that doesn't produce FOUC. Relying on `useColorMode().colorModeChoice` to display the right icon is not ideal due to how React hydration works (see also https://github.com/facebook/docusaurus/issues/7986)


Note about data attributes:
- `data-theme` is always set to `'light' | 'dark'`: it's the "effective" theme being applied
- `data-theme-choice` is always set to `'light' | 'dark' | 'auto'`: it's the explicit theme choice that we consider the user has made

In practice, it's possible to have `data-theme-choice: 'auto'` and `data-theme: 'light'` for example (most likely happens when the system theme is 'light')


This also refactors and simplifies a few things


## Test Plan

Preview 😅 

### Test links

https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

Supersede:
- https://github.com/facebook/docusaurus/pull/8474
- https://github.com/facebook/docusaurus/pull/10474

Fixes the printing edge case but in a different way (https://github.com/facebook/docusaurus/pull/6490)
