### PR TITLE
feat(core): Add bundler tracing/profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ website/i18n/**/*
 #!website/i18n/fr/**/*
 
 .netlify
+
+website/rspack-tracing.json
+website/rspack-cpu-profile.json

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ website/i18n/**/*
 .netlify
 
 website/rspack-tracing.json
-website/rspack-cpu-profile.json
+website/bundler-cpu-profile.json

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "yarn build:packages && yarn start:website",
     "start:website": "yarn workspace website start",
-    "start:website:profile": "DOCUSAURUS_RSPACK_JS_PROFILE=true DOCUSAURUS_RSPACK_TRACE=true yarn workspace website start",
+    "start:website:profile": "DOCUSAURUS_BUNDLER_CPU_PROFILE=true DOCUSAURUS_RSPACK_TRACE=true yarn workspace website start",
     "start:website:baseUrl": "yarn workspace website start:baseUrl",
     "start:website:blogOnly": "yarn workspace website start:blogOnly",
     "start:website:deployPreview": "cross-env NETLIFY=true CONTEXT='deploy-preview' yarn workspace website start",
@@ -23,7 +23,7 @@
     "build": "yarn build:packages && yarn build:website",
     "build:packages": "lerna run build --no-private",
     "build:website": "yarn workspace website build",
-    "build:website:profile": "DOCUSAURUS_RSPACK_JS_PROFILE=true DOCUSAURUS_RSPACK_TRACE=true yarn workspace website build",
+    "build:website:profile": "DOCUSAURUS_BUNDLER_CPU_PROFILE=true DOCUSAURUS_RSPACK_TRACE=true yarn workspace website build",
     "build:website:baseUrl": "yarn workspace website build:baseUrl",
     "build:website:blogOnly": "yarn workspace website build:blogOnly",
     "build:website:deployPreview:testWrap": "yarn workspace website test:swizzle:wrap:ts",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "start": "yarn build:packages && yarn start:website",
     "start:website": "yarn workspace website start",
+    "start:website:profile": "DOCUSAURUS_RSPACK_JS_PROFILE=true DOCUSAURUS_RSPACK_TRACE=true yarn workspace website start",
     "start:website:baseUrl": "yarn workspace website start:baseUrl",
     "start:website:blogOnly": "yarn workspace website start:blogOnly",
     "start:website:deployPreview": "cross-env NETLIFY=true CONTEXT='deploy-preview' yarn workspace website start",
@@ -22,6 +23,7 @@
     "build": "yarn build:packages && yarn build:website",
     "build:packages": "lerna run build --no-private",
     "build:website": "yarn workspace website build",
+    "build:website:profile": "DOCUSAURUS_RSPACK_JS_PROFILE=true DOCUSAURUS_RSPACK_TRACE=true yarn workspace website build",
     "build:website:baseUrl": "yarn workspace website build:baseUrl",
     "build:website:blogOnly": "yarn workspace website build:blogOnly",
     "build:website:deployPreview:testWrap": "yarn workspace website test:swizzle:wrap:ts",

--- a/packages/docusaurus-faster/src/index.ts
+++ b/packages/docusaurus-faster/src/index.ts
@@ -11,6 +11,16 @@ import browserslist from 'browserslist';
 import {minify as swcHtmlMinifier} from '@swc/html';
 import type {JsMinifyOptions, Options as SwcOptions} from '@swc/core';
 
