### PR TITLE
fix(theme): CodeBlock should accept `title` of `ReactNode` type

### DIFF
--- a/packages/docusaurus-theme-classic/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-classic/src/theme-classic.d.ts
@@ -410,7 +410,7 @@ declare module '@theme/CodeBlock' {
     readonly children: ReactNode;
     readonly className?: string;
     readonly metastring?: string;
-    readonly title?: string;
+    readonly title?: ReactNode;
     readonly language?: string;
     readonly showLineNumbers?: boolean | number;
   }

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -188,17 +188,27 @@ Multi-line text inside `pre` will turn into one-liner, but it's okay (https://gi
   <br />
 </CodeBlock>
 
-### Code blocks with `ReactNode` in title
+## Code blocks with `ReactNode` in title
 
-<CodeBlock 
-  className="language-yaml"
-  title={<span className="badge badge--primary">YAML</span>}
->
-  link:{'\n'}
-  {'  '}title: front page{'\n'}
-  {'  '}path: /docs/{'\n'}
+<CodeBlock
+  language="yaml"
+  title={
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+      <span>
+        <code>ReactNode</code> title
+      </span>{' '}
+      <span className="badge badge--primary">YAML</span>
+    </div>
+  }>
+  {`link:
+  title: front page
+  path: /docs/`}
 </CodeBlock>
-
 
 ## Code blocks with line numbering tests
 

--- a/website/_dogfooding/_pages tests/code-block-tests.mdx
+++ b/website/_dogfooding/_pages tests/code-block-tests.mdx
@@ -188,6 +188,18 @@ Multi-line text inside `pre` will turn into one-liner, but it's okay (https://gi
   <br />
 </CodeBlock>
 
+### Code blocks with `ReactNode` in title
+
+<CodeBlock 
+  className="language-yaml"
+  title={<span className="badge badge--primary">YAML</span>}
+>
+  link:{'\n'}
+  {'  '}title: front page{'\n'}
+  {'  '}path: /docs/{'\n'}
+</CodeBlock>
+
+
 ## Code blocks with line numbering tests
 
 ```jsx


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Docusaurus here: https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

The `CodeBlock` component is a nice component that can be reused consistently through all the docs. To allow more customization, it would be nice to pass `ReactNodes` instead of plain strings to the `title` container.  This is already possible and works by passing in `ReactNodes` and casting them `as any`:

```tsx
<CodeBlock
  language="yaml"
  title={
    (<div
      style={{
        display: 'flex',
        justifyContent: 'space-between',
        alignItems: 'center',
      }}>
      <span>
        <code>ReactNode</code> title
      </span>{' '}
      <span className="badge badge--primary">YAML</span>
    </div>) as any
  }>
  {`link:
  title: front page
  path: /docs/`}
</CodeBlock>
```

This PR fixes the types and adds a dogfood example.

```tsx
<CodeBlock
  language="yaml"
  title={
    <div
      style={{
        display: 'flex',
        justifyContent: 'space-between',
        alignItems: 'center',
      }}>
      <span>
        <code>ReactNode</code> title
      </span>{' '}
      <span className="badge badge--primary">YAML</span>
    </div>
  }>
  {`link:
  title: front page
  path: /docs/`}
</CodeBlock>
```

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
<img width="648" alt="image" src="https://github.com/user-attachments/assets/99785f65-f2d7-4d5e-a118-35c9c3b09ec5" />


## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Dogfooding example

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-10999--docusaurus-2.netlify.app/tests/pages/code-block-tests/#code-blocks-with-reactnode-in-title

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
