### PR TITLE
fix(theme): mobile drawer history blocker should be rendered conditionally (workaround)

### DIFF
--- a/website/_dogfooding/_pages tests/history-tests.tsx
+++ b/website/_dogfooding/_pages tests/history-tests.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {useEffect, type ReactNode} from 'react';
+import {useHistory} from '@docusaurus/router';
+import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
+
+// Test for https://github.com/facebook/docusaurus/issues/10988
+function BlockNavigation() {
+  const history = useHistory();
+  useEffect(() => {
+    return history.block(() => {
+      // eslint-disable-next-line no-alert
+      alert('navigation blocked successfully');
+      return false;
+    });
+  }, [history]);
+  return false;
+}
+
+export default function HistoryTestsPage(): ReactNode {
+  return (
+    <Layout>
+      <Heading as="h1">History tests</Heading>
+      <p>This page should block navigation</p>
+      <BlockNavigation />
+    </Layout>
+  );
+}

--- a/website/_dogfooding/_pages tests/index.mdx
+++ b/website/_dogfooding/_pages tests/index.mdx
@@ -39,4 +39,5 @@ import Readme from "../README.mdx"
 - [Head metadata tests](/tests/pages/head-metadata)
 - [Unlisted page](/tests/pages/unlisted)
 - [Analytics](/tests/pages/analytics)
+- [History tests](/tests/pages/history-tests)
 - [Embeds](/tests/pages/embeds)


### PR DESCRIPTION
## Motivation

`history.block()` supports only a single blocker "prompt" at a time.

Rendering the mobile drawer history blocker even when our mobile drawer is not displayed means that users can't use `history.block()` reliably anywhere in their React code.

To work around this issue, let's render our mobile drawer history blocker conditionally.

This is a workaround for https://github.com/facebook/docusaurus/issues/10988, not a completely accurate fix but probably good enough until we figure things out.


## Test Plan

Dogfood test page works after the change, fails before (doesn't print the alert).

### Test links

https://deploy-preview-10989--docusaurus-2.netlify.app/tests/pages/, then navigate to "history-tests", then press back button

## Related issues/PRs

https://github.com/facebook/docusaurus/issues/10988