+// See https://rspack.dev/contribute/development/profiling
+// File can be opened with https://ui.perfetto.dev/
+if (process.env.DOCUSAURUS_RSPACK_TRACE) {
+  Rspack.experiments.globalTrace.register(
+    'trace',
+    'chrome',
+    './rspack-tracing.json',
+  );
+}
+
 export const swcLoader = require.resolve('swc-loader');
 
 export const getSwcLoaderOptions = ({

--- a/packages/docusaurus/src/commands/start/start.ts
+++ b/packages/docusaurus/src/commands/start/start.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import logger from '@docusaurus/logger';
+import logger, {PerfLogger} from '@docusaurus/logger';
 import openBrowser from '../utils/openBrowser/openBrowser';
 import {setupSiteFileWatchers} from './watcher';
 import {createWebpackDevServer} from './webpack';
@@ -21,7 +21,7 @@ export type StartCLIOptions = HostPortOptions &
     minify?: boolean;
   };
 
-export async function start(
+async function doStart(
   siteDirParam: string = '.',
   cliOptions: Partial<StartCLIOptions> = {},
 ): Promise<void> {
@@ -61,4 +61,11 @@ export async function start(
   if (cliOptions.open) {
     await openBrowser(reloadableSite.getOpenUrl());
   }
+}
+
+export async function start(
+  siteDirParam: string = '.',
+  cliOptions: Partial<StartCLIOptions> = {},
+): Promise<void> {
+  return PerfLogger.async('CLI start', () => doStart(siteDirParam, cliOptions));
 }

--- a/packages/docusaurus/src/webpack/base.ts
+++ b/packages/docusaurus/src/webpack/base.ts
@@ -7,6 +7,7 @@
 
 import fs from 'fs-extra';
 import path from 'path';
+import inspector from 'node:inspector';
 import {getCustomBabelConfigFilePath} from '@docusaurus/babel';
 import {
   getCSSExtractPlugin,
@@ -16,7 +17,7 @@ import {
 
 import {md5Hash, getFileLoaderUtils} from '@docusaurus/utils';
 import {loadThemeAliases, loadDocusaurusAliases} from './aliases';
-import type {Configuration} from 'webpack';
+import type {Configuration, Compiler} from 'webpack';
 import type {
   ConfigureWebpackUtils,
   FasterConfig,
@@ -339,6 +340,41 @@ export async function createBaseConfig({
         // for more reasoning
         ignoreOrder: true,
       }),
-    ],
+      process.env.DOCUSAURUS_RSPACK_JS_PROFILE &&
+        new RspackProfileJSCPUProfilePlugin(),
+    ].filter(Boolean),
   };
+}
+
+// Bundle CPU profiling plugin contributed by the Rspack team
+// Can be opened in https://www.speedscope.app/
+// See also https://github.com/jerrykingxyz/docusaurus/pull/1
+// See also https://github.com/facebook/docusaurus/pull/10985
+class RspackProfileJSCPUProfilePlugin {
+  output: string;
+  constructor(output?: string) {
+    this.output = output ?? './rspack-cpu-profile.json';
+  }
+
+  apply(compiler: Compiler) {
+    const session = new inspector.Session();
+    session.connect();
+    session.post('Profiler.enable');
+    session.post('Profiler.start');
+    compiler.hooks.done.tapAsync(
+      RspackProfileJSCPUProfilePlugin.name,
+      (_stats, callback) => {
+        session.post('Profiler.stop', (error, param) => {
+          if (error) {
+            console.error('Failed to generate JS CPU profile:', error);
+            return;
+          }
+          fs.writeFile(this.output, JSON.stringify(param.profile)).catch(
+            console.error,
+          );
+        });
+        return callback();
+      },
+    );
+  }
 }

--- a/packages/docusaurus/src/webpack/plugins/BundlerCPUProfilerPlugin.ts
+++ b/packages/docusaurus/src/webpack/plugins/BundlerCPUProfilerPlugin.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import inspector from 'node:inspector';
+import fs from 'fs-extra';
+import type {Compiler} from 'webpack';
+
+// Bundle CPU profiling plugin, contributed by the Rspack team
+// Can be opened in https://www.speedscope.app/
+// See also https://github.com/jerrykingxyz/docusaurus/pull/1
+// See also https://github.com/facebook/docusaurus/pull/10985
+export class BundlerCPUProfilerPlugin {
+  output: string;
+
+  constructor(output?: string) {
+    this.output = output ?? './bundler-cpu-profile.json';
+  }
+
+  apply(compiler: Compiler): void {
+    const session = new inspector.Session();
+    session.connect();
+    session.post('Profiler.enable');
+    session.post('Profiler.start');
+
+    // In dev/watch mode, we restart the profiler before each compilation
+    compiler.hooks.watchRun.tapPromise(
+      BundlerCPUProfilerPlugin.name,
+      async () => {
+        session.post('Profiler.start');
+      },
+    );
+
+    compiler.hooks.done.tapPromise(BundlerCPUProfilerPlugin.name, async () => {
+      session.post('Profiler.stop', (error, param) => {
+        if (error) {
+          console.error('Failed to generate JS CPU profile:', error);
+          return;
+        }
+        fs.writeFile(this.output, JSON.stringify(param.profile)).catch(
+          console.error,
+        );
+      });
+    });
+  }
+}


### PR DESCRIPTION

## Motivation

Inspired by a PR from the Rspack team (https://github.com/jerrykingxyz/docusaurus/pull/1), let's add useful profiling/tracing tools to Docusaurus core.

For now, we consider it an internal feature, and we may eventually document that in the future if it works well for us and could benefit the community. Note that we already have an Rsdoctor plugin as part of our public API.




Secret env variables to toggle:

```bash
DOCUSAURUS_BUNDLER_CPU_PROFILE=true # produce bundler-cpu-profile.json - open in speedscope.app
DOCUSAURUS_RSPACK_TRACE=true # produce rspack-tracing.json - open in ui.perfetto.dev
```

More details here: https://rspack.dev/contribute/development/profiling


## Test Plan

local test only
